### PR TITLE
Add documentation for created_at parameter in Create or Update API

### DIFF
--- a/app/docs/0.10.x/admin-api.md
+++ b/app/docs/0.10.x/admin-api.md
@@ -512,11 +512,16 @@ HTTP 200 OK
 
 <div class="endpoint put">/apis/</div>
 
+Attributes | Description
+---:| ---
+`id`<br>**semi-required** | The unique identifier of the API to update (only required if updating)
+`created_at`<br>**semi-required** | The UNIX timestamp of the time the API was created (only required if updating)
+
 #### Request Body
 
 {{ page.api_body }}
 
-The body needs an `id` parameter to trigger an update on an existing entity.
+The body needs both `id` and `created_at` parameters to trigger an update on an existing entity.
 
 #### Response
 

--- a/app/docs/0.8.x/admin-api.md
+++ b/app/docs/0.8.x/admin-api.md
@@ -376,11 +376,16 @@ HTTP 200 OK
 
 <div class="endpoint put">/apis/</div>
 
+Attributes | Description
+---:| ---
+`id`<br>**semi-required** | The unique identifier of the API to update (only required if updating)
+`created_at`<br>**semi-required** | The UNIX timestamp of the time the API was created (only required if updating)
+
 #### Request Body
 
 {{ page.api_body }}
 
-The body needs an `id` parameter to trigger an update on an existing entity.
+The body needs both `id` and `created_at` parameters to trigger an update on an existing entity.
 
 #### Response
 

--- a/app/docs/0.9.x/admin-api.md
+++ b/app/docs/0.9.x/admin-api.md
@@ -415,11 +415,16 @@ HTTP 200 OK
 
 <div class="endpoint put">/apis/</div>
 
+Attributes | Description
+---:| ---
+`id`<br>**semi-required** | The unique identifier of the API to update (only required if updating)
+`created_at`<br>**semi-required** | The UNIX timestamp of the time the API was created (only required if updating)
+
 #### Request Body
 
 {{ page.api_body }}
 
-The body needs an `id` parameter to trigger an update on an existing entity.
+The body needs both `id` and `created_at` parameters to trigger an update on an existing entity.
 
 #### Response
 


### PR DESCRIPTION
https://github.com/Mashape/kong/issues/1324 mentions this, but no
documentation was ever written.
I'm not sure when created_at started to be required, put the above
issue was reported on 0.8.x and I ran into it today on 0.10.x, so I
updated the docs from 0.8.x to 0.10.x