### PR TITLE
docs(datadog) document config.tag_api_name

### DIFF
--- a/app/plugins/datadog.md
+++ b/app/plugins/datadog.md
@@ -39,6 +39,10 @@ params:
       required: false
       default: "`kong`"
       description: String to be attached as prefix to metric's name.
+    - name: tag_api_name
+      required: false
+      default: "`false`"
+      description: Whether to tag every metric with the api's name. If set to true then a tag of `api_name:<api-name>` will be included with metrics sent to datadog. When this is set to true the api name will not be prepended with the metric name.
 
 ---
 


### PR DESCRIPTION
Adds documentation related to changes in https://github.com/Kong/kong/pull/3037

![image](https://user-images.githubusercontent.com/2043529/36804306-0b172cbe-1c6f-11e8-8845-f8325b4750f8.png)
