### PR TITLE
docs(repo-link) add repo-link header button

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -62,6 +62,19 @@
     }
   }
 
+  .page-header-btn-repo {
+    &:before {
+      content: "";
+      display: inline-block;
+      width: 19px;
+      height: 22px;
+      background: url(/assets/images/logos/logo-github.svg) no-repeat;
+      background-size: contain;
+      margin-right: 5px;
+      vertical-align: middle;
+    }
+  }
+
   .page-header-right {
     position: absolute;
     right: 0;

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -29,9 +29,18 @@
         {% endif %}
       </div>
 
-      {% if page.header_btn_text %}
+      {% if page.header_btn_text or page.header_btn_repo_href %}
         <div class="page-header-right">
-          <a class="page-header-btn" href="{{ page.header_btn_href | liquify }}" target="{{ page.header_btn_target }}">{{ page.header_btn_text | liquify }}</a>
+          {% if page.header_btn_repo_href %}
+            {% if header_btn_repo_text %}
+              <a class="page-header-btn" href="{{ page.header_btn_repo_href | liquify }}" target="{{ page.header_btn_repo_target }}">{{ page.header_btn_repo_text | liquify }}</a>
+            {% else %}
+              <a class="page-header-btn page-header-btn-repo" href="{{ page.header_btn_repo_href | liquify }}" target="{{ page.header_btn_repo_target }}">Source&nbsp;Code</a>
+            {% endif %}
+          {% endif %}
+          {% if page.header_btn_text %}
+            <a class="page-header-btn" href="{{ page.header_btn_href | liquify }}" target="{{ page.header_btn_target }}">{{ page.header_btn_text | liquify }}</a>
+          {% endif %}
         </div>
       {% endif %}
 

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -29,17 +29,12 @@
         {% endif %}
       </div>
 
-      {% if page.header_btn_text or page.header_btn_repo_href %}
+      {% if page.header_btn_repo_href %}
         <div class="page-header-right">
-          {% if page.header_btn_repo_href %}
-            {% if header_btn_repo_text %}
-              <a class="page-header-btn" href="{{ page.header_btn_repo_href | liquify }}" target="{{ page.header_btn_repo_target }}">{{ page.header_btn_repo_text | liquify }}</a>
-            {% else %}
-              <a class="page-header-btn page-header-btn-repo" href="{{ page.header_btn_repo_href | liquify }}" target="{{ page.header_btn_repo_target }}">Source&nbsp;Code</a>
-            {% endif %}
-          {% endif %}
-          {% if page.header_btn_text %}
-            <a class="page-header-btn" href="{{ page.header_btn_href | liquify }}" target="{{ page.header_btn_target }}">{{ page.header_btn_text | liquify }}</a>
+          {% if page.header_btn_repo_text %}
+            <a class="page-header-btn" href="{{ page.header_btn_repo_href | liquify }}" target="{{ page.header_btn_repo_target }}">{{ page.header_btn_repo_text | liquify }}</a>
+          {% else %}
+            <a class="page-header-btn page-header-btn-repo" href="{{ page.header_btn_repo_href | liquify }}" target="{{ page.header_btn_repo_target }}">Source&nbsp;Code</a>
           {% endif %}
         </div>
       {% endif %}

--- a/app/plugins/azure-functions.md
+++ b/app/plugins/azure-functions.md
@@ -3,6 +3,7 @@ id: page-plugin
 title: Plugins - Azure Functions
 header_title: Azure Functions
 header_icon: https://konghq.com/wp-content/uploads/2018/05/azure-functions.png
+header_btn_repo_href: https://github.com/Kong/kong-plugin-azure-functions
 breadcrumbs:
   Plugins: /plugins
 nav:

--- a/app/plugins/openwhisk.md
+++ b/app/plugins/openwhisk.md
@@ -3,6 +3,7 @@ id: page-plugin
 title: Plugins - OpenWhisk
 header_title: Apache OpenWhisk
 header_icon: /assets/images/icons/plugins/openwhisk.png
+header_btn_repo_href: https://github.com/Kong/kong-plugin-openwhisk
 breadcrumbs:
   Plugins: /plugins
 nav:

--- a/app/plugins/zipkin.md
+++ b/app/plugins/zipkin.md
@@ -3,6 +3,7 @@ id: page-plugin
 title: Plugins - Zipkin
 header_title: Zipkin  
 header_icon: https://konghq.com/wp-content/uploads/2018/05/zipkin.png
+header_btn_repo_href: https://github.com/Kong/kong-plugin-zipkin
 breadcrumbs:
   Plugins: /plugins
 nav:


### PR DESCRIPTION
### Summary

Adds three `header` parameters:
- `page.header_btn_repo_href` — link to source repo
- `header_btn_repo_text` — text for the button (by default it is `Source Code`)
- `page.header_btn_repo_target ` — the target attribute value (not used, but as an option)

Also adds `page.header_btn_repo_href` to following plugins:
- `azure-functions`
- `openwhisk`
- `zipkin`

The `page.header_btn_repo_href` for `serverless-functions` is added to respective PRs:
- https://github.com/Kong/docs.konghq.com/pull/744

We need to add it to `prometheus` once such PR exists.