### PR TITLE
feat(*) Remove unused Mashape Notification Widget

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -50,6 +50,5 @@
       }}();
     </script>
 
-    <script type="text/javascript" src="//kong.github.io/notification-bar/embed.js" async defer></script>
   </body>
 </html>


### PR DESCRIPTION
This PR removes the script calling The old Mashape notification banner. This is no longer used and should not be rendered on this site.