### PR TITLE
Fix typos in RBAC API documentation

### DIFF
--- a/app/enterprise/0.31-x/plugins/rbac-api.md
+++ b/app/enterprise/0.31-x/plugins/rbac-api.md
@@ -343,7 +343,7 @@ HTTP 200 OK
 ### Update a Permission
 #### Endpoint
 
-<div class="endpoint path">/rbac/permissions/{name_or_id}</div>
+<div class="endpoint patch">/rbac/permissions/{name_or_id}</div>
 
 #### Request Body
 | Attribute | Description

--- a/app/enterprise/0.31-x/plugins/rbac-api.md
+++ b/app/enterprise/0.31-x/plugins/rbac-api.md
@@ -392,7 +392,7 @@ HTTP 204 No Content
 ### Add a User to a Role
 #### Endpoint
 
-<div class="endpoint post">/rbac/permissions/{name_or_id}/roles</div>
+<div class="endpoint post">/rbac/users/{name_or_id}/roles</div>
 
 #### Request Body
 | Attribute | Description
@@ -427,7 +427,7 @@ HTTP 201 Created
 ### List a User's Roles
 #### Endpoint
 
-<div class="endpoint get">/rbac/permissions/{name_or_id}/roles</div>
+<div class="endpoint get">/rbac/users/{name_or_id}/roles</div>
 
 #### Response
 ```
@@ -457,7 +457,7 @@ HTTP 200 OK
 ### List a User's Permissions
 #### Endpoint
 
-<div class="endpoint get">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint get">/rbac/users/{name_or_id}/permissions</div>
 
 #### Response
 ```
@@ -483,7 +483,7 @@ HTTP 200 OK
 ### Delete a Role from a User
 #### Endpoint
 
-<div class="endpoint delete">/rbac/permissions/{name_or_id}/roles</div>
+<div class="endpoint delete">/rbac/users/{name_or_id}/roles</div>
 
 #### Request Body
 | Attribute | Description
@@ -499,7 +499,7 @@ HTTP 204 No Content
 ### Add a Permission to a Role
 #### Endpoint
 
-<div class="endpoint post">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint post">/rbac/roles/{name_or_id}/permissions</div>
 
 #### Request Body
 | Attribute | Description
@@ -556,7 +556,7 @@ HTTP 201 Created
 ### List a Role's Permissions
 #### Endpoint
 
-<div class="endpoint get">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint get">/rbac/roles/{name_or_id}/permissions</div>
 
 #### Response 
 ```
@@ -608,7 +608,7 @@ HTTP 201 Created
 ### Delete A Permission from a Role
 #### Endpoint
 
-<div class="endpoint delete">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}/permissions</div>
 
 #### Request Body
 | Attribute | Description

--- a/app/enterprise/0.32-x/plugins/rbac-api.md
+++ b/app/enterprise/0.32-x/plugins/rbac-api.md
@@ -343,7 +343,7 @@ HTTP 200 OK
 ### Update a Permission
 #### Endpoint
 
-<div class="endpoint path">/rbac/permissions/{name_or_id}</div>
+<div class="endpoint patch">/rbac/permissions/{name_or_id}</div>
 
 #### Request Body
 | Attribute | Description

--- a/app/enterprise/0.32-x/plugins/rbac-api.md
+++ b/app/enterprise/0.32-x/plugins/rbac-api.md
@@ -392,7 +392,7 @@ HTTP 204 No Content
 ### Add a User to a Role
 #### Endpoint
 
-<div class="endpoint post">/rbac/permissions/{name_or_id}/roles</div>
+<div class="endpoint post">/rbac/users/{name_or_id}/roles</div>
 
 #### Request Body
 | Attribute | Description
@@ -427,7 +427,7 @@ HTTP 201 Created
 ### List a User's Roles
 #### Endpoint
 
-<div class="endpoint get">/rbac/permissions/{name_or_id}/roles</div>
+<div class="endpoint get">/rbac/users/{name_or_id}/roles</div>
 
 #### Response
 ```
@@ -457,7 +457,7 @@ HTTP 200 OK
 ### List a User's Permissions
 #### Endpoint
 
-<div class="endpoint get">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint get">/rbac/users/{name_or_id}/permissions</div>
 
 #### Response
 ```
@@ -483,7 +483,7 @@ HTTP 200 OK
 ### Delete a Role from a User
 #### Endpoint
 
-<div class="endpoint delete">/rbac/permissions/{name_or_id}/roles</div>
+<div class="endpoint delete">/rbac/users/{name_or_id}/roles</div>
 
 #### Request Body
 | Attribute | Description
@@ -499,7 +499,7 @@ HTTP 204 No Content
 ### Add a Permission to a Role
 #### Endpoint
 
-<div class="endpoint post">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint post">/rbac/roles/{name_or_id}/permissions</div>
 
 #### Request Body
 | Attribute | Description
@@ -556,7 +556,7 @@ HTTP 201 Created
 ### List a Role's Permissions
 #### Endpoint
 
-<div class="endpoint get">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint get">/rbac/roles/{name_or_id}/permissions</div>
 
 #### Response 
 ```
@@ -608,7 +608,7 @@ HTTP 201 Created
 ### Delete A Permission from a Role
 #### Endpoint
 
-<div class="endpoint delete">/rbac/permissions/{name_or_id}/permissions</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}/permissions</div>
 
 #### Request Body
 | Attribute | Description


### PR DESCRIPTION
### Summary

Fix a number of typos in RBAC API documenation

### Full changelog

* Correct mispelled `path` method to `patch`
* Use `/rbac/users/` or `/rbac/roles/` instead of `/rbac/permissions/` where appropriate.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

0.33 RBAC API docs were reviewed also and did not appear to exhibit the same issues. They were probably fixed during the general revision for entity-level RBAC.