### PR TITLE
Clarify difference between GUI key and RBAC token

### DIFF
--- a/app/enterprise/0.33-x/admin-gui/configuration/authentication.md
+++ b/app/enterprise/0.33-x/admin-gui/configuration/authentication.md
@@ -48,6 +48,8 @@ HTTP/1.1 201 Created
 }
 ```
 
+Save the generated `user_token` (`a3cebf9e-820d-4543-b760-2b6986e3bb9d` in the example above) for use later. It must be sent in the `Kong-Admin-Token` header when RBAC is enabled if using a client (e.g. cURL or HTTPie) other than the Admin GUI.
+
 After you have created an admin, you can provision a credential Key for this admin to use to login to the Admin GUI:
 
 ```bash
@@ -62,7 +64,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-Save this `"key": "62eb165c070a41d5c1b58d9d3d725ca1"` for use later. 
+Save this `"key": "62eb165c070a41d5c1b58d9d3d725ca1"` for use later. Note that this key is separate and distinct from the admin's RBAC token. 
 
 Now that you have an Admin with an associated login Key, update the following in your Kong Configuration, then restart Kong:
 


### PR DESCRIPTION
### Summary

Call out the auto-generated RBAC token when creating an admin

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

As far as I know, this distinction will actually go away in the future, but for now it's fairly easy to auto-generate an RBAC user and ignore their token when creating an admin/try to use the key auth credential as an RBAC token unsuccessfully.
