### PR TITLE
Nr 33 docs

### DIFF
--- a/app/enterprise/0.33-x/installation/docker.md
+++ b/app/enterprise/0.33-x/installation/docker.md
@@ -93,7 +93,6 @@ welcome email. Once you have your license, you can set it in an environment vari
       -e "KONG_VITALS=on" \
       -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
       -e "KONG_PORTAL=on" \
-      -e "KONG_PORTAL_GUI_URI=localhost:8003" \
       -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
       -p 8000:8000 \
       -p 8443:8443 \
@@ -107,9 +106,9 @@ welcome email. Once you have your license, you can set it in an environment vari
     ```
 
 11. Congratulations! You now have Kong Enterprise installed and running. Test
-it by visiting the Admin GUI at http://localhost:8002. If you load the Dev Portal,
-at http://localhost:8003, expect a blank page until you follow the instructions
-[here](/enterprise/{{page.kong_version}}/developer-portal/getting-started/).
+it by visiting the Admin GUI at http://localhost:8002 (replace localhost with your server IP or hostname when running Kong on 
+a remote system). The Dev Portal should also be accessible
+by visiting http://localhost:8003. 
 
 ## Enable RBAC
 

--- a/app/enterprise/0.33-x/installation/docker.md
+++ b/app/enterprise/0.33-x/installation/docker.md
@@ -106,7 +106,7 @@ welcome email. Once you have your license, you can set it in an environment vari
     ```
 
 11. Congratulations! You now have Kong Enterprise installed and running. Test
-it by visiting the Admin GUI at http://localhost:8002 (replace localhost with your server IP or hostname when running Kong on 
+it by visiting the Admin GUI at http://localhost:8002 (replace `localhost` with your server IP or hostname when running Kong on 
 a remote system). The Dev Portal should also be accessible
 by visiting http://localhost:8003. 
 


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Modified Kong EE Docker instructions for version .33. Re

### Full changelog

* removed reference to Portal_GUI_URI
* Removed assumption that dev portal should be expected to be blank
* Added text to change localhost to server host or IP if installed on remote system.
