### PR TITLE
docs(ce/install) rhel install

### DIFF
--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -13,8 +13,8 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [RHEL 6]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=centos/6/kong-community-edition-{{site.data.kong_latest.version}}.el6.noarch.rpm)
-- [RHEL 7]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-{{site.data.kong_latest.version}}.el7.noarch.rpm)
+- [RHEL 6]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=rhel/6/kong-community-edition-{{site.data.kong_latest.version}}.rhel6.noarch.rpm)
+- [RHEL 7]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=rhel/7/kong-community-edition-{{site.data.kong_latest.version}}.rhel7.noarch.rpm)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 
@@ -29,12 +29,12 @@ section on the page below.
 your RHEL version; for instance:
 
 ```
-baseurl=https://kong.bintray.com/kong-community-edition-rpm/centos/6
+baseurl=https://kong.bintray.com/kong-community-edition-rpm/rhel/6
 ```
 or
 
 ```
-baseurl=https://kong.bintray.com/kong-community-edition-rpm/centos/7
+baseurl=https://kong.bintray.com/kong-community-edition-rpm/rhel/7
 ```
 
 ----


### PR DESCRIPTION
Update RHEL packages/repository URLs. Previously to Kong CE 0.14.0, only
CentOS packages were provided - the RHEL page pointed to CentOS artifacts.
Starting with 0.14.0, we support both CentOS and RHEL. This commit updates
the RHEL install page to point to the correct packages/repository.