### PR TITLE
docs(ce/admin) fix snis certificate id attribute

### DIFF
--- a/app/0.14.x/admin-api.md
+++ b/app/0.14.x/admin-api.md
@@ -119,7 +119,7 @@ snis_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `certificate_id` | The `id` (a UUID) of the certificate with which to associate the SNI hostname.
+    `certificate.id` | The `id` (a UUID) of the certificate with which to associate the SNI hostname. With form-encoded, the notation is `certificate.id=<certificate_id>`. With JSON, use `"certificate":{"id":"<certificate_id>"}`.
 
 ---
 
@@ -1482,7 +1482,9 @@ lookup the certificate object based on the SNI associated with the certificate.
 {
     "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
     "created_at": 1485521710265
 }
 ```
@@ -1509,7 +1511,9 @@ HTTP 201 Created
 {
     "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
     "created_at": 1485521710265
 }
 ```
@@ -1536,7 +1540,9 @@ HTTP 200 OK
 {
     "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
     "created_at": 1485521710265
 }
 ```
@@ -1560,13 +1566,17 @@ HTTP 200 OK
         {
             "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
             "name": "example.com",
-            "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+            "certificate": {
+                "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+            },
             "created_at": 1485521710265
         },
         {
             "id": "88c03fcd-9a48-4937-a976-0abd0eb6b60a",
             "name": "example.org",
-            "certificate_id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b",
+            "certificate": {
+                "id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b"
+            },
             "created_at": 1485521710265
         }
     ]
@@ -1593,7 +1603,9 @@ HTTP 200 OK
 {
     "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
     "created_at": 1485521710265
 }
 ```


### PR DESCRIPTION
### Summary

In v0.14.0, the `/snis` endpoint accepts the nested attribute `certificate.id`. This is incorrectly documented as the flat attribute `certificate_id`.

See specification [here](https://github.com/Kong/kong/blob/0.14.0/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua#L681) with correct attribute.

This PR updates the snis admin API documentation.

### Full changelog

* amended `certificate.id` attribute name and description
* amended example response bodies

### Issues resolved

Found as part of another PR.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
