### PR TITLE
fix(links): Update proxy and portal gui URLs

### DIFF
--- a/app/enterprise/0.32-x/developer-portal/configuration/networking.md
+++ b/app/enterprise/0.32-x/developer-portal/configuration/networking.md
@@ -6,8 +6,8 @@ chapter: 5
 
 # Networking
 
-This document reviews how the [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url)
-and [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) config variables are utilized within the Kong proxy, Dev Portal, and Admin GUI. Below you find a summary of these config variables and their default settings.
+This document reviews how the [`proxy_url`][proxy_url]
+and [`portal_gui_url`][portal_gui_url] config variables are utilized within the Kong proxy, Dev Portal, and Admin GUI. Below you find a summary of these config variables and their default settings.
 
 ## Summary
 
@@ -32,16 +32,16 @@ The Kong Dev Portal works out of the box:
 kong start
 ```
 
-2. Navigate to `127.0.0.1:8003` (default [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) location).  You should see the Default Dev Portal.
+2. Navigate to `127.0.0.1:8003` (default [`portal_gui_url`][portal_gui_url].  You should see the Default Dev Portal.
 
 3. Open your developer tools in your browser and click on the `network` tab.
 
-4. Refresh the Dev Portal window and inspect the network tab again.  Notice that the Kong Portal is making requests to the [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) default value: `http://127.0.0.1:8000`.
+4. Refresh the Dev Portal window and inspect the network tab again.  Notice that the Kong Portal is making requests to the [`proxy_url`][proxy_url] default value: `http://127.0.0.1:8000`.
 
 
 ## Custom Configuration
 
-There _are_ cases in which [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) and [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) need to be set to accommodate your network setup.  Below you will find an example for a common use case where the Kong proxy and Dev Portal are served via different URLs.
+There _are_ cases in which [`proxy_url`][proxy_url] and [`portal_gui_url`][portal_gui_url] need to be set to accommodate your network setup.  Below you will find an example for a common use case where the Kong proxy and Dev Portal are served via different URLs.
 
 Consider this domain setup:
 
@@ -53,9 +53,9 @@ Consider this domain setup:
 
 ### proxy_url configuration
 
-With [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) set to it's default value the Dev Portal will make requests to `http://dev-portal.company.com:8000`, as [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) defaults to `window.location` when no value is set.  As a result the Dev Portal incorrectly requests files from `http://dev-portal.company.com` rather than `http://proxy.company.com`, resulting in an error.
+With [`proxy_url`][proxy_url] set to it's default value the Dev Portal will make requests to `http://dev-portal.company.com:8000`, as [`proxy_url`][proxy_url] defaults to `window.location` when no value is set.  As a result the Dev Portal incorrectly requests files from `http://dev-portal.company.com` rather than `http://proxy.company.com`, resulting in an error.
 
-Setting [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) to `http://proxy.company.com` in `kong.config` will allow the Dev Portal to make requests to the correct location.  
+Setting [`proxy_url`][proxy_url] to `http://proxy.company.com` in `kong.config` will allow the Dev Portal to make requests to the correct location.  
 
 ```
 proxy_url = http://proxy.company.com
@@ -66,20 +66,23 @@ Visiting `http://dev-portal.company.com` will now result in a successful render.
 
 ### portal_gui_url configuration
 
-[`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) has a value of `NONE` by default. It will appear as empty and commented out in `kong.conf`:
+[`portal_gui_url`][portal_gui_url] has a value of `NONE` by default. It will appear as empty and commented out in `kong.conf`:
 
 ```
 #portal_gui_url =
 ```
 
-When [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) is not defined:  
+When [`portal_gui_url`][portal_gui_url] is not defined:  
 
   - Kong Proxy will set [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to `*`, allowing any origin to make requests to the Dev Portal.
-  - Admin GUI and Dev Portal use [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) to reference Dev Portal location. As a result the Admin GUI will reference `window.location` by default when linking out to the Dev Portal resulting in a redirect to `http://admin-gui.company.com` rather than `http://dev-portal.company.com`.
+  - Admin GUI and Dev Portal use [`portal_gui_url`][portal_gui_url] to reference Dev Portal location. As a result the Admin GUI will reference `window.location` by default when linking out to the Dev Portal resulting in a redirect to `http://admin-gui.company.com` rather than `http://dev-portal.company.com`.
 
-Setting [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) to `http://dev-portal.company.com` will:  
+Setting [`portal_gui_url`][portal_gui_url] to `http://dev-portal.company.com` will:  
 
   - Give context to Admin GUI and Dev Portal.
-  - Update [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) in the Kong Proxy to only accept Dev Portal requests from the [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url).
+  - Update [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) in the Kong Proxy to only accept Dev Portal requests from the [`portal_gui_url`][portal_gui_url].
 
 Next: Learn more about our [Property Referrences &rsaquo;]({{page.book.next}})
+
+[portal_gui_url]: /enterprise/{{page.kong_version}}/developer-portal/configuration/property-reference/#portal_gui_url
+[proxy_url]: /enterprise/{{page.kong_version}}/developer-portal/configuration/property-reference/#proxy_url

--- a/app/enterprise/0.33-x/developer-portal/configuration/networking.md
+++ b/app/enterprise/0.33-x/developer-portal/configuration/networking.md
@@ -6,8 +6,8 @@ chapter: 5
 
 # Networking
 
-This document reviews how the [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url)
-and [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) config variables are utilized within the Kong proxy, Dev Portal, and Admin GUI. Below you find a summary of these config variables and their default settings.
+This document reviews how the [`proxy_url`][proxy_url]
+and [`portal_gui_url`][portal_gui_url] config variables are utilized within the Kong proxy, Dev Portal, and Admin GUI. Below you find a summary of these config variables and their default settings.
 
 ## Summary
 
@@ -19,7 +19,7 @@ The Dev Portal will use this information to build the API endpoint for requests 
 ### portal_gui_url
 
 **Description:**  
-Sets [CORS](https://developer.mozilla.org/en-US/Web/HTTP/CORS) Access Origin in regards to requests related to the developer portal (set to `*` by default). Acts as Dev Portal location reference for Kong, the Admin GUI, and the Dev Portal itself. By default, the Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol.
+Sets [CORS][CORS] Access Origin in regards to requests related to the developer portal (set to `*` by default). Acts as Dev Portal location reference for Kong, the Admin GUI, and the Dev Portal itself. By default, the Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol.
 
 
 ## Default Configuration
@@ -32,16 +32,16 @@ The Kong Dev Portal works out of the box:
 kong start
 ```
 
-2. Navigate to `127.0.0.1:8003` (default [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) location).  You should see the Default Dev Portal.
+2. Navigate to `127.0.0.1:8003` (default [`portal_gui_url`][portal_gui_url] location).  You should see the Default Dev Portal.
 
 3. Open your developer tools in your browser and click on the `network` tab.
 
-4. Refresh the Dev Portal window and inspect the network tab again.  Notice that the Kong Portal is making requests to the [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) default value: `http://127.0.0.1:8000`.
+4. Refresh the Dev Portal window and inspect the network tab again.  Notice that the Kong Portal is making requests to the [`proxy_url`][proxy_url] default value: `http://127.0.0.1:8000`.
 
 
 ## Custom Configuration
 
-There _are_ cases in which [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) and [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) need to be set to accommodate your network setup.  Below you will find an example for a common use case where the Kong proxy and Dev Portal are served via different URLs.
+There _are_ cases in which [`proxy_url`][proxy_url] and [`portal_gui_url`][portal_gui_url] need to be set to accommodate your network setup.  Below you will find an example for a common use case where the Kong proxy and Dev Portal are served via different URLs.
 
 Consider this domain setup:
 
@@ -53,9 +53,9 @@ Consider this domain setup:
 
 ### proxy_url configuration
 
-With [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) set to it's default value the Dev Portal will make requests to `http://dev-portal.company.com:8000`, as [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) defaults to `window.location` when no value is set.  As a result the Dev Portal incorrectly requests files from `http://dev-portal.company.com` rather than `http://proxy.company.com`, resulting in an error.
+With [`proxy_url`][proxy_url] set to it's default value the Dev Portal will make requests to `http://dev-portal.company.com:8000`, as [`proxy_url`][proxy_url] defaults to `window.location` when no value is set.  As a result the Dev Portal incorrectly requests files from `http://dev-portal.company.com` rather than `http://proxy.company.com`, resulting in an error.
 
-Setting [`proxy_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#proxy_url) to `http://proxy.company.com` in `kong.config` will allow the Dev Portal to make requests to the correct location.  
+Setting [`proxy_url`][proxy_url] to `http://proxy.company.com` in `kong.config` will allow the Dev Portal to make requests to the correct location.  
 
 ```
 proxy_url = http://proxy.company.com
@@ -66,20 +66,25 @@ Visiting `http://dev-portal.company.com` will now result in a successful render.
 
 ### portal_gui_url configuration
 
-[`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) has a value of `NONE` by default. It will appear as empty and commented out in `kong.conf`:
+[`portal_gui_url`][portal_gui_url] has a value of `NONE` by default. It will appear as empty and commented out in `kong.conf`:
 
 ```
 #portal_gui_url =
 ```
 
-When [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) is not defined:  
+When [`portal_gui_url`][portal_gui_url] is not defined:  
 
-  - Kong Proxy will set [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to `*`, allowing any origin to make requests to the Dev Portal.
-  - Admin GUI and Dev Portal use [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) to reference Dev Portal location. As a result the Admin GUI will reference `window.location` by default when linking out to the Dev Portal resulting in a redirect to `http://admin-gui.company.com` rather than `http://dev-portal.company.com`.
+  - Kong Proxy will set [CORS][CORS] to `*`, allowing any origin to make requests to the Dev Portal.
+  - Admin GUI and Dev Portal use [`portal_gui_url`][portal_gui_url] to reference Dev Portal location. As a result the Admin GUI will reference `window.location` by default when linking out to the Dev Portal resulting in a redirect to `http://admin-gui.company.com` rather than `http://dev-portal.company.com`.
 
-Setting [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url) to `http://dev-portal.company.com` will:  
+Setting [`portal_gui_url`][portal_gui_url] to `http://dev-portal.company.com` will:  
 
   - Give context to Admin GUI and Dev Portal.
-  - Update [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) in the Kong Proxy to only accept Dev Portal requests from the [`portal_gui_url`](/enterprise/{{page.kong_version}}/developer-portal/property-reference/#portal_gui_url).
+  - Update [CORS][CORS] in the Kong Proxy to only accept Dev Portal requests from the [`portal_gui_url`][portal_gui_url].
 
 Next: Learn more about our [Property Referrences &rsaquo;]({{page.book.next}})
+
+[portal_gui_url]: /enterprise/{{page.kong_version}}/developer-portal/configuration/property-reference/#portal_gui_url
+[proxy_url]: /enterprise/{{page.kong_version}}/developer-portal/configuration/property-reference/#proxy_url
+[CORS]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+


### PR DESCRIPTION
### Summary

Update broken proxy and gui URLs and refactor to use reference links

### Full changelog

* Edited doc `enterprise/0.32-x/developer-portal/configuration/networking`
* Edited doc `enterprise/0.330x/developer-portal/configuration/networking`

### Issues resolved

Fixes Issue #832 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x ] Spellchecked my updates
- [x ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
