### PR TITLE
fix(travis): don't cache the node_modules directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ notifications:
 cache:
   bundler: true
   yarn: true
-  directories:
-    - node_modules
 
 before_install:
   - rvm install 2.3.3
@@ -18,7 +16,6 @@ before_install:
 install:
   - bundle install
   - yarn
-
 before_script:
   - npm test
 script:


### PR DESCRIPTION
cacheing the node_modules directory can make the build faster but also leads to cases where `node_modules` is MIA so lets sacrifice the speed gain for reliability.