### PR TITLE
remove "total" from GET /consumers response

### DIFF
--- a/app/0.14.x/admin-api.md
+++ b/app/0.14.x/admin-api.md
@@ -796,7 +796,6 @@ HTTP 200 OK
 
 ```json
 {
-    "total": 10,
     "data": [
         {
             "id": "4d924084-1adb-40a5-c042-63b19db421d1",

--- a/app/0.14.x/plugin-development/custom-logic.md
+++ b/app/0.14.x/plugin-development/custom-logic.md
@@ -184,7 +184,7 @@ end
 return CustomHandler
 ```
 
-See [the source code of the Key-Auth plugin] for an example of a real-life
+See [the source code of the Key-Auth plugin](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth) for an example of a real-life
 handler code.
 
 ---

--- a/app/0.14.x/plugin-development/custom-logic.md
+++ b/app/0.14.x/plugin-development/custom-logic.md
@@ -184,7 +184,7 @@ end
 return CustomHandler
 ```
 
-See [the source code of the Key-Auth plugin](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth) for an example of a real-life
+See [the source code of the Key-Auth plugin] for an example of a real-life
 handler code.
 
 ---


### PR DESCRIPTION
### Summary

`"total"` is no longer included in the response from `GET /consumers`. This PR removes it from the example response.

### Full changelog

* Edited `app/0.14.x/admin-api.md`

### Issues resolved

Fixes: https://github.com/Kong/kong/issues/3602

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I'm unsure of when `"total`" was removed from `GET /consumers`. I can dig through the code a bit to try and find it, and then update other versions besides `0.14.x` where necessary. If someone happens to know off the top of their head and could save me a little time, that'd be much appreciated!