### PR TITLE
fix(layout) H1 cleanup on docs pages

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -158,7 +158,7 @@ a {
   }
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1, h2, h3, h4, h5, h6, .page-header-section-title {
   margin-top: 0;
   margin-bottom: 2rem;
   letter-spacing: 0;
@@ -167,7 +167,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Fix for anchor link h tags being hidden by nav */
 .page-content {
-  h1, h2, h3, h4, h5, h6 {
+  h1, h2, h3, h4, h5, h6, .page-header-section-title {
     @media (min-width: @navbar-collapse-point) {
       &::before {
         display: block;
@@ -181,7 +181,7 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-h1 {
+h1, .page-header-section-title {
   font-size: 38px;
   font-weight: 400;
 }

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -16,7 +16,7 @@
     padding: 25px 0;
   }
 
-  h1, p {
+  h1, p, .page-header-section-title {
     margin: 0;
   }
 

--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -19,8 +19,20 @@ id: documentation
       </div>
       <div class="page-header-title">
         <p>Documentation</p>
-        <h1>{% if page.edition == 'enterprise' %}Enterprise Edition {% if page.has_version %}({{page.kong_version}}){% endif %}{% endif %}</h1>
-        <h1>{% if page.edition == 'community' %}Community Edition ({{page.kong_version}}){% endif %}</h1>
+        {% assign pathParts = page.path | split: "/" %}
+        {% if pathParts.size < 2 or pathParts[0] == 'enterprise' and pathParts[2] == 'index.md' and pathParts.size == 3 or pathParts[1] == 'index.md' and pathParts.size == 2 %}
+          {% if page.edition %}
+          <h1>
+            {% if page.edition == 'enterprise' %}Enterprise Edition {% if page.has_version %}({{page.kong_version}}){% endif %}{% endif %}
+            {% if page.edition == 'community' %}Community Edition ({{page.kong_version}}){% endif %}
+          </h1>
+          {% endif %}
+        {% else %}
+        <div class="page-header-section-title">
+            {% if page.edition == 'enterprise' %}Enterprise Edition {% if page.has_version %}({{page.kong_version}}){% endif %}{% endif %}
+            {% if page.edition == 'community' %}Community Edition ({{page.kong_version}}){% endif %}
+        </div>
+        {% endif %}
       </div>
 
       {% if page.kong_versions.size > 1 %}


### PR DESCRIPTION
### Summary

Replaces h1 on docs layout, when docs page is not root.
Shows layout's h1 only when page edition is defined.

### Full changelog

* H1 cleanup on docs pages, leaving layout's h1 only on root index pages.

### Screenshots
#### Before
![kong_old_shallow](https://user-images.githubusercontent.com/1066322/45943558-bbd8e980-bfde-11e8-9bdc-d1f7c8962c47.png)
![kong_old_deep_page](https://user-images.githubusercontent.com/1066322/45943559-bbd8e980-bfde-11e8-817a-9284bedc1ec7.png)
#### After
![kong_new_ee_deep](https://user-images.githubusercontent.com/1066322/45943566-c5fae800-bfde-11e8-9cb0-3be9f632c9b5.png)
![kong_new_shallow](https://user-images.githubusercontent.com/1066322/45943567-c5fae800-bfde-11e8-8044-651ee42539d9.png)
![kong_new_deep](https://user-images.githubusercontent.com/1066322/45943568-c6937e80-bfde-11e8-8105-27cabb485173.png)

### Issues resolved

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

cc @moaiandin 
