### PR TITLE
fix(anchor-links): Remove duplicate anchor links

### DIFF
--- a/app/0.10.x/admin-api.md
+++ b/app/0.10.x/admin-api.md
@@ -111,7 +111,7 @@ Retrieve generic details about a node.
 
 <div class="endpoint get">/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -152,7 +152,7 @@ If you want to monitor the Kong process, since Kong is built on top of nginx, ev
 
 <div class="endpoint get">/status</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -206,7 +206,7 @@ Retrieve the cluster status, returning information for each node in the cluster.
 
 <div class="endpoint get">/cluster</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -246,7 +246,7 @@ Attributes | Description
 ---:| ---
 `address` | The node address to add.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -268,7 +268,7 @@ Attributes | Description
 ---:| ---
 `name` | The node name to remove.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -314,7 +314,7 @@ of `hosts`, `uris`, and `methods`. Kong will proxy all requests to the API to th
 
 {{ page.api_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -352,7 +352,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the API to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -397,7 +397,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -462,7 +462,7 @@ Attributes | Description
 
 {{ page.api_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -502,7 +502,7 @@ HTTP 200 OK
 
 The body needs an `id` parameter to trigger an update on an existing entity.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -522,7 +522,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the API to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -552,7 +552,7 @@ The Consumer object represents a consumer - or a user - of an API. You can eithe
 
 {{ page.consumer_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -578,7 +578,7 @@ Attributes | Description
 ---:| ---
 `username or id`<br>**required** | The unique identifier **or** the username of the consumer to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -610,7 +610,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -651,7 +651,7 @@ Attributes | Description
 
 {{ page.consumer_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -679,7 +679,7 @@ HTTP 200 OK
 
 The body needs an `id` parameter to trigger an update on an existing entity.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -699,7 +699,7 @@ Attributes | Description
 ---:| ---
 `username or id`<br>**required** | The unique identifier **or** the name of the consumer to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -793,7 +793,7 @@ Attributes | Description
 
 {{ page.plugin_configuration_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -826,7 +826,7 @@ Attributes | Description
 ---:| ---
 `id`<br>**required** | The unique identifier of the plugin to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -866,7 +866,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -923,7 +923,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -978,7 +978,7 @@ Attributes | Description
 
 {{ page.plugin_configuration_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1017,7 +1017,7 @@ Attributes | Description
 
 The body needs an `id` parameter to trigger an update on an existing entity.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1038,7 +1038,7 @@ Attributes | Description
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to delete the plugin configuration
 `plugin id`<br>**required** | The unique identifier of the plugin configuration to delete on this API
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1054,7 +1054,7 @@ Retrieve a list of all installed plugins on the Kong node.
 
 <div class="endpoint get">/plugins/enabled</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1102,7 +1102,7 @@ Retrieve the schema of a plugin's configuration. This is useful to understand wh
 
 <div class="endpoint get">/plugins/schema/{plugin name}</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1152,7 +1152,7 @@ tie a cert/key pair to one or more hostnames.
 
 {{ page.certificate_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1182,7 +1182,7 @@ Attributes | Description
 ---:| ---
 `SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1207,7 +1207,7 @@ HTTP 200 OK
 
 <div class="endpoint get">/certificates/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1252,7 +1252,7 @@ Attributes | Description
 
 {{ page.certificate_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1282,7 +1282,7 @@ HTTP 200 OK
 
 {{ page.certificate_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1300,7 +1300,7 @@ Attributes | Description
 ---:| ---
 `sni or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1334,7 +1334,7 @@ lookup the certificate object based on the SNI associated with the certificate.
 
 {{ page.snis_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1360,7 +1360,7 @@ Attributes | Description
 ---:| ---
 `name`<br>**required** | The name of the SNI object.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1380,7 +1380,7 @@ HTTP 200 OK
 
 <div class="endpoint get">/snis/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1414,7 +1414,7 @@ Attributes | Description
 ---:| ---
 `name`<br>**required** | The name of the SNI object.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1440,7 +1440,7 @@ HTTP 200 OK
 
 {{ page.snis_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1458,7 +1458,7 @@ Attributes | Description
 ---:| ---
 `name`<br>**required** | The name of the SNI object.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1504,7 +1504,7 @@ Requests for this API would be proxied to the targets defined within the upstrea
 
 {{ page.upstream_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1543,7 +1543,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1588,7 +1588,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1656,7 +1656,7 @@ Attributes | Description
 
 {{ page.upstream_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1697,7 +1697,7 @@ HTTP 200 OK
 
 The body needs an `id` parameter to trigger an update on an existing entity.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1717,7 +1717,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1761,7 +1761,7 @@ Attributes | Description
 
 {{ page.target_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1803,7 +1803,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1857,7 +1857,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1905,7 +1905,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
 `target or id`<br>**required** | The host/port combination element of the target to remove, or the `id` of an existing target entry.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/0.11.x/clustering.md
+++ b/app/0.11.x/clustering.md
@@ -249,11 +249,11 @@ Admin API `/cache` endpoint.
 
 #### Inspect a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/cache/{cache_key}</div>
 
-##### Response
+**Response**
 
 If a value with that key is cached:
 
@@ -279,11 +279,11 @@ this process easier.
 
 #### Purge a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache/{cache_key}</div>
 
-##### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -298,11 +298,11 @@ this process easier.
 
 #### Purge a node's cache
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache</div>
 
-##### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/0.12.x/clustering.md
+++ b/app/0.12.x/clustering.md
@@ -249,11 +249,11 @@ Admin API `/cache` endpoint.
 
 #### Inspect a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/cache/{cache_key}</div>
 
-##### Response
+**Response**
 
 If a value with that key is cached:
 
@@ -279,11 +279,11 @@ this process easier.
 
 #### Purge a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache/{cache_key}</div>
 
-##### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -298,11 +298,11 @@ this process easier.
 
 #### Purge a node's cache
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache</div>
 
-##### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/0.13.x/admin-api.md
+++ b/app/0.13.x/admin-api.md
@@ -189,7 +189,7 @@ Retrieve generic details about a node.
 
 <div class="endpoint get">/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -233,7 +233,7 @@ If you want to monitor the Kong process, since Kong is built on top of nginx, ev
 
 <div class="endpoint get">/status</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -301,7 +301,7 @@ of how Kong proxies traffic.
 
 {{ page.service_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -329,7 +329,7 @@ Attributes | Description
 ---:| ---
 `route id`<br>**required** | The unique identifier of a Route belonging to the Service to be retrieved.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -353,7 +353,7 @@ Attributes | Description
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 `size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -414,7 +414,7 @@ Attributes | Description
 
 {{ page.service_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -436,7 +436,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The `id` **or** the `name` attribute of the Service to delete.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -472,7 +472,7 @@ your infrastructure.
 
 {{ page.route_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -492,7 +492,7 @@ Attributes | Description
 ---:| ---
 `id`<br>**required** | The `id` attribute of the Route to retrieve.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -517,7 +517,7 @@ Attributes | Description
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 `size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -572,7 +572,7 @@ Attributes | Description
 ---:| ---
 `service name or id`<br>**required** | The `id` **or** the `name` attribute of the Service whose routes are to be Retrieved. When using this endpoint, only the Routes belonging to the specified Service will be listed.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -630,7 +630,7 @@ Attributes | Description
 
 {{ page.route_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -652,7 +652,7 @@ Attributes | Description
 ---:| ---
 `id`<br>**required** | The `id` attribute of the Route to delete.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -703,7 +703,7 @@ of `hosts`, `uris`, and `methods`. Kong will proxy all requests to the API to th
 
 {{ page.api_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -741,7 +741,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the API to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -786,7 +786,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -851,7 +851,7 @@ Attributes | Description
 
 {{ page.api_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -896,7 +896,7 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -916,7 +916,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the API to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -945,7 +945,7 @@ The Consumer object represents a consumer - or a user - of a Service. You can ei
 
 {{ page.consumer_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -971,7 +971,7 @@ Attributes | Description
 ---:| ---
 `username or id`<br>**required** | The unique identifier **or** the username of the consumer to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1003,7 +1003,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1044,7 +1044,7 @@ Attributes | Description
 
 {{ page.consumer_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1077,7 +1077,7 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1097,7 +1097,7 @@ Attributes | Description
 ---:| ---
 `username or id`<br>**required** | The unique identifier **or** the name of the consumer to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1197,7 +1197,7 @@ Note that not all plugins allow to specify `consumer_id`. Check the plugin docum
 
 {{ page.plugin_configuration_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1230,7 +1230,7 @@ Attributes | Description
 ---:| ---
 `id`<br>**required** | The unique identifier of the plugin to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1271,7 +1271,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1325,7 +1325,7 @@ Attributes | Description
 
 {{ page.plugin_configuration_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1365,7 +1365,7 @@ an entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1385,7 +1385,7 @@ Attributes | Description
 ---:| ---
 `plugin id`<br>**required** | The unique identifier of the plugin configuration to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1401,7 +1401,7 @@ Retrieve a list of all installed plugins on the Kong node.
 
 <div class="endpoint get">/plugins/enabled</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1449,7 +1449,7 @@ Retrieve the schema of a plugin's configuration. This is useful to understand wh
 
 <div class="endpoint get">/plugins/schema/{plugin name}</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1499,7 +1499,7 @@ tie a cert/key pair to one or more hostnames.
 
 {{ page.certificate_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1529,7 +1529,7 @@ Attributes | Description
 ---:| ---
 `SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1554,7 +1554,7 @@ HTTP 200 OK
 
 <div class="endpoint get">/certificates/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1599,7 +1599,7 @@ Attributes | Description
 
 {{ page.certificate_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1636,7 +1636,7 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1654,7 +1654,7 @@ Attributes | Description
 ---:| ---
 `sni or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1688,7 +1688,7 @@ lookup the certificate object based on the SNI associated with the certificate.
 
 {{ page.snis_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1714,7 +1714,7 @@ Attributes | Description
 ---:| ---
 `name`<br>**required** | The name of the SNI object.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1734,7 +1734,7 @@ HTTP 200 OK
 
 <div class="endpoint get">/snis/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1768,7 +1768,7 @@ Attributes | Description
 ---:| ---
 `name`<br>**required** | The name of the SNI object.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -1801,7 +1801,7 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1819,7 +1819,7 @@ Attributes | Description
 ---:| ---
 `name`<br>**required** | The name of the SNI object.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -1896,7 +1896,7 @@ object, and applies to all of its targets.
 
 {{ page.upstream_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -1961,7 +1961,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -2036,7 +2036,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -2156,7 +2156,7 @@ Attributes | Description
 
 {{ page.upstream_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -2228,7 +2228,7 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -2248,7 +2248,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream to delete
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -2293,7 +2293,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -2362,7 +2362,7 @@ Attributes | Description
 
 {{ page.target_body }}
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -2409,7 +2409,7 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -2464,7 +2464,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -2512,7 +2512,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
 `target or id`<br>**required** | The host/port combination element of the target to remove, or the `id` of an existing target entry.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -2543,7 +2543,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
 `target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -2580,7 +2580,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
 `target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/0.13.x/clustering.md
+++ b/app/0.13.x/clustering.md
@@ -255,11 +255,11 @@ Admin API `/cache` endpoint.
 
 #### Inspect a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/cache/{cache_key}</div>
 
-##### Response
+**Response**
 
 If a value with that key is cached:
 
@@ -285,11 +285,11 @@ this process easier.
 
 #### Purge a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache/{cache_key}</div>
 
-##### Response
+**Response**
 
 ```
 HTTP 204 No Content
@@ -304,11 +304,11 @@ this process easier.
 
 #### Purge a node's cache
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache</div>
 
-##### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/0.14.x/clustering.md
+++ b/app/0.14.x/clustering.md
@@ -256,7 +256,7 @@ Admin API `/cache` endpoint.
 
 #### Inspect a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/cache/{cache_key}</div>
 
@@ -286,7 +286,7 @@ this process easier.
 
 #### Purge a cached value
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache/{cache_key}</div>
 
@@ -305,7 +305,7 @@ this process easier.
 
 #### Purge a node's cache
 
-##### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/cache</div>
 

--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -176,7 +176,7 @@ The following endpoints are provided on the Admin API to examine and purge cache
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -185,7 +185,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 | `cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -193,7 +193,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -211,7 +211,7 @@ HTTP 400 Not Found
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -220,7 +220,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 |`cache_id` | The cache entity key as reported by the `X-Cache-Key` response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:cache_id</div>
 
@@ -228,7 +228,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | he cache entity key as reported by the `X-Cache-Key` response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -243,11 +243,11 @@ HTTP 400 Not Found
 ```
 
 ### Purge All Cache Entities
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/_hub/kong-inc/proxy-cache/0.32-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.32-x.md
@@ -188,7 +188,7 @@ The following endpoints are provided on the Admin API to examine and purge cache
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -197,7 +197,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 | `cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -205,7 +205,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -223,7 +223,7 @@ HTTP 400 Not Found
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -232,7 +232,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 |`cache_id` | The cache entity key as reported by the `X-Cache-Key` response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:cache_id</div>
 
@@ -240,7 +240,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | he cache entity key as reported by the `X-Cache-Key` response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -255,11 +255,11 @@ HTTP 400 Not Found
 ```
 
 ### Purge All Cache Entities
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -188,7 +188,7 @@ The following endpoints are provided on the Admin API to examine and purge cache
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -197,7 +197,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 | `cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -205,7 +205,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -223,7 +223,7 @@ HTTP 400 Not Found
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -232,7 +232,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 |`cache_id` | The cache entity key as reported by the `X-Cache-Key` response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:cache_id</div>
 
@@ -240,7 +240,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | he cache entity key as reported by the `X-Cache-Key` response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -255,11 +255,11 @@ HTTP 400 Not Found
 ```
 
 ### Purge All Cache Entities
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/enterprise/0.31-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.31-x/plugins/http-proxy-caching.md
@@ -91,7 +91,7 @@ The following endpoints are provided on the Admin API to examine and purge cache
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -100,7 +100,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 | `cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -126,7 +126,7 @@ HTTP 400 Not Found
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -135,7 +135,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 |`cache_id` | The cache entity key as reported by the `X-Cache-Key` response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:cache_id</div>
 
@@ -158,7 +158,7 @@ HTTP 400 Not Found
 ```
 
 ### Purge All Cache Entities
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/</div>
 

--- a/app/enterprise/0.32-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.32-x/plugins/http-proxy-caching.md
@@ -93,7 +93,7 @@ The following endpoints are provided on the Admin API to examine and purge cache
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -102,7 +102,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 | `cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -110,7 +110,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -128,7 +128,7 @@ HTTP 400 Not Found
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -137,7 +137,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 |`cache_id` | The cache entity key as reported by the `X-Cache-Key` response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:cache_id</div>
 
@@ -145,7 +145,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | he cache entity key as reported by the `X-Cache-Key` response header
 
-#### Response
+**Response**
 
 If the cache entity exists 
 
@@ -160,11 +160,11 @@ HTTP 400 Not Found
 ```
 
 ### Purge All Cache Entities
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/enterprise/0.33-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.33-x/plugins/http-proxy-caching.md
@@ -93,7 +93,7 @@ The following endpoints are provided on the Admin API to examine and purge cache
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -102,7 +102,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 | `cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -110,7 +110,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | The cache entity key as reported by the X-Cache-Key response header
 
-#### Response
+**Response**
 
 If the cache entity exists
 
@@ -128,7 +128,7 @@ HTTP 400 Not Found
 
 Two separate endpoints are available: one to look up a known plugin instance, and another that searches all proxy-cache plugins data stores for the given cache key. Both endpoints have the same return value.
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:plugin_id/caches/:cache_id</div>
 
@@ -137,7 +137,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 |`plugin_id` | The UUID of the proxy-cache plugin
 |`cache_id` | The cache entity key as reported by the `X-Cache-Key` response header
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/:cache_id</div>
 
@@ -145,7 +145,7 @@ Two separate endpoints are available: one to look up a known plugin instance, an
 | -------------- | -------
 |`cache_id` | he cache entity key as reported by the `X-Cache-Key` response header
 
-#### Response
+**Response**
 
 If the cache entity exists 
 
@@ -160,11 +160,11 @@ HTTP 400 Not Found
 ```
 
 ### Purge All Cache Entities
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/proxy-cache/</div>
 
-#### Response
+**Response**
 
 ```
 HTTP 204 No Content

--- a/app/enterprise/0.33-x/rbac/admin-api.md
+++ b/app/enterprise/0.33-x/rbac/admin-api.md
@@ -27,11 +27,11 @@ There are 4 basic entities involving RBAC.
   & delete` to entity `283fccff-2d4f-49a9-8730-dc8b71ec2245`.
 
 ### Add a User
-#### Endpoint
+ **Endpoint**
 
 <div class="endpoint post">/rbac/users</div>
 
-#### Request Body
+**Request Body**
 
 | Attribute                | Description                                                                                                                         |
 | ---------                | -----------                                                                                                                         |
@@ -40,7 +40,7 @@ There are 4 basic entities involving RBAC.
 | `enabled`<br>optional    | A flag to enable or disable the user. By default, users are enabled.                                                                |
 | `comment`<br>optional    | A string describing the RBAC user object.                                                                                           |
 
-#### Response
+**Response**
 ```
 HTTP 201 Created
 ```
@@ -57,7 +57,7 @@ HTTP 201 Created
 ___
 
 ### Retrieve a User
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}</div>
 
@@ -65,7 +65,7 @@ ___
 | ---------    | -----------                 |
 | `name_or_id` | The RBAC user name or UUID. |
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -82,11 +82,11 @@ HTTP 200 OK
 ___
 
 ### List Users
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/users/</div>
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -108,9 +108,9 @@ HTTP 200 OK
 ___
 
 ### Update or Create a User
-#### Endpoint
+**Endpoint**
 <div class="endpoint put">/rbac/users</div>
-#### Request Body
+**Request Body**
 
 | Attribute                | Description                                                                                                                         |
 | ---------                | -----------                                                                                                                         |
@@ -126,14 +126,14 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
 ```
 
 ### Update a User
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint patch">/rbac/users/{name_or_id}</div>
 
@@ -141,14 +141,14 @@ HTTP 201 Created or HTTP 200 OK
 | ---------    | -----------                 |
 | `name_or_id` | The RBAC user name or UUID. |
 
-#### Request Body
+**Request Body**
 | Attribute                | Description                                                                                                                         |
 | ---------                | -----------                                                                                                                         |
 | `user_token`<br>optional | The authentication token to be presented to the Admin API. If this value is not present, the token will automatically be generated. |
 | `enabled`<br>optional    | A flag to enable or disable the user. By default, users are enabled.                                                                |
 | `comment`<br>optional    | A string describing the RBAC user object.                                                                                           |
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -165,7 +165,7 @@ HTTP 200 OK
 ___
 
 ### Delete a User
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/rbac/users/{name_or_id}</div>
 
@@ -173,14 +173,14 @@ ___
 | ---------    | -----------                 |
 | `name_or_id` | The RBAC user name or UUID. |
 
-#### Response
+**Response**
 ```
 HTTP 204 No Content
 ```
 ___
 
 ### Add a Role
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint post">/rbac/roles</div>
 
@@ -189,7 +189,7 @@ ___
 | `name`                | The RBAC role name.                       |
 | `comment`<br>optional | A string describing the RBAC user object. |
 
-#### Response
+**Response**
 ```
 HTTP 201 Created
 ```
@@ -204,7 +204,7 @@ HTTP 201 Created
 ___
 
 ### Retrieve a Role
-#### Endpoint
+Endpoint
 
 <div class="endpoint get">/rbac/roles/{name_or_id}</div>
 
@@ -212,7 +212,7 @@ ___
 | ---------    | -----------                 |
 | `name_or_id` | The RBAC role name or UUID. |
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -227,11 +227,11 @@ HTTP 200 OK
 ___
 
 ### List Roles
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/roles</div>
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -251,11 +251,11 @@ HTTP 200 OK
 ___
 
 ### Update or Create a Role
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint put">/rbac/roles</div>
 
-#### Request Body
+**Request Body**
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |
@@ -269,7 +269,7 @@ entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -277,7 +277,7 @@ HTTP 201 Created or HTTP 200 OK
 
 
 ### Update a Role
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint patch">/rbac/roles/{name_or_id}</div>
 
@@ -285,12 +285,12 @@ HTTP 201 Created or HTTP 200 OK
 | ---------    | -----------                 |
 | `name_or_id` | The RBAC role or UUID. |
 
-#### Request Body
+**Request Body**
 | Attribute             | Description                               |
 | ---------             | -----------                               |
 | `comment`<br>optional | A string describing the RBAC role object. |
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -306,7 +306,7 @@ HTTP 200 OK
 ___
 
 ### Delete a Role
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/rbac/role/{name_or_id}</div>
 
@@ -314,14 +314,14 @@ ___
 | ---------             | -----------                               |
 | `name`                | The RBAC role name.                       |
 
-#### Response
+**Response**
 ```
 HTTP 204 No Content
 ```
 ___
 
 ### Add a Role Endpoint Permission
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint post">/rbac/roles/{name_or_id}/endpoints</div>
 
@@ -331,7 +331,7 @@ ___
 | `name_or_id`          | The RBAC role name.                       |
 
 
-#### Request Body
+**Request Body**
 
 | Attribute             | Description                                                                                                                     |
 | ---------             | -----------                                                                                                                     |
@@ -358,7 +358,7 @@ the path).
 Note that wildcards can be nested (`/rbac/*`, `/rbac/*/*`,
 `/rbac/*/*/*` would refer to all paths under `/rbac/`)
 
-#### Response
+**Response**
 
 ```
 HTTP 201 Created
@@ -380,7 +380,7 @@ HTTP 201 Created
 ---
 
 ### Retrieve a Role Endpoint Permission
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/roles/{name_or_id}/endpoints/{worspace_name_or_id}/{endpoint}</div>
 
@@ -390,7 +390,7 @@ HTTP 201 Created
 | `worspace_name_or_id` | The worspace name or UUID.                   |
 | `endpoint`            | The endpoint associated with this permisson. |
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -415,7 +415,7 @@ HTTP 200 OK
 
 
 ### List Role Endpoints Permissions
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/roles/{role_name_or_id}/endpoints</div>
 
@@ -423,7 +423,7 @@ HTTP 200 OK
 | ---------         | -----------                 |
 | `role_name_or_id` | The RBAC role name or UUID. |
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -460,7 +460,7 @@ HTTP 200 OK
 ---
 
 ### Update a Role Endpoint Permission
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint patch">/rbac/roles/{name_or_id}/endpoints/{worspace_name_or_id}/{endpoint}</div>
 
@@ -470,13 +470,13 @@ HTTP 200 OK
 | `worspace_name_or_id` | The worspace name or UUID.                   |
 | `endpoint`            | The endpoint associated with this permisson. |
 
-#### Request Body
+**Request Body**
 | Attribute             | Description                                                                                                                     |
 | ---------             | -----------                                                                                                                     |
 | `negative`            | If true, explicitly disallow the actions associated with the permissions tied to this resource. By default this value is false. |
 | `actions`             | One or more actions associated with this permission.                                                                            |
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -501,7 +501,7 @@ HTTP 200 OK
 
 
 ### Delete a Role Endpoint Permission
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/rbac/roles/{name_or_id}/endpoints/{worspace_name_or_id}/{endpoint}</div>
 
@@ -511,7 +511,7 @@ HTTP 200 OK
 | `worspace_name_or_id` | The worspace name or UUID.                   |
 | `endpoint`            | The endpoint associated with this permisson. |
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -536,13 +536,13 @@ HTTP 200 OK
 
 
 ### Add a Role Entity Permisson
-#### Endpoint
+**Endpoint**
 <div class="endpoint post">/rbac/roles/{name_or_id}/entities</div>
 | Attribute    | Description                 |
 | ---------    | -----------                 |
 | `name_or_id` | The RBAC role name or UUID. |
 
-#### Request Body
+**Request Body**
 | Attribute             | Description                                                                                                                     |
 | ---------             | -----------                                                                                                                     |
 | `negative`            | If true, explicitly disallow the actions associated with the permissions tied to this resource. By default this value is false. |
@@ -557,7 +557,7 @@ same permissions. A wildcard `*` will be interpreted as **all
 entities** in the system.
 
 
-#### Response
+**Response**
 ```
 HTTP 201 Created
 ```
@@ -582,7 +582,7 @@ HTTP 201 Created
 ---
 
 ### Retrieve a Role Entity Permisson
-#### Endpoint
+**Endpoint**
 <div class="endpoint get">/rbac/roles/{name_or_id}/entities/{entity_id}</div>
 
 | Attribute             | Description                                                                                                                     |
@@ -590,7 +590,7 @@ HTTP 201 Created
 | `name_or_id`          | The RBAC permisson name or UUID.                                                                                                |
 | `entity_id`           | id of the entity associated with this permission.                                                                               |
 
-#### Response
+**Response**
 ```
 HTTP 200 Ok
 ```
@@ -615,14 +615,14 @@ HTTP 200 Ok
 ---
 
 ### List Entity Permissons
-#### Endpoint
+**Endpoint**
 <div class="endpoint get">/rbac/roles/{name_or_id}/entities</div>
 
 | Attribute             | Description                                                                                                                     |
 | ---------             | -----------                                                                                                                     |
 | `name_or_id`          | The RBAC permisson name or UUID.                                                                                                |
 
-#### Response
+**Response**
 ```
 HTTP 200 Ok
 ```
@@ -650,7 +650,7 @@ HTTP 200 Ok
 
 ---
 ### Update an Entity Permission
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint patch">/rbac/roles/{name_or_id}/entities/{entity_id}</div>
 
@@ -659,13 +659,13 @@ HTTP 200 Ok
 | `name_or_id`          | The RBAC role name or UUID.                                                                                                     |
 | `entity_id`           | The entity name or UUID.                                                                                                        |
 
-#### Request Body
+**Request Body**
 | Attribute             | Description                                                                                                                     |
 | ---------             | -----------                                                                                                                     |
 | `negative`            | If true, explicitly disallow the actions associated with the permissions tied to this resource. By default this value is false. |
 | `actions`             | One or more actions associated with this permission.                                                                            |
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -687,7 +687,7 @@ HTTP 200 OK
 ---
 
 ### Delete an Entity Permission
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/rbac/roles/{name_or_id}/entities/{entity_id}</div>
 
@@ -696,7 +696,7 @@ HTTP 200 OK
 | `name_or_id` | The RBAC role name or UUID. |
 | `entity_id`  | The entity name or UUID.    |
 
-#### Response
+**Response**
 ```
 HTTP 204 No Content
 ```
@@ -704,7 +704,7 @@ HTTP 204 No Content
 ---
 
 ### List Role Permissions
-#### Endpoint
+**Endpoint**
 <div class="endpoint get">/rbac/roles/{name_or_id}/permissions/</div>
 
 | Attribute    | Description                 |
@@ -712,7 +712,7 @@ HTTP 204 No Content
 | `name_or_id` | The RBAC role name or UUID. |
 
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -736,7 +736,7 @@ HTTP 200 OK
 }
 ```
 ### Add a User to a Role
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint post">/rbac/users/{name_or_id}/roles</div>
 
@@ -745,12 +745,12 @@ HTTP 200 OK
 | `name_or_id`          | The RBAC user name or UUID.                                                                                                     |
 
 
-#### Request Body
+**Request Body**
 | Attribute | Description                                               |
 | --------- | -----------                                               |
 | `roles`   | Comma-separated list of role names to assign to the user. |
 
-#### Response
+**Response**
 ```
 HTTP 201 Created
 ```
@@ -775,7 +775,7 @@ HTTP 201 Created
 
 ---
 ### List a User's Roles
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}/roles</div>
 
@@ -784,7 +784,7 @@ HTTP 201 Created
 | `name_or_id`          | The RBAC user name or UUID.                                                                                                     |
 
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```
@@ -809,7 +809,7 @@ HTTP 200 OK
 
 ---
 ### Delete a Role from a User
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint delete">/rbac/users/{name_or_id}/roles</div>
 
@@ -818,12 +818,12 @@ HTTP 200 OK
 | `name_or_id`          | The RBAC user name or UUID.                                                                                                     |
 
 
-#### Request Body
+**Request Body**
 | Attribute | Description                                               |
 | --------- | -----------                                               |
 | `roles`   | Comma-separated list of role names to assign to the user. |
 
-#### Response
+**Response**
 ```
 HTTP 204 No Content
 ```
@@ -834,7 +834,7 @@ HTTP 204 No Content
 [Admin API]: /{{page.kong_version}}/admin-api/
 [Admin GUI]: /{{page.kong_version}}/api-admin-gui/
 ### List a User's Permissions
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}/permissions</div>
 
@@ -842,7 +842,7 @@ HTTP 204 No Content
 | ---------             | -----------                                                                                                                     |
 | `name_or_id`          | The RBAC user name or UUID.                                                                                                     |
 
-#### Response
+**Response**
 ```
 HTTP 200 OK
 ```

--- a/app/plugins/aws-lambda.md
+++ b/app/plugins/aws-lambda.md
@@ -128,7 +128,7 @@ When the plugin is added to an API entity (which is deprecated as of 0.13.0),
 it is the `upsream_url` property which must be specified and resolvable as well
 (but ignored).
 
-**Response** plugins
+#### Response plugins
 
 There is a known limitation in the system that prevents some response plugins
 from being executed. We are planning to remove this limitation in the future.

--- a/app/plugins/aws-lambda.md
+++ b/app/plugins/aws-lambda.md
@@ -128,7 +128,7 @@ When the plugin is added to an API entity (which is deprecated as of 0.13.0),
 it is the `upsream_url` property which must be specified and resolvable as well
 (but ignored).
 
-#### Response plugins
+**Response** plugins
 
 There is a known limitation in the system that prevents some response plugins
 from being executed. We are planning to remove this limitation in the future.


### PR DESCRIPTION
The docs site uses an extension that will automatically make any header into an anchor link. 

If there more than one header with the same text (aka multiple "Endpoint" headers) on the same page, the anchor link will only point to the first one

To avoid this, and improve SEO by not having too many headers, I have changed every page where "Endpoint" and "Response" appear multiple times to bolded words vs headers

**Endpoint** vs 

### Endpoint
