### PR TITLE
fix(hub): Remove link from Publishers name

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -14847,14 +14847,6 @@ header.page-header {
   z-index: 5;
 }
 
-.publisher a {
-    text-decoration: none;
-}
-
-.publisher a:hover {
-    color: #004B80;
-}
-
 .publisher p {
     margin-bottom: 8px;
 }

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -20,13 +20,12 @@
         </a>
       </div>
       <div class="publisher">
-        <a data-filter="pub-{{extn_publisher}}">
         Support by:<br>
         {% if extn_publisher == "kong-inc" %}
           {% include svgs.html img='team-kong-icon' %}
         {% else %}
           {{ extn.publisher }}
-        {% endif %}</a>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removes link from hub card's publisher attribute 

<img width="893" alt="screen shot 2018-09-17 at 3 25 29 pm" src="https://user-images.githubusercontent.com/8921227/45653813-242f4480-ba8e-11e8-963e-9a26445e9604.png">

