### PR TITLE
fix: header styling

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -14762,9 +14762,15 @@ nav.navigation.posts-navigation {
 }
 
 header.page-header {
-  margin: 40px auto;
+  margin: 100px auto 20px;
   background-color: #ffffff;
   border-bottom: none;
+}
+
+@media (max-width: 1100px) {
+    header.page-header {
+        margin: 50px auto 20px;
+    }
 }
 
 .kong-plugins .cards-collection {

--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -14762,15 +14762,9 @@ nav.navigation.posts-navigation {
 }
 
 header.page-header {
-  margin: 100px auto 20px;
+  margin: 10px auto;
   background-color: #ffffff;
   border-bottom: none;
-}
-
-@media (max-width: 1100px) {
-    header.page-header {
-        margin: 50px auto 20px;
-    }
 }
 
 .kong-plugins .cards-collection {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1,7 +1,11 @@
 .page-header {
   background-color: #fdfdfd;
   border-bottom: 1px solid @gray;
-  padding: 50px 0;
+  padding: 145px 0 20px;
+
+  @media (max-width: 1100px) {
+    padding: 50px 0 10px;
+  }
 
   // Needs to be above page-content header margins
   .container {


### PR DESCRIPTION
Adjust margin on header now that summit banner is gone

<img width="1150" alt="screen shot 2018-09-17 at 4 50 09 pm" src="https://user-images.githubusercontent.com/8921227/45656508-c3f2cf80-ba9a-11e8-9f06-4e0ae47ce0c5.png">

