### PR TITLE
docs(kubernetes/aks): add aks instructions for kubernetes deployment

### DIFF
--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -12,6 +12,7 @@ links:
   minikube: "https://github.com/Kong/kong-dist-kubernetes/blob/master/minikube/README.md"
   kubeapps_hub: "https://hub.kubeapps.com/charts/stable/kong"
   gh_repo: "https://github.com/Kong/kong-dist-kubernetes/"
+  az: "https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest"
 ---
 
 # Kubernetes Ingress Controller for Kong
@@ -40,110 +41,134 @@ and use the manifest files provided in `minikube` directory.
 
 Kong CE, or the trial version of Kong Enterprise Edition (EE), can be provisioned
 on a Kubernetes cluster via the manifest files provided
-in the [repo]({{ page.links.gh_repo }}). These instructions (mostly) assume you are using
-[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/) -
-you may need to make adjustments to deploy to other Kubernetes clusters.
+in the [repo]({{ page.links.gh_repo }}).
 
-1. **Initial setup**
+## 1. **Initial setup**
 
-    Download or clone the following repo:
+Download or clone the following repo:
 
-    ```bash
-    $ git clone git@github.com:Kong/kong-dist-kubernetes.git
-    $ cd kong-dist-kubernetes
-    ```
+```bash
+$ git clone git@github.com:Kong/kong-dist-kubernetes.git
+$ cd kong-dist-kubernetes
+```
 
-    Skip to step 3 if you have already provisioned a cluster and registered it
-    with Kubernetes.
+Skip to step 3 if you have already provisioned a cluster and registered it
+with Kubernetes.
 
-2.  **Deploy a GKE cluster**
+## 2.  **Deploy a cluster**
 
-    You need [gcloud]({{ page.links.gcloud }}) and [kubectl]({{ page.links.kubectl }})
-    command-line tools installed and set up to run deployment commands. Also
-    make sure your Google Cloud account has `STATIC_ADDRESSES` available for
-    the external access of Kong services.
+### [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
 
-    Using the `cluster.yaml` file from this repo, deploy a
-    GKE cluster. Provide the following information before deploying:
+You need [gcloud]({{ page.links.gcloud }}) and [kubectl]({{ page.links.kubectl }})
+command-line tools installed and set up to run deployment commands. Also
+make sure your Google Cloud account has `STATIC_ADDRESSES` available for
+the external access of Kong services.
 
-    1. Desired cluster name
-    2. Zone in which to run the cluster
-    3. A basicauth username and password for authenticating the access to the
-       cluster
+Using the `cluster.yaml` file from this repo, deploy a
+GKE cluster. Provide the following information before deploying:
 
-    ```bash
-    $ gcloud deployment-manager deployments \
-        create cluster --config cluster.yaml
-    ```
+1. Desired cluster name
+2. Zone in which to run the cluster
+3. A basicauth username and password for authenticating the access to the
+cluster
 
-3. **Deploy a datastore**
+```bash
+$ gcloud deployment-manager deployments \
+    create cluster --config cluster.yaml
+```
 
-    Before deploying Kong, you need to provision a Cassandra or PostgreSQL pod.
+### [Azure Kubernetes Cluster (AKS)](https://docs.microsoft.com/en-us/azure/aks/)
 
-    For Cassandra, use the `cassandra.yaml` file from this repo to deploy a
-    Cassandra `Service` and a `StatefulSet` in the cluster.
+You need [az]({{ page.links.az }}) command-line tools installed and set up to run deployment commands.
 
-    ```bash
-    $ kubectl create -f cassandra.yaml
-    ```
-
-    For PostgreSQL, use the `postgres.yaml` file from the kong-dist-kubernetes
-    repo to deploy a PostgreSQL `Service` and a `ReplicationController` in the
-    cluster:
+1. **Create a Resource Group**
 
     ```bash
-    $ kubectl create -f postgres.yaml
+    $ az group create --name myAKSCluster --location eastus
     ```
 
-    **Kong EE trial users** should complete the steps in the
-    **Additional Steps for Kong EE Trial Users** section below before proceeding.
+2. **Install kubectl**
 
-4. **Prepare database**
-
-    Using the `kong_migration_<postgres|cassandra>.yaml` file,
-    run the migration job:
+    If you already have [kubectl]({{ page.links.kubectl }}) installed, you can skip this step.
 
     ```bash
-    $ kubectl create -f kong_migration_<postgres|cassandra>.yaml
+    $ az aks install-cli
     ```
-    Once the job completes, you can remove the pod by running following command:
+
+3. **Configure kubectl**
 
     ```bash
-    $ kubectl delete -f kong_migration_<postgres|cassandra>.yaml
+    $ az aks get-credentials --resource-group myAKSCluster --name myAKSCluster
     ```
 
-5. **Deploy Kong**
+## 3. **Deploy a datastore**
 
-    Using the `kong_<postgres|cassandra>.yaml` file from this
-    repo, deploy Kong admin, proxy services, and a `Deployment` controller to
-    the cluster:
+Before deploying Kong, you need to provision a Cassandra or PostgreSQL pod.
 
-    ```bash
-    $ kubectl create -f kong_<postgres|cassandra>.yaml
-    ```
+For Cassandra, use the `cassandra.yaml` file from this repo to deploy a
+Cassandra `Service` and a `StatefulSet` in the cluster.
 
-6. **Verify your deployments**
+```bash
+$ kubectl create -f cassandra.yaml
+```
 
-    You can now see the resources that have been deployed using `kubectl`:
+For PostgreSQL, use the `postgres.yaml` file from the kong-dist-kubernetes
+repo to deploy a PostgreSQL `Service` and a `ReplicationController` in the
+cluster:
 
-    ```bash
-    $ kubectl get all
-    ```
+```bash
+$ kubectl create -f postgres.yaml
+```
 
-    Once the `EXTERNAL_IP` is available for Kong Proxy and Admin services, you
-    can test Kong by making the following requests:
+**Kong EE trial users** should complete the steps in the
+**Additional Steps for Kong EE Trial Users** section below before proceeding.
 
-    ```bash
-    $ curl <kong-admin-ip-address>:8001
-    $ curl https://<admin-ssl-ip-address>:8444
-    $ curl <kong-proxy-ip-address>:8000
-    $ curl https://<kong-proxy-ssl-ip-address>:8443
-    ```
+## 4. **Prepare database**
 
-7. **Get Started with Kong**
+Using the `kong_migration_<postgres|cassandra>.yaml` file,
+run the migration job:
 
-    Quickly learn how to use Kong with the
-    [5-minute Quickstart](/latest/getting-started/quickstart/).
+```bash
+$ kubectl create -f kong_migration_<postgres|cassandra>.yaml
+```
+Once the job completes, you can remove the pod by running following command:
+
+```bash
+$ kubectl delete -f kong_migration_<postgres|cassandra>.yaml
+```
+
+## 5. **Deploy Kong**
+
+Using the `kong_<postgres|cassandra>.yaml` file from this
+repo, deploy Kong admin, proxy services, and a `Deployment` controller to
+the cluster:
+
+```bash
+$ kubectl create -f kong_<postgres|cassandra>.yaml
+```
+
+## 6. **Verify your deployments**
+
+You can now see the resources that have been deployed using `kubectl`:
+
+```bash
+$ kubectl get all
+```
+
+Once the `EXTERNAL_IP` is available for Kong Proxy and Admin services, you
+can test Kong by making the following requests:
+
+```bash
+$ curl <kong-admin-ip-address>:8001
+$ curl https://<admin-ssl-ip-address>:8444
+$ curl <kong-proxy-ip-address>:8000
+$ curl https://<kong-proxy-ssl-ip-address>:8443
+```
+
+## 7. **Get Started with Kong**
+
+Quickly learn how to use Kong with the
+[5-minute Quickstart](/latest/getting-started/quickstart/).
 
 # Additional Steps for Kong EE Trial Users
 


### PR DESCRIPTION
### Summary

The current Kong deployment instructions for Kubernetes only has instructions for GKE (Gcloud). We are going to use in a AKS (Azure) environment.

### Full changelog

* Edited docs to add aks instructions for kubernetes deployment.

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation N/A
- [x] Spellchecked my updates
- [x] Ready to be merged