### PR TITLE
Replace redis reference in session_memcache_socket docs for OIDC plugin

### DIFF
--- a/app/enterprise/0.32-x/plugins/openid-connect.md
+++ b/app/enterprise/0.32-x/plugins/openid-connect.md
@@ -799,8 +799,8 @@ in keys prefixed with `sessions:<session-id>`.
 
 #### config.session_memcache_socket
 
-Redis `unix` socket path. If this is defined, it will override whatever
-is put in `config.session_redis_host` or `config.session_redis_port`.
+Memcache `unix` socket path. If this is defined, it will override whatever
+is put in `config.session_memcache_host` or `config.session_memcache_port`.
 
 #### config.session_memcache_host
 

--- a/app/enterprise/0.33-x/plugins/openid-connect.md
+++ b/app/enterprise/0.33-x/plugins/openid-connect.md
@@ -799,8 +799,8 @@ in keys prefixed with `sessions:<session-id>`.
 
 #### config.session_memcache_socket
 
-Redis `unix` socket path. If this is defined, it will override whatever
-is put in `config.session_redis_host` or `config.session_redis_port`.
+Memcache `unix` socket path. If this is defined, it will override whatever
+is put in `config.session_memcache_host` or `config.session_memcache_port`.
 
 #### config.session_memcache_host
 


### PR DESCRIPTION
### Summary

Noticed a small typo in the OIDC plugin docs. Redis configuration is referenced in the `session_memcache_socket` section.

### Full changelog

* Updated 0.33, 0.32 docs. 

### Issues resolved
No associated GitHub issue.

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A
- [x] Spellchecked my updates
- [x] Ready to be merged
