### PR TITLE
docs(hub) note older versions are not documented

### DIFF
--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -16,6 +16,14 @@ desc: Control which consumers can access APIs
 description: |
   Restrict access to a Service or a Route (or the deprecated API entity) by whitelisting or blacklisting consumers using arbitrary ACL group names. This plugin requires an [authentication plugin](/about/faq/#how-can-i-add-authentication-to-a-microservice-api) to have been already enabled on the Service or the Route (or API).
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.1 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a> 
+    for details.
+  </div>
+
 type: plugin
 categories:
   - traffic-control

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -16,6 +16,14 @@ description: |
   can be used in combination with other request plugins to secure, manage or extend
   the function.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.0 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a> 
+    for details.
+  </div>
+
 type: plugin
 categories:
   - serverless

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -18,6 +18,14 @@ desc: Add Basic Authentication to your APIs
 description: |
   Add Basic Authentication to a Service or a Route (or the deprecated API entity) with username and password protection. The plugin will check for valid credentials in the `Proxy-Authorization` and `Authorization` header (in this order).
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.0 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a> 
+    for details.
+  </div>
+
 type: plugin
 categories:
   - authentication

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -14,6 +14,14 @@ description: |
   Easily add __Cross-origin resource sharing *(CORS)*__ to a Service, a Route (or the deprecated API entity) by enabling
   this plugin.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.10.3 differs from what is documented herein.
+    Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - security

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -14,6 +14,14 @@ description: |
   Log [metrics](#metrics) for a Service, Route (or the deprecated API entity) to a local
   [Datadog agent](http://docs.datadoghq.com/guides/basic_agent_usage/).
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled 
+    with versions of Kong prior to 0.11.0 differs from what is documented herein.
+    Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - analytics-monitoring

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -19,6 +19,15 @@ description: |
   limitations this plugin uses blocking file i/o, which will hurt performance,
   and hence is an anti-pattern for Kong installations.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.10.2 differs from what is documented herein.
+    Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
+
 type: plugin
 categories:
   - logging

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -29,6 +29,14 @@ description: |
   [draft-cavage-http-signatures](https://tools.ietf.org/html/draft-cavage-http-signatures)
   draft with a slightly different signature scheme.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.0 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a> 
+    for details.
+  </div>
+
 
 type: plugin
 categories:

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -11,7 +11,16 @@ nav:
       - label: Kong Process Errors
 
 desc: Send request and response logs to an HTTP server
-description: Send request and response logs to an HTTP server.
+description: |
+  Send request and response logs to an HTTP server.
+
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.10.2 differs from
+    what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a> 
+    for details.
+  </div>
 
 type: plugin
 categories:

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -36,6 +36,14 @@ description: |
 
   Kong will either proxy the request to your upstream services if the token's signature is verified, or discard the request if not. Kong can also perform verifications on some of the registered claims of RFC 7519 (exp and nbf).
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.1 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a> 
+    for details.
+  </div>
+
 
 type: plugin
 categories:

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -19,6 +19,14 @@ desc: Add key authentication to your APIs
 description: |
   Add Key Authentication (also sometimes referred to as an API key) to a Service or a Route (or the deprecated API entity). Consumers then add their key either in a querystring parameter or a header to authenticate their requests.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.11.2
+    differs from what is documented herein. Refer to the 
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - authentication

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -16,6 +16,14 @@ desc: Integrate Kong with a LDAP server
 description: |
   Add LDAP Bind Authentication to a Route (or the deprecated API entity) with username and password protection. The plugin will check for valid credentials in the `Proxy-Authorization` and `Authorization` header (in this order).
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.1 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - authentication

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -33,6 +33,15 @@ description: |
     property).
   </div>
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.12.0
+    differs from what is documented herein. Refer to the 
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
+
 
 type: plugin
 categories:

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -13,6 +13,14 @@ desc: Rate-limit how many HTTP requests a developer can make
 description: |
   Rate limit how many HTTP requests a developer can make in a given period of seconds, minutes, hours, days, months or years. If the underlying Service/Route (or deprecated API entity) has no authentication layer, the **Client IP** address will be used, otherwise the Consumer will be used if an authentication plugin has been configured.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled 
+    with versions of Kong prior to 0.13.1 and Kong Enterprise prior to 0.32
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - traffic-control

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -10,6 +10,14 @@ description: |
 
   Block incoming requests whose body is greater than a specific size in megabytes.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.9.0
+    differs from what is documented herein. Refer to the 
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - traffic-control

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -14,6 +14,14 @@ desc: Modify the request before hitting the upstream server
 description: |
   Transform the request sent by a client on the fly on Kong, before hitting the upstream server.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.10.0
+    differs from what is documented herein. Refer to the 
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - transformations

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -17,6 +17,14 @@ description: |
 
   If the underlying Service/Route (or deprecated API entity) has no authentication layer, the **Client IP** address will be used, otherwise the Consumer will be used if an authentication plugin has been configured.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.13.1 and Kong Enterprise prior to 0.32 
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - traffic-control

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -18,6 +18,13 @@ description: |
   daemon by enabling its [Statsd
   plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.11.0
+    differs from what is documented herein. Refer to the 
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
 
 type: plugin
 categories:

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -14,6 +14,14 @@ desc: Send request and response logs to a TCP server
 description: |
   Log request and response data to a TCP server.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.12.0 
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - logging

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -16,6 +16,14 @@ desc: Propagate Zipkin spans and report space to a Zipkin server
 description: |
   Propagate Zipkin distributed tracing spans, and report spans to a Zipkin server.
 
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.14.1 and Kong Enterprise prior to 0.34
+    differs from what is documented herein. Refer to the 
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
+
 type: plugin
 categories:
   - analytics-monitoring


### PR DESCRIPTION

### Summary

Some plugins don't have documentation available for older versions - but currently, the docs imply that the documentation presented is correct for *all* older versions. 

### Full changelog

* Edited docs to indicate, on each relevant Kong Inc.-published plugin, when the docs don't match plugin versions we shipped in the past.

### Issues resolved

Resolves #887 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
