### PR TITLE
docs(/http-proxy-caching) Added link to RFC

### DIFF
--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -56,7 +56,7 @@ params:
       default: false
       value_in_examples:
       description: |
-        When enabled, respect the Cache-Control behaviors defined in RFC 7234
+        When enabled, respect the Cache-Control behaviors defined in RFC7234
     - name: storage_ttl
       required:
       default:
@@ -143,7 +143,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

This plugin has a parameter for config.cache_control which is a Boolean value for whether or not to respect RFC 7234. I added a link to the RFC in question as some may not know it off hand

### Full changelog

* made RFC 7234 a link pointing to ]https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2)

### Issues resolved


<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
