### PR TITLE
docs(hub) added link to RFC to proxy-cache

### DIFF
--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -56,7 +56,7 @@ params:
       default: false
       value_in_examples:
       description: |
-        When enabled, respect the Cache-Control behaviors defined in RFC 7234
+        When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2)
     - name: storage_ttl
       required:
       default:

--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -143,7 +143,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -143,7 +143,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/_hub/kong-inc/proxy-cache/0.32-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.32-x.md
@@ -68,7 +68,7 @@ params:
       default: false
       value_in_examples:
       description: |
-        When enabled, respect the Cache-Control behaviors defined in RFC 7234
+        When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2)
     - name: storage_ttl
       required:
       default:

--- a/app/_hub/kong-inc/proxy-cache/0.32-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.32-x.md
@@ -155,7 +155,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/_hub/kong-inc/proxy-cache/0.32-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.32-x.md
@@ -155,7 +155,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -68,7 +68,7 @@ params:
       default: false
       value_in_examples:
       description: |
-        When enabled, respect the Cache-Control behaviors defined in RFC 7234
+        When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2)
     - name: storage_ttl
       required:
       default:

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -155,7 +155,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -155,7 +155,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.31-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.31-x/plugins/http-proxy-caching.md
@@ -60,7 +60,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.31-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.31-x/plugins/http-proxy-caching.md
@@ -28,7 +28,7 @@ You can also apply it for every API using the `http://kong:8001/plugins/` endpoi
 |`config.request_method`|	`GET`, `HEAD` |	Downstream request methods considered cacheable.
 |`config.content_type`|	`text/plain` | Upstream response content types considered cachable.
 |`config.cache_ttl`|	`300` |	TTL, in seconds, of cache entities.
-|`config.cache_control`| `false` | When enabled, respect the Cache-Control behaviors defined in RFC 7234.
+|`config.cache_control`| `false` | When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
 |`config.storage_ttl`| || Number of seconds to keep resources in the storage backend. This value is independent of cache_ttl or resource TTLs defined by Cache-Control behaviors.
 |`config.strategy`|	|| The backing data store in which to hold cache entities.
 |`config.memory.dictionary_name` |	`kong_cache` |	The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.

--- a/app/enterprise/0.31-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.31-x/plugins/http-proxy-caching.md
@@ -60,7 +60,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.32-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.32-x/plugins/http-proxy-caching.md
@@ -62,7 +62,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.32-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.32-x/plugins/http-proxy-caching.md
@@ -62,7 +62,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.32-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.32-x/plugins/http-proxy-caching.md
@@ -30,7 +30,7 @@ You can also apply it for every API using the `http://kong:8001/plugins/` endpoi
 |`config.vary_headers` || Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.
 |`config.vary_query_params` || Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.
 |`config.cache_ttl`|	`300` |	TTL, in seconds, of cache entities.
-|`config.cache_control`| `false` | When enabled, respect the Cache-Control behaviors defined in RFC 7234.
+|`config.cache_control`| `false` | When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
 |`config.storage_ttl`| || Number of seconds to keep resources in the storage backend. This value is independent of cache_ttl or resource TTLs defined by Cache-Control behaviors.
 |`config.strategy`|	|| The backing data store in which to hold cache entities.
 |`config.memory.dictionary_name` |	`kong_cache` |	The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.

--- a/app/enterprise/0.33-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.33-x/plugins/http-proxy-caching.md
@@ -62,7 +62,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by RFC7234, with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.33-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.33-x/plugins/http-proxy-caching.md
@@ -62,7 +62,7 @@ Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `re
 
 ### Cache Control
 
-When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
+When the `cache_control` configuration option is enabled, Kong will respect request and response Cache-Control headers as defined by [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2), with a few exceptions:
 
 - Cache revalidation is not yet supported, and so directives such as `proxy-revalidate` are ignored.
 - Similarly, the behavior of `no-cache` is simplified to exclude the entity from being cached entirely.

--- a/app/enterprise/0.33-x/plugins/http-proxy-caching.md
+++ b/app/enterprise/0.33-x/plugins/http-proxy-caching.md
@@ -30,7 +30,7 @@ You can also apply it for every API using the `http://kong:8001/plugins/` endpoi
 |`config.vary_headers` || Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.
 |`config.vary_query_params` || Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.
 |`config.cache_ttl`|	`300` |	TTL, in seconds, of cache entities.
-|`config.cache_control`| `false` | When enabled, respect the Cache-Control behaviors defined in RFC 7234.
+|`config.cache_control`| `false` | When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
 |`config.storage_ttl`| || Number of seconds to keep resources in the storage backend. This value is independent of cache_ttl or resource TTLs defined by Cache-Control behaviors.
 |`config.strategy`|	|| The backing data store in which to hold cache entities.
 |`config.memory.dictionary_name` |	`kong_cache` |	The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

This plugin has a parameter for config.cache_control which is a Boolean value for whether or not to respect RFC 7234. I added a link to the RFC in question as some may not know it off hand

### Full changelog

made RFC 7234 a link pointing to ]https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2)
The following docs were updated:
* app/_hub/kong-inc/proxy-cache/0.31-x.md
* app/_hub/kong-inc/proxy-cache/0.32-x.md
* app/_hub/kong-inc/proxy-cache/index.md
* app/enterprise/0.31-x/plugins/http-proxy-caching.md
* app/enterprise/0.32-x/plugins/http-proxy-caching.md
* app/enterprise/0.33-x/plugins/http-proxy-caching.md

### Issues resolved

Fix #XXX

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
