### PR TITLE
feat(*) add Delighted CSAT survey widget

### DIFF
--- a/app/_includes/delighted.html
+++ b/app/_includes/delighted.html
@@ -1,0 +1,6 @@
+<script type="text/javascript">
+/* eslint-disable */
+  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var u=t.getElementsByTagName("script")[0];u.parentNode.insertBefore(o,u)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Mvwmq6n6DhInaFYu","delighted");
+
+  delighted.survey();
+</script>

--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -36,6 +36,9 @@
   <!-- FullStory -->
   <!-- {% include fullstory.html %} -->
 
+  <!-- Delighted -->
+  {% include delighted.html %}
+
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",


### PR DESCRIPTION

### Summary

This PR adds a customer satisfaction (CSAT) slide-up survey to the docs.KongHQ.com site.

It is intended that this survey be as un-obtrusive as possible - as such, it is currently set to:

* Display only to return visitors 
* Display to any given visitor no more than once every three months (in practice, it may display even less frequently, and it is easy to reduce this frequency if desired)

This survey will be run first as short test, no more than 7 days, though it is desired we run this survey always, to track the results of our efforts to improve Kong's documentation. 

To test this survey on any given page, add `?delighted=test` to the page URL to force the survey widget to display.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
