### PR TITLE
fix(ce-bionic-link-in-install): Include link to Bionic package in the CE

### DIFF
--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -15,6 +15,7 @@ Start by downloading the corresponding package for your configuration:
 - [14.04 Trusty]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.trusty.all.deb)
 - [16.04 Xenial]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.xenial.all.deb)
 - [17.04 Zesty]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.zesty.all.deb)
+- [18.04 Bionic]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.bionic.all.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 


### PR DESCRIPTION
### Summary

Include link to Bionic package in the CE Ubuntu installation instructions

### Full changelog

* [Edited docs to include Bionic package link]


### Issues resolved

N/A
