### PR TITLE
feat(dev-portal) document Admin API for Developers

### DIFF
--- a/app/enterprise/0.33-x/developer-portal/managing-developers.md
+++ b/app/enterprise/0.33-x/developer-portal/managing-developers.md
@@ -15,12 +15,16 @@ A status represents the state of a developer and the access they have to your AP
 
 * **Approved**
   * A Developer who can access the Developer Portal. Approved Developers can create credentials &amp; access **all** APIs that allow those credentials.
+  * In the Admin API, Approved Developers have `status = 0`.
 * **Requested**
   * A Developer who has requested access but has not yet been Approved.
+  * In the Admin API, Requested Developers have `status = 1`.
 * **Rejected**
   * A Developer who has had their request denied by a Kong Administrator.
+  * In the Admin API, Rejected Developers have `status = 2`.
 * **Revoked**
   * A Developer who once had access to the Developer Portal but has since had access Revoked.
+  * In the Admin API, Revoked Developers have `status = 3`.
 
 ![Managing Developers](https://konghq.com/wp-content/uploads/2018/05/gui-developer-tabs.png)
 
@@ -28,6 +32,14 @@ A status represents the state of a developer and the access they have to your AP
 
 Developers who have requested access to your **Kong Developer Portal** will appear under the **Requested Access** tab.
 From this tab you can choose to *Accept* or *Reject* the developer from the actions in the table row. After selecting an action the corresponding tab will update.
+
+In the Admin API, you can approve Developers by changing their `status` to 0:
+
+```
+curl -svX PATCH \
+  --url http://localhost:8001/portal/developers/53ec3f45-2da4-4d38-966a-e98743d85eac \
+  --data 'status=0'
+```
 
 #### Enabling Auto Approval
 
@@ -45,9 +57,22 @@ It should now look like:
 
 To view all currently approved developers choose the **Approved** tab. From here you can choose to *Revoke* or *Delete* a particular developer. Additionally you can use this view to send an email to a developer with the **Email Developer** `mailto` link. See [Emailing Developers](#emailing-developers) for more info.
 
+You can also view Developers using the Admin API, optionally filtering by their approval status:
+
+```
+curl -svX GET http://localhost:8001/portal/developers?status=0
+```
+
 ## Viewing Revoked Developers
 
 To view all currently revoked developers choose the **Revoked** tab. From here you can choose to *Re-approve* or *Delete* a developer.
+
+You can also delete Developers using the Admin API:
+
+```
+curl -svX DELETE \
+  --url http://localhost:8001/portal/developers/53ec3f45-2da4-4d38-966a-e98743d85eac
+```
 
 ## Viewing Rejected Developers
 


### PR DESCRIPTION
### Summary

Adds Admin API commands for manipulating Developers alongside their GUI
equivalents.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
`POST` exists but isn't covered, as we don't currently have a GUI tool for it. It's also a bit incomplete as it doesn't assign a default status and does not reject requests that don't include a status, allowing the creation of phantom developers that can't be seen in the GUI.