### PR TITLE
fixed formatting of getting-started/adding-consumers

### DIFF
--- a/app/0.14.x/getting-started/adding-consumers.md
+++ b/app/0.14.x/getting-started/adding-consumers.md
@@ -24,56 +24,56 @@ plugin][enabling-plugins] or skip steps two and three.
 
 ## 1. Create a Consumer through the RESTful API
 
-    Lets create a user named `Jason` by issuing the following request:
+Lets create a user named `Jason` by issuing the following request:
 
-    ```bash
-    $ curl -i -X POST \
-      --url http://localhost:8001/consumers/ \
-      --data "username=Jason"
-    ```
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/consumers/ \
+  --data "username=Jason"
+```
 
-    You should see a response similar to the one below:
+You should see a response similar to the one below:
 
-    ```http
-    HTTP/1.1 201 Created
-    Content-Type: application/json
-    Connection: keep-alive
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Connection: keep-alive
 
-    {
-      "username": "Jason",
-      "created_at": 1428555626000,
-      "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
-    }
-    ```
+{
+  "username": "Jason",
+  "created_at": 1428555626000,
+  "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
+}
+```
 
-    Congratulations! You've just added your first consumer to Kong.
+Congratulations! You've just added your first consumer to Kong.
 
-    **Note:** Kong also accepts a `custom_id` parameter when [creating
-    consumers][API-consumers] to associate a consumer with your existing user
-    database.
+**Note:** Kong also accepts a `custom_id` parameter when [creating
+consumers][API-consumers] to associate a consumer with your existing user
+database.
 
 ## 2. Provision key credentials for your Consumer
 
-    Now, we can create a key for our recently created consumer `Jason` by
-    issuing the following request:
+Now, we can create a key for our recently created consumer `Jason` by
+issuing the following request:
 
-    ```bash
-    $ curl -i -X POST \
-      --url http://localhost:8001/consumers/Jason/key-auth/ \
-      --data 'key=ENTER_KEY_HERE'
-    ```
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/consumers/Jason/key-auth/ \
+  --data 'key=ENTER_KEY_HERE'
+```
 
 ## 3. Verify that your Consumer credentials are valid
 
-    We can now issue the following request to verify that the credentials of
-    our `Jason` Consumer is valid:
+We can now issue the following request to verify that the credentials of
+our `Jason` Consumer is valid:
 
-    ```bash
-    $ curl -i -X GET \
-      --url http://localhost:8000 \
-      --header "Host: example.com" \
-      --header "apikey: ENTER_KEY_HERE"
-    ```
+```bash
+$ curl -i -X GET \
+  --url http://localhost:8000 \
+  --header "Host: example.com" \
+  --header "apikey: ENTER_KEY_HERE"
+```
 
 ## Next Steps
 


### PR DESCRIPTION
### Summary

Fixed formatting on getting-started/adding-consumers page.

Due to bad indents the whole content was formatted as code snippet:

![image](https://user-images.githubusercontent.com/25141164/47164821-694ecc80-d301-11e8-948e-24391a25443f.png)


### Full changelog

Fixed bad indents.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
