### PR TITLE
fixed formatting of getting-started/enabling-plugins

### DIFF
--- a/app/0.14.x/getting-started/enabling-plugins.md
+++ b/app/0.14.x/getting-started/enabling-plugins.md
@@ -31,38 +31,38 @@ from unauthorized use.
 To configure the key-auth plugin for the Service you <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured in Kong</a>,
 issue the following cURL request:
 
-    ```bash
-    $ curl -i -X POST \
-      --url http://localhost:8001/services/example-service/plugins/ \
-      --data 'name=key-auth'
-    ```
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/services/example-service/plugins/ \
+  --data 'name=key-auth'
+```
 
-    **Note:** This plugin also accepts a `config.key_names` parameter, which
-    defaults to `['apikey']`. It is a list of headers and parameters names (both
-    are supported) that are supposed to contain the apikey during a request.
+**Note:** This plugin also accepts a `config.key_names` parameter, which
+defaults to `['apikey']`. It is a list of headers and parameters names (both
+are supported) that are supposed to contain the apikey during a request.
 
 ## 2. Verify that the plugin is properly configured
 
-    Issue the following cURL request to verify that the [key-auth][key-auth]
-    plugin was properly configured on the Service:
+Issue the following cURL request to verify that the [key-auth][key-auth]
+plugin was properly configured on the Service:
 
-    ```bash
-    $ curl -i -X GET \
-      --url http://localhost:8000/ \
-      --header 'Host: example.com'
-    ```
+```bash
+$ curl -i -X GET \
+  --url http://localhost:8000/ \
+  --header 'Host: example.com'
+```
 
-    Since you did not specify the required `apikey` header or parameter, the
-    response should be `401 Unauthorized`:
+Since you did not specify the required `apikey` header or parameter, the
+response should be `401 Unauthorized`:
 
-    ```http
-    HTTP/1.1 401 Unauthorized
-    ...
+```http
+HTTP/1.1 401 Unauthorized
+...
 
-    {
-      "message": "No API key found in request"
-    }
-    ```
+{
+  "message": "No API key found in request"
+}
+```
 
 ## Next Steps
 


### PR DESCRIPTION
### Summary

Fixed formatting on getting-started/enabling-plugins page.

Due to bad indents the whole content was formatted as code snippet:

![image](https://user-images.githubusercontent.com/25141164/47179951-091f5100-d328-11e8-9e4c-2a87f875622a.png)



### Full changelog

Fixed bad indents.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
