### PR TITLE
docs(getting-started-configuring-a-service) fixed formatting

### DIFF
--- a/app/0.14.x/getting-started/configuring-a-service.md
+++ b/app/0.14.x/getting-started/configuring-a-service.md
@@ -31,99 +31,99 @@ Routes, is made via requests on that API.
 
 ## 1. Add your Service using the Admin API
 
-    Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
-    to Kong:
+Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
+to Kong:
 
-    ```bash
-    $ curl -i -X POST \
-      --url http://localhost:8001/services/ \
-      --data 'name=example-service' \
-      --data 'url=http://mockbin.org'
-    ```
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/services/ \
+  --data 'name=example-service' \
+  --data 'url=http://mockbin.org'
+```
 
-    You should receive a response similar to:
+You should receive a response similar to:
 
-    ```http
-    HTTP/1.1 201 Created
-    Content-Type: application/json
-    Connection: keep-alive
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Connection: keep-alive
 
-    {
-       "host":"mockbin.org",
-       "created_at":1519130509,
-       "connect_timeout":60000,
-       "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
-       "protocol":"http",
-       "name":"example-service",
-       "read_timeout":60000,
-       "port":80,
-       "path":null,
-       "updated_at":1519130509,
-       "retries":5,
-       "write_timeout":60000
-    }
-    ```
+{
+   "host":"mockbin.org",
+   "created_at":1519130509,
+   "connect_timeout":60000,
+   "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
+   "protocol":"http",
+   "name":"example-service",
+   "read_timeout":60000,
+   "port":80,
+   "path":null,
+   "updated_at":1519130509,
+   "retries":5,
+   "write_timeout":60000
+}
+```
 
 
 ## 2. Add a Route for the Service
 
-    ```bash
-    $ curl -i -X POST \
-      --url http://localhost:8001/services/example-service/routes \
-      --data 'hosts[]=example.com'
-    ```
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --data 'hosts[]=example.com'
+```
 
-    The answer should be similar to:
+The answer should be similar to:
 
-    ```http
-    HTTP/1.1 201 Created
-    Content-Type: application/json
-    Connection: keep-alive
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Connection: keep-alive
 
-    {
-       "created_at":1519131139,
-       "strip_path":true,
-       "hosts":[
-          "example.com"
-       ],
-       "preserve_host":false,
-       "regex_priority":0,
-       "updated_at":1519131139,
-       "paths":null,
-       "service":{
-          "id":"79d7ee6e-9fc7-4b95-aa3b-61d2e17e7516"
-       },
-       "methods":null,
-       "protocols":[
-          "http",
-          "https"
-       ],
-       "id":"f9ce2ed7-c06e-4e16-bd5d-3a82daef3f9d"
-    }
-    ```
+{
+   "created_at":1519131139,
+   "strip_path":true,
+   "hosts":[
+      "example.com"
+   ],
+   "preserve_host":false,
+   "regex_priority":0,
+   "updated_at":1519131139,
+   "paths":null,
+   "service":{
+      "id":"79d7ee6e-9fc7-4b95-aa3b-61d2e17e7516"
+   },
+   "methods":null,
+   "protocols":[
+      "http",
+      "https"
+   ],
+   "id":"f9ce2ed7-c06e-4e16-bd5d-3a82daef3f9d"
+}
+```
 
-    Kong is now aware of your Service and ready to proxy requests.
+Kong is now aware of your Service and ready to proxy requests.
 
 ## 3. Forward your requests through Kong
 
-    Issue the following cURL request to verify that Kong is properly forwarding
-    requests to your Service. Note that [by default][proxy-port] Kong handles proxy
-    requests on port `:8000`:
+Issue the following cURL request to verify that Kong is properly forwarding
+requests to your Service. Note that [by default][proxy-port] Kong handles proxy
+requests on port `:8000`:
 
-    ```bash
-    $ curl -i -X GET \
-      --url http://localhost:8000/ \
-      --header 'Host: example.com'
-    ```
+```bash
+$ curl -i -X GET \
+  --url http://localhost:8000/ \
+  --header 'Host: example.com'
+```
 
-    A successful response means Kong is now forwarding requests made to
-    `http://localhost:8000` to the `url` we configured in step #1,
-    and is forwarding the response back to us. Kong knows to do this through
-    the header defined in the above cURL request:
+A successful response means Kong is now forwarding requests made to
+`http://localhost:8000` to the `url` we configured in step #1,
+and is forwarding the response back to us. Kong knows to do this through
+the header defined in the above cURL request:
 
-    <ul>
-      <li><strong>Host: &lt;given host></strong></li>
-    </ul>
+<ul>
+  <li><strong>Host: &lt;given host></strong></li>
+</ul>
 
 <hr>
 


### PR DESCRIPTION
### Summary

Fixed formatting on getting-started/configuring-a-service page.

Due to bad indents the whole content was formatted as code snippet:

![image](https://user-images.githubusercontent.com/25141164/47180599-96af7080-d329-11e8-93b2-cecefa160131.png)

### Full changelog

Fixed bad indents.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
