### PR TITLE
docs(getting-started-quickstart) fixed formatting

### DIFF
--- a/app/0.14.x/getting-started/quickstart.md
+++ b/app/0.14.x/getting-started/quickstart.md
@@ -17,32 +17,32 @@ supports PostgreSQL and Cassandra).
 
 ## 1. Start Kong
 
-    Issue the following command to prepare your datastore by running the Kong
-    migrations:
+Issue the following command to prepare your datastore by running the Kong
+migrations:
 
-    ```bash
-    $ kong migrations up [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong migrations up [-c /path/to/kong.conf]
+```
 
-    You should see a message that tells you Kong has successfully migrated your
-    database. If not, you probably incorrectly configured your database
-    connection settings in your configuration file.
+You should see a message that tells you Kong has successfully migrated your
+database. If not, you probably incorrectly configured your database
+connection settings in your configuration file.
 
-    Now let's [start][CLI] Kong:
+Now let's [start][CLI] Kong:
 
-    ```bash
-    $ kong start [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong start [-c /path/to/kong.conf]
+```
 
-    **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to your own configuration.
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to your own configuration.
 
 ## 2. Verify that Kong has started successfully
 
-    If everything went well, you should see a message (`Kong started`)
-    informing you that Kong is running.
+If everything went well, you should see a message (`Kong started`)
+informing you that Kong is running.
 
-    By default Kong listens on the following ports:
+By default Kong listens on the following ports:
 
 - `:8000` on which Kong listens for incoming HTTP traffic from your
   clients, and forwards it to your upstream services.
@@ -54,20 +54,20 @@ supports PostgreSQL and Cassandra).
 
 ## 3. Stop Kong
 
-    As needed you can stop the Kong process by issuing the following
-    [command][CLI]:
+As needed you can stop the Kong process by issuing the following
+[command][CLI]:
 
-    ```bash
-    $ kong stop
-    ```
+```bash
+$ kong stop
+```
 
 ## 4. Reload Kong
 
-    Issue the following command to [reload][CLI] Kong without downtime:
+Issue the following command to [reload][CLI] Kong without downtime:
 
-    ```bash
-    $ kong reload
-    ```
+```bash
+$ kong reload
+```
 
 ## Next Steps
 


### PR DESCRIPTION
### Summary

Fixed formatting on getting-started/quickstart page.

Due to bad indents the whole content was formatted as code snippet:

![image](https://user-images.githubusercontent.com/25141164/47180927-5bfa0800-d32a-11e8-87a8-ccd74ee1d6be.png)

### Full changelog

Fixed bad indents.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
