### PR TITLE
doc: Specify that kong host names are case-sensitive

### DIFF
--- a/app/0.10.x/admin-api.md
+++ b/app/0.10.x/admin-api.md
@@ -1914,3 +1914,6 @@ HTTP 204 No Content
 [clustering]: /{{page.kong_version}}/clustering
 [cli]: /{{page.kong_version}}/cli
 [secure-admin-api]: /{{page.kong_version}}/secure-admin-api
+
+
+Notice that when matching a request against an api's hosts field, the match is case sensitive.

--- a/app/0.10.x/getting-started/adding-your-api.md
+++ b/app/0.10.x/getting-started/adding-your-api.md
@@ -20,6 +20,8 @@ helpful for learning how Kong proxies your API requests.
 Kong exposes a [RESTful Admin API][API] on port `:8001` for managing the
 configuration of your Kong instance or cluster.
 
+When matching a request against an api's hosts field, the match is case sensitive.
+
 1. ### Add your API using the Admin API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin])


### PR DESCRIPTION
### Summary
Specify that kong host names are case-sensitive


### Full changelog

* Edited getting started to add about host name case sensitive
* Edited admin to add about host name case sensitive

### Issues resolved

Fix #586

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

