### PR TITLE
docs(configuration) fix broken link (#838)

### DIFF
--- a/app/enterprise/0.33-x/admin-gui/configuration/getting-started.md
+++ b/app/enterprise/0.33-x/admin-gui/configuration/getting-started.md
@@ -12,7 +12,7 @@ Start Kong.
 
 `kong start -c kong.conf.default`
 
-> Note: Not all deployments of Kong utilize a configuration file, if this describes you (or you are unsure) please reference the [Kong configuration docs](https://getkong.org/latest/configuration/) in order to implement this step.
+> Note: Not all deployments of Kong utilize a configuration file, if this describes you (or you are unsure) please reference the [Kong configuration docs](/enterprise/0.33-x/developer-portal/configuration/getting-started/) in order to implement this step.
 
 Visit the Admin GUI:
 


### PR DESCRIPTION
### Summary
On the configuration/getting-started/ page, the configuration docs weren't correctly linking to the enterprise version of the configuration files. It took a little bit of hunting to find it. 

### Full changelog

Fixes broken link.

### Issues resolved

Fix #838

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
