### PR TITLE
docs(install) update aws install url for dc/os

### DIFF
--- a/app/install/dcos.md
+++ b/app/install/dcos.md
@@ -6,7 +6,7 @@ header_icon: /assets/images/icons/icn-installation.svg
 breadcrumbs:
   Installation: /install
 links:
-  mesos-aws: "https://dcos.io/docs/1.9/installing/cloud/aws/"
+  mesos-aws: "https://dcos.io/docs/1.9/installing/oss/cloud/aws/"
   mesos-cli: "https://dcos.io/docs/1.9/cli/"
   mesos-gui: "https://dcos.io/docs/1.9/gui/"
   marathon: "https://mesosphere.github.io/marathon/"


### PR DESCRIPTION
### Summary

The link to setting up DC/OS on AWS is no longer found as there are now OSS/Enterprise install instructions.

### Full changelog

* Fixes a broken link on the [DCOS install page](https://docs.konghq.com/install/dcos/) (part 2)

### Issues resolved

N/A

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
