### PR TITLE
Making it so there are permalinks for page

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -15075,3 +15075,33 @@ header.page-header {
     padding: 7px;
     width: 0
 }
+
+#documentation {
+    .content {
+        // anchor links for titles
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            a.header-link {
+                margin-left: -.9em;
+                padding-right: .2em;
+                color: inherit;
+                
+                i {
+                    font-size: 70%;
+                    visibility: hidden;
+                }
+            }
+            
+            &:hover {
+                .header-link i {
+                    visibility: visible;
+                }
+            }
+        }
+        
+    }
+}

--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -15089,19 +15089,16 @@ header.page-header {
                 margin-left: -.9em;
                 padding-right: .2em;
                 color: inherit;
-                
                 i {
                     font-size: 70%;
                     visibility: hidden;
                 }
             }
-            
             &:hover {
                 .header-link i {
                     visibility: visible;
                 }
             }
         }
-        
     }
 }

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -24,6 +24,36 @@
     }
   }
 }
+#documentation {
+.content {
+// anchor links for titles
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+a.header-link {
+margin-left: -.9em;
+padding-right: .2em;
+color: inherit;
+
+i {
+font-size: 70%;
+visibility: hidden;
+}
+}
+
+&:hover {
+.header-link i {
+visibility: visible;
+}
+}
+}
+
+}
+}
+
 
 .page-extension-profile {
   .content {

--- a/app/_hub/heroku/kong-app/index.md
+++ b/app/_hub/heroku/kong-app/index.md
@@ -10,7 +10,7 @@ type: integration
 desc: Deploy Kong CE clusters to Heroku Common Runtime or Private Spaces
 
 description: |
-  Easily deploy Kong Community Edition as a Heroku app. Supports both
+  Easily deploy Kong Community Edition as a Heroku app. Support for both
   Heroku Common Runtime and Private Spaces. Includes a preset secure-by-default
   loopback proxy to Kong's Admin API.
 

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -91,8 +91,6 @@ If you are also using the [ACL](/plugins/acl/) plugin and whitelists with this
 service, you must add the new consumer to a whitelisted group. See
 [ACL: Associating Consumers][acl-associating] for details.
 
-[Back to TOC](#table-of-contents)
-
 ### Create a Credential
 
 You can provision new username/password credentials by making the following HTTP request:
@@ -110,7 +108,6 @@ form parameter             | default | description
 `username`                 |         | The username to use in the Basic Authentication
 `password`<br>*optional*   |         | The password to use in the Basic Authentication
 
-[Back to TOC](#table-of-contents)
 
 ### Using the Credential
 
@@ -131,7 +128,6 @@ $ curl http://kong:8000/{path matching a configured Route} \
     -H 'Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l'
 ```
 
-[Back to TOC](#table-of-contents)
 
 ### Upstream Headers
 
@@ -145,7 +141,6 @@ When a client has been authenticated, the plugin will append some headers to the
 
 You can use this information on your side to implement additional logic. You can use the `X-Consumer-ID` value to query the Kong Admin API and retrieve more information about the Consumer.
 
-[Back to TOC](#table-of-contents)
 
 ### Paginate through the basic-auth Credentials
 
@@ -197,7 +192,6 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional*                   | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
-[Back to TOC](#table-of-contents)
 
 ### Retrieve the Consumer associated with a Credential
 
@@ -229,4 +223,3 @@ Consumer.
 [acl-associating]: /plugins/acl/#associating-consumers
 [faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?
 
-[Back to TOC](#table-of-contents)

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -91,6 +91,8 @@ If you are also using the [ACL](/plugins/acl/) plugin and whitelists with this
 service, you must add the new consumer to a whitelisted group. See
 [ACL: Associating Consumers][acl-associating] for details.
 
+[Back to TOC](#table-of-contents)
+
 ### Create a Credential
 
 You can provision new username/password credentials by making the following HTTP request:
@@ -107,6 +109,8 @@ form parameter             | default | description
 ---                        | ---     | ---
 `username`                 |         | The username to use in the Basic Authentication
 `password`<br>*optional*   |         | The password to use in the Basic Authentication
+
+[Back to TOC](#table-of-contents)
 
 ### Using the Credential
 
@@ -127,6 +131,8 @@ $ curl http://kong:8000/{path matching a configured Route} \
     -H 'Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l'
 ```
 
+[Back to TOC](#table-of-contents)
+
 ### Upstream Headers
 
 When a client has been authenticated, the plugin will append some headers to the request before proxying it to the upstream service, so that you can identify the Consumer in your code:
@@ -138,6 +144,8 @@ When a client has been authenticated, the plugin will append some headers to the
 * `X-Anonymous-Consumer`, will be set to `true` when authentication failed, and the 'anonymous' consumer was set instead.
 
 You can use this information on your side to implement additional logic. You can use the `X-Consumer-ID` value to query the Kong Admin API and retrieve more information about the Consumer.
+
+[Back to TOC](#table-of-contents)
 
 ### Paginate through the basic-auth Credentials
 
@@ -189,6 +197,8 @@ Attributes | Description
 `size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
 `offset`<br>*optional*                   | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
 
+[Back to TOC](#table-of-contents)
+
 ### Retrieve the Consumer associated with a Credential
 
 <div class="alert alert-warning">
@@ -218,3 +228,5 @@ Consumer.
 [consumer-object]: /latest/admin-api/#consumer-object
 [acl-associating]: /plugins/acl/#associating-consumers
 [faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?
+
+[Back to TOC](#table-of-contents)

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -222,4 +222,3 @@ Consumer.
 [consumer-object]: /latest/admin-api/#consumer-object
 [acl-associating]: /plugins/acl/#associating-consumers
 [faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?
-

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -228,7 +228,7 @@ When a client has been authenticated and authorized, the plugin will append some
 * `X-Authenticated-Userid`, the logged-in user ID who has granted permission to the client (only if the consumer is not the 'anonymous' consumer)
 * `X-Anonymous-Consumer`, will be set to `true` when authentication failed, and the 'anonymous' consumer was set instead.
 
-You can use this information on your side to implement additional logic. You can use the `X-Consumer-ID` value to query the Kong Admin API and retrieve more information about the Consumer.
+You can use this information on your side to implement additional logic. For example, you can use the `X-Consumer-ID` value to query the Kong Admin API and retrieve more information about the Consumer.
 
 ----
 

--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -136,7 +136,7 @@ params:
 
 ### Template as Value
 
-User can use any of the the current request headers, query params, and captured URI named groups as template to populate above supported config fields.
+Users can use any of the the current request headers, query params, and captured URI named groups as template to populate above supported config fields.
 
 | Request Param | Template
 | --------- | -----------
@@ -163,7 +163,7 @@ $ curl -X POST http://localhost:8001/apis \
 
 Enable the ‘request-transformer-advanced’ plugin to add a new header `x-consumer-id`
 and its value is being set with the value sent with header `x-user-id` or
-with the default value alice is `header` is missing.
+with the default value alice `header` is missing.
 
 ```
 $ curl -X POST http://localhost:8001/apis/test/plugins \

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -228,7 +228,8 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 
       {% if page.type == "plugin" %}
         <hr>
-        <h2 id="terminology">Terminology</h2>
+        <h2 id="terminology">
+        <a class="header-link" href="#terminology" title="Permalink"><span class="sr-only">Permalink</span><i class="fa fa-link"></i></a>Terminology</h2>
         <ul>
           <li><code>plugin</code>: a plugin executing actions inside Kong before or after a request has been proxied to the upstream API.</li>
 
@@ -259,7 +260,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
       {% endif %}
 
       {% if page.type == "plugin" %}
-        <h2 id="configuration">Configuration</h2>
+        <h2 id="configuration"><a class="header-link" href="#configuration" title="Permalink"><span class="sr-only">Permalink</span><i class="fa fa-link"></i></a>Configuration</h2>
         {% if page.params.service_id %}
           {{ plugin_config_for_service | markdownify }}
         {% endif %}


### PR DESCRIPTION
### Summary

Updated the html to have an anchor tag which will have the get the permalink class for Terminology and Configuration headers which are contained within a plugin that is called from the basic-auth page.
I also then added the permalinks with markdown to each section also.

### Full changelog

*  Updated app/layouts/extensions.html to have a permalink
* Updated app/hub/kong-inc/basic-auth/index.md to have permalinks


### Issues resolved

Issue #904 


### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A
- [x] Spellchecked my updates
- [x] Ready to be merged 

This is my first time contributing to Kong and even to a really large repo. Let me know if there is anything I should do better! Thanks for giving me a shot!