### PR TITLE
style(syntax) dont allow selecting generic prompt symbol

### DIFF
--- a/app/_assets/stylesheets/syntax.less
+++ b/app/_assets/stylesheets/syntax.less
@@ -59,3 +59,14 @@
 .vg { color: #008080 } /* Name.Variable.Global */
 .vi { color: #008080 } /* Name.Variable.Instance */
 .il { color: #009999 } /* Literal.Number.Integer.Long */
+
+/* Disable selecting $ prompt, e.g. shell curl call docs */
+.gp {
+  -webkit-user-select: none;
+  -khtml-user-drag: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -moz-user-select: -moz-none;
+  -ms-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
### Summary
Dont allow user to select generic prompt `$`. This will only work when the markdown language is used e.g. ```bash. Will need to search and find places where bash is not specified in another PR.

### Issues resolved
Fix #939 

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Spellchecked my updates
- [x] Ready to be merged
