### PR TITLE
docs(install) fix typo in kong universe link

### DIFF
--- a/app/install/dcos.md
+++ b/app/install/dcos.md
@@ -128,7 +128,7 @@ have basic knowledge of [DC/OS]({{ page.links.dcos }}),
 5. **Deploy Kong**
 
     Now we have an external load balancer and Kong-supported database
-    running. Using the [kong package]{{ page.links.universe }} from Universe repo, deploy Kong
+    running. Using the [kong package]({{ page.links.universe }}) from Universe repo, deploy Kong
     with the following options:
 
     ```json


### PR DESCRIPTION
### Summary

Fix a link to the Kong universe in section 5 of the [Kong DCOS](https://docs.konghq.com/install/dcos/) docs.

### Full changelog

* Fix a link in the deployment documentation

### Issues resolved

N/A

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
