### PR TITLE
docs(*) Add bash annotations to markdown code snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,7 +321,7 @@ From #623
 As mentioned in the guidelines, to submit a patch, the linter must succeed. You
 can run the linter like so:
 
-```
+```bash
 $ npm run test
 ```
 

--- a/app/0.10.x/configuration.md
+++ b/app/0.10.x/configuration.md
@@ -10,7 +10,7 @@ Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
 packages. To start configuring Kong, you can copy this file:
 
-```
+```bash
 $ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
 ```
 
@@ -26,7 +26,7 @@ default locations that might contain a configuration file:
 You can override this behavior by specifying a custom path for your
 configuration file using the `-c / --conf` argument in the CLI:
 
-```
+```bash
 $ kong start --conf /path/to/kong.conf
 ```
 
@@ -40,7 +40,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 You can verify the integrity of your settings with the `check` command:
 
-```
+```bash
 $ kong check <path/to/kong.conf>
 configuration at <path/to/kong.conf> is valid
 ```
@@ -51,7 +51,7 @@ currently set, and will error out in case your settings are invalid.
 Additionally, you can also use the CLI in debug mode to have more insight
 as to what properties Kong is being started with:
 
-```
+```bash
 $ kong start -c <kong.conf> --vv
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
@@ -85,7 +85,7 @@ log_level = debug # in kong.conf
 
 Can be overridden with:
 
-```
+```bash
 $ export KONG_LOG_LEVEL=error
 ```
 
@@ -156,7 +156,7 @@ http {
 
 You can then start Kong with:
 
-```
+```bash
 $ kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
@@ -259,7 +259,7 @@ by including the Kong Nginx sub-configuration using the `include` directive
 final configuration and not the template. For this, use the `compile` command,
 which outputs a fully-compiled Nginx sub-configuration to `stdout`:
 
-```
+```bash
 $ bin/kong compile --conf kong.conf > /usr/local/openresty/conf/nginx-kong.conf
 
 # now start OpenResty with a configuration that "includes" nginx-kong.conf

--- a/app/0.11.x/configuration.md
+++ b/app/0.11.x/configuration.md
@@ -10,7 +10,7 @@ Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
 packages. To start configuring Kong, you can copy this file:
 
-```
+```bash
 $ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
 ```
 
@@ -26,7 +26,7 @@ default locations that might contain a configuration file:
 You can override this behavior by specifying a custom path for your
 configuration file using the `-c / --conf` argument in the CLI:
 
-```
+```bash
 $ kong start --conf /path/to/kong.conf
 ```
 
@@ -40,7 +40,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 You can verify the integrity of your settings with the `check` command:
 
-```
+```bash
 $ kong check <path/to/kong.conf>
 configuration at <path/to/kong.conf> is valid
 ```
@@ -51,7 +51,7 @@ currently set, and will error out in case your settings are invalid.
 Additionally, you can also use the CLI in debug mode to have more insight
 as to what properties Kong is being started with:
 
-```
+```bash
 $ kong start -c <kong.conf> --vv
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
@@ -81,7 +81,7 @@ log_level = debug # in kong.conf
 
 Can be overridden with:
 
-```
+```bash
 $ export KONG_LOG_LEVEL=error
 ```
 
@@ -152,7 +152,7 @@ http {
 
 You can then start Kong with:
 
-```
+```bash
 $ kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
@@ -257,7 +257,7 @@ by including the Kong Nginx sub-configuration using the `include` directive
 final configuration and not the template. For this, use the `compile` command,
 which outputs a fully-compiled Nginx sub-configuration to `stdout`:
 
-```
+```bash
 $ bin/kong compile --conf kong.conf > /usr/local/openresty/conf/nginx-kong.conf
 
 # now start OpenResty with a configuration that "includes" nginx-kong.conf

--- a/app/0.12.x/configuration.md
+++ b/app/0.12.x/configuration.md
@@ -10,7 +10,7 @@ Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
 packages. To start configuring Kong, you can copy this file:
 
-```
+```bash
 $ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
 ```
 
@@ -26,7 +26,7 @@ default locations that might contain a configuration file:
 You can override this behavior by specifying a custom path for your
 configuration file using the `-c / --conf` argument in the CLI:
 
-```
+```bash
 $ kong start --conf /path/to/kong.conf
 ```
 
@@ -40,7 +40,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 You can verify the integrity of your settings with the `check` command:
 
-```
+```bash
 $ kong check <path/to/kong.conf>
 configuration at <path/to/kong.conf> is valid
 ```
@@ -51,7 +51,7 @@ currently set, and will error out in case your settings are invalid.
 Additionally, you can also use the CLI in debug mode to have more insight
 as to what properties Kong is being started with:
 
-```
+```bash
 $ kong start -c <kong.conf> --vv
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
@@ -81,7 +81,7 @@ log_level = debug # in kong.conf
 
 Can be overridden with:
 
-```
+```bash
 $ export KONG_LOG_LEVEL=error
 ```
 
@@ -152,7 +152,7 @@ http {
 
 You can then start Kong with:
 
-```
+```bash
 $ kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
@@ -203,7 +203,7 @@ http {
 
 you can start your instance like so:
 
-```
+```bash
 $ nginx -p /usr/local/openresty -c my_nginx.conf
 ```
 

--- a/app/0.13.x/configuration.md
+++ b/app/0.13.x/configuration.md
@@ -10,7 +10,7 @@ Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
 packages. To start configuring Kong, you can copy this file:
 
-```
+```bash
 $ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
 ```
 
@@ -26,7 +26,7 @@ default locations that might contain a configuration file:
 You can override this behavior by specifying a custom path for your
 configuration file using the `-c / --conf` argument in the CLI:
 
-```
+```bash
 $ kong start --conf /path/to/kong.conf
 ```
 
@@ -40,7 +40,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 You can verify the integrity of your settings with the `check` command:
 
-```
+```bash
 $ kong check <path/to/kong.conf>
 configuration at <path/to/kong.conf> is valid
 ```
@@ -51,7 +51,7 @@ currently set, and will error out in case your settings are invalid.
 Additionally, you can also use the CLI in debug mode to have more insight
 as to what properties Kong is being started with:
 
-```
+```bash
 $ kong start -c <kong.conf> --vv
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
@@ -81,7 +81,7 @@ log_level = debug # in kong.conf
 
 Can be overridden with:
 
-```
+```bash
 $ export KONG_LOG_LEVEL=error
 ```
 
@@ -152,7 +152,7 @@ http {
 
 You can then start Kong with:
 
-```
+```bash
 $ kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
@@ -203,7 +203,7 @@ http {
 
 you can start your instance like so:
 
-```
+```bash
 $ nginx -p /usr/local/openresty -c my_nginx.conf
 ```
 

--- a/app/0.13.x/proxy.md
+++ b/app/0.13.x/proxy.md
@@ -83,7 +83,7 @@ how Kong is configured via the [Admin API][API].
 
 Adding a Service to Kong is done by sending an HTTP request to the Admin API:
 
-```
+```bash
 $ curl -i -X POST http://localhost:8001/services/ \
     -d 'name=foo-service' \
     -d 'url=http://foo-service.com'
@@ -115,7 +115,7 @@ points to `http://foo-service.com` (your upstream).
 Now, in order to send traffic to this Service through Kong, we need to specify
 a Route, which acts as an entrypoint to Kong:
 
-```
+```bash
 $ curl -i -X POST http://localhost:8001/routes/ \
     -d 'hosts[]=example.com' \
     -d 'paths[]=/foo' \

--- a/app/0.14.x/configuration.md
+++ b/app/0.14.x/configuration.md
@@ -10,7 +10,7 @@ Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
 packages. To start configuring Kong, you can copy this file:
 
-```
+```bash
 $ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
 ```
 
@@ -26,7 +26,7 @@ default locations that might contain a configuration file:
 You can override this behavior by specifying a custom path for your
 configuration file using the `-c / --conf` argument in the CLI:
 
-```
+```bash
 $ kong start --conf /path/to/kong.conf
 ```
 
@@ -40,7 +40,7 @@ Boolean values can be specified as `on`/`off` or `true`/`false` for convenience.
 
 You can verify the integrity of your settings with the `check` command:
 
-```
+```bash
 $ kong check <path/to/kong.conf>
 configuration at <path/to/kong.conf> is valid
 ```
@@ -51,7 +51,7 @@ currently set, and will error out in case your settings are invalid.
 Additionally, you can also use the CLI in debug mode to have more insight
 as to what properties Kong is being started with:
 
-```
+```bash
 $ kong start -c <kong.conf> --vv
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
@@ -81,7 +81,7 @@ log_level = debug # in kong.conf
 
 can be overridden with:
 
-```
+```bash
 $ export KONG_LOG_LEVEL=error
 ```
 
@@ -128,7 +128,7 @@ Like any other entry in `kong.conf`, these directives can also be specified
 using [environment variables](#environment-variables) as shown above. For
 example, if you declare an environment variable like this:
 
-```
+```bash
 $ export KONG_NGINX_HTTP_OUTPUT_BUFFERS="4 64k"
 ```
 
@@ -179,7 +179,7 @@ nginx_http_include = /path/to/your/my-server.kong.conf
 
 or, alternatively, by configuring it via an environment variable:
 
-```
+```bash
 $ export KONG_NGINX_HTTP_INCLUDE="/path/to/your/my-server.kong.conf"
 ```
 
@@ -187,7 +187,7 @@ Now, when you start Kong, the `server` section from that file will be added to
 that file, meaning that the custom server defined in it will be responding,
 alongside the regular Kong ports:
 
-```
+```bash
 $ curl -I http://127.0.0.1:2112
 HTTP/1.1 200 OK
 ...
@@ -275,7 +275,7 @@ http {
 
 You can then start Kong with:
 
-```
+```bash
 $ kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
@@ -303,7 +303,7 @@ http {
 
 You can then start your Nginx instance like so:
 
-```
+```bash
 $ nginx -p /usr/local/openresty -c my_nginx.conf
 ```
 

--- a/app/0.14.x/proxy.md
+++ b/app/0.14.x/proxy.md
@@ -83,7 +83,7 @@ how Kong is configured via the [Admin API][API].
 
 Adding a Service to Kong is done by sending an HTTP request to the Admin API:
 
-```
+```bash
 $ curl -i -X POST http://localhost:8001/services/ \
     -d 'name=foo-service' \
     -d 'url=http://foo-service.com'
@@ -115,7 +115,7 @@ points to `http://foo-service.com` (your upstream).
 Now, in order to send traffic to this Service through Kong, we need to specify
 a Route, which acts as an entrypoint to Kong:
 
-```
+```bash
 $ curl -i -X POST http://localhost:8001/routes/ \
     -d 'hosts[]=example.com' \
     -d 'paths[]=/foo' \

--- a/app/0.4.x/tutorials/hello-world.md
+++ b/app/0.4.x/tutorials/hello-world.md
@@ -6,7 +6,7 @@ title: Tutorials - Hello World
 
 Kong sits in front of any configured API, and it's the main entry point of any HTTP request. For example, let's configure Kong to support [mockbin](http://mockbin.com/) as an API:
 
-```
+```bash
 $ curl -i -X POST \
   --url http://127.0.0.1:8001/apis/ \
   --data 'name=mockbin&target_url=http://mockbin.com&public_dns=api.mockbin.com'
@@ -17,7 +17,7 @@ We used the `8001` port, which the RESTful Admin API of Kong listens on.
 
 We can now make our first HTTP requests through Kong by using the `8000` port, which is the port that API consumers will use to consume any API behind Kong:
 
-```
+```bash
 $ curl -i -X GET \
   --url http://127.0.0.1:8000/ \
   --header 'Host: api.mockbin.com'

--- a/app/0.9.x/configuration.md
+++ b/app/0.9.x/configuration.md
@@ -10,7 +10,7 @@ Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
 packages. To start configuring Kong, you can copy this file:
 
-```
+```bash
 $ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
 ```
 
@@ -26,7 +26,7 @@ default locations that might contain a configuration file:
 You can override this behavior by specifying a custom path for your
 configuration file using the `-c / --conf` argument in the CLI:
 
-```
+```bash
 $ kong start --conf /path/to/kong.conf
 ```
 
@@ -40,7 +40,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 You can verify the integrity of your settings with the `check` command:
 
-```
+```bash
 $ kong check <path/to/kong.conf>
 configuration at <path/to/kong.conf> is valid
 ```
@@ -51,7 +51,7 @@ currently set, and will error out in case your settings are invalid.
 Additionally, you can also use the CLI in debug mode to have more insight
 as to what properties Kong is being started with:
 
-```
+```bash
 $ kong start -c <kong.conf> --vv
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
 2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
@@ -87,7 +87,7 @@ log_level = debug # in kong.conf
 
 Can be overridden with:
 
-```
+```bash
 $ export KONG_LOG_LEVEL=error
 ```
 
@@ -156,7 +156,7 @@ http {
 
 You can then start Kong with:
 
-```
+```bash
 $ kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
@@ -197,7 +197,7 @@ by including the Kong Nginx sub-configuration using the `include` directive
 final configuration and not the template. For this, use the `compile` command,
 which outputs a fully-compiled Nginx sub-configuration to `stdout`:
 
-```
+```bash
 $ bin/kong compile --conf kong.conf > /usr/local/openresty/conf/nginx-kong.conf
 
 # now start OpenResty with a configuration that "includes" nginx-kong.conf

--- a/app/_hub/kong-inc/rate-limiting-advanced/0.31-x.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/0.31-x.md
@@ -160,7 +160,7 @@ params:
 
 An arbitrary number of limits/window sizes can be applied per plugin instance. This allows users to create multiple rate limiting windows (e.g., rate limit per minute and per hour, and/or per any arbitrary window size); because of limitation with Kong's plugin configuration interface, each *nth* limit will apply to each *nth* window size. For example:
 
-```
+```bash
 $ curl -i -X POST http://kong:8001/apis/{api}/plugins \
   --data name=rate-limiting \
   --data config.limit=10,100 \

--- a/app/_hub/kong-inc/rate-limiting-advanced/0.32-x.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/0.32-x.md
@@ -136,7 +136,7 @@ params:
 
 An arbitrary number of limits/window sizes can be applied per plugin instance. This allows users to create multiple rate limiting windows (e.g., rate limit per minute and per hour, and/or per any arbitrary window size); because of limitation with Kong's plugin configuration interface, each *nth* limit will apply to each *nth* window size. For example:
 
-```
+```bash
 $ curl -i -X POST http://kong:8001/apis/{api}/plugins \
   --data name=rate-limiting-advanced \
   --data config.limit=10,100 \

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -136,7 +136,7 @@ params:
 
 An arbitrary number of limits/window sizes can be applied per plugin instance. This allows users to create multiple rate limiting windows (e.g., rate limit per minute and per hour, and/or per any arbitrary window size); because of limitation with Kong's plugin configuration interface, each *nth* limit will apply to each *nth* window size. For example:
 
-```
+```bash
 $ curl -i -X POST http://kong:8001/apis/{api}/plugins \
   --data name=rate-limiting-advanced \
   --data config.limit=10,100 \

--- a/app/_hub/kong-inc/request-transformer-advanced/0.31-x.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/0.31-x.md
@@ -153,7 +153,7 @@ Note: Plugin creates a non mutable table of request headers, querystrings, and c
 
 Add an API `test` with `uris` configured with a named capture group `user_id`
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
@@ -165,7 +165,7 @@ Enable the ‘request-transformer-advanced’ plugin to add a new header `x-cons
 and its value is being set with the value sent with header `x-user-id` or
 with the default value alice is `header` is missing.
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/test/plugins \
     --data "name=request-transformer-advanced" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
@@ -174,14 +174,14 @@ $ curl -X POST http://localhost:8001/apis/test/plugins \
 
 Now send a request without setting header `x-user-id`
 
-```
+```bash
 $ curl -i -X GET localhost:8000/requests/user/foo
 ```
 
 Plugin will add a new header `x-consumer-id` with value alice before proxying
 request upstream. Now try sending request with header `x-user-id` set
 
-```
+```bash
 $ curl -i -X GET localhost:8000/requests/user/foo \
   -H "X-User-Id:bob"
 ```
@@ -199,7 +199,7 @@ remove –> replace –> add –> append
 
 Add multiple headers by passing each header:value pair separately:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
@@ -212,7 +212,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers by passing comma separated header:value pair:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
@@ -224,7 +224,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers passing config as JSON body:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
@@ -236,7 +236,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add a querystring and a header:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
@@ -256,7 +256,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Append multiple headers and remove a body parameter:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
@@ -275,7 +275,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers and querystring parameters if not already set:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \

--- a/app/_hub/kong-inc/request-transformer-advanced/0.32-x.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/0.32-x.md
@@ -153,7 +153,7 @@ Note: Plugin creates a non mutable table of request headers, querystrings, and c
 
 Add an API `test` with `uris` configured with a named capture group `user_id`
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
@@ -165,7 +165,7 @@ Enable the ‘request-transformer-advanced’ plugin to add a new header `x-cons
 and its value is being set with the value sent with header `x-user-id` or
 with the default value alice is `header` is missing.
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/test/plugins \
     --data "name=request-transformer-advanced" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
@@ -174,14 +174,14 @@ $ curl -X POST http://localhost:8001/apis/test/plugins \
 
 Now send a request without setting header `x-user-id`
 
-```
+```bash
 $ curl -i -X GET localhost:8000/requests/user/foo
 ```
 
 Plugin will add a new header `x-consumer-id` with value alice before proxying
 request upstream. Now try sending request with header `x-user-id` set
 
-```
+```bash
 $ curl -i -X GET localhost:8000/requests/user/foo \
   -H "X-User-Id:bob"
 ```
@@ -199,7 +199,7 @@ remove –> replace –> add –> append
 
 Add multiple headers by passing each header:value pair separately:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
@@ -212,7 +212,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers by passing comma separated header:value pair:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
@@ -224,7 +224,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers passing config as JSON body:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
@@ -236,7 +236,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add a querystring and a header:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
@@ -256,7 +256,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Append multiple headers and remove a body parameter:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
@@ -275,7 +275,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers and querystring parameters if not already set:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \

--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -153,7 +153,7 @@ Note: Plugin creates a non mutable table of request headers, querystrings, and c
 
 Add an API `test` with `uris` configured with a named capture group `user_id`
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
@@ -165,7 +165,7 @@ Enable the ‘request-transformer-advanced’ plugin to add a new header `x-cons
 and its value is being set with the value sent with header `x-user-id` or
 with the default value alice is `header` is missing.
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/test/plugins \
     --data "name=request-transformer-advanced" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
@@ -174,14 +174,14 @@ $ curl -X POST http://localhost:8001/apis/test/plugins \
 
 Now send a request without setting header `x-user-id`
 
-```
+```bash
 $ curl -i -X GET localhost:8000/requests/user/foo
 ```
 
 Plugin will add a new header `x-consumer-id` with value alice before proxying
 request upstream. Now try sending request with header `x-user-id` set
 
-```
+```bash
 $ curl -i -X GET localhost:8000/requests/user/foo \
   -H "X-User-Id:bob"
 ```
@@ -199,7 +199,7 @@ remove –> replace –> add –> append
 
 Add multiple headers by passing each header:value pair separately:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
@@ -212,7 +212,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers by passing comma separated header:value pair:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
@@ -224,7 +224,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers passing config as JSON body:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
@@ -236,7 +236,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add a querystring and a header:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
@@ -256,7 +256,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Append multiple headers and remove a body parameter:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
@@ -275,7 +275,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 
 Add multiple headers and querystring parameters if not already set:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -139,7 +139,7 @@ similarly for Routes, or the depreciated API entity.
 
 - Add multiple headers by passing each header:value pair separately:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \
   --data "name=request-transformer" \
   --data "config.add.headers[1]=h1:v1" \
@@ -152,7 +152,7 @@ h1: v1        | <ul><li>h1: v1</li><li>h2: v1</li></ul>
 
 - Add multiple headers by passing comma separated header:value pair:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \
   --data "name=request-transformer" \
   --data "config.add.headers=h1:v1,h2:v2"
@@ -164,7 +164,7 @@ h1: v1        | <ul><li>h1: v1</li><li>h2: v1</li></ul>
 
 - Add multiple headers passing config as JSON body:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
@@ -177,7 +177,7 @@ h1: v1        | <ul><li>h1: v1</li><li>h2: v1</li></ul>
 
 - Add a querystring and a header:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \
   --data "name=request-transformer" \
   --data "config.add.querystring=q1:v2,q2=v1" \
@@ -197,7 +197,7 @@ incoming request querystring | upstream proxied querystring
 
 - Append multiple headers and remove a body parameter:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer", "config": {"append": {"headers": ["h1:v2", "h2:v1"]}, "remove": {"body": ["p1"]}}}'

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -88,7 +88,7 @@ similar for Services, or the depreciated API entity.
 
 - Add multiple headers by passing each header:value pair separately:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer" \
   --data "config.add.headers[1]=h1:v1" \
@@ -101,7 +101,7 @@ h1: v1        | <ul><li>h1: v1</li><li>h2: v1</li></ul>
 
 - Add multiple headers by passing comma separated header:value pair:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer" \
   --data "config.add.headers=h1:v1,h2:v2"
@@ -113,7 +113,7 @@ h1: v1        | <ul><li>h1: v1</li><li>h2: v1</li></ul>
 
 - Add multiple headers passing config as JSON body:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "response-transformer", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
@@ -126,7 +126,7 @@ h1: v1        | <ul><li>h1: v1</li><li>h2: v1</li></ul>
 
 - Add a body property and a header:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer" \
   --data "config.add.json=p1:v1,p2=v2" \
@@ -146,7 +146,7 @@ upstream response JSON body | proxied response body
 
 - Append multiple headers and remove a body property:
 
-```
+```bash
 $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "response-transformer", "config": {"append": {"headers": ["h1:v2", "h2:v1"]}, "remove": {"json": ["p1"]}}}'

--- a/app/_hub/optum/kong-response-size-limiting/index.md
+++ b/app/_hub/optum/kong-response-size-limiting/index.md
@@ -77,13 +77,13 @@ If the upstream lacks the response header, then this plugin will allow the respo
 ### Installation
 Recommended:
 
-```
+```bash
 $ luarocks install kong-response-size-limiting
 ```
 
 Other:
 
-```
+```bash
 $ git clone https://github.com/Optum/kong-response-size-limiting.git /path/to/kong/plugins/kong-response-size-limiting
 $ cd /path/to/kong/plugins/kong-response-size-limiting
 $ luarocks make *.rockspec

--- a/app/_hub/optum/kong-service-virtualization/index.md
+++ b/app/_hub/optum/kong-service-virtualization/index.md
@@ -162,13 +162,13 @@ Content-Type: application/json; charset=utf-8
 ### Installation
 Recommended:
 
-```
+```bash
 $ luarocks install kong-service-virtualization
 ```
 
 Optional:
 
-```
+```bash
 $ git clone https://github.com/Optum/kong-service-virtualization
 $ cd /path/to/kong/plugins/kong-service-virtualization
 $ luarocks make *.rockspec

--- a/app/_hub/optum/kong-spec-expose/index.md
+++ b/app/_hub/optum/kong-spec-expose/index.md
@@ -81,13 +81,13 @@ params:
 
 Recommended:
 
-```
+```bash
 $ luarocks install kong-spec-expose
 ```
 
 Other:
 
-```
+```bash
 $ git clone https://github.com/Optum/kong-spec-expose.git /path/to/kong/plugins/kong-spec-expose
 $ cd /path/to/kong/plugins/kong-spec-expose
 $ luarocks make *.rockspec

--- a/app/_hub/optum/kong-splunk-log/index.md
+++ b/app/_hub/optum/kong-splunk-log/index.md
@@ -124,13 +124,13 @@ params:
 
 Recommended:
 
-```
+```bash
 $ luarocks install kong-splunk-log
 ```
 
 Other:
 
-```
+```bash
 $ git clone https://github.com/Optum/kong-splunk-log.git /path/to/kong/plugins/kong-splunk-log
 $ cd /path/to/kong/plugins/kong-splunk-log
 $ luarocks make *.rockspec
@@ -146,7 +146,7 @@ The plugin requires an environment variable `SPLUNK_HOST`. This is how we define
 
 If not already set, it can be done so as follows:
 
-```
+```bash
 $ export SPLUNK_HOST="gateway.company.com"
 ```
 

--- a/app/_hub/optum/kong-upstream-jwt/index.md
+++ b/app/_hub/optum/kong-upstream-jwt/index.md
@@ -76,13 +76,13 @@ extra: |
 
 Recommended:
 
-```
+```bash
 $ luarocks install kong-upstream-jwt
 ```
 
 Other:
 
-```
+```bash
 $ git clone https://github.com/Optum/kong-upstream-jwt.git /path/to/kong/plugins/kong-upstream-jwt
 $ cd /path/to/kong/plugins/kong-upstream-jwt
 $ luarocks make *.rockspec
@@ -94,7 +94,7 @@ The plugin requires that Kong's private key be accessible in order to sign the J
 
 If not already set, these can be done so as follows:
 
-```
+```bash
 $ export KONG_SSL_CERT_KEY="/path/to/kong/ssl/privatekey.key"
 $ export KONG_SSL_CERT_DER="/path/to/kong/ssl/kongpublickey.cer"
 ```

--- a/app/enterprise/0.31-x/allowing-multiple-authentication-methods.md
+++ b/app/enterprise/0.31-x/allowing-multiple-authentication-methods.md
@@ -7,7 +7,7 @@ The default behavior for Kong authentication plugins is to require credentials f
 
 To begin, [create an API](/latest/getting-started/adding-your-api/) and then create three consumers:
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers \
     -H "Content-Type: application/json" \
     --data '{"username": "anonymous"}'
@@ -31,7 +31,7 @@ The `anonymous` consumer does not correspond to any real user, and will only ser
 
 Next, we add both Key Auth and Basic Auth plugins to our consumer, and set the anonymous fallback to the consumer we created earlier.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/apis/example-api/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "key-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
@@ -49,7 +49,7 @@ If using [OpenID Connect](/enterprise/latest/plugins/openid-connect), you must a
 
 At this point unauthenticated requests and requests with invalid credentials are still allowed. The anonymous consumer is allowed, and will be applied to any request that does not pass a set of credentials associated with some other consumer.
 
-```
+```bash
 $ curl -s example.com:8000/user-agent
 
 {"user-agent": "curl/7.58.0"}
@@ -61,7 +61,7 @@ $ curl -s example.com:8000/user-agent?apikey=nonsense
 
 We'll now add a Key Auth credential for one consumer, and a Basic Auth credential for another.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers/medvezhonok/basic-auth \
     -H "Content-Type: application/json" \
     --data '{"username": "medvezhonok", "password": "hunter2"}'
@@ -78,7 +78,7 @@ $ curl -sX POST kong-admin:8001/consumers/ezhik/key-auth \
 
 Lastly, we add a Request Terminator to the anonymous consumer.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "request-termination", "config": { "status_code": 401, "content_type": "application/json; charset=utf-8", "body": "{\"error\": \"Authentication required\"}"} }'
@@ -88,7 +88,7 @@ $ curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/p
 
 Requests with missing or invalid credentials are now rejected, whereas authorized requests using either authentication method are allowed.
 
-```
+```bash
 $ curl -s example.com:8000/user-agent?apikey=nonsense
 
 {"error": "Authentication required"}

--- a/app/enterprise/0.31-x/setting-up-admin-api-rbac.md
+++ b/app/enterprise/0.31-x/setting-up-admin-api-rbac.md
@@ -99,7 +99,7 @@ kong restart
 
 RBAC policies will now be enforced by Kong, based on the user token presented to the request. By default, this user token should be presented via the Kong-Admin-Token request header; the name of this header is configurable via the Kong configuration file. In order to test our setup, we can send a request to the Admin API without sending an authentication. Because Kong does not recognize a user associated with the requesting client, it will reject the request:
 
-```
+```bash
 $ curl -i http://localhost:8001/status
 HTTP/1.1 401 Unauthorized
 Date: Fri, 04 Aug 2017 22:06:00 GMT
@@ -114,7 +114,7 @@ Server: kong/0.11.0
 
 By sending a request with our user's token, we will be granted read access to the resource in question.
 
-```
+```bash
 $ curl -H "Kong-Admin-Token: 12345" -i http://localhost:8001/status
 HTTP/1.1 200 OK
 Date: Fri, 04 Aug 2017 22:09:25 GMT
@@ -127,7 +127,7 @@ Server: kong/0.11.0
 
 We can also see that attempting to create a new resource with our RBAC user is not permitted, as they are not assigned any roles that have permissions with create access:
 
-```
+```bash
 $ curl -H "Kong-Admin-Token: 12345" -i http://localhost:8001/consumers -d name=alic
 HTTP/1.1 401 Unauthorized
 Date: Fri, 04 Aug 2017 22:15:47 GMT

--- a/app/enterprise/0.32-x/allowing-multiple-authentication-methods.md
+++ b/app/enterprise/0.32-x/allowing-multiple-authentication-methods.md
@@ -7,7 +7,7 @@ The default behavior for Kong authentication plugins is to require credentials f
 
 To begin, [create an API](/latest/getting-started/adding-your-api/) and then create three consumers:
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers \
     -H "Content-Type: application/json" \
     --data '{"username": "anonymous"}'
@@ -31,7 +31,7 @@ The `anonymous` consumer does not correspond to any real user, and will only ser
 
 Next, we add both Key Auth and Basic Auth plugins to our consumer, and set the anonymous fallback to the consumer we created earlier.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/apis/example-api/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "key-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
@@ -49,7 +49,7 @@ If using [OpenID Connect](/enterprise/latest/plugins/openid-connect), you must a
 
 At this point unauthenticated requests and requests with invalid credentials are still allowed. The anonymous consumer is allowed, and will be applied to any request that does not pass a set of credentials associated with some other consumer.
 
-```
+```bash
 $ curl -s example.com:8000/user-agent
 
 {"user-agent": "curl/7.58.0"}
@@ -61,7 +61,7 @@ $ curl -s example.com:8000/user-agent?apikey=nonsense
 
 We'll now add a Key Auth credential for one consumer, and a Basic Auth credential for another.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers/medvezhonok/basic-auth \
     -H "Content-Type: application/json" \
     --data '{"username": "medvezhonok", "password": "hunter2"}'
@@ -78,7 +78,7 @@ $ curl -sX POST kong-admin:8001/consumers/ezhik/key-auth \
 
 Lastly, we add a Request Terminator to the anonymous consumer.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "request-termination", "config": { "status_code": 401, "content_type": "application/json; charset=utf-8", "body": "{\"error\": \"Authentication required\"}"} }'
@@ -88,7 +88,7 @@ $ curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/p
 
 Requests with missing or invalid credentials are now rejected, whereas authorized requests using either authentication method are allowed.
 
-```
+```bash
 $ curl -s example.com:8000/user-agent?apikey=nonsense
 
 {"error": "Authentication required"}

--- a/app/enterprise/0.32-x/setting-up-admin-api-rbac.md
+++ b/app/enterprise/0.32-x/setting-up-admin-api-rbac.md
@@ -99,7 +99,7 @@ kong restart
 
 RBAC policies will now be enforced by Kong, based on the user token presented to the request. By default, this user token should be presented via the Kong-Admin-Token request header; the name of this header is configurable via the Kong configuration file. In order to test our setup, we can send a request to the Admin API without sending an authentication. Because Kong does not recognize a user associated with the requesting client, it will reject the request:
 
-```
+```bash
 $ curl -i http://localhost:8001/status
 HTTP/1.1 401 Unauthorized
 Date: Fri, 04 Aug 2017 22:06:00 GMT
@@ -114,7 +114,7 @@ Server: kong/0.11.0
 
 By sending a request with our user's token, we will be granted read access to the resource in question.
 
-```
+```bash
 $ curl -H "Kong-Admin-Token: 12345" -i http://localhost:8001/status
 HTTP/1.1 200 OK
 Date: Fri, 04 Aug 2017 22:09:25 GMT
@@ -127,7 +127,7 @@ Server: kong/0.11.0
 
 We can also see that attempting to create a new resource with our RBAC user is not permitted, as they are not assigned any roles that have permissions with create access:
 
-```
+```bash
 $ curl -H "Kong-Admin-Token: 12345" -i http://localhost:8001/consumers -d name=alic
 HTTP/1.1 401 Unauthorized
 Date: Fri, 04 Aug 2017 22:15:47 GMT

--- a/app/enterprise/0.33-x/allowing-multiple-authentication-methods.md
+++ b/app/enterprise/0.33-x/allowing-multiple-authentication-methods.md
@@ -7,7 +7,7 @@ The default behavior for Kong authentication plugins is to require credentials f
 
 To begin, [create an API](/latest/getting-started/adding-your-api/) and then create three consumers:
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers \
     -H "Content-Type: application/json" \
     --data '{"username": "anonymous"}'
@@ -31,7 +31,7 @@ The `anonymous` consumer does not correspond to any real user, and will only ser
 
 Next, we add both Key Auth and Basic Auth plugins to our consumer, and set the anonymous fallback to the consumer we created earlier.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/apis/example-api/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "key-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
@@ -49,7 +49,7 @@ If using [OpenID Connect](/enterprise/latest/plugins/openid-connect), you must a
 
 At this point unauthenticated requests and requests with invalid credentials are still allowed. The anonymous consumer is allowed, and will be applied to any request that does not pass a set of credentials associated with some other consumer.
 
-```
+```bash
 $ curl -s example.com:8000/user-agent
 
 {"user-agent": "curl/7.58.0"}
@@ -61,7 +61,7 @@ $ curl -s example.com:8000/user-agent?apikey=nonsense
 
 We'll now add a Key Auth credential for one consumer, and a Basic Auth credential for another.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers/medvezhonok/basic-auth \
     -H "Content-Type: application/json" \
     --data '{"username": "medvezhonok", "password": "hunter2"}'
@@ -78,7 +78,7 @@ $ curl -sX POST kong-admin:8001/consumers/ezhik/key-auth \
 
 Lastly, we add a Request Terminator to the anonymous consumer.
 
-```
+```bash
 $ curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "request-termination", "config": { "status_code": 401, "content_type": "application/json; charset=utf-8", "body": "{\"error\": \"Authentication required\"}"} }'
@@ -88,7 +88,7 @@ $ curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/p
 
 Requests with missing or invalid credentials are now rejected, whereas authorized requests using either authentication method are allowed.
 
-```
+```bash
 $ curl -s example.com:8000/user-agent?apikey=nonsense
 
 {"error": "Authentication required"}

--- a/app/enterprise/0.33-x/rbac/overview.md
+++ b/app/enterprise/0.33-x/rbac/overview.md
@@ -57,7 +57,7 @@ to the Admin API without sending an authentication. Because Kong does not
 recognize a user associated with the requesting client, it rejects the
 request:
 
-```
+```bash
 $ curl -i http://localhost:8001/status
 HTTP/1.1 401 Unauthorized
 Access-Control-Allow-Origin: *
@@ -74,7 +74,7 @@ Transfer-Encoding: chunked
 By sending a request with a valid user token, we are granted read access to
 the resource in question:
 
-```
+```bash
 $ curl -H "Kong-Admin-Token: 12345" -i http://localhost:8001/status
 HTTP/1.1 200 OK
 Date: Fri, 04 Aug 2017 22:09:25 GMT
@@ -89,7 +89,7 @@ Attempting to create a new resource which our RBAC user is also
 not permitted, as it is not assigned any roles that have permissions with
 create access:
 
-```
+```bash
 $ curl -H "Kong-Admin-Token: 12345" -i http://localhost:8001/consumers -d name=alice
 HTTP/1.1 403 Forbidden
 Access-Control-Allow-Origin: *


### PR DESCRIPTION
### Summary

Add bash annotations to markdown code snippets throughout the documentation.
I.e., replace

    ```
    $ some_command

with

    ```bash
    $ some_command

where appropriate.

### Issues resolved

Needed for #969 

### Checklist:

- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation, N/A
- [x] Spellchecked my updates
- [x] Ready to be merged

