### PR TITLE
Switch to Kramdown engine

### DIFF
--- a/jekyll.yml
+++ b/jekyll.yml
@@ -3,17 +3,7 @@ source: app
 destination: dist
 permalink: pretty
 timezone: America/San_Francisco
-markdown: redcarpet
-redcarpet:
-  extensions:
-    - fenced_code_blocks
-    - no_intra_emphasis
-    - autolink
-    - with_toc_data
-    - strikethrough
-    - lax_html_blocks
-    - superscript
-    - tables
+markdown: kramdown
 
 keep_files:
   - assets


### PR DESCRIPTION
### Summary
Switch to Jekyll's default markdown engine **Kramdown**.

Kramdown fixes the [TOC issue](https://github.com/Kong/docs.konghq.com/pull/920#issuecomment-428736885) present in articles with duplicate headings, such as https://docs.konghq.com/0.14.x/admin-api/.

Additionally, before migrating from existing engine Redcarpet, the following points need to be verified to make sure nothing breaks in the docs:

- [x] No [autolink](https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use) usages in the articles
- [x] No [superscript](https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use) usages in the articles
- [x] No markdown present inside html blocks. If so, add [markdown="1"](https://kramdown.gettalong.org/syntax.html#html-blocks) attribute to these html tags
- [x] Visual comparison (non-exhaustive) between redcarpet and kramdown versions does not reveal any differences in articles (especially with ubiquitous components like code snippets, tables etc.)

Found no instances of the above in the docs. Someone more familiar with the contents of the docs could verify.

### Full changelog
* Update Jekyll config to use Kramdown instead of Redcarpet

### Issues resolved
Fix #933, #942  

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation N/A
- [x] Spellchecked my updates
- [x] Ready to be merged