### PR TITLE
docs(plugins-dev) remove mentions of `hooks.lua`

### DIFF
--- a/app/0.11.x/plugin-development/entities-cache.md
+++ b/app/0.11.x/plugin-development/entities-cache.md
@@ -10,7 +10,6 @@ chapter: 7
 
 ```
 "kong.plugins.<plugin_name>.daos"
-"kong.plugins.<plugin_name>.hooks"
 ```
 
 ---

--- a/app/0.11.x/plugin-development/file-structure.md
+++ b/app/0.11.x/plugin-development/file-structure.md
@@ -102,7 +102,6 @@ Next: [Write custom logic &rsaquo;]({{page.book.next}})
 
 [api.lua]: {{page.book.chapters.admin-api}}
 [daos.lua]: {{page.book.chapters.custom-entities}}
-[hooks.lua]: {{page.book.chapters.plugin-configuration}}
 [handler.lua]: {{page.book.chapters.custom-logic}}
 [schema.lua]: {{page.book.chapters.plugin-configuration}}
 [migrations/*.lua]: {{page.book.chapters.custom-entities}}

--- a/app/0.12.x/plugin-development/entities-cache.md
+++ b/app/0.12.x/plugin-development/entities-cache.md
@@ -10,7 +10,6 @@ chapter: 7
 
 ```
 "kong.plugins.<plugin_name>.daos"
-"kong.plugins.<plugin_name>.hooks"
 ```
 
 ---

--- a/app/0.12.x/plugin-development/file-structure.md
+++ b/app/0.12.x/plugin-development/file-structure.md
@@ -102,7 +102,6 @@ Next: [Write custom logic &rsaquo;]({{page.book.next}})
 
 [api.lua]: {{page.book.chapters.admin-api}}
 [daos.lua]: {{page.book.chapters.custom-entities}}
-[hooks.lua]: {{page.book.chapters.plugin-configuration}}
 [handler.lua]: {{page.book.chapters.custom-logic}}
 [schema.lua]: {{page.book.chapters.plugin-configuration}}
 [migrations/*.lua]: {{page.book.chapters.custom-entities}}

--- a/app/0.13.x/plugin-development/entities-cache.md
+++ b/app/0.13.x/plugin-development/entities-cache.md
@@ -10,7 +10,6 @@ chapter: 7
 
 ```
 "kong.plugins.<plugin_name>.daos"
-"kong.plugins.<plugin_name>.hooks"
 ```
 
 ---
@@ -238,8 +237,7 @@ somehow abusing the caching mechanism.
 
 In those cases, you can manually setup your own subscriber to the same
 invalidation channels Kong is listening to, and perform your own, custom
-invalidation work. This process is similar to the old `hooks.lua` module that
-was required in < 0.11.0 for cache invalidations.
+invalidation work.
 
 To listen on invalidation channels inside of Kong, implement the following in
 your plugin's `init_worker` handler:

--- a/app/0.13.x/plugin-development/file-structure.md
+++ b/app/0.13.x/plugin-development/file-structure.md
@@ -102,7 +102,6 @@ Next: [Write custom logic &rsaquo;]({{page.book.next}})
 
 [api.lua]: {{page.book.chapters.admin-api}}
 [daos.lua]: {{page.book.chapters.custom-entities}}
-[hooks.lua]: {{page.book.chapters.plugin-configuration}}
 [handler.lua]: {{page.book.chapters.custom-logic}}
 [schema.lua]: {{page.book.chapters.plugin-configuration}}
 [migrations/*.lua]: {{page.book.chapters.custom-entities}}

--- a/app/0.14.x/plugin-development/file-structure.md
+++ b/app/0.14.x/plugin-development/file-structure.md
@@ -117,7 +117,6 @@ Next: [Write custom logic &rsaquo;]({{page.book.next}})
 
 [api.lua]: {{page.book.chapters.admin-api}}
 [daos.lua]: {{page.book.chapters.custom-entities}}
-[hooks.lua]: {{page.book.chapters.plugin-configuration}}
 [handler.lua]: {{page.book.chapters.custom-logic}}
 [schema.lua]: {{page.book.chapters.plugin-configuration}}
 [migrations/*.lua]: {{page.book.chapters.custom-entities}}


### PR DESCRIPTION
### Summary

Removed in Kong 0.11, the old `hooks.lua` module is irrelevant to
subsequent versions of the plugins development guide. See:

https://github.com/Kong/kong/blob/master/CHANGELOG.md#0110---20170816

We keep the note on how the new process is similar to pre-0.11 in 0.11
and 0.12 versions, but remove this note from the 0.13 version.

The 0.14 version already got rid of mentions of the `hooks.lua` module.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? --> NA
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
