### PR TITLE
style(*) Fix mis-ordered headings in older docs

### DIFF
--- a/app/0.10.x/admin-api.md
+++ b/app/0.10.x/admin-api.md
@@ -737,7 +737,7 @@ values for some specific Consumers, you can do so by specifying the
 
 See the [Precedence](#precedence) section below for more details.
 
-#### Precedence
+### Precedence
 
 Plugins can be added globally (all APIs), on a single API, single Consumer,
 or a combination of both an API and a Consumer. Additionally, a given plugin
@@ -816,7 +816,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.10.x/cli.md
+++ b/app/0.10.x/cli.md
@@ -10,7 +10,7 @@ current machine).
 
 If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
 
-### Global flags
+## Global flags
 
 All commands take a set of special, optional flags as arguments:
 
@@ -20,9 +20,9 @@ All commands take a set of special, optional flags as arguments:
 
 [Back to TOC](#table-of-contents)
 
-### Available commands
+## Available commands
 
-#### kong check
+### kong check
 
 ```
 Usage: kong check <conf>
@@ -36,7 +36,7 @@ Check the validity of a given Kong configuration file.
 
 ---
 
-#### kong cluster
+### kong cluster
 
 ```
 Usage: kong cluster COMMAND [OPTIONS]
@@ -74,7 +74,7 @@ Options:
 
 ---
 
-#### kong compile
+### kong compile
 
 For a detailed example of this command, see the
 [Embedding Kong](/{{page.kong_version}}/configuration#embedding-kong)
@@ -108,7 +108,7 @@ Options:
 
 ---
 
-#### kong health
+### kong health
 
 ```
 Usage: kong health [OPTIONS]
@@ -123,7 +123,7 @@ Options:
 
 ---
 
-#### kong migrations
+### kong migrations
 
 ```
 Usage: kong migrations COMMAND [OPTIONS]
@@ -143,7 +143,7 @@ Options:
 
 ---
 
-#### kong quit
+### kong quit
 
 ```
 Usage: kong quit [OPTIONS]
@@ -165,7 +165,7 @@ Options:
 
 ---
 
-#### kong reload
+### kong reload
 
 ```
 Usage: kong reload [OPTIONS]
@@ -188,7 +188,7 @@ Options:
 
 ---
 
-#### kong restart
+### kong restart
 
 ```
 Usage: kong restart [OPTIONS]
@@ -209,7 +209,7 @@ Options:
 
 ---
 
-#### kong start
+### kong start
 
 ```
 Usage: kong start [OPTIONS]
@@ -227,7 +227,7 @@ Options:
 
 ---
 
-#### kong stop
+### kong stop
 
 ```
 Usage: kong stop [OPTIONS]
@@ -245,7 +245,7 @@ Options:
 
 ---
 
-#### kong version
+### kong version
 
 ```
 Usage: kong version [OPTIONS]

--- a/app/0.10.x/configuration.md
+++ b/app/0.10.x/configuration.md
@@ -4,7 +4,7 @@ title: Configuration Reference
 
 # Configuration Reference
 
-### Configuration loading
+## Configuration loading
 
 Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
@@ -36,7 +36,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 [Back to TOC](#table-of-contents)
 
-### Verifying your configuration
+## Verifying your configuration
 
 You can verify the integrity of your settings with the `check` command:
 
@@ -67,7 +67,7 @@ $ kong start -c <kong.conf> --vv
 
 [Back to TOC](#table-of-contents)
 
-### Environment variables
+## Environment variables
 
 When loading properties out of a configuration file, Kong will also look for
 environment variables of the same name. This allows you to fully configure Kong
@@ -91,13 +91,13 @@ $ export KONG_LOG_LEVEL=error
 
 [Back to TOC](#table-of-contents)
 
-### Custom Nginx configuration & embedding Kong
+## Custom Nginx configuration & embedding Kong
 
 Tweaking the Nginx configuration is an essential part of setting up your Kong
 instances since it allows you to optimize its performance for your
 infrastructure, or embed Kong in an already running OpenResty instance.
 
-#### Custom Nginx configuration
+### Custom Nginx configuration
 
 Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
@@ -187,7 +187,7 @@ http {
 }
 ```
 
-#### Serving both a website and your APIs from Kong
+### Serving both a website and your APIs from Kong
 
 A common use case for API providers is to make Kong serve both a website
 and the APIs themselves over the Proxy port &mdash; `80` or `443` in
@@ -251,7 +251,7 @@ http {
 
 [Back to TOC](#table-of-contents)
 
-#### Embed Kong in OpenResty
+### Embed Kong in OpenResty
 
 If you are running your own OpenResty servers, you can also easily embed Kong
 by including the Kong Nginx sub-configuration using the `include` directive
@@ -275,11 +275,11 @@ $ nginx -c /usr/local/openresty/conf/nginx.conf
 
 [Back to TOC](#table-of-contents)
 
-### Properties reference
+## Properties reference
 
-#### General section
+### General section
 
-##### prefix
+#### prefix
 
 Working directory. Equivalent to Nginx's prefix path, containing temporary files
 and logs. Each Kong process must have a separate working directory.
@@ -288,7 +288,7 @@ Default: `/usr/local/kong`
 
 ---
 
-##### log_level
+#### log_level
 
 Log level of the Nginx server. Logs can be found at `<prefix>/logs/error.log`
 
@@ -299,7 +299,7 @@ Default: `notice`
 
 ---
 
-##### proxy_access_log
+#### proxy_access_log
 
 Path for proxy port request access logs. Set this value to `off` to disable
 logging proxy requests. If this value is a relative path, it will be placed
@@ -309,7 +309,7 @@ Default: `logs/access.log`
 
 ---
 
-##### proxy_error_log
+#### proxy_error_log
 
 Path for proxy port request error logs. Granularity of these logs is adjusted
 by the `log_level` directive.
@@ -318,7 +318,7 @@ Default: `logs/error.log`
 
 ---
 
-##### admin_access_log
+#### admin_access_log
 
 Path for Admin API request access logs. Set this value to `off` to disable
 logging Admin API requests. If this value is a relative path, it will be placed
@@ -328,7 +328,7 @@ Default: `logs/admin_access.log`
 
 ---
 
-##### admin_error_log
+#### admin_error_log
 
 Path for Admin API request error logs. Granularity of these logs is adjusted by
 the `log_level` directive.
@@ -337,7 +337,7 @@ Default: `logs/error.log`
 
 ---
 
-##### custom_plugins
+#### custom_plugins
 
 Comma-separated list of additional plugins this node should load. Use this
 property to load custom plugins that are not bundled with Kong. Plugins will
@@ -349,7 +349,7 @@ Example: `my-plugin,hello-world,custom-rate-limiting`
 
 ---
 
-##### anonymous_reports
+#### anonymous_reports
 
 Send anonymous usage data such as error stack traces to help improve Kong.
 
@@ -359,9 +359,9 @@ Default: `on`
 
 ---
 
-#### Nginx section
+### Nginx section
 
-##### proxy_listen
+#### proxy_listen
 
 Address and port on which Kong will accept HTTP requests. This is the
 public-facing entrypoint of Kong, to which your consumers will make
@@ -376,7 +376,7 @@ Example: `0.0.0.0:80`
 
 ---
 
-##### proxy_listen_ssl
+#### proxy_listen_ssl
 
 Address and port on which Kong will accept HTTPS requests if `ssl` is enabled.
 
@@ -386,7 +386,7 @@ Example: `0.0.0.0:443`
 
 ---
 
-##### admin_listen
+#### admin_listen
 
 Address and port on which Kong will expose an entrypoint to the Admin API.
 This API lets you configure and manage Kong, and should be kept private
@@ -398,7 +398,7 @@ Example: `127.0.0.1:8001`
 
 ---
 
-##### admin_listen_ssl
+#### admin_listen_ssl
 
 Address and port on which Kong will accept HTTPS requests to the Admin API if
 `admin_ssl` is enabled.
@@ -409,7 +409,7 @@ Example: `127.0.0.1:8444`
 
 ---
 
-##### nginx_worker_processes
+#### nginx_worker_processes
 
 Determines the number of worker processes spawned by Nginx.
 See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed
@@ -419,7 +419,7 @@ Default: `auto`
 
 ---
 
-##### nginx_daemon
+#### nginx_daemon
 
 Determines whether Nginx will run as a daemon or as a foreground process.
 Mainly useful for development or when running Kong inside a Docker environment.
@@ -430,7 +430,7 @@ Default: `on`
 
 ---
 
-##### mem_cache_size
+#### mem_cache_size
 
 Size of the in-memory cache for database entities. The accepted units are `k` and
 `m`, with a minimum recommended value of a few MBs.
@@ -439,7 +439,7 @@ Default: `128m`
 
 ---
 
-##### ssl
+#### ssl
 
 Determines if Nginx should be listening for HTTPS traffic on the
 `proxy_listen_ssl` address. If disabled, Nginx will only bind itself
@@ -449,7 +449,7 @@ Default: `on`
 
 ---
 
-##### ssl_cipher_suite
+#### ssl_cipher_suite
 
 Defines the TLS ciphers served by Nginx. Accepted values are `modern`,
 `intermediate`, `old`, or `custom`.
@@ -460,7 +460,7 @@ Default: `modern`
 
 ---
 
-##### ssl_ciphers
+#### ssl_ciphers
 
 Defines a custom list of TLS ciphers to be served by Nginx. This list must
 conform to the pattern defined by `openssl ciphers`. This value is ignored if
@@ -470,7 +470,7 @@ Default: none
 
 ---
 
-##### ssl_cert
+#### ssl_cert
 
 If `ssl` is enabled, the absolute path to the SSL certificate for the
 `proxy_listen_ssl` address. If none is specified and `ssl` is enabled, Kong will
@@ -480,7 +480,7 @@ Default: none
 
 ---
 
-##### ssl_cert_key
+#### ssl_cert_key
 
 If `ssl` is enabled, the absolute path to the SSL key for the
 `proxy_listen_ssl` address.
@@ -489,7 +489,7 @@ Default: none
 
 ---
 
-##### client_ssl
+#### client_ssl
 
 Determines if Nginx should send client-side SSL certificates when proxying
 requests.
@@ -498,7 +498,7 @@ Default: `off`
 
 ---
 
-##### client_ssl_cert
+#### client_ssl_cert
 
 If `client_ssl` is enabled, the absolute path to the client SSL certificate for
 the `proxy_ssl_certificate` directive. Note that this value is statically
@@ -508,7 +508,7 @@ Default: none
 
 ---
 
-##### client_ssl_cert_key
+#### client_ssl_cert_key
 
 If `client_ssl` is enabled, the absolute path to the client SSL key for the
 `proxy_ssl_certificate_key` address. Note this value is statically defined on
@@ -518,7 +518,7 @@ Default: none
 
 ---
 
-##### admin_ssl
+#### admin_ssl
 
 Determines if Nginx should be listening for HTTPS traffic on the
 `admin_listen_ssl` address. If disabled, Nginx will only bind itself on
@@ -528,7 +528,7 @@ Default: `on`
 
 ---
 
-##### admin_ssl_cert
+#### admin_ssl_cert
 
 If `admin_ssl` is enabled, the absolute path to the SSL certificate for the
 `admin_listen_ssl` address. If none is specified and `admin_ssl` is enabled,
@@ -538,7 +538,7 @@ Default: none
 
 ---
 
-##### admin_ssl_cert_key
+#### admin_ssl_cert_key
 
 If `admin_ssl` is enabled, the absolute path to the SSL key for the
 `admin_listen_ssl` address.
@@ -547,7 +547,7 @@ Default: none
 
 ---
 
-##### upstream_keepalive
+#### upstream_keepalive
 
 Sets the maximum number of idle keepalive connections to upstream servers that
 are preserved in the cache of each worker process. When this number is
@@ -557,7 +557,7 @@ Default: `60`
 
 ---
 
-##### server_tokens
+#### server_tokens
 
 Enables or disables emitting Kong version on error pages and in the `Server`
 or `Via` (in case the request was proxied) response header field.
@@ -566,7 +566,7 @@ Default: `on`
 
 ---
 
-##### latency_tokens
+#### latency_tokens
 
 Enables or disables emitting Kong latency information in the `X-Kong-Proxy-Latency` 
 and `X-Kong-Upstream-Latency` response header fields.
@@ -577,7 +577,7 @@ Default: `on`
 
 ---
 
-#### Datastore section
+### Datastore section
 
 Kong will store all of its data (such as APIs, Consumers and Plugins) in
 either Cassandra or PostgreSQL.
@@ -587,7 +587,7 @@ same database.
 
 ---
 
-##### database
+#### database
 
 Determines which of PostgreSQL or Cassandra this node will use as its
 datastore. Accepted values are `postgres` and `cassandra`.
@@ -596,7 +596,7 @@ Default: `postgres`
 
 ---
 
-##### Postgres settings
+#### Postgres settings
 
 name                  |  description
 ----------------------|-------------------
@@ -610,7 +610,7 @@ name                  |  description
 
 ---
 
-##### Cassandra settings
+#### Cassandra settings
 
 name                            | description
 --------------------------------|------------------
@@ -635,7 +635,7 @@ name                            | description
 
 ---
 
-#### Clustering section
+### Clustering section
 
 In addition to pointing to the same database, each Kong node must join the
 same cluster.
@@ -652,7 +652,7 @@ https://docs.konghq.com/latest/clustering/
 
 ---
 
-##### cluster_listen
+#### cluster_listen
 
 Address and port used to communicate with other nodes in the cluster.
 All other Kong nodes in the same cluster must be able to communicate over both
@@ -662,7 +662,7 @@ Default: `0.0.0.0:7946`
 
 ---
 
-##### cluster_listen_rpc
+#### cluster_listen_rpc
 
 Address and port used to communicate with the cluster through the agent
 running on this node. Only contains TCP traffic local to this node.
@@ -671,7 +671,7 @@ Default: `127.0.0.1:7373`
 
 ---
 
-##### cluster_advertise
+#### cluster_advertise
 
 By default, the `cluster_listen` address is advertised over the cluster.
 If the `cluster_listen` host is '0.0.0.0', then the first local, non-loopback
@@ -684,7 +684,7 @@ Default: none
 
 ---
 
-##### cluster_encrypt_key
+#### cluster_encrypt_key
 
 Base64-encoded 16-bytes key to encrypt cluster traffic with.
 
@@ -692,7 +692,7 @@ Default: none
 
 ---
 
-##### cluster_keyring_file
+#### cluster_keyring_file
 
 Specifies a file to load keyring data from.
 Kong is able to keep encryption keys in sync
@@ -706,7 +706,7 @@ Default: none
 
 ---
 
-##### cluster_ttl_on_failure
+#### cluster_ttl_on_failure
 
 Time to live (in seconds) of a node in the cluster when it stops sending
 healthcheck pings, possibly caused by a node or network failure.
@@ -719,7 +719,7 @@ Default: `3600`
 
 ---
 
-##### cluster_profile
+#### cluster_profile
 
 The timing profile for inter-cluster pings and timeouts. If a `lan` or `local`
 profile is used over the Internet, a high rate of failures is risked as the
@@ -733,7 +733,7 @@ Default: `wan`
 
 ---
 
-#### DNS resolver section
+### DNS resolver section
 
 Kong will resolve hostnames as either `SRV` or `A` records (in that order, and
 `CNAME` records will be dereferenced in the process).
@@ -747,7 +747,7 @@ field entries in the record.
 
 ---
 
-##### dns_resolver
+#### dns_resolver
 
 Comma separated list of nameservers, each
 entry in `ipv4[:port]` format to be used by
@@ -759,7 +759,7 @@ Default: none
 
 ---
 
-##### dns_hostsfile
+#### dns_hostsfile
 
 The hosts file to use. This file is read once and its content is static
 in memory. To read the file again after modifying it, Kong must be reloaded.
@@ -770,7 +770,7 @@ Default: `/etc/hosts`
 
 ---
 
-#### Development & miscellaneous section
+### Development & miscellaneous section
 
 Additional settings inherited from lua-nginx-module allowing for more
 flexibility and advanced usage.
@@ -780,7 +780,7 @@ https://github.com/openresty/lua-nginx-module
 
 ---
 
-##### lua_ssl_trusted_certificate
+#### lua_ssl_trusted_certificate
 
 Absolute path to the certificate authority file for Lua cosockets in PEM
 format. This certificate will be the one used for verifying Kong's database
@@ -792,7 +792,7 @@ Default: none
 
 ---
 
-##### lua_ssl_verify_depth
+#### lua_ssl_verify_depth
 
 Sets the verification depth in the server certificates chain used by Lua
 cosockets, set by `lua_ssl_trusted_certificate`.
@@ -805,7 +805,7 @@ Default: `1`
 
 ---
 
-##### lua_code_cache
+#### lua_code_cache
 
 When disabled, every request will run in a separate Lua VM instance: all Lua
 modules will be loaded from scratch. Useful for adopting an edit-and-refresh
@@ -819,7 +819,7 @@ Default: `on`
 
 ---
 
-##### lua_package_path
+#### lua_package_path
 
 Sets the Lua module search path (LUA_PATH). Useful when developing or using
 custom plugins not stored in the default search path.
@@ -830,7 +830,7 @@ Default: none
 
 ---
 
-##### lua_package_cpath
+#### lua_package_cpath
 
 Sets the Lua C module search path (LUA_CPATH).
 
@@ -840,7 +840,7 @@ Default: none
 
 ---
 
-##### lua_socket_pool_size
+#### lua_socket_pool_size
 
 Specifies the size limit for every cosocket connection pool associated with
 every remote server.

--- a/app/0.10.x/getting-started/adding-consumers.md
+++ b/app/0.10.x/getting-started/adding-consumers.md
@@ -22,7 +22,7 @@ management, and more.
 [key-auth][key-auth] plugin. If you haven't, you can either [enable the
 plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -52,7 +52,7 @@ plugin][enabling-plugins] or skip steps two and three.
     consumers][API-consumers] to associate a consumer with your existing user
     database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by
     issuing the following request:
@@ -63,7 +63,7 @@ plugin][enabling-plugins] or skip steps two and three.
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of
     our `Jason` Consumer is valid:
@@ -75,7 +75,7 @@ plugin][enabling-plugins] or skip steps two and three.
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of adding APIs, Consumers and enabling
 Plugins, feel free to read more on Kong in one of the following documents:

--- a/app/0.10.x/getting-started/adding-your-api.md
+++ b/app/0.10.x/getting-started/adding-your-api.md
@@ -20,7 +20,7 @@ helpful for learning how Kong proxies your API requests.
 Kong exposes a [RESTful Admin API][API] on port `:8001` for managing the
 configuration of your Kong instance or cluster.
 
-1. ### Add your API using the Admin API
+## 1. Add your API using the Admin API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin])
     to Kong:
@@ -33,7 +33,7 @@ configuration of your Kong instance or cluster.
       --data 'upstream_url=http://mockbin.org'
     ```
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     You should see a similar response from that request:
 
@@ -63,7 +63,7 @@ configuration of your Kong instance or cluster.
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding
     requests to your API. Note that [by default][proxy-port] Kong handles proxy

--- a/app/0.10.x/getting-started/enabling-plugins.md
+++ b/app/0.10.x/getting-started/enabling-plugins.md
@@ -25,7 +25,7 @@ plugin, **only** requests with the correct API key(s) will be proxied - all
 other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
-1. ### Configure the key-auth plugin for your API
+## 1. Configure the key-auth plugin for your API
 
     Issue the following cURL request on the previously created API named
     `example-api`:
@@ -40,7 +40,7 @@ from unauthorized use.
     defaults to `[apikey]`. It is a list of headers and parameters names (both
     are supported) that are supposed to contain the API key during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth]
     plugin was properly configured on the API:
@@ -63,7 +63,7 @@ from unauthorized use.
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add
 consumers to your API so we can continue proxying requests through Kong.

--- a/app/0.10.x/getting-started/introduction.md
+++ b/app/0.10.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.10.x/getting-started/quickstart.md
+++ b/app/0.10.x/getting-started/quickstart.md
@@ -15,7 +15,7 @@ interface, through which you manage your APIs, consumers, and more. Data sent
 through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
 supports PostgreSQL and Cassandra).
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -26,7 +26,7 @@ supports PostgreSQL and Cassandra).
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`)
     option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare your database.
     Once these have finished you should see a message (`Kong started`)
@@ -42,7 +42,7 @@ supports PostgreSQL and Cassandra).
 - `:8001` on which the [Admin API][API] used to configure Kong listens.
 - `:8444` on which the Admin API listens for HTTPS traffic.
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following
     [command][CLI]:
@@ -51,7 +51,7 @@ supports PostgreSQL and Cassandra).
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -59,7 +59,7 @@ supports PostgreSQL and Cassandra).
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.10.x/loadbalancing.md
+++ b/app/0.10.x/loadbalancing.md
@@ -8,7 +8,7 @@ Kong provides multiple ways of load balancing requests to multiple backend servi
 a straightforward DNS-based method, and a more dynamic ring-balancer that also
 allows for service registry without needing a DNS server.
 
-### DNS-based loadbalancing
+## DNS-based loadbalancing
 
 When using DNS based load balancing the registration of the backend services is
 done outside of Kong, and Kong only receives updates from the DNS server.
@@ -25,7 +25,7 @@ updates/changes will be very low.
 
 [Back to TOC](#table-of-contents)
 
-#### A records
+### A records
 
 An A record contains one or more IP addresses. Hence, when a hostname
 resolves to an A record, each backend service must have its own IP address.
@@ -39,7 +39,7 @@ make sure that even with a `ttl` of 0 the load is properly distributed.
 
 [Back to TOC](#table-of-contents)
 
-#### SRV records
+### SRV records
 
 An SRV record contains weight and port information for all of its IP addresses.
 A backend service can be identified by a unique combination of IP address 
@@ -67,7 +67,7 @@ especially with a very small (or even 0) `ttl` value.
 
 [Back to TOC](#table-of-contents)
 
-#### DNS priorities
+### DNS priorities
 
 The DNS resolver will start resolving the following record types in order:
 
@@ -83,7 +83,7 @@ it will fallback on an A query, etc.
 
 [Back to TOC](#table-of-contents)
 
-### Ring-balancer
+## Ring-balancer
 
 When using the ring-balancer, the adding and removing of backend services will
 be handled by Kong, and no DNS updates will be necessary. Kong will act as the
@@ -102,7 +102,7 @@ entities.
 
 [Back to TOC](#table-of-contents)
 
-#### Upstream
+### Upstream
 
 Each upstream gets its own ring-balancer. Each `upstream` can have many 
 `target` entries attached to it, and requests proxied to the 'virtual hostname' 
@@ -139,7 +139,7 @@ distribution, but the more expensive the changes are (add/removing targets)
 
 [Back to TOC](#table-of-contents)
 
-#### Target
+### Target
 
 Because the `upstream` maintains a history of changes, targets can only be 
 added, not modified nor deleted. To change a target, just add a new entry for
@@ -172,7 +172,7 @@ to this target it will query the nameserver again.
 
 [Back to TOC](#table-of-contents)
 
-### Blue-Green Deployments
+## Blue-Green Deployments
 
 Using the ring-balancer a [blue-green deployment][blue-green-canary] can be easily orchestrated for 
 an API. Switching target infrastructure only requires a `PATCH` request on an
@@ -241,7 +241,7 @@ requests will be dropped.
 
 [Back to TOC](#table-of-contents)
 
-### Canary Releases
+## Canary Releases
 
 Using the ring-balancer, target weights can be adjusted granularly, allowing
 for a smooth, controlled [canary release][blue-green-canary].

--- a/app/0.10.x/plugin-development/access-the-datastore.md
+++ b/app/0.10.x/plugin-development/access-the-datastore.md
@@ -12,7 +12,7 @@ As of `0.8.0`, Kong supports two primary datastores: [Cassandra {{site.data.kong
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -34,7 +34,7 @@ local plugins_dao = singletons.dao.plugins
 
 ---
 
-### The DAO Lua API
+## The DAO Lua API
 
 The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
 

--- a/app/0.10.x/plugin-development/admin-api.md
+++ b/app/0.10.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses.
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.10.x/plugin-development/custom-entities.md
+++ b/app/0.10.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -21,7 +21,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
 
@@ -103,7 +103,7 @@ While Postgres does, Cassandra does not support constraints such as "NOT NULL", 
 **IMPORTANT**: if your `schema` uses a `unique` constraint, then Kong will enforce it for Cassandra, but for Postgres you must set this constraint in the `migrations` file.
 ---
 
-### Retrieve your custom DAO from the Dao Factory
+## Retrieve your custom DAO from the Dao Factory
 
 To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
 
@@ -162,7 +162,7 @@ The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Fa
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.10.x/plugin-development/custom-logic.md
+++ b/app/0.10.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -22,7 +22,7 @@ Kong allows you to execute custom code at different times in the lifecycle of a 
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts. Each function to implement in your `handler.lua` file will be executed when the context is reached for a request:
 
@@ -48,7 +48,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish to be executed. In favor of brevity, here is a commented example module implementing all the available methods:
 
@@ -168,7 +168,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on how plugins execution order should be configurable in the future, see <a href="https://github.com/Kong/kong/issues/267">Kong/kong#267</a>.

--- a/app/0.10.x/plugin-development/distribution.md
+++ b/app/0.10.x/plugin-development/distribution.md
@@ -14,7 +14,7 @@ plugin(s).
 These steps should be applied to each node in your Kong cluster, to ensure the
 custom plugin(s) are available on each one of them.
 
-### Packaging sources
+## Packaging sources
 
 You can either use a regular packing strategy (eg. `tar`), or use the LuaRocks
 package manager to do it for you. We recommend LuaRocks as it is installed
@@ -63,7 +63,7 @@ The contents of this archive should be close to the following:
 
 ---
 
-### Installing the plugin
+## Installing the plugin
 
 For a Kong node to be able to use the custom plugin, the custom plugin's Lua
 sources must be installed on your host's file system. There are multiple ways
@@ -163,7 +163,7 @@ sources, you must still do so for each node in your Kong cluster.
 
 ---
 
-### Load the plugin
+## Load the plugin
 
 You must now add the custom plugin's name to the `custom_plugins` list in your
 Kong configuration (on each Kong node):
@@ -184,7 +184,7 @@ in your Kong cluster.
 
 ---
 
-### Verify loading the plugin
+## Verify loading the plugin
 
 You should now be able to start Kong without any issue. Consult your custom
 plugin's instructions on how to enable/configure your plugin
@@ -208,7 +208,7 @@ Then, you should see the following log for each plugin being loaded:
 
 ---
 
-### Removing a plugin
+## Removing a plugin
 
 There are three steps to completely remove a plugin.
 
@@ -234,7 +234,7 @@ There are three steps to completely remove a plugin.
 
 ---
 
-### Distribute your plugin
+## Distribute your plugin
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a
 package manager for Lua modules. It calls such modules "rocks". **Your module
@@ -256,7 +256,7 @@ about the format see the LuaRocks [documentation on rockspecs][rockspec].
 
 ---
 
-### Troubleshooting
+## Troubleshooting
 
 Kong can fail to start because of a misconfigured custom plugin for several
 reasons:

--- a/app/0.10.x/plugin-development/entities-cache.md
+++ b/app/0.10.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -30,7 +30,7 @@ To avoid querying the datastore every time, we can cache custom entities in-memo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in your code by requiring the `database_cache` dependency:
 
@@ -108,13 +108,13 @@ end
 
 By doing so it doesn't matter how many requests the client makes with that particular api-key, after the first request every lookup will be done in-memory without querying the datastore.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted on the datastore, for example using the Admin API, it creates an inconsistency between the data in the datastore, and the data cached in-memory in the Kong node. To avoid this inconsistency, we need to delete the cached entity from the in-memory store and force Kong to request it again from the datastore. In order to do so we must implement an invalidation hook.
 
 ---
 
-### Invalidating custom entities
+## Invalidating custom entities
 
 Every time an entity is being created/updated/deleted in the datastore, Kong notifies the datastore operation across all the nodes telling what command has been executed and what entity has been affected by it. This happens for APIs, Plugins and Consumers, but also for custom entities.
 
@@ -169,7 +169,7 @@ In the example above the plugin is listening to the `ENTITY_UPDATED` and `ENTITY
 
 The entities being transmitted in the `entity` and `old_entity` properties do not have all the fields defined in the schema, but only a subset. This is required because every event is sent in a UDP packet with a payload size limit of 512 bytes. This subset is being returned by the `marshall_event` function in the schema, that you can optionally implement.
 
-#### marshall_event
+### marshall_event
 
 This function serializes the custom entity to a minimal version that only includes the fields we will later need to use in `hooks.lua`. If `marshall_event` is not implemented, by default Kong does not send any entity field value along with the event.
 
@@ -201,7 +201,7 @@ In the example above the custom entity provides a `marshall_event` function that
 
 ---
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with Kong to setup their APIs and plugins. It is likely that they also need to be able to interact with the custom entities you implemented for your plugin (for example, creating and deleting API keys). The way you would do this is by extending the Admin API, which we will detail in the next chapter: [Extending the Admin API]({{page.book.next}}).
 

--- a/app/0.10.x/plugin-development/file-structure.md
+++ b/app/0.10.x/plugin-development/file-structure.md
@@ -32,7 +32,7 @@ Now let's describe what are the modules you can implement and what their purpose
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -47,7 +47,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in the database, expose endpoints in the Admin API, etc... Each of those can be done by adding a new module to your plugin. Here is what the structure of a plugin would look like if it was implementing all of the optional modules:
 

--- a/app/0.10.x/plugin-development/index.md
+++ b/app/0.10.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.10.x/plugin-development/plugin-configuration.md
+++ b/app/0.10.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -32,7 +32,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -68,7 +68,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -105,7 +105,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.10.x/plugin-development/tests.md
+++ b/app/0.10.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/) running with the [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are free to use another one if you wish. In the Kong repository, the busted executable can be found at `bin/busted`.
 

--- a/app/0.11.x/admin-api.md
+++ b/app/0.11.x/admin-api.md
@@ -659,7 +659,7 @@ values for some specific Consumers, you can do so by specifying the
 
 See the [Precedence](#precedence) section below for more details.
 
-#### Precedence
+### Precedence
 
 Plugins can be added globally (all APIs), on a single API, single Consumer,
 or a combination of both an API and a Consumer. Additionally, a given plugin
@@ -738,7 +738,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.11.x/cli.md
+++ b/app/0.11.x/cli.md
@@ -10,7 +10,7 @@ current machine).
 
 If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
 
-### Global flags
+## Global flags
 
 All commands take a set of special, optional flags as arguments:
 
@@ -20,9 +20,9 @@ All commands take a set of special, optional flags as arguments:
 
 [Back to TOC](#table-of-contents)
 
-### Available commands
+## Available commands
 
-#### kong check
+### kong check
 
 ```
 Usage: kong check <conf>
@@ -36,7 +36,7 @@ Check the validity of a given Kong configuration file.
 
 ---
 
-#### kong compile
+### kong compile
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This command has been deprecated.
@@ -70,7 +70,7 @@ Options:
 
 ---
 
-#### kong prepare
+### kong prepare
 
 This command prepares the Kong prefix folder, with its sub-folders and files.
 
@@ -95,7 +95,7 @@ Options:
 
 ---
 
-#### kong health
+### kong health
 
 ```
 Usage: kong health [OPTIONS]
@@ -110,7 +110,7 @@ Options:
 
 ---
 
-#### kong migrations
+### kong migrations
 
 ```
 Usage: kong migrations COMMAND [OPTIONS]
@@ -130,7 +130,7 @@ Options:
 
 ---
 
-#### kong quit
+### kong quit
 
 ```
 Usage: kong quit [OPTIONS]
@@ -152,7 +152,7 @@ Options:
 
 ---
 
-#### kong reload
+### kong reload
 
 ```
 Usage: kong reload [OPTIONS]
@@ -175,7 +175,7 @@ Options:
 
 ---
 
-#### kong restart
+### kong restart
 
 ```
 Usage: kong restart [OPTIONS]
@@ -196,7 +196,7 @@ Options:
 
 ---
 
-#### kong start
+### kong start
 
 ```
 Usage: kong start [OPTIONS]
@@ -215,7 +215,7 @@ Options:
 
 ---
 
-#### kong stop
+### kong stop
 
 ```
 Usage: kong stop [OPTIONS]
@@ -233,7 +233,7 @@ Options:
 
 ---
 
-#### kong version
+### kong version
 
 ```
 Usage: kong version [OPTIONS]

--- a/app/0.11.x/clustering.md
+++ b/app/0.11.x/clustering.md
@@ -12,7 +12,7 @@ configuration since they point to the same database. Kong nodes pointing to the
 You need a load-balancer in front of your Kong cluster to distribute traffic
 across your available nodes.
 
-### What a Kong cluster does and doesn't do
+## What a Kong cluster does and doesn't do
 
 **Having a Kong cluster does not mean that your clients traffic will be
 load-balanced across your Kong nodes out of the box.** You still need a
@@ -31,7 +31,7 @@ performance and consistency.
 
 [Back to TOC](#table-of-contents)
 
-### Single node Kong clusters
+## Single node Kong clusters
 
 A single Kong node connected to a database (Cassandra or PostgreSQL) creates a
 Kong cluster of one node. Any changes applied via the Admin API of this node
@@ -52,7 +52,7 @@ $ curl -i http://127.0.0.1:8000/test-api
 
 [Back to TOC](#table-of-contents)
 
-### Multiple nodes Kong clusters
+## Multiple nodes Kong clusters
 
 In a cluster of multiple Kong nodes, other nodes connected to the same database
 would not instantly be notified that the API was deleted by node `A`.  While
@@ -77,7 +77,7 @@ This makes Kong clusters **eventually consistent**.
 
 [Back to TOC](#table-of-contents)
 
-### What is being cached?
+## What is being cached?
 
 All of the core entities such as APIs, Plugins, Consumers, Credentials are
 cached in memory by Kong and depend on their invalidation via the polling
@@ -135,7 +135,7 @@ polling job.
 
 [Back to TOC](#table-of-contents)
 
-### How to configure database caching?
+## How to configure database caching?
 
 You can configure 3 properties in the Kong configuration file, the most
 important one being `db_update_frequency`, which determine where your Kong
@@ -146,7 +146,7 @@ experiment with its clustering capabilities while avoiding "surprises". As you
 prepare a production setup, you should consider tuning those values to ensure
 that your performance constraints are respected.
 
-#### 1. [db_update_frequency][db_update_frequency] (default: 5s)
+### 1. [db_update_frequency][db_update_frequency] (default: 5s)
 
 This value determines the frequency at which your Kong nodes will be polling
 the database for invalidation events. A lower value will mean that the polling
@@ -160,7 +160,7 @@ seconds.
 
 [Back to TOC](#table-of-contents)
 
-#### 2. [db_update_propagation][db_update_propagation] (default: 0s)
+### 2. [db_update_propagation][db_update_propagation] (default: 0s)
 
 If your database itself is eventually consistent (ie: Cassandra), you **must**
 configure this value. It is to ensure that the change has time to propagate
@@ -180,7 +180,7 @@ up to `db_update_frequency + db_update_propagation` seconds.
 
 [Back to TOC](#table-of-contents)
 
-#### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
+### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
 
 The time (in seconds) for which Kong will cache database entities (both hits
 and misses). This Time-To-Live value acts as a safeguard in case a Kong node
@@ -196,7 +196,7 @@ manually purged, or the node is restarted.
 
 [Back to TOC](#table-of-contents)
 
-#### 4. When using Cassandra
+### 4. When using Cassandra
 
 If you use Cassandra as your Kong database, you **must** set
 [db_update_propagation][db_update_propagation] to a non-zero value. Since
@@ -211,13 +211,13 @@ Kong nodes are up-to-date values from your database.
 
 [Back to TOC](#table-of-contents)
 
-### Interacting with the cache via the Admin API
+## Interacting with the cache via the Admin API
 
 If for some reason, you wish to investigate the cached values, or manually
 invalidate a value cached by Kong (a cached hit or miss), you can do so via the
 Admin API `/cache` endpoint.
 
-#### Inspect a cached value
+### Inspect a cached value
 
 **Endpoint**
 
@@ -247,7 +247,7 @@ this process easier.
 
 [Back to TOC](#table-of-contents)
 
-#### Purge a cached value
+### Purge a cached value
 
 **Endpoint**
 
@@ -266,7 +266,7 @@ this process easier.
 
 [Back to TOC](#table-of-contents)
 
-#### Purge a node's cache
+### Purge a node's cache
 
 **Endpoint**
 

--- a/app/0.11.x/getting-started/adding-consumers.md
+++ b/app/0.11.x/getting-started/adding-consumers.md
@@ -22,7 +22,7 @@ management, and more.
 [key-auth][key-auth] plugin. If you haven't, you can either [enable the
 plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -52,7 +52,7 @@ plugin][enabling-plugins] or skip steps two and three.
     consumers][API-consumers] to associate a consumer with your existing user
     database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by
     issuing the following request:
@@ -63,7 +63,7 @@ plugin][enabling-plugins] or skip steps two and three.
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of
     our `Jason` Consumer is valid:
@@ -75,7 +75,7 @@ plugin][enabling-plugins] or skip steps two and three.
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of adding APIs, Consumers and enabling
 Plugins, feel free to read more on Kong in one of the following documents:

--- a/app/0.11.x/getting-started/adding-your-api.md
+++ b/app/0.11.x/getting-started/adding-your-api.md
@@ -20,7 +20,7 @@ helpful for learning how Kong proxies your API requests.
 Kong exposes a [RESTful Admin API][API] on port `:8001` for managing the
 configuration of your Kong instance or cluster.
 
-1. ### Add your API using the Admin API
+## 1. Add your API using the Admin API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin])
     to Kong:
@@ -33,7 +33,7 @@ configuration of your Kong instance or cluster.
       --data 'upstream_url=http://mockbin.org'
     ```
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     You should see a similar response from that request:
 
@@ -63,7 +63,7 @@ configuration of your Kong instance or cluster.
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding
     requests to your API. Note that [by default][proxy-port] Kong handles proxy

--- a/app/0.11.x/getting-started/enabling-plugins.md
+++ b/app/0.11.x/getting-started/enabling-plugins.md
@@ -25,7 +25,7 @@ plugin, **only** requests with the correct API key(s) will be proxied - all
 other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
-1. ### Configure the key-auth plugin for your API
+## 1. Configure the key-auth plugin for your API
 
     Issue the following cURL request on the previously created API named
     `example-api`:
@@ -40,7 +40,7 @@ from unauthorized use.
     defaults to `[apikey]`. It is a list of headers and parameters names (both
     are supported) that are supposed to contain the API key during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth]
     plugin was properly configured on the API:
@@ -63,7 +63,7 @@ from unauthorized use.
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add
 consumers to your API so we can continue proxying requests through Kong.

--- a/app/0.11.x/getting-started/introduction.md
+++ b/app/0.11.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.11.x/getting-started/quickstart.md
+++ b/app/0.11.x/getting-started/quickstart.md
@@ -15,7 +15,7 @@ interface, through which you manage your APIs, consumers, and more. Data sent
 through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
 supports PostgreSQL and Cassandra).
 
-1. ### Start Kong
+## 1. Start Kong
 
     Issue the following command to prepare your datastore by running the Kong
     migrations:
@@ -37,7 +37,7 @@ supports PostgreSQL and Cassandra).
     **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
     allowing you to point to your own configuration.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     If everything went well, you should see a message (`Kong started`)
     informing you that Kong is running.
@@ -52,7 +52,7 @@ supports PostgreSQL and Cassandra).
 - `:8001` on which the [Admin API][API] used to configure Kong listens.
 - `:8444` on which the Admin API listens for HTTPS traffic.
 
-3. ### Stop Kong
+## 3. Stop Kong
 
     As needed you can stop the Kong process by issuing the following
     [command][CLI]:
@@ -61,7 +61,7 @@ supports PostgreSQL and Cassandra).
     $ kong stop
     ```
 
-4. ### Reload Kong
+## 4. Reload Kong
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -69,7 +69,7 @@ supports PostgreSQL and Cassandra).
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.11.x/loadbalancing.md
+++ b/app/0.11.x/loadbalancing.md
@@ -8,7 +8,7 @@ Kong provides multiple ways of load balancing requests to multiple backend servi
 a straightforward DNS-based method, and a more dynamic ring-balancer that also
 allows for service registry without needing a DNS server.
 
-### DNS-based loadbalancing
+## DNS-based loadbalancing
 
 When using DNS based load balancing the registration of the backend services is
 done outside of Kong, and Kong only receives updates from the DNS server.
@@ -25,7 +25,7 @@ updates/changes will be very low.
 
 [Back to TOC](#table-of-contents)
 
-#### A records
+### A records
 
 An A record contains one or more IP addresses. Hence, when a hostname
 resolves to an A record, each backend service must have its own IP address.
@@ -40,7 +40,7 @@ record entries.
 
 [Back to TOC](#table-of-contents)
 
-#### SRV records
+### SRV records
 
 An SRV record contains weight and port information for all of its IP addresses.
 A backend service can be identified by a unique combination of IP address 
@@ -68,7 +68,7 @@ especially with a very small (or even 0) `ttl` value.
 
 [Back to TOC](#table-of-contents)
 
-#### DNS priorities
+### DNS priorities
 
 The DNS resolver will start resolving the following record types in order:
 
@@ -84,7 +84,7 @@ it will fallback on an A query, etc.
 
 [Back to TOC](#table-of-contents)
 
-### Ring-balancer
+## Ring-balancer
 
 When using the ring-balancer, the adding and removing of backend services will
 be handled by Kong, and no DNS updates will be necessary. Kong will act as the
@@ -104,7 +104,7 @@ entities.
 
 [Back to TOC](#table-of-contents)
 
-#### Upstream
+### Upstream
 
 Each upstream gets its own ring-balancer. Each `upstream` can have many 
 `target` entries attached to it, and requests proxied to the 'virtual hostname' 
@@ -141,7 +141,7 @@ distribution, but the more expensive the changes are (add/removing targets)
 
 [Back to TOC](#table-of-contents)
 
-#### Target
+### Target
 
 Because the `upstream` maintains a history of changes, targets can only be 
 added, not modified nor deleted. To change a target, just add a new entry for
@@ -174,7 +174,7 @@ to this target it will query the nameserver again.
 
 [Back to TOC](#table-of-contents)
 
-### Blue-Green Deployments
+## Blue-Green Deployments
 
 Using the ring-balancer a [blue-green deployment][blue-green-canary] can be easily orchestrated for 
 an API. Switching target infrastructure only requires a `PATCH` request on an
@@ -243,7 +243,7 @@ requests will be dropped.
 
 [Back to TOC](#table-of-contents)
 
-### Canary Releases
+## Canary Releases
 
 Using the ring-balancer, target weights can be adjusted granularly, allowing
 for a smooth, controlled [canary release][blue-green-canary].

--- a/app/0.11.x/plugin-development/access-the-datastore.md
+++ b/app/0.11.x/plugin-development/access-the-datastore.md
@@ -12,7 +12,7 @@ As of `0.8.0`, Kong supports two primary datastores: [Cassandra {{site.data.kong
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -34,7 +34,7 @@ local plugins_dao = singletons.dao.plugins
 
 ---
 
-### The DAO Lua API
+## The DAO Lua API
 
 The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
 

--- a/app/0.11.x/plugin-development/admin-api.md
+++ b/app/0.11.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses.
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.11.x/plugin-development/custom-entities.md
+++ b/app/0.11.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -21,7 +21,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
 
@@ -105,7 +105,7 @@ While Postgres does, Cassandra does not support constraints such as "NOT NULL", 
 
 ---
 
-### Retrieve your custom DAO from the Dao Factory
+## Retrieve your custom DAO from the Dao Factory
 
 To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
 
@@ -164,7 +164,7 @@ The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Fa
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.11.x/plugin-development/custom-logic.md
+++ b/app/0.11.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -27,7 +27,7 @@ at: `"kong.plugins.<plugin_name>.handler"`
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts.
 Each function to implement in your `handler.lua` file will be executed when the
@@ -55,7 +55,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish
 to be executed. In favor of brevity, here is a commented example module
@@ -182,7 +182,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on

--- a/app/0.11.x/plugin-development/distribution.md
+++ b/app/0.11.x/plugin-development/distribution.md
@@ -14,7 +14,7 @@ plugin(s).
 These steps should be applied to each node in your Kong cluster, to ensure the
 custom plugin(s) are available on each one of them.
 
-### Packaging sources
+## Packaging sources
 
 You can either use a regular packing strategy (eg. `tar`), or use the LuaRocks
 package manager to do it for you. We recommend LuaRocks as it is installed
@@ -63,7 +63,7 @@ The contents of this archive should be close to the following:
 
 ---
 
-### Installing the plugin
+## Installing the plugin
 
 For a Kong node to be able to use the custom plugin, the custom plugin's Lua
 sources must be installed on your host's file system. There are multiple ways
@@ -163,7 +163,7 @@ sources, you must still do so for each node in your Kong cluster.
 
 ---
 
-### Load the plugin
+## Load the plugin
 
 You must now add the custom plugin's name to the `custom_plugins` list in your
 Kong configuration (on each Kong node):
@@ -184,7 +184,7 @@ in your Kong cluster.
 
 ---
 
-### Verify loading the plugin
+## Verify loading the plugin
 
 You should now be able to start Kong without any issue. Consult your custom
 plugin's instructions on how to enable/configure your plugin
@@ -208,7 +208,7 @@ Then, you should see the following log for each plugin being loaded:
 
 ---
 
-### Removing a plugin
+## Removing a plugin
 
 There are three steps to completely remove a plugin.
 
@@ -234,7 +234,7 @@ There are three steps to completely remove a plugin.
 
 ---
 
-### Distribute your plugin
+## Distribute your plugin
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a
 package manager for Lua modules. It calls such modules "rocks". **Your module
@@ -256,7 +256,7 @@ about the format see the LuaRocks [documentation on rockspecs][rockspec].
 
 ---
 
-### Troubleshooting
+## Troubleshooting
 
 Kong can fail to start because of a misconfigured custom plugin for several
 reasons:

--- a/app/0.11.x/plugin-development/entities-cache.md
+++ b/app/0.11.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -41,7 +41,7 @@ under heavy load).
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in
 your code by using the `singletons.cache` module provided by Kong:
@@ -126,7 +126,7 @@ With the above mechanism in place, once a Consumer has made a request with
 their API key, the cache will be considered warm and subsequent requests
 won't result in a database query.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted in the datastore (i.e.
 using the Admin API), it creates an inconsistency between the data in
@@ -137,7 +137,7 @@ cache invalidation.
 
 ---
 
-### Cache invalidation for your entities
+## Cache invalidation for your entities
 
 If you wish that your cached entities be invalidated upon a CRUD operation
 rather than having to wait for them to reach their TTL, you have to follow
@@ -145,7 +145,7 @@ a few steps. This process can be automated since 0.11.0 for most entities,
 but manually subscribing to some CRUD events might be required to invalidate
 some entities with more complex relationships.
 
-#### Automatic cache invalidation
+### Automatic cache invalidation
 
 Cache invalidation can be provided out of the box for your entities if you
 rely on the `cache_key` property of your entity's schema. For example, in the
@@ -226,7 +226,7 @@ properly fetch the newly created API key from the datastore.
 See the [Clustering Guide](/{{page.kong_version}}/clustering/) to ensure
 that you have properly configured your cluster for such invalidation events.
 
-#### Manual cache invalidation
+### Manual cache invalidation
 
 In some cases, the `cache_key` property of an entity's schema is not flexible
 enough, and one must manually invalidate its cache. Reasons for this could be
@@ -275,7 +275,7 @@ singletons.worker_events.register(function(data)
 end, "crud", "consumers")
 ```
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with
 Kong to setup their APIs and plugins. It is likely that they also need to be

--- a/app/0.11.x/plugin-development/file-structure.md
+++ b/app/0.11.x/plugin-development/file-structure.md
@@ -47,7 +47,7 @@ purpose is.
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -66,7 +66,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in
 the database, expose endpoints in the Admin API, etc... Each of those can be

--- a/app/0.11.x/plugin-development/index.md
+++ b/app/0.11.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.11.x/plugin-development/plugin-configuration.md
+++ b/app/0.11.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -32,7 +32,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -68,7 +68,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -105,7 +105,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.11.x/plugin-development/tests.md
+++ b/app/0.11.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/) running with the [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are free to use another one if you wish. In the Kong repository, the busted executable can be found at `bin/busted`.
 

--- a/app/0.12.x/admin-api.md
+++ b/app/0.12.x/admin-api.md
@@ -682,7 +682,7 @@ values for some specific Consumers, you can do so by specifying the
 
 See the [Precedence](#precedence) section below for more details.
 
-#### Precedence
+### Precedence
 
 Plugins can be added globally (all APIs), on a single API, single Consumer,
 or a combination of both an API and a Consumer. Additionally, a given plugin
@@ -761,7 +761,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.12.x/cli.md
+++ b/app/0.12.x/cli.md
@@ -10,7 +10,7 @@ current machine).
 
 If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
 
-### Global flags
+## Global flags
 
 All commands take a set of special, optional flags as arguments:
 
@@ -20,9 +20,9 @@ All commands take a set of special, optional flags as arguments:
 
 [Back to TOC](#table-of-contents)
 
-### Available commands
+## Available commands
 
-#### kong check
+### kong check
 
 ```
 Usage: kong check <conf>
@@ -36,7 +36,7 @@ Check the validity of a given Kong configuration file.
 
 ---
 
-#### kong prepare
+### kong prepare
 
 This command prepares the Kong prefix folder, with its sub-folders and files.
 
@@ -61,7 +61,7 @@ Options:
 
 ---
 
-#### kong health
+### kong health
 
 ```
 Usage: kong health [OPTIONS]
@@ -76,7 +76,7 @@ Options:
 
 ---
 
-#### kong migrations
+### kong migrations
 
 ```
 Usage: kong migrations COMMAND [OPTIONS]
@@ -96,7 +96,7 @@ Options:
 
 ---
 
-#### kong quit
+### kong quit
 
 ```
 Usage: kong quit [OPTIONS]
@@ -118,7 +118,7 @@ Options:
 
 ---
 
-#### kong reload
+### kong reload
 
 ```
 Usage: kong reload [OPTIONS]
@@ -141,7 +141,7 @@ Options:
 
 ---
 
-#### kong restart
+### kong restart
 
 ```
 Usage: kong restart [OPTIONS]
@@ -162,7 +162,7 @@ Options:
 
 ---
 
-#### kong start
+### kong start
 
 ```
 Usage: kong start [OPTIONS]
@@ -181,7 +181,7 @@ Options:
 
 ---
 
-#### kong stop
+### kong stop
 
 ```
 Usage: kong stop [OPTIONS]
@@ -199,7 +199,7 @@ Options:
 
 ---
 
-#### kong version
+### kong version
 
 ```
 Usage: kong version [OPTIONS]

--- a/app/0.12.x/clustering.md
+++ b/app/0.12.x/clustering.md
@@ -12,7 +12,7 @@ configuration since they point to the same database. Kong nodes pointing to the
 You need a load-balancer in front of your Kong cluster to distribute traffic
 across your available nodes.
 
-### What a Kong cluster does and doesn't do
+## What a Kong cluster does and doesn't do
 
 **Having a Kong cluster does not mean that your clients traffic will be
 load-balanced across your Kong nodes out of the box.** You still need a
@@ -31,7 +31,7 @@ performance and consistency.
 
 [Back to TOC](#table-of-contents)
 
-### Single node Kong clusters
+## Single node Kong clusters
 
 A single Kong node connected to a database (Cassandra or PostgreSQL) creates a
 Kong cluster of one node. Any changes applied via the Admin API of this node
@@ -52,7 +52,7 @@ $ curl -i http://127.0.0.1:8000/test-api
 
 [Back to TOC](#table-of-contents)
 
-### Multiple nodes Kong clusters
+## Multiple nodes Kong clusters
 
 In a cluster of multiple Kong nodes, other nodes connected to the same database
 would not instantly be notified that the API was deleted by node `A`.  While
@@ -77,7 +77,7 @@ This makes Kong clusters **eventually consistent**.
 
 [Back to TOC](#table-of-contents)
 
-### What is being cached?
+## What is being cached?
 
 All of the core entities such as APIs, Plugins, Consumers, Credentials are
 cached in memory by Kong and depend on their invalidation via the polling
@@ -135,7 +135,7 @@ polling job.
 
 [Back to TOC](#table-of-contents)
 
-### How to configure database caching?
+## How to configure database caching?
 
 You can configure 3 properties in the Kong configuration file, the most
 important one being `db_update_frequency`, which determine where your Kong
@@ -146,7 +146,7 @@ experiment with its clustering capabilities while avoiding "surprises". As you
 prepare a production setup, you should consider tuning those values to ensure
 that your performance constraints are respected.
 
-#### 1. [db_update_frequency][db_update_frequency] (default: 5s)
+### 1. [db_update_frequency][db_update_frequency] (default: 5s)
 
 This value determines the frequency at which your Kong nodes will be polling
 the database for invalidation events. A lower value will mean that the polling
@@ -160,7 +160,7 @@ seconds.
 
 [Back to TOC](#table-of-contents)
 
-#### 2. [db_update_propagation][db_update_propagation] (default: 0s)
+### 2. [db_update_propagation][db_update_propagation] (default: 0s)
 
 If your database itself is eventually consistent (ie: Cassandra), you **must**
 configure this value. It is to ensure that the change has time to propagate
@@ -180,7 +180,7 @@ up to `db_update_frequency + db_update_propagation` seconds.
 
 [Back to TOC](#table-of-contents)
 
-#### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
+### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
 
 The time (in seconds) for which Kong will cache database entities (both hits
 and misses). This Time-To-Live value acts as a safeguard in case a Kong node
@@ -196,7 +196,7 @@ manually purged, or the node is restarted.
 
 [Back to TOC](#table-of-contents)
 
-#### 4. When using Cassandra
+### 4. When using Cassandra
 
 If you use Cassandra as your Kong database, you **must** set
 [db_update_propagation][db_update_propagation] to a non-zero value. Since
@@ -211,13 +211,13 @@ Kong nodes are up-to-date values from your database.
 
 [Back to TOC](#table-of-contents)
 
-### Interacting with the cache via the Admin API
+## Interacting with the cache via the Admin API
 
 If for some reason, you wish to investigate the cached values, or manually
 invalidate a value cached by Kong (a cached hit or miss), you can do so via the
 Admin API `/cache` endpoint.
 
-#### Inspect a cached value
+### Inspect a cached value
 
 **Endpoint**
 
@@ -247,7 +247,7 @@ this process easier.
 
 [Back to TOC](#table-of-contents)
 
-#### Purge a cached value
+### Purge a cached value
 
 **Endpoint**
 
@@ -266,7 +266,7 @@ this process easier.
 
 [Back to TOC](#table-of-contents)
 
-#### Purge a node's cache
+### Purge a node's cache
 
 **Endpoint**
 

--- a/app/0.12.x/configuration.md
+++ b/app/0.12.x/configuration.md
@@ -4,7 +4,7 @@ title: Configuration Reference
 
 # Configuration Reference
 
-### Configuration loading
+## Configuration loading
 
 Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
@@ -36,7 +36,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 [Back to TOC](#table-of-contents)
 
-### Verifying your configuration
+## Verifying your configuration
 
 You can verify the integrity of your settings with the `check` command:
 
@@ -63,7 +63,7 @@ $ kong start -c <kong.conf> --vv
 
 [Back to TOC](#table-of-contents)
 
-### Environment variables
+## Environment variables
 
 When loading properties out of a configuration file, Kong will also look for
 environment variables of the same name. This allows you to fully configure Kong
@@ -87,13 +87,13 @@ $ export KONG_LOG_LEVEL=error
 
 [Back to TOC](#table-of-contents)
 
-### Custom Nginx configuration & embedding Kong
+## Custom Nginx configuration & embedding Kong
 
 Tweaking the Nginx configuration is an essential part of setting up your Kong
 instances since it allows you to optimize its performance for your
 infrastructure, or embed Kong in an already running OpenResty instance.
 
-#### Custom Nginx configuration
+### Custom Nginx configuration
 
 Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
@@ -185,7 +185,7 @@ http {
 
 [Back to TOC](#table-of-contents)
 
-#### Embedding Kong in OpenResty
+### Embedding Kong in OpenResty
 
 If you are running your own OpenResty servers, you can also easily embed Kong
 by including the Kong Nginx sub-configuration using the `include` directive
@@ -211,7 +211,7 @@ And Kong will be running in that instance (as configured in `nginx-kong.conf`).
 
 [Back to TOC](#table-of-contents)
 
-#### Serving both a website and your APIs from Kong
+### Serving both a website and your APIs from Kong
 
 A common use case for API providers is to make Kong serve both a website
 and the APIs themselves over the Proxy port &mdash; `80` or `443` in
@@ -275,11 +275,11 @@ http {
 
 [Back to TOC](#table-of-contents)
 
-### Properties reference
+## Properties reference
 
-#### General section
+### General section
 
-##### prefix
+#### prefix
 
 Working directory. Equivalent to Nginx's prefix path, containing temporary files
 and logs. Each Kong process must have a separate working directory.
@@ -288,7 +288,7 @@ Default: `/usr/local/kong`
 
 ---
 
-##### log_level
+#### log_level
 
 Log level of the Nginx server. Logs can be found at `<prefix>/logs/error.log`
 
@@ -299,7 +299,7 @@ Default: `notice`
 
 ---
 
-##### proxy_access_log
+#### proxy_access_log
 
 Path for proxy port request access logs. Set this value to `off` to disable
 logging proxy requests. If this value is a relative path, it will be placed
@@ -309,7 +309,7 @@ Default: `logs/access.log`
 
 ---
 
-##### proxy_error_log
+#### proxy_error_log
 
 Path for proxy port request error logs. Granularity of these logs is adjusted
 by the `log_level` directive.
@@ -318,7 +318,7 @@ Default: `logs/error.log`
 
 ---
 
-##### admin_access_log
+#### admin_access_log
 
 Path for Admin API request access logs. Set this value to `off` to disable
 logging Admin API requests. If this value is a relative path, it will be placed
@@ -328,7 +328,7 @@ Default: `logs/admin_access.log`
 
 ---
 
-##### admin_error_log
+#### admin_error_log
 
 Path for Admin API request error logs. Granularity of these logs is adjusted by
 the `log_level` directive.
@@ -337,7 +337,7 @@ Default: `logs/error.log`
 
 ---
 
-##### custom_plugins
+#### custom_plugins
 
 Comma-separated list of additional plugins this node should load. Use this
 property to load custom plugins that are not bundled with Kong. Plugins will
@@ -349,7 +349,7 @@ Example: `my-plugin,hello-world,custom-rate-limiting`
 
 ---
 
-##### anonymous_reports
+#### anonymous_reports
 
 Send anonymous usage data such as error stack traces to help improve Kong.
 
@@ -359,9 +359,9 @@ Default: `on`
 
 ---
 
-#### Nginx section
+### Nginx section
 
-##### proxy_listen
+#### proxy_listen
 
 Address and port on which Kong will accept HTTP requests. This is the
 public-facing entrypoint of Kong, to which your consumers will make
@@ -376,7 +376,7 @@ Example: `0.0.0.0:80`
 
 ---
 
-##### proxy_listen_ssl
+#### proxy_listen_ssl
 
 Address and port on which Kong will accept HTTPS requests if `ssl` is enabled.
 
@@ -386,7 +386,7 @@ Example: `0.0.0.0:443`
 
 ---
 
-##### admin_listen
+#### admin_listen
 
 Address and port on which Kong will expose an entrypoint to the Admin API.
 This API lets you configure and manage Kong, and should be kept private
@@ -398,7 +398,7 @@ Example: `0.0.0.0:8001`
 
 ---
 
-##### admin_listen_ssl
+#### admin_listen_ssl
 
 Address and port on which Kong will accept HTTPS requests to the Admin API if
 `admin_ssl` is enabled.
@@ -409,7 +409,7 @@ Example: `0.0.0.0:8444`
 
 ---
 
-##### nginx_user
+#### nginx_user
 
 Defines user and group credentials used by worker processes. If group is omitted, a
 group whose name equals that of user is used.
@@ -420,7 +420,7 @@ Example: `nginx www`
 
 ---
 
-##### nginx_worker_processes
+#### nginx_worker_processes
 
 Determines the number of worker processes spawned by Nginx.
 See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed
@@ -430,7 +430,7 @@ Default: `auto`
 
 ---
 
-##### nginx_daemon
+#### nginx_daemon
 
 Determines whether Nginx will run as a daemon or as a foreground process.
 Mainly useful for development or when running Kong inside a Docker environment.
@@ -441,7 +441,7 @@ Default: `on`
 
 ---
 
-##### mem_cache_size
+#### mem_cache_size
 
 Size of the in-memory cache for database entities. The accepted units are `k` and
 `m`, with a minimum recommended value of a few MBs.
@@ -450,7 +450,7 @@ Default: `128m`
 
 ---
 
-##### ssl
+#### ssl
 
 Determines if Nginx should be listening for HTTPS traffic on the
 `proxy_listen_ssl` address. If disabled, Nginx will only bind itself
@@ -460,7 +460,7 @@ Default: `on`
 
 ---
 
-##### ssl_cipher_suite
+#### ssl_cipher_suite
 
 Defines the TLS ciphers served by Nginx. Accepted values are `modern`,
 `intermediate`, `old`, or `custom`.
@@ -471,7 +471,7 @@ Default: `modern`
 
 ---
 
-##### ssl_ciphers
+#### ssl_ciphers
 
 Defines a custom list of TLS ciphers to be served by Nginx. This list must
 conform to the pattern defined by `openssl ciphers`. This value is ignored if
@@ -481,7 +481,7 @@ Default: none
 
 ---
 
-##### ssl_cert
+#### ssl_cert
 
 If `ssl` is enabled, the absolute path to the SSL certificate for the
 `proxy_listen_ssl` address. If none is specified and `ssl` is enabled, Kong will
@@ -491,7 +491,7 @@ Default: none
 
 ---
 
-##### ssl_cert_key
+#### ssl_cert_key
 
 If `ssl` is enabled, the absolute path to the SSL key for the
 `proxy_listen_ssl` address.
@@ -500,7 +500,7 @@ Default: none
 
 ---
 
-##### http2
+#### http2
 
 Enables HTTP2 support for HTTPS traffic on the `proxy_listen_ssl` address.
 
@@ -508,7 +508,7 @@ Default: `off`
 
 ---
 
-##### client_ssl
+#### client_ssl
 
 Determines if Nginx should send client-side SSL certificates when proxying
 requests.
@@ -517,7 +517,7 @@ Default: `off`
 
 ---
 
-##### client_ssl_cert
+#### client_ssl_cert
 
 If `client_ssl` is enabled, the absolute path to the client SSL certificate for
 the `proxy_ssl_certificate` directive. Note that this value is statically
@@ -527,7 +527,7 @@ Default: none
 
 ---
 
-##### client_ssl_cert_key
+#### client_ssl_cert_key
 
 If `client_ssl` is enabled, the absolute path to the client SSL key for the
 `proxy_ssl_certificate_key` address. Note this value is statically defined on
@@ -537,7 +537,7 @@ Default: none
 
 ---
 
-##### admin_ssl
+#### admin_ssl
 
 Determines if Nginx should be listening for HTTPS traffic on the
 `admin_listen_ssl` address. If disabled, Nginx will only bind itself on
@@ -547,7 +547,7 @@ Default: `on`
 
 ---
 
-##### admin_ssl_cert
+#### admin_ssl_cert
 
 If `admin_ssl` is enabled, the absolute path to the SSL certificate for the
 `admin_listen_ssl` address. If none is specified and `admin_ssl` is enabled,
@@ -557,7 +557,7 @@ Default: none
 
 ---
 
-##### admin_ssl_cert_key
+#### admin_ssl_cert_key
 
 If `admin_ssl` is enabled, the absolute path to the SSL key for the
 `admin_listen_ssl` address.
@@ -566,7 +566,7 @@ Default: none
 
 ---
 
-##### admin_http2
+#### admin_http2
 
 Enables HTTP2 support for HTTPS traffic on the `admin_listen_ssl` address.
 
@@ -574,7 +574,7 @@ Default: `off`
 
 ---
 
-##### upstream_keepalive
+#### upstream_keepalive
 
 Sets the maximum number of idle keepalive connections to upstream servers that
 are preserved in the cache of each worker process. When this number is
@@ -584,7 +584,7 @@ Default: `60`
 
 ---
 
-##### server_tokens
+#### server_tokens
 
 Enables or disables emitting Kong version on error pages and in the `Server`
 or `Via` (in case the request was proxied) response header field.
@@ -593,7 +593,7 @@ Default: `on`
 
 ---
 
-##### latency_tokens
+#### latency_tokens
 
 Enables or disables emitting Kong latency information in the `X-Kong-Proxy-Latency`
 and `X-Kong-Upstream-Latency` response header fields.
@@ -602,7 +602,7 @@ Default: `on`
 
 ---
 
-##### trusted_ips
+#### trusted_ips
 
 Defines trusted IP address blocks that are known to send correct
 `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their
@@ -625,7 +625,7 @@ Default: none
 
 ---
 
-##### real_ip_header
+#### real_ip_header
 
 Defines the request header field whose value will be used to replace the client
 address. This value sets the [ngx_http_realip_module][ngx_http_realip_module]
@@ -641,7 +641,7 @@ Default: `X-Real-IP`
 
 ---
 
-##### real_ip_recursive
+#### real_ip_recursive
 
 This value sets the [ngx_http_realip_module][ngx_http_realip_module] directive
 of the same name in the Nginx configuration.
@@ -653,7 +653,7 @@ Default: `off`
 
 ---
 
-##### client_max_body_size
+#### client_max_body_size
 
 Defines the maximum request body size allowed by requests proxied by Kong, specified in the
 Content-Length request header. If a request exceeds this limit, Kong will respond with a
@@ -668,7 +668,7 @@ Default: `0`
 
 ---
 
-##### client_body_buffer_size
+#### client_body_buffer_size
 
 Defines the buffer size for reading the request body. If the client request body is
 larger than this value, the body will be buffered to disk. Note that when the body is
@@ -686,7 +686,7 @@ Default: `8k`
 
 ---
 
-##### error_default_type
+#### error_default_type
 
 Default MIME type to use when the request `Accept` header is missing and Nginx is
 returning an error for the request. Accepted values are `text/plain`,
@@ -698,7 +698,7 @@ Default: `text/plain`
 
 ---
 
-#### Datastore section
+### Datastore section
 
 Kong will store all of its data (such as APIs, Consumers and Plugins) in
 either Cassandra or PostgreSQL.
@@ -716,7 +716,7 @@ same database.
 
 ---
 
-##### database
+#### database
 
 Determines which of PostgreSQL or Cassandra this node will use as its
 datastore. Accepted values are `postgres` and `cassandra`.
@@ -725,7 +725,7 @@ Default: `postgres`
 
 ---
 
-##### Postgres settings
+#### Postgres settings
 
 name                  |  description
 ----------------------|-------------------
@@ -739,7 +739,7 @@ name                  |  description
 
 ---
 
-##### Cassandra settings
+#### Cassandra settings
 
 name                            | description
 --------------------------------|------------------
@@ -764,7 +764,7 @@ name                            | description
 
 ---
 
-#### Datastore cache section
+### Datastore cache section
 
 In order to avoid unnecessary communication with the datastore, Kong caches
 entities (such as APIs, Consumers, Credentials, etc...) for a configurable
@@ -775,7 +775,7 @@ caching of such configuration entities.
 
 ---
 
-##### db_update_frequency
+#### db_update_frequency
 
 Frequency (in seconds) at which to check for
 updated entities with the datastore.
@@ -789,7 +789,7 @@ Default: 5 seconds
 
 ---
 
-##### db_update_propagation
+#### db_update_propagation
 
 Time (in seconds) taken for an entity in the
 datastore to be propagated to replica nodes
@@ -810,7 +810,7 @@ Default: 0 seconds
 
 ---
 
-##### db_cache_ttl
+#### db_cache_ttl
 
 Time-to-live (in seconds) of an entity from
 the datastore when cached by this node.
@@ -825,7 +825,7 @@ Default: 3600 seconds (1 hour)
 
 ---
 
-#### DNS resolver section
+### DNS resolver section
 
 Kong will resolve hostnames as either `SRV` or `A` records (in that order, and
 `CNAME` records will be dereferenced in the process).
@@ -844,7 +844,7 @@ field entries in the record.
 
 ---
 
-##### dns_resolver
+#### dns_resolver
 
 Comma separated list of nameservers, each
 entry in `ip[:port]` format to be used by
@@ -857,7 +857,7 @@ Default: none
 
 ---
 
-##### dns_hostsfile
+#### dns_hostsfile
 
 The hosts file to use. This file is read once and its content is static
 in memory. To read the file again after modifying it, Kong must be reloaded.
@@ -866,7 +866,7 @@ Default: `/etc/hosts`
 
 ---
 
-##### dns_order
+#### dns_order
 
 The order in which to resolve different
 record types. The `LAST` type means the
@@ -878,7 +878,7 @@ Default: `LAST,SRV,A,CNAME`
 
 ---
 
-##### dns_stale_ttl
+#### dns_stale_ttl
 
 Defines, in seconds, how long a record will
 remain in cache past its TTL. This value
@@ -893,7 +893,7 @@ Default: `4`
 
 ---
 
-##### dns_not_found_ttl
+#### dns_not_found_ttl
 
 TTL in seconds for empty DNS responses and
 "(3) name error" responses.
@@ -902,7 +902,7 @@ Default: `30`
 
 ---
 
-##### dns_error_ttl
+#### dns_error_ttl
 
 TTL in seconds for error responses.
 
@@ -910,7 +910,7 @@ Default: `1`
 
 ---
 
-##### dns_no_sync
+#### dns_no_sync
 
 If enabled, then upon a cache-miss every
 request will trigger its own dns query.
@@ -924,7 +924,7 @@ Default: off
 
 ---
 
-#### Development & miscellaneous section
+### Development & miscellaneous section
 
 Additional settings inherited from lua-nginx-module allowing for more
 flexibility and advanced usage.
@@ -934,7 +934,7 @@ https://github.com/openresty/lua-nginx-module
 
 ---
 
-##### lua_ssl_trusted_certificate
+#### lua_ssl_trusted_certificate
 
 Absolute path to the certificate authority file for Lua cosockets in PEM
 format. This certificate will be the one used for verifying Kong's database
@@ -946,7 +946,7 @@ Default: none
 
 ---
 
-##### lua_ssl_verify_depth
+#### lua_ssl_verify_depth
 
 Sets the verification depth in the server certificates chain used by Lua
 cosockets, set by `lua_ssl_trusted_certificate`.
@@ -959,7 +959,7 @@ Default: `1`
 
 ---
 
-##### lua_package_path
+#### lua_package_path
 
 Sets the Lua module search path (LUA_PATH). Useful when developing or using
 custom plugins not stored in the default search path.
@@ -970,7 +970,7 @@ Default: none
 
 ---
 
-##### lua_package_cpath
+#### lua_package_cpath
 
 Sets the Lua C module search path (LUA_CPATH).
 
@@ -980,7 +980,7 @@ Default: none
 
 ---
 
-##### lua_socket_pool_size
+#### lua_socket_pool_size
 
 Specifies the size limit for every cosocket connection pool associated with
 every remote server.

--- a/app/0.12.x/getting-started/adding-consumers.md
+++ b/app/0.12.x/getting-started/adding-consumers.md
@@ -22,7 +22,7 @@ management, and more.
 [key-auth][key-auth] plugin. If you haven't, you can either [enable the
 plugin][enabling-plugins] or skip steps two and three.
 
-### 1. Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
 Lets create a user named `Jason` by issuing the following request:
 
@@ -52,7 +52,7 @@ Congratulations! You've just added your first consumer to Kong.
 consumers][API-consumers] to associate a consumer with your existing user
 database.
 
-### 2. Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
 Now, we can create a key for our recently created consumer `Jason` by
 issuing the following request:
@@ -63,7 +63,7 @@ $ curl -i -X POST \
   --data 'key=ENTER_KEY_HERE'
 ```
 
-### 3. Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
 We can now issue the following request to verify that the credentials of
 our `Jason` Consumer is valid:

--- a/app/0.12.x/getting-started/adding-your-api.md
+++ b/app/0.12.x/getting-started/adding-your-api.md
@@ -20,7 +20,7 @@ helpful for learning how Kong proxies your API requests.
 Kong exposes a [RESTful Admin API][API] on port `:8001` for managing the
 configuration of your Kong instance or cluster.
 
-### 1. Add your API using the Admin API
+## 1. Add your API using the Admin API
 
 Issue the following cURL request to add your first API ([Mockbin][mockbin])
 to Kong:
@@ -33,7 +33,7 @@ $ curl -i -X POST \
   --data 'upstream_url=http://mockbin.org'
 ```
 
-### 2. Verify that your API has been added
+## 2. Verify that your API has been added
 
 You should see a similar response from that request:
 
@@ -63,7 +63,7 @@ Connection: keep-alive
 
 Kong is now aware of your API and ready to proxy requests.
 
-### 3. Forward your requests through Kong
+## 3. Forward your requests through Kong
 
 Issue the following cURL request to verify that Kong is properly forwarding
 requests to your API. Note that [by default][proxy-port] Kong handles proxy

--- a/app/0.12.x/getting-started/enabling-plugins.md
+++ b/app/0.12.x/getting-started/enabling-plugins.md
@@ -25,7 +25,7 @@ plugin, **only** requests with the correct API key(s) will be proxied - all
 other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
-### 1. Configure the key-auth plugin for your API
+## 1. Configure the key-auth plugin for your API
 
 Issue the following cURL request on the previously created API named
 `example-api`:
@@ -40,7 +40,7 @@ $ curl -i -X POST \
 defaults to `[apikey]`. It is a list of headers and parameters names (both
 are supported) that are supposed to contain the API key during a request.
 
-### 2. Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
 Issue the following cURL request to verify that the [key-auth][key-auth]
 plugin was properly configured on the API:
@@ -63,7 +63,7 @@ HTTP/1.1 401 Unauthorized
 }
 ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add
 consumers to your API so we can continue proxying requests through Kong.

--- a/app/0.12.x/getting-started/introduction.md
+++ b/app/0.12.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.12.x/getting-started/quickstart.md
+++ b/app/0.12.x/getting-started/quickstart.md
@@ -15,7 +15,7 @@ interface, through which you manage your APIs, consumers, and more. Data sent
 through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
 supports PostgreSQL and Cassandra).
 
-1. ### Start Kong
+## 1. Start Kong
 
     Issue the following command to prepare your datastore by running the Kong
     migrations:
@@ -37,7 +37,7 @@ supports PostgreSQL and Cassandra).
     **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
     allowing you to point to your own configuration.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     If everything went well, you should see a message (`Kong started`)
     informing you that Kong is running.
@@ -52,7 +52,7 @@ supports PostgreSQL and Cassandra).
 - `:8001` on which the [Admin API][API] used to configure Kong listens.
 - `:8444` on which the Admin API listens for HTTPS traffic.
 
-3. ### Stop Kong
+## 3. Stop Kong
 
     As needed you can stop the Kong process by issuing the following
     [command][CLI]:
@@ -61,7 +61,7 @@ supports PostgreSQL and Cassandra).
     $ kong stop
     ```
 
-4. ### Reload Kong
+## 4. Reload Kong
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -69,7 +69,7 @@ supports PostgreSQL and Cassandra).
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.12.x/loadbalancing.md
+++ b/app/0.12.x/loadbalancing.md
@@ -8,7 +8,7 @@ Kong provides multiple ways of load balancing requests to multiple backend servi
 a straightforward DNS-based method, and a more dynamic ring-balancer that also
 allows for service registry without needing a DNS server.
 
-### DNS-based loadbalancing
+## DNS-based loadbalancing
 
 When using DNS based load balancing the registration of the backend services is
 done outside of Kong, and Kong only receives updates from the DNS server.
@@ -25,7 +25,7 @@ updates/changes will be very low.
 
 [Back to TOC](#table-of-contents)
 
-#### A records
+### A records
 
 An A record contains one or more IP addresses. Hence, when a hostname
 resolves to an A record, each backend service must have its own IP address.
@@ -36,7 +36,7 @@ round-robin.
 
 [Back to TOC](#table-of-contents)
 
-#### SRV records
+### SRV records
 
 An SRV record contains weight and port information for all of its IP addresses.
 A backend service can be identified by a unique combination of IP address 
@@ -54,7 +54,7 @@ overridden by `456`.
 
 [Back to TOC](#table-of-contents)
 
-#### DNS priorities
+### DNS priorities
 
 The DNS resolver will start resolving the following record types in order:
 
@@ -67,7 +67,7 @@ This order is configurable through the [`dns_order` configuration property][dns-
 
 [Back to TOC](#table-of-contents)
 
-#### DNS caveats
+### DNS caveats
 
 - Whenever the DNS record is refreshed a list is generated to handle the
 weighting properly. Try to keep the weights as multiples of each other to keep
@@ -96,7 +96,7 @@ expected to randomize the record entries.
 
 [Back to TOC](#table-of-contents)
 
-### Ring-balancer
+## Ring-balancer
 
 When using the ring-balancer, the adding and removing of backend services will
 be handled by Kong, and no DNS updates will be necessary. Kong will act as the
@@ -116,7 +116,7 @@ entities.
 
 [Back to TOC](#table-of-contents)
 
-#### Upstream
+### Upstream
 
 Each upstream gets its own ring-balancer. Each `upstream` can have many 
 `target` entries attached to it, and requests proxied to the 'virtual hostname' 
@@ -153,7 +153,7 @@ upstreams is available in the `upstream` section of the
 
 [Back to TOC](#table-of-contents)
 
-#### Target
+### Target
 
 Because the `upstream` maintains a history of changes, targets can only be 
 added, not modified nor deleted. To change a target, just add a new entry for
@@ -187,7 +187,7 @@ to this target it will query the nameserver again.
 
 [Back to TOC](#table-of-contents)
 
-#### Balancing algorithms
+### Balancing algorithms
 
 By default a ring-balancer will use a weighted-round-robin scheme. The alternative
 would be to use the hash-based algorithm. The input for the hash can be either
@@ -222,7 +222,7 @@ For more information on the exact settings see the `upstream` section of the
 
 [Back to TOC](#table-of-contents)
 
-#### Balancing caveats
+### Balancing caveats
 
 The ring-balancer is designed to work both with a single node as well as in a cluster.
 For the weighted-round-robin algorithm there isn't much difference, but when using
@@ -247,7 +247,7 @@ in the hash output.
 
 [Back to TOC](#table-of-contents)
 
-### Blue-Green Deployments
+## Blue-Green Deployments
 
 Using the ring-balancer a [blue-green deployment][blue-green-canary] can be easily orchestrated for 
 an API. Switching target infrastructure only requires a `PATCH` request on an
@@ -316,7 +316,7 @@ requests will be dropped.
 
 [Back to TOC](#table-of-contents)
 
-### Canary Releases
+## Canary Releases
 
 Using the ring-balancer, target weights can be adjusted granularly, allowing
 for a smooth, controlled [canary release][blue-green-canary].

--- a/app/0.12.x/plugin-development/access-the-datastore.md
+++ b/app/0.12.x/plugin-development/access-the-datastore.md
@@ -12,7 +12,7 @@ As of `0.8.0`, Kong supports two primary datastores: [Cassandra {{site.data.kong
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -34,7 +34,7 @@ local plugins_dao = singletons.dao.plugins
 
 ---
 
-### The DAO Lua API
+## The DAO Lua API
 
 The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
 

--- a/app/0.12.x/plugin-development/admin-api.md
+++ b/app/0.12.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses.
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.12.x/plugin-development/custom-entities.md
+++ b/app/0.12.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -21,7 +21,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
 
@@ -105,7 +105,7 @@ While Postgres does, Cassandra does not support constraints such as "NOT NULL", 
 
 ---
 
-### Retrieve your custom DAO from the Dao Factory
+## Retrieve your custom DAO from the Dao Factory
 
 To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
 
@@ -164,7 +164,7 @@ The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Fa
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.12.x/plugin-development/custom-logic.md
+++ b/app/0.12.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -27,7 +27,7 @@ at: `"kong.plugins.<plugin_name>.handler"`
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts.
 Each function to implement in your `handler.lua` file will be executed when the
@@ -55,7 +55,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish
 to be executed. In favor of brevity, here is a commented example module
@@ -182,7 +182,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on

--- a/app/0.12.x/plugin-development/distribution.md
+++ b/app/0.12.x/plugin-development/distribution.md
@@ -14,7 +14,7 @@ plugin(s).
 These steps should be applied to each node in your Kong cluster, to ensure the
 custom plugin(s) are available on each one of them.
 
-### Packaging sources
+## Packaging sources
 
 You can either use a regular packing strategy (eg. `tar`), or use the LuaRocks
 package manager to do it for you. We recommend LuaRocks as it is installed
@@ -63,7 +63,7 @@ The contents of this archive should be close to the following:
 
 ---
 
-### Installing the plugin
+## Installing the plugin
 
 For a Kong node to be able to use the custom plugin, the custom plugin's Lua
 sources must be installed on your host's file system. There are multiple ways
@@ -163,7 +163,7 @@ sources, you must still do so for each node in your Kong cluster.
 
 ---
 
-### Load the plugin
+## Load the plugin
 
 You must now add the custom plugin's name to the `custom_plugins` list in your
 Kong configuration (on each Kong node):
@@ -184,7 +184,7 @@ in your Kong cluster.
 
 ---
 
-### Verify loading the plugin
+## Verify loading the plugin
 
 You should now be able to start Kong without any issue. Consult your custom
 plugin's instructions on how to enable/configure your plugin
@@ -208,7 +208,7 @@ Then, you should see the following log for each plugin being loaded:
 
 ---
 
-### Removing a plugin
+## Removing a plugin
 
 There are three steps to completely remove a plugin.
 
@@ -234,7 +234,7 @@ There are three steps to completely remove a plugin.
 
 ---
 
-### Distribute your plugin
+## Distribute your plugin
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a
 package manager for Lua modules. It calls such modules "rocks". **Your module
@@ -256,7 +256,7 @@ about the format see the LuaRocks [documentation on rockspecs][rockspec].
 
 ---
 
-### Troubleshooting
+## Troubleshooting
 
 Kong can fail to start because of a misconfigured custom plugin for several
 reasons:

--- a/app/0.12.x/plugin-development/entities-cache.md
+++ b/app/0.12.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -41,7 +41,7 @@ under heavy load).
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in
 your code by using the `singletons.cache` module provided by Kong:
@@ -126,7 +126,7 @@ With the above mechanism in place, once a Consumer has made a request with
 their API key, the cache will be considered warm and subsequent requests
 won't result in a database query.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted in the datastore (i.e.
 using the Admin API), it creates an inconsistency between the data in
@@ -137,7 +137,7 @@ cache invalidation.
 
 ---
 
-### Cache invalidation for your entities
+## Cache invalidation for your entities
 
 If you wish that your cached entities be invalidated upon a CRUD operation
 rather than having to wait for them to reach their TTL, you have to follow
@@ -145,7 +145,7 @@ a few steps. This process can be automated since 0.11.0 for most entities,
 but manually subscribing to some CRUD events might be required to invalidate
 some entities with more complex relationships.
 
-#### Automatic cache invalidation
+### Automatic cache invalidation
 
 Cache invalidation can be provided out of the box for your entities if you
 rely on the `cache_key` property of your entity's schema. For example, in the
@@ -226,7 +226,7 @@ properly fetch the newly created API key from the datastore.
 See the [Clustering Guide](/{{page.kong_version}}/clustering/) to ensure
 that you have properly configured your cluster for such invalidation events.
 
-#### Manual cache invalidation
+### Manual cache invalidation
 
 In some cases, the `cache_key` property of an entity's schema is not flexible
 enough, and one must manually invalidate its cache. Reasons for this could be
@@ -275,7 +275,7 @@ singletons.worker_events.register(function(data)
 end, "crud", "consumers")
 ```
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with
 Kong to setup their APIs and plugins. It is likely that they also need to be

--- a/app/0.12.x/plugin-development/file-structure.md
+++ b/app/0.12.x/plugin-development/file-structure.md
@@ -47,7 +47,7 @@ purpose is.
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -66,7 +66,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in
 the database, expose endpoints in the Admin API, etc... Each of those can be

--- a/app/0.12.x/plugin-development/index.md
+++ b/app/0.12.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.12.x/plugin-development/plugin-configuration.md
+++ b/app/0.12.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -32,7 +32,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -68,7 +68,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -105,7 +105,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.12.x/plugin-development/tests.md
+++ b/app/0.12.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/) running with the [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are free to use another one if you wish. In the Kong repository, the busted executable can be found at `bin/busted`.
 

--- a/app/0.13.x/admin-api.md
+++ b/app/0.13.x/admin-api.md
@@ -1135,7 +1135,7 @@ values for some specific Consumers, you can do so by specifying the
 
 See the [Precedence](#precedence) section below for more details.
 
-#### Precedence
+### Precedence
 
 A plugin will always be run once and only once per request. But the
 configuration with which it will run depends on the entities it has been
@@ -1220,7 +1220,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.13.x/cli.md
+++ b/app/0.13.x/cli.md
@@ -10,7 +10,7 @@ current machine).
 
 If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
 
-### Global flags
+## Global flags
 
 All commands take a set of special, optional flags as arguments:
 
@@ -20,9 +20,9 @@ All commands take a set of special, optional flags as arguments:
 
 [Back to TOC](#table-of-contents)
 
-### Available commands
+## Available commands
 
-#### kong check
+### kong check
 
 ```
 Usage: kong check <conf>
@@ -36,7 +36,7 @@ Check the validity of a given Kong configuration file.
 
 ---
 
-#### kong prepare
+### kong prepare
 
 This command prepares the Kong prefix folder, with its sub-folders and files.
 
@@ -61,7 +61,7 @@ Options:
 
 ---
 
-#### kong health
+### kong health
 
 ```
 Usage: kong health [OPTIONS]
@@ -76,7 +76,7 @@ Options:
 
 ---
 
-#### kong migrations
+### kong migrations
 
 ```
 Usage: kong migrations COMMAND [OPTIONS]
@@ -96,7 +96,7 @@ Options:
 
 ---
 
-#### kong quit
+### kong quit
 
 ```
 Usage: kong quit [OPTIONS]
@@ -118,7 +118,7 @@ Options:
 
 ---
 
-#### kong reload
+### kong reload
 
 ```
 Usage: kong reload [OPTIONS]
@@ -141,7 +141,7 @@ Options:
 
 ---
 
-#### kong restart
+### kong restart
 
 ```
 Usage: kong restart [OPTIONS]
@@ -162,7 +162,7 @@ Options:
 
 ---
 
-#### kong start
+### kong start
 
 ```
 Usage: kong start [OPTIONS]
@@ -181,7 +181,7 @@ Options:
 
 ---
 
-#### kong stop
+### kong stop
 
 ```
 Usage: kong stop [OPTIONS]
@@ -199,7 +199,7 @@ Options:
 
 ---
 
-#### kong version
+### kong version
 
 ```
 Usage: kong version [OPTIONS]

--- a/app/0.13.x/clustering.md
+++ b/app/0.13.x/clustering.md
@@ -12,7 +12,7 @@ configuration since they point to the same database. Kong nodes pointing to the
 You need a load-balancer in front of your Kong cluster to distribute traffic
 across your available nodes.
 
-### What a Kong cluster does and doesn't do
+## What a Kong cluster does and doesn't do
 
 **Having a Kong cluster does not mean that your clients traffic will be
 load-balanced across your Kong nodes out of the box.** You still need a
@@ -31,7 +31,7 @@ performance and consistency.
 
 [Back to TOC](#table-of-contents)
 
-### Single node Kong clusters
+## Single node Kong clusters
 
 A single Kong node connected to a database (Cassandra or PostgreSQL) creates a
 Kong cluster of one node. Any changes applied via the Admin API of this node
@@ -52,7 +52,7 @@ $ curl -i http://127.0.0.1:8000/test-service
 
 [Back to TOC](#table-of-contents)
 
-### Multiple nodes Kong clusters
+## Multiple nodes Kong clusters
 
 In a cluster of multiple Kong nodes, other nodes connected to the same database
 would not instantly be notified that the Service was deleted by node `A`.  While
@@ -77,7 +77,7 @@ This makes Kong clusters **eventually consistent**.
 
 [Back to TOC](#table-of-contents)
 
-### What is being cached?
+## What is being cached?
 
 All of the core entities such as Services, Routes, Plugins, Consumers, Credentials are
 cached in memory by Kong and depend on their invalidation via the polling
@@ -141,7 +141,7 @@ polling job.
 
 [Back to TOC](#table-of-contents)
 
-### How to configure database caching?
+## How to configure database caching?
 
 You can configure 3 properties in the Kong configuration file, the most
 important one being `db_update_frequency`, which determine where your Kong
@@ -152,7 +152,7 @@ experiment with its clustering capabilities while avoiding "surprises". As you
 prepare a production setup, you should consider tuning those values to ensure
 that your performance constraints are respected.
 
-#### 1. [db_update_frequency][db_update_frequency] (default: 5s)
+### 1. [db_update_frequency][db_update_frequency] (default: 5s)
 
 This value determines the frequency at which your Kong nodes will be polling
 the database for invalidation events. A lower value will mean that the polling
@@ -166,7 +166,7 @@ seconds.
 
 [Back to TOC](#table-of-contents)
 
-#### 2. [db_update_propagation][db_update_propagation] (default: 0s)
+### 2. [db_update_propagation][db_update_propagation] (default: 0s)
 
 If your database itself is eventually consistent (ie: Cassandra), you **must**
 configure this value. It is to ensure that the change has time to propagate
@@ -186,7 +186,7 @@ up to `db_update_frequency + db_update_propagation` seconds.
 
 [Back to TOC](#table-of-contents)
 
-#### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
+### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
 
 The time (in seconds) for which Kong will cache database entities (both hits
 and misses). This Time-To-Live value acts as a safeguard in case a Kong node
@@ -202,7 +202,7 @@ manually purged, or the node is restarted.
 
 [Back to TOC](#table-of-contents)
 
-#### 4. When using Cassandra
+### 4. When using Cassandra
 
 If you use Cassandra as your Kong database, you **must** set
 [db_update_propagation][db_update_propagation] to a non-zero value. Since
@@ -217,13 +217,13 @@ Kong nodes are up-to-date values from your database.
 
 [Back to TOC](#table-of-contents)
 
-### Interacting with the cache via the Admin API
+## Interacting with the cache via the Admin API
 
 If for some reason, you wish to investigate the cached values, or manually
 invalidate a value cached by Kong (a cached hit or miss), you can do so via the
 Admin API `/cache` endpoint.
 
-#### Inspect a cached value
+### Inspect a cached value
 
 **Endpoint**
 
@@ -253,7 +253,7 @@ this process easier.
 
 [Back to TOC](#table-of-contents)
 
-#### Purge a cached value
+### Purge a cached value
 
 **Endpoint**
 
@@ -272,7 +272,7 @@ this process easier.
 
 [Back to TOC](#table-of-contents)
 
-#### Purge a node's cache
+### Purge a node's cache
 
 **Endpoint**
 

--- a/app/0.13.x/configuration.md
+++ b/app/0.13.x/configuration.md
@@ -4,7 +4,7 @@ title: Configuration Reference
 
 # Configuration Reference
 
-### Configuration loading
+## Configuration loading
 
 Kong comes with a default configuration file that can be found at
 `/etc/kong/kong.conf.default` if you installed Kong via one of the official
@@ -36,7 +36,7 @@ Booleans values can be specified as `on/off` or `true`/`false` for convenience.
 
 [Back to TOC](#table-of-contents)
 
-### Verifying your configuration
+## Verifying your configuration
 
 You can verify the integrity of your settings with the `check` command:
 
@@ -63,7 +63,7 @@ $ kong start -c <kong.conf> --vv
 
 [Back to TOC](#table-of-contents)
 
-### Environment variables
+## Environment variables
 
 When loading properties out of a configuration file, Kong will also look for
 environment variables of the same name. This allows you to fully configure Kong
@@ -87,13 +87,13 @@ $ export KONG_LOG_LEVEL=error
 
 [Back to TOC](#table-of-contents)
 
-### Custom Nginx configuration & embedding Kong
+## Custom Nginx configuration & embedding Kong
 
 Tweaking the Nginx configuration is an essential part of setting up your Kong
 instances since it allows you to optimize its performance for your
 infrastructure, or embed Kong in an already running OpenResty instance.
 
-#### Custom Nginx configuration
+### Custom Nginx configuration
 
 Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
@@ -185,7 +185,7 @@ http {
 
 [Back to TOC](#table-of-contents)
 
-#### Embedding Kong in OpenResty
+### Embedding Kong in OpenResty
 
 If you are running your own OpenResty servers, you can also easily embed Kong
 by including the Kong Nginx sub-configuration using the `include` directive
@@ -211,7 +211,7 @@ And Kong will be running in that instance (as configured in `nginx-kong.conf`).
 
 [Back to TOC](#table-of-contents)
 
-#### Serving both a website and your APIs from Kong
+### Serving both a website and your APIs from Kong
 
 A common use case for API providers is to make Kong serve both a website
 and the APIs themselves over the Proxy port &mdash; `80` or `443` in
@@ -275,11 +275,11 @@ http {
 
 [Back to TOC](#table-of-contents)
 
-### Properties reference
+## Properties reference
 
-#### General section
+### General section
 
-##### prefix
+#### prefix
 
 Working directory. Equivalent to Nginx's prefix path, containing temporary files
 and logs. Each Kong process must have a separate working directory.
@@ -288,7 +288,7 @@ Default: `/usr/local/kong`
 
 ---
 
-##### log_level
+#### log_level
 
 Log level of the Nginx server. Logs can be found at `<prefix>/logs/error.log`
 
@@ -299,7 +299,7 @@ Default: `notice`
 
 ---
 
-##### proxy_access_log
+#### proxy_access_log
 
 Path for proxy port request access logs. Set this value to `off` to disable
 logging proxy requests. If this value is a relative path, it will be placed
@@ -309,7 +309,7 @@ Default: `logs/access.log`
 
 ---
 
-##### proxy_error_log
+#### proxy_error_log
 
 Path for proxy port request error logs. Granularity of these logs is adjusted
 by the `log_level` directive.
@@ -318,7 +318,7 @@ Default: `logs/error.log`
 
 ---
 
-##### admin_access_log
+#### admin_access_log
 
 Path for Admin API request access logs. Set this value to `off` to disable
 logging Admin API requests. If this value is a relative path, it will be placed
@@ -328,7 +328,7 @@ Default: `logs/admin_access.log`
 
 ---
 
-##### admin_error_log
+#### admin_error_log
 
 Path for Admin API request error logs. Granularity of these logs is adjusted by
 the `log_level` directive.
@@ -337,7 +337,7 @@ Default: `logs/error.log`
 
 ---
 
-##### custom_plugins
+#### custom_plugins
 
 Comma-separated list of additional plugins this node should load. Use this
 property to load custom plugins that are not bundled with Kong. Plugins will
@@ -349,7 +349,7 @@ Example: `my-plugin,hello-world,custom-rate-limiting`
 
 ---
 
-##### anonymous_reports
+#### anonymous_reports
 
 Send anonymous usage data such as error stack traces to help improve Kong.
 
@@ -359,9 +359,9 @@ Default: `on`
 
 ---
 
-#### Nginx section
+### Nginx section
 
-##### proxy_listen
+#### proxy_listen
 
 Comma-separated list of addresses and ports on which the proxy server should
 listen. The proxy server is the public entrypoint of Kong, which proxies
@@ -390,7 +390,7 @@ Example: `0.0.0.0:80, 0.0.0.0:81 http2, 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`
 
 ---
 
-##### admin_listen
+#### admin_listen
 
 Comma-separated list of addresses and ports on which the Admin interface
 should listen. The Admin interface is the API allowing you to configure and
@@ -415,7 +415,7 @@ Example: `127.0.0.1:8444 http2 ssl`
 
 ---
 
-##### nginx_user
+#### nginx_user
 
 Defines user and group credentials used by worker processes. If group is omitted, a
 group whose name equals that of user is used.
@@ -426,7 +426,7 @@ Example: `nginx www`
 
 ---
 
-##### nginx_worker_processes
+#### nginx_worker_processes
 
 Determines the number of worker processes spawned by Nginx.
 See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed
@@ -436,7 +436,7 @@ Default: `auto`
 
 ---
 
-##### nginx_daemon
+#### nginx_daemon
 
 Determines whether Nginx will run as a daemon or as a foreground process.
 Mainly useful for development or when running Kong inside a Docker environment.
@@ -447,7 +447,7 @@ Default: `on`
 
 ---
 
-##### mem_cache_size
+#### mem_cache_size
 
 Size of the in-memory cache for database entities. The accepted units are `k` and
 `m`, with a minimum recommended value of a few MBs.
@@ -456,7 +456,7 @@ Default: `128m`
 
 ---
 
-##### ssl_cipher_suite
+#### ssl_cipher_suite
 
 Defines the TLS ciphers served by Nginx. Accepted values are `modern`,
 `intermediate`, `old`, or `custom`.
@@ -467,7 +467,7 @@ Default: `modern`
 
 ---
 
-##### ssl_ciphers
+#### ssl_ciphers
 
 Defines a custom list of TLS ciphers to be served by Nginx. This list must
 conform to the pattern defined by `openssl ciphers`. This value is ignored if
@@ -477,7 +477,7 @@ Default: none
 
 ---
 
-##### ssl_cert
+#### ssl_cert
 
 The absolute path to the SSL certificate for `proxy_listen` values with SSL enabled.
 
@@ -485,7 +485,7 @@ Default: none
 
 ---
 
-##### ssl_cert_key
+#### ssl_cert_key
 
 The absolute path to the SSL key for `proxy_listen` values with SSL enabled.
 
@@ -493,7 +493,7 @@ Default: none
 
 ---
 
-##### client_ssl
+#### client_ssl
 
 Determines if Nginx should send client-side SSL certificates when proxying
 requests.
@@ -502,7 +502,7 @@ Default: `off`
 
 ---
 
-##### client_ssl_cert
+#### client_ssl_cert
 
 If `client_ssl` is enabled, the absolute path to the client SSL certificate for
 the `proxy_ssl_certificate` directive. Note that this value is statically
@@ -512,7 +512,7 @@ Default: none
 
 ---
 
-##### client_ssl_cert_key
+#### client_ssl_cert_key
 
 If `client_ssl` is enabled, the absolute path to the client SSL key for the
 `proxy_ssl_certificate_key` address. Note this value is statically defined on
@@ -522,7 +522,7 @@ Default: none
 
 ---
 
-##### admin_ssl_cert
+#### admin_ssl_cert
 
 The absolute path to the SSL certificate for `admin_listen` values with SSL enabled.
 
@@ -530,7 +530,7 @@ Default: none
 
 ---
 
-##### admin_ssl_cert_key
+#### admin_ssl_cert_key
 
 The absolute path to the SSL key for `admin_listen` values with SSL enabled.
 
@@ -538,7 +538,7 @@ Default: none
 
 ---
 
-##### upstream_keepalive
+#### upstream_keepalive
 
 Sets the maximum number of idle keepalive connections to upstream servers that
 are preserved in the cache of each worker process. When this number is
@@ -548,7 +548,7 @@ Default: `60`
 
 ---
 
-##### server_tokens
+#### server_tokens
 
 Enables or disables emitting Kong version on error pages and in the `Server`
 or `Via` (in case the request was proxied) response header field.
@@ -557,7 +557,7 @@ Default: `on`
 
 ---
 
-##### latency_tokens
+#### latency_tokens
 
 Enables or disables emitting Kong latency information in the `X-Kong-Proxy-Latency`
 and `X-Kong-Upstream-Latency` response header fields.
@@ -566,7 +566,7 @@ Default: `on`
 
 ---
 
-##### trusted_ips
+#### trusted_ips
 
 Defines trusted IP address blocks that are known to send correct
 `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their
@@ -589,7 +589,7 @@ Default: none
 
 ---
 
-##### real_ip_header
+#### real_ip_header
 
 Defines the request header field whose value will be used to replace the client
 address. This value sets the [ngx_http_realip_module][ngx_http_realip_module]
@@ -605,7 +605,7 @@ Default: `X-Real-IP`
 
 ---
 
-##### real_ip_recursive
+#### real_ip_recursive
 
 This value sets the [ngx_http_realip_module][ngx_http_realip_module] directive
 of the same name in the Nginx configuration.
@@ -617,7 +617,7 @@ Default: `off`
 
 ---
 
-##### client_max_body_size
+#### client_max_body_size
 
 Defines the maximum request body size allowed by requests proxied by Kong, specified in the
 Content-Length request header. If a request exceeds this limit, Kong will respond with a
@@ -632,7 +632,7 @@ Default: `0`
 
 ---
 
-##### client_body_buffer_size
+#### client_body_buffer_size
 
 Defines the buffer size for reading the request body. If the client request body is
 larger than this value, the body will be buffered to disk. Note that when the body is
@@ -650,7 +650,7 @@ Default: `8k`
 
 ---
 
-##### error_default_type
+#### error_default_type
 
 Default MIME type to use when the request `Accept` header is missing and Nginx is
 returning an error for the request. Accepted values are `text/plain`,
@@ -662,7 +662,7 @@ Default: `text/plain`
 
 ---
 
-#### Datastore section
+### Datastore section
 
 Kong will store all of its data (such as APIs, Consumers and Plugins) in
 either Cassandra or PostgreSQL.
@@ -680,7 +680,7 @@ same database.
 
 ---
 
-##### database
+#### database
 
 Determines which of PostgreSQL or Cassandra this node will use as its
 datastore. Accepted values are `postgres` and `cassandra`.
@@ -689,7 +689,7 @@ Default: `postgres`
 
 ---
 
-##### Postgres settings
+#### Postgres settings
 
 name                  |  description
 ----------------------|-------------------
@@ -703,7 +703,7 @@ name                  |  description
 
 ---
 
-##### Cassandra settings
+#### Cassandra settings
 
 name                            | description
 --------------------------------|------------------
@@ -728,7 +728,7 @@ name                            | description
 
 ---
 
-#### Datastore cache section
+### Datastore cache section
 
 In order to avoid unnecessary communication with the datastore, Kong caches
 entities (such as APIs, Consumers, Credentials, etc...) for a configurable
@@ -739,7 +739,7 @@ caching of such configuration entities.
 
 ---
 
-##### db_update_frequency
+#### db_update_frequency
 
 Frequency (in seconds) at which to check for
 updated entities with the datastore.
@@ -753,7 +753,7 @@ Default: 5 seconds
 
 ---
 
-##### db_update_propagation
+#### db_update_propagation
 
 Time (in seconds) taken for an entity in the
 datastore to be propagated to replica nodes
@@ -774,7 +774,7 @@ Default: 0 seconds
 
 ---
 
-##### db_cache_ttl
+#### db_cache_ttl
 
 Time-to-live (in seconds) of an entity from
 the datastore when cached by this node.
@@ -789,7 +789,7 @@ Default: 3600 seconds (1 hour)
 
 ---
 
-#### DNS resolver section
+### DNS resolver section
 
 Kong will resolve hostnames as either `SRV` or `A` records (in that order, and
 `CNAME` records will be dereferenced in the process).
@@ -808,7 +808,7 @@ field entries in the record.
 
 ---
 
-##### dns_resolver
+#### dns_resolver
 
 Comma separated list of nameservers, each
 entry in `ip[:port]` format to be used by
@@ -821,7 +821,7 @@ Default: none
 
 ---
 
-##### dns_hostsfile
+#### dns_hostsfile
 
 The hosts file to use. This file is read once and its content is static
 in memory. To read the file again after modifying it, Kong must be reloaded.
@@ -830,7 +830,7 @@ Default: `/etc/hosts`
 
 ---
 
-##### dns_order
+#### dns_order
 
 The order in which to resolve different
 record types. The `LAST` type means the
@@ -842,7 +842,7 @@ Default: `LAST,SRV,A,CNAME`
 
 ---
 
-##### dns_stale_ttl
+#### dns_stale_ttl
 
 Defines, in seconds, how long a record will
 remain in cache past its TTL. This value
@@ -857,7 +857,7 @@ Default: `4`
 
 ---
 
-##### dns_not_found_ttl
+#### dns_not_found_ttl
 
 TTL in seconds for empty DNS responses and
 "(3) name error" responses.
@@ -866,7 +866,7 @@ Default: `30`
 
 ---
 
-##### dns_error_ttl
+#### dns_error_ttl
 
 TTL in seconds for error responses.
 
@@ -874,7 +874,7 @@ Default: `1`
 
 ---
 
-##### dns_no_sync
+#### dns_no_sync
 
 If enabled, then upon a cache-miss every
 request will trigger its own dns query.
@@ -888,7 +888,7 @@ Default: off
 
 ---
 
-#### Development & miscellaneous section
+### Development & miscellaneous section
 
 Additional settings inherited from lua-nginx-module allowing for more
 flexibility and advanced usage.
@@ -898,7 +898,7 @@ https://github.com/openresty/lua-nginx-module
 
 ---
 
-##### lua_ssl_trusted_certificate
+#### lua_ssl_trusted_certificate
 
 Absolute path to the certificate authority file for Lua cosockets in PEM
 format. This certificate will be the one used for verifying Kong's database
@@ -910,7 +910,7 @@ Default: none
 
 ---
 
-##### lua_ssl_verify_depth
+#### lua_ssl_verify_depth
 
 Sets the verification depth in the server certificates chain used by Lua
 cosockets, set by `lua_ssl_trusted_certificate`.
@@ -923,7 +923,7 @@ Default: `1`
 
 ---
 
-##### lua_package_path
+#### lua_package_path
 
 Sets the Lua module search path (LUA_PATH). Useful when developing or using
 custom plugins not stored in the default search path.
@@ -934,7 +934,7 @@ Default: none
 
 ---
 
-##### lua_package_cpath
+#### lua_package_cpath
 
 Sets the Lua C module search path (LUA_CPATH).
 
@@ -944,7 +944,7 @@ Default: none
 
 ---
 
-##### lua_socket_pool_size
+#### lua_socket_pool_size
 
 Specifies the size limit for every cosocket connection pool associated with
 every remote server.

--- a/app/0.13.x/getting-started/adding-consumers.md
+++ b/app/0.13.x/getting-started/adding-consumers.md
@@ -22,7 +22,7 @@ management, and more.
 [key-auth][key-auth] plugin. If you haven't, you can either [enable the
 plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -52,7 +52,7 @@ plugin][enabling-plugins] or skip steps two and three.
     consumers][API-consumers] to associate a consumer with your existing user
     database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by
     issuing the following request:
@@ -63,7 +63,7 @@ plugin][enabling-plugins] or skip steps two and three.
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of
     our `Jason` Consumer is valid:
@@ -75,7 +75,7 @@ plugin][enabling-plugins] or skip steps two and three.
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of adding Services, Routes, Consumers and enabling
 Plugins, feel free to read more on Kong in one of the following documents:

--- a/app/0.13.x/getting-started/configuring-a-service.md
+++ b/app/0.13.x/getting-started/configuring-a-service.md
@@ -29,7 +29,7 @@ After configuring the Service and the Route, you'll be able to make requests thr
 Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, including adding Services and
 Routes, is made via requests on that API.
 
-1. ### Add your Service using the Admin API
+## 1. Add your Service using the Admin API
 
     Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
     to Kong:
@@ -65,7 +65,7 @@ Routes, is made via requests on that API.
     ```
 
 
-2. ### Add a Route for the Service
+## 2. Add a Route for the Service
 
     ```bash
     $ curl -i -X POST \
@@ -104,7 +104,7 @@ Routes, is made via requests on that API.
 
     Kong is now aware of your Service and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding
     requests to your Service. Note that [by default][proxy-port] Kong handles proxy

--- a/app/0.13.x/getting-started/enabling-plugins.md
+++ b/app/0.13.x/getting-started/enabling-plugins.md
@@ -26,7 +26,7 @@ other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
 
-1. ### Configure the key-auth plugin for the Service you <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured in Kong</a>.
+## 1. Configure the key-auth plugin for the Service you <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured in Kong</a>.
 
     Issue the following cURL request:
 
@@ -40,7 +40,7 @@ from unauthorized use.
     defaults to `['apikey']`. It is a list of headers and parameters names (both
     are supported) that are supposed to contain the apikey during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth]
     plugin was properly configured on the Service:
@@ -63,7 +63,7 @@ from unauthorized use.
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add
 consumers to your Service so we can continue proxying requests through Kong.

--- a/app/0.13.x/getting-started/introduction.md
+++ b/app/0.13.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming Services][configuring-a-service].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.13.x/getting-started/quickstart.md
+++ b/app/0.13.x/getting-started/quickstart.md
@@ -15,7 +15,7 @@ interface, through which you manage your Services, Routes, Consumers, and more. 
 through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
 supports PostgreSQL and Cassandra).
 
-1. ### Start Kong
+## 1. Start Kong
 
     Issue the following command to prepare your datastore by running the Kong
     migrations:
@@ -37,7 +37,7 @@ supports PostgreSQL and Cassandra).
     **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
     allowing you to point to your own configuration.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     If everything went well, you should see a message (`Kong started`)
     informing you that Kong is running.
@@ -52,7 +52,7 @@ supports PostgreSQL and Cassandra).
 - `:8001` on which the [Admin API][API] used to configure Kong listens.
 - `:8444` on which the Admin API listens for HTTPS traffic.
 
-3. ### Stop Kong
+## 3. Stop Kong
 
     As needed you can stop the Kong process by issuing the following
     [command][CLI]:
@@ -61,7 +61,7 @@ supports PostgreSQL and Cassandra).
     $ kong stop
     ```
 
-4. ### Reload Kong
+## 4. Reload Kong
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -69,7 +69,7 @@ supports PostgreSQL and Cassandra).
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.13.x/health-checks-circuit-breakers.md
+++ b/app/0.13.x/health-checks-circuit-breakers.md
@@ -23,7 +23,7 @@ response;
 the ongoing traffic being proxied and determines the health of targets based
 on their behavior responding requests.
 
-### Healthy and unhealthy targets
+## Healthy and unhealthy targets
 
 The objective of the health checks functionality is to dynamically mark
 targets as healthy or unhealthy, **for a given Kong node**. There is
@@ -122,9 +122,9 @@ Note:
    and does not limit the response. *Failing to do so might lead to health
    checks not being executed.*
 
-### Types of health checks
+## Types of health checks
 
-#### Active health checks
+### Active health checks
 
 Active health checks, as the name implies, actively probe targets for
 their health. When active health checks are enabled in an upstream entity,
@@ -139,7 +139,7 @@ When both are zero, active health checks are disabled altogether.
 
 [Back to TOC](#table-of-contents)
 
-#### Passive health checks (circuit breakers)
+### Passive health checks (circuit breakers)
 
 Passive health checks, also known as circuit breakers, are
 checks performed based on the requests being proxied by Kong,
@@ -170,7 +170,7 @@ be re-enabled again by the system administrator.
 
 [Back to TOC](#table-of-contents)
 
-#### Summary of pros and cons
+### Summary of pros and cons
 
 * Active health checks can automatically re-enable a target in the
 ring balancer as soon as it is healthy again. Passive health checks cannot.
@@ -191,9 +191,9 @@ passive health checks to monitor the target health based solely on its
 traffic, and only use active health checks while the target is unhealthy,
 in order to re-enable it automatically.
 
-### Enabling and disabling health checks
+## Enabling and disabling health checks
 
-#### Enabling active health checks
+### Enabling active health checks
 
 To enable active health checks, you need to specify the configuration items
 under `healthchecks.active` in the [Upstream object][upstreamobjects] configuration. You
@@ -239,7 +239,7 @@ probes to consider a target unhealthy.
 active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to
 consider a target unhealthy.
 
-#### Enabling passive health checks
+### Enabling passive health checks
 
 Passive health checks do not feature a probe, as they work by interpreting
 the ongoing traffic that flows from a target. This means that to enable
@@ -259,7 +259,7 @@ traffic to consider a target unhealthy, as observed by passive health checks.
 proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`)
 to consider a target unhealthy, as observed by passive health checks.
 
-#### Disabling health checks
+### Disabling health checks
 
 In all counter thresholds and intervals specified in the `healthchecks`
 configuration, setting a value to zero means that the functionality the field

--- a/app/0.13.x/loadbalancing.md
+++ b/app/0.13.x/loadbalancing.md
@@ -8,7 +8,7 @@ Kong provides multiple ways of load balancing requests to multiple backend
 services: a straightforward DNS-based method, and a more dynamic ring-balancer
 that also allows for service registry without needing a DNS server.
 
-### DNS-based loadbalancing
+## DNS-based loadbalancing
 
 When using DNS-based load balancing, the registration of the backend services
 is done outside of Kong, and Kong only receives updates from the DNS server.
@@ -25,7 +25,7 @@ updates/changes will be very low.
 
 [Back to TOC](#table-of-contents)
 
-#### A records
+### A records
 
 An A record contains one or more IP addresses. Hence, when a hostname
 resolves to an A record, each backend service must have its own IP address.
@@ -36,7 +36,7 @@ round-robin.
 
 [Back to TOC](#table-of-contents)
 
-#### SRV records
+### SRV records
 
 An SRV record contains weight and port information for all of its IP addresses.
 A backend service can be identified by a unique combination of IP address
@@ -54,7 +54,7 @@ overridden by `456`.
 
 [Back to TOC](#table-of-contents)
 
-#### DNS priorities
+### DNS priorities
 
 The DNS resolver will start resolving the following record types in order:
 
@@ -67,7 +67,7 @@ This order is configurable through the [`dns_order` configuration property][dns-
 
 [Back to TOC](#table-of-contents)
 
-#### DNS caveats
+### DNS caveats
 
 - Whenever the DNS record is refreshed a list is generated to handle the
 weighting properly. Try to keep the weights as multiples of each other to keep
@@ -96,7 +96,7 @@ expected to randomize the record entries.
 
 [Back to TOC](#table-of-contents)
 
-### Ring-balancer
+## Ring-balancer
 
 When using the ring-balancer, the adding and removing of backend services will
 be handled by Kong, and no DNS updates will be necessary. Kong will act as the
@@ -116,7 +116,7 @@ entities.
 
 [Back to TOC](#table-of-contents)
 
-#### Upstream
+### Upstream
 
 Each upstream gets its own ring-balancer. Each `upstream` can have many
 `target` entries attached to it, and requests proxied to the 'virtual hostname'
@@ -153,7 +153,7 @@ upstreams is available in the `upstream` section of the
 
 [Back to TOC](#table-of-contents)
 
-#### Target
+### Target
 
 Because the `upstream` maintains a history of changes, targets can only be
 added, not modified nor deleted. To change a target, just add a new entry for
@@ -187,7 +187,7 @@ to this target it will query the nameserver again.
 
 [Back to TOC](#table-of-contents)
 
-#### Balancing algorithms
+### Balancing algorithms
 
 By default a ring-balancer will use a weighted-round-robin scheme. The alternative
 would be to use the hash-based algorithm. The input for the hash can be either
@@ -222,7 +222,7 @@ For more information on the exact settings see the `upstream` section of the
 
 [Back to TOC](#table-of-contents)
 
-#### Balancing caveats
+### Balancing caveats
 
 The ring-balancer is designed to work both with a single node as well as in a cluster.
 For the weighted-round-robin algorithm there isn't much difference, but when using
@@ -247,7 +247,7 @@ in the hash output.
 
 [Back to TOC](#table-of-contents)
 
-### Blue-Green Deployments
+## Blue-Green Deployments
 
 Using the ring-balancer a [blue-green deployment][blue-green-canary] can be easily orchestrated for
 a Service. Switching target infrastructure only requires a `PATCH` request on a
@@ -320,7 +320,7 @@ requests will be dropped.
 
 [Back to TOC](#table-of-contents)
 
-### Canary Releases
+## Canary Releases
 
 Using the ring-balancer, target weights can be adjusted granularly, allowing
 for a smooth, controlled [canary release][blue-green-canary].

--- a/app/0.13.x/plugin-development/access-the-datastore.md
+++ b/app/0.13.x/plugin-development/access-the-datastore.md
@@ -15,7 +15,7 @@ Kong supports two primary datastores: [Cassandra {{site.data.kong_latest.depende
 </div>
 ---
 
-### `singletons.db` and `singletons.dao`
+## `singletons.db` and `singletons.dao`
 
 All entities in Kong are represented by:
 
@@ -40,7 +40,7 @@ local plugins_dao = singletons.dao.plugins
 
 ---
 
-### The DAO Lua API
+## The DAO Lua API
 
 The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
 

--- a/app/0.13.x/plugin-development/admin-api.md
+++ b/app/0.13.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses.
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.13.x/plugin-development/custom-entities.md
+++ b/app/0.13.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -21,7 +21,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
 
@@ -105,7 +105,7 @@ While Postgres does, Cassandra does not support constraints such as "NOT NULL", 
 
 ---
 
-### Retrieve your custom DAO from the Dao Factory
+## Retrieve your custom DAO from the Dao Factory
 
 To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
 
@@ -164,7 +164,7 @@ The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Fa
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.13.x/plugin-development/custom-logic.md
+++ b/app/0.13.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -27,7 +27,7 @@ at: `"kong.plugins.<plugin_name>.handler"`
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts.
 Each function to implement in your `handler.lua` file will be executed when the
@@ -55,7 +55,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish
 to be executed. In favor of brevity, here is a commented example module
@@ -182,7 +182,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on

--- a/app/0.13.x/plugin-development/distribution.md
+++ b/app/0.13.x/plugin-development/distribution.md
@@ -14,7 +14,7 @@ plugin(s).
 These steps should be applied to each node in your Kong cluster, to ensure the
 custom plugin(s) are available on each one of them.
 
-### Packaging sources
+## Packaging sources
 
 You can either use a regular packing strategy (eg. `tar`), or use the LuaRocks
 package manager to do it for you. We recommend LuaRocks as it is installed
@@ -63,7 +63,7 @@ The contents of this archive should be close to the following:
 
 ---
 
-### Installing the plugin
+## Installing the plugin
 
 For a Kong node to be able to use the custom plugin, the custom plugin's Lua
 sources must be installed on your host's file system. There are multiple ways
@@ -163,7 +163,7 @@ sources, you must still do so for each node in your Kong cluster.
 
 ---
 
-### Load the plugin
+## Load the plugin
 
 You must now add the custom plugin's name to the `custom_plugins` list in your
 Kong configuration (on each Kong node):
@@ -184,7 +184,7 @@ in your Kong cluster.
 
 ---
 
-### Verify loading the plugin
+## Verify loading the plugin
 
 You should now be able to start Kong without any issue. Consult your custom
 plugin's instructions on how to enable/configure your plugin
@@ -208,7 +208,7 @@ Then, you should see the following log for each plugin being loaded:
 
 ---
 
-### Removing a plugin
+## Removing a plugin
 
 There are three steps to completely remove a plugin.
 
@@ -234,7 +234,7 @@ There are three steps to completely remove a plugin.
 
 ---
 
-### Distribute your plugin
+## Distribute your plugin
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a
 package manager for Lua modules. It calls such modules "rocks". **Your module
@@ -256,7 +256,7 @@ about the format see the LuaRocks [documentation on rockspecs][rockspec].
 
 ---
 
-### Troubleshooting
+## Troubleshooting
 
 Kong can fail to start because of a misconfigured custom plugin for several
 reasons:

--- a/app/0.13.x/plugin-development/entities-cache.md
+++ b/app/0.13.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -41,7 +41,7 @@ under heavy load).
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in
 your code by using the `singletons.cache` module provided by Kong:
@@ -126,7 +126,7 @@ With the above mechanism in place, once a Consumer has made a request with
 their API key, the cache will be considered warm and subsequent requests
 won't result in a database query.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted in the datastore (i.e.
 using the Admin API), it creates an inconsistency between the data in
@@ -137,7 +137,7 @@ cache invalidation.
 
 ---
 
-### Cache invalidation for your entities
+## Cache invalidation for your entities
 
 If you wish that your cached entities be invalidated upon a CRUD operation
 rather than having to wait for them to reach their TTL, you have to follow
@@ -145,7 +145,7 @@ a few steps. This process can be automated since 0.11.0 for most entities,
 but manually subscribing to some CRUD events might be required to invalidate
 some entities with more complex relationships.
 
-#### Automatic cache invalidation
+### Automatic cache invalidation
 
 Cache invalidation can be provided out of the box for your entities if you
 rely on the `cache_key` property of your entity's schema. For example, in the
@@ -226,7 +226,7 @@ properly fetch the newly created API key from the datastore.
 See the [Clustering Guide](/{{page.kong_version}}/clustering/) to ensure
 that you have properly configured your cluster for such invalidation events.
 
-#### Manual cache invalidation
+### Manual cache invalidation
 
 In some cases, the `cache_key` property of an entity's schema is not flexible
 enough, and one must manually invalidate its cache. Reasons for this could be
@@ -274,7 +274,7 @@ singletons.worker_events.register(function(data)
 end, "crud", "consumers")
 ```
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with
 Kong to setup their APIs and plugins. It is likely that they also need to be

--- a/app/0.13.x/plugin-development/file-structure.md
+++ b/app/0.13.x/plugin-development/file-structure.md
@@ -47,7 +47,7 @@ purpose is.
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -66,7 +66,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in
 the database, expose endpoints in the Admin API, etc... Each of those can be

--- a/app/0.13.x/plugin-development/index.md
+++ b/app/0.13.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.13.x/plugin-development/plugin-configuration.md
+++ b/app/0.13.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -32,7 +32,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -68,7 +68,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -105,7 +105,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.13.x/plugin-development/tests.md
+++ b/app/0.13.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/) running with the [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are free to use another one if you wish. In the Kong repository, the busted executable can be found at `bin/busted`.
 

--- a/app/0.14.x/admin-api.md
+++ b/app/0.14.x/admin-api.md
@@ -932,7 +932,7 @@ values for some specific Consumers, you can do so by specifying the
 
 See the [Precedence](#precedence) section below for more details.
 
-#### Precedence
+### Precedence
 
 A plugin will always be run once and only once per request. But the
 configuration with which it will run depends on the entities it has been
@@ -1017,7 +1017,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.2.x/getting-started/adding-consumers.md
+++ b/app/0.2.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [keyauth][keyauth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `consumer_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request with the Consumer `id` from our previous request:
 
@@ -56,7 +56,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'consumer_id=bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     Using the `id` of the Consumer we just created we can issue the following request to verify that the credentials of our Consumer is valid:
 
@@ -67,7 +67,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.2.x/getting-started/adding-your-api.md
+++ b/app/0.2.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     You should see a similar response from the initial request:
 
@@ -48,7 +48,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.2.x/getting-started/enabling-plugins.md
+++ b/app/0.2.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to enable plugins. One of the core principals 
 
 First, we'll have you configure and enable the [keyauth][keyauth] plugin to add authentication to your API.
 
-1. ### Add plugin to your Kong config
+## 1. Add plugin to your Kong config
 
     Add `keyauth` under the `plugins_available` property in your Kong instance configuration file should it not already exist:
 
@@ -26,7 +26,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
       - keyauth
     ```
 
-2. ### Restart Kong
+## 2. Restart Kong
 
     Issue the following command to restart Kong. This allows Kong to load the plugin.
 
@@ -36,7 +36,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
 
     **Note:** If you have a cluster of Kong instances that share the configuration, you should restart each node in the cluster.
 
-3. ### Configure the plugin for your API
+## 3. Configure the plugin for your API
 
     Now that Kong has loaded the plugin, we should configure it to be enabled on your API.
 
@@ -52,7 +52,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
 
     **Note:** `value.key_names` is the authentication header name each request will require.
 
-4. ### Verify that the plugin is enabled for your API
+## 4. Verify that the plugin is enabled for your API
 
     Issue the following cURL request to verify that the [keyauth][keyauth] plugin was enabled for your API:
 
@@ -73,7 +73,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've enabled the **keyauth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.2.x/getting-started/introduction.md
+++ b/app/0.2.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.2.x/getting-started/quickstart.md
+++ b/app/0.2.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to start [kong][CLI]:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare the Cassandra keyspace.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the [kong][CLI] process by issuing the following command:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to reload [kong][CLI] without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the RESTful API.
 

--- a/app/0.3.x/getting-started/adding-consumers.md
+++ b/app/0.3.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [keyauth][keyauth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.3.x/getting-started/adding-your-api.md
+++ b/app/0.3.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.3.x/getting-started/enabling-plugins.md
+++ b/app/0.3.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to enable plugins. One of the core principals 
 
 First, we'll have you configure and enable the [keyauth][keyauth] plugin to add authentication to your API.
 
-1. ### Add plugin to your Kong config
+## 1. Add plugin to your Kong config
 
     Add `keyauth` under the `plugins_available` property in your Kong instance [configuration file][configuration] should it not already exist:
 
@@ -26,7 +26,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
       - keyauth
     ```
 
-2. ### Restart Kong
+## 2. Restart Kong
 
     Issue the following command to restart Kong. This allows Kong to load the plugin.
 
@@ -36,7 +36,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
 
     **Note:** If you have a cluster of Kong instances that share the configuration, you should restart each node in the cluster.
 
-3. ### Configure the plugin for your API
+## 3. Configure the plugin for your API
 
     Now that Kong has loaded the plugin, we should configure it to be enabled on your API.
 
@@ -50,7 +50,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
 
     **Note:** This plugin also accepts a `value.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-4. ### Verify that the plugin is enabled for your API
+## 4. Verify that the plugin is enabled for your API
 
     Issue the following cURL request to verify that the [keyauth][keyauth] plugin was enabled for your API:
 
@@ -71,7 +71,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've enabled the **keyauth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.3.x/getting-started/introduction.md
+++ b/app/0.3.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.3.x/getting-started/quickstart.md
+++ b/app/0.3.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to start [kong][CLI]:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare the Cassandra keyspace.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the [kong][CLI] process by issuing the following command:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to reload [kong][CLI] without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the RESTful API.
 

--- a/app/0.4.x/getting-started/adding-consumers.md
+++ b/app/0.4.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [keyauth][keyauth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.4.x/getting-started/adding-your-api.md
+++ b/app/0.4.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.4.x/getting-started/enabling-plugins.md
+++ b/app/0.4.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to enable plugins. One of the core principals 
 
 First, we'll have you configure and enable the [keyauth][keyauth] plugin to add authentication to your API.
 
-1. ### Add plugin to your Kong config
+## 1. Add plugin to your Kong config
 
     Add `keyauth` under the `plugins_available` property in your Kong instance [configuration file][configuration] should it not already exist:
 
@@ -26,7 +26,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
       - keyauth
     ```
 
-2. ### Restart Kong
+## 2. Restart Kong
 
     Issue the following command to restart Kong. This allows Kong to load the plugin.
 
@@ -36,7 +36,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
 
     **Note:** If you have a cluster of Kong instances that share the configuration, you should restart each node in the cluster.
 
-3. ### Configure the plugin for your API
+## 3. Configure the plugin for your API
 
     Now that Kong has loaded the plugin, we should configure it to be enabled on your API.
 
@@ -50,7 +50,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
 
     **Note:** This plugin also accepts a `value.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-4. ### Verify that the plugin is enabled for your API
+## 4. Verify that the plugin is enabled for your API
 
     Issue the following cURL request to verify that the [keyauth][keyauth] plugin was enabled for your API:
 
@@ -71,7 +71,7 @@ First, we'll have you configure and enable the [keyauth][keyauth] plugin to add 
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've enabled the **keyauth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.4.x/getting-started/introduction.md
+++ b/app/0.4.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.4.x/getting-started/quickstart.md
+++ b/app/0.4.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare the Cassandra keyspace.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.4.x/proxy.md
+++ b/app/0.4.x/proxy.md
@@ -60,7 +60,7 @@ Once this request is processed by Kong, the API is stored in your Cassandra clus
 
 ## 3. Proxy an API by its request_host value
 
-#### Using the "**Host**" header
+### Using the "**Host**" header
 
 Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `public_dns` value in the `Host` header of your request:
 
@@ -76,7 +76,7 @@ By doing so, Kong recognizes the `Host` value as being the `public_dns` of the "
   <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
-#### Using the "**X-Host-Override**" header
+### Using the "**X-Host-Override**" header
 
 When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
@@ -88,7 +88,7 @@ $ curl -i -X GET \
 
 This request will be proxied just as well by Kong.
 
-#### Using a wildcard DNS
+### Using a wildcard DNS
 
 Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**public_dns**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
@@ -111,7 +111,7 @@ $ curl -i -X GET \
 
 You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `target_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
 
-#### Using the "**strip_path**" property
+### Using the "**strip_path**" property
 
 By enabling the `strip_path` property on an API, the requests will be proxied without the `path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
 

--- a/app/0.5.x/admin-api.md
+++ b/app/0.5.x/admin-api.md
@@ -579,7 +579,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.5.x/getting-started/adding-consumers.md
+++ b/app/0.5.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [key-auth][key-auth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.5.x/getting-started/adding-your-api.md
+++ b/app/0.5.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.5.x/getting-started/enabling-plugins.md
+++ b/app/0.5.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to enable plugins. One of the core principals 
 
 First, we'll have you configure and enable the [key-auth][key-auth] plugin to add authentication to your API.
 
-1. ### Add plugin to your Kong config
+## 1. Add plugin to your Kong config
 
     Add `key-auth` under the `plugins_available` property in your Kong instance [configuration file][configuration] should it not already exist:
 
@@ -26,7 +26,7 @@ First, we'll have you configure and enable the [key-auth][key-auth] plugin to ad
       - key-auth
     ```
 
-2. ### Restart Kong
+## 2. Restart Kong
 
     Issue the following command to restart Kong. This allows Kong to load the plugin.
 
@@ -36,7 +36,7 @@ First, we'll have you configure and enable the [key-auth][key-auth] plugin to ad
 
     **Note:** If you have a cluster of Kong instances that share the configuration, you should restart each node in the cluster.
 
-3. ### Configure the plugin for your API
+## 3. Configure the plugin for your API
 
     Now that Kong has loaded the plugin, we should configure it to be enabled on your API.
 
@@ -50,7 +50,7 @@ First, we'll have you configure and enable the [key-auth][key-auth] plugin to ad
 
     **Note:** This plugin also accepts a `config.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-4. ### Verify that the plugin is enabled for your API
+## 4. Verify that the plugin is enabled for your API
 
     Issue the following cURL request to verify that the [key-auth][key-auth] plugin was enabled for your API:
 
@@ -71,7 +71,7 @@ First, we'll have you configure and enable the [key-auth][key-auth] plugin to ad
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've enabled the **key-auth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.5.x/getting-started/introduction.md
+++ b/app/0.5.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.5.x/getting-started/quickstart.md
+++ b/app/0.5.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare the Cassandra keyspace.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.5.x/plugin-development/access-the-datastore.md
+++ b/app/0.5.x/plugin-development/access-the-datastore.md
@@ -14,7 +14,7 @@ Kong interacts with the model layer through classes we refer to as "DAOs". This 
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -38,7 +38,7 @@ For [performance](http://lua-users.org/wiki/OptimisingUsingLocalVariables) [reas
 
 ---
 
-### DAOs Lua API
+## DAOs Lua API
 
 All methods available on DAOs are documented in the [kong.dao.cassandra.base_dao] module in Kong's Public Lua API Reference. See the [public interface] and [children DAOs interface] sections of the base_dao module.
 
@@ -56,7 +56,7 @@ local inserted_api, err = dao.apis:insert({
 
 ---
 
-### Custom DAOs
+## Custom DAOs
 
 Because Kong needs to deal with more than the three core entities, the [kong.dao.cassandra.base_dao][kong.dao.cassandra.base_dao] can be inherited to support any entity. Plugins make heavy use of this feature, and every existing plugin implements their own DAO, loaded by the DAO Factory and made available everywhere the factory is, just like the core entities.
 

--- a/app/0.5.x/plugin-development/admin-api.md
+++ b/app/0.5.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses. See [kong.tools.responses](/{{page.kong_version}}/lua-reference/modules/kong.tools.responses).
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.5.x/plugin-development/custom-entities.md
+++ b/app/0.5.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.migrations.cassandra"
@@ -25,7 +25,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create a migration file which will be executed by Kong to create your column family. A migration file simply holds an array of migrations, and returns them.
 
@@ -78,7 +78,7 @@ Cassandra does not support constraints such as "must be unique" or "is a foreign
 
 ---
 
-### Extending the Base DAO
+## Extending the Base DAO
 
 To make the DAO Factory load your custom DAO(s), you will need:
 
@@ -151,7 +151,7 @@ The property name depends on the key with which you exported your DAO in the ret
 
 ---
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with Kong to setup their APIs and plugins. It is likely that they also need to be able to interact with the custom entities you implemented for your plugin (for example, creating and deleting API keys). The way you would do this is by extending the Admin API, which we will detail in the next chapter: [Extending the Admin API]({{page.book.next}}).
 

--- a/app/0.5.x/plugin-development/custom-logic.md
+++ b/app/0.5.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -22,7 +22,7 @@ Kong allows you to execute custom code at different times in the lifecycle of a 
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts. Each function to implement in your `handler.lua` file will be executed when the context is reached for a request:
 
@@ -45,7 +45,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish to be executed. In favor of brevity, here is a commented example module implementing all the available methods:
 
@@ -157,7 +157,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on how plugins execution order should be configurable in the future, see <a href="https://github.com/Kong/kong/issues/267">Kong/kong#267</a>.

--- a/app/0.5.x/plugin-development/distribution.md
+++ b/app/0.5.x/plugin-development/distribution.md
@@ -31,7 +31,7 @@ You need to make these modules available in your LUA_PATH.
 
 ---
 
-### Distribute your modules
+## Distribute your modules
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a package manager for Lua modules. It calls such modules "rocks". **Your module does not have to live inside the Kong repository!**, but it can be if that's how you'd like to maintain your Kong setup.
 

--- a/app/0.5.x/plugin-development/file-structure.md
+++ b/app/0.5.x/plugin-development/file-structure.md
@@ -33,7 +33,7 @@ Now let's describe what are the modules you can implement and what their purpose
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -48,7 +48,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in the database, expose endpoints in the Admin API, etc... Each of those can be done by adding a new module to your plugin. Here is what the structure of a plugin would look like if it was implementing all of the optional modules:
 

--- a/app/0.5.x/plugin-development/index.md
+++ b/app/0.5.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what does Lua has to do with it.
 

--- a/app/0.5.x/plugin-development/plugin-configuration.md
+++ b/app/0.5.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -35,7 +35,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -71,7 +71,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -106,7 +106,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.5.x/plugin-development/tests.md
+++ b/app/0.5.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/), though you are free to use another one if you wish.
 

--- a/app/0.5.x/proxy.md
+++ b/app/0.5.x/proxy.md
@@ -60,7 +60,7 @@ Once this request is processed by Kong, the API is stored in your Cassandra clus
 
 ## 3. Proxy an API by its request_host value
 
-#### Using the "**Host**" header
+### Using the "**Host**" header
 
 Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `request_host` value in the `Host` header of your request:
 
@@ -76,7 +76,7 @@ By doing so, Kong recognizes the `Host` value as being the `request_host` of the
   <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
-#### Using the "**X-Host-Override**" header
+### Using the "**X-Host-Override**" header
 
 When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
@@ -88,7 +88,7 @@ $ curl -i -X GET \
 
 This request will be proxied just as well by Kong.
 
-#### Using a wildcard DNS
+### Using a wildcard DNS
 
 Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**request_host**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
@@ -111,7 +111,7 @@ $ curl -i -X GET \
 
 You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `upstream_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
 
-#### Using the "**strip_request_path**" property
+### Using the "**strip_request_path**" property
 
 By enabling the `strip_request_path` property on an API, the requests will be proxied without the `request_path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
 

--- a/app/0.6.x/admin-api.md
+++ b/app/0.6.x/admin-api.md
@@ -648,7 +648,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.6.x/clustering.md
+++ b/app/0.6.x/clustering.md
@@ -34,7 +34,7 @@ Kong cluster settings are specified in the configuration file at the following e
 * [cluster_listen_rpc][cluster_listen_rpc]
 * [cluster][cluster]
 
-#### Why do we need Kong Clustering?
+### Why do we need Kong Clustering?
 
 To understand why a Kong Cluster is needed, we need to spend a few words on how Kong interacts with the datastore.
 
@@ -86,19 +86,19 @@ Kong will try to automatically determine the first non-loopback IPv4 address and
 
 The implementation of the clustering feature of Kong is rather complex and may involve some edge case scenarios.
 
-#### Asynchronous join on concurrent node starts
+### Asynchronous join on concurrent node starts
 
 When multiple nodes are all being started simultaneously, a node may not be aware of the other nodes yet because the other nodes didn't have time to write their data to the datastore. To prevent this situation Kong implements by default a feature called "asynchronous auto-join".
 
 Asynchronous auto-join will check the datastore every 3 seconds for 60 seconds after a Kong node starts, and will join any node that may appear in those 60 seconds. This means that concurrent environments where multiple nodes are started simultaneously it could take up to 60 seconds for them to auto-join the cluster.
 
-#### Automatic cache purge on join
+### Automatic cache purge on join
 
 Every time a new node joins the cluster, or a failed node re-joins the cluster, the cache for every node is purged and all the data is forced to be reloaded. This is to avoid inconsistencies between the data that has already been invalidated in the cluster, and the data stored on the node.
 
 This also means that after joining the cluster the new node's performance will be slower until the data has been re-cached into its memory.
 
-#### Node failures
+### Node failures
 
 A node in the cluster can fail more multiple reasons, including networking problems or crashes. A node failure will also occur if Kong is not properly terminated by running `kong stop` or `kong quit`.
 

--- a/app/0.6.x/getting-started/adding-consumers.md
+++ b/app/0.6.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [key-auth][key-auth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.6.x/getting-started/adding-your-api.md
+++ b/app/0.6.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.6.x/getting-started/enabling-plugins.md
+++ b/app/0.6.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to configure plugins. One of the core principa
 
 As an example, we'll have you configure the [key-auth][key-auth] plugin to add authentication to your API.
 
-1. ### Configure the plugin for your API
+## 1. Configure the plugin for your API
 
     Issue the following cURL request on the previously created API named `mockbin`:
 
@@ -29,7 +29,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
 
     **Note:** This plugin also accepts a `config.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth] plugin was properly configured on the API:
 
@@ -50,7 +50,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.6.x/getting-started/introduction.md
+++ b/app/0.6.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.6.x/getting-started/quickstart.md
+++ b/app/0.6.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare the Cassandra keyspace.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.6.x/plugin-development/access-the-datastore.md
+++ b/app/0.6.x/plugin-development/access-the-datastore.md
@@ -14,7 +14,7 @@ Kong interacts with the model layer through classes we refer to as "DAOs". This 
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -38,7 +38,7 @@ For [performance](http://lua-users.org/wiki/OptimisingUsingLocalVariables) [reas
 
 ---
 
-### DAOs Lua API
+## DAOs Lua API
 
 All methods available on DAOs are documented in the [kong.dao.cassandra.base_dao] module in Kong's Public Lua API Reference. See the [public interface] and [children DAOs interface] sections of the base_dao module.
 
@@ -56,7 +56,7 @@ local inserted_api, err = dao.apis:insert({
 
 ---
 
-### Custom DAOs
+## Custom DAOs
 
 Because Kong needs to deal with more than the three core entities, the [kong.dao.cassandra.base_dao][kong.dao.cassandra.base_dao] can be inherited to support any entity. Plugins make heavy use of this feature, and every existing plugin implements their own DAO, loaded by the DAO Factory and made available everywhere the factory is, just like the core entities.
 

--- a/app/0.6.x/plugin-development/admin-api.md
+++ b/app/0.6.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses. See [kong.tools.responses](/{{page.kong_version}}/lua-reference/modules/kong.tools.responses).
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.6.x/plugin-development/custom-entities.md
+++ b/app/0.6.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -25,7 +25,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create a migration file which will be executed by Kong to create your column family. A migration file simply holds an array of migrations, and returns them.
 
@@ -79,7 +79,7 @@ Cassandra does not support constraints such as "must be unique" or "is a foreign
 
 ---
 
-### Extending the Base DAO
+## Extending the Base DAO
 
 To make the DAO Factory load your custom DAO(s), you will need:
 
@@ -156,7 +156,7 @@ The property name (`keyauth_credentials`) depends on the key with which you expo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.6.x/plugin-development/custom-logic.md
+++ b/app/0.6.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -22,7 +22,7 @@ Kong allows you to execute custom code at different times in the lifecycle of a 
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts. Each function to implement in your `handler.lua` file will be executed when the context is reached for a request:
 
@@ -45,7 +45,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish to be executed. In favor of brevity, here is a commented example module implementing all the available methods:
 
@@ -157,7 +157,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on how plugins execution order should be configurable in the future, see <a href="https://github.com/Kong/kong/issues/267">Kong/kong#267</a>.

--- a/app/0.6.x/plugin-development/distribution.md
+++ b/app/0.6.x/plugin-development/distribution.md
@@ -30,7 +30,7 @@ You need to make these modules available in your LUA_PATH.
 
 ---
 
-### Distribute your modules
+## Distribute your modules
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a package manager for Lua modules. It calls such modules "rocks". **Your module does not have to live inside the Kong repository!**, but it can be if that's how you'd like to maintain your Kong setup.
 

--- a/app/0.6.x/plugin-development/entities-cache.md
+++ b/app/0.6.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -30,7 +30,7 @@ To avoid querying the datastore every time, we can cache custom entities in-memo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in your code by requiring the `database_cache` dependency:
 
@@ -80,13 +80,13 @@ end
 
 By doing so it doesn't matter how many requests the client makes with that particular api-key, after the first request every lookup will be done in-memory without querying the datastore.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted on the datastore, for example using the Admin API, it creates an inconsistency between the data in the datastore, and the data cached in-memory in the Kong node. To avoid this inconsistency, we need to delete the cached entity from the in-memory store and force Kong to request it again from the datastore. In order to do so we must implement an invalidation hook.
 
 ---
 
-### Invalidating custom entities
+## Invalidating custom entities
 
 Every time an entity is being created/updated/deleted in the datastore, Kong notifies the datastore operation across all the nodes telling what command has been executed and what entity has been affected by it. This happens for APIs, Plugins and Consumers, but also for custom entities.
 
@@ -141,7 +141,7 @@ In the example above the plugin is listening to the `ENTITY_UPDATED` and `ENTITY
 
 The entities being transmitted in the `entity` and `old_entity` properties do not have all the fields defined in the schema, but only a subset. This is required because every event is sent in a UDP packet with a payload size limit of 512 bytes. This subset is being returned by the `marshall_event` function in the schema, that you **must** implement.
 
-#### marshall_event
+### marshall_event
 
 This function serializes the custom entity to a minimal version that only includes the fields we will later need to use in `hooks.lua`. For example:
 
@@ -171,7 +171,7 @@ In the example above the custom entity provides a `marshall_event` function that
 
 ---
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with Kong to setup their APIs and plugins. It is likely that they also need to be able to interact with the custom entities you implemented for your plugin (for example, creating and deleting API keys). The way you would do this is by extending the Admin API, which we will detail in the next chapter: [Extending the Admin API]({{page.book.next}}).
 

--- a/app/0.6.x/plugin-development/file-structure.md
+++ b/app/0.6.x/plugin-development/file-structure.md
@@ -31,7 +31,7 @@ Now let's describe what are the modules you can implement and what their purpose
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -46,7 +46,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in the database, expose endpoints in the Admin API, etc... Each of those can be done by adding a new module to your plugin. Here is what the structure of a plugin would look like if it was implementing all of the optional modules:
 

--- a/app/0.6.x/plugin-development/index.md
+++ b/app/0.6.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.6.x/plugin-development/plugin-configuration.md
+++ b/app/0.6.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -35,7 +35,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -71,7 +71,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -106,7 +106,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.6.x/plugin-development/tests.md
+++ b/app/0.6.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/), though you are free to use another one if you wish.
 

--- a/app/0.6.x/proxy.md
+++ b/app/0.6.x/proxy.md
@@ -78,7 +78,7 @@ Once this request is processed by Kong, the API is stored in your Cassandra clus
 
 ## 3. Proxy an API by its DNS value
 
-#### Using the "**Host**" header
+### Using the "**Host**" header
 
 Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `request_host` value in the `Host` header of your request:
 
@@ -94,7 +94,7 @@ By doing so, Kong recognizes the `Host` value as being the `request_host` of the
   <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
-#### Using the "**X-Host-Override**" header
+### Using the "**X-Host-Override**" header
 
 When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
@@ -106,7 +106,7 @@ $ curl -i -X GET \
 
 This request will be proxied just as well by Kong.
 
-#### Using a wildcard DNS
+### Using a wildcard DNS
 
 Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**request_host**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
@@ -129,7 +129,7 @@ $ curl -i -X GET \
 
 You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `upstream_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
 
-#### Using the "**strip_request_path**" property
+### Using the "**strip_request_path**" property
 
 By enabling the `strip_request_path` property on an API, the requests will be proxied without the `request_path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
 

--- a/app/0.7.x/admin-api.md
+++ b/app/0.7.x/admin-api.md
@@ -648,7 +648,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.7.x/clustering.md
+++ b/app/0.7.x/clustering.md
@@ -34,7 +34,7 @@ Kong cluster settings are specified in the configuration file at the following e
 * [cluster_listen_rpc][cluster_listen_rpc]
 * [cluster][cluster]
 
-#### Why do we need Kong Clustering?
+### Why do we need Kong Clustering?
 
 To understand why a Kong Cluster is needed, we need to spend a few words on how Kong interacts with the datastore.
 
@@ -86,19 +86,19 @@ Kong will try to automatically determine the first non-loopback IPv4 address and
 
 The implementation of the clustering feature of Kong is rather complex and may involve some edge case scenarios.
 
-#### Asynchronous join on concurrent node starts
+### Asynchronous join on concurrent node starts
 
 When multiple nodes are all being started simultaneously, a node may not be aware of the other nodes yet because the other nodes didn't have time to write their data to the datastore. To prevent this situation Kong implements by default a feature called "asynchronous auto-join".
 
 Asynchronous auto-join will check the datastore every 3 seconds for 60 seconds after a Kong node starts, and will join any node that may appear in those 60 seconds. This means that concurrent environments where multiple nodes are started simultaneously it could take up to 60 seconds for them to auto-join the cluster.
 
-#### Automatic cache purge on join
+### Automatic cache purge on join
 
 Every time a new node joins the cluster, or a failed node re-joins the cluster, the cache for every node is purged and all the data is forced to be reloaded. This is to avoid inconsistencies between the data that has already been invalidated in the cluster, and the data stored on the node.
 
 This also means that after joining the cluster the new node's performance will be slower until the data has been re-cached into its memory.
 
-#### Node failures
+### Node failures
 
 A node in the cluster can fail more multiple reasons, including networking problems or crashes. A node failure will also occur if Kong is not properly terminated by running `kong stop` or `kong quit`.
 

--- a/app/0.7.x/getting-started/adding-consumers.md
+++ b/app/0.7.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [key-auth][key-auth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.7.x/getting-started/adding-your-api.md
+++ b/app/0.7.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.7.x/getting-started/enabling-plugins.md
+++ b/app/0.7.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to configure plugins. One of the core principa
 
 As an example, we'll have you configure the [key-auth][key-auth] plugin to add authentication to your API.
 
-1. ### Configure the plugin for your API
+## 1. Configure the plugin for your API
 
     Issue the following cURL request on the previously created API named `mockbin`:
 
@@ -29,7 +29,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
 
     **Note:** This plugin also accepts a `config.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth] plugin was properly configured on the API:
 
@@ -50,7 +50,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.7.x/getting-started/introduction.md
+++ b/app/0.7.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.7.x/getting-started/quickstart.md
+++ b/app/0.7.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** If you haven't already, go ahead and make sure that you have a Kong configuration file located under `/etc/kong/kong.yml` and points to your Cassandra instance or cluster. If you haven't, consult the [configuration reference][configuration] before starting.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare the Cassandra keyspace.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.7.x/plugin-development/access-the-datastore.md
+++ b/app/0.7.x/plugin-development/access-the-datastore.md
@@ -14,7 +14,7 @@ Kong interacts with the model layer through classes we refer to as "DAOs". This 
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -38,7 +38,7 @@ For [performance](http://lua-users.org/wiki/OptimisingUsingLocalVariables) [reas
 
 ---
 
-### DAOs Lua API
+## DAOs Lua API
 
 All methods available on DAOs are documented in the [kong.dao.cassandra.base_dao] module in Kong's Public Lua API Reference. See the [public interface] and [children DAOs interface] sections of the base_dao module.
 
@@ -56,7 +56,7 @@ local inserted_api, err = dao.apis:insert({
 
 ---
 
-### Custom DAOs
+## Custom DAOs
 
 Because Kong needs to deal with more than the three core entities, the [kong.dao.cassandra.base_dao][kong.dao.cassandra.base_dao] can be inherited to support any entity. Plugins make heavy use of this feature, and every existing plugin implements their own DAO, loaded by the DAO Factory and made available everywhere the factory is, just like the core entities.
 

--- a/app/0.7.x/plugin-development/admin-api.md
+++ b/app/0.7.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses. See [kong.tools.responses](/{{page.kong_version}}/lua-reference/modules/kong.tools.responses).
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.7.x/plugin-development/custom-entities.md
+++ b/app/0.7.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -25,7 +25,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create a migration file which will be executed by Kong to create your column family. A migration file simply holds an array of migrations, and returns them.
 
@@ -79,7 +79,7 @@ Cassandra does not support constraints such as "must be unique" or "is a foreign
 
 ---
 
-### Extending the Base DAO
+## Extending the Base DAO
 
 To make the DAO Factory load your custom DAO(s), you will need:
 
@@ -156,7 +156,7 @@ The property name (`keyauth_credentials`) depends on the key with which you expo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.7.x/plugin-development/custom-logic.md
+++ b/app/0.7.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -22,7 +22,7 @@ Kong allows you to execute custom code at different times in the lifecycle of a 
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts. Each function to implement in your `handler.lua` file will be executed when the context is reached for a request:
 
@@ -45,7 +45,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish to be executed. In favor of brevity, here is a commented example module implementing all the available methods:
 
@@ -157,7 +157,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on how plugins execution order should be configurable in the future, see <a href="https://github.com/Kong/kong/issues/267">Kong/kong#267</a>.

--- a/app/0.7.x/plugin-development/distribution.md
+++ b/app/0.7.x/plugin-development/distribution.md
@@ -30,7 +30,7 @@ You need to make these modules available in your LUA_PATH.
 
 ---
 
-### Distribute your modules
+## Distribute your modules
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a package manager for Lua modules. It calls such modules "rocks". **Your module does not have to live inside the Kong repository!**, but it can be if that's how you'd like to maintain your Kong setup.
 

--- a/app/0.7.x/plugin-development/entities-cache.md
+++ b/app/0.7.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -30,7 +30,7 @@ To avoid querying the datastore every time, we can cache custom entities in-memo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in your code by requiring the `database_cache` dependency:
 
@@ -80,13 +80,13 @@ end
 
 By doing so it doesn't matter how many requests the client makes with that particular api-key, after the first request every lookup will be done in-memory without querying the datastore.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted on the datastore, for example using the Admin API, it creates an inconsistency between the data in the datastore, and the data cached in-memory in the Kong node. To avoid this inconsistency, we need to delete the cached entity from the in-memory store and force Kong to request it again from the datastore. In order to do so we must implement an invalidation hook.
 
 ---
 
-### Invalidating custom entities
+## Invalidating custom entities
 
 Every time an entity is being created/updated/deleted in the datastore, Kong notifies the datastore operation across all the nodes telling what command has been executed and what entity has been affected by it. This happens for APIs, Plugins and Consumers, but also for custom entities.
 
@@ -141,7 +141,7 @@ In the example above the plugin is listening to the `ENTITY_UPDATED` and `ENTITY
 
 The entities being transmitted in the `entity` and `old_entity` properties do not have all the fields defined in the schema, but only a subset. This is required because every event is sent in a UDP packet with a payload size limit of 512 bytes. This subset is being returned by the `marshall_event` function in the schema, that you can optionally implement.
 
-#### marshall_event
+### marshall_event
 
 This function serializes the custom entity to a minimal version that only includes the fields we will later need to use in `hooks.lua`. If `marshall_event` is not implemented, by default Kong does not send any entity field value along with the event.
 
@@ -173,7 +173,7 @@ In the example above the custom entity provides a `marshall_event` function that
 
 ---
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with Kong to setup their APIs and plugins. It is likely that they also need to be able to interact with the custom entities you implemented for your plugin (for example, creating and deleting API keys). The way you would do this is by extending the Admin API, which we will detail in the next chapter: [Extending the Admin API]({{page.book.next}}).
 

--- a/app/0.7.x/plugin-development/file-structure.md
+++ b/app/0.7.x/plugin-development/file-structure.md
@@ -31,7 +31,7 @@ Now let's describe what are the modules you can implement and what their purpose
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -46,7 +46,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in the database, expose endpoints in the Admin API, etc... Each of those can be done by adding a new module to your plugin. Here is what the structure of a plugin would look like if it was implementing all of the optional modules:
 

--- a/app/0.7.x/plugin-development/index.md
+++ b/app/0.7.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.7.x/plugin-development/plugin-configuration.md
+++ b/app/0.7.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -35,7 +35,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -71,7 +71,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -106,7 +106,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.7.x/plugin-development/tests.md
+++ b/app/0.7.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/), though you are free to use another one if you wish.
 

--- a/app/0.7.x/proxy.md
+++ b/app/0.7.x/proxy.md
@@ -56,7 +56,7 @@ Once this request is processed by Kong, the API is stored in your Cassandra clus
 
 ## 3. Proxy an API by its DNS value
 
-#### Using the "**Host**" header
+### Using the "**Host**" header
 
 Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `request_host` value in the `Host` header of your request:
 
@@ -72,7 +72,7 @@ By doing so, Kong recognizes the `Host` value as being the `request_host` of the
   <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
-#### Using the "**X-Host-Override**" header
+### Using the "**X-Host-Override**" header
 
 When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
@@ -84,7 +84,7 @@ $ curl -i -X GET \
 
 This request will be proxied just as well by Kong.
 
-#### Using a wildcard DNS
+### Using a wildcard DNS
 
 Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**request_host**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
@@ -107,7 +107,7 @@ $ curl -i -X GET \
 
 You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `upstream_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
 
-#### Using the "**strip_request_path**" property
+### Using the "**strip_request_path**" property
 
 By enabling the `strip_request_path` property on an API, the requests will be proxied without the `request_path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
 

--- a/app/0.8.x/admin-api.md
+++ b/app/0.8.x/admin-api.md
@@ -648,7 +648,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.8.x/clustering.md
+++ b/app/0.8.x/clustering.md
@@ -34,7 +34,7 @@ Kong cluster settings are specified in the configuration file at the following e
 * [cluster_listen_rpc][cluster_listen_rpc]
 * [cluster][cluster]
 
-#### Why do we need Kong Clustering?
+### Why do we need Kong Clustering?
 
 To understand why a Kong Cluster is needed, we need to spend a few words on how Kong interacts with the datastore.
 
@@ -86,19 +86,19 @@ Kong will try to automatically determine the first non-loopback IPv4 address and
 
 The implementation of the clustering feature of Kong is rather complex and may involve some edge case scenarios.
 
-#### Asynchronous join on concurrent node starts
+### Asynchronous join on concurrent node starts
 
 When multiple nodes are all being started simultaneously, a node may not be aware of the other nodes yet because the other nodes didn't have time to write their data to the datastore. To prevent this situation Kong implements by default a feature called "asynchronous auto-join".
 
 Asynchronous auto-join will check the datastore every 3 seconds for 60 seconds after a Kong node starts, and will join any node that may appear in those 60 seconds. This means that concurrent environments where multiple nodes are started simultaneously it could take up to 60 seconds for them to auto-join the cluster.
 
-#### Automatic cache purge on join
+### Automatic cache purge on join
 
 Every time a new node joins the cluster, or a failed node re-joins the cluster, the cache for every node is purged and all the data is forced to be reloaded. This is to avoid inconsistencies between the data that has already been invalidated in the cluster, and the data stored on the node.
 
 This also means that after joining the cluster the new node's performance will be slower until the data has been re-cached into its memory.
 
-#### Node failures
+### Node failures
 
 A node in the cluster can fail more multiple reasons, including networking problems or crashes. A node failure will also occur if Kong is not properly terminated by running `kong stop` or `kong quit`.
 

--- a/app/0.8.x/getting-started/adding-consumers.md
+++ b/app/0.8.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [key-auth][key-auth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.8.x/getting-started/adding-your-api.md
+++ b/app/0.8.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.8.x/getting-started/enabling-plugins.md
+++ b/app/0.8.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to configure plugins. One of the core principa
 
 As an example, we'll have you configure the [key-auth][key-auth] plugin to add authentication to your API.
 
-1. ### Configure the plugin for your API
+## 1. Configure the plugin for your API
 
     Issue the following cURL request on the previously created API named `mockbin`:
 
@@ -29,7 +29,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
 
     **Note:** This plugin also accepts a `config.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth] plugin was properly configured on the API:
 
@@ -50,7 +50,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.8.x/getting-started/introduction.md
+++ b/app/0.8.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.8.x/getting-started/quickstart.md
+++ b/app/0.8.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** make sure you have your database instance running and [configured][configuration] in Kong.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare your database.
     Once these have finished you should see a message (`[OK] Started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.8.x/plugin-development/access-the-datastore.md
+++ b/app/0.8.x/plugin-development/access-the-datastore.md
@@ -12,7 +12,7 @@ As of `0.8.0`, Kong supports two primary datastores: [Cassandra {{site.data.kong
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -34,7 +34,7 @@ local plugins_dao = singletons.dao.plugins
 
 ---
 
-### The DAO Lua API
+## The DAO Lua API
 
 The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
 

--- a/app/0.8.x/plugin-development/admin-api.md
+++ b/app/0.8.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses. See [kong.tools.responses](/{{page.kong_version}}/lua-reference/modules/kong.tools.responses).
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.8.x/plugin-development/custom-entities.md
+++ b/app/0.8.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -21,7 +21,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
 
@@ -103,7 +103,7 @@ While Postgres does, Cassandra does not support constraints such as "NOT NULL", 
 
 ---
 
-### Retrieve your custom DAO from the Dao Factory
+## Retrieve your custom DAO from the Dao Factory
 
 To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
 
@@ -162,7 +162,7 @@ The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Fa
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.8.x/plugin-development/custom-logic.md
+++ b/app/0.8.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -22,7 +22,7 @@ Kong allows you to execute custom code at different times in the lifecycle of a 
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts. Each function to implement in your `handler.lua` file will be executed when the context is reached for a request:
 
@@ -46,7 +46,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish to be executed. In favor of brevity, here is a commented example module implementing all the available methods:
 
@@ -158,7 +158,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on how plugins execution order should be configurable in the future, see <a href="https://github.com/Kong/kong/issues/267">Kong/kong#267</a>.

--- a/app/0.8.x/plugin-development/distribution.md
+++ b/app/0.8.x/plugin-development/distribution.md
@@ -31,7 +31,7 @@ You need to make these modules available in your LUA_PATH.
 
 ---
 
-### Distribute your modules
+## Distribute your modules
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a package manager for Lua modules. It calls such modules "rocks". **Your module does not have to live inside the Kong repository!**, but it can be if that's how you'd like to maintain your Kong setup.
 

--- a/app/0.8.x/plugin-development/entities-cache.md
+++ b/app/0.8.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -30,7 +30,7 @@ To avoid querying the datastore every time, we can cache custom entities in-memo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in your code by requiring the `database_cache` dependency:
 
@@ -80,13 +80,13 @@ end
 
 By doing so it doesn't matter how many requests the client makes with that particular api-key, after the first request every lookup will be done in-memory without querying the datastore.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted on the datastore, for example using the Admin API, it creates an inconsistency between the data in the datastore, and the data cached in-memory in the Kong node. To avoid this inconsistency, we need to delete the cached entity from the in-memory store and force Kong to request it again from the datastore. In order to do so we must implement an invalidation hook.
 
 ---
 
-### Invalidating custom entities
+## Invalidating custom entities
 
 Every time an entity is being created/updated/deleted in the datastore, Kong notifies the datastore operation across all the nodes telling what command has been executed and what entity has been affected by it. This happens for APIs, Plugins and Consumers, but also for custom entities.
 
@@ -141,7 +141,7 @@ In the example above the plugin is listening to the `ENTITY_UPDATED` and `ENTITY
 
 The entities being transmitted in the `entity` and `old_entity` properties do not have all the fields defined in the schema, but only a subset. This is required because every event is sent in a UDP packet with a payload size limit of 512 bytes. This subset is being returned by the `marshall_event` function in the schema, that you can optionally implement.
 
-#### marshall_event
+### marshall_event
 
 This function serializes the custom entity to a minimal version that only includes the fields we will later need to use in `hooks.lua`. If `marshall_event` is not implemented, by default Kong does not send any entity field value along with the event.
 
@@ -173,7 +173,7 @@ In the example above the custom entity provides a `marshall_event` function that
 
 ---
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with Kong to setup their APIs and plugins. It is likely that they also need to be able to interact with the custom entities you implemented for your plugin (for example, creating and deleting API keys). The way you would do this is by extending the Admin API, which we will detail in the next chapter: [Extending the Admin API]({{page.book.next}}).
 

--- a/app/0.8.x/plugin-development/file-structure.md
+++ b/app/0.8.x/plugin-development/file-structure.md
@@ -31,7 +31,7 @@ Now let's describe what are the modules you can implement and what their purpose
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -46,7 +46,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in the database, expose endpoints in the Admin API, etc... Each of those can be done by adding a new module to your plugin. Here is what the structure of a plugin would look like if it was implementing all of the optional modules:
 

--- a/app/0.8.x/plugin-development/index.md
+++ b/app/0.8.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.8.x/plugin-development/plugin-configuration.md
+++ b/app/0.8.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -32,7 +32,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -68,7 +68,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -103,7 +103,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.8.x/plugin-development/tests.md
+++ b/app/0.8.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/), though you are free to use another one if you wish.
 

--- a/app/0.8.x/proxy.md
+++ b/app/0.8.x/proxy.md
@@ -52,7 +52,7 @@ Once this request is processed by Kong, the API is stored in the database and a 
 
 ## 3. Proxy an API by its DNS values
 
-#### Using the "**Host**" header
+### Using the "**Host**" header
 
 Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `request_host` value in the `Host` header of your request:
 
@@ -68,7 +68,7 @@ By doing so, Kong recognizes the `Host` value as being the `request_host` of the
   <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
-#### Using the "**X-Host-Override**" header
+### Using the "**X-Host-Override**" header
 
 When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
@@ -80,7 +80,7 @@ $ curl -i -X GET \
 
 This request will be proxied just as well by Kong.
 
-#### Using a wildcard DNS
+### Using a wildcard DNS
 
 Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**request_host**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
@@ -103,7 +103,7 @@ $ curl -i -X GET \
 
 You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `upstream_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
 
-#### Using the "**strip_request_path**" property
+### Using the "**strip_request_path**" property
 
 By enabling the `strip_request_path` property on an API, the requests will be proxied without the `request_path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
 

--- a/app/0.9.x/admin-api.md
+++ b/app/0.9.x/admin-api.md
@@ -641,7 +641,7 @@ values for some specific Consumers, you can do so by specifying the
 
 See the [Precedence](#precedence) section below for more details.
 
-#### Precedence
+### Precedence
 
 Plugins can be added globally (all APIs), on a single API, single Consumer,
 or a combination of both an API and a Consumer. Additionally, a given plugin
@@ -720,7 +720,7 @@ HTTP 201 Created
 
 ---
 
-## Retrieve Plugin
+### Retrieve Plugin
 
 <div class="endpoint get">/plugins/{id}</div>
 

--- a/app/0.9.x/clustering.md
+++ b/app/0.9.x/clustering.md
@@ -103,19 +103,19 @@ Check the [Node Failures](#node-failures) paragraph for more info.
 
 The implementation of the clustering feature of Kong is rather complex and may involve some edge case scenarios.
 
-#### Asynchronous join on concurrent node starts
+### Asynchronous join on concurrent node starts
 
 When multiple nodes are all being started simultaneously, a node may not be aware of the other nodes yet because the other nodes didn't have time to write their data to the datastore. To prevent this situation Kong implements by default a feature called "asynchronous auto-join".
 
 Asynchronous auto-join will check the datastore every 3 seconds for 60 seconds after a Kong node starts, and will join any node that may appear in those 60 seconds. This means that concurrent environments where multiple nodes are started simultaneously it could take up to 60 seconds for them to auto-join the cluster.
 
-#### Automatic cache purge on join
+### Automatic cache purge on join
 
 Every time a new node joins the cluster, or a failed node re-joins the cluster, the in-memory cache for every node is purged and all the data is forced to be re-fetched from the datastore. This is to avoid inconsistencies between the data that has already been invalidated in the cluster, and the data stored on the node.
 
 This also means that after joining the cluster the new node's performance will be slower until the data has been re-cached into the local memory.
 
-#### Node failures
+### Node failures
 
 A node in the cluster can fail more multiple reasons, including networking problems or crashes. A node failure will also occur if Kong is not properly terminated by running `kong stop` or `kong quit`.
 

--- a/app/0.9.x/getting-started/adding-consumers.md
+++ b/app/0.9.x/getting-started/adding-consumers.md
@@ -17,7 +17,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
 **Note:** This section assumes you have [enabled][enabling-plugins] the [key-auth][key-auth] plugin. If you haven't, you can either [enable the plugin][enabling-plugins] or skip steps two and three.
 
-1. ### Create a Consumer through the RESTful API
+## 1. Create a Consumer through the RESTful API
 
     Lets create a user named `Jason` by issuing the following request:
 
@@ -45,7 +45,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
 
     **Note:** Kong also accepts a `custom_id` parameter when [creating consumers][API-consumers] to associate a consumer with your existing user database.
 
-2. ### Provision key credentials for your Consumer
+## 2. Provision key credentials for your Consumer
 
     Now, we can create a key for our recently created consumer `Jason` by issuing the following request:
 
@@ -55,7 +55,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --data 'key=ENTER_KEY_HERE'
     ```
 
-3. ### Verify that your Consumer credentials are valid
+## 3. Verify that your Consumer credentials are valid
 
     We can now issue the following request to verify that the credentials of our `Jason` Consumer is valid:
 
@@ -66,7 +66,7 @@ In the last section, we learned how to add plugins to Kong, in this section we'r
       --header "apikey: ENTER_KEY_HERE"
     ```
 
-### Next Steps
+## Next Steps
 
 Now that we've covered the basics of creating consumers, enabling plugins, and adding apis you can start giving out access and sharing your API.
 

--- a/app/0.9.x/getting-started/adding-your-api.md
+++ b/app/0.9.x/getting-started/adding-your-api.md
@@ -14,7 +14,7 @@ title: Adding your API
 
 In this section, you'll be adding your API to the Kong layer. This is the first step to having Kong manage your API. Kong exposes a [RESTful Admin API][API] for managing the details of your Kong instances.
 
-1. ### Add your API using the RESTful API
+## 1. Add your API using the RESTful API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin]) to Kong:
 
@@ -28,7 +28,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     **Note:** Kong handles API configuration requests on port `:8001`
 
-2. ### Verify that your API has been added
+## 2. Verify that your API has been added
 
     <div class="alert alert-warning">
       For security reasons we suggest <a href="/{{page.kong_version}}/getting-started/enabling-plugins">enabling</a> the <a href="/plugins/request-size-limiting/">Request Size Limiting</a> plugin for any API you add to Kong to prevent a DOS (Denial of Service) attack.
@@ -52,7 +52,7 @@ In this section, you'll be adding your API to the Kong layer. This is the first 
 
     Kong is now aware of your API and ready to proxy requests.
 
-3. ### Forward your requests through Kong
+## 3. Forward your requests through Kong
 
     Issue the following cURL request to verify that Kong is properly forwarding requests to your API:
 

--- a/app/0.9.x/getting-started/enabling-plugins.md
+++ b/app/0.9.x/getting-started/enabling-plugins.md
@@ -17,7 +17,7 @@ In this section, you'll learn how to configure plugins. One of the core principa
 
 As an example, we'll have you configure the [key-auth][key-auth] plugin to add authentication to your API.
 
-1. ### Configure the plugin for your API
+## 1. Configure the plugin for your API
 
     Issue the following cURL request on the previously created API named `mockbin`:
 
@@ -29,7 +29,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
 
     **Note:** This plugin also accepts a `config.key_names` parameter, which defaults to `[apikey]`. It is a list of headers and parameters names (both are supported) that are supposed to contain the API key during a request.
 
-2. ### Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
     Issue the following cURL request to verify that the [key-auth][key-auth] plugin was properly configured on the API:
 
@@ -50,7 +50,7 @@ As an example, we'll have you configure the [key-auth][key-auth] plugin to add a
     }
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add consumers to your API so we can continue proxying requests through Kong.
 

--- a/app/0.9.x/getting-started/introduction.md
+++ b/app/0.9.x/getting-started/introduction.md
@@ -14,7 +14,7 @@ Before going further into Kong, make sure you understand its [purpose and philos
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
 
@@ -22,7 +22,7 @@ To be more precise, Kong is a Lua application running in Nginx and made possible
 
 This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong.
 

--- a/app/0.9.x/getting-started/quickstart.md
+++ b/app/0.9.x/getting-started/quickstart.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
 **Note:** make sure you have your database instance running and [configured][configuration] in Kong.
 
-1. ### Start Kong.
+## 1. Start Kong.
 
     Issue the following command to [start][CLI] Kong:
 
@@ -22,7 +22,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     **Note:** The CLI also accepts a configuration (`-c <path_to_config>`) option allowing you to point to different configurations.
 
-2. ### Verify that Kong has started successfully
+## 2. Verify that Kong has started successfully
 
     The previous step runs migrations to prepare your database.
     Once these have finished you should see a message (`Kong started`) informing you that Kong is running.
@@ -33,7 +33,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
 
     `:8001` - [RESTful Admin API][API] for configuration
 
-3. ### Stop Kong.
+## 3. Stop Kong.
 
     As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -41,7 +41,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong stop
     ```
 
-4. ### Reload Kong.
+## 4. Reload Kong.
 
     Issue the following command to [reload][CLI] Kong without downtime:
 
@@ -49,7 +49,7 @@ In this section, you'll learn how to manage your Kong instance. First we'll have
     $ kong reload
     ```
 
-### Next Steps
+## Next Steps
 
 Now that you have Kong running you can interact with the Admin API.
 

--- a/app/0.9.x/plugin-development/access-the-datastore.md
+++ b/app/0.9.x/plugin-development/access-the-datastore.md
@@ -12,7 +12,7 @@ As of `0.8.0`, Kong supports two primary datastores: [Cassandra {{site.data.kong
 
 ---
 
-### The DAO Factory
+## The DAO Factory
 
 All entities in Kong are represented by:
 
@@ -34,7 +34,7 @@ local plugins_dao = singletons.dao.plugins
 
 ---
 
-### The DAO Lua API
+## The DAO Lua API
 
 The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
 

--- a/app/0.9.x/plugin-development/admin-api.md
+++ b/app/0.9.x/plugin-development/admin-api.md
@@ -6,7 +6,7 @@ chapter: 8
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.api"
@@ -24,7 +24,7 @@ The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's leve
 
 ---
 
-### Adding endpoints to the Admin API
+## Adding endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 
@@ -59,14 +59,14 @@ In addition to the HTTPS verbs it supports, a route table can also contain two o
 
 ---
 
-### Helpers
+## Helpers
 
 When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
 
 - `responses`: a module with helper functions to send HTTP responses.
 - `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
 
-#### crud_helpers
+### crud_helpers
 
 Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
 

--- a/app/0.9.x/plugin-development/custom-entities.md
+++ b/app/0.9.x/plugin-development/custom-entities.md
@@ -6,7 +6,7 @@ chapter: 6
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.schema.migrations"
@@ -21,7 +21,7 @@ As explained in the [previous chapter]({{page.book.previous}}), Kong interacts w
 
 ---
 
-### Create a migration file
+## Create a migration file
 
 Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
 
@@ -103,7 +103,7 @@ While Postgres does, Cassandra does not support constraints such as "NOT NULL", 
 
 ---
 
-### Retrieve your custom DAO from the Dao Factory
+## Retrieve your custom DAO from the Dao Factory
 
 To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
 
@@ -162,7 +162,7 @@ The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Fa
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
 

--- a/app/0.9.x/plugin-development/custom-logic.md
+++ b/app/0.9.x/plugin-development/custom-logic.md
@@ -6,7 +6,7 @@ chapter: 3
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.handler"
@@ -22,7 +22,7 @@ Kong allows you to execute custom code at different times in the lifecycle of a 
 
 ---
 
-### Available request contexts
+## Available request contexts
 
 Kong allows you to write your code in all of the lua-nginx-module contexts. Each function to implement in your `handler.lua` file will be executed when the context is reached for a request:
 
@@ -46,7 +46,7 @@ All of those functions take one parameter given by Kong: the configuration of yo
 
 ---
 
-### handler.lua specifications
+## handler.lua specifications
 
 The `handler.lua` file must return a table implementing the functions you wish to be executed. In favor of brevity, here is a commented example module implementing all the available methods:
 
@@ -158,7 +158,7 @@ return CustomHandler
 
 ---
 
-### Plugins execution order
+## Plugins execution order
 
 <div class="alert alert-warning">
   <strong>Note:</strong> This is still a work-in-progress API. For thoughts on how plugins execution order should be configurable in the future, see <a href="https://github.com/Kong/kong/issues/267">Kong/kong#267</a>.

--- a/app/0.9.x/plugin-development/distribution.md
+++ b/app/0.9.x/plugin-development/distribution.md
@@ -30,7 +30,7 @@ You need to make these modules available in your LUA_PATH.
 
 ---
 
-### Distribute your modules
+## Distribute your modules
 
 The preferred way to do so is to use [Luarocks](https://luarocks.org/), a package manager for Lua modules. It calls such modules "rocks". **Your module does not have to live inside the Kong repository!**, but it can be if that's how you'd like to maintain your Kong setup.
 

--- a/app/0.9.x/plugin-development/entities-cache.md
+++ b/app/0.9.x/plugin-development/entities-cache.md
@@ -6,7 +6,7 @@ chapter: 7
 
 ## Introduction
 
-#### Modules
+## Modules
 
 ```
 "kong.plugins.<plugin_name>.daos"
@@ -30,7 +30,7 @@ To avoid querying the datastore every time, we can cache custom entities in-memo
 
 ---
 
-### Caching custom entities
+## Caching custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in your code by requiring the `database_cache` dependency:
 
@@ -80,13 +80,13 @@ end
 
 By doing so it doesn't matter how many requests the client makes with that particular api-key, after the first request every lookup will be done in-memory without querying the datastore.
 
-#### Updating or deleting a custom entity
+### Updating or deleting a custom entity
 
 Every time a cached custom entity is updated or deleted on the datastore, for example using the Admin API, it creates an inconsistency between the data in the datastore, and the data cached in-memory in the Kong node. To avoid this inconsistency, we need to delete the cached entity from the in-memory store and force Kong to request it again from the datastore. In order to do so we must implement an invalidation hook.
 
 ---
 
-### Invalidating custom entities
+## Invalidating custom entities
 
 Every time an entity is being created/updated/deleted in the datastore, Kong notifies the datastore operation across all the nodes telling what command has been executed and what entity has been affected by it. This happens for APIs, Plugins and Consumers, but also for custom entities.
 
@@ -141,7 +141,7 @@ In the example above the plugin is listening to the `ENTITY_UPDATED` and `ENTITY
 
 The entities being transmitted in the `entity` and `old_entity` properties do not have all the fields defined in the schema, but only a subset. This is required because every event is sent in a UDP packet with a payload size limit of 512 bytes. This subset is being returned by the `marshall_event` function in the schema, that you can optionally implement.
 
-#### marshall_event
+### marshall_event
 
 This function serializes the custom entity to a minimal version that only includes the fields we will later need to use in `hooks.lua`. If `marshall_event` is not implemented, by default Kong does not send any entity field value along with the event.
 
@@ -173,7 +173,7 @@ In the example above the custom entity provides a `marshall_event` function that
 
 ---
 
-### Extending the Admin API
+## Extending the Admin API
 
 As you are probably aware, the [Admin API] is where Kong users communicate with Kong to setup their APIs and plugins. It is likely that they also need to be able to interact with the custom entities you implemented for your plugin (for example, creating and deleting API keys). The way you would do this is by extending the Admin API, which we will detail in the next chapter: [Extending the Admin API]({{page.book.next}}).
 

--- a/app/0.9.x/plugin-development/file-structure.md
+++ b/app/0.9.x/plugin-development/file-structure.md
@@ -32,7 +32,7 @@ Now let's describe what are the modules you can implement and what their purpose
 
 ---
 
-### Basic plugin modules
+## Basic plugin modules
 
 In its purest form, a plugin consists of two mandatory modules:
 
@@ -47,7 +47,7 @@ simple-plugin
 
 ---
 
-### Advanced plugin modules
+## Advanced plugin modules
 
 Some plugins might have to integrate deeper with Kong: have their own table in the database, expose endpoints in the Admin API, etc... Each of those can be done by adding a new module to your plugin. Here is what the structure of a plugin would look like if it was implementing all of the optional modules:
 

--- a/app/0.9.x/plugin-development/index.md
+++ b/app/0.9.x/plugin-development/index.md
@@ -6,7 +6,7 @@ chapter: 1
 
 # Plugin development - Introduction
 
-### What are plugins and how do they integrate with Kong?
+## What are plugins and how do they integrate with Kong?
 
 Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
 

--- a/app/0.9.x/plugin-development/plugin-configuration.md
+++ b/app/0.9.x/plugin-development/plugin-configuration.md
@@ -6,7 +6,7 @@ chapter: 4
 
 ## Introduction
 
-#### Module
+## Module
 
 ```
 "kong.plugins.<plugin_name>.schema"
@@ -32,7 +32,7 @@ If all properties of the `config` object are valid according to your schema, the
 
 ---
 
-### schema.lua specifications
+## schema.lua specifications
 
 This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
 
@@ -68,7 +68,7 @@ return {
 }
 ```
 
-### Describing your configuration schema
+## Describing your configuration schema
 
 The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
 
@@ -103,7 +103,7 @@ Here is the list of accepted rules for a property:
 
 ---
 
-#### Examples:
+### Examples:
 
 This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
 

--- a/app/0.9.x/plugin-development/tests.md
+++ b/app/0.9.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ If you are serious about your plugins, you probably want to write tests for it. 
 
 ---
 
-### Write integration tests
+## Write integration tests
 
 The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/) running with the [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are free to use another one if you wish. In the Kong repository, the busted executable can be found at `bin/busted`.
 

--- a/app/0.9.x/proxy.md
+++ b/app/0.9.x/proxy.md
@@ -74,7 +74,7 @@ Once this request is processed by Kong, the API is stored in the database and a 
 
 ## 3. Proxy an API by its DNS values
 
-#### Using the "**Host**" header
+### Using the "**Host**" header
 
 Now that we added an API to Kong (via the Admin API), Kong can proxy it via the `8000` port. One way to do so is to specify the API's `request_host` value in the `Host` header of your request:
 
@@ -90,7 +90,7 @@ By doing so, Kong recognizes the `Host` value as being the `request_host` of the
   <strong>Going to production:</strong> If you're planning to go into production with your setup, you'll most likely not want your consumers to manually set the "<strong>Host</strong>" header on each request. You can let Kong and DNS take care of it by simply setting an A or CNAME record on your domain pointing to your Kong installation. Hence, any request made to `example.org` will already contain a `Host: example.org` header.
 </div>
 
-#### Using the "**X-Host-Override**" header
+### Using the "**X-Host-Override**" header
 
 When performing a request from a browser, you might not be able to set the `Host` header. Thus, Kong also checks a request for a header named `X-Host-Override` and treats it exactly like the `Host` header:
 
@@ -102,7 +102,7 @@ $ curl -i -X GET \
 
 This request will be proxied just as well by Kong.
 
-#### Using a wildcard DNS
+### Using a wildcard DNS
 
 Sometimes you might want to route all requests matching a wildcard DNS to your upstream services. A "**request_host**" wildcard name may contain an asterisk only on the name’s start or end, and only on a dot border.
 
@@ -125,7 +125,7 @@ $ curl -i -X GET \
 
 You will notice this command makes a request to `KONG_URL:PROXY_PORT/status/200`. Since the configured `upstream_url` is `http://mockbin.com/`, the request will hit the upstream service at `http://mockbin.com/status/200`.
 
-#### Using the "**strip_request_path**" property
+### Using the "**strip_request_path**" property
 
 By enabling the `strip_request_path` property on an API, the requests will be proxied without the `request_path` property being included in the upstream request. Let's enable this option by making a request to the Admin API:
 

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -65,7 +65,7 @@ If a header bearing the same name is already present in the client request, it i
 
 ## Generators
 
-#### uuid
+### uuid
 
 Format:
 ```
@@ -74,7 +74,7 @@ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 Using this format, a UUID is generated in its hexadecimal form for each request.
 
-#### uuid#counter
+### uuid#counter
 
 Format:
 ```
@@ -85,7 +85,7 @@ In this format, a single UUID is generated on a per-worker basis, and further re
 
 This format provides a better performance, but might be harder to store or process for analyzing (due to its format and low cardinality).
 
-#### tracker
+### tracker
 
 Format:
 ```
@@ -107,6 +107,6 @@ form parameter      | description
 
 ## FAQ
 
-#### Can I see my correlation ids in my Kong logs?
+### Can I see my correlation ids in my Kong logs?
 
 The correlation id will not show up in the Nginx access or error logs. As such, we suggest you use this plugin alongside one of the Logging plugins, or store this id on your backend-side.

--- a/app/_hub/kong-inc/openid-connect/0.32-x.md
+++ b/app/_hub/kong-inc/openid-connect/0.32-x.md
@@ -122,7 +122,7 @@ kong_version_compatibility:
 
 ---
 
-#### Kong OpenID Connect Plugin
+## Kong OpenID Connect Plugin
 
 The Kong OpenID Connect plugin provides a general-purpose OpenID Connect and OAuth toolkit.
 
@@ -1961,9 +1961,9 @@ Location: https://<ISSUER>/authorize?scope=openid&client_id=<CLIENT_ID>&response
 Server: kong/0.10.3
 Set-Cookie: authorization=<COOKIE>; Path=/; HttpOnly
 ```
-```html
+```
 <html>
-  <head><title>302 Found</title></head>
+  <head><title>302 FoundDDD</title></head>
   <body bgcolor="white">
     <center><h1>302 Found</h1></center>
     <hr><center>openresty/1.11.2.2</center>

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -112,7 +112,7 @@ params:
 
 ---
 
-### Dynamic Transformation Based on Request Content
+## Dynamic Transformation Based on Request Content
 
 The Request Transformer plugin bundled with Kong Enterprise Edition allows for
 adding or replacing content in the upstream request based on variable data found

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -80,6 +80,6 @@ The `http_endpoint` configuration variable must contain the full uri including s
 
 ## FAQ
 
-#### Can I use this plugin with other tracing systems, like Jaeger?
+### Can I use this plugin with other tracing systems, like Jaeger?
 
 Probably! Jaeger accepts spans in Zipkin format - see https://www.jaegertracing.io/docs/features/#backwards-compatibility-with-zipkin for more information.

--- a/app/_hub/peter-evans/paseto/index.md
+++ b/app/_hub/peter-evans/paseto/index.md
@@ -113,7 +113,7 @@ params:
 
 ## Installation
 
-#### Sodium Crypto Library
+### Sodium Crypto Library
 
 This plugin uses the [PASETO for Lua](https://github.com/peter-evans/paseto-lua) library, which in turn depends on the [Sodium crypto library (libsodium)](https://github.com/jedisct1/libsodium).
 The following is a convenient way to install libsodium via LuaRocks.
@@ -125,7 +125,7 @@ luarocks install libsodium
 
 Note: The Sodium Crypto Library must be installed on each node in your Kong cluster.
 
-#### PASETO Kong Plugin
+### PASETO Kong Plugin
 Install the plugin on each node in your Kong cluster via luarocks:
 
 ```
@@ -142,7 +142,7 @@ custom_plugins = paseto
 
 In order to use the plugin, you first need to create a Consumer and associate one or more PASETO credentials (holding the public key used to verify the token) to it. The Consumer represents a developer using the final service.
 
-#### Create a Consumer
+### Create a Consumer
 
 You need to associate a credential to an existing Consumer object. To create a Consumer, you can execute the following request:
 
@@ -160,7 +160,7 @@ HTTP/1.1 201 Created
 
 A Consumer can have many PASETO credentials.
 
-#### Create a PASETO credential
+### Create a PASETO credential
 
 You can provision a new PASETO credential by issuing the following HTTP request:
 
@@ -188,7 +188,7 @@ HTTP/1.1 201 Created
 
 If neither `secret_key` or `public_key` are supplied the plugin will generate a new key pair.
 
-#### Delete a PASETO credential
+### Delete a PASETO credential
 
 You can remove a Consumer's PASETO credential by issuing the following HTTP
 request:
@@ -201,7 +201,7 @@ HTTP/1.1 204 No Content
 - `consumer`: The `id` or `username` property of the Consumer entity to associate the credentials to.
 - `id`: The `id` of the PASETO credential.
 
-#### List PASETO credentials
+### List PASETO credentials
 
 You can list a Consumer's PASETO credentials by issuing the following HTTP
 request:
@@ -229,7 +229,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-#### Send a request with a PASETO
+### Send a request with a PASETO
 
 PASETOs can now be included in a request to Kong by adding it to the `Authorization` header:
 

--- a/app/enterprise/0.31-x/getting-started/enabling-plugins.md
+++ b/app/enterprise/0.31-x/getting-started/enabling-plugins.md
@@ -16,7 +16,7 @@ plugin, **only** requests with the correct API key(s) will be proxied - all
 other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
-### 1. Configure the key-auth plugin for your API
+## 1. Configure the key-auth plugin for your API
 
 Issue the following cURL request on the previously created API named
 `example-api`:
@@ -38,7 +38,7 @@ Or, add your first plugin via the Admin GUI:
 defaults to `[apikey]`. It is a list of headers and parameters names (both
 are supported) that are supposed to contain the API key during a request.
 
-### 2. Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
 Issue the following cURL request to verify that the [key-auth][key-auth]
 plugin was properly configured on the API:
@@ -61,7 +61,7 @@ HTTP/1.1 401 Unauthorized
 }
 ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin, let's learn to add
 Consumers to your API so we can continue proxying requests through Kong.

--- a/app/enterprise/0.31-x/getting-started/introduction.md
+++ b/app/enterprise/0.31-x/getting-started/introduction.md
@@ -13,7 +13,7 @@ how to use Kong and perform basic operations such as:
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on NGINX, leveraging its stability and
 efficiency. But how is this possible exactly?
@@ -32,7 +32,7 @@ architecture**: at its core, it implements database abstraction, routing and
 plugin management. Plugins can live in separate code bases and be injected
 anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong EE.
 

--- a/app/enterprise/0.31-x/getting-started/quickstart.md
+++ b/app/enterprise/0.31-x/getting-started/quickstart.md
@@ -14,7 +14,7 @@ The easiest way to start using Kong EE is by following our [Docker installation]
 Alternately, you can install and run without containers by following our [CentOS][centos] or 
 [Amazon Linux][amazonlinux] instructions.
 
-### 1. Start Kong EE
+## 1. Start Kong EE
 
 Issue the following command to prepare your datastore by running the Kong
 migrations:
@@ -36,7 +36,7 @@ $ kong start [-c /path/to/kong.conf]
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
 allowing you to point to your own configuration.
 
-### 2. Verify that Kong EE has started successfully
+## 2. Verify that Kong EE has started successfully
 
 If everything went well, you should see a message (`Kong started`)
 informing you that Kong is running.
@@ -56,7 +56,7 @@ By default Kong listens on the following ports:
 - `:8445` on which the [Admin GUI][GUI] listens for HTTPS traffic.
 
 
-### 3. Stop Kong EE
+## 3. Stop Kong EE
 
 As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -64,7 +64,7 @@ As needed you can stop the Kong process by issuing the following [command][CLI]:
 $ kong stop
 ```
 
-### 4. Reload Kong EE
+## 4. Reload Kong EE
 
 Issue the following command to [reload][CLI] Kong without downtime:
 

--- a/app/enterprise/0.31-x/installation/amazon-linux.md
+++ b/app/enterprise/0.31-x/installation/amazon-linux.md
@@ -4,7 +4,7 @@ title: How to install Kong Enterprise and PostgreSQL onto Amazon Linux
 
 # How to Install Kong Enterprise and PostgreSQL onto Amazon Linux
 
-### Install Kong
+## Install Kong
 ```bash
 EITHER (assuming free trial .rpm loaded locally)
 $ sudo yum install kong-free-trials-enterprise-edition-0.31-1.aws.rpm
@@ -20,7 +20,7 @@ baseurl=https://<BINTRAY_USER>:<BINTRAY_API_KEY>@kong.bintray.com/kong-enterpris
 $ sudo yum install kong-enterprise-edition
 ```
 
-### Install Postgres
+## Install Postgres
 ```bash
 $ sudo yum install postgresql95 postgresql95-server
 $ sudo service postgresql95 initdb
@@ -28,7 +28,7 @@ $ sudo service postgresql95 start
 $ sudo -i -u postgres (puts you into new shell)
 ```
 
-#### Create `kong` user
+### Create `kong` user
 ```bash
 $ psql
 > CREATE USER kong; CREATE DATABASE kong OWNER kong; ALTER USER kong WITH password 'kong'; 
@@ -36,7 +36,7 @@ $ psql
 $ exit
 ```
 
-#### Add required DB and Kong settings
+### Add required DB and Kong settings
 ```bash
 # Change entries from ident to md5
 $ sudo vi /var/lib/pgsql95/data/pg_hba.conf
@@ -53,7 +53,7 @@ $ kong migrations up -c /etc/kong/kong.conf.default
 $ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
 ```
 
-#### Test your Kong installation
+### Test your Kong installation
 
 ```bash
 $ curl -X POST \
@@ -66,7 +66,7 @@ $ curl -X POST \
 $ curl -X GET --url 'http://localhost:8000/ip'
 ```
 
-#### Setup Admin GUI
+### Setup Admin GUI
 
 ```bash
 # Get the local IP address

--- a/app/enterprise/0.31-x/kong-implementation-checklist.md
+++ b/app/enterprise/0.31-x/kong-implementation-checklist.md
@@ -6,17 +6,17 @@ title: Kong Implementation Checklist
 - Kong can run on instances of any size with any resources. While the system requirements vary significantly depending on the use-case, generally speaking, we recommend to start big and then gradually reduce the instances to the appropriate number and size.
 - When allocating resources to a Kong cluster, slightly over-provision the cluster to make room for request spikes. Kong requires a database to run and you can choose either Cassandra or PostgreSQL.
 
-### PostgreSQL
+## PostgreSQL
 
 - Generally speaking, PostgreSQL works well for most of the use-cases, and it’s usually easier to setup. We recommend setting up a master-slave replication with servers located in different racks, data centers or availability zones to account for infrastructure failures.
 - In multi-DC environments, PostgreSQL may not be the right fit, since a Kong node located in a different datacenter will have to send write requests all the way to the PostgreSQL data-center, adding increased latency to the system.
 
-### Cassandra
+## Cassandra
 
 - We recommend using Cassandra in multi-DC environments because it supports native replication and availability capabilities of the system. When starting a Cassandra cluster for Kong, we recommend starting at least 3 nodes in every datacenter with a replication setting of 2.
 - Cassandra is an eventually consistent datastore, which means that over time the data will be the same across the cluster, so please account for inconsistencies in the system.
 
-### Kong Cluster
+## Kong Cluster
 
 - Regardless of the datastore being adopted with Kong, the Kong nodes themselves need to join in a cluster. The Kong nodes will talk to each other via their connections to the database (PostgreSQL or Cassandra). Please refer to the [clustering reference](/latest/clustering/) for more details.
 

--- a/app/enterprise/0.31-x/plugins/rbac-api.md
+++ b/app/enterprise/0.31-x/plugins/rbac-api.md
@@ -8,12 +8,12 @@ title: RBAC API
   Be sure to review the <a href="/enterprise/latest/setting-up-admin-api-rbac">RBAC overview</a> before exploring the RBAC API below.
 </div>
 
-### Add A User
+## Add A User
 **Endpoint**
 
 <div class="endpoint post">/rbac/users</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
@@ -23,6 +23,7 @@ title: RBAC API
 | `comment`<br>optional | A string describing the RBAC user object.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -38,7 +39,7 @@ HTTP 201 Created
 ```
 ___
 
-### Retrieve A User
+## Retrieve A User
 **Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}</div>
@@ -48,6 +49,7 @@ ___
 | `name_or_id` | The RBAC user name or UUID.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -63,12 +65,13 @@ HTTP 200 OK
 ```
 ___
 
-### List Users
+## List Users
 **Endpoint**
 
 <div class="endpoint get">/rbac/users/</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -89,7 +92,7 @@ HTTP 200 OK
 ```
 ___
 
-### Update A User
+## Update A User
 **Endpoint**
 
 <div class="endpoint patch">/rbac/users/{name_or_id}</div>
@@ -102,6 +105,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC user object.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -117,18 +121,19 @@ HTTP 200 OK
 ```
 ___
 
-### Delete a User
+## Delete a User
 **Endpoint**
 
 <div class="endpoint delete">/rbac/users/{name_or_id}</div>
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ___
 
-### Add a Role
+## Add a Role
 **Endpoint**
 
 <div class="endpoint post">/rbac/roles</div>
@@ -139,6 +144,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC user object.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -152,7 +158,7 @@ HTTP 201 Created
 ```
 ___
 
-### Retrieve a Role
+## Retrieve a Role
 **Endpoint**
 
 <div class="endpoint get">/rbac/role{name_or_id}</div>
@@ -162,6 +168,7 @@ ___
 | `name_or_id` | The RBAC role name or UUID.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -175,12 +182,13 @@ HTTP 200 OK
 ```
 ___
 
-### List Roles
+## List Roles
 **Endpoint**
 
 <div class="endpoint get">/rbac/roles</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -199,7 +207,7 @@ HTTP 200 OK
 ```
 ___
 
-### Update A Role
+## Update A Role
 **Endpoint**
 
 <div class="endpoint patch">/rbac/roles/{name_or_id}</div>
@@ -210,6 +218,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC role object.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -225,23 +234,24 @@ HTTP 200 OK
 ```
 ___
 
-### Delete A Role
+## Delete A Role
 **Endpoint**
 
 <div class="endpoint delete">/rbac/role/{name_or_id}</div>
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ___
 
-### Add A Permission
+## Add A Permission
 **Endpoint**
 
 <div class="endpoint post">/rbac/permissions</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
@@ -275,7 +285,7 @@ HTTP 201 Created
 ```
 ---
 
-### Retrieve A Permission
+## Retrieve A Permission
 **Endpoint**
 
 <div class="endpoint get">/rbac/permissions/{name_or_id}</div>
@@ -308,12 +318,13 @@ HTTP 200 OK
 ```
 ---
 
-### List Permissions
+## List Permissions
 **Endpoint**
 
 <div class="endpoint get">/rbac/permissions/</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -341,12 +352,12 @@ HTTP 200 OK
 ```
 ---
 
-### Update a Permission
+## Update a Permission
 **Endpoint**
 
 <div class="endpoint patch">/rbac/permissions/{name_or_id}</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
@@ -380,29 +391,31 @@ HTTP 200 OK
 ```
 ---
 
-### Delete A Permission
+## Delete A Permission
 **Endpoint**
 
 <div class="endpoint delete">/rbac/permissions/{name_or_id}</div>
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ---
 
-### Add a User to a Role
+## Add a User to a Role
 **Endpoint**
 
 <div class="endpoint post">/rbac/users/{name_or_id}/roles</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
 | `roles` | Comma-separated list of role names to assign to the user.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -427,12 +440,13 @@ HTTP 201 Created
 ```
 ---
 
-### List a User's Roles
+## List a User's Roles
 **Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}/roles</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -457,12 +471,13 @@ HTTP 200 OK
 ```
 ---
 
-### List a User's Permissions
+## List a User's Permissions
 **Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}/permissions</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -483,34 +498,36 @@ HTTP 200 OK
 ```
 ---
 
-### Delete a Role from a User
+## Delete a Role from a User
 **Endpoint**
 
 <div class="endpoint delete">/rbac/users/{name_or_id}/roles</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
 | `roles` | Comma-separated list of role names to assign to the user.
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ---
 
-### Add a Permission to a Role
+## Add a Permission to a Role
 **Endpoint**
 
 <div class="endpoint post">/rbac/roles/{name_or_id}/permissions</div>
 
-#### Request Body
+### Request Body
 | Attribute | Description
 | --------- | -----------
 | `permissions` | Comma-separated list of permission names to assign to the role.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -557,12 +574,13 @@ HTTP 201 Created
 ```
 ---
 
-### List a Role's Permissions
+## List a Role's Permissions
 **Endpoint**
 
 <div class="endpoint get">/rbac/roles/{name_or_id}/permissions</div>
 
 **Response**
+
 ```
 200 OK
 ```
@@ -609,28 +627,30 @@ HTTP 201 Created
 ```
 ---
 
-### Delete A Permission from a Role
+## Delete A Permission from a Role
 **Endpoint**
 
 <div class="endpoint delete">/rbac/roles/{name_or_id}/permissions</div>
 
-#### Request Body
+### Request Body
 | Attribute | Description
 | --------- | -----------
 | `permissions` | Comma-separated list of permission names to remove from the user.
 
 **Response**
+
 ```
 204 No Content
 ```
 ---
 
-### List Available RBAC Resources
+## List Available RBAC Resources
 **Endpoint**
 
 <div class="endpoint get">/rbac/resources</div>
 
 **Response**
+
 ```
 200 OK
 ```

--- a/app/enterprise/0.32-x/developer-portal/configuration/getting-started.md
+++ b/app/enterprise/0.32-x/developer-portal/configuration/getting-started.md
@@ -27,10 +27,10 @@ You should now see the Default Dev Portal Homepage, and be able to navigate thro
 
 ## Next Steps
 
-#### Adding Authentication
+### Adding Authentication
 To add Authentication, head on over to [Authenticating the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication).
 
-#### Customizing
+### Customizing
 To begin customizing your Dev Portal, jump to [Customizing the Kong Developer Portal](/enterprise/{{page.kong_version}}/developer-portal/customization).
 
 Next: [Authentication &rsaquo;]({{page.book.next}})

--- a/app/enterprise/0.32-x/developer-portal/faq.md
+++ b/app/enterprise/0.32-x/developer-portal/faq.md
@@ -6,13 +6,13 @@ chapter: 11
 
 # FAQ
 
-### Why do I get `{"message":"not found"}` when I visit my Developer Portal?
+## Why do I get `{"message":"not found"}` when I visit my Developer Portal?
 
 You most likely have not configured the [`portal`][property_portal] 
 property correctly. Check your Kong Configuration and ensure that [`portal`][property_portal]
 is set to `on`.
 
-### Why do I see `No Files Found` when I visit my Developer Portal?
+## Why do I see `No Files Found` when I visit my Developer Portal?
 
 This can be caused by a few reasons:
 
@@ -22,7 +22,7 @@ This can be caused by a few reasons:
 If you have confirmed that you have files and your network setup is properly
 configured, please [contact support](mailto:support@konghq.com) for further assistance.
 
-### Why do I have files with `unauthenticated/` in them?
+## Why do I have files with `unauthenticated/` in them?
 
 When a user requests a particular page to access that they are not authorized to
 view, the Dev Portal will check for the same filename under the `unauthenticated`
@@ -30,12 +30,12 @@ namespace to serve instead. For this reason `unauthenticated` is a reserved
 namespace, and should **only** be used for portals that have Authentication
 enabled.
 
-### What file types are supported?
+## What file types are supported?
 
 You can find a list of supported template types on the 
 [File Management][file_types] page.
 
-### Does the developer portal support uploading images, scripts, and videos?
+## Does the developer portal support uploading images, scripts, and videos?
 
 Currently the Kong Developer Portal only supports text based content, custom 
 scripts &amp; styles, can be added by leveraging `partials`.
@@ -43,25 +43,25 @@ scripts &amp; styles, can be added by leveraging `partials`.
 Media like images, SVGs, and videos should be encoded and inserted inline or 
 hosted elsewhere and referenced.
 
-### Can I use other API specification formats like API Blueprint?
+## Can I use other API specification formats like API Blueprint?
 
 Currently only Swagger 2 and OpenAPI 3 are supported.
 
-### Can I modify the Header and Meta tags? 
+## Can I modify the Header and Meta tags? 
 
 Direct modification of the `<meta>` and `<head>` tags is currently not supported, 
 you can accomplish this through Custom JS included as a handlebars partial.
 
-### Can I host my API spec files outside of the File API?
+## Can I host my API spec files outside of the File API?
 
 Currently the Kong Developer Portal can only render API specifications that are
 served by the File API.
 
-### Can I write my content in markdown?
+## Can I write my content in markdown?
 
 Currently content written in Markdown format is not supported.
 
-### Can I change the code snippet languages displayed on my documentation?
+## Can I change the code snippet languages displayed on my documentation?
 
 Yes! You can change the display and languages of the code snippets by modifying
 the `unauthenticated/code-snippet-languages.hbs` partial through the Portal API. 

--- a/app/enterprise/0.32-x/developer-portal/file-management.md
+++ b/app/enterprise/0.32-x/developer-portal/file-management.md
@@ -123,7 +123,7 @@ An example Specification Loader is as follows:
 
 ## Adding Files
 
-#### File Requirements
+### File Requirements
 
 * File names **must not** include the file extension, unless you wish your pages and partials to be referenced with them.
     * A **Page** with `name=guides.hbs` would be accessible at: `http://127.0.0.1:8003/guides.hbs`
@@ -136,7 +136,7 @@ An example Specification Loader is as follows:
     * Files with the `.hbs` extension may contain HTML or [Handlebars](https://handlebarsjs.com/) code
 * Specification files **must** be in `yaml` or `json` format
 
-#### Uploading a new page or partial
+### Uploading a new page or partial
 
 Create a new file with the name `example.hbs` in your Example Dev Portal files directory under the `pages/` directory.
 

--- a/app/enterprise/0.32-x/developer-portal/glossary.md
+++ b/app/enterprise/0.32-x/developer-portal/glossary.md
@@ -5,12 +5,12 @@ chapter: 2
 ---
 ## Introduction
 
-### Key Terms
+## Key Terms
 
 * **Example Dev Portal** = The set of pages, partials, and specs that are provided in the example Dev Portal files.
 * **Handlebars** = [Handlebars](https://handlebarsjs.com/) is a semantic JavaScript templating language.
 
-### Types of Humans
+## Types of Humans
 
 * **Developer** = A human that wants to learn about your APIs by visiting your Dev Portal.
 * **Admin** = A human that has access to administer **Kong** functionality.
@@ -22,7 +22,7 @@ chapter: 2
 * **User** = A human that uses an Application.
     * When OpenID Connect is in use, the **User** is typically involved in delegating permission to **Kong API Gateway** to proxy the requests that are coming from the **Application** that the **User** is using.
 
-### Types of Files
+## Types of Files
 
 * **Specifications / Specs** = An API specification, in **OpenAPI** (formerly known as Swagger) format. 
 * **Partials** = These are Handlebar files made up of HTML, JS, and CSS content that define the look, feel, functionality, and structure of your Dev Portal.
@@ -31,7 +31,7 @@ chapter: 2
     * The Loader requests **Pages**, **Partials** and **Specifications** from Kong, which it uses to render your **Dev Portal** in the visitor's browser.
     * The **Loader** is not modifiable by Admins - instead, customization is performed by modifying **Specifications**, **Partials**, and **Pages**.
 
-### Other Concepts
+## Other Concepts
 
 * **API** = The APIs that are proxied by Kong API Gateway, the APIs that are documented in Dev Portal, and APIs whose usage is monitored by Vitals, etc.
     * Note that this is *not* the **Admin API** of Kong - we consistently refer to that as **Admin API**

--- a/app/enterprise/0.32-x/developer-portal/managing-developers.md
+++ b/app/enterprise/0.32-x/developer-portal/managing-developers.md
@@ -29,7 +29,7 @@ A status represents the state of a developer and the access they have to your AP
 Developers who have requested access to your **Kong Developer Portal** will appear under the **Requested Access** tab.
 From this tab you can choose to *Accept* or *Reject* the developer from the actions in the table row. After selecting an action the corresponding tab will update.
 
-#### Enabling Auto Approval
+### Enabling Auto Approval
 
 You can choose to have developers automatically approved and skip the requested state. To enable follow these steps:
 

--- a/app/enterprise/0.32-x/getting-started/accessing-your-license.md
+++ b/app/enterprise/0.32-x/getting-started/accessing-your-license.md
@@ -32,7 +32,7 @@ curl -L <u$username>@kong<$api-key>
 
 > Please note: This command requires your Bintray API key, not your account password. Once logged into Bintray, you can find your API key by visiting (https://bintray.com/profile/edit) and clicking "API Key" in the menud. Please contact your CSE or <support@konghq.com> if you need assistance accessing your API key.
 
-### Free Trial Users
+## Free Trial Users
 
 If you are a Free Trial user a link to your license file can be found in the Download and Install Instructions email sent immediately after signing up for your free trial.
 

--- a/app/enterprise/0.32-x/getting-started/enabling-plugins.md
+++ b/app/enterprise/0.32-x/getting-started/enabling-plugins.md
@@ -16,7 +16,7 @@ plugin, **only** requests with the correct API key(s) will be proxied - all
 other requests will be rejected by Kong, thus protecting your upstream service
 from unauthorized use.
 
-### 1. Configure the key-auth plugin for your API
+## 1. Configure the key-auth plugin for your API
 
 Issue the following cURL request on the previously created API named
 `example-api`:
@@ -38,7 +38,7 @@ Or, add your first plugin via the Admin GUI:
 defaults to `[apikey]`. It is a list of headers and parameters names (both
 are supported) that are supposed to contain the API key during a request.
 
-### 2. Verify that the plugin is properly configured
+## 2. Verify that the plugin is properly configured
 
 Issue the following cURL request to verify that the [key-auth][key-auth]
 plugin was properly configured on the API:
@@ -61,7 +61,7 @@ HTTP/1.1 401 Unauthorized
 }
 ```
 
-### Next Steps
+## Next Steps
 
 Now that you've configured the **key-auth** plugin, let's learn to add
 Consumers to your API so we can continue proxying requests through Kong.

--- a/app/enterprise/0.32-x/getting-started/introduction.md
+++ b/app/enterprise/0.32-x/getting-started/introduction.md
@@ -13,7 +13,7 @@ how to use Kong and perform basic operations such as:
 - [Adding and consuming APIs][adding-your-api].
 - [Installing plugins on Kong][enabling-plugins].
 
-### What is Kong, technically?
+## What is Kong, technically?
 
 You’ve probably heard that Kong is built on NGINX, leveraging its stability and
 efficiency. But how is this possible exactly?
@@ -32,7 +32,7 @@ architecture**: at its core, it implements database abstraction, routing and
 plugin management. Plugins can live in separate code bases and be injected
 anywhere into the request lifecycle, all in a few lines of code.
 
-### Next Steps
+## Next Steps
 
 Now, lets get familiar with learning how to "start" and "stop" Kong EE.
 

--- a/app/enterprise/0.32-x/getting-started/quickstart.md
+++ b/app/enterprise/0.32-x/getting-started/quickstart.md
@@ -14,7 +14,7 @@ The easiest way to start using Kong EE is by following our [Docker installation]
 Alternately, you can install and run without containers by following our [CentOS][centos] or 
 [Amazon Linux][amazonlinux] instructions.
 
-### 1. Start Kong EE
+## 1. Start Kong EE
 
 Issue the following command to prepare your datastore by running the Kong
 migrations:
@@ -36,7 +36,7 @@ $ kong start [-c /path/to/kong.conf]
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
 allowing you to point to your own configuration.
 
-### 2. Verify that Kong EE has started successfully
+## 2. Verify that Kong EE has started successfully
 
 If everything went well, you should see a message (`Kong started`)
 informing you that Kong is running.
@@ -56,7 +56,7 @@ By default Kong listens on the following ports:
 - `:8445` on which the [Admin GUI][GUI] listens for HTTPS traffic.
 
 
-### 3. Stop Kong EE
+## 3. Stop Kong EE
 
 As needed you can stop the Kong process by issuing the following [command][CLI]:
 
@@ -64,7 +64,7 @@ As needed you can stop the Kong process by issuing the following [command][CLI]:
 $ kong stop
 ```
 
-### 4. Reload Kong EE
+## 4. Reload Kong EE
 
 Issue the following command to [reload][CLI] Kong without downtime:
 

--- a/app/enterprise/0.32-x/installation/amazon-linux.md
+++ b/app/enterprise/0.32-x/installation/amazon-linux.md
@@ -49,7 +49,7 @@ $ kong migrations up -c /etc/kong/kong.conf.default
 $ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
 ```
 
-### Setup HTTPie to make commands easier
+## Setup HTTPie to make commands easier
 
 ```bash
 $ sudo yum install python-pip

--- a/app/enterprise/0.32-x/kong-implementation-checklist.md
+++ b/app/enterprise/0.32-x/kong-implementation-checklist.md
@@ -6,17 +6,17 @@ title: Kong Implementation Checklist
 - Kong can run on instances of any size with any resources. While the system requirements vary significantly depending on the use-case, generally speaking, we recommend to start big and then gradually reduce the instances to the appropriate number and size.
 - When allocating resources to a Kong cluster, slightly over-provision the cluster to make room for request spikes. Kong requires a database to run and you can choose either Cassandra or PostgreSQL.
 
-### PostgreSQL
+## PostgreSQL
 
 - Generally speaking, PostgreSQL works well for most of the use-cases, and it’s usually easier to setup. We recommend setting up a master-slave replication with servers located in different racks, data centers or availability zones to account for infrastructure failures.
 - In multi-DC environments, PostgreSQL may not be the right fit, since a Kong node located in a different datacenter will have to send write requests all the way to the PostgreSQL data-center, adding increased latency to the system.
 
-### Cassandra
+## Cassandra
 
 - We recommend using Cassandra in multi-DC environments because it supports native replication and availability capabilities of the system. When starting a Cassandra cluster for Kong, we recommend starting at least 3 nodes in every datacenter with a replication setting of 2.
 - Cassandra is an eventually consistent datastore, which means that over time the data will be the same across the cluster, so please account for inconsistencies in the system.
 
-### Kong Cluster
+## Kong Cluster
 
 - Regardless of the datastore being adopted with Kong, the Kong nodes themselves need to join in a cluster. The Kong nodes will talk to each other via their connections to the database (PostgreSQL or Cassandra). Please refer to the [clustering reference](/latest/clustering/) for more details.
 

--- a/app/enterprise/0.32-x/plugins/rbac-api.md
+++ b/app/enterprise/0.32-x/plugins/rbac-api.md
@@ -7,12 +7,12 @@ title: RBAC API
   Be sure to review the <a href="/enterprise/latest/setting-up-admin-api-rbac">RBAC overview</a> before exploring the RBAC API below.
 </div>
 
-### Add A User
+## Add A User
 **Endpoint**
 
 <div class="endpoint post">/rbac/users</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
@@ -22,6 +22,7 @@ title: RBAC API
 | `comment`<br>optional | A string describing the RBAC user object.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -37,7 +38,7 @@ HTTP 201 Created
 ```
 ___
 
-### Retrieve A User
+## Retrieve A User
 **Endpoint** 
 
 <div class="endpoint get">/rbac/users/{name_or_id}</div>
@@ -47,6 +48,7 @@ ___
 | `name_or_id` | The RBAC user name or UUID.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -62,12 +64,13 @@ HTTP 200 OK
 ```
 ___
 
-### List Users
+## List Users
 **Endpoint** 
 
 <div class="endpoint get">/rbac/users/</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -88,7 +91,7 @@ HTTP 200 OK
 ```
 ___
 
-### Update A User
+## Update A User
 **Endpoint** 
 
 <div class="endpoint patch">/rbac/users/{name_or_id}</div>
@@ -101,6 +104,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC user object.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -116,18 +120,19 @@ HTTP 200 OK
 ```
 ___
 
-### Delete a User
+## Delete a User
 **Endpoint** 
 
 <div class="endpoint delete">/rbac/users/{name_or_id}</div>
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ___
 
-### Add a Role
+## Add a Role
 **Endpoint** 
 
 <div class="endpoint post">/rbac/roles</div>
@@ -138,6 +143,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC user object.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -151,7 +157,7 @@ HTTP 201 Created
 ```
 ___
 
-### Retrieve a Role
+## Retrieve a Role
 **Endpoint** 
 
 <div class="endpoint get">/rbac/role{name_or_id}</div>
@@ -161,6 +167,7 @@ ___
 | `name_or_id` | The RBAC role name or UUID.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -174,12 +181,13 @@ HTTP 200 OK
 ```
 ___
 
-### List Roles
+## List Roles
 **Endpoint** 
 
 <div class="endpoint get">/rbac/roles</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -198,7 +206,7 @@ HTTP 200 OK
 ```
 ___
 
-### Update A Role
+## Update A Role
 **Endpoint** 
 
 <div class="endpoint patch">/rbac/roles/{name_or_id}</div>
@@ -209,6 +217,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC role object.
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -224,23 +233,24 @@ HTTP 200 OK
 ```
 ___
 
-### Delete A Role
+## Delete A Role
 **Endpoint** 
 
 <div class="endpoint delete">/rbac/role/{name_or_id}</div>
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ___
 
-### Add A Permission
+## Add A Permission
 **Endpoint**
 
 <div class="endpoint post">/rbac/permissions</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
@@ -274,7 +284,7 @@ HTTP 201 Created
 ```
 ---
 
-### Retrieve A Permission
+## Retrieve A Permission
 **Endpoint**
 
 <div class="endpoint get">/rbac/permissions/{name_or_id}</div>
@@ -307,12 +317,13 @@ HTTP 200 OK
 ```
 ---
 
-### List Permissions
+## List Permissions
 **Endpoint**
 
 <div class="endpoint get">/rbac/permissions/</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -340,12 +351,12 @@ HTTP 200 OK
 ```
 ---
 
-### Update a Permission
+## Update a Permission
 **Endpoint**
 
 <div class="endpoint patch">/rbac/permissions/{name_or_id}</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
@@ -379,29 +390,31 @@ HTTP 200 OK
 ```
 ---
 
-### Delete A Permission
+## Delete A Permission
 **Endpoint**
 
 <div class="endpoint delete">/rbac/permissions/{name_or_id}</div>
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ---
 
-### Add a User to a Role
+## Add a User to a Role
 **Endpoint**
 
 <div class="endpoint post">/rbac/users/{name_or_id}/roles</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
 | `roles` | Comma-separated list of role names to assign to the user.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -426,12 +439,13 @@ HTTP 201 Created
 ```
 ---
 
-### List a User's Roles
+## List a User's Roles
 **Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}/roles</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -456,12 +470,13 @@ HTTP 200 OK
 ```
 ---
 
-### List a User's Permissions
+## List a User's Permissions
 **Endpoint**
 
 <div class="endpoint get">/rbac/users/{name_or_id}/permissions</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -482,34 +497,36 @@ HTTP 200 OK
 ```
 ---
 
-### Delete a Role from a User
+## Delete a Role from a User
 **Endpoint**
 
 <div class="endpoint delete">/rbac/users/{name_or_id}/roles</div>
 
-#### Request Body
+### Request Body
 
 | Attribute | Description
 | --------- | -----------
 | `roles` | Comma-separated list of role names to assign to the user.
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
 ---
 
-### Add a Permission to a Role
+## Add a Permission to a Role
 **Endpoint**
 
 <div class="endpoint post">/rbac/roles/{name_or_id}/permissions</div>
 
-#### Request Body
+### Request Body
 | Attribute | Description
 | --------- | -----------
 | `permissions` | Comma-separated list of permission names to assign to the role.
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -556,12 +573,13 @@ HTTP 201 Created
 ```
 ---
 
-### List a Role's Permissions
+## List a Role's Permissions
 **Endpoint**
 
 <div class="endpoint get">/rbac/roles/{name_or_id}/permissions</div>
 
-**Response** 
+**Response**
+
 ```
 200 OK
 ```
@@ -608,28 +626,30 @@ HTTP 201 Created
 ```
 ---
 
-### Delete A Permission from a Role
+## Delete A Permission from a Role
 **Endpoint**
 
 <div class="endpoint delete">/rbac/roles/{name_or_id}/permissions</div>
 
-#### Request Body
+### Request Body
 | Attribute | Description
 | --------- | -----------
 | `permissions` | Comma-separated list of permission names to remove from the user.
 
 **Response**
+
 ```
 204 No Content
 ```
 ---
 
-### List Available RBAC Resources
+## List Available RBAC Resources
 **Endpoint**
 
 <div class="endpoint get">/rbac/resources</div>
 
 **Response**
+
 ```
 200 OK
 ```

--- a/app/enterprise/0.33-x/developer-portal/file-management.md
+++ b/app/enterprise/0.33-x/developer-portal/file-management.md
@@ -117,7 +117,7 @@ An example Specification Loader is as follows:
 
 ## Adding Files
 
-#### File Requirements
+### File Requirements
 
 * File names **must not** include the file extension, unless you wish your pages and partials to be referenced with them.
     * A **Page** with `name=guides.hbs` would be accessible at: `http://127.0.0.1:8003/guides.hbs`
@@ -130,7 +130,7 @@ An example Specification Loader is as follows:
     * Files with the `.hbs` extension may contain HTML or [Handlebars](https://handlebarsjs.com/) code
 * Specification files **must** be in `yaml` or `json` format
 
-#### Uploading a new page or partial
+### Uploading a new page or partial
 
 Create a new file with the name `example.hbs` in your Example Dev Portal files directory under the `pages/` directory.
 

--- a/app/enterprise/0.33-x/developer-portal/managing-developers.md
+++ b/app/enterprise/0.33-x/developer-portal/managing-developers.md
@@ -41,7 +41,7 @@ curl -svX PATCH \
   --data 'status=0'
 ```
 
-#### Enabling Auto Approval
+### Enabling Auto Approval
 
 You can choose to have developers automatically approved and skip the requested state. To enable follow these steps:
 

--- a/app/enterprise/0.33-x/rbac/admin-api.md
+++ b/app/enterprise/0.33-x/rbac/admin-api.md
@@ -41,6 +41,7 @@ There are 4 basic entities involving RBAC.
 | `comment`<br>optional    | A string describing the RBAC user object.                                                                                           |
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -66,6 +67,7 @@ ___
 | `name_or_id` | The RBAC user name or UUID. |
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -87,6 +89,7 @@ ___
 <div class="endpoint get">/rbac/users/</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -150,6 +153,7 @@ HTTP 201 Created or HTTP 200 OK
 | `comment`<br>optional    | A string describing the RBAC user object.                                                                                           |
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -175,6 +179,7 @@ ___
 | `name_or_id` | The RBAC user name or UUID. |
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
@@ -191,6 +196,7 @@ ___
 | `comment`<br>optional | A string describing the RBAC user object. |
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -214,6 +220,7 @@ Endpoint
 | `name_or_id` | The RBAC role name or UUID. |
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -233,6 +240,7 @@ ___
 <div class="endpoint get">/rbac/roles</div>
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -293,6 +301,7 @@ HTTP 201 Created or HTTP 200 OK
 | `comment`<br>optional | A string describing the RBAC role object. |
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -317,6 +326,7 @@ ___
 | `name`                | The RBAC role name.                       |
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
@@ -426,6 +436,7 @@ HTTP 200 OK
 | `role_name_or_id` | The RBAC role name or UUID. |
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -562,6 +573,7 @@ entities** in the system.
 
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -595,6 +607,7 @@ HTTP 201 Created
 | `entity_id`           | id of the entity associated with this permission.                                                                               |
 
 **Response**
+
 ```
 HTTP 200 Ok
 ```
@@ -628,6 +641,7 @@ HTTP 200 Ok
 | `name_or_id`          | The RBAC permisson name or UUID.                                                                                                |
 
 **Response**
+
 ```
 HTTP 200 Ok
 ```
@@ -703,6 +717,7 @@ HTTP 200 OK
 | `entity_id`  | The entity name or UUID.    |
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
@@ -719,6 +734,7 @@ HTTP 204 No Content
 
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -758,6 +774,7 @@ HTTP 200 OK
 | `roles`   | Comma-separated list of role names to assign to the user. |
 
 **Response**
+
 ```
 HTTP 201 Created
 ```
@@ -792,6 +809,7 @@ HTTP 201 Created
 
 
 **Response**
+
 ```
 HTTP 200 OK
 ```
@@ -831,6 +849,7 @@ HTTP 200 OK
 | `roles`   | Comma-separated list of role names to assign to the user. |
 
 **Response**
+
 ```
 HTTP 204 No Content
 ```
@@ -850,6 +869,7 @@ HTTP 204 No Content
 | `name_or_id`          | The RBAC user name or UUID.                                                                                                     |
 
 **Response**
+
 ```
 HTTP 200 OK
 ```

--- a/app/enterprise/0.33-x/rbac/overview.md
+++ b/app/enterprise/0.33-x/rbac/overview.md
@@ -103,7 +103,7 @@ Transfer-Encoding: chunked
 }
 ```
 
-#### User
+### User
 
 A user identifies the actor sending the current request. Users are identified
 by Kong via the `user_token` element, sent to the Admin API as a request header.
@@ -113,7 +113,7 @@ the `enabled` flag on the User entity in the Admin API; this allows Kong
 administrators to quickly enable and disable users without removing their
 tokens or metadata.
 
-#### Role
+### Role
 
 Roles tie together users and permissions, effectively assignment permissions to
 a user based on the assignment of permissions to the roles. Roles have a


### PR DESCRIPTION
### Summary

This pull request changes the nesting of many headers in the markdown files so that the table-of-contents generator handles them properly.
This also fixes an issue where too little spacing occasionally caused ``` to become headings.

### Issues resolved

Fix #944

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation, N/A
- [x] Spellchecked my updates
- [x] Ready to be merged
