### PR TITLE
docs: format <code> in <a> to look 'linky'

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -156,6 +156,11 @@ a {
   &:hover {
     color: @blue - 30%;
   }
+
+  code {
+    color: @blue;
+    background-color: #ebf7ff;
+  }
 }
 
 h1, h2, h3, h4, h5, h6, .page-header-section-title {


### PR DESCRIPTION
### Summary

Added styling to display `<code>` in links better.

#### Examples:

**Existing**: https://docs.konghq.com/enterprise/0.33-x/developer-portal/configuration/networking/

**Updated:**
![image](https://user-images.githubusercontent.com/5520415/47548345-a42aa480-d8ad-11e8-9831-cbd5cd2ba9f5.png)

------

**Existing:** https://docs.konghq.com/0.14.x/proxy/

**Updated:**
![image](https://user-images.githubusercontent.com/5520415/47548381-bb699200-d8ad-11e8-9e4a-eacfc8ac8366.png)


### Full changelog

* Added styles to `<code>` nested in `<a>`

### Issues resolved

Fix #834 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [X] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
