### PR TITLE
Add currently active version to version dropdown

### DIFF
--- a/app/0.10.x/lua-reference/index.html
+++ b/app/0.10.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.dao.html
+++ b/app/0.10.x/lua-reference/modules/kong.dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.10.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.plugins.galileo.alf.html
+++ b/app/0.10.x/lua-reference/modules/kong.plugins.galileo.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.plugins.galileo.buffer.html
+++ b/app/0.10.x/lua-reference/modules/kong.plugins.galileo.buffer.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.10.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.10.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.10.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.10.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.10.x/lua-reference/modules/spec.helpers.html
+++ b/app/0.10.x/lua-reference/modules/spec.helpers.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/index.html
+++ b/app/0.11.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.dao.html
+++ b/app/0.11.x/lua-reference/modules/kong.dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.11.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.plugins.galileo.alf.html
+++ b/app/0.11.x/lua-reference/modules/kong.plugins.galileo.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.plugins.galileo.buffer.html
+++ b/app/0.11.x/lua-reference/modules/kong.plugins.galileo.buffer.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.11.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.11.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.11.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.11.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.11.x/lua-reference/modules/spec.helpers.html
+++ b/app/0.11.x/lua-reference/modules/spec.helpers.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/index.html
+++ b/app/0.12.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.dao.html
+++ b/app/0.12.x/lua-reference/modules/kong.dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.12.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.plugins.galileo.alf.html
+++ b/app/0.12.x/lua-reference/modules/kong.plugins.galileo.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.plugins.galileo.buffer.html
+++ b/app/0.12.x/lua-reference/modules/kong.plugins.galileo.buffer.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.12.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.12.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.12.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.12.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.12.x/lua-reference/modules/spec.helpers.html
+++ b/app/0.12.x/lua-reference/modules/spec.helpers.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/index.html
+++ b/app/0.13.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.dao.html
+++ b/app/0.13.x/lua-reference/modules/kong.dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.13.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.plugins.galileo.alf.html
+++ b/app/0.13.x/lua-reference/modules/kong.plugins.galileo.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.plugins.galileo.buffer.html
+++ b/app/0.13.x/lua-reference/modules/kong.plugins.galileo.buffer.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.13.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.13.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.13.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.13.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.13.x/lua-reference/modules/spec.helpers.html
+++ b/app/0.13.x/lua-reference/modules/spec.helpers.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/index.html
+++ b/app/0.5.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.dao.cassandra.base_dao.html
+++ b/app/0.5.x/lua-reference/modules/kong.dao.cassandra.base_dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.5.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.5.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
+++ b/app/0.5.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.tools.io.html
+++ b/app/0.5.x/lua-reference/modules/kong.tools.io.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.5.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.5.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.5.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.5.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/index.html
+++ b/app/0.6.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.dao.cassandra.base_dao.html
+++ b/app/0.6.x/lua-reference/modules/kong.dao.cassandra.base_dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.kong.html
+++ b/app/0.6.x/lua-reference/modules/kong.kong.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.6.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.6.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
+++ b/app/0.6.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.tools.io.html
+++ b/app/0.6.x/lua-reference/modules/kong.tools.io.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.6.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.6.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.6.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.6.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/index.html
+++ b/app/0.7.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.dao.cassandra.base_dao.html
+++ b/app/0.7.x/lua-reference/modules/kong.dao.cassandra.base_dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.kong.html
+++ b/app/0.7.x/lua-reference/modules/kong.kong.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.7.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.7.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
+++ b/app/0.7.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.tools.io.html
+++ b/app/0.7.x/lua-reference/modules/kong.tools.io.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.7.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.7.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.7.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.7.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/index.html
+++ b/app/0.8.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.dao.html
+++ b/app/0.8.x/lua-reference/modules/kong.dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.8.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.8.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
+++ b/app/0.8.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.tools.io.html
+++ b/app/0.8.x/lua-reference/modules/kong.tools.io.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.8.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.8.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.8.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.8.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/index.html
+++ b/app/0.9.x/lua-reference/index.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.dao.html
+++ b/app/0.9.x/lua-reference/modules/kong.dao.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/0.9.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/0.9.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
+++ b/app/0.9.x/lua-reference/modules/kong.plugins.log-serializers.alf.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.tools.io.html
+++ b/app/0.9.x/lua-reference/modules/kong.tools.io.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/0.9.x/lua-reference/modules/kong.tools.responses.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/0.9.x/lua-reference/modules/kong.tools.timestamp.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/0.9.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/0.9.x/lua-reference/modules/kong.tools.utils.html
@@ -14,30 +14,10 @@ layout: default
       <p>For plugins developers and core contributors</p>
     </div>
     {% if site.data.kong_versions.size > 1 %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Version {{page.kong_version}}
-          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
-            {% if page.kong_version != ver.release %}
-              <li>
-                {% if ver.lua_doc %}
-                  <a href="/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
-                  </a>
-                {% else %}
-                  <span>Not available for {{ver.release}}</span>
-                {% endif %}
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% include lua-reference-dropdown.html
+        page=page
+        site=site
+      %}
     {% endif %}
   </div>
 </header>

--- a/app/_assets/stylesheets/dropdown.less
+++ b/app/_assets/stylesheets/dropdown.less
@@ -49,6 +49,18 @@
   }
 }
 
+.versions-dropdown {
+  li {
+    border-left: 2px solid transparent;
+  }
+  li.active {
+    border-left-color: @blue;
+    a {
+      font-weight: 600;
+    }
+  }
+}
+
 .dropdown-menu > .active > a {
   &,
   &:hover,

--- a/app/_assets/stylesheets/dropdown.less
+++ b/app/_assets/stylesheets/dropdown.less
@@ -52,11 +52,12 @@
 .versions-dropdown {
   li {
     border-left: 2px solid transparent;
-  }
-  li.active {
-    border-left-color: @blue;
-    a {
-      font-weight: 600;
+
+    &.active {
+      border-left-color: @blue;
+      a {
+        font-weight: 600;
+      }
     }
   }
 }

--- a/app/_includes/lua-reference-dropdown.html
+++ b/app/_includes/lua-reference-dropdown.html
@@ -1,0 +1,22 @@
+<div class="dropdown page-header-right">
+  <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Version {{page.kong_version}}
+    {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+    <span class="caret"></span>
+  </button>
+
+  <ul class="versions-dropdown dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+    {% for ver in site.data.kong_versions %}
+      <li {% if ver.release== page.kong_version %} class="active" {% endif %}>
+        {% if ver.lua_doc %}
+          <a href="/{{ver.release}}/lua-reference/">
+            {{ver.release}}
+            {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+          </a>
+        {% else %}
+          <span>Not available for {{ver.release}}</span>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -22,7 +22,7 @@ id: documentation
       </div>
 
       {% if page.kong_versions.size > 1 %}
-        <div class="dropdown page-header-right">
+        <div class="versions-dropdown dropdown page-header-right">
           <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Version {{page.kong_version}}
             {% if page.kong_version == page.kong_latest.release %}<em>(latest)</em>{% endif %}
@@ -30,13 +30,11 @@ id: documentation
           </button>
             <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
             {% for ver in page.kong_versions reversed %}
-              {% unless page.kong_version == ver.release %}
-                <li>
-                  <a href="/{%if page.edition == 'enterprise' %}enterprise/{% endif %}{{ver.release}}"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                    {{ver.release}}
-                  </a>
-                </li>
-              {% endunless %}
+              <li {% if page.kong_version == ver.release %} class="active" {% endif %}>
+                <a href="/{%if page.edition == 'enterprise' %}enterprise/{% endif %}{{ver.release}}"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                  {{ver.release}}
+                </a>
+              </li>
             {% endfor %}
           </ul>
           {% if page.edition == 'community' %}

--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -32,7 +32,7 @@ id: documentation
             {% for ver in page.kong_versions reversed %}
               <li {% if page.kong_version == ver.release %} class="active" {% endif %}>
                 <a href="/{%if page.edition == 'enterprise' %}enterprise/{% endif %}{{ver.release}}"{% if ver.release == page.kong_version %} class="active"{% endif %}>
-                  {{ver.release}}
+                  {{ver.release}} {% if ver.release == page.kong_latest.release %}<em>(latest)</em>{% endif %}
                 </a>
               </li>
             {% endfor %}

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -198,7 +198,9 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
               {% assign ver_path = ver.release | append: ".html" %}
             {% endif %}
             <li {% if extn_release == ver.release %} class="active" {% endif %}>
-              <a href="/hub/{{ extn_publisher }}/{{ extn_slug }}/{{ ver_path }}">{{ver.release}}</a>
+              <a href="/hub/{{ extn_publisher }}/{{ extn_slug }}/{{ ver_path }}">
+                {{ver.release}} {% if ver.release == extn_latest %}<em>(latest)</em>{% endif %}
+              </a>
             </li>
           {% endfor %}
         </ul>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -183,26 +183,23 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
   <div class="container">
 
     {% if extn_versions %}
-      <div class="dropdown page-header-right">
-        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <div class="versions-dropdown dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true"
+                aria-expanded="false">
           {{extn_type | capitalize }} Version {{extn_release}}
           {% if extn_release == extn_latest %}<em>(latest)</em>{% endif %}
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
           {% for ver in extn_versions %}
-            {% unless extn_release == ver.release %}
-              {% if ver.release == extn_latest %}
-                {% assign ver_path = "" %}
-              {% else %}
-                {% assign ver_path = ver.release | append: ".html" %}
-              {% endif %}
-              <li>
-                <a href="/hub/{{ extn_publisher }}/{{ extn_slug }}/{{ ver_path }}">
-                  {{ver.release}}
-                </a>
-              </li>
-            {% endunless %}
+            {% if ver.release == extn_latest %}
+              {% assign ver_path = "" %}
+            {% else %}
+              {% assign ver_path = ver.release | append: ".html" %}
+            {% endif %}
+            <li {% if extn_release == ver.release %} class="active" {% endif %}>
+              <a href="/hub/{{ extn_publisher }}/{{ extn_slug }}/{{ ver_path }}">{{ver.release}}</a>
+            </li>
           {% endfor %}
         </ul>
       </div>


### PR DESCRIPTION
### Summary

Add the currently selected version of the documentation to the version selection dropdown so that users can see what version they're viewing easily.

**Documentation Example**
![image](https://user-images.githubusercontent.com/5520415/47595098-61abab00-d933-11e8-85cb-f2ef7b8e7126.png)

**Plugin Example**
![image](https://user-images.githubusercontent.com/5520415/47595694-6d4ca100-d936-11e8-85c6-6762079d675a.png)


**Lua Reference Example**
![image](https://user-images.githubusercontent.com/5520415/47595534-bb14d980-d935-11e8-8870-f13f1d105459.png)

I couldn't find a way that looked good to change the width to make the button and dropdown the same size, so that's left off of this PR.

### Full changelog

* Show currently selected documentation version in version dropdown

### Issues resolved

Fix #886 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [X] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A<!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates N/A
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
