### PR TITLE
docs(terms and privacy) redirect and mark dead

### DIFF
--- a/app/privacy/index.md
+++ b/app/privacy/index.md
@@ -1,7 +1,19 @@
 ---
 title: Privacy
-header_title: Privacy
-header_caption: Privacy and cookie policy
+
+redirect_to: https://konghq.com/privacy/
+
+
+# !!!!!!!!!!!!!!!!!!!!!!!!   WARNING   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#
+# FIXME This file is dead code - it is no longer being rendered or utilized,
+# and updates to this file will have no effect.
+#
+# The remaining contents of this file (below) will be deleted soon.
+##
+# !!!!!!!!!!!!!!!!!!!!!!!!   WARNING   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
 ---
 
 # Overview

--- a/app/terms/index.md
+++ b/app/terms/index.md
@@ -1,7 +1,19 @@
 ---
 title: Terms
-header_title: Terms of service
-header_caption: "Last Revised: March 2, 2015"
+
+redirect_to: https://konghq.com/terms/
+
+
+# !!!!!!!!!!!!!!!!!!!!!!!!   WARNING   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#
+# FIXME This file is dead code - it is no longer being rendered or utilized,
+# and updates to this file will have no effect.
+#
+# The remaining contents of this file (below) will be deleted soon.
+##
+# !!!!!!!!!!!!!!!!!!!!!!!!   WARNING   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
 ---
 
 # Welcome to Kong.


### PR DESCRIPTION
Redirect /terms and /privacy to www.KongHQ.com website pages

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
