### PR TITLE
Removed button styling from <ul> items

### DIFF
--- a/app/_assets/stylesheets/pages/install-method.less
+++ b/app/_assets/stylesheets/pages/install-method.less
@@ -64,59 +64,53 @@
     }
 
     ul {
-      list-style: none;
-      padding: 0;
+      list-style: disc;
+      padding: 0 0 0 20px;
       margin: 0;
 
       li {
         margin-right: 10px;
+        display: list-item;
 
-        display: inline-flex;
-        align-items: center;
+      }
+    }
 
-        a {
-          display: flex;
-          align-items: center;
+    .btn{
+      display: inline-block;
+      margin-right:10px;
+      position:relative;
 
-          &:extend(.button all);
-          border-color: #d4d7d9;
-          background-image: linear-gradient(to top, #f7f9fa, #fcfcfc);
-          color: @gray-dark;
-          font-size: 14px;
-          line-height: 39px;
-          height: 40px;
-
-          em {
-            margin-left: 5px;
-            font-style: normal;
-            color: #aab0b2;
-          }
-
-          &:active {
-            background: #f7f9fa;
-          }
-
-          &:before {
-            content: '';
-            display: inline-block;
-            width: 16px;
-            height: 16px;
-            background-image: url('/assets/images/icons/icn-download.svg');
-            background-size: 16px;
-            background-repeat: no-repeat;
-            margin-right: 5px;
-          }
-        }
-
-        &:not(:last-of-type):after {
+      &.download{
+        padding-left:35px;
+        &:before {
           content: '';
+          position:absolute;
+          left:10px;
+          top:12.5px;
           display: inline-block;
-          width: 1px;
-          height: 30px;
-          margin-left: 10px;
-
-          border-right: 1px solid #d4d7d9;
+          width: 16px;
+          height: 16px;
+          background-image: url('/assets/images/icons/icn-download.svg');
+          background-size: 16px;
+          background-repeat: no-repeat;
         }
+      }
+
+      &:extend(.button all);
+      border-color: #d4d7d9;
+      background-image: linear-gradient(to top, #f7f9fa, #fcfcfc);
+      color: @gray-dark;
+      font-size: 14px;
+      line-height: 39px;
+      height: 40px;
+      em {
+        margin-left: 5px;
+        font-style: normal;
+        color: #aab0b2;
+      }
+
+      &:active {
+        background: #f7f9fa;
       }
     }
 

--- a/app/_includes/button.html
+++ b/app/_includes/button.html
@@ -1,0 +1,1 @@
+<button type="button" class="btn {{include.button_class}}">{{include.button_name}}</button>

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -18,11 +18,11 @@ links:
 ## Table of Contents
 
 <!-- FIXME the list below should be an unordered list, but currently those do not render correctly in this section of the Docs site - depends on https://github.com/Kong/docs.konghq.com/issues/917 -->
-1. [Kubernetes Ingress Controller for Kong](#kubernetes-ingress-controller-for-kong)
-1. [Kong via Google Cloud Platform Marketplace](#kong-via-google-cloud-platform-marketplace)
-1. [Kong via Helm or Minikube](#kong-via-helm-or-minikube)
-1. [Kong via Manifest Files](#kong-via-manifest-files)
-1. [Additional Steps for Kong Enterprise Trial Users](#additional-steps-for-kong-enterprise-trial-users)
+* [Kubernetes Ingress Controller for Kong](#kubernetes-ingress-controller-for-kong)
+* [Kong via Google Cloud Platform Marketplace](#kong-via-google-cloud-platform-marketplace)
+* [Kong via Helm or Minikube](#kong-via-helm-or-minikube)
+* [Kong via Manifest Files](#kong-via-manifest-files)
+* [Additional Steps for Kong Enterprise Trial Users](#additional-steps-for-kong-enterprise-trial-users)
 
 # Kubernetes Ingress Controller for Kong
 
@@ -46,9 +46,9 @@ Platform Marketplace and [Google Kubernetes Engine](https://cloud.google.com/kub
 plus, with Google Cloud Platform's [Free Tier and credit](https://cloud.google.com/free/),
 it will likely be free for you to get started.
 
-1. Visit https://console.cloud.google.com/marketplace/details/kong/kong
-1. Click "Configure" and follow the on-screen prompts
-1. Refer to https://github.com/Kong/google-marketplace-kong-app/blob/master/README.md
+* Visit https://console.cloud.google.com/marketplace/details/kong/kong
+* Click "Configure" and follow the on-screen prompts
+* Refer to https://github.com/Kong/google-marketplace-kong-app/blob/master/README.md
 for important details regarding exposing the Admin API so that you can configure Kong.
 
 If you were only experimenting, consider deleting your Google Cloud resources


### PR DESCRIPTION

added a button include to apply these styles, reverted <ul> to default bulleted list styles (install pages)

<img width="371" alt="screen shot 2018-11-02 at 9 27 30 am" src="https://user-images.githubusercontent.com/215949/47918458-0b82be80-de83-11e8-827a-48f2c3242ea4.png">

Button include markup is as follows:
{% include button.html button_name="Foo" button_class="download" %}
(classname 'download' will include download icon)

### Full changelog

* updated unordered list and unordered list links to standard disc formatting
* created new button tags w/ optional download styling
* added guideline unordered to /app/install/kubernetes.md

### Issues resolved

Fix #917

