### PR TITLE
Alter criteria for IDing versioned content

### DIFF
--- a/app/_plugins/versions.rb
+++ b/app/_plugins/versions.rb
@@ -28,7 +28,7 @@ module Jekyll
         parts = Pathname(page.path).each_filename.to_a
         page.data["has_version"] = true
         # Only apply those rules to documentation pages
-        if (parts[0] == "enterprise" || parts[0].include?(".x"))
+        if (parts[0] == "enterprise" || parts[0].match?(/[0-3]\.[0-9]{1,2}.*$/))
           if(parts[0] == 'enterprise')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]


### PR DESCRIPTION
### Summary

This code was checking for `.x` in directory names to identify the directory as containing versioned content. Though there are currently no other sibling directories at that tier (`app/`), looking for a mere `.` would suffice, but replacing with a regular expression that looks for values like `1.0` or `1.0.1` or `1.0.x` but not `about` or `_includes`.

### Full changelog

Just one change.

- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- N/A Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- N/A Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
