### PR TITLE
removed name from route in example

### DIFF
--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -228,7 +228,6 @@ The HMAC plugin can be enabled on a Service or a Route (or the deprecated API en
 
   ```bash
   $ curl -i -f -X POST http://localhost:8001/services/example-service/routes \
-      -d "name=hmac-test" \
       -d "paths[]=/"
   HTTP/1.1 201 Created
   ...


### PR DESCRIPTION
In the example, the step that adds a route included a name on it. Routes do not support names currently, so this would have produced an error.

<!-- 
Thank your for making Kong better! #kongstrong

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Removed `-d "name=hmac-test" ` from the demo as routes do not support names currently

### Full changelog

* removed a single line
### Issues resolved

Fix #XXX

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
