### PR TITLE
feat(versions) support version numbers without trailing x

### DIFF
--- a/app/_plugins/versions.rb
+++ b/app/_plugins/versions.rb
@@ -28,7 +28,7 @@ module Jekyll
         parts = Pathname(page.path).each_filename.to_a
         page.data["has_version"] = true
         # Only apply those rules to documentation pages
-        if (parts[0] == "enterprise" || parts[0].include?(".x"))
+        if (parts[0] == "enterprise" || parts[0].match(/[0-3]\.[0-9]{1,2}(\..*)?$/))
           if(parts[0] == 'enterprise')
             page.data["edition"] = parts[0]
             page.data["kong_version"] = parts[1]


### PR DESCRIPTION

### Summary

Support version numbers without a trailing `x` - like the upcoming `Kong 1.0` release. 

### Issues resolved

Fix #947 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A<!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
