### PR TITLE
Fix typo in variable name

### DIFF
--- a/app/enterprise/0.33-x/admin-gui/configuration/managing-admins.md
+++ b/app/enterprise/0.33-x/admin-gui/configuration/managing-admins.md
@@ -30,7 +30,7 @@ Login to the Kong Admin GUI as the Super Admin. Click "Admins" in the sidebar. C
 
 ## Grant Admin Access
 
-Now that you have created an Admin and assigned them roles, you will need to give them access to login to the Admin GUI. If not using the [LDAP Auth Advanced plugin](/enterprise/{{page.kong_versions}}/admin-gui/configuration/authentication/#ldap-authentication), you will need to create Credentials via the API, as it is not currently supported in the Admin GUI.
+Now that you have created an Admin and assigned them roles, you will need to give them access to login to the Admin GUI. If not using the [LDAP Auth Advanced plugin](/enterprise/{{page.kong_version}}/admin-gui/configuration/authentication/#ldap-authentication), you will need to create Credentials via the API, as it is not currently supported in the Admin GUI.
 
 If you are using LDAP Auth Advanced Plugin, then you can skip credential creation and utilize the Consumer mapping feature, which allows you to map a LDAP user's `username` to a consumer's `username` or `custom_id`.
 
@@ -61,10 +61,10 @@ HTTP/1.1 200 OK
 
 Now that you have the `<CONSUMER_ID>`, you can use this to create a credential with your associated `admin_gui_auth` plugin:
 
-* [Create a Basic Authentication Credential Username/Password](/enterprise/{{page.kong_versions}}/admin-gui/configuration/authentication/#enable-authentication)
-* [Create a Key Authentication Credential Key](/enterprise/{{page.kong_versions}}/admin-gui/configuration/authentication/#basic-authentication)
+* [Create a Basic Authentication Credential Username/Password](/enterprise/{{page.kong_version}}/admin-gui/configuration/authentication/#enable-authentication)
+* [Create a Key Authentication Credential Key](/enterprise/{{page.kong_version}}/admin-gui/configuration/authentication/#basic-authentication)
 
-Once a user has a credential, they can use the credential to [log in](/enterprise/{{page.kong_versions}}/admin-gui/configuration/authentication/#logging-in).
+Once a user has a credential, they can use the credential to [log in](/enterprise/{{page.kong_version}}/admin-gui/configuration/authentication/#logging-in).
 
 Next: [Networking &rsaquo;]({{page.book.next}})
 


### PR DESCRIPTION
### Summary
Fixes a typo where `page.kong_versions` was used instead of `page.kong_version`, which broke several links.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
