### PR TITLE
docs (install) optional step to add kong.conf

### DIFF
--- a/app/install/macos.md
+++ b/app/install/macos.md
@@ -19,39 +19,52 @@ breadcrumbs:
 
     Use the [Homebrew](https://brew.sh/) package manager to add Kong as a tap and install it:
 
-    ```
+    ```bash
     $ brew tap kong/kong
     $ brew install kong
     ```
 
-2. **Prepare your database**
+1. **Add `kong.conf`**
+
+    **Note**: This step is **required** if you are using Cassandra; it is **optional** for Postgres users.
+
+    By default, Kong is configured to communicate with a local Postgres instance.
+    If you are using Cassandra, or need to modify any settings, download the [`kong.conf.default`](https://raw.githubusercontent.com/Kong/kong/master/kong.conf.default) file and [adjust][configuration] it as necessary.
+    Then, as root, add it to `/etc`:
+
+    ```bash
+    $ sudo mkdir -p /etc/kong
+    $ sudo cp kong.conf.default /etc/kong/kong.conf
+    ```
+
+1. **Prepare your database**
 
     [Configure][configuration] Kong so it can connect to your database. Kong supports both [PostgreSQL {{site.data.kong_latest.dependencies.postgres}}](http://www.postgresql.org/) and [Cassandra {{site.data.kong_latest.dependencies.cassandra}}](http://cassandra.apache.org/) as its datastore.
 
-    If you are using Postgres, please provision a database and a user before starting Kong, ie:
+    If you are using Postgres, provision a database and a user before starting Kong:
 
     ```sql
     CREATE USER kong; CREATE DATABASE kong OWNER kong;
     ```
 
-    Now, run the Kong migrations:
+    Next, run the Kong migrations:
 
     ```bash
     $ kong migrations up [-c /path/to/kong.conf]
     ```
 
-    **Note**: migrations should never be run concurrently; only
-    one Kong nodes should be performing migrations at a time.
+    **Note**: Migrations should never be run concurrently; only
+    one Kong node should be performing migrations at a time.
 
-3. **Start Kong**
+1. **Start Kong**
 
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```
 
-4. **Use Kong**
+1. **Use Kong**
 
-    Kong is running:
+    Verify that Kong is running:
 
     ```bash
     $ curl -i http://localhost:8001/

--- a/app/install/source.md
+++ b/app/install/source.md
@@ -52,7 +52,7 @@ redirect_from: /install/compile/
       --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1
     ```
 
-2. **Install Kong**
+1. **Install Kong**
 
     Now that OpenResty is installed, we can use Luarocks to install Kong's Lua sources:
 
@@ -64,42 +64,56 @@ redirect_from: /install/compile/
 
     ```bash
     $ git clone git@github.com:Kong/kong.git
+    $ cd kong
     $ [sudo] make install # this simply runs the `luarocks make kong-*.rockspec` command
     ```
 
     Finally, place the `bin/kong` script in your `$PATH`.
 
-3. **Prepare your database**
+1. **Add `kong.conf`**
+
+    **Note**: This step is **required** if you are using Cassandra; it is **optional** for Postgres users.
+
+    By default, Kong is configured to communicate with a local Postgres instance.
+    If you are using Cassandra, or need to modify any settings, download the [`kong.conf.default`](https://raw.githubusercontent.com/Kong/kong/master/kong.conf.default) file and [adjust][configuration] it as necessary.
+    Then, as root, add it to `/etc`:
+
+    ```bash
+    $ sudo mkdir -p /etc/kong
+    $ sudo cp kong.conf.default /etc/kong/kong.conf
+    ```
+
+1. **Prepare your database**
 
     [Configure][configuration] Kong so it can connect to your database. Kong
     supports both [PostgreSQL {{site.data.kong_latest.dependencies.postgres}}](http://www.postgresql.org/)
     and [Cassandra {{site.data.kong_latest.dependencies.cassandra}}](http://cassandra.apache.org/)
     as its datastore.
 
-    If you are using Postgres, please provision a database and a user before starting Kong, ie:
+    If you are using Postgres, provision a database and a user before starting Kong:
 
     ```sql
     CREATE USER kong; CREATE DATABASE kong OWNER kong;
     ```
 
-    Now, run the Kong migrations:
+    Next, run the Kong migrations:
 
     ```bash
     $ kong migrations up [-c /path/to/kong.conf]
     ```
 
-    **Note**: migrations should never be run concurrently; only
-    one Kong nodes should be performing migrations at a time.
+    **Note**: Migrations should never be run concurrently; only
+    one Kong node should be performing migrations at a time.
 
-4. **Start Kong**
+1. **Start Kong**
 
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```
 
-5. **Use Kong**
+1. **Use Kong**
 
-    Kong is running:
+    Verify that Kong is running:
 
     ```bash
     $ curl -i http://localhost:8001/


### PR DESCRIPTION
### Summary

The macOS (Homebrew) and source install instructions don't mention that you need to manually add a `kong.conf` file, nor where to find one. This fixes that. :)

(Also made a few very small Markdown and style changes, which should be very obvious in the diff.)

### Full changelog

* Added a step to `macos.md` and `source.md` to add `/etc/kong/kong.conf`.

* Fixed a bit of Markdown formatting (use `1.` to start each list item, add `bash` to a code snippet).

* A couple of small language edits.

### Checklist:

- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->