### PR TITLE
docs(css) fix h2 size for bug 993

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -62,14 +62,14 @@
     // titles proportions overridden from base.less
 
     h1 {
-      font-size: 33px;
+      font-size: 38px;
       font-weight: 400;
     }
 
     h2 {
       margin-top: 1.2em;
       margin-bottom: .8em;
-      font-size: 28px;
+      font-size: 30px;
       font-weight: 400;
     }
 

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -34,7 +34,7 @@
     }
 
     h2 {
-      font-size: 26px;
+      font-size: 30px;
       margin: 20px 0;
     }
 


### PR DESCRIPTION
### Summary

Bug 993 is caused by an incorrect font-size for h2 elements. An incorrect assignment meant that h2 and h3 were the same 26px size.

### Full changelog

* Change h2 size from 26px to 30px

### Issues resolved

Fix #993 

### Checklist:
- [x] [Commit message & atomicity]
- [x] Documentation
- [x] Spellchecked my updates
- [x] Ready to be merged