### PR TITLE
docs(ee/header) widen page header

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -51,6 +51,10 @@
     }
   }
 
+  .page-header-title-enterprise {
+    max-width:calc(~"100% - 280px");
+  }
+
   .page-header-btn {
     &#version-dropdown{
       @media screen and (max-width:476px){
@@ -101,6 +105,10 @@
       display: inline-block;
       vertical-align: bottom;
     }
+  }
+
+  .page-header-right-enterprise {
+    min-width: 180px;
   }
 
   .dropdown .dropdown-menu {

--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -19,12 +19,12 @@ id: documentation
         <img src="/assets/images/icons/icn-documentation{% if page.edition == 'enterprise' %}-ee{%else%}-ce{% endif %}.svg"
           alt="Documentation" />
       </div>
-      <div class="page-header-title">
+      <div class="page-header-title {% if page.edition=='enterprise' %} page-header-title-enterprise {% endif %}">
         <h1>{{page.title}}</h1>
       </div>
 
       {% if page.kong_versions.size > 1 %}
-      <div class="versions-dropdown dropdown page-header-right">
+      <div class="versions-dropdown dropdown page-header-right {% if page.edition=='enterprise' %} page-header-right-enterprise {% endif %}">
         <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false">
           Version {{page.kong_version}}


### PR DESCRIPTION
### Summary

Widens the header title and decreases the drop-down menu's container so that the full width of the header section is occupied. Enterprise does not have search (yet); the space allocated to search remained open and empty in Kong Enterprise doc, which squished the page titles and created too much whitespace.

Before:
<img width="1274" alt="screen shot 2018-11-20 at 12 38 25 pm" src="https://user-images.githubusercontent.com/21048592/48801543-7c1e3d80-ecc1-11e8-8f1c-b2c9b8c52281.png">

After:
<img width="1274" alt="screen shot 2018-11-20 at 12 38 07 pm" src="https://user-images.githubusercontent.com/21048592/48801558-84767880-ecc1-11e8-9f25-b96d16a90158.png">

### Full changelog

* Create classes for Enterprise headers that can easily be deleted if a search bar is added later.
* Only apply classes if the page edition is Enterprise.

### Checklist:

- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged 
