### PR TITLE
docs(ee/upgrade) style values of config properties as code

### DIFF
--- a/app/enterprise/0.34-x/deployment-guide.md
+++ b/app/enterprise/0.34-x/deployment-guide.md
@@ -235,13 +235,13 @@ the Admin API won’t be available on the old cluster for the entire process.
 3. Download Kong Enterprise 0.34
 4. Ensure the following properties are configured:
 
-      [`enforce_rbac`](/enterprise/0.34-x/property-reference#enforce_rbac) is 'on'
+      [`enforce_rbac`](/enterprise/0.34-x/property-reference#enforce_rbac) is `on`
 
-      [`admin_gui_auth`](/enterprise/0.34-x/property-reference/#admin_gui_auth) is set to 'basic-auth' or 'ldap-auth'
+      [`admin_gui_auth`](/enterprise/0.34-x/property-reference/#admin_gui_auth) is set to `basic-auth` or `ldap-auth`
 
-      [`portal_gui_protocol`](/enterprise/0.34-x/property-reference/#portal_gui_protocol) is set to 'http' or 'https'
+      [`portal_gui_protocol`](/enterprise/0.34-x/property-reference/#portal_gui_protocol) is set to `http` or `https`
 
-      [`portal_gui_host`](/enterprise/0.34-x/property-reference/#portal_gui_host) is set to 'localhost:8003' or the custom host name configured for Dev Portal
+      [`portal_gui_host`](/enterprise/0.34-x/property-reference/#portal_gui_host) is set to `localhost:8003` or the custom host name configured for Dev Portal
 5. Create a node in a new Kong cluster and run kong migrations up to process migrations. 
 6. Once the node has completed the migration, start it with kong start. 
 7. Confirm that it can process requests and configuration changes (creating and deleting a test Service will suffice to confirm Kong can communicate with the datastore).


### PR DESCRIPTION
### Summary

Styles the values of configuration properties listed in the upgrade guide as inline code. They were wrapped in single quotes, rather than back ticks.

### Full changelog

* Change quotes to backticks

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] Spellchecked my updates
- [x] Ready to be merged 