### PR TITLE
docs(ee/property-table) fix table formatting

### DIFF
--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -199,11 +199,12 @@ authentication plugin you have chosen.
 
 Supported Plugins:
 
-Value to Use        | Authentication Type
-----------------------+--------------------------
-basic-auth          | Basic Authentication
-ldap-auth-advanced  | LDAP Authentication
-
+```
+ Value to Use      | Authentication Type  
+-------------------|----------------------
+basic-auth         | Basic Authentication 
+ldap-auth-advanced | LDAP Authentication  
+```
 
 ### admin_gui_auth_conf
 


### PR DESCRIPTION
### Summary

Formats the table for the `admin_gui_auth` reference. Instead of making a markdown table, the format is as a code block to be consistent with other property reference documentation.

### Full changelog

* Format table as a code block

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] Spellchecked my updates
- [x] Ready to be merged 