### PR TITLE
docs(ee/smtp) warning about not configuring smtp

### DIFF
--- a/app/enterprise/0.34-x/kong-manager/configuration/networking.md
+++ b/app/enterprise/0.34-x/kong-manager/configuration/networking.md
@@ -74,7 +74,7 @@ configured incorrectly, e.g. if they point to a non-existent
 email address, Kong Manager will not display an error message. 
 
 In addition, refer to the 
-[general SMTP configuration](enterprise/{{page.kong_version}}/property-reference/#general-smtp-configuration) 
+[general SMTP configuration](/enterprise/{{page.kong_version}}/property-reference/#general-smtp-configuration) 
 shared by Kong Manager and Dev Portal.
 
 

--- a/app/enterprise/0.34-x/kong-manager/configuration/networking.md
+++ b/app/enterprise/0.34-x/kong-manager/configuration/networking.md
@@ -68,9 +68,10 @@ Emails from Kong Manager require the following configuration:
 * [`admin_emails_reply_to`](/enterprise/{{page.kong_version}}/property-reference/#admin_emails_reply_to)
 * [`admin_invitation_expiry`](/enterprise/{{page.kong_version}}/property-reference/#admin_invitation_expiry)
 
-⚠️**Important:** If the SMTP settings are configured incorrectly, 
-e.g. if they point to a non-existent email address, Kong Manager will not 
-display errors. 
+⚠️**Important:** Kong does not check for the validity of email
+addresses set in the configuration. If the SMTP settings are 
+configured incorrectly, e.g. if they point to a non-existent 
+email address, Kong Manager will not display an error message. 
 
 In addition, refer to the 
 [general SMTP configuration](enterprise/{{page.kong_version}}/property-reference/#general-smtp-configuration) 

--- a/app/enterprise/0.34-x/kong-manager/configuration/networking.md
+++ b/app/enterprise/0.34-x/kong-manager/configuration/networking.md
@@ -68,6 +68,10 @@ Emails from Kong Manager require the following configuration:
 * [`admin_emails_reply_to`](/enterprise/{{page.kong_version}}/property-reference/#admin_emails_reply_to)
 * [`admin_invitation_expiry`](/enterprise/{{page.kong_version}}/property-reference/#admin_invitation_expiry)
 
+⚠️**Important:** If the SMTP settings are configured incorrectly, 
+e.g. if they point to a non-existent email address, Kong Manager will not 
+display errors. 
+
 In addition, refer to the 
 [general SMTP configuration](enterprise/{{page.kong_version}}/property-reference/#general-smtp-configuration) 
 shared by Kong Manager and Dev Portal.

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -605,6 +605,7 @@ The name and email address for the 'From' header included in all Dev Portal emai
 portal_emails_from = Your Name <example@example.com>
 ```
 
+**Important** Some SMTP servers may require valid email addresses
 
 ### portal_emails_reply_to
 
@@ -620,6 +621,7 @@ The email address for the 'Reply-To' header included in all Dev Portal emails.
 portal_emails_reply_to: noreply@example.com
 ```
 
+**Important** Some SMTP servers may require valid email addresses
 
 ## Admin SMTP Configuration
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -605,7 +605,7 @@ The name and email address for the 'From' header included in all Dev Portal emai
 portal_emails_from = Your Name <example@example.com>
 ```
 
-**Important** Some SMTP servers may require valid email addresses
+⚠️ **IMPORTANT:** Some SMTP servers may require valid email addresses
 
 ### portal_emails_reply_to
 
@@ -621,7 +621,7 @@ The email address for the 'Reply-To' header included in all Dev Portal emails.
 portal_emails_reply_to: noreply@example.com
 ```
 
-**Important** Some SMTP servers may require valid email addresses
+⚠️ **IMPORTANT:** Some SMTP servers may require valid email addresses
 
 ## Admin SMTP Configuration
 


### PR DESCRIPTION
### Summary

Makes users aware of a potential issue if they do not configure SMTP correctly. Currently, the application does not provide an error message; noting it in documentation is the best temporary solution.

### Full changelog

* Mention importance of SMTP configuration in Networking section

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] Spellchecked my updates
- [ ] Ready to be merged
