### PR TITLE
repo(pr) add preview info to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!-- 
 Thank your for making Kong better! #kongstrong
 
+After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.
+
 note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
 -->
 


### PR DESCRIPTION
### Summary

Add a note about the automatic Netlify preview to the header comment in the PR template.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
