### PR TITLE
docs(hub/kong_inc/prometheus) correct API flag

### DIFF
--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -19,7 +19,7 @@ kong_version_compatibility:
 
 params:
   name: prometheus
-  api_id: true
+  api_id: false
   service_id: true
   route_id: true
 


### PR DESCRIPTION

### Summary

Corrects docs to show that Prometheus plugin can NOT be added to an API. 


### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation N/A <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Spellchecked my updates N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
