### PR TITLE
fix(kong-manager) fix typos on authentication page

### DIFF
--- a/app/enterprise/0.34-x/kong-manager/configuration/authentication.md
+++ b/app/enterprise/0.34-x/kong-manager/configuration/authentication.md
@@ -21,24 +21,24 @@ admin_gui_auth = basic-auth
 
 ## How to Log In as the First Super Admin
 
-To create credentials for the first Super Admin account:
+To create the first Super Admin account:
 
 1. Set the Super Admin's password. 
 
       ```
-      $ KONG_ADMIN_PASSWORD=<password-only-you-know>
+      $ export KONG_ADMIN_PASSWORD=<password-only-you-know>
       ```
 
 2. Run migrations. 
 
       ```
-      $ kong migrations up - c kong.conf.default
+      $ kong migrations up [-c /path/to/kong/conf]
       ```
 
 3. Start Kong.
 
       ```
-      $ kong start -c kong.conf.default
+      $ kong start [-c /path/to/kong/conf]
       ```
 
 4. Log in to Kong Manager with the username `kong_admin` and the password set 
@@ -54,9 +54,10 @@ to store and retrieve the RBAC token, parameters, and headers. Local Storage is
 saved on every successful login, and it is retrieved on every Kong Manager API 
 XHR request based on the `auth-store-types` value until you log out.
 
-⚠️ **IMPORTANT**: Local Storage Authentication credentials are stored in the 
-browser via `base64-encoding`, but are not encrypted. Therefore, it advised 
-that you always used SSL/TLS to encrypt your Kong Manager traffic.
+⚠️ **IMPORTANT**: Information in Local Storage, including the current 
+user's RBAC token, is stored in the browser via `base64-encoding`, but 
+is not encrypted. Therefore, it advised that you always use SSL/TLS to 
+encrypt your Kong Manager traffic.
 
 ## How to Log Out and Log In
 
@@ -65,12 +66,12 @@ This will clear the Local Storage authentication data (if exists) and redirect
 to the login page.
 
 2. *Ensure you are logged out* before attempting to log in with a different 
-account. Visit the Kong Manager, where you will be prompted with a login form.
+account. Visit Kong Manager, where you will be prompted with a login form.
 
 3. When you submit the login form, Kong Manager will make a request against the 
 Admin API using the specified `admin_gui_auth` with the data in the form. For 
 instance, if you have `basic-auth` enabled, then the form will submit with the 
-Authorization header e.g. `Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=`. 
+Authorization header; e.g., `Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=`. 
 
 4. If successful, the RBAC token associated with this Admin will be stored 
 locally and used for subsequent browser requests.


### PR DESCRIPTION
### Summary

Fix typos on https://docs.konghq.com/enterprise/0.34-x/kong-manager/configuration/authentication/, including one that would prevent the initial super admin from being created

### Full changelog

* updated commands
* fixed typos

### Issues resolved



<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
