### PR TITLE
docs(prometheus) disable docs on routes for Prometheus plugin

### DIFF
--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -21,7 +21,7 @@ params:
   name: prometheus
   api_id: false
   service_id: true
-  route_id: true
+  route_id: false
 
 ---
 


### PR DESCRIPTION
This was a documentation error as the plugin makes sense only at the
service level currently.

ad31ba0888 disabled it for API entity but during the review. @hbagdi
missed to disable it for Route entity as well.