### PR TITLE
Docs / Make the 1.0.x dropdown appear

### DIFF
--- a/app/1.0.x/admin-api.md
+++ b/app/1.0.x/admin-api.md
@@ -1,0 +1,2416 @@
+---
+title: Admin API
+
+service_body: |
+    Attributes | Description
+    ---:| ---
+    `name` <br>*optional*         | The Service name.
+    `protocol`                    | The protocol used to communicate with the upstream. It can be one of `http` (default) or `https`.
+    `host`                        | The host of the upstream server.
+    `port`                        | The upstream server port. Defaults to `80`.
+    `path`<br>*optional*          | The path to be used in requests to the upstream server. Empty by default.
+    `retries`<br>*optional*       | The number of retries to execute upon failure to proxy. The default is `5`.
+    `connect_timeout`<br>*optional* | The timeout in milliseconds for establishing a connection to the upstream server. Defaults to `60000`.
+    `write_timeout`<br>*optional*    | The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server. Defaults to `60000`.
+    `read_timeout`<br>*optional*    | The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server. Defaults to `60000`.
+    `url`<br>*shorthand-attribute*    | Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never "returns" the url).
+
+service_json: |
+    {
+        "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2",
+        "created_at": 1488869076800,
+        "updated_at": 1488869076800,
+        "connect_timeout": 60000,
+        "protocol": "http",
+        "host": "example.org",
+        "port": 80,
+        "path": "/api",
+        "name": "example-service",
+        "retries": 5,
+        "read_timeout": 60000,
+        "write_timeout": 60000
+    }
+
+route_body: |
+    Attributes | Description
+    ---:| ---
+    `protocols`<br>                | A list of the protocols this Route should allow. By default it is `["http", "https"]`, which means that the Route accepts both. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS. With form-encoded, the notation is `protocols[]=http&protocols[]=https`. With JSON, use an Array.
+    `methods`<br>*semi-optional*   | A list of HTTP methods that match this Route. For example: `["GET", "POST"]`. At least one of `hosts`, `paths`, or `methods` must be set. With form-encoded, the notation is `methods[]=GET&methods[]=OPTIONS`. With JSON, use an Array.
+    `hosts`<br>*semi-optional*     | A list of domain names that match this Route. For example: `example.com`. At least one of `hosts`, `paths`, or `methods` must be set. With form-encoded, the notation is `hosts[]=foo.com&hosts[]=bar.com`. With JSON, use an Array.
+    `paths`<br>*semi-optional*     | A list of paths that match this Route. For example: `/my-path`. At least one of `hosts`, `paths`, or `methods` must be set. With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
+    `strip_path`<br>*optional*     | When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL. Defaults to `true`.
+    `preserve_host`<br>*optional*  | When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. By default set to `false`, and the upstream `Host` header will be that of the Service's `host`.
+    `service`                      | The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
+
+route_json: |
+    {
+        "id": "22108377-8f26-4c0e-bd9e-2962c1d6b0e6",
+        "created_at": 14888869056483,
+        "updated_at": 14888869056483,
+        "protocols": ["http", "https"],
+        "methods": null,
+        "hosts": ["example.com"],
+        "paths": null,
+        "regex_priority": 0,
+        "strip_path": true,
+        "preserve_host": false,
+        "service": {
+            "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+        }
+    }
+
+consumer_body: |
+    Attributes | Description
+    ---:| ---
+    `username`<br>**semi-optional** | The unique username of the consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>**semi-optional** | Field for storing an existing unique ID for the consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+
+plugin_configuration_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
+    `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
+    `service_id`<br>*optional* | The unique identifier of the service that overrides the existing settings for this specific service on incoming requests.
+    `route_id`<br>*optional* | The unique identifier of the route that overrides the existing settings for this specific route on incoming requests.
+    `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
+    `enabled` | Whether the plugin is applied. Default: `true`.
+
+target_body: |
+    Attributes | Description
+    ---:| ---
+    `target` | The target address (ip or hostname) and port. If omitted the `port` defaults to `8000`. If the hostname resolves to an SRV record, the `port` value will overridden by the value from the dns record.
+    `weight`<br>*optional* | The weight this target gets within the upstream loadbalancer (`0`-`1000`, defaults to `100`). If the hostname resolves to an SRV record, the `weight` value will overridden by the value from the dns record.
+
+upstream_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | This is a hostname, which must be equal to the `host` of a Service.
+    `slots`<br>*optional* | The number of slots in the loadbalancer algorithm (`10`-`65536`, defaults to `1000`).
+    `hash_on`<br>*optional* | What to use as hashing input: `none`, `consumer`, `ip`, `header`, or `cookie` (defaults to `none` resulting in a weighted-round-robin scheme).
+    `hash_fallback`<br>*optional* | What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no consumer identified). One of: `none`, `consumer`, `ip`, `header`, or `cookie` (defaults to `none`, not available if `hash_on` is set to `cookie`).
+    `hash_on_header`<br>*semi-optional* | The header name to take the value from as hash input (only required when `hash_on` is set to `header`).
+    `hash_fallback_header`<br>*semi-optional* | The header name to take the value from as hash input (only required when `hash_fallback` is set to `header`).
+    `hash_on_cookie`<br>*semi-optional* | The cookie name to take the value from as hash input (only required when `hash_on` or `hash_fallback` is set to `cookie`). If the specified cookie is not in the request, Kong will generate a value and set the cookie in the response.
+    `hash_on_cookie_path`<br>*semi-optional* | The cookie path to set in the response headers (only required when `hash_on` or `hash_fallback` is set to `cookie`, defaults to `"/"`)
+    `healthchecks.active.timeout`<br>*optional* | Socket timeout for active health checks (in seconds).
+    `healthchecks.active.concurrency`<br>*optional* | Number of targets to check concurrently in active health checks.
+    `healthchecks.active.http_path`<br>*optional* | Path to use in GET HTTP request to run as a probe on active health checks.
+    `healthchecks.active.healthy.interval`<br>*optional* | Interval between active health checks for healthy targets (in seconds). A value of zero indicates that active probes for healthy targets should not be performed.
+    `healthchecks.active.healthy.http_statuses`<br>*optional* | An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks.
+    `healthchecks.active.healthy.successes`<br>*optional* | Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a target healthy.
+    `healthchecks.active.unhealthy.interval`<br>*optional* | Interval between active health checks for unhealthy targets (in seconds). A value of zero indicates that active probes for unhealthy targets should not be performed.
+    `healthchecks.active.unhealthy.http_statuses`<br>*optional* | An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks.
+    `healthchecks.active.unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in active probes to consider a target unhealthy.
+    `healthchecks.active.unhealthy.timeouts`<br>*optional* | Number of timeouts in active probes to consider a target unhealthy.
+    `healthchecks.active.unhealthy.http_failures`<br>*optional* | Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a target unhealthy.
+    `healthchecks.passive.healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks.
+    `healthchecks.passive.healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in proxied traffic to consider a target unhealthy, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.timeouts`<br>*optional* | Number of timeouts in proxied traffic to consider a target unhealthy, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.http_failures`<br>*optional* | Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a target unhealthy, as observed by passive health checks.
+
+certificate_body: |
+    Attributes | Description
+    ---:| ---
+    `cert` | PEM-encoded public certificate of the SSL key pair.
+    `key` | PEM-encoded private key of the SSL key pair.
+    `snis`<br>*optional* | An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience.
+
+snis_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | The SNI name to associate with the given certificate.
+    `certificate.id` | The `id` (a UUID) of the certificate with which to associate the SNI hostname. With form-encoded, the notation is `certificate.id=<certificate_id>`. With JSON, use `"certificate":{"id":"<certificate_id>"}`.
+
+---
+
+## Introduction
+
+Kong comes with an **internal** RESTful Admin API for administration purposes.
+Requests to the Admin API can be sent to any node in the cluster, and Kong will
+keep the configuration consistent across all nodes.
+
+- `8001` is the default port on which the Admin API listens.
+- `8444` is the default port for HTTPS traffic to the Admin API.
+
+This API is designed for internal use and provides full control over Kong, so
+care should be taken when setting up Kong environments to avoid undue public
+exposure of this API. See [this document][secure-admin-api] for a discussion
+of methods to secure the Admin API.
+
+## Supported Content Types
+
+The Admin API accepts 2 content types on every endpoint:
+
+- **application/x-www-form-urlencoded**
+
+Simple enough for basic request bodies, you will probably use it most of the time. Note that when sending nested values, Kong expects nested objects to be referenced with dotted keys. Example:
+
+```
+config.limit=10&config.period=seconds
+```
+
+- **application/json**
+
+Handy for complex bodies (ex: complex plugin configuration), in that case simply send a JSON representation of the data you want to send. Example:
+
+```json
+{
+    "config": {
+        "limit": 10,
+        "period": "seconds"
+    }
+}
+```
+
+---
+
+## Information routes
+
+### Retrieve node information
+
+Retrieve generic details about a node.
+
+**Endpoint**
+
+<div class="endpoint get">/</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "hostname": "",
+    "node_id": "6a72192c-a3a1-4c8d-95c6-efabae9fb969",
+    "lua_version": "LuaJIT 2.1.0-beta3",
+    "plugins": {
+        "available_on_server": [
+            ...
+        ],
+        "enabled_in_cluster": [
+            ...
+        ]
+    },
+    "configuration" : {
+        ...
+    },
+    "tagline": "Welcome to Kong",
+    "version": "0.14.0"
+}
+```
+
+* `node_id`: A UUID representing the running Kong node. This UUID is randomly generated when Kong starts, so the node will have a different `node_id` each
+  time it is restarted.
+* `available_on_server`: Names of plugins that are installed on the node.
+* `enabled_in_cluster`: Names of plugins that are enabled/configured. That is, the plugins configurations currently in the datastore shared by all Kong nodes.
+
+---
+
+### Retrieve node status
+
+Retrieve usage information about a node, with some basic information about the connections being processed by the underlying nginx process, and the status of the database connection.
+
+If you want to monitor the Kong process, since Kong is built on top of nginx, every existing nginx monitoring tool or agent can be used.
+
+**Endpoint**
+
+<div class="endpoint get">/status</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "server": {
+        "total_requests": 3,
+        "connections_active": 1,
+        "connections_accepted": 1,
+        "connections_handled": 1,
+        "connections_reading": 0,
+        "connections_writing": 1,
+        "connections_waiting": 0
+    },
+    "database": {
+        "reachable": true
+    }
+}
+```
+
+* `server`: Metrics about the nginx HTTP/S server.
+    * `total_requests`: The total number of client requests.
+    * `connections_active`: The current number of active client connections including Waiting connections.
+    * `connections_accepted`: The total number of accepted client connections.
+    * `connections_handled`: The total number of handled connections. Generally, the parameter value is the same as accepts unless some resource limits have been reached.
+    * `connections_reading`: The current number of connections where Kong is reading the request header.
+    * `connections_writing`: The current number of connections where nginx is writing the response back to the client.
+    * `connections_waiting`: The current number of idle client connections waiting for a request.
+* `database`: Metrics about the database.
+    * `reachable`: A boolean value reflecting the state of the database connection. Please note that this flag **does not** reflect the health of the database itself.
+
+---
+
+## Service Object
+
+Service entities, as the name implies, are abstractions of each of your own
+upstream services. Examples of Services would be a data transformation
+microservice, a billing API, etc.
+
+The main attribute of a Service is its URL (where Kong should proxy traffic
+to), which can be set as a single string or by specifying its `protocol`,
+`host`, `port` and `path` individually.
+
+Services are associated to Routes (a Service can have many Routes associated
+with it). Routes are entry-points in Kong and define rules to match client
+requests. Once a Route is matched, Kong proxies the request to its associated
+Service. See the [Proxy Reference][proxy-reference] for a detailed explanation
+of how Kong proxies traffic.
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Add Service
+
+**Endpoint**
+
+<div class="endpoint post">/services/</div>
+
+#### Request Body
+
+{{ page.service_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Retrieve Service
+
+**Endpoints**
+
+<div class="endpoint get">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+
+<div class="endpoint get">/routes/{route id}/service</div>
+
+Attributes | Description
+---:| ---
+`route id`<br>**required** | The unique identifier of a Route belonging to the Service to be retrieved.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+---
+
+### List Services
+
+**Endpoint**
+
+<div class="endpoint get">/services/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+`size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": [{
+        "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2",
+        "created_at": 1488869076800,
+        "updated_at": 1488869076800,
+        "connect_timeout": 60000,
+        "protocol": "http",
+        "host": "example.org",
+        "port": 80,
+        "path": "/api",
+        "name": "example-service",
+        "retries": 5,
+        "read_timeout": 60000,
+        "write_timeout": 60000
+    }, {
+        "id": "8e13faaa-ee42-44ea-8421-255bc12316a1",
+        "created_at": 1488869077320,
+        "updated_at": 1488869077320,
+        "connect_timeout": 60000,
+        "protocol": "http",
+        "host": "example2.org",
+        "port": 80,
+        "path": "/api",
+        "name": "example-service2",
+        "retries": 5,
+        "read_timeout": 60000,
+        "write_timeout": 60000
+    }],
+    "next": "http://localhost:8001/services?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### Update Service
+
+**Endpoints**
+
+<div class="endpoint patch">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The `id` **or** the `name` attribute of the Service to update.
+
+<div class="endpoint patch">/routes/{route id}/service</div>
+
+Attributes | Description
+---:| ---
+`route id`<br>**required** | The `id` attribute of the Route whose Service is to be updated.
+
+#### Request Body
+
+{{ page.service_body }}
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Update or create Service
+
+**Endpoint**
+
+<div class="endpoint put">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The `id` **or** the `name` attribute of the Service to update.
+
+#### Request Body
+
+{{ page.service_body }}
+
+Inserts (or replaces) the Service under the requested resource with the
+definition specified in the body. The Service will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Service being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Service without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Service
+
+**Endpoint**
+
+<div class="endpoint delete">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The `id` **or** the `name` attribute of the Service to delete.
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## Route Object
+
+The Route entities defines rules to match client requests. Each Route is
+associated with a Service, and a Service may have multiple Routes associated to
+it. Every request matching a given Route will be proxied to its associated
+Service.
+
+The combination of Routes and Services (and the separation of concerns between
+them) offers a powerful routing mechanism with which it is possible to define
+fine-grained entry-points in Kong leading to different upstream services of
+your infrastructure.
+
+```json
+{{ page.route_json }}
+```
+
+---
+
+### Add Route
+
+**Endpoints**
+
+<div class="endpoint post">/routes/</div>
+
+#### Request Body
+
+{{ page.route_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.route_json }}
+```
+
+### Retrieve Route
+
+**Endpoints**
+
+<div class="endpoint get">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to retrieve.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.route_json }}
+```
+
+---
+
+### List Routes
+
+**Endpoints**
+
+<div class="endpoint get">/routes</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+`size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": [{
+      "id": "22108377-8f26-4c0e-bd9e-2962c1d6b0e6",
+      "created_at": 14888869056483,
+      "updated_at": 14888869056483,
+      "protocols": ["http", "https"],
+      "methods": null,
+      "hosts": ["example.com"],
+      "paths": null,
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }, {
+      "id": "8d9b862b-527c-4bf1-9786-bfbb728f6539",
+      "created_at": 14888869056435,
+      "updated_at": 14888869056435,
+      "protocols": ["http"],
+      "methods": ["GET"],
+      "hosts": ["example.com"],
+      "paths": ["/private"],
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }],
+    "next": "http://localhost:8001/services/foo/routes?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### List Routes associated to a Service
+
+**Endpoints**
+
+<div class="endpoint get">/services/{service name or id}/routes</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The `id` **or** the `name` attribute of the Service whose routes are to be Retrieved. When using this endpoint, only the Routes belonging to the specified Service will be listed.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 10,
+    "data": [{
+      "id": "22108377-8f26-4c0e-bd9e-2962c1d6b0e6",
+      "created_at": 14888869056483,
+      "updated_at": 14888869056483,
+      "protocols": ["http", "https"],
+      "methods": null,
+      "hosts": ["example.com"],
+      "paths": null,
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }, {
+      "id": "8d9b862b-527c-4bf1-9786-bfbb728f6539",
+      "created_at": 14888869056435,
+      "updated_at": 14888869056435,
+      "protocols": ["http"],
+      "methods": ["GET"],
+      "hosts": ["example.com"],
+      "paths": ["/private"],
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }],
+    "next": "http://localhost:8001/services/foo/routes?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### Update Route
+
+**Endpoint**
+
+<div class="endpoint patch">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to update.
+
+#### Request Body
+
+{{ page.route_body }}
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+---
+
+### Update or create Route
+
+**Endpoint**
+
+<div class="endpoint put">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to update.
+
+#### Request Body
+
+{{ page.route_body }}
+
+Inserts (or replaces) the Route under the requested resource with the
+definition specified in the body.
+
+The Route will be identified by the `id` attribute given in the URL.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+```json
+{{ page.route_json }}
+```
+---
+
+### Delete Route
+
+**Endpoint**
+
+<div class="endpoint delete">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to delete.
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## Consumer Object
+
+The Consumer object represents a consumer - or a user - of a Service. You can either rely on Kong as the primary datastore, or you can map the consumer list with your database to keep consistency between Kong and your existing primary datastore.
+
+```json
+{
+    "custom_id": "abc123"
+}
+```
+
+---
+
+### Create Consumer
+
+**Endpoint**
+
+<div class="endpoint post">/consumers/</div>
+
+#### Request Form Parameters
+
+{{ page.consumer_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Retrieve Consumer
+
+**Endpoint**
+
+<div class="endpoint get">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the username of the consumer to retrieve
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List Consumers
+
+**Endpoint**
+
+<div class="endpoint get">/consumers/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`custom_id`<br>*optional* | A filter on the list based on the consumer `custom_id` field.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": [
+        {
+            "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+            "custom_id": "abc123",
+            "created_at": 1422386534
+        },
+        {
+            "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+            "custom_id": "def345",
+            "created_at": 1422386585
+        }
+    ],
+    "next": "http://localhost:8001/consumers/?size=2&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update Consumer
+
+**Endpoint**
+
+<div class="endpoint patch">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the username of the consumer to update
+
+#### Request Body
+
+{{ page.consumer_body }}
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "updated_abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Update or create Consumer
+
+**Endpoint**
+
+<div class="endpoint put">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the username of the consumer to update
+
+#### Request Body
+
+{{ page.consumer_body }}
+
+Inserts (or replaces) the Consumer under the requested resource with the
+definition specified in the body. The Consumer will be identified via the
+`username or id` attribute.
+
+When the `username or id` attribute has the structure of a UUID, the Consumer
+being inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `username`.
+
+When creating a new Consumer without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `username` in the URL and a different one in the
+request body is not allowed.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Consumer
+
+**Endpoint**
+
+<div class="endpoint delete">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the name of the consumer to delete
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## Plugin Object
+
+A Plugin entity represents a plugin configuration that will be executed during
+the HTTP request/response lifecycle. It is how you can add functionalities
+to Services that run behind Kong, like Authentication or Rate Limiting for
+example. You can find more information about how to install and what values
+each plugin takes by visiting the [Kong Hub](https://docs.konghq.com/hub/).
+
+When adding a Plugin Configuration to a Service, every request made by a client to
+that Service will run said Plugin. If a Plugin needs to be tuned to different
+values for some specific Consumers, you can do so by specifying the
+`consumer_id` value:
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+See the [Precedence](#precedence) section below for more details.
+
+### Precedence
+
+A plugin will always be run once and only once per request. But the
+configuration with which it will run depends on the entities it has been
+configured for.
+
+Plugins can be configured for various entities, combination of entities, or
+even globally. This is useful, for example, when you wish to configure a plugin
+a certain way for most requests, but make _authenticated requests_ behave
+slightly differently.
+
+Therefore, there exists an order of precedence for running a plugin when it has
+been applied to different entities with different configurations. The rule of
+thumb is: the more specific a plugin is with regards to how many entities it
+has been configured on, the higher its priority.
+
+The complete order of precedence when a plugin has been configured multiple
+times is:
+
+1. Plugins configured on a combination of: a Route, a Service, and a Consumer.
+   _(Consumer means the request must be authenticated)._
+2. Plugins configured on a combination of a Route and a Consumer.
+   _(Consumer means the request must be authenticated)._
+3. Plugins configured on a combination of a Service and a Consumer.
+   _(Consumer means the request must be authenticated)._
+4. Plugins configured on a combination of a Route and a Service.
+5. Plugins configured on a Consumer.
+   _(Consumer means the request must be authenticated)._
+6. Plugins configured on a Route.
+7. Plugins configured on a Service.
+8. Plugins configured to run globally.
+
+**Example**: if the `rate-limiting` plugin is applied twice (with different
+configurations): for a Service (Plugin config A), and for a Consumer (Plugin
+config B), then requests authenticating this Consumer will run Plugin config B
+and ignore A. However, requests that do not authenticate this Consumer will
+fallback to running Plugin config A. Note that if config B is disabled
+(its `enabled` flag is set to `false`), config A will apply to requests that
+would have otherwise matched config B.
+
+---
+
+### Add Plugin
+
+You can add a plugin in four different ways:
+
+* For every Service/Route and Consumer. Don't set `consumer_id` and set `service_id` or `route_id`.
+* For every Service/Route and a specific Consumer. Only set `consumer_id`.
+* For every Consumer and a specific Service. Only set `service_id` (warning: some plugins only allow setting their `route_id`)
+* For every Consumer and a specific Route. Only set `route_id` (warning: some plugins only allow setting their `service_id`)
+* For a specific Service/Route and Consumer. Set both `service_id`/`route_id` and `consumer_id`.
+
+Note that not all plugins allow to specify `consumer_id`. Check the plugin documentation.
+
+**Endpoint**
+
+<div class="endpoint post">/plugins/</div>
+
+#### Request Body
+
+{{ page.plugin_configuration_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Retrieve Plugin
+
+<div class="endpoint get">/plugins/{id}</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The unique identifier of the plugin to retrieve
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List All Plugins
+
+**Endpoint**
+
+<div class="endpoint get">/plugins/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the `id` field.
+`name`<br>*optional* | A filter on the list based on the `name` field.
+`service_id`<br>*optional* | A filter on the list based on the `service_id` field.
+`route_id`<br>*optional* | A filter on the list based on the `route_id` field.
+`consumer_id`<br>*optional* | A filter on the list based on the `consumer_id` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 10,
+    "data": [
+      {
+          "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+          "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+          "name": "rate-limiting",
+          "config": {
+              "minute": 20,
+              "hour": 500
+          },
+          "enabled": true,
+          "created_at": 1422386534
+      },
+      {
+          "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+          "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+          "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+          "name": "rate-limiting",
+          "config": {
+              "minute": 300,
+              "hour": 20000
+          },
+          "enabled": true,
+          "created_at": 1422386585
+      }
+    ],
+    "next": "http://localhost:8001/plugins?size=2&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update Plugin
+
+**Endpoint**
+
+<div class="endpoint patch">/plugins/{plugin id}</div>
+
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to update
+
+#### Request Body
+
+{{ page.plugin_configuration_body }}
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Update or Add Plugin
+
+**Endpoint**
+
+<div class="endpoint put">/plugins/</div>
+
+#### Request Body
+
+{{ page.plugin_configuration_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` and `name` for Plugins), the entity
+will be created with the given payload. If the request payload **does** contain
+an entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Plugin
+
+**Endpoint**
+
+<div class="endpoint delete">/plugins/{plugin id}</div>
+
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to delete
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Retrieve Enabled Plugins
+
+Retrieve a list of all installed plugins on the Kong node.
+
+**Endpoint**
+
+<div class="endpoint get">/plugins/enabled</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "enabled_plugins": [
+        "jwt",
+        "acl",
+        "cors",
+        "oauth2",
+        "tcp-log",
+        "udp-log",
+        "file-log",
+        "http-log",
+        "key-auth",
+        "hmac-auth",
+        "basic-auth",
+        "ip-restriction",
+        "request-transformer",
+        "response-transformer",
+        "request-size-limiting",
+        "rate-limiting",
+        "response-ratelimiting",
+        "aws-lambda",
+        "bot-detection",
+        "correlation-id",
+        "datadog",
+        "galileo",
+        "ldap-auth",
+        "loggly",
+        "statsd",
+        "syslog"
+    ]
+}
+```
+
+---
+
+### Retrieve Plugin Schema
+
+Retrieve the schema of a plugin's configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong's plugin system.
+
+<div class="endpoint get">/plugins/schema/{plugin name}</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "fields": {
+        "hide_credentials": {
+            "default": false,
+            "type": "boolean"
+        },
+        "key_names": {
+            "default": "function",
+            "required": true,
+            "type": "array"
+        }
+    }
+}
+```
+
+---
+
+## Certificate Object
+
+A certificate object represents a public certificate/private key pair for an SSL
+certificate. These objects are used by Kong to handle SSL/TLS termination for
+encrypted requests. Certificates are optionally associated with SNI objects to
+tie a cert/key pair to one or more hostnames.
+
+```json
+{
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----..."
+}
+```
+
+---
+
+### Add Certificate
+
+**Endpoint**
+
+<div class="endpoint post">/certificates/</div>
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----...",
+    "snis": [
+        "example.com"
+    ],
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Retrieve Certificate
+
+**Endpoint**
+
+<div class="endpoint get">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----...",
+    "snis": [
+        "example.com"
+    ],
+    "created_at": 1485521710265
+}
+```
+---
+
+### List Certificates
+
+**Endpoint**
+
+<div class="endpoint get">/certificates/</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+            "cert": "-----BEGIN CERTIFICATE-----...",
+            "key": "-----BEGIN RSA PRIVATE KEY-----...",
+            "snis": [
+                "example.com"
+            ],
+            "created_at": 1485521710265
+        },
+        {
+            "id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b",
+            "cert": "-----BEGIN CERTIFICATE-----...",
+            "key": "-----BEGIN RSA PRIVATE KEY-----...",
+            "snis": [
+                "example.org"
+            ],
+            "created_at": 1485522651185
+        }
+    ]
+}
+```
+---
+
+### Update Certificate
+
+<div class="endpoint patch">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----...",
+    "snis": [
+        "example.com"
+    ],
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Update or create Certificate
+
+**Endpoint**
+
+<div class="endpoint put">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+Inserts (or replaces) the Certificate under the requested resource with the definition
+specified in the body. The Certificate will be identified by the `SNI or id` attribute.
+
+If the Certificate for the provided id exists, or an SNI with the provided name exists,
+this request will update said certificate using the request body. If the body includes an `snis`
+pseudo-attribute, then the list of snis associated with the certificate will also be updated.
+
+If the certificate for the provided id does not exist, a new certificate will be created
+using the request body with the provided `id`. If the request body includes an `snis` pseudo-attribute,
+then it will also create a list SNIs associated to the new certificate.
+
+If no SNI with the provided sni name can be found, then a new certificate will be created using the
+request body. If no `id` is included on the body, the newly-created certificate will have a random `id`.
+
+If present, the `snis` pseudo-attribute will be used to create other SNIs associated to the certificate.
+Note that providing an `snis` pseudo-attribute which does not include the provided SNI name is not allowed.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Certificate
+
+<div class="endpoint delete">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`sni or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## SNI Objects
+
+An SNI object represents a many-to-one mapping of hostnames to a certificate.
+That is, a certificate object can have many hostnames associated with it; when
+Kong receives an SSL request, it uses the SNI field in the Client Hello to
+lookup the certificate object based on the SNI associated with the certificate.
+
+```json
+{
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
+    "name": "example.com",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Add SNI
+
+**Endpoint**
+
+<div class="endpoint post">/snis/</div>
+
+#### Request Body
+
+{{ page.snis_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
+    "name": "example.com",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Retrieve SNI
+
+**Endpoint**
+
+<div class="endpoint get">/snis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
+    "name": "example.com",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
+    "created_at": 1485521710265
+}
+```
+
+### List SNIs
+
+**Endpoint**
+
+<div class="endpoint get">/snis/</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
+            "name": "example.com",
+            "certificate": {
+                "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+            },
+            "created_at": 1485521710265
+        },
+        {
+            "id": "88c03fcd-9a48-4937-a976-0abd0eb6b60a",
+            "name": "example.org",
+            "certificate": {
+                "id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b"
+            },
+            "created_at": 1485521710265
+        }
+    ]
+}
+```
+
+---
+
+### Update SNI
+
+<div class="endpoint patch">/snis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
+    "name": "example.com",
+    "certificate": {
+        "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    },
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Update or create SNI
+
+**Endpoint**
+
+<div class="endpoint put">/snis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
+
+#### Request Body
+
+{{ page.snis_body }}
+
+Inserts (or replaces) the SNI under the requested resource with the definition
+specified in the body. The SNI will be identified via the `name or id` attribute.
+
+When the `name or id` attribute has the structure of an UUID, the SNI being inserted/replaced
+will be identified by its `id`. Otherwise it will be identified by its `name`.
+
+When creating a new SNI, if an `id` is not specified (neither in the URL or the body) then
+the newly created one will be random. If an `id` is provided, the newly created Service will have
+said `id`.
+
+Notice that specifying a `name` in the url and a different one on the request body is not allowed.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete SNI
+
+<div class="endpoint delete">/snis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+---
+
+## Upstream Objects
+
+The upstream object represents a virtual hostname and can be used to loadbalance
+incoming requests over multiple services (targets). So for example an upstream
+named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`.
+Requests for this Service would be proxied to the targets defined within the upstream.
+
+An upstream also includes a [health checker][healthchecks], which is able to
+enable and disable targets based on their ability or inability to serve
+requests. The configuration for the health checker is stored in the upstream
+object, and applies to all of its targets.
+
+```json
+{
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10
+}
+```
+
+---
+
+### Add upstream
+
+**Endpoint**
+
+<div class="endpoint post">/upstreams/</div>
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "13611da7-703f-44f8-b790-fc1e7bf51b3e",
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10,
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Retrieve upstream
+
+**Endpoint**
+
+<div class="endpoint get">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to retrieve
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "13611da7-703f-44f8-b790-fc1e7bf51b3e",
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10,
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### List upstreams
+
+**Endpoint**
+
+<div class="endpoint get">/upstreams/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the upstream `id` field.
+`name`<br>*optional* | A filter on the list based on the upstream `name` field.
+`hash_on`<br>*optional* | A filter on the list based on the upstream `hash_on` field.
+`hash_fallback`<br>*optional* | A filter on the list based on the upstream `hash_fallback` field.
+`hash_on_header`<br>*optional* | A filter on the list based on the upstream `hash_on_header` field.
+`hash_fallback_header`<br>*optional* | A filter on the list based on the upstream `hash_fallback_header` field.
+`slots`<br>*optional* | A filter on the list based on the upstream `slots` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 3,
+    "data": [
+        {
+            "created_at": 1485521710265,
+            "id": "13611da7-703f-44f8-b790-fc1e7bf51b3e",
+            "name": "service.v1.xyz",
+            "hash_on": "none",
+            "hash_fallback": "none",
+            "healthchecks": {
+                "active": {
+                    "concurrency": 10,
+                    "healthy": {
+                        "http_statuses": [ 200, 302 ],
+                        "interval": 0,
+                        "successes": 0
+                    },
+                    "http_path": "/",
+                    "timeout": 1,
+                    "unhealthy": {
+                        "http_failures": 0,
+                        "http_statuses": [ 429, 404, 500, 501,
+                                           502, 503, 504, 505 ],
+                        "interval": 0,
+                        "tcp_failures": 0,
+                        "timeouts": 0
+                    }
+                },
+                "passive": {
+                    "healthy": {
+                        "http_statuses": [ 200, 201, 202, 203,
+                                           204, 205, 206, 207,
+                                           208, 226, 300, 301,
+                                           302, 303, 304, 305,
+                                           306, 307, 308 ],
+                        "successes": 0
+                    },
+                    "unhealthy": {
+                        "http_failures": 0,
+                        "http_statuses": [ 429, 500, 503 ],
+                        "tcp_failures": 0,
+                        "timeouts": 0
+                    }
+                }
+            },
+            "slots": 10
+        },
+        {
+            "created_at": 1485522651185,
+            "id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "name": "service.v2.xyz",
+            "hash_on": "none",
+            "hash_fallback": "none",
+            "healthchecks": {
+                "active": {
+                    "concurrency": 10,
+                    "healthy": {
+                        "http_statuses": [ 200, 302 ],
+                        "interval": 5,
+                        "successes": 2
+                    },
+                    "http_path": "/health_status",
+                    "timeout": 1,
+                    "unhealthy": {
+                        "http_failures": 5,
+                        "http_statuses": [ 429, 404, 500, 501,
+                                           502, 503, 504, 505 ],
+                        "interval": 5,
+                        "tcp_failures": 2,
+                        "timeouts": 3
+                    }
+                },
+                "passive": {
+                    "healthy": {
+                        "http_statuses": [ 200, 201, 202, 203,
+                                           204, 205, 206, 207,
+                                           208, 226, 300, 301,
+                                           302, 303, 304, 305,
+                                           306, 307, 308 ],
+                        "successes": 5
+                    },
+                    "unhealthy": {
+                        "http_failures": 5,
+                        "http_statuses": [ 429, 500, 503 ],
+                        "tcp_failures": 2,
+                        "timeouts": 7
+                    }
+                }
+            },
+            "slots": 10
+        }
+    ],
+    "next": "http://localhost:8001/upstreams?size=2&offset=Mg%3D%3D",
+    "offset": "Mg=="
+}
+```
+
+---
+
+### Update upstream
+
+**Endpoint**
+
+<div class="endpoint patch">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to update
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "slots": 10,
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Update or create Upstream
+
+**Endpoint**
+
+<div class="endpoint put">/upstreams/</div>
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` for Upstreams), the entity will be
+created with the given payload. If the request payload **does** contain an
+entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+**Response**
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete upstream
+
+**Endpoint**
+
+<div class="endpoint delete">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to delete
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Show Upstream health for node
+
+Displays the health status for all Targets of a given Upstream, according to
+the perspective of a specific Kong node. Note that, being node-specific
+information, making this same request to different nodes of the Kong cluster
+may produce different results. For example, one specific node of the Kong
+cluster may be experiencing network issues, causing it to fail to connect to
+some Targets: these Targets will be marked as unhealthy by that node
+(directing traffic from this node to other Targets that it can successfully
+reach), but healthy to all others Kong nodes (which have no problems using that
+Target).
+
+The `data` field of the response contains an array of Target objects.
+The health for each Target is returned in its `health` field:
+
+* If a Target fails to be activated in the ring balancer due to DNS issues,
+  its status displays as `DNS_ERROR`.
+* When [health checks][healthchecks] are not enabled in the Upstream
+  configuration, the health status for active Targets is displayed as
+  `HEALTHCHECKS_OFF`.
+* When health checks are enabled and the Target is determined to be healthy,
+  either automatically or [manually](#set-target-as-healthy),
+  its status is displayed as `HEALTHY`. This means that this Target is
+  currently included in this Upstream's load balancer ring.
+* When a Target has been disabled by either active or passive health checks
+  (circuit breakers) or [manually](#set-target-as-unhealthy),
+  its status is displayed as `UNHEALTHY`. The load balancer is not directing
+  any traffic to this Target via this Upstream.
+
+### Endpoint
+
+<div class="endpoint get">/upstreams/{name or id}/health/</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "node_id": "cbb297c0-14a9-46bc-ad91-1d0ef9b42df9",
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "health": "HEALTHY",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "health": "UNHEALTHY",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+---
+
+## Target Object
+
+A target is an ip address/hostname with a port that identifies an instance of a backend
+service. Every upstream can have many targets, and the targets can be
+dynamically added. Changes are effectuated on the fly.
+
+Because the upstream maintains a history of target changes, the targets cannot
+be deleted or modified. To disable a target, post a new one with `weight=0`;
+alternatively, use the `DELETE` convenience method to accomplish the same.
+
+The current target object definition is the one with the latest `created_at`.
+
+```json
+{
+    "target": "1.2.3.4:80",
+    "weight": 15,
+    "upstream_id": "ee3310c1-6789-40ac-9386-f79c0cb58432"
+}
+```
+
+---
+
+### Add target
+
+**Endpoint**
+
+<div class="endpoint post">/upstreams/{name or id}/targets</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to which to add the target
+
+#### Request Body
+
+{{ page.target_body }}
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4661f55e-95c2-4011-8fd6-c5c56df1c9db",
+    "target": "1.2.3.4:80",
+    "weight": 15,
+    "upstream_id": "ee3310c1-6789-40ac-9386-f79c0cb58432",
+    "created_at": 1485523507446
+}
+```
+
+---
+
+### List targets
+
+Lists all targets currently active on the upstream's load balancing wheel.
+
+**Endpoint**
+
+<div class="endpoint get">/upstreams/{name or id}/targets</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the target `id` field.
+`target`<br>*optional* | A filter on the list based on the target `target` field.
+`weight`<br>*optional* | A filter on the list based on the target `weight` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 30,
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524897232,
+            "id": "9b96f13d-65af-4f30-bbe9-b367121dd26b",
+            "target": "127.0.0.1:20001",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 0
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+---
+
+### List all targets
+
+Lists all targets of the upstream. Multiple target objects for the same
+target may be returned, showing the history of changes for a specific target.
+The target object with the latest `created_at` is the current definition.
+
+### Endpoint
+
+<div class="endpoint get">/upstreams/{name or id}/targets/all/</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+---
+
+### Delete target
+
+Disable a target in the load balancer. Under the hood, this method creates
+a new entry for the given target definition with a `weight` of 0.
+
+**Endpoint**
+
+<div class="endpoint delete">/upstreams/{upstream name or id}/targets/{target or id}</div>
+
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
+`target or id`<br>**required** | The host/port combination element of the target to remove, or the `id` of an existing target entry.
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Set target as healthy
+
+Set the current health status of a target in the load balancer to "healthy"
+in the entire Kong cluster.
+
+This endpoint can be used to manually re-enable a target that was previously
+disabled by the upstream's [health checker][healthchecks]. Upstreams only
+forward requests to healthy nodes, so this call tells Kong to start using this
+target again.
+
+This resets the health counters of the health checkers running in all workers
+of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
+status is propagated to the whole Kong cluster.
+
+**Endpoint**
+
+<div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
+
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Set target as unhealthy
+
+Set the current health status of a target in the load balancer to "unhealthy"
+in the entire Kong cluster.
+
+This endpoint can be used to manually disable a target and have it stop
+responding to requests. Upstreams only forward requests to healthy nodes, so
+this call tells Kong to start skipping this target in the ring-balancer
+algorithm.
+
+This call resets the health counters of the health checkers running in all
+workers of the Kong node, and broadcasts a cluster-wide message so that the
+"unhealthy" status is propagated to the whole Kong cluster.
+
+[Active health checks][active] continue to execute for unhealthy
+targets. Note that if active health checks are enabled and the probe detects
+that the target is actually healthy, it will automatically re-enable it again.
+To permanently remove a target from the ring-balancer, you should [delete a
+target](#delete-target) instead.
+
+**Endpoint**
+
+<div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+[clustering]: /{{page.kong_version}}/clustering
+[cli]: /{{page.kong_version}}/cli
+[active]: /{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+[healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
+[secure-admin-api]: /{{page.kong_version}}/secure-admin-api
+[proxy-reference]: /{{page.kong_version}}/proxy

--- a/app/1.0.x/auth.md
+++ b/app/1.0.x/auth.md
@@ -1,0 +1,215 @@
+---
+title: Authentication Reference
+---
+
+## Introduction
+
+Traffic to your upstream services (APIs or microservices) is typically controlled by the application and
+configuration of various Kong [authentication plugins][plugins]. Since Kong's Service entity represents
+a 1-to-1 mapping of your own upstream services, the simplest scenario is to configure authentication
+plugins on the Services of your choosing.
+
+## Generic authentication
+
+The most common scenario is to require authentication and to not allow access for any unauthenticated request.
+To achieve this any of the authentication plugins can be used. The generic scheme/flow of those plugins
+works as follows:
+
+1. Apply an auth plugin to a Service, or globally (you cannot apply one on consumers)
+2. Create a `consumer` entity
+3. Provide the consumer with authentication credentials for the specific authentication method
+4. Now whenever a request comes in Kong will check the provided credentials (depends on the auth type) and
+it will either block the request if it cannot validate, or add consumer and credential details
+in the headers and forward the request
+
+The generic flow above does not always apply, for example when using external authentication like LDAP,
+then there is no consumer to be identified, and only the credentials will be added in the forwarded headers.
+
+The authentication method specific elements and examples can be found in each [plugin's documentation][plugins].
+
+## Consumers
+
+The easiest way to think about consumers is to map them one-on-one to users. Yet, to Kong this does not matter.
+The core principle for consumers is that you can attach plugins to them, and hence customize request behaviour.
+So you might have mobile apps, and define one consumer for each app, or version of it. Or have a consumer per
+platform, e.g. an android consumer, an iOS consumer, etc.
+
+It is an opaque concept to Kong and hence they are called "consumers" and not "users".
+
+## Anonymous Access
+
+Kong has the ability to configure a given Service to allow **both** authenticated **and** anonymous access.
+You might use this configuration to grant access to anonymous users with a low rate-limit, and grant access
+to authenticated users with a higher rate limit.
+
+To configure a Service like this, you first apply your selected authentication plugin, then create a new
+consumer to represent anonymous users, then configure your authentication plugin to allow anonymous
+access. Here is an example, which assumes you have already configured a Service named `example-service` and
+the corresponding route:
+
+1. ### Create an example Service and a Route
+
+    Issue the following cURL request to create `example-service` pointing to mockbin.org, which will echo
+    the request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/ \
+      --data 'name=example-service' \
+      --data 'url=http://mockbin.org/request'
+    ```
+
+    Add a route to the Service:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/example-service/routes \
+      --data 'paths[]=/auth-sample'
+    ```
+
+    The url `http://localhost:8000/auth-sample` will now echo whatever is being requested.
+
+2. ### Configure the key-auth Plugin for your Service
+
+    Issue the following cURL request to add a plugin to a Service:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/example-service/plugins/ \
+      --data 'name=key-auth'
+    ```
+
+    Be sure to note the created Plugin `id` - you'll need it in step 5.
+
+3. ### Verify that the key-auth plugin is properly configured
+
+    Issue the following cURL request to verify that the [key-auth][key-auth]
+    plugin was properly configured on the Service:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000/auth-sample
+    ```
+
+    Since you did not specify the required `apikey` header or parameter, and you have not yet
+    enabled anonymous access, the response should be `403 Forbidden`:
+
+    ```http
+    HTTP/1.1 403 Forbidden
+    ...
+
+    {
+      "message": "No API key found in headers or querystring"
+    }
+    ```
+
+4. ### Create an anonymous Consumer
+
+    Every request proxied by Kong must be associated with a Consumer. You'll now create a Consumer
+    named `anonymous_users` (that Kong will utilize when proxying anonymous access) by issuing the
+    following request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/consumers/ \
+      --data "username=anonymous_users"
+    ```
+
+    You should see a response similar to the one below:
+
+    ```http
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+    Connection: keep-alive
+
+    {
+      "username": "anonymous_users",
+      "created_at": 1428555626000,
+      "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
+    }
+    ```
+
+    Be sure to note the Consumer `id` - you'll need it in the next step.
+
+5. ### Enable anonymous access
+
+    You'll now re-configure the key-auth plugin to permit anonymous access by issuing the following
+    request (**replace the sample uuids below by the `id` values from step 2 and 4**):
+
+    ```bash
+    $ curl -i -X PATCH \
+      --url http://localhost:8001/plugins/<your-plugin-id> \
+      --data "config.anonymous=<your-consumer-id>"
+    ```
+
+    The `config.anonymous=<your-consumer-id>` parameter instructs the key-auth plugin on this Service to permit
+    anonymous access, and to associate such access with the Consumer `id` we received in the previous step. It is
+    required that you provide a valid and pre-existing Consumer `id` in this step - validity of the Consumer `id`
+    is not currently checked when configuring anonymous access, and provisioning of a Consumer `id` that doesn't already
+    exist will result in an incorrect configuration.
+
+6. ### Check anonymous access
+
+    Confirm that your Service now permits anonymous access by issuing the following request:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000/auth-sample
+    ```
+
+    This is the same request you made in step #3, however this time the request should succeed, because you
+    enabled anonymous access in step #5.
+
+    The response (which is the request as Mockbin received it) should have these elements:
+
+    ```json
+    {
+      ...
+      "headers": {
+        ...
+        "x-consumer-id": "713c592c-38b8-4f5b-976f-1bd2b8069494",
+        "x-consumer-username": "anonymous_users",
+        "x-anonymous-consumer": "true",
+        ...
+      },
+      ...
+    }
+    ```
+
+    It shows the request was successful, but anonymous.
+
+## Multiple Authentication
+
+Kong supports multiple authentication plugins for a given Service, allowing
+different clients to utilize different authentication methods to access a given Service or Route.
+
+The behaviour of the auth plugins can be set to do either a logical `AND`, or a logical `OR` when evaluating
+multiple authentication credentials. The key to the behaviour is the `config.anonymous` property.
+
+- `config.anonymous` not set <br/>
+  If this property is not set (empty) then the auth plugins will always perform authentication and return
+  a `40x` response if not validated. This results in a logical `AND` when multiple auth plugins are being
+  invoked.
+- `config.anonymous` set to a valid consumer id <br/>
+  In this case the auth plugin will only perform authentication if it was not already authenticated. When
+  authentication fails, it will not return a `40x` response, but set the anonymous consumer as the consumer. This
+  results in a logical `OR` + 'anonymous access' when multiple auth plugins are being invoked.
+
+**NOTE 1**: Either all or none of the auth plugins must be configured for anonymous access. The behaviour is
+undefined if they are mixed.
+
+**NOTE 2**: When using the `AND` method, the last plugin executed will be the one setting the credentials
+passed to the upstream service. With the `OR` method, it will be the first plugin that successfully authenticates
+the consumer, or the last plugin that will set its configured anonymous consumer.
+
+**NOTE 3**: When using the OAuth2 plugin in an `AND` fashion, then also the OAuth2 endpoints for requesting
+tokens etc. will require authentication by the other configured auth plugins.
+
+<div class="alert alert-warning">
+  When multiple authentication plugins are enabled in an <tt>OR</tt> fashion on a given Service, and it is desired that
+  anonymous access be forbidden, then the <a href="/plugins/request-termination"><tt>request-termination</tt> plugin</a> should be
+  configured on the anonymous consumer. Failure to do so will allow unauthorized requests.
+</div>
+
+[plugins]: https://konghq.com/plugins/
+[key-auth]: /plugins/key-authentication

--- a/app/1.0.x/cli.md
+++ b/app/1.0.x/cli.md
@@ -1,0 +1,216 @@
+---
+title: CLI Reference
+---
+
+## Introduction
+
+The provided CLI (*Command Line Interface*) allows you to start, stop, and
+manage your Kong instances. The CLI manages your local node (as in, on the
+current machine).
+
+If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
+
+## Global flags
+
+All commands take a set of special, optional flags as arguments:
+
+* `--help`: print the command's help message
+* `--v`: enable verbose mode
+* `--vv`: enable debug mode (noisy)
+
+[Back to TOC](#table-of-contents)
+
+## Available commands
+
+### kong check
+
+```
+Usage: kong check <conf>
+
+Check the validity of a given Kong configuration file.
+
+<conf> (default /etc/kong.conf or /etc/kong/kong.conf) configuration file
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong prepare
+
+This command prepares the Kong prefix folder, with its sub-folders and files.
+
+```
+Usage: kong prepare [OPTIONS]
+
+Prepare the Kong prefix in the configured prefix directory. This command can
+be used to start Kong from the nginx binary without using the 'kong start'
+command.
+
+Example usage:
+  kong prepare -p /usr/local/kong -c kong.conf && kong migrations up &&
+    nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf
+
+Options:
+ -c,--conf    (optional string) configuration file
+ -p,--prefix  (optional string) override prefix directory
+ --nginx-conf (optional string) custom Nginx configuration template
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong health
+
+```
+Usage: kong health [OPTIONS]
+
+Check if the necessary services are running for this node.
+
+Options:
+  -p,--prefix (optional string) prefix at which Kong should be running
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong migrations
+
+```
+Usage: kong migrations COMMAND [OPTIONS]
+
+Manage Kong's database migrations.
+
+The available commands are:
+  list   List migrations currently executed.
+  up     Execute all missing migrations up to the latest available.
+  reset  Reset the configured database (irreversible).
+
+Options:
+  -c,--conf (optional string) configuration file
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong quit
+
+```
+Usage: kong quit [OPTIONS]
+
+Gracefully quit a running Kong node (Nginx and other
+configured services) in given prefix directory.
+
+This command sends a SIGQUIT signal to Nginx, meaning all
+requests will finish processing before shutting down.
+If the timeout delay is reached, the node will be forcefully
+stopped (SIGTERM).
+
+Options:
+  -p,--prefix  (optional string) prefix Kong is running at
+  -t,--timeout (default 10) timeout before forced shutdown
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong reload
+
+```
+Usage: kong reload [OPTIONS]
+
+Reload a Kong node (and start other configured services
+if necessary) in given prefix directory.
+
+This command sends a HUP signal to Nginx, which will spawn
+new workers (taking configuration changes into account),
+and stop the old ones when they have finished processing
+current requests.
+
+Options:
+  -c,--conf    (optional string) configuration file
+  -p,--prefix  (optional string) prefix Kong is running at
+  --nginx-conf (optional string) custom Nginx configuration template
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong restart
+
+```
+Usage: kong restart [OPTIONS]
+
+Restart a Kong node in the given prefix directory.
+
+This command is equivalent to doing both 'kong stop' and
+'kong start'.
+
+Options:
+  -c,--conf        (optional string)   configuration file
+  -p,--prefix      (optional string)   prefix at which Kong should be running
+  --nginx-conf     (optional string)   custom Nginx configuration template
+  --run-migrations (optional boolean)  optionally run migrations on the DB
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong start
+
+```
+Usage: kong start [OPTIONS]
+
+Start Kong (Nginx and other configured services) in the configured
+prefix directory.
+
+Options:
+  -c,--conf        (optional string)   configuration file
+  -p,--prefix      (optional string)   prefix at which Kong should be running
+  --nginx-conf     (optional string)   custom Nginx configuration template
+  --run-migrations (optional boolean)  optionally run migrations on the DB
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong stop
+
+```
+Usage: kong stop [OPTIONS]
+
+Stop a running Kong node (Nginx and other configured services) in given
+prefix directory.
+
+This command sends a SIGTERM signal to Nginx.
+
+Options:
+  -p,--prefix (optional string) prefix Kong is running at
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### kong version
+
+```
+Usage: kong version [OPTIONS]
+
+Print Kong's version. With the -a option, will print
+the version of all underlying dependencies.
+
+Options:
+  -a,--all    get version of all dependencies
+```
+
+[Back to TOC](#table-of-contents)
+
+[configuration-reference]: /{{page.kong_version}}/configuration

--- a/app/1.0.x/clustering.md
+++ b/app/1.0.x/clustering.md
@@ -1,0 +1,297 @@
+---
+title: Clustering Reference
+---
+
+## Introduction
+
+A Kong cluster allows you to scale the system horizontally by adding more
+machines to handle more incoming requests. They will all share the same
+configuration since they point to the same database. Kong nodes pointing to the
+**same datastore** will be part of the same Kong cluster.
+
+You need a load-balancer in front of your Kong cluster to distribute traffic
+across your available nodes.
+
+## What a Kong cluster does and doesn't do
+
+**Having a Kong cluster does not mean that your clients traffic will be
+load-balanced across your Kong nodes out of the box.** You still need a
+load-balancer in front of your Kong nodes to distribute your traffic. Instead,
+a Kong cluster means that those nodes will share the same configuration.
+
+For performance reasons, Kong avoids database connections when proxying
+requests, and caches the contents of your database in memory. The cached
+entities include Services, Routes, Consumers, Plugins, Credentials, etc... Since those
+values are in memory, any change made via the Admin API of one of the nodes
+needs to be propagated to the other nodes.
+
+This document describes how those cached entities are being invalidated and how
+to configure your Kong nodes for your use case, which lies somewhere between
+performance and consistency.
+
+[Back to TOC](#table-of-contents)
+
+## Single node Kong clusters
+
+A single Kong node connected to a database (Cassandra or PostgreSQL) creates a
+Kong cluster of one node. Any changes applied via the Admin API of this node
+will instantly take effect. Example:
+
+Consider a single Kong node `A`. If we delete a previously registered Service:
+
+```bash
+$ curl -X DELETE http://127.0.0.1:8001/services/test-service
+```
+
+Then any subsequent request to `A` would instantly return `404 Not Found`, as
+the node purged it from its local cache:
+
+```bash
+$ curl -i http://127.0.0.1:8000/test-service
+```
+
+[Back to TOC](#table-of-contents)
+
+## Multiple nodes Kong clusters
+
+In a cluster of multiple Kong nodes, other nodes connected to the same database
+would not instantly be notified that the Service was deleted by node `A`.  While
+the Service is **not** in the database anymore (it was deleted by node `A`), it is
+**still** in node `B`'s memory.
+
+All nodes perform a periodic background job to synchronize with changes that
+may have been triggered by other nodes. The frequency of this job can be
+configured via:
+
+* [db_update_frequency][db_update_frequency] (default: 5 seconds)
+
+Every `db_update_frequency` seconds, all running Kong nodes will poll the
+database for any update, and will purge the relevant entities from their cache
+if necessary.
+
+If we delete a Service from node `A`, this change will not be effective in node
+`B` until node `B`s next database poll, which will occur up to
+`db_update_frequency` seconds later (though it could happen sooner).
+
+This makes Kong clusters **eventually consistent**.
+
+[Back to TOC](#table-of-contents)
+
+## What is being cached?
+
+All of the core entities such as Services, Routes, Plugins, Consumers, Credentials are
+cached in memory by Kong and depend on their invalidation via the polling
+mechanism to be updated.
+
+Additionally, Kong also caches **database misses**. This means that if you
+configure a Service with no plugin, Kong will cache this information. Example:
+
+On node `A`, we add a Service and a Route:
+
+```bash
+# node A
+$ curl -X POST http://127.0.0.1:8001/services \
+    --data "name=example-service" \
+    --data "url=http://example.com"
+
+$ curl -X POST http://127.0.0.1:8001/services/example-service/routes \
+    --data "paths[]=/example"
+```
+
+(Note that we used `/services/example-service/routes` as a shortcut: we
+could have used the `/routes` endpoint instead, but then we would need to
+pass `service_id` as an argument, with the UUID of the new Service.)
+
+A request to the Proxy port of both node `A` and `B` will cache this Service, and
+the fact that no plugin is configured on it:
+
+```bash
+# node A
+$ curl http://127.0.0.1:8000/example
+HTTP 200 OK
+...
+```
+
+```bash
+# node B
+$ curl http://127.0.0.2:8000/example
+HTTP 200 OK
+...
+```
+
+Now, say we add a plugin to this Service via node `A`'s Admin API:
+
+```bash
+# node A
+$ curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
+    --data "name=example-plugin"
+```
+
+Because this request was issued via node `A`'s Admin API, node `A` will locally
+invalidate its cache and on subsequent requests, it will detect that this API
+has a plugin configured.
+
+However, node `B` hasn't run a database poll yet, and still caches that this
+API has no plugin to run. It will be so until node `B` runs its database
+polling job.
+
+**Conclusion**: all CRUD operations trigger cache invalidations. Creation
+(`POST`, `PUT`) will invalidate cached database misses, and update/deletion
+(`PATCH`, `DELETE`) will invalidate cached database hits.
+
+[Back to TOC](#table-of-contents)
+
+## How to configure database caching?
+
+You can configure 3 properties in the Kong configuration file, the most
+important one being `db_update_frequency`, which determine where your Kong
+nodes stand on the performance vs consistency trade off.
+
+Kong comes with default values tuned for consistency, in order to let you
+experiment with its clustering capabilities while avoiding "surprises". As you
+prepare a production setup, you should consider tuning those values to ensure
+that your performance constraints are respected.
+
+### 1. [db_update_frequency][db_update_frequency] (default: 5s)
+
+This value determines the frequency at which your Kong nodes will be polling
+the database for invalidation events. A lower value will mean that the polling
+job will be executed more frequently, but that your Kong nodes will keep up
+with changes you apply. A higher value will mean that your Kong nodes will
+spend less time running the polling jobs, and will focus on proxying your
+traffic.
+
+**Note**: changes propagate through the cluster in up to `db_update_frequency`
+seconds.
+
+[Back to TOC](#table-of-contents)
+
+### 2. [db_update_propagation][db_update_propagation] (default: 0s)
+
+If your database itself is eventually consistent (ie: Cassandra), you **must**
+configure this value. It is to ensure that the change has time to propagate
+across your database nodes. When set, Kong nodes receiving invalidation events
+from their polling jobs will delay the purging of their cache for
+`db_update_propagation` seconds.
+
+If a Kong node connected to an eventual consistent database was not delaying
+the event handling, it could purge its cache, only to cache the non-updated
+value again (because the change hasn't propagated through the database yet)!
+
+You should set this value to an estimate of the amount of time your database
+cluster takes to propagate changes.
+
+**Note**: when this value is set, changes propagate through the cluster in
+up to `db_update_frequency + db_update_propagation` seconds.
+
+[Back to TOC](#table-of-contents)
+
+### 3. [db_cache_ttl][db_cache_ttl] (default: 0s)
+
+The time (in seconds) for which Kong will cache database entities (both hits
+and misses). This Time-To-Live value acts as a safeguard in case a Kong node
+misses an invalidation event, to avoid it from running on stale data for too
+long. When the TTL is reached, the value will be purged from its cache, and the
+next database result will be cached again.
+
+By default no data is invalidated based on this TTL (the default value is `0`).
+This is usually fine: Kong nodes rely on invalidation events, which are handled
+at the db store level (Cassandra/PosgreSQL). If you are concerned that a Kong
+node might miss invalidation event for any reason, you should set a TTL. Otherwise
+the node might run with a stale value in its cache for an undefined amount of time,
+until the cache is manually purged, or the node is restarted.
+
+[Back to TOC](#table-of-contents)
+
+### 4. When using Cassandra
+
+If you use Cassandra as your Kong database, you **must** set
+[db_update_propagation][db_update_propagation] to a non-zero value. Since
+Cassandra is eventually consistent by nature, this will ensure that Kong nodes
+do not prematurely invalidate their cache, only to fetch and catch a
+not up-to-date entity again. Kong will present you a warning logs if you did
+not configure this value when using Cassandra.
+
+Additionally, you might want to configure `cassandra_consistency` to a value
+like `QUORUM` or `LOCAL_QUORUM`, to ensure that values being cached by your
+Kong nodes are up-to-date values from your database.
+
+[Back to TOC](#table-of-contents)
+
+## Interacting with the cache via the Admin API
+
+If for some reason, you wish to investigate the cached values, or manually
+invalidate a value cached by Kong (a cached hit or miss), you can do so via the
+Admin API `/cache` endpoint.
+
+### Inspect a cached value
+
+**Endpoint**
+
+<div class="endpoint get">/cache/{cache_key}</div>
+
+**Response**
+
+If a value with that key is cached:
+
+```
+HTTP 200 OK
+...
+{
+    ...
+}
+```
+
+Else:
+
+```
+HTTP 404 Not Found
+```
+
+**Note**: retrieving the `cache_key` for each entity being cached by Kong is
+currently an undocumented process. Future versions of the Admin API will make
+this process easier.
+
+[Back to TOC](#table-of-contents)
+
+### Purge a cached value
+
+**Endpoint**
+
+<div class="endpoint delete">/cache/{cache_key}</div>
+
+**Response**
+
+```
+HTTP 204 No Content
+...
+```
+
+**Note**: retrieving the `cache_key` for each entity being cached by Kong is
+currently an undocumented process. Future versions of the Admin API will make
+this process easier.
+
+[Back to TOC](#table-of-contents)
+
+### Purge a node's cache
+
+**Endpoint**
+
+<div class="endpoint delete">/cache</div>
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+**Note**: be wary of using this endpoint on a warm, production running node.
+If the node is receiving a lot of traffic, purging its cache at the same time
+will trigger many requests to your database, and could cause a
+[dog-pile effect](https://en.wikipedia.org/wiki/Cache_stampede).
+
+[Back to TOC](#table-of-contents)
+
+[db_update_frequency]: /{{page.kong_version}}/configuration/#db_update_frequency
+[db_update_propagation]: /{{page.kong_version}}/configuration/#db_update_propagation
+[db_cache_ttl]: /{{page.kong_version}}/configuration/#db_cache_ttl

--- a/app/1.0.x/getting-started/adding-consumers.md
+++ b/app/1.0.x/getting-started/adding-consumers.md
@@ -1,0 +1,97 @@
+---
+title: Adding Consumers
+---
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+    <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
+  </ol>
+</div>
+
+In the last section, we learned how to add plugins to Kong, in this section
+we're going to learn how to add consumers to your Kong instances. Consumers are
+associated to individuals using your API, and can be used for tracking, access
+management, and more.
+
+**Note:** This section assumes you have [enabled][enabling-plugins] the
+[key-auth][key-auth] plugin. If you haven't, you can either [enable the
+plugin][enabling-plugins] or skip steps two and three.
+
+## 1. Create a Consumer through the RESTful API
+
+Lets create a user named `Jason` by issuing the following request:
+
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/consumers/ \
+  --data "username=Jason"
+```
+
+You should see a response similar to the one below:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Connection: keep-alive
+
+{
+  "username": "Jason",
+  "created_at": 1428555626000,
+  "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
+}
+```
+
+Congratulations! You've just added your first consumer to Kong.
+
+**Note:** Kong also accepts a `custom_id` parameter when [creating
+consumers][API-consumers] to associate a consumer with your existing user
+database.
+
+## 2. Provision key credentials for your Consumer
+
+Now, we can create a key for our recently created consumer `Jason` by
+issuing the following request:
+
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/consumers/Jason/key-auth/ \
+  --data 'key=ENTER_KEY_HERE'
+```
+
+## 3. Verify that your Consumer credentials are valid
+
+We can now issue the following request to verify that the credentials of
+our `Jason` Consumer is valid:
+
+```bash
+$ curl -i -X GET \
+  --url http://localhost:8000 \
+  --header "Host: example.com" \
+  --header "apikey: ENTER_KEY_HERE"
+```
+
+## Next Steps
+
+Now that we've covered the basics of adding Services, Routes, Consumers and enabling
+Plugins, feel free to read more on Kong in one of the following documents:
+
+- [Configuration file Reference][configuration]
+- [CLI Reference][CLI]
+- [Proxy Reference][proxy]
+- [Admin API Reference][API]
+- [Clustering Reference][cluster]
+
+Questions? Issues? Contact us on one of the [Community Channels](/community)
+for help!
+
+[key-auth]: /plugins/key-authentication
+[API-consumers]: /{{page.kong_version}}/admin-api#create-consumer
+[enabling-plugins]: /{{page.kong_version}}/getting-started/enabling-plugins
+[configuration]: /{{page.kong_version}}/configuration
+[CLI]: /{{page.kong_version}}/cli
+[proxy]: /{{page.kong_version}}/proxy
+[API]: /{{page.kong_version}}/admin-api
+[cluster]: /{{page.kong_version}}/clustering

--- a/app/1.0.x/getting-started/configuring-a-service.md
+++ b/app/1.0.x/getting-started/configuring-a-service.md
@@ -1,0 +1,137 @@
+---
+title: Configuring a Service
+---
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+  </ol>
+</div>
+
+In this section, you'll be adding an API to Kong. In order to do this, you'll
+first need to add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
+it manages.
+
+For the purpose of this guide, we'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is
+an "echo" type public website which returns the requests it gets back to the requester, as responses. This
+makes it helpful for learning how Kong proxies your API requests.
+
+Before you can start making requests against the Service, you will need to add a _Route_ to it.
+Routes specify how (and _if_) requests are sent to their Services after they reach Kong. A single
+Service can have many Routes.
+
+After configuring the Service and the Route, you'll be able to make requests through Kong using them.
+
+Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, including adding Services and
+Routes, is made via requests on that API.
+
+## 1. Add your Service using the Admin API
+
+Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
+to Kong:
+
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/services/ \
+  --data 'name=example-service' \
+  --data 'url=http://mockbin.org'
+```
+
+You should receive a response similar to:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Connection: keep-alive
+
+{
+   "host":"mockbin.org",
+   "created_at":1519130509,
+   "connect_timeout":60000,
+   "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
+   "protocol":"http",
+   "name":"example-service",
+   "read_timeout":60000,
+   "port":80,
+   "path":null,
+   "updated_at":1519130509,
+   "retries":5,
+   "write_timeout":60000
+}
+```
+
+
+## 2. Add a Route for the Service
+
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --data 'hosts[]=example.com'
+```
+
+The answer should be similar to:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+Connection: keep-alive
+
+{
+   "created_at":1519131139,
+   "strip_path":true,
+   "hosts":[
+      "example.com"
+   ],
+   "preserve_host":false,
+   "regex_priority":0,
+   "updated_at":1519131139,
+   "paths":null,
+   "service":{
+      "id":"79d7ee6e-9fc7-4b95-aa3b-61d2e17e7516"
+   },
+   "methods":null,
+   "protocols":[
+      "http",
+      "https"
+   ],
+   "id":"f9ce2ed7-c06e-4e16-bd5d-3a82daef3f9d"
+}
+```
+
+Kong is now aware of your Service and ready to proxy requests.
+
+## 3. Forward your requests through Kong
+
+Issue the following cURL request to verify that Kong is properly forwarding
+requests to your Service. Note that [by default][proxy-port] Kong handles proxy
+requests on port `:8000`:
+
+```bash
+$ curl -i -X GET \
+  --url http://localhost:8000/ \
+  --header 'Host: example.com'
+```
+
+A successful response means Kong is now forwarding requests made to
+`http://localhost:8000` to the `url` we configured in step #1,
+and is forwarding the response back to us. Kong knows to do this through
+the header defined in the above cURL request:
+
+<ul>
+  <li><strong>Host: &lt;given host></strong></li>
+</ul>
+
+<hr>
+
+## Next Steps
+
+Now that you've added your Service to Kong, let's learn how to enable plugins.
+
+Go to [Enabling Plugins &rsaquo;][enabling-plugins]
+
+[API]: /{{page.kong_version}}/admin-api
+[enabling-plugins]: /{{page.kong_version}}/getting-started/enabling-plugins
+[proxy-port]: /{{page.kong_version}}/configuration/#nginx-section
+[mockbin]: https://mockbin.com/

--- a/app/1.0.x/getting-started/enabling-plugins.md
+++ b/app/1.0.x/getting-started/enabling-plugins.md
@@ -1,0 +1,74 @@
+---
+title: Enabling Plugins
+---
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+    <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
+  </ol>
+</div>
+
+In this section, you'll learn how to configure Kong plugins. One of the core
+principles of Kong is its extensibility through [plugins][plugins]. Plugins
+allow you to easily add new features to your API or make your API easier to
+manage.
+
+In the steps below you will configure the [key-auth][key-auth] plugin to add
+authentication to your Service. Prior to the addition of this plugin, **all**
+requests to your Service would be proxied upstream. Once you add and configure this
+plugin, **only** requests with the correct API key(s) will be proxied - all
+other requests will be rejected by Kong, thus protecting your upstream service
+from unauthorized use.
+
+
+## 1. Configure the key-auth plugin
+
+To configure the key-auth plugin for the Service you <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured in Kong</a>,
+issue the following cURL request:
+
+```bash
+$ curl -i -X POST \
+  --url http://localhost:8001/services/example-service/plugins/ \
+  --data 'name=key-auth'
+```
+
+**Note:** This plugin also accepts a `config.key_names` parameter, which
+defaults to `['apikey']`. It is a list of headers and parameters names (both
+are supported) that are supposed to contain the apikey during a request.
+
+## 2. Verify that the plugin is properly configured
+
+Issue the following cURL request to verify that the [key-auth][key-auth]
+plugin was properly configured on the Service:
+
+```bash
+$ curl -i -X GET \
+  --url http://localhost:8000/ \
+  --header 'Host: example.com'
+```
+
+Since you did not specify the required `apikey` header or parameter, the
+response should be `401 Unauthorized`:
+
+```http
+HTTP/1.1 401 Unauthorized
+...
+
+{
+  "message": "No API key found in request"
+}
+```
+
+## Next Steps
+
+Now that you've configured the **key-auth** plugin lets learn how to add
+consumers to your Service so we can continue proxying requests through Kong.
+
+Go to [Adding Consumers &rsaquo;][adding-consumers]
+
+[key-auth]: /plugins/key-authentication
+[plugins]: /plugins
+[adding-consumers]: /{{page.kong_version}}/getting-started/adding-consumers

--- a/app/1.0.x/getting-started/introduction.md
+++ b/app/1.0.x/getting-started/introduction.md
@@ -1,0 +1,31 @@
+---
+title: Welcome to Kong
+---
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+</div>
+
+Before going further into Kong, make sure you understand its [purpose and philosophy](/about). Once you are confident with the concept of API Gateways, this guide is going to take you through a quick introduction on how to use Kong and perform basic operations such as:
+
+- [Running your own Kong instance][quickstart]
+- [Adding and consuming Services][configuring-a-service]
+- [Installing plugins on Kong][enabling-plugins]
+
+## What is Kong, technically?
+
+You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
+
+To be more precise, Kong is a Lua application running in Nginx and made possible by the [lua-nginx-module](https://github.com/openresty/lua-nginx-module). Instead of compiling Nginx with this module, Kong is distributed along with [OpenResty](https://openresty.org/), which already includes lua-nginx-module. OpenResty is *not* a fork of Nginx, but a bundle of modules extending its capabilities.
+
+This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
+
+## Next Steps
+
+Now, lets get familiar with learning how to "start" and "stop" Kong.
+
+Go to [5-minute quickstart with Kong &rsaquo;][quickstart]
+
+[quickstart]: /{{page.kong_version}}/getting-started/quickstart
+[configuring-a-service]: /{{page.kong_version}}/getting-started/configuring-a-service
+[enabling-plugins]: /{{page.kong_version}}/getting-started/enabling-plugins

--- a/app/1.0.x/getting-started/quickstart.md
+++ b/app/1.0.x/getting-started/quickstart.md
@@ -1,0 +1,79 @@
+---
+title: 5-minute Quickstart
+---
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong> Make sure you've
+  <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+</div>
+
+In this section, you'll learn how to manage your Kong instance. First we'll
+have you start Kong giving in order to give you access to the RESTful Admin
+interface, through which you manage your Services, Routes, Consumers, and more. Data sent
+through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
+supports PostgreSQL and Cassandra).
+
+## 1. Start Kong
+
+Issue the following command to prepare your datastore by running the Kong
+migrations:
+
+```bash
+$ kong migrations up [-c /path/to/kong.conf]
+```
+
+You should see a message that tells you Kong has successfully migrated your
+database. If not, you probably incorrectly configured your database
+connection settings in your configuration file.
+
+Now let's [start][CLI] Kong:
+
+```bash
+$ kong start [-c /path/to/kong.conf]
+```
+
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to your own configuration.
+
+## 2. Verify that Kong has started successfully
+
+If everything went well, you should see a message (`Kong started`)
+informing you that Kong is running.
+
+By default Kong listens on the following ports:
+
+- `:8000` on which Kong listens for incoming HTTP traffic from your
+  clients, and forwards it to your upstream services.
+- `:8443` on which Kong listens for incoming HTTPS traffic. This port has a
+  similar behavior as the `:8000` port, except that it expects HTTPS
+  traffic only. This port can be disabled via the configuration file.
+- `:8001` on which the [Admin API][API] used to configure Kong listens.
+- `:8444` on which the Admin API listens for HTTPS traffic.
+
+## 3. Stop Kong
+
+As needed you can stop the Kong process by issuing the following
+[command][CLI]:
+
+```bash
+$ kong stop
+```
+
+## 4. Reload Kong
+
+Issue the following command to [reload][CLI] Kong without downtime:
+
+```bash
+$ kong reload
+```
+
+## Next Steps
+
+Now that you have Kong running you can interact with the Admin API.
+
+To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
+
+[CLI]: /{{page.kong_version}}/cli
+[API]: /{{page.kong_version}}/admin-api
+[datastore-section]: /{{page.kong_version}}/configuration/#datastore-section
+[configuring-a-service]: /{{page.kong_version}}/getting-started/configuring-a-service

--- a/app/1.0.x/health-checks-circuit-breakers.md
+++ b/app/1.0.x/health-checks-circuit-breakers.md
@@ -1,0 +1,294 @@
+---
+title: Health Checks and Circuit Breakers Reference
+---
+
+## Introduction
+
+You can make an API proxied by Kong use a [ring-balancer][ringbalancer], configured
+by adding an [upstream][upstream] entity that contains one or more [target][ringtarget]
+entities, each target pointing to a different IP address (or hostname) and
+port. The ring-balancer will balance load among the various targets, and based
+on the [upstream][upstream] configuration, will perform health checks on the targets,
+making them as healthy or unhealthy whether they are responsive or not. The
+ring-balancer will then only route traffic to healthy targets.
+
+Kong supports two kinds of health checks, which can be used separately or in
+conjunction:
+
+* **active checks**, where a specific HTTP endpoint in the target is
+periodically requested and the health of the target is determined based on its
+response;
+
+* **passive checks** (also known as **circuit breakers**), where Kong analyzes
+the ongoing traffic being proxied and determines the health of targets based
+on their behavior responding requests.
+
+## Healthy and unhealthy targets
+
+The objective of the health checks functionality is to dynamically mark
+targets as healthy or unhealthy, **for a given Kong node**. There is
+no cluster-wide synchronization of health information: each Kong node
+determines the health of its targets separately. This is desirable since at a
+given point one Kong node may be able to connect to a target successfully
+while another node is failing to reach it: the first node will consider
+it healthy, while the second will mark it as unhealthy and start routing
+traffic to other targets of the upstream.
+
+Either an active probe (on active health checks) or a proxied request
+(on passive health checks) produces data which is used to determine
+whether a target is healthy or unhealthy. A request may produce a TCP
+error, timeout, or produce an HTTP status code. Based on this
+information, the health checker updates a series of internal counters:
+
+* If the returned status code is one configured as "healthy", it will
+increment the "Successes" counter for the target and clear all its other
+counters;
+* If it fails to connect, it will increment the "TCP failures" counter
+for the target and clear the "Successes" counter;
+* If it times out, it will increment the "timeouts" counter
+for the target and clear the "Successes" counter;
+* If the returned status code is one configured as "unhealthy", it will
+increment the "HTTP failures" counter for the target and clear the "Successes" counter.
+
+If any of the "TCP failures", "HTTP failures" or "timeouts" counters reaches
+their configured threshold, the target will be marked as unhealthy.
+
+If the "Successes" counter reaches its configured threshold, the target will be
+marked as healthy.
+
+The list of which HTTP status codes are "healthy" or "unhealthy", and the
+individual thresholds for each of these counters are configurable on a
+per-upstream basis. Below, we have an example of a configuration for an
+Upstream entity, showcasing the default values of the various fields
+available for configuring health checks. A description of each
+field is included in the [Admin API][addupstream] reference documentation.
+
+```json
+{
+    "name": "service.v1.xyz",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10
+}
+```
+
+If all targets of an upstream are unhealthy, Kong will respond to requests
+to the upstream with `503 Service Unavailable`.
+
+Note:
+
+1. health checks operate only on [*active* targets][targetobject] and do not
+   modify the *active* status of a target in the Kong database.
+2. unhealthy targets will not be removed from the loadbalancer, and hence will
+   not have any impact on the balancer layout when using the hashing algorithm
+   (they will just be skipped).
+3. The [DNS caveats][dnscaveats] and [balancer caveats][balancercaveats]
+   also apply to health checks. If using hostnames for the targets, then make
+   sure the DNS server always returns the full set of IP addresses for a name,
+   and does not limit the response. *Failing to do so might lead to health
+   checks not being executed.*
+
+## Types of health checks
+
+### Active health checks
+
+Active health checks, as the name implies, actively probe targets for
+their health. When active health checks are enabled in an upstream entity,
+Kong will periodically issue HTTP requests to a configured path at each target
+of the upstream. This allows Kong to automatically enable and disable targets
+in the balancer based on the [probe results](#healthy-and-unhealthy-targets).
+
+The periodicity of active health checks can be configured separately for
+when a target is healthy or unhealthy. If the `interval` value for either
+is set to zero, the checking is disabled at the corresponding scenario.
+When both are zero, active health checks are disabled altogether.
+
+[Back to TOC](#table-of-contents)
+
+### Passive health checks (circuit breakers)
+
+Passive health checks, also known as circuit breakers, are
+checks performed based on the requests being proxied by Kong,
+with no additional traffic being generated. When a target becomes
+unresponsive, the passive health checker will detect that and mark
+the target as unhealthy. The ring-balancer will start skipping this
+target, so no more traffic will be routed to it.
+
+Once the problem with a target is solved and it is ready to receive
+traffic again, the Kong administrator can manually inform the
+health checker that the target should be enabled again, via an
+Admin API endpoint:
+
+```bash
+$ curl -i -X POST http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
+HTTP/1.1 204 No Content
+```
+
+This command will broadcast a cluster-wide message so that the "healthy"
+status is propagated to the whole [Kong cluster][clustering]. This will cause Kong nodes to
+reset the health counters of the health checkers running in all workers of the
+Kong node, allowing the ring-balancer to route traffic to the target again.
+
+Passive health checks have the advantage of not producing extra
+traffic, but they are unable to automatically mark a target as
+healthy again: the "circuit is broken", and the target needs to
+be re-enabled again by the system administrator.
+
+[Back to TOC](#table-of-contents)
+
+## Summary of pros and cons
+
+* Active health checks can automatically re-enable a target in the
+ring balancer as soon as it is healthy again. Passive health checks cannot.
+* Passive health checks do not produce additional traffic to the
+target. Active health checks do.
+* An active health checker demands a known URL with a reliable status response
+in the target to be configured as a probe endpoint (which may be as
+simple as `"/"`). Passive health checks do not demand such configuration.
+* By providing a custom probe endpoint for an active health checker,
+an application may determine its own health metrics and produce a status
+code to be consumed by Kong. Even though a target continues to serve
+traffic which looks healthy to the passive health checker,
+it would be able to respond to the active probe with a failure
+status, essentially requesting to be relieved from taking new traffic.
+
+It is possible to combine the two modes. For example, one can enable
+passive health checks to monitor the target health based solely on its
+traffic, and only use active health checks while the target is unhealthy,
+in order to re-enable it automatically.
+
+## Enabling and disabling health checks
+
+### Enabling active health checks
+
+To enable active health checks, you need to specify the configuration items
+under `healthchecks.active` in the [Upstream object][upstreamobjects] configuration. You
+need to specify the necessary information so that Kong can perform periodic
+probing on the target, and how to interpret the resulting information.
+
+For configuring the probe, you need to specify:
+
+* `healthchecks.active.http_path` - The path that should be used when
+issuing the HTTP GET request to the target. The default value is `"/"`.
+* `healthchecks.active.timeout` - The connection timeout limit for the
+HTTP GET request of the probe. The default value is 1 second.
+* `healthchecks.active.concurrency` - Number of targets to check concurrently
+in active health checks.
+
+You also need to specify positive values for intervals, for running
+probes:
+
+* `healthchecks.active.healthy.interval` - Interval between active health
+checks for healthy targets (in seconds). A value of zero indicates that active
+probes for healthy targets should not be performed.
+* `healthchecks.active.unhealthy.interval` - Interval between active health
+checks for unhealthy targets (in seconds). A value of zero indicates that active
+probes for unhealthy targets should not be performed.
+
+This allows you to tune the behavior of the active health checks, whether you
+want probes for healthy and unhealthy targets to run at the same interval, or
+one to be more frequent than the other.
+
+Finally, you need to configure how Kong should interpret the probe, by setting
+the various thresholds on the [health
+counters](#healthy-and-unhealthy-targets), which, once reached will trigger a
+status change. The counter threshold fields are:
+
+* `healthchecks.active.healthy.successes` - Number of successes in active
+probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider
+a target healthy.
+* `healthchecks.active.unhealthy.tcp_failures` - Number of TCP failures in
+active probes to consider a target unhealthy.
+* `healthchecks.active.unhealthy.timeouts` - Number of timeouts in active
+probes to consider a target unhealthy.
+* `healthchecks.active.unhealthy.http_failures` - Number of HTTP failures in
+active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to
+consider a target unhealthy.
+
+### Enabling passive health checks
+
+Passive health checks do not feature a probe, as they work by interpreting
+the ongoing traffic that flows from a target. This means that to enable
+passive checks you only need to configure its counter thresholds:
+
+* `healthchecks.passive.healthy.successes` - Number of successes in proxied
+traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to
+consider a target healthy, as observed by passive health checks. This needs to
+be positive when passive checks are enabled so that healthy traffic resets the
+unhealthy counters.
+* `healthchecks.passive.unhealthy.tcp_failures` - Number of TCP failures in
+proxied traffic to consider a target unhealthy, as observed by passive health
+checks.
+* `healthchecks.passive.unhealthy.timeouts` - Number of timeouts in proxied
+traffic to consider a target unhealthy, as observed by passive health checks.
+* `healthchecks.passive.unhealthy.http_failures` - Number of HTTP failures in
+proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`)
+to consider a target unhealthy, as observed by passive health checks.
+
+### Disabling health checks
+
+In all counter thresholds and intervals specified in the `healthchecks`
+configuration, setting a value to zero means that the functionality the field
+represents is disabled. Setting a probe interval to zero disables a probe.
+Likewise, you can disable certain types of checks by setting their counter
+thresholds to zero. For example, to not consider timeouts when performing
+healthchecks, you can set both `timeouts` fields (for active and passive
+checks) to zero. This gives you a fine-grained control of the behavior of the
+health checker.
+
+In summary, to completely disable active health checks for an upstream, you
+need to set both `healthchecks.active.healthy.interval` and
+`healthchecks.active.unhealthy.interval` to `0`.
+
+To completely disable passive health checks, you need to set all counter
+thresholds under `healthchecks.passive` for its various counters to zero.
+
+All counter thresholds and intervals in `healthchecks` are zero by default,
+meaning that health checks are completely disabled by default in newly created
+upstreams.
+
+[Back to TOC](#table-of-contents)
+
+[ringbalancer]: /{{page.kong_version}}/loadbalancing#ring-balancer
+[ringtarget]: /{{page.kong_version}}/loadbalancing#target
+[upstream]: /{{page.kong_version}}/loadbalancing#upstream
+[targetobject]: /{{page.kong_version}}/admin-api#target-object
+[addupstream]: /{{page.kong_version}}/admin-api#add-upstream
+[clustering]: /{{page.kong_version}}/clustering
+[upstreamobjects]: /{{page.kong_version}}/admin-api#upstream-objects
+[balancercaveats]: /{{page.kong_version}}/loadbalancing#balancing-caveats
+[dnscaveats]: /{{page.kong_version}}/loadbalancing#dns-caveats

--- a/app/1.0.x/index.md
+++ b/app/1.0.x/index.md
@@ -1,0 +1,65 @@
+---
+title: Documentation for Kong
+---
+
+<div class="docs-grid">
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="https://konghq.com/install/">Installation</a></h3>
+    <p>You can install Kong on most Linux distributions and macOS. We even provide the source so you can compile yourself.</p>
+    <a href="https://konghq.com/install/">Install Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-quickstart.svg" /><a href="/{{page.kong_version}}/getting-started/quickstart">5-minute Quickstart</a></h3>
+    <p>Learn how to start Kong, add your API, enable plugins, and add consumers in under thirty seconds.</p>
+    <a href="/{{page.kong_version}}/getting-started/quickstart">Start using Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/{{page.kong_version}}/configuration">Configuration file</a></h3>
+    <p>Want to further optimize your Kong cluster, database, or configure NGINX? Dive into the configuration.</p>
+    <a href="/{{page.kong_version}}/configuration">Start configuring Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/{{page.kong_version}}/cli">CLI reference</a></h3>
+    <p>Want a better understanding of the CLI tool and its options? Browse the detailed command reference.</p>
+    <a href="/{{page.kong_version}}/cli">Use the CLI &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/{{page.kong_version}}/admin-api">Admin API reference</a></h3>
+    <p>Ready to learn the underlying interface? Browse the Admin API reference to learn how to start making requests.</p>
+    <a href="/{{page.kong_version}}/admin-api">Explore the interface &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/{{page.kong_version}}/proxy">Proxy reference</a></h3>
+    <p>Learn every way to configure Kong to proxy your APIs, serve them over SSL or use WebSockets.</p>
+    <a href="/{{page.kong_version}}/proxy">Read the Proxy Reference &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/{{page.kong_version}}/loadbalancing">Load balancing reference</a></h3>
+    <p>Learn how to setup Kong to load balance traffic through replicas of your upstream services.</p>
+    <a href="/{{page.kong_version}}/loadbalancing">Read the Load balancing Reference &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/{{page.kong_version}}/health-checks-circuit-breakers">Health checks and circuit breakers</a></h3>
+    <p>Let Kong monitor the availability of your services and adjust its load balancing accordingly.</p>
+    <a href="/{{page.kong_version}}/health-checks-circuit-breakers">Learn about health checks and circuit breakers &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-clustering.svg" /><a href="/{{page.kong_version}}/clustering">Clustering</a></h3>
+    <p>If you are starting more than one node, you must use clustering to make sure all the nodes belong to the same Kong cluster.</p>
+    <a href="/{{page.kong_version}}/clustering">Read the clustering reference &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="/{{page.kong_version}}/plugin-development">Write your own plugins</a></h3>
+    <p>Looking for something Kong does not do for you? Easy: write it as a plugin. Learn how to write your own plugins for Kong.</p>
+    <a href="/{{page.kong_version}}/plugin-development">Read the plugin development guide &rarr;</a>
+  </div>
+</div>

--- a/app/1.0.x/loadbalancing.md
+++ b/app/1.0.x/loadbalancing.md
@@ -1,0 +1,374 @@
+---
+title: Loadbalancing reference
+---
+
+## Introduction
+
+Kong provides multiple ways of load balancing requests to multiple backend
+services: a straightforward DNS-based method, and a more dynamic ring-balancer
+that also allows for service registry without needing a DNS server.
+
+## DNS-based loadbalancing
+
+When using DNS-based load balancing, the registration of the backend services
+is done outside of Kong, and Kong only receives updates from the DNS server.
+
+Every Service that has been defined with a `host` containing a hostname
+(instead of an IP address) will automatically use DNS-based load balancing
+if the name resolves to multiple IP addresses, provided the hostname does not
+resolve to an `upstream` name or a name in your DNS hostsfile.
+
+The DNS record `ttl` setting (time to live) determines how often the information
+is refreshed. When using a `ttl` of 0, every request will be resolved using its
+own DNS query. Obviously this will have a performance penalty, but the latency of
+updates/changes will be very low.
+
+[Back to TOC](#table-of-contents)
+
+### A records
+
+An A record contains one or more IP addresses. Hence, when a hostname
+resolves to an A record, each backend service must have its own IP address.
+
+Because there is no `weight` information, all entries will be treated as equally
+weighted in the load balancer, and the balancer will do a straight forward
+round-robin.
+
+[Back to TOC](#table-of-contents)
+
+### SRV records
+
+An SRV record contains weight and port information for all of its IP addresses.
+A backend service can be identified by a unique combination of IP address
+and port number. Hence, a single IP address can host multiple instances of the
+same service on different ports.
+
+Because the `weight` information is available, each entry will get its own
+weight in the load balancer and it will perform a weighted round-robin.
+
+Similarly, any given port information will be overridden by the port information from
+the DNS server. If a Service has attributes `host=myhost.com` and `port=123`,
+and `myhost.com` resolves to an SRV record with `127.0.0.1:456`, then the request
+will be proxied to `http://127.0.0.1:456/somepath`, as port `123` will be
+overridden by `456`.
+
+[Back to TOC](#table-of-contents)
+
+### DNS priorities
+
+The DNS resolver will start resolving the following record types in order:
+
+  1. The last successful type previously resolved
+  2. SRV record
+  3. A record
+  4. CNAME record
+
+This order is configurable through the [`dns_order` configuration property][dns-order-config].
+
+[Back to TOC](#table-of-contents)
+
+### DNS caveats
+
+- Whenever the DNS record is refreshed a list is generated to handle the
+weighting properly. Try to keep the weights as multiples of each other to keep
+the algorithm performant, e.g., 2 weights of 17 and 31 would result in a structure
+with 527 entries, whereas weights 16 and 32 (or their smallest relative
+counterparts 1 and 2) would result in a structure with merely 3 entries,
+especially with a very small (or even 0) `ttl` value.
+
+- Some nameservers do not return all entries (due to UDP packet size) in those
+cases (for example Consul returns a maximum of 3) a given Kong node will only
+use the few upstream service instances provided by the nameserver. In this
+scenario, it is possible that the pool of upstream instances will be loaded
+inconsistently, because the Kong node is effectively unaware of some of the
+instances, due to the limited information provided by the nameserver.
+To mitigate this use a different nameserver, use IP
+addresses instead of names, or make sure you use enough Kong nodes to still
+have all upstream services being used.
+
+- When the nameserver returns a `3 name error`, then that is a valid response
+for Kong. If this is unexpected, first validate the correct name is being
+queried for, and second check your nameserver configuration.
+
+- The initial pick of an IP address from a DNS record (A or SRV) is not
+randomized. So when using records with a `ttl` of 0, the nameserver is
+expected to randomize the record entries.
+
+[Back to TOC](#table-of-contents)
+
+## Ring-balancer
+
+When using the ring-balancer, the adding and removing of backend services will
+be handled by Kong, and no DNS updates will be necessary. Kong will act as the
+service registry. Nodes can be added/deleted with a single HTTP request and
+will instantly start/stop receiving traffic.
+
+Configuring the ring-balancer is done through the `upstream` and `target`
+entities.
+
+  - `target`: an IP address or hostname with a port number where a backend
+    service resides, eg. "192.168.100.12:80". Each target gets an additional
+    `weight` to indicate the relative load it gets. IP addresses can be
+    in both IPv4 and IPv6 format.
+  - `upstream`: a 'virtual hostname' which can be used in a Route `host`
+    field, e.g., an upstream named `weather.v2.service` would get all requests
+    from a Service with `host=weather.v2.service`.
+
+[Back to TOC](#table-of-contents)
+
+### Upstream
+
+Each upstream gets its own ring-balancer. Each `upstream` can have many
+`target` entries attached to it, and requests proxied to the 'virtual hostname'
+will be load balanced over the targets. A ring-balancer has a pre-defined
+number of slots, and based on the target weights the slots get assigned to the
+targets of the upstream.
+
+Adding and removing targets can be done with a simple HTTP request on the
+Admin API. This operation is relatively cheap. Changing the upstream
+itself is more expensive as the balancer will need to be rebuilt when the
+number of slots change for example.
+
+The only occurrence where the balancer will be rebuilt automatically is when
+the target history is cleaned; other than that, it will only rebuild upon changes.
+
+Within the balancer there are the positions (from 1 to `slots`),
+which are __randomly distributed__ on the ring.
+The randomness is required to make invoking the ring-balancer cheap at
+runtime. A simple round-robin over the wheel (the positions) will do to
+provide a well distributed weighted round-robin over the `targets`, whilst
+also having cheap operations when inserting/deleting targets.
+
+The number of slots to use per target should (at least) be around 100 to make
+sure the slots are properly distributed. Eg. for an expected maximum of 8
+targets, the `upstream` should be defined with at least `slots=800`, even if
+the initial setup only features 2 targets.
+
+The tradeoff here is that the higher the number of slots, the better the random
+distribution, but the more expensive the changes are (add/removing targets)
+
+Detailed information on adding and manipulating
+upstreams is available in the `upstream` section of the
+[Admin API reference][upstream-object-reference].
+
+[Back to TOC](#table-of-contents)
+
+### Target
+
+Because the `upstream` maintains a history of changes, targets can only be
+added, not modified nor deleted. To change a target, just add a new entry for
+the target, and change the `weight` value. The last entry is the one that will
+be used. As such setting `weight=0` will disable a target, effectively
+deleting it from the balancer. Detailed information on adding and manipulating
+targets is available in the `target` section of the
+[Admin API reference][target-object-reference].
+
+The targets will be automatically cleaned when there are 10x more inactive
+entries than active ones. Cleaning will involve rebuilding the balancer, and
+hence is more expensive than just adding a target entry.
+
+A `target` can also have a hostname instead of an IP address. In that case
+the name will be resolved and all entries found will individually be added to
+the ring balancer, e.g., adding `api.host.com:123` with `weight=100`. The
+name 'api.host.com' resolves to an A record with 2 IP addresses. Then both
+ip addresses will be added as target, each getting `weight=100` and port 123.
+__NOTE__: the weight is used for the individual entries, not for the whole!
+
+Would it resolve to an SRV record, then also the `port` and `weight` fields
+from the DNS record would be picked up, and would overrule the given port `123`
+and `weight=100`.
+
+The balancer will honor the DNS record's `ttl` setting and requery and update
+the balancer when it expires.
+
+__Exception__: When a DNS record has `ttl=0`, the hostname will be added
+as a single target, with the specified weight. Upon every proxied request
+to this target it will query the nameserver again.
+
+[Back to TOC](#table-of-contents)
+
+### Balancing algorithms
+
+By default a ring-balancer will use a weighted-round-robin scheme. The alternative
+would be to use the hash-based algorithm. The input for the hash can be either
+`none`, `consumer`, `ip`, `header`, or `cookie`. When set to `none` the
+weighted-round-robin scheme will be used, and hashing will be disabled.
+
+There are two options, a primary and a fallback in case the primary fails
+(e.g., if the primary is set to `consumer`, but no consumer is authenticated)
+
+The different hashing options:
+
+- `none`: Do not use hashing, but use weighted-round-robin instead (default).
+
+- `consumer`: Use the consumer id as the hash input. This option will fallback
+  on the credential id if no consumer id is available (in case of external auth
+  like ldap).
+
+- `ip`: The remote (originating) IP address will be used as input. Review the
+  configuration settings for [determining the real IP][real-ip-config] when
+  using this.
+
+- `header`: Use a specified header (in either `hash_on_header` or `hash_fallback_header`
+  field) as input for the hash.
+
+- `cookie`: Use a specified cookie name (in the `hash_on_cookie` field) with a
+  specified path (in the `hash_on_cookie_path` field, default `"/"`) as input for
+  the hash. If the cookie is not present in the request, it will be set by the
+  response. Hence, the `hash_fallback` setting is invalid if `cookie` is the primary
+  hashing mechanism.
+
+The hashing algorithm is based on 'consistent-hashing' (or the 'ketama principle')
+which makes sure that when the balancer gets modified by changing the targets
+(adding, removing, failing, or changing weights) only the minimum number of
+hashing losses occur. This will maximize upstream cache hits.
+
+For more information on the exact settings see the `upstream` section of the
+[Admin API reference][upstream-object-reference].
+
+[Back to TOC](#table-of-contents)
+
+### Balancing caveats
+
+The ring-balancer is designed to work both with a single node as well as in a cluster.
+For the weighted-round-robin algorithm there isn't much difference, but when using
+the hash based algorithm it is important that all nodes build the exact same
+ring-balancer to make sure they all work identical. To do this the balancer
+must be build in a deterministic way.
+
+- Do not use hostnames in the balancer as the
+balancers might/will slowly diverge because the DNS ttl has only second precision
+and renewal is determined by when a name is actually requested. On top of this is
+the issue with some nameservers not returning all entries, which exacerbates
+this problem. So when using the hashing approach in a Kong cluster, add `target`
+entities only by their IP address, and never by name.
+
+- When picking your hash input make sure the input has enough variance to get
+to a well distributed hash. Hashes will be calculated using the CRC-32 digest.
+So for example, if your system has thousands of users, but only a few consumers, defined
+per platform (eg. 3 consumers: Web, iOS and Android) then picking the `consumer`
+hash input will not suffice, using the remote IP address by setting the hash to
+`ip` would provide more variance in the input and hence a better distribution
+in the hash output. However, if many clients will be behind the same NAT gateway (e.g. in
+call center), `cookie` will provide a better distribution than `ip`.
+
+[Back to TOC](#table-of-contents)
+
+# Blue-Green Deployments
+
+Using the ring-balancer a [blue-green deployment][blue-green-canary] can be easily orchestrated for
+a Service. Switching target infrastructure only requires a `PATCH` request on a
+Service, to change its `host` value.
+
+Set up the "Blue" environment, running version 1 of the address service:
+
+```bash
+# create an upstream
+$ curl -X POST http://kong:8001/upstreams \
+    --data "name=address.v1.service"
+
+# add two targets to the upstream
+$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+    --data "target=192.168.34.15:80"
+    --data "weight=100"
+$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+    --data "target=192.168.34.16:80"
+    --data "weight=50"
+
+# create a Service targeting the Blue upstream
+$ curl -X POST http://kong:8001/services/ \
+    --data "name=address-service" \
+    --data "host=address.v1.service" \
+    --data "path=/address"
+
+# finally, add a Route as an entry-point into the Service
+$ curl -X POST http://kong:8001/services/address-service/routes/ \
+    --data "hosts[]=address.mydomain.com"
+```
+
+Requests with host header set to `address.mydomain.com` will now be proxied
+by Kong to the two defined targets; 2/3 of the requests will go to
+`http://192.168.34.15:80/address` (`weight=100`), and 1/3 will go to
+`http://192.168.34.16:80/address` (`weight=50`).
+
+Before deploying version 2 of the address service, set up the "Green"
+environment:
+
+```bash
+# create a new Green upstream for address service v2
+$ curl -X POST http://kong:8001/upstreams \
+    --data "name=address.v2.service"
+
+# add targets to the upstream
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.17:80"
+    --data "weight=100"
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.18:80"
+    --data "weight=100"
+```
+
+To activate the Blue/Green switch, we now only need to update the Service:
+
+```bash
+# Switch the Service from Blue to Green upstream, v1 -> v2
+$ curl -X PATCH http://kong:8001/services/address-service \
+    --data "host=address.v2.service"
+```
+
+Incoming requests with host header set to `address.mydomain.com` will now be
+proxied by Kong to the new targets; 1/2 of the requests will go to
+`http://192.168.34.17:80/address` (`weight=100`), and the other 1/2 will go to
+`http://192.168.34.18:80/address` (`weight=100`).
+
+As always, the changes through the Kong Admin API are dynamic and will take
+effect immediately. No reload or restart is required, and no in progress
+requests will be dropped.
+
+[Back to TOC](#table-of-contents)
+
+# Canary Releases
+
+Using the ring-balancer, target weights can be adjusted granularly, allowing
+for a smooth, controlled [canary release][blue-green-canary].
+
+Using a very simple 2 target example:
+
+```bash
+# first target at 1000
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.17:80"
+    --data "weight=1000"
+
+# second target at 0
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.18:80"
+    --data "weight=0"
+```
+
+By repeating the requests, but altering the weights each time, traffic will
+slowly be routed towards the other target. For example, set it at 10%:
+
+```bash
+# first target at 900
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.17:80"
+    --data "weight=900"
+
+# second target at 100
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.18:80"
+    --data "weight=100"
+```
+
+The changes through the Kong Admin API are dynamic and will take
+effect immediately. No reload or restart is required, and no in progress
+requests will be dropped.
+
+[Back to TOC](#table-of-contents)
+
+[upstream-object-reference]: /{{page.kong_version}}/admin-api#upstream-object
+[target-object-reference]: /{{page.kong_version}}/admin-api#target-object
+[dns-order-config]: /{{page.kong_version}}/configuration/#dns_order
+[real-ip-config]: /{{page.kong_version}}/configuration/#real_ip_header
+[blue-green-canary]: http://blog.christianposta.com/deploy/blue-green-deployments-a-b-testing-and-canary-releases/

--- a/app/1.0.x/logging.md
+++ b/app/1.0.x/logging.md
@@ -1,0 +1,132 @@
+---
+title: Logging Reference
+toc: false
+---
+
+## Removing Certain Elements From Your Kong Logs
+
+With new regulations surrounding protecting private data like GDPR, there is a chance you may need to change your logging habits. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your APIs. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
+
+For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/apiname/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
+
+To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{NGINX_WORKER_PROCESSES}}; # can be set by kong.conf
+daemon ${{NGINX_DAEMON}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log logs/error.log ${{LOG_LEVEL}}; # can be set by kong.conf
+
+events {
+    use epoll; # custom setting
+    multi_accept on;
+}
+
+http {
+    # include default Kong Nginx config
+    include 'nginx-kong.conf';
+
+    # custom server
+    server {
+        listen 8888;
+        server_name custom_server;
+
+        location / {
+          ... # etc
+        }
+    }
+}
+```
+
+In order to control what is placed in the logs, we will be using the NGINX map module in our template. For more detailed information abut using the map directive, please see [this guide](http://nginx.org/en/docs/http/ngx_http_map_module.html). This will create a new variable whose value depends on values of one or more of the source variables specified in the first parameter. The format is:
+
+```
+
+map $paramater_to_look_at $variable_name {
+    pattern_to_look_for 0;
+    second_pattern_to_look_for 0;
+
+    default 1;
+}
+```
+
+For this example, we will be mapping a new variable called `keeplog` which is dependent on certain values appearing in the `$request_uri`. We will be placing our map directive right at the start of the http block, this must be before `include 'nginx-kong.conf';`. So, for our example, we will add something along the lines of:
+
+```
+map $request_uri $keeplog {
+    ~.+\@.+\..+ 0;
+    ~/apiname/v2/verify 0;
+    ~/v3/verify 0;
+
+    default 1;
+}
+```
+
+You’ll probably notice that each of those lines start with a tilde. This is what tells NGINX to use RegEx when evaluating the line. We have three things to look for in this example:
+- The first line uses regex to look for any email address in the x@y.z format
+- The second line looks for any part of the URI which is /apiname/v2/verify
+- The third line looks at any part of the URI which contains /v3/verify
+
+Because all of those have a value of something other than 0, if a request has one of those elements, it will not be added to the log.
+
+Now, we need to set the log format for what we will keep in the logs. We will use the `log_format` module and assign our new logs a name of show_everything. The contents of the log can be customized for you needs, but for this example, I will simply change everything back to the Kong standards. To see the full list of options you can use, please refer to [this guide](https://nginx.org/en/docs/http/ngx_http_core_module.html#variables).
+
+```
+log_format show_everything '$remote_addr - $remote_user [$time_local] '
+    '$request_uri $status $body_bytes_sent '
+    '"$http_referer" "$http_user_agent"';
+```
+
+Now, our custom NGINX template is all ready to be used. If you have been following along, your file should now be look like this:
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{NGINX_WORKER_PROCESSES}}; # can be set by kong.conf
+daemon ${{NGINX_DAEMON}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log stderr ${{LOG_LEVEL}}; # can be set by kong.conf
+
+
+
+events {
+    use epoll; # custom setting
+    multi_accept on;
+}
+
+http {
+
+
+    map $request_uri $keeplog {
+        ~.+\@.+\..+ 0;
+        ~/v1/invitation/ 0;
+        ~/reset/v1/customer/password/token 0;
+        ~/v2/verify 0;
+
+        default 1;
+    }
+    log_format show_everything '$remote_addr - $remote_user [$time_local] '
+        '$request_uri $status $body_bytes_sent '
+        '"$http_referer" "$http_user_agent"';
+
+    include 'nginx-kong.conf';  
+}
+```
+
+The last thing we need to do is tell Kong to use the newly created log, `show_everything`. To do this, we will be altering the Kong variable `prpxy_access_log`. Either by opening and editing `etc/kong/kong.conf` or by using an environmental variable `KONG_PROXY_ACCESS_LOG=` you will want to mend the default location to show
+
+```
+proxy_access_log=logs/access.log show_everything if=$keeplog
+```
+
+The final step in the process to make all the changes take effect is to restart kong. you can use the `kong restart` command to do so.
+
+Now, any requests made with an email address in it will no longer be logged. Of course, we can use this logic to remove anything we want from the logs on a conditional manner.

--- a/app/1.0.x/network.md
+++ b/app/1.0.x/network.md
@@ -1,0 +1,45 @@
+---
+title: Network & Firewall
+---
+
+## Introduction
+
+In this section you will find a summary about the recommended network and firewall settings for Kong.
+
+## Ports
+
+Kong uses multiple connections for different purposes.
+
+* proxy
+* management api
+
+### Proxy
+
+The proxy ports is where Kong receives its incoming traffic. There are two ports with the following defaults;
+
+* `8000` for proxying. This is where Kong listens for HTTP traffic. Be sure to change it to `80` once you go to production. See [proxy_listen].
+* `8443` for proxying HTTPS traffic. Be sure to change it to `443` once you go to production. See [proxy_listen] and the `ssl` suffix.
+
+These are the **only ports** that should be made available to your clients.
+
+### Management api
+
+This is the port where Kong exposes its management api. Hence in production this port should be firewalled to protect
+it from unauthorized access.
+
+* `8001` provides Kong's **Admin API** that you can use to operate Kong. See [admin_listen].
+* `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
+
+## Firewall
+
+Below are the recommended firewall settings:
+
+* The upstream APIs behind Kong will be available via the [proxy_listen] interface/port values.
+  Configure these values according to the access level you wish to grant to the upstream APIs.
+* If you are binding the Admin API to a public-facing interface (via [admin_listen]), then **protect** it to only allow trusted clients to access the Admin API.
+  See also [Securing the Admin API][secure_admin_api].
+
+
+[proxy_listen]: /{{page.kong_version}}/configuration/#proxy_listen
+[admin_listen]: /{{page.kong_version}}/configuration/#admin_listen
+[secure_admin_api]: /{{page.kong_version}}/secure-admin-api

--- a/app/1.0.x/pdk/index.md
+++ b/app/1.0.x/pdk/index.md
@@ -1,0 +1,214 @@
+---
+title: PDK
+pdk: true
+---
+
+# Plugin Development Kit
+
+The Plugin Development Kit (or "PDK") is set of Lua functions and variables
+ that can be used by plugins to implement their own logic.  The PDK is a
+ [Semantically Versioned](https://semver.org/) component, originally
+ released in Kong 0.14.0. The PDK will be guaranteed to be forward-compatible
+ from its 1.0.0 release and on.
+
+ As of this release, the PDK has not yet reached 1.0.0, but plugin authors
+ can already depend on it for a safe and reliable way of interacting with the
+ request, response, or the core components.
+
+ The Plugin Development Kit is accessible from the `kong` global variable,
+ and various functionalities are namespaced under this table, such as
+ `kong.request`, `kong.log`, etc...
+
+
+## Table of Contents
+
+* [kong.version](#kong_version)
+* [kong.version_num](#kong_version_num)
+* [kong.pdk_major_version](#kong_pdk_major_version)
+* [kong.pdk_version](#kong_pdk_version)
+* [kong.configuration](#kong_configuration)
+* [kong.ctx](kong.ctx)
+* [kong.client](kong.client)
+* [kong.request](kong.request)
+* [kong.service](kong.service)
+* [kong.service.request](kong.service.request)
+* [kong.service.response](kong.service.response)
+* [kong.response](kong.response)
+* [kong.dao](#kong_dao)
+* [kong.db](#kong_db)
+* [kong.dns](#kong_dns)
+* [kong.worker_events](#kong_worker_events)
+* [kong.cluster_events](#kong_cluster_events)
+* [kong.cache](#kong_cache)
+* [kong.ip](kong.ip)
+* [kong.table](kong.table)
+* [kong.log](kong.log)
+
+
+
+
+### <a name="kong_version"></a>kong.version
+
+A human-readable string containing the version number of the currently
+ running node.
+
+**Usage**
+
+``` lua
+print(kong.version) -- "0.14.0"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_version_num"></a>kong.version_num
+
+An integral number representing the version number of the currently running
+ node, useful for comparison and feature-existence checks.
+
+**Usage**
+
+``` lua
+if kong.version_num < 13000 then -- 000.130.00 -> 0.13.0
+  -- no support for Routes & Services
+end
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_pdk_major_version"></a>kong.pdk_major_version
+
+A number representing the major version of the current PDK (e.g.
+ `1`). Useful for feature-existence checks or backwards-compatible behavior
+ as users of the PDK.
+
+
+**Usage**
+
+``` lua
+if kong.pdk_version_num < 2 then
+  -- PDK is below version 2
+end
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_pdk_version"></a>kong.pdk_version
+
+A human-readable string containing the version number of the current PDK.
+
+**Usage**
+
+``` lua
+print(kong.pdk_version) -- "0.1.0"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_configuration"></a>kong.configuration
+
+A read-only table containing the configuration of the current Kong node,
+ based on the configuration file and environment variables.
+
+ See [kong.conf.default](https://github.com/Kong/kong/blob/master/kong.conf.default)
+ for details.
+
+ Comma-separated lists in that file get promoted to arrays of strings in this
+ table.
+
+
+**Usage**
+
+``` lua
+print(kong.configuration.prefix) -- "/usr/local/kong"
+-- this table is read-only; the following throws an error:
+kong.configuration.custom_plugins = "foo"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+
+
+### <a name="kong_dao"></a>kong.dao
+
+Instance of Kong's legacy DAO.  This has the same interface as the object
+ returned by `new(config, db)` in the core's `kong.dao.factory` module.
+
+ * [Plugin Development Guide - Accessing the
+ Datastore](https://getkong.org/docs/latest/plugin-development/access-the-datastore/)
+ * Kong legacy DAO: https://github.com/Kong/kong/tree/master/kong/dao
+
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_db"></a>kong.db
+
+Instance of Kong's DAO (the new `kong.db` module).  Contains accessor objects
+ to various entities.
+
+ A more thorough documentation of this DAO and new schema definitions is to
+ be made available in the future, once this object will replace the old DAO
+ as the standard interface with which to create custom entities in plugins.
+
+
+**Usage**
+
+``` lua
+kong.db.services:insert()
+kong.db.routes:select()
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_dns"></a>kong.dns
+
+Instance of Kong's DNS resolver, a client object from the
+ [lua-resty-dns-client](https://github.com/kong/lua-resty-dns-client) module.
+
+ **Note:** usage of this module is currently reserved to the core or to
+ advanced users.
+
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_worker_events"></a>kong.worker_events
+
+Instance of Kong's IPC module for inter-workers communication from the
+ [lua-resty-worker-events](https://github.com/Kong/lua-resty-worker-events)
+ module.
+
+ **Note:** usage of this module is currently reserved to the core or to
+ advanced users.
+
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_cluster_events"></a>kong.cluster_events
+
+Instance of Kong's cluster events module for inter-nodes communication.
+
+ **Note:** usage of this module is currently reserved to the core or to
+ advanced users.
+
+
+[Back to TOC](#table-of-contents)
+
+
+### <a name="kong_cache"></a>kong.cache
+
+Instance of Kong's database caching object, from the `kong.cache` module.
+
+ **Note:** usage of this module is currently reserved to the core or to
+ advanced users.
+
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.client.md
+++ b/app/1.0.x/pdk/kong.client.md
@@ -1,0 +1,144 @@
+---
+title: kong.client
+pdk: true
+---
+
+# kong.client
+
+Client information module
+ A set of functions to retrieve information about the client connecting to
+ Kong in the context of a given request.
+
+ See also:
+ [nginx.org/en/docs/http/ngx_http_realip_module.html](http://nginx.org/en/docs/http/ngx_http_realip_module.html)
+
+## kong.client.get_ip()
+
+Returns the remote address of the client making the request.  This will
+ **always** return the address of the client directly connecting to Kong.
+ That is, in cases when a load balancer is in front of Kong, this function
+ will return the load balancer's address, and **not** that of the
+ downstream client.
+
+
+**Phases**
+
+* certificate, rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` ip The remote address of the client making the request
+
+
+**Usage**
+
+``` lua
+-- Given a client with IP 127.0.0.1 making connection through
+-- a load balancer with IP 10.0.0.1 to Kong answering the request for
+-- https://example.com:1234/v1/movies
+kong.client.get_ip() -- "10.0.0.1"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.client.get_forwarded_ip()
+
+Returns the remote address of the client making the request.  Unlike
+ `kong.client.get_ip`, this function will consider forwarded addresses in
+ cases when a load balancer is in front of Kong. Whether this function
+ returns a forwarded address or not depends on several Kong configuration
+ parameters:
+
+ * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
+ * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
+ * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
+
+
+**Phases**
+
+* certificate, rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string`  ip The remote address of the client making the request,
+ considering forwarded addresses
+
+
+
+**Usage**
+
+``` lua
+-- Given a client with IP 127.0.0.1 making connection through
+-- a load balancer with IP 10.0.0.1 to Kong answering the request for
+-- https://username:password@example.com:1234/v1/movies
+
+kong.request.get_forwarded_ip() -- "127.0.0.1"
+
+-- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
+-- the load balancer adds the right headers matching with the configuration
+-- of `real_ip_header`, e.g. `proxy_protocol`.
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.client.get_port()
+
+Returns the remote port of the client making the request.  This will
+ **always** return the port of the client directly connecting to Kong. That
+ is, in cases when a load balancer is in front of Kong, this function will
+ return load balancer's port, and **not** that of the downstream client.
+
+**Phases**
+
+* certificate, rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `number` The remote client port
+
+
+**Usage**
+
+``` lua
+-- [client]:40000 <-> 80:[balancer]:30000 <-> 80:[kong]:20000 <-> 80:[service]
+kong.client.get_port() -- 30000
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.client.get_forwarded_port()
+
+Returns the remote port of the client making the request.  Unlike
+ `kong.client.get_port`, this function will consider forwarded ports in cases
+ when a load balancer is in front of Kong. Whether this function returns a
+ forwarded port or not depends on several Kong configuration parameters:
+
+ * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
+ * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
+ * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
+
+**Phases**
+
+* certificate, rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `number` The remote client port, considering forwarded ports
+
+
+**Usage**
+
+``` lua
+-- [client]:40000 <-> 80:[balancer]:30000 <-> 80:[kong]:20000 <-> 80:[service]
+kong.client.get_forwarded_port() -- 40000
+
+-- Note: assuming that [balancer] is one of the trusted IPs, and that
+-- the load balancer adds the right headers matching with the configuration
+-- of `real_ip_header`, e.g. `proxy_protocol`.
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.ctx.md
+++ b/app/1.0.x/pdk/kong.ctx.md
@@ -1,0 +1,103 @@
+---
+title: kong.ctx
+pdk: true
+---
+
+# kong.ctx
+
+Current request context data
+
+## kong.ctx.shared
+
+A table that has the lifetime of the current request and is shared between
+ all plugins.  It can be used to share data between several plugins in a given
+ request.
+
+ Since only relevant in the context of a request, this table cannot be
+ accessed from the top-level chunk of Lua modules. Instead, it can only be
+ accessed in request phases, which are represented by the `rewrite`,
+ `access`, `header_filter`, `body_filter`, and `log` phases of the plugin
+ interfaces.  Accessing this table in those functions (and their callees) is
+ fine.
+
+ Values inserted in this table by a plugin will be visible by all other
+ plugins.  One must use caution when interacting with its values, as a naming
+ conflict could result in the overwrite of data.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Usage**
+
+``` lua
+-- Two plugins A and B, and if plugin A has a higher priority than B's
+-- (it executes before B):
+
+-- plugin A handler.lua
+function plugin_a_handler:access(conf)
+  kong.ctx.shared.foo = "hello world"
+
+  kong.ctx.shared.tab = {
+    bar = "baz"
+  }
+end
+
+-- plugin B handler.lua
+function plugin_b_handler:access(conf)
+  kong.log(kong.ctx.shared.foo) -- "hello world"
+  kong.log(kong.ctx.shared.tab.bar) -- "baz"
+end
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.ctx.plugin
+
+A table that has the lifetime of the current request - Unlike
+ `kong.ctx.shared`, this table is **not** shared between plugins.   Instead,
+ it is only visible for the current plugin _instance_. That is, if several
+ instances of the rate-limiting plugin are configured (e.g. on different
+ Services), each instance has its own table, for every request.
+
+ Because of its namespaced nature, this table is safer for a plugin to use
+ than `kong.ctx.shared` since it avoids potential naming conflicts, which
+ could lead to several plugins unknowingly overwrite each other's data.
+
+ Since only relevant in the context of a request, this table cannot be
+ accessed from the top-level chunk of Lua modules. Instead, it can only be
+ accessed in request phases, which are represented by the `rewrite`,
+ `access`, `header_filter`, `body_filter`, and `log` phases of the plugin
+ interfaces.  Accessing this table in those functions (and their callees) is
+ fine.
+
+ Values inserted in this table by a plugin will be visible in successful
+ phases of this plugin's instance only. For example, if a plugin wants to
+ save some value for post-processing during the `log` phase:
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Usage**
+
+``` lua
+-- plugin handler.lua
+
+function plugin_handler:access(conf)
+  kong.ctx.plugin.val_1 = "hello"
+  kong.ctx.plugin.val_2 = "world"
+end
+
+function plugin_handler:log(conf)
+  local value = kong.ctx.plugin.val_1 .. " " .. kong.ctx.plugin.val_2
+
+  kong.log(value) -- "hello world"
+end
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.ip.md
+++ b/app/1.0.x/pdk/kong.ip.md
@@ -1,0 +1,47 @@
+---
+title: kong.ip
+pdk: true
+---
+
+# kong.ip
+
+Trusted IPs module
+
+ This module can be used to determine whether or not a given IP address is
+ in the range of trusted IP addresses defined by the `trusted_ips` configuration
+ property.
+
+ Trusted IP addresses are those that are known to send correct replacement
+ addresses for clients (as per the chosen header field, e.g. X-Forwarded-*).
+
+ See [docs.konghq.com/latest/configuration/#trusted_ips](https://docs.konghq.com/latest/configuration/#trusted_ips)
+
+## kong.ip.is_trusted(address)
+
+Depending on the `trusted_ips` configuration property,
+ this function will return whether a given ip is trusted or not  Both ipv4 and ipv6 are supported.
+
+
+**Phases**
+
+* init_worker, certificate, rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **address** (string):  A string representing an IP address
+
+**Returns**
+
+* `boolean` `true` if the IP is trusted, `false` otherwise
+
+
+**Usage**
+
+``` lua
+if kong.ip.is_trusted("1.1.1.1") then
+  kong.log("The IP is trusted")
+end
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.log.md
+++ b/app/1.0.x/pdk/kong.log.md
@@ -1,0 +1,257 @@
+---
+title: kong.log
+pdk: true
+---
+
+# kong.log
+
+This namespace contains an instance of a "logging facility", which is a
+ table containing all of the methods described below.
+
+ This instance is namespaced per plugin, and Kong will make sure that before
+ executing a plugin, it will swap this instance with a logging facility
+ dedicated to the plugin. This allows the logs to be prefixed with the
+ plugin's name for debugging purposes.
+
+## kong.log(...)
+
+Write a log line to the location specified by the current Nginx
+ configuration block's `error_log` directive, with the `notice` level (similar
+ to `print()`).
+
+ The Nginx `error_log` directive is set via the `log_level`, `proxy_error_log`
+ and `admin_error_log` Kong configuration properties.
+
+ Arguments given to this function will be concatenated similarly to
+ `ngx.log()`, and the log line will report the Lua file and line number from
+ which it was invoked. Unlike `ngx.log()`, this function will prefix error
+ messages with `[kong]` instead of `[lua]`.
+
+ Arguments given to this function can be of any type, but table arguments
+ will be converted to strings via `tostring` (thus potentially calling a
+ table's `__tostring` metamethod if set). This behavior differs from
+ `ngx.log()` (which only accepts table arguments if they define the
+ `__tostring` metamethod) with the intent to simplify its usage and be more
+ forgiving and intuitive.
+
+ Produced log lines have the following format when logging is invoked from
+ within the core:
+
+ ``` plain
+ [kong] %file_src:%line_src %message
+ ```
+
+ In comparison, log lines produced by plugins have the following format:
+
+ ``` plain
+ [kong] %file_src:%line_src [%namespace] %message
+ ```
+
+ Where:
+
+ * `%namespace`: is the configured namespace (the plugin name in this case).
+ * `%file_src`: is the file name from where the log was called from.
+ * `%line_src`: is the line number from where the log was called from.
+ * `%message`: is the message, made of concatenated arguments given by the caller.
+
+ For example, the following call:
+
+ ``` lua
+ kong.log("hello ", "world")
+ ```
+
+ would, within the core, produce a log line similar to:
+
+ ``` plain
+ 2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
+ ```
+
+ If invoked from within a plugin (e.g. `key-auth`) it would include the
+ namespace prefix, like so:
+
+ ``` plain
+ 2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
+ ```
+
+
+**Phases**
+
+* init_worker, certificate, rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **...** :  all params will be concatenated and stringified before being sent to the log
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.log("hello ", "world") -- alias to kong.log.notice()
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### kong.log.LEVEL(...)
+
+Similar to `kong.log()`, but the produced log will have the severity given by
+ `<level>`, instead of `notice`.  The supported levels are:
+
+ * `kong.log.alert()`
+ * `kong.log.crit()`
+ * `kong.log.err()`
+ * `kong.log.warn()`
+ * `kong.log.notice()`
+ * `kong.log.info()`
+ * `kong.log.debug()`
+
+ Logs have the same format as that of `kong.log()`. For
+ example, the following call:
+
+ ``` lua
+  kong.log.err("hello ", "world")
+ ```
+
+ would, within the core, produce a log line similar to:
+
+ ``` plain
+ 2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
+ ```
+
+ If invoked from within a plugin (e.g. `key-auth`) it would include the
+ namespace prefix, like so:
+
+ ``` plain
+ 2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
+ ```
+
+
+**Phases**
+
+* init_worker, certificate, rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **...** :  all params will be concatenated and stringified before being sent to the log
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.log.warn("something require attention")
+kong.log.err("something failed: ", err)
+kong.log.alert("something requires immediate action")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### kong.log.inspect(...)
+
+Like `kong.log()`, this function will produce a log with the `notice` level,
+ and accepts any number of arguments as well.  If inspect logging is disabled
+ via `kong.log.inspect.off()`, then this function prints nothing, and is
+ aliased to a "NOP" function in order to save CPU cycles.
+
+ ``` lua
+ kong.log.inspect("...")
+ ```
+
+ This function differs from `kong.log()` in the sense that arguments will be
+ concatenated with a space(`" "`), and each argument will be
+ "pretty-printed":
+
+ * numbers will printed (e.g. `5` -> `"5"`)
+ * strings will be quoted (e.g. `"hi"` -> `'"hi"'`)
+ * array-like tables will be rendered (e.g. `{1,2,3}` -> `"{1, 2, 3}"`)
+ * dictionary-like tables will be rendered on multiple lines
+
+ This function is intended for use with debugging purposes in mind, and usage
+ in production code paths should be avoided due to the expensive formatting
+ operations it can perform. Existing statements can be left in production code
+ but nopped by calling `kong.log.inspect.off()`.
+
+ When writing logs, `kong.log.inspect()` always uses its own format, defined
+ as:
+
+ ``` plain
+ %file_src:%func_name:%line_src %message
+ ```
+
+ Where:
+
+ * `%file_src`: is the file name from where the log was called from.
+ * `%func_name`: is the name of the function from where the log was called
+   from.
+ * `%line_src`: is the line number from where the log was called from.
+ * `%message`: is the message, made of concatenated, pretty-printed arguments
+   given by the caller.
+
+ This function uses the [inspect.lua](https://github.com/kikito/inspect.lua)
+ library to pretty-print its arguments.
+
+
+**Phases**
+
+* init_worker, certificate, rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **...** :  Parameters will be concatenated with spaces between them and
+ rendered as described
+
+**Usage**
+
+``` lua
+kong.log.inspect("some value", a_variable)
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### kong.log.inspect.on()
+
+Enables inspect logs for this logging facility.  Calls to
+ `kong.log.inspect` will be writing log lines with the appropriate
+ formatting of arguments.
+
+
+**Phases**
+
+* init_worker, certificate, rewrite, access, header_filter, body_filter, log
+
+**Usage**
+
+``` lua
+kong.log.inspect.on()
+```
+
+[Back to TOC](#table-of-contents)
+
+
+### kong.log.inspect.off()
+
+Disables inspect logs for this logging facility.  All calls to
+ `kong.log.inspect()` will be nopped.
+
+
+**Phases**
+
+* init_worker, certificate, rewrite, access, header_filter, body_filter, log
+
+**Usage**
+
+``` lua
+kong.log.inspect.off()
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.request.md
+++ b/app/1.0.x/pdk/kong.request.md
@@ -1,0 +1,570 @@
+---
+title: kong.request
+pdk: true
+---
+
+# kong.request
+
+Client request module
+ A set of functions to retrieve information about the incoming requests made
+ by clients.
+
+## kong.request.get_scheme()
+
+Returns the scheme component of the request's URL.  The returned value is
+ normalized to lower-case form.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` a string like `"http"` or `"https"`
+
+
+**Usage**
+
+``` lua
+-- Given a request to https://example.com:1234/v1/movies
+
+kong.request.get_scheme() -- "https"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_host()
+
+Returns the host component of the request's URL, or the value of the
+ "Host" header.  The returned value is normalized to lower-case form.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` the host
+
+
+**Usage**
+
+``` lua
+-- Given a request to https://example.com:1234/v1/movies
+
+kong.request.get_host() -- "example.com"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_port()
+
+Returns the port component of the request's URL.  The value is returned
+ as a Lua number.
+
+
+**Phases**
+
+* certificate, rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `number` the port
+
+
+**Usage**
+
+``` lua
+-- Given a request to https://example.com:1234/v1/movies
+
+kong.request.get_port() -- 1234
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_forwarded_scheme()
+
+Returns the scheme component of the request's URL, but also considers
+ `X-Forwarded-Proto` if it comes from a trusted source.  The returned
+ value is normalized to lower-case.
+
+ Whether this function considers `X-Forwarded-Proto` or not depends on
+ several Kong configuration parameters:
+
+ * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
+ * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
+ * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
+
+ **Note**: support for the Forwarded HTTP Extension (RFC 7239) is not
+ offered yet since it is not supported by ngx\_http\_realip\_module.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` the forwarded scheme
+
+
+**Usage**
+
+``` lua
+kong.request.get_forwarded_scheme() -- "https"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_forwarded_host()
+
+Returns the host component of the request's URL or the value of the "host"
+ header.  Unlike `kong.request.get_host()`, this function will also consider
+ `X-Forwarded-Host` if it comes from a trusted source. The returned value
+ is normalized to lower-case.
+
+ Whether this function considers `X-Forwarded-Proto` or not depends on
+ several Kong configuration parameters:
+
+ * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
+ * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
+ * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
+
+ **Note**: we do not currently offer support for Forwarded HTTP Extension
+ (RFC 7239) since it is not supported by ngx_http_realip_module.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` the forwarded host
+
+
+**Usage**
+
+``` lua
+kong.request.get_forwarded_host() -- "example.com"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_forwareded_port()
+
+Returns the port component of the request's URL, but also considers
+ `X-Forwarded-Host` if it comes from a trusted source.  The value
+ is returned as a Lua number.
+
+ Whether this function considers `X-Forwarded-Proto` or not depends on
+ several Kong configuration parameters:
+
+ * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
+ * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
+ * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
+
+ **Note**: we do not currently offer support for Forwarded HTTP Extension
+ (RFC 7239) since it is not supported by ngx_http_realip_module.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `number` the forwarded port
+
+
+**Usage**
+
+``` lua
+kong.request.get_forwarded_port() -- 1234
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_http_version()
+
+Returns the HTTP version used by the client in the request as a Lua
+ number, returning values such as `"1.1"` and `"2.0."`, or `nil` for
+ unrecognized values.
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string|nil` the http version
+
+
+**Usage**
+
+``` lua
+kong.request.get_http_version() -- "1.1"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_method()
+
+Returns the HTTP method of the request.  The value is normalized to
+ upper-case.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` the request method
+
+
+**Usage**
+
+``` lua
+kong.request.get_method() -- "GET"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_path()
+
+Returns the path component of the request's URL.  It is not normalized in
+ any way and does not include the querystring.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string` the path
+
+
+**Usage**
+
+``` lua
+-- Given a request to https://example.com:1234/v1/movies?movie=foo
+
+kong.request.get_path() -- "/v1/movies"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_raw_query()
+
+Returns the query component of the request's URL.  It is not normalized in
+ any way (not even URL-decoding of special characters) and does not
+ include the leading `?` character.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+*  string the query component of the request's URL
+
+
+**Usage**
+
+``` lua
+-- Given a request to https://example.com/foo?msg=hello%20world&bla=&bar
+
+kong.request.get_raw_query() -- "msg=hello%20world&bla=&bar"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_query_arg()
+
+Returns the value of the specified argument, obtained from the query
+ arguments of the current request.
+
+ The returned value is either a `string`, a boolean `true` if an
+ argument was not given a value, or `nil` if no argument with `name` was
+ found.
+
+ If an argument with the same name is present multiple times in the
+ querystring, this function will return the value of the first occurrence.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Returns**
+
+* `string|boolean|nil` the value of the argument
+
+
+**Usage**
+
+``` lua
+-- Given a request GET /test?foo=hello%20world&bar=baz&zzz&blo=&bar=bla&bar
+
+kong.request.get_query_arg("foo") -- "hello world"
+kong.request.get_query_arg("bar") -- "baz"
+kong.request.get_query_arg("zzz") -- true
+kong.request.get_query_arg("blo") -- ""
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_query([max_args])
+
+Returns the table of query arguments obtained from the querystring.  Keys
+ are query argument names. Values are either a string with the argument
+ value, a boolean `true` if an argument was not given a value, or an array
+ if an argument was given in the query string multiple times. Keys and
+ values are unescaped according to URL-encoded escaping rules.
+
+ Note that a query string `?foo&bar` translates to two boolean `true`
+ arguments, and `?foo=&bar=` translates to two string arguments containing
+ empty strings.
+
+ By default, this function returns up to **100** arguments. The optional
+ `max_args` argument can be specified to customize this limit, but must be
+ greater than **1** and not greater than **1000**.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **max_args** (number, _optional_):  set a limit on the maximum number of parsed
+ arguments
+
+**Returns**
+
+* `table` A table representation of the query string
+
+
+**Usage**
+
+``` lua
+-- Given a request GET /test?foo=hello%20world&bar=baz&zzz&blo=&bar=bla&bar
+
+for k, v in pairs(kong.request.get_query()) do
+  kong.log.inspect(k, v)
+end
+
+-- Will print
+-- "foo" "hello world"
+-- "bar" {"baz", "bla", true}
+-- "zzz" true
+-- "blo" ""
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_header(name)
+
+Returns the value of the specified request header.
+
+ The returned value is either a `string`, or can be `nil` if a header with
+ `name` was not found in the request. If a header with the same name is
+ present multiple times in the request, this function will return the value
+ of the first occurrence of this header.
+
+ Header names in are case-insensitive and are normalized to lowercase, and
+ dashes (`-`) can be written as underscores (`_`); that is, the header
+ `X-Custom-Header` can also be retrieved as `x_custom_header`.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **name** (string):  the name of the header to be returned
+
+**Returns**
+
+* `string` the value of the header
+
+
+**Usage**
+
+``` lua
+-- Given a request with the following headers:
+
+-- Host: foo.com
+-- X-Custom-Header: bla
+-- X-Another: foo bar
+-- X-Another: baz
+
+kong.request.get_header("Host")            -- "foo.com"
+kong.request.get_header("x-custom-header") -- "bla"
+kong.request.get_header("X-Another")       -- "foo bar"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_headers([max_headers])
+
+Returns a Lua table holding the request headers.  Keys are header names.
+ Values are either a string with the header value, or an array of strings
+ if a header was sent multiple times. Header names in this table are
+ case-insensitive and are normalized to lowercase, and dashes (`-`) can be
+ written as underscores (`_`); that is, the header `X-Custom-Header` can
+ also be retrieved as `x_custom_header`.
+
+ By default, this function returns up to **100** headers. The optional
+ `max_headers` argument can be specified to customize this limit, but must
+ be greater than **1** and not greater than **1000**.
+
+
+**Phases**
+
+* rewrite, access, header_filter, body_filter, log
+
+**Parameters**
+
+* **max_headers** (number, _optional_):  set a limit on the maximum number of
+ parsed headers
+
+**Returns**
+
+* `table` the request headers in table form
+
+
+**Usage**
+
+``` lua
+-- Given a request with the following headers:
+
+-- Host: foo.com
+-- X-Custom-Header: bla
+-- X-Another: foo bar
+-- X-Another: baz
+local headers = kong.request.get_headers()
+
+headers.host            -- "foo.com"
+headers.x_custom_header -- "bla"
+headers.x_another[1]    -- "foo bar"
+headers["X-Another"][2] -- "baz"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_raw_body()
+
+Returns the plain request body.
+
+ If the body has no size (empty), this function returns an empty string.
+
+ If the size of the body is greater than the Nginx buffer size (set by
+ `client_body_buffer_size`), this function will fail and return an error
+ message explaining this limitation.
+
+
+**Phases**
+
+* rewrite, access
+
+**Returns**
+
+* `string` the plain request body
+
+
+**Usage**
+
+``` lua
+-- Given a body with payload "Hello, Earth!":
+
+kong.request.get_raw_body():gsub("Earth", "Mars") -- "Hello, Mars!"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.request.get_body([mimetype[, max_args]])
+
+Returns the request data as a key/value table.
+ A high-level convenience function.
+ The body is parsed with the most appropriate format:
+
+ * If `mimetype` is specified:
+   * Decodes the body with the requested content type (if supported).
+ * If the request content type is `application/x-www-form-urlencoded`:
+   * Returns the body as form-encoded.
+ * If the request content type is `multipart/form-data`:
+   * Decodes the body as multipart form data
+     (same as `multipart(kong.request.get_raw_body(),
+     kong.request.get_header("Content-Type")):get_all()` ).
+ * If the request content type is `application/json`:
+   * Decodes the body as JSON
+     (same as `json.decode(kong.request.get_raw_body())`).
+   * JSON types are converted to matching Lua types.
+ * If none of the above, returns `nil` and an error message indicating the
+   body could not be parsed.
+
+ The optional argument `mimetype` can be one of the following strings:
+
+ * `application/x-www-form-urlencoded`
+ * `application/json`
+ * `multipart/form-data`
+
+ The optional argument `max_args` can be used to set a limit on the number
+ of form arguments parsed for `application/x-www-form-urlencoded` payloads.
+
+ The third return value is string containing the mimetype used to parsed
+ the body (as per the `mimetype` argument), allowing the caller to identify
+ what MIME type the body was parsed as.
+
+
+**Phases**
+
+* rewrite, access
+
+**Parameters**
+
+* **mimetype** (string, _optional_):  the MIME type
+* **max_args** (number, _optional_):  set a limit on the maximum number of parsed
+ arguments
+
+**Returns**
+
+1.  `table|nil` a table representation of the body
+
+1.  `string|nil` an error message
+
+1.  `string|nil` mimetype the MIME type used
+
+
+**Usage**
+
+``` lua
+local body, err, mimetype = kong.request.get_body()
+body.name -- "John Doe"
+body.age  -- "42"
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.response.md
+++ b/app/1.0.x/pdk/kong.response.md
@@ -1,0 +1,465 @@
+---
+title: kong.response
+pdk: true
+---
+
+# kong.response
+
+Client response module
+
+ The downstream response module contains a set of functions for producing and
+ manipulating responses sent back to the client ("downstream").  Responses can
+ be produced by Kong (e.g. an authentication plugin rejecting a request), or
+ proxied back from an Service's response body.
+
+ Unlike `kong.service.response`, this module allows mutating the response
+ before sending it back to the client.
+
+## kong.response.get_status()
+
+Returns the HTTP status code currently set for the downstream response (as
+ a Lua number).
+
+ If the request was proxied (as per `kong.service.get_source()`), the
+ return value will be that of the response from the Service (identical to
+ `kong.service.response.get_status()`).
+
+ If the request was _not_ proxied, and the response was produced by Kong
+ itself (i.e. via `kong.response.exit()`), the return value will be
+ returned as-is.
+
+
+**Phases**
+
+* header_filter, body_filter, log
+
+**Returns**
+
+* `number` status The HTTP status code currently set for the
+ downstream response
+
+
+**Usage**
+
+``` lua
+kong.response.get_status() -- 200
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.get_header(name)
+
+Returns the value of the specified response header, as would be seen by
+ the client once received.
+
+ The list of headers returned by this function can consist of both response
+ headers from the proxied Service _and_ headers added by Kong (e.g. via
+ `kong.response.add_header()`).
+
+ The return value is either a `string`, or can be `nil` if a header with
+ `name` was not found in the response. If a header with the same name is
+ present multiple times in the request, this function will return the value
+ of the first occurrence of this header.
+
+
+**Phases**
+
+* header_filter, body_filter, log
+
+**Parameters**
+
+* **name** (string):  The name of the header
+
+ Header names are case-insensitive and dashes (`-`) can be written as
+ underscores (`_`); that is, the header `X-Custom-Header` can also be
+ retrieved as `x_custom_header`.
+
+
+**Returns**
+
+* `string|nil` The value of the header
+
+
+**Usage**
+
+``` lua
+-- Given a response with the following headers:
+-- X-Custom-Header: bla
+-- X-Another: foo bar
+-- X-Another: baz
+
+kong.response.get_header("x-custom-header") -- "bla"
+kong.response.get_header("X-Another")       -- "foo bar"
+kong.response.get_header("X-None")          -- nil
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.get_headers([max_headers])
+
+Returns a Lua table holding the response headers.  Keys are header names.
+ Values are either a string with the header value, or an array of strings
+ if a header was sent multiple times. Header names in this table are
+ case-insensitive and are normalized to lowercase, and dashes (`-`) can be
+ written as underscores (`_`); that is, the header `X-Custom-Header` can
+ also be retrieved as `x_custom_header`.
+
+ A response initially has no headers until a plugin short-circuits the
+ proxying by producing one (e.g. an authentication plugin rejecting a
+ request), or the request has been proxied, and one of the latter execution
+ phases is currently running.
+
+ Unlike `kong.service.response.get_headers()`, this function returns *all*
+ headers as the client would see them upon reception, including headers
+ added by Kong itself.
+
+ By default, this function returns up to **100** headers. The optional
+ `max_headers` argument can be specified to customize this limit, but must
+ be greater than **1** and not greater than **1000**.
+
+
+**Phases**
+
+* header_filter, body_filter, log
+
+**Parameters**
+
+* **max_headers** (number, _optional_):  Limits how many headers are parsed
+
+**Returns**
+
+1.  `table`  headers A table representation of the headers in the
+ response
+
+
+1.  `string` err If more headers than `max_headers` were present, a
+ string with the error `"truncated"`.
+
+
+**Usage**
+
+``` lua
+-- Given an response from the Service with the following headers:
+-- X-Custom-Header: bla
+-- X-Another: foo bar
+-- X-Another: baz
+
+local headers = kong.response.get_headers()
+
+headers.x_custom_header -- "bla"
+headers.x_another[1]    -- "foo bar"
+headers["X-Another"][2] -- "baz"
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.get_source()
+
+This function helps determining where the current response originated
+ from.   Kong being a reverse proxy, it can short-circuit a request and
+ produce a response of its own, or the response can come from the proxied
+ Service.
+
+ Returns a string with three possible values:
+
+ * "exit" is returned when, at some point during the processing of the
+   request, there has been a call to `kong.response.exit()`. In other
+   words, when the request was short-circuited by a plugin or by Kong
+   itself (e.g.  invalid credentials)
+ * "error" is returned when an error has happened while processing the
+   request - for example, a timeout while connecting to the upstream
+   service.
+ * "service" is returned when the response was originated by successfully
+   contacting the proxied Service.
+
+
+**Phases**
+
+* header_filter, body_filter, log
+
+**Returns**
+
+* `string` the source.
+
+
+**Usage**
+
+``` lua
+if kong.response.get_source() == "service" then
+  kong.log("The response comes from the Service")
+elseif kong.response.get_source() == "error" then
+  kong.log("There was an error while processing the request")
+elseif kong.response.get_source() == "exit" then
+  kong.log("There was an early exit while processing the request")
+end
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.set_status(status)
+
+Allows changing the downstream response HTTP status code before sending it
+ to the client.
+
+ This function should be used in the `header_filter` phase, as Kong is
+ preparing headers to be sent back to the client.
+
+
+**Phases**
+
+* rewrite, access, header_filter
+
+**Parameters**
+
+* **status** (number):  The new status
+
+**Returns**
+
+*  Nothing; throws an error on invalid input.
+
+
+**Usage**
+
+``` lua
+kong.response.set_status(404)
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.set_header(name, value)
+
+Sets a response header with the given value.  This function overrides any
+ existing header with the same name.
+
+ This function should be used in the `header_filter` phase, as Kong is
+ preparing headers to be sent back to the client.
+
+**Phases**
+
+* rewrite, access, header_filter
+
+**Parameters**
+
+* **name** (string):  The name of the header
+* **value** (string|number|boolean):  The new value for the header
+
+**Returns**
+
+*  Nothing; throws an error on invalid input.
+
+
+**Usage**
+
+``` lua
+kong.response.set_header("X-Foo", "value")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.add_header(name, value)
+
+Adds a response header with the given value.  Unlike
+ `kong.response.set_header()`, this function does not remove any existing
+ header with the same name. Instead, another header with the same name will
+ be added to the response. If no header with this name already exists on
+ the response, then it is added with the given value, similarly to
+ `kong.response.set_header().`
+
+ This function should be used in the `header_filter` phase, as Kong is
+ preparing headers to be sent back to the client.
+
+**Phases**
+
+* rewrite, access, header_filter
+
+**Parameters**
+
+* **name** (string):  The header name
+* **value** (string|number|boolean):  The header value
+
+**Returns**
+
+*  Nothing; throws an error on invalid input.
+
+
+**Usage**
+
+``` lua
+kong.response.add_header("Cache-Control", "no-cache")
+kong.response.add_header("Cache-Control", "no-store")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.clear_header(name)
+
+Removes all occurrences of the specified header in the response sent to
+ the client.
+
+ This function should be used in the `header_filter` phase, as Kong is
+ preparing headers to be sent back to the client.
+
+
+**Phases**
+
+* rewrite, access, header_filter
+
+**Parameters**
+
+* **name** (string):  The name of the header to be cleared
+
+**Returns**
+
+*  Nothing; throws an error on invalid input.
+
+
+**Usage**
+
+``` lua
+kong.response.set_header("X-Foo", "foo")
+kong.response.add_header("X-Foo", "bar")
+
+kong.response.clear_header("X-Foo")
+-- from here onwards, no X-Foo headers will exist in the response
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.set_headers(headers)
+
+Sets the headers for the response.  Unlike `kong.response.set_header()`,
+ the `headers` argument must be a table in which each key is a string
+ (corresponding to a header's name), and each value is a string, or an
+ array of strings.
+
+ This function should be used in the `header_filter` phase, as Kong is
+ preparing headers to be sent back to the client.
+
+ The resulting headers are produced in lexicographical order. The order of
+ entries with the same name (when values are given as an array) is
+ retained.
+
+ This function overrides any existing header bearing the same name as those
+ specified in the `headers` argument. Other headers remain unchanged.
+
+
+**Phases**
+
+* rewrite, access, header_filter
+
+**Parameters**
+
+* **headers** (table):
+
+**Returns**
+
+*  Nothing; throws an error on invalid input.
+
+
+**Usage**
+
+``` lua
+kong.response.set_headers({
+  ["Bla"] = "boo",
+  ["X-Foo"] = "foo3",
+  ["Cache-Control"] = { "no-store", "no-cache" }
+})
+
+-- Will add the following headers to the response, in this order:
+-- X-Bar: bar1
+-- Bla: boo
+-- Cache-Control: no-store
+-- Cache-Control: no-cache
+-- X-Foo: foo3
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.response.exit(status[, body[, headers]])
+
+This function interrupts the current processing and produces a response.
+ It is typical to see plugins using it to produce a response before Kong
+ has a chance to proxy the request (e.g. an authentication plugin rejecting
+ a request, or a caching plugin serving a cached response).
+
+ It is recommended to use this function in conjunction with the `return`
+ operator, to better reflect its meaning:
+
+ ```lua
+ return kong.response.exit(200, "Success")
+ ```
+
+ Calling `kong.response.exit()` will interrupt the execution flow of
+ plugins in the current phase. Subsequent phases will still be invoked.
+ E.g. if a plugin called `kong.response.exit()` in the `access` phase, no
+ other plugin will be executed in that phase, but the `header_filter`,
+ `body_filter`, and `log` phases will still be executed, along with their
+ plugins. Plugins should thus be programmed defensively against cases when
+ a request was **not** proxied to the Service, but instead was produced by
+ Kong itself.
+
+ The first argument `status` will set the status code of the response that
+ will be seen by the client.
+
+ The second, optional, `body` argument will set the response body. If it is
+ a string, no special processing will be done, and the body will be sent
+ as-is.  It is the caller's responsibility to set the appropriate
+ Content-Type header via the third argument.  As a convenience, `body` can
+ be specified as a table; in which case, it will be JSON-encoded and the
+ `application/json` Content-Type header will be set.
+
+ The third, optional, `headers` argument can be a table specifying response
+ headers to send. If specified, its behavior is similar to
+ `kong.response.set_headers()`.
+
+ Unless manually specified, this method will automatically set the
+ Content-Length header in the produced response for convenience.
+
+**Phases**
+
+* rewrite, access
+
+**Parameters**
+
+* **status** (number):  The status to be used
+* **body** (table|string, _optional_):  The body to be used
+* **headers** (table, _optional_):  The headers to be used
+
+**Returns**
+
+*  Nothing; throws an error on invalid input.
+
+
+**Usage**
+
+``` lua
+return kong.response.exit(403, "Access Forbidden", {
+  ["Content-Type"] = "text/plain",
+  ["WWW-Authenticate"] = "Basic"
+})
+
+---
+
+return kong.response.exit(403, [[{"message":"Access Forbidden"}]], {
+  ["Content-Type"] = "application/json",
+  ["WWW-Authenticate"] = "Basic"
+})
+
+---
+
+return kong.response.exit(403, { message = "Access Forbidden" }, {
+  ["WWW-Authenticate"] = "Basic"
+})
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.service.md
+++ b/app/1.0.x/pdk/kong.service.md
@@ -1,0 +1,86 @@
+---
+title: kong.service
+pdk: true
+---
+
+# kong.service
+
+The service module contains a set of functions to manipulate the connection
+ aspect of the request to the Service, such as connecting to a given host, IP
+ address/port, or choosing a given Upstream entity for load-balancing and
+ healthchecking.
+
+## kong.service.set_upstream(host)
+
+Sets the desired Upstream entity to handle the load-balancing step for
+ this request.  Using this method is equivalent to creating a Service with a
+ `host` property equal to that of an Upstream entity (in which case, the
+ request would be proxied to one of the Targets associated with that
+ Upstream).
+
+ The `host` argument should receive a string equal to that of one of the
+ Upstream entities currently configured.
+
+
+**Phases**
+
+* access
+
+**Parameters**
+
+* **host** (string):
+
+**Returns**
+
+1.  `boolean|nil` `true` on success, or `nil` if no upstream entities
+ where found
+
+1.  `string|nil`  An error message describing the error if there was
+ one.
+
+
+
+**Usage**
+
+``` lua
+local ok, err = kong.service.set_upstream("service.prod")
+if not ok then
+  kong.log.err(err)
+  return
+end
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.set_target(host, port)
+
+Sets the host and port on which to connect to for proxying the request.  ]]
+ Using this method is equivalent to ask Kong to not run the load-balancing
+ phase for this request, and consider it manually overridden.
+ Load-balancing components such as retries and health-checks will also be
+ ignored for this request.
+
+ The `host` argument expects a string containing the IP address of the
+ upstream server (IPv4/IPv6), and the `port` argument must contain a number
+ representing the port on which to connect to.
+
+
+**Phases**
+
+* access
+
+**Parameters**
+
+* **host** (string):
+* **port** (number):
+
+**Usage**
+
+``` lua
+kong.service.set_target("service.local", 443)
+kong.service.set_target("192.168.130.1", 80)
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.service.request.md
+++ b/app/1.0.x/pdk/kong.service.request.md
@@ -1,0 +1,434 @@
+---
+title: kong.service.request
+pdk: true
+---
+
+# kong.service.request
+
+Manipulation of the request to the Service
+
+## kong.service.request.set_scheme(scheme)
+
+Sets the protocol to use when proxying the request to the Service.
+
+**Phases**
+
+* `access`
+
+**Parameters**
+
+* **scheme** (string):  The scheme to be used. Supported values are `"http"` or `"https"`
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_scheme("https")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_path(path)
+
+Sets the path component for the request to the service.  It is not
+ normalized in any way and should **not** include the querystring.
+
+**Phases**
+
+* `access`
+
+**Parameters**
+
+* **path** :  The path string. Example: "/v2/movies"
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_path("/v2/movies")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_raw_query(query)
+
+Sets the querystring of the request to the Service.  The `query` argument is a
+ string (without the leading `?` character), and will not be processed in any
+ way.
+
+ For a higher-level function to set the query string from a Lua table of
+ arguments, see `kong.service.request.set_query()`.
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **query** (string):  The raw querystring. Example: "foo=bar&bla&baz=hello%20world"
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_raw_query("zzz&bar=baz&bar=bla&bar&blo=&foo=hello%20world")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_method(method)
+
+Sets the HTTP method for the request to the service.
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **method** :  The method string, which should be given in all
+ uppercase. Supported values are: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`,
+ `"DELETE"`, `"OPTIONS"`, `"MKCOL"`, `"COPY"`, `"MOVE"`, `"PROPFIND"`,
+ `"PROPPATCH"`, `"LOCK"`, `"UNLOCK"`, `"PATCH"`, `"TRACE"`.
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_method("DELETE")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_query(args)
+
+Set the querystring of the request to the Service.
+
+ Unlike `kong.service.request.set_raw_query()`, the `query` argument must be a
+ table in which each key is a string (corresponding to an arguments name), and
+ each value is either a boolean, a string or an array of strings or booleans.
+ Additionally, all string values will be URL-encoded.
+
+ The resulting querystring will contain keys in their lexicographical order. The
+ order of entries within the same key (when values are given as an array) is
+ retained.
+
+ If further control of the querystring generation is needed, a raw querystring
+ can be given as a string with `kong.service.request.set_raw_query()`.
+
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **args** (table):  A table where each key is a string (corresponding to an
+   argument name), and each value is either a boolean, a string or an array of
+   strings or booleans. Any string values given are URL-encoded.
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_query({
+  foo = "hello world",
+  bar = {"baz", "bla", true},
+  zzz = true,
+  blo = ""
+})
+-- Will produce the following query string:
+-- bar=baz&bar=bla&bar&blo=&foo=hello%20world&zzz
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_header(header, value)
+
+Sets a header in the request to the Service with the given value.  Any existing header
+ with the same name will be overridden.
+
+ If the `header` argument is `"host"` (case-insensitive), then this is
+ will also set the SNI of the request to the Service.
+
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **header** (string):  The header name. Example: "X-Foo"
+* **value** (string|boolean|number):  The header value. Example: "hello world"
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_header("X-Foo", "value")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.add_header(header, value)
+
+Adds a request header with the given value to the request to the Service.  Unlike
+ `kong.service.request.set_header()`, this function will not remove any existing
+ headers with the same name. Instead, several occurrences of the header will be
+ present in the request. The order in which headers are added is retained.
+
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **header** (string):  The header name. Example: "Cache-Control"
+* **value** (string|number|boolean):  The header value. Example: "no-cache"
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.add_header("Cache-Control", "no-cache")
+kong.service.request.add_header("Cache-Control", "no-store")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.clear_header(header)
+
+Removes all occurrences of the specified header in the request to the Service.
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **header** (string):  The header name. Example: "X-Foo"
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+   The function does not throw an error if no header was removed.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_header("X-Foo", "foo")
+kong.service.request.add_header("X-Foo", "bar")
+kong.service.request.clear_header("X-Foo")
+-- from here onwards, no X-Foo headers will exist in the request
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_headers(headers)
+
+Sets the headers of the request to the Service.  Unlike
+ `kong.service.request.set_header()`, the `headers` argument must be a table in
+ which each key is a string (corresponding to a header's name), and each value
+ is a string, or an array of strings.
+
+ The resulting headers are produced in lexicographical order. The order of
+ entries with the same name (when values are given as an array) is retained.
+
+ This function overrides any existing header bearing the same name as those
+ specified in the `headers` argument. Other headers remain unchanged.
+
+ If the `"Host"` header is set (case-insensitive), then this is
+ will also set the SNI of the request to the Service.
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **headers** (table):  A table where each key is a string containing a header name
+   and each value is either a string or an array of strings.
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_header("X-Foo", "foo1")
+kong.service.request.add_header("X-Foo", "foo2")
+kong.service.request.set_header("X-Bar", "bar1")
+kong.service.request.set_headers({
+  ["X-Foo"] = "foo3",
+  ["Cache-Control"] = { "no-store", "no-cache" },
+  ["Bla"] = "boo"
+})
+
+-- Will add the following headers to the request, in this order:
+-- X-Bar: bar1
+-- Bla: boo
+-- Cache-Control: no-store
+-- Cache-Control: no-cache
+-- X-Foo: foo3
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_raw_body(body)
+
+Sets the body of the request to the Service.
+
+ The `body` argument must be a string and will not be processed in any way.
+ This function also sets the `Content-Length` header appropriately. To set an
+ empty body, one can give an empty string `""` to this function.
+
+ For a higher-level function to set the body based on the request content type,
+ see `kong.service.request.set_body()`.
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **body** (string):  The raw body
+
+**Returns**
+
+*  Nothing; throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.request.set_raw_body("Hello, world!")
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.request.set_body(args[, mimetype])
+
+Sets the body of the request to the Service.  Unlike
+ `kong.service.request.set_raw_body()`, the `args` argument must be a table, and
+ will be encoded with a MIME type.  The encoding MIME type can be specified in
+ the optional `mimetype` argument, or if left unspecified, will be chosen based
+ on the `Content-Type` header of the client's request.
+
+ If the MIME type is `application/x-www-form-urlencoded`:
+
+ * Encodes the arguments as form-encoded: keys are produced in lexicographical
+   order. The order of entries within the same key (when values are
+   given as an array) is retained. Any string values given are URL-encoded.
+
+ If the MIME type is `multipart/form-data`:
+
+ * Encodes the arguments as multipart form data.
+
+ If the MIME type is `application/json`:
+
+ * Encodes the arguments as JSON (same as
+   `kong.service.request.set_raw_body(json.encode(args))`)
+ * Lua types are converted to matching JSON types.mej
+
+ If none of the above, returns `nil` and an error message indicating the
+ body could not be encoded.
+
+ The optional argument `mimetype` can be one of:
+
+ * `application/x-www-form-urlencoded`
+ * `application/json`
+ * `multipart/form-data`
+
+ If the `mimetype` argument is specified, the `Content-Type` header will be
+ set accordingly in the request to the Service.
+
+ If further control of the body generation is needed, a raw body can be given as
+ a string with `kong.service.request.set_raw_body()`.
+
+
+**Phases**
+
+* `rewrite`, `access`
+
+**Parameters**
+
+* **args** (table):  A table with data to be converted to the appropriate format
+ and stored in the body.
+* **mimetype** (string, _optional_):  can be one of:
+
+**Returns**
+
+1.  `boolean|nil` `true` on success, `nil` otherwise
+
+1.  `string|nil` `nil` on success, an error message in case of error.
+ Throws an error on invalid inputs.
+
+
+**Usage**
+
+``` lua
+kong.service.set_header("application/json")
+local ok, err = kong.service.request.set_body({
+  name = "John Doe",
+  age = 42,
+  numbers = {1, 2, 3}
+})
+
+-- Produces the following JSON body:
+-- { "name": "John Doe", "age": 42, "numbers":[1, 2, 3] }
+
+local ok, err = kong.service.request.set_body({
+  foo = "hello world",
+  bar = {"baz", "bla", true},
+  zzz = true,
+  blo = ""
+}, "application/x-www-form-urlencoded")
+
+-- Produces the following body:
+-- bar=baz&bar=bla&bar&blo=&foo=hello%20world&zzz
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.service.response.md
+++ b/app/1.0.x/pdk/kong.service.response.md
@@ -1,0 +1,129 @@
+---
+title: kong.service.response
+pdk: true
+---
+
+# kong.service.response
+
+Manipulation of the response from the Service
+
+## kong.service.response.get_status()
+
+Returns the HTTP status code of the response from the Service as a Lua number.
+
+**Phases**
+
+* `header_filter`, `body_filter`, `log`
+
+**Returns**
+
+* `number|nil`  the status code from the response from the Service, or `nil`
+ if the request was not proxied (i.e. `kong.service.get_source()` returned
+ anything other than `"service"`.
+
+
+**Usage**
+
+``` lua
+kong.log.inspect(kong.service.response.get_status()) -- 418
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.response.get_headers([max_headers])
+
+Returns a Lua table holding the headers from the response from the Service.  Keys are
+ header names. Values are either a string with the header value, or an array of
+ strings if a header was sent multiple times. Header names in this table are
+ case-insensitive and dashes (`-`) can be written as underscores (`_`); that is,
+ the header `X-Custom-Header` can also be retrieved as `x_custom_header`.
+
+ Unlike `kong.response.get_headers()`, this function will only return headers that
+ were present in the response from the Service (ignoring headers added by Kong itself).
+ If the request was not proxied to a Service (e.g. an authentication plugin rejected
+ a request and produced an HTTP 401 response), then the returned `headers` value
+ might be `nil`, since no response from the Service has been received.
+
+ By default, this function returns up to **100** headers. The optional
+ `max_headers` argument can be specified to customize this limit, but must be
+ greater than **1** and not greater than **1000**.
+
+**Phases**
+
+* `header_filter`, `body_filter`, `log`
+
+**Parameters**
+
+* **max_headers** (number, _optional_):  customize the headers to parse
+
+**Returns**
+
+1.  `table` the response headers in table form
+
+1.  `string` err If more headers than `max_headers` were present, a
+ string with the error `"truncated"`.
+
+
+**Usage**
+
+``` lua
+-- Given a response with the following headers:
+-- X-Custom-Header: bla
+-- X-Another: foo bar
+-- X-Another: baz
+local headers = kong.service.response.get_headers()
+if headers then
+  kong.log.inspect(headers.x_custom_header) -- "bla"
+  kong.log.inspect(headers.x_another[1])    -- "foo bar"
+  kong.log.inspect(headers["X-Another"][2]) -- "baz"
+end
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.service.response.get_header(name)
+
+Returns the value of the specified response header.
+
+ Unlike `kong.response.get_header()`, this function will only return a header
+ if it was present in the response from the Service (ignoring headers added by Kong
+ itself).
+
+
+**Phases**
+
+* `header_filter`, `body_filter`, `log`
+
+**Parameters**
+
+* **name** (string):  The name of the header.
+
+ Header names in are case-insensitive and are normalized to lowercase, and
+ dashes (`-`) can be written as underscores (`_`); that is, the header
+ `X-Custom-Header` can also be retrieved as `x_custom_header`.
+
+
+**Returns**
+
+* `string|nil`  The value of the header, or `nil` if a header with
+ `name` was not found in the response. If a header with the same name is present
+ multiple times in the response, this function will return the value of the
+ first occurrence of this header.
+
+
+**Usage**
+
+``` lua
+-- Given a response with the following headers:
+-- X-Custom-Header: bla
+-- X-Another: foo bar
+-- X-Another: baz
+
+kong.log.inspect(kong.service.response.get_header("x-custom-header")) -- "bla"
+kong.log.inspect(kong.service.response.get_header("X-Another"))       -- "foo bar"
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/pdk/kong.table.md
+++ b/app/1.0.x/pdk/kong.table.md
@@ -1,0 +1,64 @@
+---
+title: kong.table
+pdk: true
+---
+
+# kong.table
+
+Utilities for Lua tables
+
+## kong.table.new([narr[, nrec]])
+
+Returns a table with pre-allocated number of slots in its array and hash
+ parts.
+
+**Parameters**
+
+* **narr** (number, _optional_):  specifies the number of slots to pre-allocate
+ in the array part.
+* **nrec** (number, _optional_):  specifies the number of slots to pre-allocate in
+ the hash part.
+
+**Returns**
+
+* `table` the newly created table
+
+
+**Usage**
+
+``` lua
+local tab = kong.table.new(4, 4)
+```
+
+[Back to TOC](#table-of-contents)
+
+
+## kong.table.clear(tab)
+
+Clears a table from all of its array and hash parts entries.
+
+**Parameters**
+
+* **tab** (table):  the table which will be cleared
+
+**Returns**
+
+*  Nothing
+
+
+**Usage**
+
+``` lua
+local tab = {
+  "hello",
+  foo = "bar"
+}
+
+kong.table.clear(tab)
+
+kong.log(tab[1]) -- nil
+kong.log(tab.foo) -- nil
+```
+
+[Back to TOC](#table-of-contents)
+

--- a/app/1.0.x/plugin-development/access-the-datastore.md
+++ b/app/1.0.x/plugin-development/access-the-datastore.md
@@ -1,0 +1,87 @@
+---
+title: Plugin Development - Accessing the datastore
+book: plugin_dev
+chapter: 5
+---
+
+## Introduction
+
+Kong interacts with the model layer through classes we refer to as "DAOs". This
+chapter will detail the available API to interact with the datastore.
+
+Kong supports two primary datastores: [Cassandra
+{{site.data.kong_latest.dependencies.cassandra}}](http://cassandra.apache.org/)
+and [PostgreSQL
+{{site.data.kong_latest.dependencies.postgres}}](http://www.postgresql.org/).
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> As of 0.13.0, Kong is rolling out a new version of
+  the DAO abstraction layer called `kong.db`, which will gradually
+  replace `kong.dao`
+</div>
+---
+
+## kong.db and kong.dao
+
+All entities in Kong are represented by:
+
+- A schema that describes which table the entity relates to in the datastore,
+  constraints on its fields such as foreign keys, non-null constraints etc...
+  This schema is a table described in the [plugin
+  configuration]({{page.book.chapters.plugin-configuration}}) chapter.
+- An instance of the `DAO` class mapping to the database currently in use
+  (Cassandra or PostgreSQL). This class' methods consume the schema and expose
+  methods to insert, update, find and delete entities of that type.
+
+The core entities in Kong are: Services, Routes, Consumers and Plugins.
+Services, Routes, and Consumers are available through the new `kong.db`
+singleton. The rest of the entities are available through `kong.dao`. In the
+future, all entities will be gradually migrated to `kong.db`, including custom
+plugins entities (currently relying on `kong.dao`).
+
+Both the DAO Factory and the new `db` interface are singleton instances in Kong
+and thus, are accessible through the `kong` global:
+
+```lua
+-- Core DAOs
+local services_dao = kong.db.services
+local routes_dao = kong.db.routes
+local consumers_dao = kong.db.consumers
+local plugins_dao = kong.dao.plugins
+```
+
+The `kong` global exposes the [Plugin Development Kit], and its `kong.dao` and
+`kong.db` properties are instances of the DAO and DB singletons.
+
+---
+
+## The DAO Lua API
+
+The DAO class is responsible for the operations executed on a given table in
+the datastore, generally mapping to an entity in Kong. All the underlying
+supported databases (currently Cassandra and PostgreSQL) comply to the same
+interface, thus making the DAO compatible with all of them.
+
+For example, inserting a Service (with `kong.db`) and a Plugin (with
+`kong.dao`) is as easy as:
+
+```lua
+local inserted_service, err = kong.db.services:insert({
+  name = "mockbin",
+  url = "http://mockbin.org"
+})
+
+local inserted_plugin, err = kong.dao.plugins:insert({
+  name = "key-auth",
+  service_id = inserted_service.id
+})
+```
+
+For a real-life example of the DAO being used in a plugin, see the
+[Key-Auth plugin source code](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/handler.lua).
+
+---
+
+Next: [Custom Entities &rsaquo;]({{page.book.next}})
+
+[Plugin Development Kit]: /{{page.kong_version}}/pdk

--- a/app/1.0.x/plugin-development/admin-api.md
+++ b/app/1.0.x/plugin-development/admin-api.md
@@ -1,0 +1,136 @@
+---
+title: Plugin Development - Extending the Admin API
+book: plugin_dev
+chapter: 8
+---
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This chapter assumes that you have a relative
+  knowledge of <a href="http://leafo.net/lapis/">Lapis</a>.
+</div>
+
+## Introduction
+
+Kong can be configured using a REST interface referred to as the [Admin API].
+Plugins can extend it by adding their own endpoints to accommodate custom
+entities or other personalized management needs. A typical example of this is
+the creation, retrieval, and deletion (commonly referred to as "CRUD
+operations") of API keys.
+
+The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's
+level of abstraction makes it easy for you to add endpoints.
+
+## Module
+
+```
+kong.plugins.<plugin_name>.api
+```
+
+## Adding endpoints to the Admin API
+
+Kong will detect and load your endpoints if they are defined in a module named:
+
+```
+"kong.plugins.<plugin_name>.api"
+```
+
+This module is bound to return a table containing strings describing your
+routes (See [Lapis routes & URL
+Patterns](http://leafo.net/lapis/reference/actions.html#routes--url-patterns))
+and HTTP verbs they support. Routes are then assigned a simple handler
+function.
+
+This table is then fed to Lapis (See Lapis' [handling HTTP verbs
+documentation](http://leafo.net/lapis/reference/actions.html#handling-http-verbs)).
+Example:
+
+```lua
+return {
+  ["/my-plugin/new/get/endpoint"] = {
+    GET = function(self, dao_factory, helpers)
+      -- ...
+    end
+  }
+}
+```
+
+The handler function takes three arguments, which are, in order:
+
+- `self`: The request object. See [Lapis request
+  object](http://leafo.net/lapis/reference/actions.html#request-object)
+- `dao_factory`: The DAO Factory. See the
+  [datastore]({{page.book.chapters.access-the-datastore}}) chapter of this
+  guide.
+- `helpers`: A table containing a few helpers, described below.
+
+In addition to the HTTPS verbs it supports, a route table can also contain two
+other keys:
+
+- **before**: as in
+  [Lapis](http://leafo.net/lapis/reference/actions.html#handling-http-verbs), a
+  before_filter that runs before the executed verb action.
+- **on_error**: a custom error handler function that overrides the one provided
+  by Kong. See Lapis' [capturing recoverable
+  errors](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors)
+  documentation.
+
+---
+
+## Helpers
+
+When handling a request on the Admin API, there are times when you want to send
+back responses and handle errors, to help you do so the third parameter
+`helpers` is a table with the following properties:
+
+- `responses`: a module with helper functions to send HTTP responses.
+- `yield_error`: the
+  [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors)
+  function from Lapis. To call when your handler encounters an error (from a
+  DAO, for example). Since all Kong errors are tables with context, it can send
+  the appropriate response code depending on the error (Internal Server Error,
+  Bad Request, etc...).
+
+### crud_helpers
+
+Since most of the operations you will perform in your endpoints will be CRUD
+operations, you can also use the `kong.api.crud_helpers` module. This module
+provides you with helpers for any insert, retrieve, update or delete operations
+and performs the necessary DAO operations and replies with the appropriate HTTP
+status codes. It also provides you with functions to retrieve parameters from
+the path, such as an API's name or id, or a Consumer's username or id.
+
+Example:
+
+```lua
+local crud = require "kong.api.crud_helpers"
+
+return {
+  ["/consumers/:username_or_id/key-auth/"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      crud.paginated_set(self, dao_factory.keyauth_credentials)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.keyauth_credentials)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.keyauth_credentials)
+    end
+  }
+}
+```
+
+See the [complete Admin API of the Key-Auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua)
+for an extended version of this example.
+
+---
+
+Next: [Write tests for your plugin]({{page.book.next}})
+
+[Admin API]: /{{page.kong_version}}/admin-api/

--- a/app/1.0.x/plugin-development/custom-entities.md
+++ b/app/1.0.x/plugin-development/custom-entities.md
@@ -1,0 +1,225 @@
+---
+title: Plugin Development - Storing Custom Entities
+book: plugin_dev
+chapter: 6
+---
+
+## Introduction
+
+Your plugin might need to store more than its configuration in the database. In
+that case, Kong provides you with an abstraction on top of its primary
+datastores which allows you to store custom entities.
+
+As explained in the [previous chapter]({{page.book.previous}}), Kong interacts
+with the model layer through classes we refer to as "DAOs", and available on a
+singleton often referred to as the "DAO Factory". This chapter will explain how
+to to provide an abstraction for your own entities.
+
+## Modules
+
+```
+kong.plugins.<plugin_name>.schema.migrations
+kong.plugins.<plugin_name>.daos
+```
+
+## Create a migration file
+
+Once you have defined your model, you must create your migration modules which
+will be executed by Kong to create the table in which your records of your
+entity will be stored. A migration file holds an array of migrations, and
+returns them.
+
+If you plugin is intended to support both Cassandra and PostgreSQL, then both
+migrations must be written.
+
+Each migration must bear a unique name, and `up` and `down` fields. Such fields
+can either be strings of SQL/CQL queries for simple migrations, or actual Lua
+code to execute for complex ones. The `up` field will be executed when Kong
+migrates **forward**. It must bring your database's schema to the latest state
+required by your plugin. The `down` field must execute the necessary actions to
+revert your schema to its previous state, before `up` was ran.
+
+One of the main benefits of this approach is should you need to release a new
+version of your plugin that modifies a model, you can add new migrations to the
+array before releasing your plugin. Another benefit is that it is also possible
+to revert such migrations.
+
+As described in the [file structure]({{page.book.chapters.file-structure}})
+chapter, your migrations modules must be named:
+
+```
+"kong.plugins.<plugin_name>.migrations.cassandra"
+"kong.plugins.<plugin_name>.migrations.postgres"
+```
+
+Here is an example of how one would define a migration file to store API keys:
+
+```lua
+-- cassandra.lua
+return {
+  {
+    name = "2015-07-31-172400_init_keyauth",
+    up =  [[
+      CREATE TABLE IF NOT EXISTS keyauth_credentials(
+        id uuid,
+        consumer_id uuid,
+        key text,
+        created_at timestamp,
+        PRIMARY KEY (id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ON keyauth_credentials(key);
+      CREATE INDEX IF NOT EXISTS keyauth_consumer_id ON keyauth_credentials(consumer_id);
+    ]],
+    down = [[
+      DROP TABLE keyauth_credentials;
+    ]]
+  }
+}
+```
+
+```lua
+-- postgres.lua
+return {
+  {
+    name = "2015-07-31-172400_init_keyauth",
+    up = [[
+      CREATE TABLE IF NOT EXISTS keyauth_credentials(
+        id uuid,
+        consumer_id uuid REFERENCES consumers (id) ON DELETE CASCADE,
+        key text UNIQUE,
+        created_at timestamp without time zone default (CURRENT_TIMESTAMP(0) at time zone 'utc'),
+        PRIMARY KEY (id)
+      );
+
+      DO $$
+      BEGIN
+        IF (SELECT to_regclass('public.keyauth_key_idx')) IS NULL THEN
+          CREATE INDEX keyauth_key_idx ON keyauth_credentials(key);
+        END IF;
+        IF (SELECT to_regclass('public.keyauth_consumer_idx')) IS NULL THEN
+          CREATE INDEX keyauth_consumer_idx ON keyauth_credentials(consumer_id);
+        END IF;
+      END$$;
+    ]],
+    down = [[
+      DROP TABLE keyauth_credentials;
+    ]]
+  }
+}
+```
+
+- `name`: Must be a unique string. The format does not matter but can help you
+  debug issues while developing your plugin, so make sure to name it in a
+  relevant way.
+- `up`: Executed when Kong migrates **forward**.
+- `down`: Executed when Kong migrates **backward**.
+
+While PostgreSQL does, Cassandra does not support constraints such as "NOT
+NULL", "UNIQUE" or "FOREIGN KEY", but Kong provides you with such features when
+you define your model's schema. Bear in mind that this schema will be the same
+for both PostgreSQL and Cassandra, hence, you might trade-off a pure SQL schema
+for one that works with Cassandra too.
+
+**IMPORTANT**: if your `schema` uses a `unique` constraint, then Kong will
+enforce it for Cassandra, but for PostgreSQL you must set this constraint in
+the `migrations` file.
+
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations)
+
+---
+
+## Retrieve your custom DAO from the DAO Factory
+
+To make the DAO Factory load your custom DAO(s), you will need to define your
+entity's schema (just like the schemas describing your [plugin
+configuration]({{page.book.chapters.plugin-configuration}})). This schema
+contains a few more values since it must describes which table the entity
+relates to in the datastore, constraints on its fields such as foreign keys,
+non-null constraints and such.
+
+This schema is to be defined in a module named:
+
+```
+"kong.plugins.<plugin_name>.daos"
+```
+
+Once that module returns your entity's schema, and assuming your plugin is
+loaded by Kong (see the `plugins` property in `kong.conf`), the DAO Factory
+will use it to instantiate a DAO object.
+
+Here is an example of how one would define a schema to store API keys in a his
+or her database:
+
+```lua
+-- daos.lua
+local SCHEMA = {
+  primary_key = {"id"},
+  table = "keyauth_credentials", -- the actual table in the database
+  fields = {
+    id = {type = "id", dao_insert_value = true}, -- a value to be inserted by the DAO itself (think of serial ID and the uniqueness of such required here)
+    created_at = {type = "timestamp", immutable = true, dao_insert_value = true}, -- also interted by the DAO itself
+    consumer_id = {type = "id", required = true, foreign = "consumers:id"}, -- a foreign key to a Consumer's id
+    key = {type = "string", required = false, unique = true} -- a unique API key
+  }
+}
+
+return {keyauth_credentials = SCHEMA} -- this plugin only results in one custom DAO, named `keyauth_credentials`
+```
+
+Since your plugin might have to deal with multiple custom DAOs (in the case
+when you want to store several entities), this module is bound to return a
+key/value table where keys are the name on which the custom DAO will be
+available in the DAO Factory.
+
+You will have noticed a few new properties in the schema definition (compared
+to your [schema.lua]({{page.book.chapters.plugin-configuration}}) file):
+
+| Property name         | Lua type                  | Description
+|-----------------------|---------------------------|-------------
+| `primary_key`         | Integer indexed table     | An array of each part of your column family's primary key. It also supports **composite keys**, even if all Kong entities currently use a simple `id` for usability of the [Admin API]. If your primary key is composite, only include what makes your **partition key**.
+| `fields.*.dao_insert_value` | Boolean              | If true, specifies that this field is to be automatically populated by the DAO (in the base_dao implementation) depending on it's type. A property of type `id` will be a generated uuid, and `timestamp` a timestamp with second-precision.
+| `fields.*.queryable`  | Boolean                   | If true, specifies that Cassandra maintains an index on the specified column. This allows for querying the column family filtered by this column.
+| `fields.*.foreign`    | String                    | Specifies that this column is a foreign key to another entity's column. The format is: `dao_name:column_name`. This makes it up for Cassandra not supporting foreign keys. When the parent row will be deleted, Kong will also delete rows containing the parent's column value.
+
+Your DAO will now be loaded by the DAO Factory and available as one of its
+properties. Since the DAO Factory is exposed by the [Plugin Development Kit]'s
+`kong` global (see [kong.dao](/{{page.kong_version}}/pdk/#kong-dao), you can
+retrieve it like so:
+
+```lua
+local key_credential, err = kong.dao.key_credentials:insert({
+  consumer_id = consumer.id,
+  key = "abcd"
+})
+```
+
+The DAO name (`keyauth_credentials`) with which it is accessible from the DAO
+Factory depends on the key with which you exported your DAO in the returned
+table of `daos.lua`.
+
+You can see an example of this in the [Key-Auth `daos.lua` file](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/daos.lua).
+
+---
+
+## Caching custom entities
+
+Sometimes custom entities are required on every request/response, which in turn
+triggers a query on the datastore every time. This is very inefficient because
+querying the datastore adds latency and slows the request/response down, and
+the resulting increased load on the datastore could affect the datastore
+performance itself and, in turn, other Kong nodes.
+
+When a custom entity is required on every request/response it is good practice
+to cache it in-memory by leveraging the in-memory cache API provided by Kong.
+
+The next chapter will focus on caching custom entities, and invalidating them
+when they change in the datastore: [Caching custom
+entities]({{page.book.next}}).
+
+---
+
+Next: [Caching custom entities &rsaquo;]({{page.book.next}})
+
+[Admin API]: /{{page.kong_version}}/admin-api/
+[Plugin Development Kit]: /{{page.kong_version}}/pdk

--- a/app/1.0.x/plugin-development/custom-logic.md
+++ b/app/1.0.x/plugin-development/custom-logic.md
@@ -1,0 +1,263 @@
+---
+title: Plugin Development - Implementing custom logic
+book: plugin_dev
+chapter: 3
+---
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This chapter assumes that you are familiar with
+  <a href="http://www.lua.org/">Lua</a>.
+</div>
+
+## Introduction
+
+A Kong plugin allows you to inject custom logic (in Lua) at several
+entry-points in the life-cycle of a request/response as it is proxied by Kong.
+To do so, one must implement one or several of the methods of the
+`base_plugin.lua` interface. Those methods are to be implemented in a module
+namespaced under: `kong.plugins.<plugin_name>.handler`
+
+## Module
+
+```
+kong.plugins.<plugin_name>.handler
+```
+
+## Available request contexts
+
+The plugins interface allows you to override any of the following methods in
+your `handler.lua` file to implement custom logic at various entry-points
+of the execution life-cycle of Kong:
+
+| Function name           | lua-nginx-module context           | Description
+|-------------------------|------------------------------------|--------------
+| `:init_worker()`         | [init_worker_by_lua]               | Executed upon every Nginx worker process's startup.
+| `:certificate()`         | [ssl_certificate_by_lua_block]     | Executed during the SSL certificate serving phase of the SSL handshake.
+| `:rewrite()`             | [rewrite_by_lua_block]             | Executed for every request upon its reception from a client as a rewrite phase handler. *NOTE* in this phase neither the `api` nor the `consumer` have been identified, hence this handler will only be executed if the plugin was configured as a global plugin!
+| `:access()`              | [access_by_lua]                    | Executed for every request from a client and before it is being proxied to the upstream service.
+| `:header_filter()`       | [header_filter_by_lua]             | Executed when all response headers bytes have been received from the upstream service.
+| `:body_filter()`         | [body_filter_by_lua]               | Executed for each chunk of the response body received from the upstream service. Since the response is streamed back to the client, it can exceed the buffer size and be streamed chunk by chunk. hence this method can be called multiple times if the response is large. See the [lua-nginx-module] documentation for more details.
+| `:log()`                 | [log_by_lua]                       | Executed when the last response byte has been sent to the client.
+
+All of those functions take one parameter which is given by Kong upon its
+invocation: the configuration of your plugin. This parameter is a Lua table,
+and contains values derined by your users, according to your plugin's schema
+(described in the `schema.lua` module). More on plugins schemas in the [next
+chapter]({{page.book.next}}).
+
+[init_worker_by_lua]: https://github.com/openresty/lua-nginx-module#init_worker_by_lua
+[ssl_certificate_by_lua_block]: https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block
+[rewrite_by_lua_block]: https://github.com/openresty/lua-nginx-module#rewrite_by_lua_block
+[access_by_lua]: https://github.com/openresty/lua-nginx-module#access_by_lua
+[header_filter_by_lua]: https://github.com/openresty/lua-nginx-module#header_filter_by_lua
+[body_filter_by_lua]: https://github.com/openresty/lua-nginx-module#body_filter_by_lua
+[log_by_lua]: https://github.com/openresty/lua-nginx-module#log_by_lua
+
+---
+
+## handler.lua specifications
+
+The `handler.lua` file must return a table implementing the functions you wish
+to be executed. In favor of brevity, here is a commented example module
+implementing all the available methods:
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> Kong uses the
+  <a href="https://github.com/rxi/classic">rxi/classic</a> module to simulate
+  classes in Lua and ease the inheritance pattern.
+</div>
+
+```lua
+-- Extending the Base Plugin handler is optional, as there is no real
+-- concept of interface in Lua, but the Base Plugin handler's methods
+-- can be called from your child implementation and will print logs
+-- in your `error.log` file (where all logs are printed).
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+
+-- Your plugin handler's constructor. If you are extending the
+-- Base Plugin handler, it's only role is to instantiate itself
+-- with a name. The name is your plugin name as it will be printed in the logs.
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:init_worker()
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.init_worker(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:certificate(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.certificate(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:rewrite(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.rewrite(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:access(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.access(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:header_filter(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.header_filter(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:body_filter(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.body_filter(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:log(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.log(self)
+
+  -- Implement any custom logic here
+end
+
+-- This module needs to return the created table, so that Kong
+-- can execute those functions.
+return CustomHandler
+```
+
+Of course, the logic of your plugin itself can be abstracted away in another
+module, and called from your `handler` module. Many existing plugins have
+already chosen this pattern when their logic is verbose, but it is purely
+optional:
+
+```lua
+local BasePlugin = require "kong.plugins.base_plugin"
+
+-- The actual logic is implemented in those modules
+local access = require "kong.plugins.my-custom-plugin.access"
+local body_filter = require "kong.plugins.my-custom-plugin.body_filter"
+
+local CustomHandler = BasePlugin:extend()
+
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:access(config)
+  CustomHandler.super.access(self)
+
+  -- Execute any function from the module loaded in `access`,
+  -- for example, `execute()` and passing it the plugin's configuration.
+  access.execute(config)
+end
+
+function CustomHandler:body_filter(config)
+  CustomHandler.super.body_filter(self)
+
+  -- Execute any function from the module loaded in `body_filter`,
+  -- for example, `execute()` and passing it the plugin's configuration.
+  body_filter.execute(config)
+end
+
+return CustomHandler
+```
+
+See [the source code of the Key-Auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/handler.lua) for an example of a real-life
+handler code.
+
+---
+
+## Plugin Development Kit
+
+Logic implemented in those phases will most likely have to interact with the
+request/response objects or core components (e.g. access the cache,
+database...). Kong provides a [Plugin Development Kit][pdk] (or "PDK") for such
+purposes: a set of Lua functions and variables that can be used by plugins to
+execute various gateway operations in a way that is guaranteed to be
+forward-compatible with future releases of Kong.
+
+When you are trying to implement some logic that needs to interact with Kong
+(e.g. retrieving request headers, producing a response from a plugin, logging
+some error or debug information...), you should consult the [Plugin Development
+Kit Reference][pdk].
+
+---
+
+## Plugins execution order
+
+Some plugins might depend on the execution of others to perform some
+operations. For example, plugins relying on the identity of the consumer have
+to run **after** authentication plugins. Considering this, Kong defines
+**priorities** between plugins execution to ensure that order is respected.
+
+Your plugin's priority can be configured via a property accepting a number in
+the returned handler table:
+
+```lua
+CustomHandler.PRIORITY = 10
+```
+
+The higher the priority, the sooner your plugin's phases will be executed in
+regard to other plugins' phases (such as `:access()`, `:log()`, etc...).
+
+The current order of execution for the bundled plugins is:
+
+Plugin                    | Priority
+-------------------------:|:------------
+pre-function              | `+inf`
+zipkin                    | 100000
+ip-restriction            | 3000
+bot-detection             | 2500
+cors                      | 2000
+jwt                       | 1005
+oauth2                    | 1004
+key-auth                  | 1003
+ldap-auth                 | 1002
+basic-auth                | 1001
+hmac-auth                 | 1000
+request-size-limiting     | 951
+acl                       | 950
+rate-limiting             | 901
+response-ratelimiting     | 900
+request-transformer       | 801
+response-transformer      | 800
+aws-lambda                | 750
+azure-functions           | 749
+prometheus                | 13
+http-log                  | 12
+statsd                    | 11
+datadog                   | 10
+file-log                  | 9
+udp-log                   | 8
+tcp-log                   | 7
+loggly                    | 6
+syslog                    | 4
+galileo                   | 3
+request-termination       | 2
+correlation-id            | 1
+post-function             | -1000
+
+---
+
+Next: [Store configuration &rsaquo;]({{page.book.next}})
+
+[lua-nginx-module]: https://github.com/openresty/lua-nginx-module
+[pdk]: /{{page.kong_version}}/pdk

--- a/app/1.0.x/plugin-development/distribution.md
+++ b/app/1.0.x/plugin-development/distribution.md
@@ -1,0 +1,296 @@
+---
+title: Plugin Development - (un)Installing your plugin
+book: plugin_dev
+chapter: 10
+---
+
+## Introduction
+
+Custom plugins for Kong consist of Lua source files that need to be in the file
+system of each of your Kong nodes. This guide will provide you with
+step-by-step instructions that will make a Kong node aware of your custom
+plugin(s).
+
+These steps should be applied to each node in your Kong cluster, to ensure the
+custom plugin(s) are available on each one of them.
+
+## Packaging sources
+
+You can either use a regular packing strategy (e.g. `tar`), or use the LuaRocks
+package manager to do it for you. We recommend LuaRocks as it is installed
+along with Kong when using one of the official distribution packages.
+
+When using LuaRocks, you must create a `rockspec` file, which specifies the
+package contents. For an example see the [Kong plugin
+template][plugin-template], for more info about the format see the LuaRocks
+[documentation on rockspecs][rockspec].
+
+Pack your rock using the following command (from the plugin repo):
+
+    # install it locally (based on the `.rockspec` in the current directory)
+    $ luarocks make
+
+    # pack the installed rock
+    $ luarocks pack <plugin-name> <version>
+
+Assuming your plugin rockspec is called
+`kong-plugin-myPlugin-0.1.0-1.rockspec`, the above would become;
+
+    $ luarocks pack kong-plugin-myPlugin 0.1.0-1
+
+The LuaRocks `pack` command has now created a `.rock` file (this is simply a
+zip file containing everything needed to install the rock).
+
+If you do not or cannot use LuaRocks, then use `tar` to pack the
+`.lua` files of which your plugin consists into a `.tar.gz` archive. You can
+also include the `.rockspec` file if you do have LuaRocks on the target
+systems.
+
+The contents of this archive should be close to the following:
+
+    $ tree <plugin-name>
+    <plugin-name>
+    ├── INSTALL.txt
+    ├── README.md
+    ├── kong
+    │   └── plugins
+    │       └── <plugin-name>
+    │           ├── handler.lua
+    │           └── schema.lua
+    └── <plugin-name>-<version>.rockspec
+
+[Back to TOC](#table-of-contents)
+
+---
+
+## Installing the plugin
+
+For a Kong node to be able to use the custom plugin, the custom plugin's Lua
+sources must be installed on your host's file system. There are multiple ways
+of doing so: via LuaRocks, or manually. Choose one, and jump to section 3.
+
+1. Via LuaRocks from the created 'rock'
+
+    The `.rock` file is a self contained package that can be installed locally
+    or from a remote server.
+
+    If the `luarocks` utility is installed in your system (this is likely the
+    case if you used one of the official installation packages), you can
+    install the 'rock' in your LuaRocks tree (a directory in which LuaRocks
+    installs Lua modules).
+
+    It can be installed by doing:
+
+        $ luarocks install <rock-filename>
+
+    The filename can be a local name, or any of the supported methods, eg.
+    `http://myrepository.lan/rocks/myplugin-0.1.0-1.all.rock`
+
+2. Via LuaRocks from the source archive
+
+    If the `luarocks` utility is installed in your system (this is likely the
+    case if you used one of the official installation packages), you can
+    install the Lua sources in your LuaRocks tree (a directory in which
+    LuaRocks installs Lua modules).
+
+    You can do so by changing the current directory to the extracted archive,
+    where the rockspec file is:
+
+        $ cd <plugin-name>
+
+    And then run the following:
+
+        $ luarocks make
+
+    This will install the Lua sources in `kong/plugins/<plugin-name>` in your
+    system's LuaRocks tree, where all the Kong sources are already present.
+
+3. Manually
+
+    A more conservative way of installing your plugin's sources is
+    to avoid "polluting" the LuaRocks tree, and instead, point Kong
+    to the directory containing them.
+
+    This is done by tweaking the `lua_package_path` property of your Kong
+    configuration. Under the hood, this property is an alias to the `LUA_PATH`
+    variable of the Lua VM, if you are familiar with it.
+
+    Those properties contain a semicolon-separated list of directories in
+    which to search for Lua sources. It should be set like so in your Kong
+    configuration file:
+
+        lua_package_path = /<path-to-plugin-location>/?.lua;;
+
+    Where:
+
+    * `/<path-to-plugin-location>` is the path to the directory containing the
+      extracted archive. It should be the location of the `kong` directory
+      from the archive.
+    * `?` is a placeholder that will be replaced by
+      `kong.plugins.<plugin-name>` when Kong will try to load your plugin. Do
+      not change it.
+    * `;;` a placeholder for the "the default Lua path". Do not change it.
+
+    Example:
+
+    The plugin `something` being located on the file system such that the
+    handler file is:
+
+        /usr/local/custom/kong/plugins/<something>/handler.lua
+
+    The location of the `kong` directory is: `/usr/local/custom`, hence the
+    proper path setup would be:
+
+        lua_package_path = /usr/local/custom/?.lua;;
+
+    Multiple plugins:
+
+    If you wish to install two or more custom plugins this way, you can set
+    the variable to something like:
+
+        lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
+
+    * `;` is the separator between directories.
+    * `;;` still means "the default Lua path".
+
+    Note: you can also set this property via its environment variable
+    equivalent: `KONG_LUA_PACKAGE_PATH`.
+
+Reminder: regardless of which method you are using to install your plugin's
+sources, you must still do so for each node in your Kong cluster.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+## Load the plugin
+
+You must now add the custom plugin's name to the `plugins` list in your
+Kong configuration (on each Kong node):
+
+    plugins = bundled,<plugin-name>
+
+Or, if you don't want to include the bundled plugins:
+
+    plugins = <plugin-name>
+
+
+If you are using two or more custom plugins, insert commas in between, like so:
+
+    plugins = bundled,plugin1,plugin2
+
+Or
+
+    plugins = plugin1,plugin2
+
+Note: you can also set this property via its environment variable equivalent:
+`KONG_PLUGINS`.
+
+Reminder: don't forget to update the `plugins` directive for each node
+in your Kong cluster.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+## Verify loading the plugin
+
+You should now be able to start Kong without any issue. Consult your custom
+plugin's instructions on how to enable/configure your plugin
+on a Service, Route, or Consumer entity.
+
+To make sure your plugin is being loaded by Kong, you can start Kong with a
+`debug` log level:
+
+    log_level = debug
+
+or:
+
+    KONG_LOG_LEVEL=debug
+
+Then, you should see the following log for each plugin being loaded:
+
+    [debug] Loading plugin <plugin-name>
+
+
+[Back to TOC](#table-of-contents)
+
+---
+
+## Removing a plugin
+
+There are three steps to completely remove a plugin.
+
+1. Remove the plugin from your Kong Service or Route configuration. Make sure
+   that it is no longer applied globally nor for any Service, Route, or
+   consumer. This has to be done only once for the entire Kong cluster, no
+   restart/reload required.  This step in itself will make that the plugin is
+   no longer in use. But it remains available and it is still possible to
+   re-apply the plugin.
+
+2. Remove the plugin from the `plugins` directive (on each Kong node).
+   Make sure to have completed step 1 before doing so. After this step
+   it will be impossible for anyone to re-apply the plugin to any Kong
+   Service, Route, Consumer, or even globally. This step requires to
+   restart/reload the Kong node to take effect.
+
+3. To remove the plugin thoroughly, delete the plugin-related files from
+   each of the Kong nodes. Make sure to have completed step 2, including
+   restarting/reloading Kong, before deleting the files. If you used LuaRocks
+   to install the plugin, you can do `luarocks remove <plugin-name>` to remove
+   it.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+## Distributing your plugin
+
+The preferred way to do so is to use [LuaRocks](https://luarocks.org/), a
+package manager for Lua modules. It calls such modules "rocks". **Your module
+does not have to live inside the Kong repository**, but it can be if that's
+how you'd like to maintain your Kong setup.
+
+By defining your modules (and their eventual dependencies) in a [rockspec]
+file, you can install those modules on your platform via LuaRocks. You can
+also upload your module on LuaRocks and make it available to everyone!
+
+Here is an example rockspec which would use the "builtin" build type to define
+modules in Lua notation and their corresponding file:
+
+
+For an example see the [Kong plugin template][plugin-template], for more info
+about the format see the LuaRocks [documentation on rockspecs][rockspec].
+
+[Back to TOC](#table-of-contents)
+
+---
+
+## Troubleshooting
+
+Kong can fail to start because of a misconfigured custom plugin for several
+reasons:
+
+* "plugin is in use but not enabled" -> You configured a custom plugin from
+  another node, and that the plugin configuration is in the database, but the
+  current node you are trying to start does not have it in its `plugins`
+  directive. To resolve, add the plugin's name to the node's `plugins`
+  directive.
+
+* "plugin is enabled but not installed" -> The plugin's name is present in the
+  `plugins` directive, but that Kong is unable to load the `handler.lua`
+  source file from the file system. To resolve, make sure that the
+  [lua_package_path](/{{page.kong_version}}/configuration/#development-miscellaneous-section)
+  directive is properly set to load this plugin's Lua sources.
+
+* "no configuration schema found for plugin" -> The plugin is installed,
+  enabled in the `plugins` directive, but Kong is unable to load the
+  `schema.lua` source file from the file system. To resolve, make sure that
+  the `schema.lua` file is present alongside the plugin's `handler.lua` file.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+[rockspec]: https://github.com/keplerproject/luarocks/wiki/Creating-a-rock
+[plugin-template]: https://github.com/Kong/kong-plugin

--- a/app/1.0.x/plugin-development/entities-cache.md
+++ b/app/1.0.x/plugin-development/entities-cache.md
@@ -1,0 +1,292 @@
+---
+title: Plugin Development - Caching custom entities
+book: plugin_dev
+chapter: 7
+---
+
+## Introduction
+
+Your plugin may need to frequently access custom entities (explained in the
+[previous chapter]({{page.book.previous}})) on every request and/or response.
+Usually, loading them once and caching them in-memory dramatically improves
+the performance while making sure the datastore is not stressed with an
+increased load.
+
+Think of an api-key authentication plugin that needs to validate the api-key on
+every request, thus loading the custom credential object from the datastore on
+every request. When the client provides an api-key along with the request,
+normally you would query the datastore to check if that key exists, and then
+either block the request or retrieve the Consumer ID to identify the user. This
+would happen on every request, and it would be very inefficient:
+
+* Querying the datastore adds latency on every request, making the request
+  processing slower.
+* The datastore would also be affected by an increase of load, potentially
+  crashing or slowing down, which in turn would affect every Kong
+  node.
+
+To avoid querying the datastore every time, we can cache custom entities
+in-memory on the node, so that frequent entity lookups don't trigger a
+datastore query every time (only the first time), but happen in-memory, which
+is much faster and reliable that querying it from the datastore (especially
+under heavy load).
+
+## Modules
+
+```
+kong.plugins.<plugin_name>.daos
+```
+
+## Caching custom entities
+
+Once you have defined your custom entities, you can cache them in-memory in
+your code by using the [kong.cache](/{{page.kong_version}}/pdk/#kong-cache)
+module provided by the [Plugin Development Kit]:
+
+```
+local cache = kong.cache
+```
+
+There are 2 levels of cache:
+
+1. L1: Lua memory cache - local to an nginx worker
+   This can hold any type of Lua value.
+2. L2: Shared memory cache (SHM) - local to an nginx node, but shared between
+   all workers. This can only hold scalar values, and hence requires
+   (de)serialization.
+
+When data is fetched from the database, it will be stored in both caches. Now
+if the same worker process requests the data again, it will retrieve the
+previously-deserialized data from the Lua memory cache. If a different
+worker within the same Nginx node requests that data, it will find the data
+in the SHM, deserialize it (and store it in its own Lua memory cache) and
+then return it.
+
+This module exposes the following functions:
+
+Function name                                 | Description
+----------------------------------------------|---------------------------
+`value, err = cache:get(key, opts?, cb, ...)` | Retrieves the value from the cache. If the cache does not have value (miss), invokes `cb` in protected mode. `cb` must return one (and only one) value that will be cached. It *can* throw errors, as those will be caught and properly logged by Kong, at the `ngx.ERR` level. This function **does** cache negative results (`nil`). As such, one must rely on its second argument `err` when checking for errors.
+`ttl, err, value = cache:probe(key)`          | Checks if a value is cached. If it is, returns its remaining TTL. It not, returns `nil`. The value being cached can also be a negative caching. The third return value is the value being cached itself.
+`cache:invalidate_local(key)`                       | Evicts a value from the node's cache.
+`cache:invalidate(key)`                             | Evicts a value from the node's cache **and** propagates the eviction events to all other nodes in the cluster.
+`cache:purge()`                                     | Evicts **all** values from the node's cache.
+
+Bringing back our authentication plugin example, to lookup a credential with a
+specific api-key, we would write something similar to:
+
+```lua
+-- access.lua
+
+local function load_entity_key(api_key)
+  -- IMPORTANT: the callback is executed inside a lock, hence we cannot terminate
+  -- a request here, we MUST always return.
+  local apikeys, err = kong.dao.apikeys:find_all({key = api_key}) -- Lookup in the datastore
+  if err then
+    error(err) -- caught by kong.cache and logged
+  end
+
+  if not apikeys then
+    return nil -- nothing was found (cached for `neg_ttl`)
+  end
+
+  -- assuming the key was unique, we always only have 1 value...
+  return apikeys[1] -- cache the credential (cached for `ttl`)
+end
+
+-- retrieve the apikey from the request querystring
+local querystring = kong.request.get_query()
+local apikey = querystring.apikey
+
+-- We are using cache.get to first check if the apikey has been already
+-- stored into the in-memory cache at the key: "apikeys." .. apikey
+-- If it's not, then we lookup the datastore and return the credential
+-- object. Internally cache.get will save the value in-memory, and then
+-- return the credential.
+local credential, err = kong.cache:get("apikeys." .. apikey, nil,
+                                       load_entity_key, apikey)
+if err then
+  return kong.response.exit(500, "Unexpected error: " .. err)
+end
+
+if not credential then
+  -- no credentials in cache nor datastore
+  return kong.response.exit(403, "Invalid authentication credentials")
+end
+
+-- set an upstream header if the credential exists and is valid
+kong.service.request.set_header("X-API-Key", credential.apikey)
+```
+
+Note that in the above example, we use various components from the [Plugin
+Development Kit] to interact with the request, cache module, or even produce a
+response from our plugin.
+
+Now, with the above mechanism in place, once a Consumer has made a request with
+their API key, the cache will be considered warm and subsequent requests won't
+result in a database query.
+
+The cache is used in several places in the [Key-Auth plugin handler](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/handler.lua).
+Give that file a look in order to see how an official plugin uses the cache.
+
+### Updating or deleting a custom entity
+
+Every time a cached custom entity is updated or deleted in the datastore (i.e.
+using the Admin API), it creates an inconsistency between the data in
+the datastore, and the data cached in the Kong nodes' memory. To avoid this
+inconsistency, we need to evict the cached entity from the in-memory store and
+force Kong to request it again from the datastore. We refer to this process as
+cache invalidation.
+
+---
+
+## Cache invalidation for your entities
+
+If you wish that your cached entities be invalidated upon a CRUD operation
+rather than having to wait for them to reach their TTL, you have to follow a
+few steps. This process can be automated for most entities, but manually
+subscribing to some CRUD events might be required to invalidate some entities
+with more complex relationships.
+
+### Automatic cache invalidation
+
+Cache invalidation can be provided out of the box for your entities if you rely
+on the `cache_key` property of your entity's schema. For example, in the
+following schema:
+
+```lua
+local SCHEMA = {
+  primary_key = { "id" },
+  table = "keyauth_credentials",
+  cache_key = { "key" }, -- cache key for this entity
+  fields = {
+    id = { type = "id" },
+    created_at = { type = "timestamp", immutable = true },
+    consumer_id = { type = "id", required = true, foreign = "consumers:id"},
+    key = { type = "string", required = false, unique = true }
+  }
+}
+
+return { keyauth_credentials = SCHEMA }
+```
+
+We can see that we declare the cache key of this API key entity to be its
+`key` attribute. We use `key` here because it has a unique constraints
+applied to it. Hence, the attributes added to `cache_key` should result in
+a unique combination, so that no two entities could yield the same cache key.
+
+Adding this value allows you to use the following function on the DAO of that
+entity:
+
+```lua
+cache_key = kong.dao:cache_key(arg1, arg2, arg3, ...)
+```
+
+Where the arguments must be the attributes specified in your schema's
+`cache_key` property, in the order they were specified. This function then
+computes a string value `cache_key` that is ensured to be unique.
+
+For example, if we were to generate the cache_key of an API key:
+
+```lua
+local cache_key = kong.dao.keyauth_credentials:cache_key("abcd")
+```
+
+This would produce a cache_key for the API key `"abcd"` (retrieved from one
+of the query's arguments) that we can the use to retrieve the key from the
+cache (or fetch from the database if the cache is a miss):
+
+```lua
+local apikey = kong.request.get_query().apikey
+local cache_key = kong.dao.keyauth_credentials:cache_key(apikey)
+
+local credential, err = kong.cache:get(cache_key, nil, load_entity_key, apikey)
+if err then
+  return kong.response.exit(500, "Unexpected error: " .. err)
+end
+
+-- do something with the credential
+```
+
+If the `cache_key` is generated like so and specified in an entity's schema,
+cache invalidation will be an automatic process: every CRUD operation that
+affects this API key will be make Kong generate the affected `cache_key`, and
+broadcast it to all of the other nodes on the cluster so they can evict
+that particular value from their cache, and fetch the fresh value from the
+datastore on the next request.
+
+When a parent entity is receiving a CRUD operation (e.g. the Consumer owning
+this API key, as per our schema's `consumer_id` attribute), Kong performs the
+cache invalidation mechanism for both the parent and the child entity.
+
+**Note**: Be aware of the negative caching that Kong provides. In the above
+example, if there is no API key in the datastore for a given key, the cache
+module will store the miss just as if it was a hit. This means that a
+"Create" event (one that would create an API key with this given key) is also
+propagated by Kong so that all nodes that stored the miss can evict it, and
+properly fetch the newly created API key from the datastore.
+
+See the [Clustering Guide](/{{page.kong_version}}/clustering/) to ensure
+that you have properly configured your cluster for such invalidation events.
+
+### Manual cache invalidation
+
+In some cases, the `cache_key` property of an entity's schema is not flexible
+enough, and one must manually invalidate its cache. Reasons for this could be
+that the plugin is not defining a relationship with another entity via the
+traditional `foreign = "parent_entity:parent_attribute"` syntax, or because
+it is not using the `cache_key` method from its DAO, or even because it is
+somehow abusing the caching mechanism.
+
+In those cases, you can manually setup your own subscriber to the same
+invalidation channels Kong is listening to, and perform your own, custom
+invalidation work.
+
+To listen on invalidation channels inside of Kong, implement the following in
+your plugin's `init_worker` handler:
+
+```lua
+function MyCustomHandler:init_worker()
+  -- listen to all CRUD operations made on Consumers
+  kong.worker_events.register(function(data)
+
+  end, "crud", "consumers")
+
+  -- or, listen to a specific CRUD operation only
+  kong.worker_events.register(function(data)
+    kong.log.inspect(data.operation)  -- "update"
+    kong.log.inspect(data.old_entity) -- old entity table (only for "update")
+    kong.log.inspect(data.entity)     -- new entity table
+    kong.log.inspect(data.schema)     -- entity's schema
+  end, "crud", "consumers:update")
+end
+```
+
+Once the above listeners are in place for the desired entities, you can perform
+manual invalidations of any entity that your plugin has cached as you wish so.
+For instance:
+
+```lua
+kong.worker_events.register(function(data)
+  if data.operation == "delete" then
+    local cache_key = data.entity.id
+    kong.cache:invalidate("prefix:" .. cache_key)
+  end
+end, "crud", "consumers")
+```
+
+## Extending the Admin API
+
+As you are probably aware, the [Admin API] is where Kong users communicate with
+Kong to setup their APIs and plugins. It is likely that they also need to be
+able to interact with the custom entities you implemented for your plugin (for
+example, creating and deleting API keys). The way you would do this is by
+extending the Admin API, which we will detail in the next chapter: [Extending
+the Admin API]({{page.book.next}}).
+
+---
+
+Next: [Extending the Admin API &rsaquo;]({{page.book.next}})
+
+[Admin API]: /{{page.kong_version}}/admin-api/
+[Plugin Development Kit]: /{{page.kong_version}}/pdk

--- a/app/1.0.x/plugin-development/file-structure.md
+++ b/app/1.0.x/plugin-development/file-structure.md
@@ -1,0 +1,124 @@
+---
+title: Plugin Development - File Structure
+book: plugin_dev
+chapter: 2
+---
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This chapter assumes that you are familiar with
+  <a href="http://www.lua.org/">Lua</a>.
+</div>
+
+## Introduction
+
+Consider your plugin as a set of [Lua
+modules](http://www.lua.org/manual/5.1/manual.html#6.3). Each file described in
+this chapter is to be considered as a separate module. Kong will detect and
+load your plugin's modules if their names follow this convention:
+
+```
+kong.plugins.<plugin_name>.<module_name>
+```
+
+> Your modules of course need to be accessible through your
+> [package.path](http://www.lua.org/manual/5.1/manual.html#pdf-package.path)
+> variable, which can be tweaked to your needs via the
+> [lua_package_path](/{{page.kong_version}}/configuration/#development-miscellaneous-section)
+> configuration property.
+> However, the preferred way of installing plugins is through
+> [LuaRocks](https://luarocks.org/), which Kong natively integrates with.
+> More on LuaRocks-installed plugins later in this guide.
+
+To make Kong aware that it has to look for your plugin's modules, you'll have
+to add it to the
+[plugins](/{{page.kong_version}}/configuration/#general-section) property in
+your configuration file, which is a comma-separated list. For example:
+
+```yaml
+plugins = bundled,my-custom-plugin # your plugin name here
+```
+
+Or, if you don't want to load any of the bundled plugins:
+
+```yaml
+plugins = my-custom-plugin # your plugin name here
+```
+
+Now, Kong will try to load several Lua modules from the following namespace:
+
+```
+kong.plugins.my-custom-plugin.<module_name>
+```
+
+Some of these modules are mandatory (e.g. `handler.lua`), and some are
+optional, and will allow the plugin to implement some extra-functionalities
+(e.g. `api.lua` to extend the Admin API endpoints).
+
+Now let's describe exactly what are the modules you can implement and what
+their purpose is.
+
+---
+
+## Basic plugin modules
+
+In its purest form, a plugin consists of two mandatory modules:
+
+```
+simple-plugin
+├── handler.lua
+└── schema.lua
+```
+
+- [handler.lua]: the core of your plugin. It is an interface to implement, in
+  which each function will be run at the desired moment in the lifecycle of a
+  request.
+- [schema.lua]: your plugin probably has to retain some configuration entered
+  by the user. This module holds the *schema* of that configuration and defines
+  rules on it, so that the user can only enter valid configuration values.
+
+---
+
+## Advanced plugin modules
+
+Some plugins might have to integrate deeper with Kong: have their own table in
+the database, expose endpoints in the Admin API, etc... Each of those can be
+done by adding a new module to your plugin. Here is what the structure of a
+plugin would look like if it was implementing all of the optional modules:
+
+```
+complete-plugin
+├── api.lua
+├── daos.lua
+├── handler.lua
+├── migrations
+│   ├── cassandra.lua
+│   └── postgres.lua
+└── schema.lua
+```
+
+Here is the complete list of possible modules to implement and a brief
+description of what their purpose is. This guide will go in details to let you
+master each one of them.
+
+| Module name        | Required   | Description
+|:-------------------|------------|----------
+| [api.lua]          | No         | Defines a list of endpoints to be available in the Admin API to interact with entities custom entities handled by your plugin.
+| [daos.lua]         | No         | Defines a list of DAOs (Database Access Objects) that are abstractions of custom entities needed by your plugin and stored in the datastore.
+| [handler.lua]      | Yes        | An interface to implement. Each function is to be run by Kong at the desired moment in the lifecycle of a request.
+| [migrations/*.lua] | No         | The corresponding migrations for a given datastore. Migrations are only necessary when your plugin has to store custom entities in the database and interact with them through one of the DAOs defined by [daos.lua].
+| [schema.lua]       | Yes        | Holds the schema of your plugin's configuration, so that the user can only enter valid configuration values.
+
+The [Key-Auth plugin] is an example of plugin with this file structure. See
+[its source code] for more details.
+
+---
+
+Next: [Write custom logic &rsaquo;]({{page.book.next}})
+
+[api.lua]: {{page.book.chapters.admin-api}}
+[daos.lua]: {{page.book.chapters.custom-entities}}
+[handler.lua]: {{page.book.chapters.custom-logic}}
+[schema.lua]: {{page.book.chapters.plugin-configuration}}
+[migrations/*.lua]: {{page.book.chapters.custom-entities}}
+[Key-Auth plugin]: /plugins/key-authentication/
+[its source code]: https://github.com/Kong/kong/tree/master/kong/plugins/key-auth

--- a/app/1.0.x/plugin-development/index.md
+++ b/app/1.0.x/plugin-development/index.md
@@ -1,0 +1,38 @@
+---
+title: Plugin Development - Introduction
+book: plugin_dev
+chapter: 1
+---
+
+# What are plugins and how do they integrate with Kong?
+
+Before going further, it is necessary to briefly explain how Kong is built,
+especially how it integrates with Nginx and what Lua has to do with it.
+
+[lua-nginx-module] enables Lua scripting capabilities in Nginx. Instead of
+compiling Nginx with this module, Kong is distributed along with
+[OpenResty](https://openresty.org/), which already includes lua-nginx-module.
+OpenResty is *not* a fork of Nginx, but a bundle of modules extending its
+capabilities.
+
+Hence, Kong is a Lua application designed to load and execute Lua modules
+(which we more commonly refer to as "*plugins*") and provides an entire
+development environment for them, including an SDK, database abstractions,
+migrations, and more...
+
+Plugins consist of Lua modules interacting with the request/response objects
+(among other things) via the **Plugin Development Kit** (or "PDK") to implement
+arbitrary logic. The PDK is a set of Lua functions that a plugin can use to
+facilitate interactions between plugins and the core (or other components) of
+Kong.
+
+This guide will explore in detail the structure of plugins, what they can
+extend, and how to distribute and install them. For a complete reference of the
+PDK, see the [Plugin Development Kit] reference.
+
+---
+
+Next: [File structure of a plugin &rsaquo;]({{page.book.next}})
+
+[lua-nginx-module]: https://github.com/openresty/lua-nginx-module
+[Plugin Development Kit]: /{{page.kong_version}}/pdk

--- a/app/1.0.x/plugin-development/plugin-configuration.md
+++ b/app/1.0.x/plugin-development/plugin-configuration.md
@@ -1,0 +1,249 @@
+---
+title: Plugin Development - Store Configuration
+book: plugin_dev
+chapter: 4
+---
+
+## Introduction
+
+Most of the time, it makes sense for your plugin to be configurable to answer
+all of your user's needs. Your plugin's configuration is stored in the
+datastore for Kong to retrieve it and pass it to your
+[handler.lua]({{page.book.chapters.custom-logic}}) methods when the plugin is
+being executed.
+
+The configuration consists of a Lua table in Kong that we call a **schema**. It
+contains key/value properties that the user will set when enabling the plugin
+through the [Admin API]. Kong provides you with a way of validating the user's
+configuration for your plugin.
+
+Your plugin's configuration is being verified against your schema when a user
+issues a request to the [Admin API] to enable or update a plugin on a given
+Service, Route and/or Consumer.
+
+For example, a user performs the following request:
+
+```bash
+$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins/ \
+    -d "name=my-custom-plugin" \
+    -d "config.foo=bar"
+```
+
+If all properties of the `config` object are valid according to your schema,
+then the API would return `201 Created` and the plugin would be stored in the
+database along with its configuration (`{foo = "bar"}` in this case). If the
+configuration is not valid, the Admin API would return `400 Bad Request` and
+the appropriate error messages.
+
+## Module
+
+```
+kong.plugins.<plugin_name>.schema
+```
+
+## schema.lua specifications
+
+This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
+
+| Property name                 | Lua type    | Default          | Description
+|-------------------------------|-------------|------------------|-------------
+| `no_consumer`                 | Boolean     | `false`          | If true, it will not be possible to apply this plugin to a specific Consumer. This plugin must be applied to Services and Routes only. For example: authentication plugins.
+| `fields`                      | Table       | `{}`             | Your plugin's **schema**. A key/value table of available properties and their rules.
+| `self_check`                  | Function    | `nil`            | A function to implement if you want to perform any custom validation before accepting the plugin's configuration.
+
+The `self_check` function must be implemented as follows:
+
+```lua
+-- @param `schema` A table describing the schema (rules) of your plugin configuration.
+-- @param `config` A key/value table of the current plugin's configuration.
+-- @param `dao` An instance of the DAO (see DAO chapter).
+-- @param `is_updating` A boolean indicating whether or not this check is performed in the context of an update.
+-- @return `valid` A boolean indicating if the plugin's configuration is valid or not.
+-- @return `error` A DAO error (see DAO chapter)
+```
+
+Here is an example of a potential `schema.lua` file:
+
+```lua
+return {
+  no_consumer = true, -- this plugin will only be applied to Services or Routes,
+  fields = {
+    -- Describe your plugin's configuration's schema here.
+  },
+  self_check = function(schema, plugin_t, dao, is_updating)
+    -- perform any custom verification
+    return true
+  end
+}
+```
+
+## Describing your configuration schema
+
+The `fields` property of your `schema.lua` file described the schema of your
+plugin's configuration. It is a flexible key/value table where each key will be
+a valid configuration property for your plugin, and each value a table
+describing the rules for that property. For example:
+
+```lua
+  fields = {
+    some_string = {type = "string", required = true},
+    some_boolean = {type = "boolean", default = false},
+    some_array = {type = "array", enum = {"GET", "POST", "PUT", "DELETE"}}
+  }
+```
+
+Here is the list of accepted rules for a property:
+
+| Rule          | Lua type(s)              | Accepted values                                 | Description
+|---------------|--------------------------|-------------------------------------------------|----------------------------
+| `type`        | string                   | "id", "number", "boolean", "string", "table", "array", "url", "timestamp" | Validates the type of a property.
+| `required`    | boolean                  |                                                 | **Default**: false. If true, the property must be present in the configuration.
+| `unique`      | boolean                  |                                                 | **Default**: false. If true, the value must be unique (see remark below).
+| `default`     | any                      |                                                 | If the property is not specified in the configuration, will set the property to the given value.
+| `immutable`   | boolean                  |                                                 | **Default**: false. If true, the property will not be allowed to be updated once the plugin configuration has been created.
+| `enum`        | table                    | Integer indexed table                           | A list of accepted values for a property. Any value not included in this list will not be accepted.
+| `regex`       | string                   | A valid PCRE regular expression                 | A regex against which to validate the property's value.
+| `schema`      | table                    | A nested schema definition                      | If the property's `type` is table, defines a schema against which to validate those sub-properties.
+| `func`        | function                 |                                                 | A function to perform any custom validation on a property. See later examples for its parameters and return values.
+
+> - **type**: will cast the value retrieved from the request parameters. If the type is not one of the native Lua types, custom verification is performed against it:
+>   - id: must be a string
+>   - timestamp: must be a number
+>   - url: must be a valid URL
+>   - array: must be an integer-indexed table (equivalent of arrays in Lua). In
+>     the Admin API, such an array can either be sent by having several times
+>     the property's key with different values in the request's body, or
+>     comma-delimited through a single body parameter.
+> - **unique**: This property does not make sense for a plugin configuration,
+>   but is used when a plugin needs to store custom entities in the datastore.
+> - **schema**: if you need to perform deepened validation of nested
+>   properties, this field allows you to create a nested schema. Schema
+>   verification is **recursive**. Any level of nesting is valid, but bear in
+>   mind that this will affect the usability of your plugin.
+> - **Any property attached to a configuration object but not present in your
+>   schema will also invalidate the said configuration.**
+
+---
+
+### Examples
+
+This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin
+defines a default list of accepted parameter names for an API key, and a
+boolean whose default is set to `false`:
+
+```lua
+-- schema.lua
+return {
+  no_consumer = true,
+  fields = {
+    key_names = {type = "array", required = true, default = {"apikey"}},
+    hide_credentials = {type = "boolean", default = false}
+  }
+}
+```
+
+Hence, when implementing the `access()` function of your plugin in
+[handler.lua]({{page.book.chapters.custom-logic}}) and given that the user
+enabled the plugin with the default values, you'd have access to:
+
+```lua
+-- handler.lua
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:access(config)
+  CustomHandler.super.access(self)
+
+  kong.log.inspect(config.key_names)        -- {"apikey"}
+  kong.log.inspect(config.hide_credentials) -- false
+end
+
+return CustomHandler
+```
+
+Note that the above example uses the
+[kong.log.inspect](http://localhost:3000/docs/0.14.x/pdk/kong.log/#kong_log_inspect)
+function of the [Plugin Development Kit] to print out those values to the Kong
+logs.
+
+---
+
+A more complex example, which could be used for an eventual logging plugin:
+
+```lua
+-- schema.lua
+
+local function server_port(given_value, given_config)
+  -- Custom validation
+  if given_value > 65534 then
+    return false, "port value too high"
+  end
+
+  -- If environment is "development", 8080 will be the default port
+  if given_config.environment == "development" then
+    return true, nil, {port = 8080}
+  end
+end
+
+return {
+  fields = {
+    environment = {type = "string", required = true, enum = {"production", "development"}}
+    server = {
+      type = "table",
+      schema = {
+        fields = {
+          host = {type = "url", default = "http://example.com"},
+          port = {type = "number", func = server_port, default = 80}
+        }
+      }
+    }
+  }
+}
+```
+
+Such a configuration will allow a user to post the configuration to your plugin
+as follows:
+
+```bash
+$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+    -d "name=my-custom-plugin" \
+    -d "config.environment=development" \
+    -d "config.server.host=http://localhost"
+```
+
+And the following will be available in
+[handler.lua]({{page.book.chapters.custom-logic}}):
+
+```lua
+-- handler.lua
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:access(config)
+  CustomHandler.super.access(self)
+
+  kong.log.inspect(config.environment) -- "development"
+  kong.log.inspect(config.server.host) -- "http://localhost"
+  kong.log.inspect(config.server.port) -- 8080
+end
+
+return CustomHandler
+```
+
+You can also see a real-world example of schema in [the Key-Auth plugin source code].
+
+---
+
+Next: [Store custom entities &rsaquo;]({{page.book.next}})
+
+[Admin API]: /{{page.kong_version}}/admin-api
+[Plugin Development Kit]: /{{page.kong_version}}/pdk
+[the Key-Auth plugin source code]: https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/schema.lua

--- a/app/1.0.x/plugin-development/tests.md
+++ b/app/1.0.x/plugin-development/tests.md
@@ -1,0 +1,108 @@
+---
+title: Plugin Development - Writing tests
+book: plugin_dev
+chapter: 9
+toc: false
+---
+
+## Introduction
+
+If you are serious about your plugins, you probably want to write tests for it.
+Unit testing Lua is easy, and [many testing
+frameworks](http://lua-users.org/wiki/UnitTesting) are available. However, you
+might also want to write integration tests. Again, Kong has your back.
+
+## Write integration tests
+
+The preferred testing framework for Kong is
+[busted](http://olivinelabs.com/busted/) running with the
+[resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
+free to use another one if you wish. In the Kong repository, the busted
+executable can be found at `bin/busted`.
+
+Kong provides you with a helper to start and stop it from Lua in your test
+suite: `spec.helpers`. This helper also provides you with ways to insert
+fixtures in your datastore before running your tests, as well as dropping it,
+and various other helpers.
+
+If you are writing your plugin in your own repository, you will need to copy
+the following files until the Kong testing framework is released:
+
+- `bin/busted`: the busted executable running with the resty-cli interpreter
+- `spec/helpers.lua`: helper functions to start/stop Kong from busted
+- `spec/kong_tests.conf`: a configuration file for your running your test Kong instances with the helpers module
+
+Assuming that the `spec.helpers` module is available in your `LUA_PATH`, you
+can use the following Lua code in busted to start and stop Kong:
+
+```lua
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+  describe("my plugin", function()
+
+    local bp = helpers.get_db_utils(strategy)
+
+    setup(function()
+      local service = bp.services:insert {
+        name = "test-service",
+        host = "httpbin.org"
+      }
+
+      bp.routes:insert({
+        hosts = { "test.com" },
+        service = { id = service.id }
+      })
+
+      -- start Kong with your testing Kong configuration (defined in "spec.helpers")
+      assert(helpers.start_kong( { plugins = "bundled,my-plugin" }))
+
+      admin_client = helpers.admin_client()
+    end)
+
+    teardown(function()
+      if admin_client then
+        admin_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+      if proxy_client then
+        proxy_client:close()
+      end
+    end)
+
+    describe("thing", function()
+      it("should do thing", function()
+        -- send requests through Kong
+        local res = proxy_client:get("/get", {
+          headers = {
+            ["Host"] = "test.com"
+          }
+        })
+
+        local body = assert.res_status(200, res)
+
+        -- body is a string containing the response
+      end)
+    end)
+  end)
+end
+```
+
+> Reminder: With the test Kong configuration file, Kong is running with
+its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
+and Admin API on port 9001.
+
+If you want to see a real-world example, give a look at the
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/10-key-auth)
+
+---
+
+Next: [Distribute your plugin &rsaquo;]({{page.book.next}})

--- a/app/1.0.x/proxy.md
+++ b/app/1.0.x/proxy.md
@@ -1,0 +1,1075 @@
+---
+title: Proxy Reference
+---
+
+## Introduction
+
+In this document we will cover Kong's **proxying capabilities**  by explaining
+its routing capabilities and internal workings in details.
+
+Kong exposes several interfaces which can be tweaked by two configuration
+properties:
+
+- `proxy_listen`, which defines a list of addresses/ports on which Kong will
+  accept **public traffic** from clients and proxy it to your upstream services
+  (`8000` by default).
+- `admin_listen`, which also defines a list of addresses and ports, but those
+  should be restricted to only be accessed by administrators, as they expose
+  Kong's configuration capabilities: the **Admin API** (`8001` by default).
+
+<div class="alert alert-warning">
+<p><strong>Note:</strong> Starting with 0.13.0, the API entity was
+deprecated. This document will cover proxying with the new Routes and
+Services entities.</p>
+<p>See an older version of this document if you are using 0.12 or
+below.</p>
+</div>
+
+## Terminology
+
+- `client`: Refers to the *downstream* client making requests to Kong's
+  proxy port.
+- `upstream service`: Refers to your own API/service sitting behind Kong, to
+  which client requests are forwarded.
+- `Service`: Service entities, as the name implies, are abstractions of each of
+  your own upstream services. Examples of Services would be a data
+  transformation microservice, a billing API, etc.
+- `Route`: This refers to the Kong Routes entity. Routes are entrypoints into
+  Kong, and defining rules for a request to be matched, and routed to a given
+  Service.
+- `Plugin`: This refers to Kong "plugins", which are pieces of business logic
+  that run in the proxying lifecycle. Plugins can be configured through the
+  Admin API - either globally (all incoming traffic) or on specific Routes
+  and Services.
+
+[Back to TOC](#table-of-contents)
+
+## Overview
+
+From a high-level perspective, Kong listens for HTTP traffic on its configured
+proxy port(s) (`8000` and `8443` by default). Kong will evaluate any incoming
+HTTP request against the Routes you have configured and try to find a matching
+one. If a given request matches the rules of a specific Route, Kong will
+process proxying the request. Because each Route is linked to a Service, Kong
+will run the plugins you have configured on your Route and its associated
+Service, and then proxy the request upstream.
+
+You can manage Routes via Kong's Admin API. The `hosts`, `paths`, and `methods`
+attributes of Routes define rules for matching incoming HTTP requests.
+
+If Kong receives a request that it cannot match against any of the configured
+Routes (or if no Routes are configured), it will respond with:
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+Server: kong/<x.x.x>
+
+{
+    "message": "no route and no API found with those values"
+}
+```
+
+**Note**: this message mentions "APIs" since for backwards-compatibility
+reasons, Kong 0.13 still supports the API entity (and tries to match a request
+against any configured API if no Route was matched first).
+
+[Back to TOC](#table-of-contents)
+
+## Reminder: How to configure a Service
+
+The [Configuring a Service][configuring-a-service] quickstart guide explains
+how Kong is configured via the [Admin API][API].
+
+Adding a Service to Kong is done by sending an HTTP request to the Admin API:
+
+```bash
+$ curl -i -X POST http://localhost:8001/services/ \
+    -d 'name=foo-service' \
+    -d 'url=http://foo-service.com'
+HTTP/1.1 201 Created
+...
+
+{
+    "connect_timeout": 60000,
+    "created_at": 1515537771,
+    "host": "foo-service.com",
+    "id": "d54da06c-d69f-4910-8896-915c63c270cd",
+    "name": "foo-service",
+    "path": "/",
+    "port": 80,
+    "protocol": "http",
+    "read_timeout": 60000,
+    "retries": 5,
+    "updated_at": 1515537771,
+    "write_timeout": 60000
+}
+```
+
+This request instructs Kong to register a Service named "foo-service", which
+points to `http://foo-service.com` (your upstream).
+
+**Note:** the `url` argument is a shorthand argument to populate the
+`protocol`, `host`, `port`, and `path` attributes at once.
+
+Now, in order to send traffic to this Service through Kong, we need to specify
+a Route, which acts as an entrypoint to Kong:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes/ \
+    -d 'hosts[]=example.com' \
+    -d 'paths[]=/foo' \
+    -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+HTTP/1.1 201 Created
+...
+
+{
+    "created_at": 1515539858,
+    "hosts": [
+        "example.com"
+    ],
+    "id": "ee794195-6783-4056-a5cc-a7e0fde88c81",
+    "methods": null,
+    "paths": [
+        "/foo"
+    ],
+    "preserve_host": false,
+    "priority": 0,
+    "protocols": [
+        "http",
+        "https"
+    ],
+    "service": {
+        "id": "d54da06c-d69f-4910-8896-915c63c270cd"
+    },
+    "strip_path": true,
+    "updated_at": 1515539858
+}
+```
+
+We have now configured a Route to match incoming requests matching the given
+`hosts` and `paths`, and forward them to the `foo-service` we configured, thus
+proxying this traffic to `http://foo-service.com`.
+
+Kong is a transparent proxy, and it will by default forward the request to your
+upstream service untouched, with the exception of various headers such as
+`Connection`, `Date`, and others as required by the HTTP specifications.
+
+[Back to TOC](#table-of-contents)
+
+## Routes and matching capabilities
+
+Let's now discuss how Kong matches a request against the configured `hosts`,
+`paths` and `methods` properties (or fields) of a Route. Note that all three of
+these fields are **optional**, but at least **one of them** must be specified.
+
+For a request to match a Route:
+
+- The request **must** include **all** of the configured fields
+- The values of the fields in the request **must** match at least one of the
+  configured values (While the field configurations accepts one or more values,
+  a request needs only one of the values to be considered a match)
+
+Let's go through a few examples. Consider a Route configured like this:
+
+```json
+{
+    "hosts": ["example.com", "foo-service.com"],
+    "paths": ["/foo", "/bar"],
+    "methods": ["GET"]
+}
+```
+
+Some of the possible requests matching this Route would look like:
+
+```http
+GET /foo HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /bar HTTP/1.1
+Host: foo-service.com
+```
+
+```http
+GET /foo/hello/world HTTP/1.1
+Host: example.com
+```
+
+All three of these requests satisfy all the conditions set in the Route
+definition.
+
+However, the following requests would **not** match the configured conditions:
+
+```http
+GET / HTTP/1.1
+Host: example.com
+```
+
+```http
+POST /foo HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /foo HTTP/1.1
+Host: foo.com
+```
+
+All three of these requests satisfy only two of configured conditions. The
+first request's path is not a match for any of the configured `paths`, same for
+the second request's HTTP method, and the third request's Host header.
+
+Now that we understand how the `hosts`, `paths`, and `methods` properties work
+together, let's explore each property individually.
+
+[Back to TOC](#table-of-contents)
+
+### Request Host header
+
+Routing a request based on its Host header is the most straightforward way to
+proxy traffic through Kong, especially since this is the intended usage of the
+HTTP Host header. Kong makes it easy to do via the `hosts` field of the Route
+entity.
+
+`hosts` accepts multiple values, which must be comma-separated when specifying
+them via the Admin API:
+
+`hosts` accepts multiple values, which is straightforward to represent in a
+JSON payload:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes/ \
+    -H 'Content-Type: application/json' \
+    -d '{"hosts":["example.com", "foo-service.com"]}'
+HTTP/1.1 201 Created
+...
+```
+
+But since the Admin API also supports form-urlencoded content types, you
+can specify an array via the `[]` notation:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes/ \
+    -d 'hosts[]=example.com' \
+    -d 'hosts[]=foo-service.com'
+HTTP/1.1 201 Created
+...
+```
+
+To satisfy the `hosts` condition of this Route, any incoming request from a
+client must now have its Host header set to one of:
+
+```
+Host: example.com
+```
+
+or:
+
+```
+Host: foo-service.com
+```
+
+[Back to TOC](#table-of-contents)
+
+#### Using wildcard hostnames
+
+To provide flexibility, Kong allows you to specify hostnames with wildcards in
+the `hosts` field. Wildcard hostnames allow any matching Host header to satisfy
+the condition, and thus match a given Route.
+
+Wildcard hostnames **must** contain **only one** asterisk at the leftmost
+**or** rightmost label of the domain. Examples:
+
+- `*.example.com` would allow Host values such as `a.example.com` and
+  `x.y.example.com` to match.
+- `example.*` would allow Host values such as `example.com` and `example.org`
+  to match.
+
+A complete example would look like this:
+
+```json
+{
+    "hosts": ["*.example.com", "service.com"]
+}
+```
+
+Which would allow the following requests to match this Route:
+
+```http
+GET / HTTP/1.1
+Host: an.example.com
+```
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+[Back to TOC](#table-of-contents)
+
+#### The `preserve_host` property
+
+When proxying, Kong's default behavior is to set the upstream request's Host
+header to the hostname specified in the Service's `host`. The
+`preserve_host` field accepts a boolean flag instructing Kong not to do so.
+
+For example, when the `preserve_host` property is not changed and a Route is
+configured like so:
+
+```json
+{
+    "hosts": ["service.com"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+A possible request from a client to Kong could be:
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+Kong would extract the Host header value from the Service's `host` property, ,
+and would send the following upstream request:
+
+```http
+GET / HTTP/1.1
+Host: <my-service-host.com>
+```
+
+However, by explicitly configuring a Route with `preserve_host=true`:
+
+```json
+{
+    "hosts": ["service.com"],
+    "preserve_host": true,
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+And assuming the same request from the client:
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+Kong would preserve the Host on the client request and would send the following
+upstream request instead:
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+[Back to TOC](#table-of-contents)
+
+### Request path
+
+Another way for a Route to be matched is via request paths. To satisfy this
+routing condition, a client request's path **must** be prefixed with one of the
+values of the `paths` attribute.
+
+For example, with a Route configured like so:
+
+```json
+{
+    "paths": ["/service", "/hello/world"]
+}
+```
+
+The following requests would be matched:
+
+```http
+GET /service HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /service/resource?param=value HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /hello/world/resource HTTP/1.1
+Host: anything.com
+```
+
+For each of these requests, Kong detects that their URL path is prefixed with
+one of the Routes's `paths` values. By default, Kong would then proxy the
+request upstream without changing the URL path.
+
+When proxying with path prefixes, **the longest paths get evaluated first**.
+This allow you to define two Routes with two paths: `/service` and
+`/service/resource`, and ensure that the former does not "shadow" the latter.
+
+[Back to TOC](#table-of-contents)
+
+#### Using regexes in paths
+
+Kong supports regular expression pattern matching for an Route's `paths` field
+via [PCRE](http://pcre.org/) (Perl Compatible Regular Expression). You can
+assign paths as both prefixes and regexes to a Route at the same time.
+
+For example, if we consider the following Route:
+
+```json
+{
+    "paths": ["/users/\d+/profile", "/following"]
+}
+```
+
+The following requests would be matched by this Route:
+
+```http
+GET /following HTTP/1.1
+Host: ...
+```
+
+```http
+GET /users/123/profile HTTP/1.1
+Host: ...
+```
+
+The provided regexes are evaluated with the `a` PCRE flag (`PCRE_ANCHORED`),
+meaning that they will be constrained to match at the first matching point
+in the path (the root `/` character).
+
+[Back to TOC](#table-of-contents)
+
+##### Evaluation order
+
+As previously mentioned, Kong evaluates prefix paths by length: the longest
+prefix paths are evaluated first. However, Kong will evaluate regex paths based
+on the `regex_priority` attribute of Routes. This means that considering
+the following Routes:
+
+```json
+[
+    {
+        "paths": ["/status/\d+"],
+        "regex_priority": 0
+    },
+    {
+        "paths": ["/version/\d+/status/\d+"],
+        "regex_priority": 6
+    },
+    {
+        "paths": ["/version"],
+        "regex_priority": 3
+    },
+]
+```
+
+In this scenario, Kong will evaluate incoming requests against the following
+defined URIs, in this order:
+
+1. `/version`
+2. `/version/\d+/status/\d+`
+3. `/status/\d+`
+
+Prefix paths are always evaluated first.
+
+As usual, a request must still match a Route's `hosts` and `methods` properties
+as well, and Kong will traverse your Routes until it finds one that matches
+the most rules (see [Routing priorities][proxy-routing-priorities]).
+
+[Back to TOC](#table-of-contents)
+
+##### Capturing groups
+
+Capturing groups are also supported, and the matched group will be extracted
+from the path and available for plugins consumption. If we consider the
+following regex:
+
+```
+/version/(?<version>\d+)/users/(?<user>\S+)
+```
+
+And the following request path:
+
+```
+/version/1/users/john
+```
+
+Kong will consider the request path a match, and if the overall Route is
+matched (considering the `hosts` and `methods` fields), the extracted capturing
+groups will be available from the plugins in the `ngx.ctx` variable:
+
+```lua
+local router_matches = ngx.ctx.router_matches
+
+-- router_matches.uri_captures is:
+-- { "1", "john", version = "1", user = "john" }
+```
+
+[Back to TOC](#table-of-contents)
+
+##### Escaping special characters
+
+Next, it is worth noting that characters found in regexes are often
+reserved characters according to
+[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+should be percent-encoded. **When configuring Routes with regex paths via the
+Admin API, be sure to URL encode your payload if necessary**. For example,
+with `curl` and using an `application/x-www-form-urlencoded` MIME type:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes \
+    --data-urlencode 'uris[]=/status/\d+'
+HTTP/1.1 201 Created
+...
+```
+
+Note that `curl` does not automatically URL encode your payload, and note the
+usage of `--data-urlencode`, which prevents the `+` character to be URL decoded
+and interpreted as a space ` ` by Kong's Admin API.
+
+[Back to TOC](#table-of-contents)
+
+#### The `strip_path` property
+
+It may be desirable to specify a path prefix to match a Route, but not
+include it in the upstream request. To do so, use the `strip_path` boolean
+property by configuring a Route like so:
+
+```json
+{
+    "paths": ["/service"],
+    "strip_path": true,
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+Enabling this flag instructs Kong that when matching this Route, and proceeding
+with the proxying to a Service, it should **not** include the matched part of
+the URL path in the upstream request's URL. For example, the following
+client's request to the above Route:
+
+```http
+GET /service/path/to/resource HTTP/1.1
+Host: ...
+```
+
+Will cause Kong to send the following upstream request:
+
+```http
+GET /path/to/resource HTTP/1.1
+Host: ...
+```
+
+The same way, if a regex path is defined on a Route that has `strip_path`
+enabled, the entirety of the request URL matching sequence will be stripped.
+Example:
+
+```json
+{
+    "paths": ["/version/\d+/service"],
+    "strip_path": true,
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+The following HTTP request matching the provided regex path:
+
+```http
+GET /version/1/service/path/to/resource HTTP/1.1
+Host: ...
+```
+
+Will be proxied upstream by Kong as:
+
+```http
+GET /path/to/resource HTTP/1.1
+Host: ...
+```
+
+[Back to TOC](#table-of-contents)
+
+### Request HTTP method
+
+The `methods` field allows matching the requests depending on their HTTP
+method.  It accepts multiple values. Its default value is empty (the HTTP
+method is not used for routing).
+
+The following Route allows routing via `GET` and `HEAD`:
+
+```json
+{
+    "methods": ["GET", "HEAD"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+Such a Route would be matched with the following requests:
+
+```http
+GET / HTTP/1.1
+Host: ...
+```
+
+```http
+HEAD /resource HTTP/1.1
+Host: ...
+```
+
+But it would not match a `POST` or `DELETE` request. This allows for much more
+granularity when configuring plugins on Routes. For example, one could imagine
+two Routes pointing to the same service: one with unlimited unauthenticated
+`GET` requests, and a second one allowing only authenticated and rate-limited
+`POST` requests (by applying the authentication and rate limiting plugins to
+such requests).
+
+[Back to TOC](#table-of-contents)
+
+## Matching priorities
+
+A Route may define matching rules based on its `hosts`, `paths`, and `methods`
+fields. For Kong to match an incoming request to a Route, all existing fields
+must be satisfied. However, Kong allows for quite some flexibility by allowing
+two or more Routes to be configured with fields containing the same values -
+when this occurs, Kong applies a priority rule.
+
+The rule is: **when evaluating a request, Kong will first try to match the
+Routes with the most rules**.
+
+For example, if two Routes are configured like so:
+
+```json
+{
+    "hosts": ["example.com"],
+    "service": {
+        "id": "..."
+    }
+},
+{
+    "hosts": ["example.com"],
+    "methods": ["POST"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+The second Route has a `hosts` field **and** a `methods` field, so it will be
+evaluated first by Kong. By doing so, we avoid the first Route "shadowing"
+calls intended for the second one.
+
+Thus, this request will match the first Route
+
+```http
+GET / HTTP/1.1
+Host: example.com
+```
+
+And this request will match the second one:
+
+```http
+POST / HTTP/1.1
+Host: example.com
+```
+
+Following this logic, if a third Route was to be configured with a `hosts`
+field, a `methods` field, and a `uris` field, it would be evaluated first by
+Kong.
+
+[Back to TOC](#table-of-contents)
+
+## Proxying behavior
+
+The proxying rules above detail how Kong forwards incoming requests to your
+upstream services. Below, we detail what happens internally between the time
+Kong *matches* an HTTP request with a registered Route, and the actual
+*forwarding* of the request.
+
+[Back to TOC](#table-of-contents)
+
+### 1. Load balancing
+
+Kong implements load balancing capabilities to distribute proxied
+requests across a pool of instances of an upstream service.
+
+You can find more information about configuring load balancing by consulting
+the [Load Balancing Reference][load-balancing-reference].
+
+[Back to TOC](#table-of-contents)
+
+### 2. Plugins execution
+
+Kong is extensible via "plugins" that hook themselves in the request/response
+lifecycle of the proxied requests. Plugins can perform a variety of operations
+in your environment and/or transformations on the proxied request.
+
+Plugins can be configured to run globally (for all proxied traffic) or on
+specific Routes and Services. In both cases, you must create a [plugin
+configuration][plugin-configuration-object] via the Admin API.
+
+Once a Route has been matched (and its associated Service entity), Kong will
+run plugins associated to either of those entities. Plugins configured on a
+Route run before plugins configured on a Service, but otherwise, the usual
+rules of [plugins association][plugin-association-rules] apply.
+
+These configured plugins will run their `access` phase, which you can find more
+information about in the [Plugin development guide][plugin-development-guide].
+
+[Back to TOC](#table-of-contents)
+
+### 3. Proxying & upstream timeouts
+
+Once Kong has executed all the necessary logic (including plugins), it is ready
+to forward the request to your upstream service. This is done via Nginx's
+[ngx_http_proxy_module][ngx-http-proxy-module]. You can configure the desired
+timeouts for the connection between Kong and a given upstream, via the following
+properties of a Service:
+
+- `upstream_connect_timeout`: defines in milliseconds the timeout for
+  establishing a connection to your upstream service. Defaults to `60000`.
+- `upstream_send_timeout`: defines in milliseconds a timeout between two
+  successive write operations for transmitting a request to your upstream
+  service.  Defaults to `60000`.
+- `upstream_read_timeout`: defines in milliseconds a timeout between two
+  successive read operations for receiving a request from your upstream
+  service.  Defaults to `60000`.
+
+Kong will send the request over HTTP/1.1, and set the following headers:
+
+- `Host: <your_upstream_host>`, as previously described in this document.
+- `Connection: keep-alive`, to allow for reusing the upstream connections.
+- `X-Real-IP: <remote_addr>`, where `$remote_addr` is the variable bearing
+  the same name provided by
+  [ngx_http_core_module][ngx-remote-addr-variable]. Please note that the
+  `$remote_addr` is likely overridden by
+  [ngx_http_realip_module][ngx-http-realip-module].
+- `X-Forwarded-For: <address>`, where `<address>` is the content of
+  `$realip_remote_addr` provided by
+  [ngx_http_realip_module][ngx-http-realip-module] appended to the request
+  header with the same name.
+- `X-Forwarded-Proto: <protocol>`, where `<protocol>` is the protocol used by
+  the client. In the case where `$realip_remote_addr` is one of the **trusted**
+  addresses, the request header with the same name gets forwarded if provided.
+  Otherwise, the value of the `$scheme` variable provided by
+  [ngx_http_core_module][ngx-scheme-variable] will be used.
+- `X-Forwarded-Host: <host>`, where `<host>` is the host name sent by
+  the client. In the case where `$realip_remote_addr` is one of the **trusted**
+  addresses, the request header with the same name gets forwarded if provided.
+  Otherwise, the value of the `$host` variable provided by
+  [ngx_http_core_module][ngx-host-variable] will be used.
+- `X-Forwarded-Port: <port>`, where `<port>` is the port of the server which
+  accepted a request. In the case where `$realip_remote_addr` is one of the
+  **trusted** addresses, the request header with the same name gets forwarded
+  if provided. Otherwise, the value of the `$server_port` variable provided by
+  [ngx_http_core_module][ngx-server-port-variable] will be used.
+
+All the other request headers are forwarded as-is by Kong.
+
+One exception to this is made when using the WebSocket protocol. If so, Kong
+will set the following headers to allow for upgrading the protocol between the
+client and your upstream services:
+
+- `Connection: Upgrade`
+- `Upgrade: websocket`
+
+More information on this topic is covered in the
+[Proxy WebSocket traffic][proxy-websocket] section.
+
+[Back to TOC](#table-of-contents)
+
+### 4. Errors & retries
+
+Whenever an error occurs during proxying, Kong will use the underlying
+Nginx [retries][ngx-http-proxy-retries] mechanism to pass the request on to
+the next upstream.
+
+There are two configurable elements here:
+
+1. The number of retries: this can be configured per Service using the
+   `retries` property. See the [Admin API][API] for more details on this.
+
+2. What exactly constitutes an error: here Kong uses the Nginx defaults, which
+   means an error or timeout occurring while establishing a connection with the
+   server, passing a request to it, or reading the response headers.
+
+The second option is based on Nginx's
+[proxy_next_upstream][proxy_next_upstream] directive. This option is not
+directly configurable through Kong, but can be added using a custom Nginx
+configuration. See the [configuration reference][configuration-reference] for
+more details.
+
+[Back to TOC](#table-of-contents)
+
+### 5. Response
+
+Kong receives the response from the upstream service and sends it back to the
+downstream client in a streaming fashion. At this point Kong will execute
+subsequent plugins added to the Route and/or Service that implement a hook in
+the `header_filter` phase.
+
+Once the `header_filter` phase of all registered plugins has been executed, the
+following headers will be added by Kong and the full set of headers be sent to
+the client:
+
+- `Via: kong/x.x.x`, where `x.x.x` is the Kong version in use
+- `X-Kong-Proxy-Latency: <latency>`, where `latency` is the time in milliseconds
+  between Kong receiving the request from the client and sending the request to
+  your upstream service.
+- `X-Kong-Upstream-Latency: <latency>`, where `latency` is the time in
+  milliseconds that Kong was waiting for the first byte of the upstream service
+  response.
+
+Once the headers are sent to the client, Kong will start executing
+registered plugins for the Route and/or Service that implement the
+`body_filter` hook. This hook may be called multiple times, due to the
+streaming nature of Nginx. Each chunk of the upstream response that is
+successfully processed by such `body_filter` hooks is sent back to the client.
+You can find more information about the `body_filter` hook in the [Plugin
+development guide][plugin-development-guide].
+
+[Back to TOC](#table-of-contents)
+
+## Configuring a fallback Route
+
+As a practical use-case and example of the flexibility offered by Kong's
+proxying capabilities, let's try to implement a "fallback Route", so that in
+order to avoid Kong responding with an HTTP `404`, "no route found", we can
+catch such requests and proxy them to a special upstream service, or apply a
+plugin to it (such a plugin could, for example, terminate the request with a
+different status code or response without proxying the request).
+
+Here is an example of such a fallback Route:
+
+```json
+{
+    "paths": ["/"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+As you can guess, any HTTP request made to Kong would actually match this
+Route, since all URIs are prefixed by the root character `/`. As we know from
+the [Request path][proxy-request-path] section, the longest URL paths are
+evaluated first by Kong, so the `/` path will eventually be evaluated last by
+Kong, and effectively provide a "fallback" Route, only matched as a last
+resort. You can then send traffic to a special Service or apply any plugin you
+wish on this Route.
+
+[Back to TOC](#table-of-contents)
+
+## Configuring SSL for a Route
+
+Kong provides a way to dynamically serve SSL certificates on a per-connection
+basis. SSL certificates are directly handled by the core, and configurable via
+the Admin API. Clients connecting to Kong over TLS must support the [Server
+Name Indication][SNI] extension to make use of this feature.
+
+SSL certificates are handled by two resources in the Kong Admin API:
+
+- `/certificates`, which stores your keys and certificates.
+- `/snis`, which associates a registered certificate with a Server Name
+  Indication.
+
+You can find the documentation for those two resources in the
+[Admin API Reference][API].
+
+Here is how to configure an SSL certificate on a given Route: first, upload
+your SSL certificate and key via the Admin API:
+
+```bash
+$ curl -i -X POST http://localhost:8001/certificates \
+    -F "cert=@/path/to/cert.pem" \
+    -F "key=@/path/to/cert.key" \
+    -F "snis=ssl-example.com,other-ssl-example.com"
+HTTP/1.1 201 Created
+...
+```
+
+The `snis` form parameter is a sugar parameter, directly inserting an SNI and
+associating the uploaded certificate to it.
+
+You must now register the following Route within Kong. We will match requests
+to this Route using only the Host header for convenience:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes \
+    -d 'hosts=ssl-example.com,other-ssl-example.com' \
+    -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+HTTP/1.1 201 Created
+...
+```
+
+You can now expect the Route to be served over HTTPS by Kong:
+
+```bash
+$ curl -i https://localhost:8443/ \
+  -H "Host: ssl-example.com"
+HTTP/1.1 200 OK
+...
+```
+
+When establishing the connection and negotiating the SSL handshake, if your
+client sends `ssl-example.com` as part of the SNI extension, Kong will serve
+the `cert.pem` certificate previously configured.
+
+[Back to TOC](#table-of-contents)
+
+### Restricting the client protocol (HTTP/HTTPS)
+
+Routes have a `protocols` property to restrict the client protocol they should
+listen for. This attribute accepts a set of values, which can be `http` or
+`https`.
+
+A Route with `http` and `https` will accept traffic regardless of the protocol
+the client is connecting with (plain-text or over TLS):
+
+```json
+{
+    "hosts": ["..."],
+    "paths": ["..."],
+    "methods": ["..."],
+    "protocols": ["http", "https"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+Not specifying `https` has the same effect, a route would accept both
+plain-text and TLS traffic:
+
+```json
+{
+    "hosts": ["..."],
+    "paths": ["..."],
+    "methods": ["..."],
+    "protocols": ["http"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+However, a Route with only `https` would _only_ accept traffic over TLS. It
+would _also_ accept unencrypted traffic _if_ SSL termination previously
+occurred from a trusted IP. SSL termination is considered valid when the
+request comes from one of the configured IPs in
+[trusted_ips][configuration-trusted-ips] and if the `X-Forwarded-Proto: https`
+header is set:
+
+```json
+{
+    "hosts": ["..."],
+    "paths": ["..."],
+    "methods": ["..."],
+    "protocols": ["https"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+If a Route such as the above matches a request, but that request is in
+plain-text without valid prior SSL termination, Kong responds with:
+
+```http
+HTTP/1.1 426 Upgrade Required
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: Upgrade
+Upgrade: TLS/1.2, HTTP/1.1
+Server: kong/x.y.z
+
+{"message":"Please use HTTPS protocol"}
+```
+
+[Back to TOC](#table-of-contents)
+
+## Proxy WebSocket traffic
+
+Kong supports WebSocket traffic thanks to the underlying Nginx implementation.
+When you wish to establish a WebSocket connection between a client and your
+upstream services *through* Kong, you must establish a WebSocket handshake.
+This is done via the HTTP Upgrade mechanism. This is what your client request
+made to Kong would look like:
+
+```http
+GET / HTTP/1.1
+Connection: Upgrade
+Host: my-websocket-api.com
+Upgrade: WebSocket
+```
+
+This will make Kong forward the `Connection` and `Upgrade` headers to your
+upstream service, instead of dismissing them due to the hop-by-hop nature of a
+standard HTTP proxy.
+
+[Back to TOC](#table-of-contents)
+
+### WebSocket and TLS
+
+Kong will accept `ws` and `wss` connections on its respective `http` and
+`https` ports. To enforce TLS connections from clients, set the `protocols`
+property of the [Route][route-entity] to `https` only.
+
+When setting up the [Service][service-entity] to point to your upstream
+WebSocket service, you should carefully pick the protocol you want to use
+between Kong and the upstream. If you want to use TLS (`wss`), then the
+upstream WebSocket service must be defined using the `https` protocol in the
+Service `protocol` property, and the proper port (usually 443). To connect
+without TLS (`ws`), then the `http` protocol and port (usually 80) should be
+used in `protocol` instead.
+
+If you want Kong to terminate SSL/TLS, you can accept `wss` only from the
+client, but proxy to the upstream service over plain text, or `ws`.
+
+[Back to TOC](#table-of-contents)
+
+## Conclusion
+
+Through this guide, we hope you gained knowledge of the underlying proxying
+mechanism of Kong, from how does a request match a Route to be routed to its
+associated Service, on to how to allow for using the WebSocket protocol or
+setup dynamic SSL certificates.
+
+This website is Open-Source and can be found at
+[github.com/Kong/docs.konghq.com](https://github.com/Kong/docs.konghq.com/).
+Feel free to provide feedback to this document there, or propose improvements!
+
+If you haven't already, we suggest that you also read the [Load balancing
+Reference][load-balancing-reference], as it closely relates to the topic we
+just covered.
+
+[Back to TOC](#table-of-contents)
+
+[plugin-configuration-object]: /{{page.kong_version}}/admin-api#plugin-object
+[plugin-development-guide]: /{{page.kong_version}}/plugin-development
+[plugin-association-rules]: /{{page.kong_version}}/admin-api/#precedence
+[load-balancing-reference]: /{{page.kong_version}}/loadbalancing
+[configuration-reference]: /{{page.kong_version}}/configuration-reference
+[configuration-trusted-ips]: /{{page.kong_version}}/configuration/#trusted_ips
+[configuring-a-service]: /{{page.kong_version}}/getting-started/configuring-a-service
+[API]: /{{page.kong_version}}/admin-api
+[service-entity]: /{{page.kong_version}}/admin-api/#add-service
+[route-entity]: /{{page.kong_version}}/admin-api/#add-route
+
+[ngx-http-proxy-module]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html
+[ngx-http-realip-module]: http://nginx.org/en/docs/http/ngx_http_realip_module.html
+[ngx-remote-addr-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_remote_addr
+[ngx-scheme-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_scheme
+[ngx-host-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host
+[ngx-server-port-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_server_port
+[ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
+[SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication

--- a/app/1.0.x/secure-admin-api.md
+++ b/app/1.0.x/secure-admin-api.md
@@ -1,0 +1,159 @@
+---
+title: Securing the Admin API
+---
+
+## Introduction
+
+Kong's Admin API provides a RESTful interface for administration and
+configuration of Services, Routes, Plugins, Consumers, and Credentials. Because this
+API allows full control of Kong, it is important to secure this API against
+unwanted access. This document describes a few possible approaches to securing
+the Admin API.
+
+## Network Layer Access Restrictions
+
+### Minimal Listening Footprint
+
+By default since its 0.12.0 release, Kong will only accept requests from the
+local interface, as specified in its default `admin_listen` value:
+
+```
+admin_listen = 127.0.0.1:8001
+```
+
+If you change this value, always ensure to keep the listening footprint to a
+minimum, in order to avoid exposing your Admin API to third-parties, which
+could seriously compromise the security of your Kong cluster as a whole.
+For example, **avoid binding Kong to all of your interfaces**, by using
+values such as `0.0.0.0:8001`.
+
+[Back to TOC](#table-of-contents)
+
+### Layer 3/4 Network Controls
+
+In cases where the Admin API must be exposed beyond a localhost interface,
+network security best practices dictate that network-layer access be restricted
+as much as possible. Consider an environment in which Kong listens on a private
+network interface, but should only be accessed by a small subset of an IP range.
+In such a case, host-based firewalls (e.g. iptables) are useful in limiting
+input traffic ranges. For example:
+
+
+```bash
+# assume that Kong is listening on the address defined below, as defined as a
+# /24 CIDR block, and only a select few hosts in this range should have access
+
+$ grep admin_listen /etc/kong/kong.conf
+admin_listen 10.10.10.3:8001
+
+# explicitly allow TCP packets on port 8001 from the Kong node itself
+# this is not necessary if Admin API requests are not sent from the node
+$ iptables -A INPUT -s 10.10.10.3 -m tcp -p tcp --dport 8001 -j ACCEPT
+
+# explicitly allow TCP packets on port 8001 from the following addresses
+$ iptables -A INPUT -s 10.10.10.4 -m tcp -p tcp --dport 8001 -j ACCEPT
+$ iptables -A INPUT -s 10.10.10.5 -m tcp -p tcp --dport 8001 -j ACCEPT
+
+# drop all TCP packets on port 8001 not in the above IP list
+$ iptables -A INPUT -m tcp -p tcp --dport 8001 -j DROP
+
+```
+
+Additional controls, such as similar ACLs applied at a network device level, are
+encouraged, but fall outside the scope of this document.
+
+[Back to TOC](#table-of-contents)
+
+## Kong API Loopback
+
+Kong's routing design allows it to serve as a proxy for the Admin API itself. In
+this manner, Kong itself can be used to provide fine-grained access control to
+the Admin API. Such an environment requires bootstrapping a new Service that defines
+the `admin_listen` address as the Service's `url`. For example:
+
+```bash
+# assume that Kong has defined admin_listen as 127.0.0.1:8001, and we want to
+# reach the Admin API via the url `/admin-api`
+
+$ curl -X POST http://localhost:8001/services \
+  --data name=admin-api \
+  --data host=localhost \
+  --data port=8001
+
+$ curl -X POST http://localhost:8001/services/admin-api/routes \
+  --data paths[]=/admin-api
+
+# we can now transparently reach the Admin API through the proxy server
+$ curl localhost:8000/admin-api/apis
+{
+   "data":[
+      {
+         "uris":[
+            "\/admin-api"
+         ],
+         "id":"653b21bd-4d81-4573-ba00-177cc0108dec",
+         "upstream_read_timeout":60000,
+         "preserve_host":false,
+         "created_at":1496351805000,
+         "upstream_connect_timeout":60000,
+         "upstream_url":"http:\/\/localhost:8001",
+         "strip_uri":true,
+         "https_only":false,
+         "name":"admin-api",
+         "http_if_terminated":true,
+         "upstream_send_timeout":60000,
+         "retries":5
+      }
+   ],
+   "total":1
+}
+```
+
+From here, simply apply desired Kong-specific security controls (such as
+[basic][basic-auth] or [key authentication][key-auth],
+[IP restrictions][ip-restriction], or [access control lists][acl]) as you would
+normally to any other Kong API.
+
+[Back to TOC](#table-of-contents)
+
+## Custom Nginx Configuration
+
+Kong is tightly coupled with Nginx as an HTTP daemon, and can thus be integrated
+into environments with custom Nginx configurations. In this manner, use cases
+with complex security/access control requirements can use the full power of
+Nginx/OpenResty to build server/location blocks to house the Admin API as
+necessary. This allows such environments to leverage native Nginx authorization
+and authentication mechanisms, ACL modules, etc., in addition to providing the
+OpenResty environment on which custom/complex security controls can be built.
+
+For more information on integrating Kong into custom Nginx configurations, see
+[Custom Nginx configuration & embedding Kong][custom-configuration].
+
+[Back to TOC](#table-of-contents)
+
+## Role Based Access Control ##
+
+<div class="alert alert-warning">
+  <strong>Enterprise-Only</strong> This feature is only available with an
+  Enterprise Subscription.
+</div>
+
+Enterprise users can configure role-based access control to secure access to the
+Admin API. RBAC allows for fine-grained control over resource access based on
+a model of user roles and permissions. Users are assigned to one or more roles,
+which each in turn possess one or more permissions granting or denying access
+to a particular resource. In this way, fine-grained control over specific Admin
+API resources can be enforced, while scaling to allow complex, case-specific
+uses.
+
+If you are not a Kong Enterprise customer, you can inquire about our
+Enterprise offering by [contacting us](/enterprise).
+
+[Back to TOC](#table-of-contents)
+
+
+[acl]: /plugins/acl
+[basic-auth]: /plugins/basic-authentication/
+[custom-configuration]: /{{page.kong_version}}/configuration/#custom-nginx-configuration
+[ip-restriction]: /plugins/ip-restriction
+[key-auth]: /plugins/key-authentication

--- a/app/_data/docs_nav_1.0.x.yml
+++ b/app/_data/docs_nav_1.0.x.yml
@@ -1,0 +1,311 @@
+- title: Getting Started
+  items:
+    - text: Introduction
+      url: /getting-started/introduction
+
+    - text: Five-minute quickstart
+      url: /getting-started/quickstart
+
+    - text: Configuring a Service
+      url: /getting-started/configuring-a-service
+
+    - text: Enabling Plugins
+      url: /getting-started/enabling-plugins
+
+    - text: Adding Consumers
+      url: /getting-started/adding-consumers
+
+- title: Guides &amp; References
+  items:
+    - text: Configuration reference
+      url: /configuration
+
+    - text: CLI reference
+      url: /cli
+
+    - text: Proxy reference
+      url: /proxy
+
+    - text: Authentication reference
+      url: /auth
+
+    - text: Load balancing reference
+      url: /loadbalancing
+
+    - text: Health checks and circuit breakers reference
+      url: /health-checks-circuit-breakers
+
+    - text: Clustering reference
+      url: /clustering
+
+    - text: Logging reference
+      url: /logging
+
+    - text: Network &amp; Firewall
+      url: /network
+
+    - text: Securing the Admin API
+      url: /secure-admin-api
+
+    - text: Plugin Development Guide
+      url: /plugin-development
+      items:
+        - text: Introduction
+          url: /plugin-development
+
+        - text: File structure
+          url: /plugin-development/file-structure
+
+        - text: Implementing custom logic
+          url: /plugin-development/custom-logic
+
+        - text: Plugin configuration
+          url: /plugin-development/plugin-configuration
+
+        - text: Accessing the datastore
+          url: /plugin-development/access-the-datastore
+
+        - text: Storing custom entities
+          url: /plugin-development/custom-entities
+
+        - text: Caching custom entities
+          url: /plugin-development/entities-cache
+
+        - text: Extending the Admin API
+          url: /plugin-development/admin-api
+
+        - text: Writing tests
+          url: /plugin-development/tests
+
+        - text: (un)Installing your plugin
+          url: /plugin-development/distribution
+
+    - text: Plugin Development Kit
+      url: /pdk
+      items:
+
+      - text: kong.client
+        url: /pdk/kong.client
+
+      - text: kong.ctx
+        url: /pdk/kong.ctx
+
+      - text: kong.ip
+        url: /pdk/kong.ip
+
+      - text: kong.log
+        url: /pdk/kong.log
+
+      - text: kong.request
+        url: /pdk/kong.request
+
+      - text: kong.response
+        url: /pdk/kong.response
+
+      - text: kong.service
+        url: /pdk/kong.service
+
+      - text: kong.service.request
+        url: /pdk/kong.service.request
+
+      - text: kong.service.response
+        url: /pdk/kong.service.response
+
+      - text: kong.table
+        url: /pdk/kong.table
+
+
+- title: Admin API
+  url: /admin-api/
+  items:
+    - text: Supported Content Types
+      url: /admin-api/#supported-content-types
+
+    - text: Information routes
+      url: /admin-api/#information-routes
+      items:
+        - text: Retrieve node information
+          url: /admin-api/#retrieve-node-information
+
+        - text: Retrieve node status
+          url: /admin-api/#retrieve-node-status
+
+    - text: Service Object
+      url: /admin-api/#service-object
+      items:
+        - text: Add Service
+          url: /admin-api/#add-service
+
+        - text: Retrieve Service
+          url: /admin-api/#retrieve-service
+
+        - text: List Services
+          url: /admin-api/#list-services
+
+        - text: Update Service
+          url: /admin-api/#update-service
+
+        - text: Update or create Service
+          url: /admin-api/#update-or-create-service
+
+        - text: Delete Service
+          url: /admin-api/#delete-service
+
+    - text: Route Object
+      url: /admin-api/#route-object
+      items:
+        - text: Add Route
+          url: /admin-api/#add-route
+
+        - text: Retrieve Route
+          url: /admin-api/#retrieve-route
+
+        - text: List Routes
+          url: /admin-api/#list-routes
+
+        - text: List Routes associated to a Service
+          url: /admin-api/#list-routes-associated-to-a-service
+
+        - text: Update Route
+          url: /admin-api/#update-route
+
+        - text: Update or create Route
+          url: /admin-api/#update-or-create-route
+
+        - text: Delete Route
+          url: /admin-api/#delete-route
+
+    - text: Consumer Object routes
+      url: /admin-api/#consumer-object
+      items:
+        - text: Create Consumer
+          url: /admin-api/#create-consumer
+
+        - text: Retrieve Consumer
+          url: /admin-api/#retrieve-consumer
+
+        - text: List Consumers
+          url: /admin-api/#list-consumers
+
+        - text: Update Consumer
+          url: /admin-api/#update-consumer
+
+        - text: Update or create Consumer
+          url: /admin-api/#update-or-create-consumer
+
+        - text: Delete Consumer
+          url: /admin-api/#delete-consumer
+
+    - text: Plugin Object routes
+      url: /admin-api/#plugin-object
+      items:
+        - text: Add Plugin
+          url: /admin-api/#add-plugin
+
+        - text: Retrieve Plugin
+          url: /admin-api/#retrieve-plugin
+
+        - text: List all Plugins
+          url: /admin-api/#list-all-plugins
+
+        - text: Update Plugin
+          url: /admin-api/#update-plugin
+
+        - text: Update or Add Plugin
+          url: /admin-api/#update-or-add-plugin
+
+        - text: Delete Plugin
+          url: /admin-api/#delete-plugin
+
+        - text: Retrieve Enabled Plugins
+          url: /admin-api/#retrieve-enabled-plugins
+
+        - text: Retrieve Plugin Schema
+          url: /admin-api/#retrieve-plugin-schema
+
+    - text: Certificate Object routes
+      url: /admin-api/#certificate-object
+      items:
+        - text: Add Certificate
+          url: /admin-api/#add-certificate
+
+        - text: Retrieve Certificate
+          url: /admin-api/#retrieve-certificate
+
+        - text: List Certificates
+          url: /admin-api/#list-certificates
+
+        - text: Update Certificate
+          url: /admin-api/#update-certificate
+
+        - text: Update or Create Certificate
+          url: /admin-api/#update-or-create-certificate
+
+        - text: Delete Certificate
+          url: /admin-api/#delete-certificate
+
+    - text: SNI Object routes
+      url: /admin-api/#sni-objects
+      items:
+        - text: Add SNI
+          url: /admin-api/#add-sni
+
+        - text: Retrieve SNI
+          url: /admin-api/#retrieve-sni
+
+        - text: List SNIs
+          url: /admin-api/#list-snis
+
+        - text: Update SNI
+          url: /admin-api/#update-sni
+
+        - text: Update or Create SNI
+          url: /admin-api/#update-or-create-sni
+
+        - text: Delete SNI
+          url: /admin-api/#delete-sni
+
+    - text: Upstream Object routes
+      url: /admin-api/#upstream-objects
+      items:
+        - text: Add Upstream
+          url: /admin-api/#add-upstream
+
+        - text: Retrieve Upstream
+          url: /admin-api/#retrieve-upstream
+
+        - text: List all Upstreams
+          url: /admin-api/#list-upstreams
+
+        - text: Update Upstream
+          url: /admin-api/#update-upstream
+
+        - text: Update or create Upstream
+          url: /admin-api/#update-or-create-upstream
+
+        - text: Delete Upstream
+          url: /admin-api/#delete-upstream
+
+        - text: Show Upstream health for node
+          url: /admin-api/#show-upstream-health-for-node
+
+    - text: Target Object routes
+      url: /admin-api/#target-object
+      items:
+        - text: Add Target
+          url: /admin-api/#add-target
+
+        - text: List Targets
+          url: /admin-api/#list-targets
+
+        - text: List All Targets
+          url: /admin-api/#list-all-targets
+
+        - text: Delete Target
+          url: /admin-api/#delete-target
+
+        - text: Set Target as Healthy
+          url: /admin-api/#set-target-as-healthy
+
+        - text: Set Target as Unhealthy
+          url: /admin-api/#set-target-as-unhealthy

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -134,6 +134,16 @@
     postgres: "9.5+"
     openresty: "1.13.6.2"
 -
+  release: "1.0"
+  version: "1.0"
+  luarocks_version: "1.0.0-0"
+  dependencies:
+    luajit: "2.1.0-beta2"
+    luarocks: "2.4.3"
+    cassandra: "3.x.x"
+    postgres: "9.5+"
+    openresty: "1.13.6.2"
+-
   release: "0.31-x"
   version: "0.31"
   edition: "enterprise"

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -134,12 +134,12 @@
     postgres: "9.5+"
     openresty: "1.13.6.2"
 -
-  release: "1.0"
-  version: "1.0"
+  release: "1.0.x"
+  version: "1.0.0"
   luarocks_version: "1.0.0-0"
   dependencies:
     luajit: "2.1.0-beta2"
-    luarocks: "2.4.3"
+    luarocks: "3.0.4"
     cassandra: "3.x.x"
     postgres: "9.5+"
     openresty: "1.13.6.2"

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -128,7 +128,7 @@
   version: "0.14.1"
   luarocks_version: "0.14.1-0"
   dependencies:
-    luajit: "2.1.0-beta2"
+    luajit: "2.1.0-beta3"
     luarocks: "2.4.3"
     cassandra: "3.x.x"
     postgres: "9.5+"
@@ -138,7 +138,7 @@
   version: "1.0.0"
   luarocks_version: "1.0.0-0"
   dependencies:
-    luajit: "2.1.0-beta2"
+    luajit: "2.1.0-beta3"
     luarocks: "3.0.4"
     cassandra: "3.x.x"
     postgres: "9.5+"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ignore": [
       "Makefile",
       "dist/**",
-      "app/0*/**",
+      "app/*.x/**",
       "app/enterprise/**/*",
       "app/_assets/images/**",
       "app/_assets/fonts/**",


### PR DESCRIPTION
* Changes the kong_versions.yml file so that it is "in sync" with the folder structure we have (1.0.x instead of 1.0)
* Copies 0.14.x files on the folder so we can see the website while we make changes

Things pending:

* The PDK needs to be regenerated
* The "install" section seems to be independent from the rest of the docs. It is unclear if changing the kong_versions.yml affects it or not
* 0.14.x plugins still have references to old APIs
* admin api is for 0.14.x. We might need to update changed objects (Upstreams, targets, plugins)
* We need service mesh / streams docs
* @thibaultcha mentioned that we might want to drop the .x on the 1.0.x urls
