### PR TITLE
Clarify route priority example

### DIFF
--- a/app/0.14.x/proxy.md
+++ b/app/0.14.x/proxy.md
@@ -448,8 +448,8 @@ in the path (the root `/` character).
 
 As previously mentioned, Kong evaluates prefix paths by length: the longest
 prefix paths are evaluated first. However, Kong will evaluate regex paths based
-on the `regex_priority` attribute of Routes. This means that considering
-the following Routes:
+on the `regex_priority` attribute of Routes from highest priority to lowest.
+This means that considering the following Routes:
 
 ```json
 [
@@ -463,19 +463,22 @@ the following Routes:
     },
     {
         "paths": ["/version"],
-        "regex_priority": 3
     },
+    {
+        "paths": ["/version/any/"],
+    }
 ]
 ```
 
 In this scenario, Kong will evaluate incoming requests against the following
 defined URIs, in this order:
 
-1. `/version`
-2. `/version/\d+/status/\d+`
-3. `/status/\d+`
+1. `/version/any/`
+2. `/version
+3. `/version/\d+/status/\d+`
+4. `/status/\d+`
 
-Prefix paths are always evaluated first.
+Prefix paths are always evaluated before regex paths.
 
 As usual, a request must still match a Route's `hosts` and `methods` properties
 as well, and Kong will traverse your Routes until it finds one that matches

--- a/app/1.0.x/proxy.md
+++ b/app/1.0.x/proxy.md
@@ -444,8 +444,8 @@ in the path (the root `/` character).
 
 As previously mentioned, Kong evaluates prefix paths by length: the longest
 prefix paths are evaluated first. However, Kong will evaluate regex paths based
-on the `regex_priority` attribute of Routes. This means that considering
-the following Routes:
+on the `regex_priority` attribute of Routes from highest priority to lowest.
+This means that considering the following Routes:
 
 ```json
 [
@@ -459,19 +459,22 @@ the following Routes:
     },
     {
         "paths": ["/version"],
-        "regex_priority": 3
     },
+    {
+        "paths": ["/version/any/"],
+    }
 ]
 ```
 
 In this scenario, Kong will evaluate incoming requests against the following
 defined URIs, in this order:
 
-1. `/version`
-2. `/version/\d+/status/\d+`
-3. `/status/\d+`
+1. `/version/any/`
+2. `/version`
+3. `/version/\d+/status/\d+`
+4. `/status/\d+`
 
-Prefix paths are always evaluated first.
+Prefix paths are always evaluated before regex paths.
 
 As usual, a request must still match a Route's `hosts` and `methods` properties
 as well, and Kong will traverse your Routes until it finds one that matches


### PR DESCRIPTION
### Summary

Update route priority example to clarify difference between regex and prefix path routes. Add a second prefix example to demonstrate prefix path sorting. Added several minor points of clarification to surrounding description.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

The existing prefix example included a `regex_priority` on a prefix route although it does serve any function. Though this route was then (correctly) sorted above regex routes, the inclusion of a superfluous priority could confuse users into thinking priority was evaluated lowest to highest, which is incorrect.

This change removes the superfluous priority and adds a second prefix route to demonstrate their sorting (by length).

Only applied to 0.14 and 1.0, as I don't think this is significant enough to backport to earlier docs. 0.15 doesn't have this doc yet for some reason; I did not create it.