### PR TITLE
docs(config) replace kong.conf.default with generic path and a note TD-31

### DIFF
--- a/app/0.11.x/getting-started/quickstart.md
+++ b/app/0.11.x/getting-started/quickstart.md
@@ -35,7 +35,7 @@ supports PostgreSQL and Cassandra).
     ```
 
     **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to your own configuration.
+    allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 

--- a/app/0.11.x/getting-started/quickstart.md
+++ b/app/0.11.x/getting-started/quickstart.md
@@ -17,32 +17,32 @@ supports PostgreSQL and Cassandra).
 
 ## 1. Start Kong
 
-    Issue the following command to prepare your datastore by running the Kong
-    migrations:
+Issue the following command to prepare your datastore by running the Kong
+migrations:
 
-    ```bash
-    $ kong migrations up [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong migrations up [-c /path/to/kong.conf]
+```
 
-    You should see a message that tells you Kong has successfully migrated your
-    database. If not, you probably incorrectly configured your database
-    connection settings in your configuration file.
+You should see a message that tells you Kong has successfully migrated your
+database. If not, you probably incorrectly configured your database
+connection settings in your configuration file.
 
-    Now let's [start][CLI] Kong:
+Now let's [start][CLI] Kong:
 
-    ```bash
-    $ kong start [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong start [-c /path/to/kong.conf]
+```
 
-    **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to [your own configuration][configuration-loading].
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
-    If everything went well, you should see a message (`Kong started`)
-    informing you that Kong is running.
+If everything went well, you should see a message (`Kong started`)
+informing you that Kong is running.
 
-    By default Kong listens on the following ports:
+By default Kong listens on the following ports:
 
 - `:8000` on which Kong listens for incoming HTTP traffic from your
   clients, and forwards it to your upstream services.
@@ -54,20 +54,20 @@ supports PostgreSQL and Cassandra).
 
 ## 3. Stop Kong
 
-    As needed you can stop the Kong process by issuing the following
-    [command][CLI]:
+As needed you can stop the Kong process by issuing the following
+[command][CLI]:
 
-    ```bash
-    $ kong stop
-    ```
+```bash
+$ kong stop
+```
 
 ## 4. Reload Kong
 
-    Issue the following command to [reload][CLI] Kong without downtime:
+Issue the following command to [reload][CLI] Kong without downtime:
 
-    ```bash
-    $ kong reload
-    ```
+```bash
+$ kong reload
+```
 
 ## Next Steps
 

--- a/app/0.11.x/getting-started/quickstart.md
+++ b/app/0.11.x/getting-started/quickstart.md
@@ -75,6 +75,7 @@ Now that you have Kong running you can interact with the Admin API.
 
 To begin, go to [Adding your API &rsaquo;][adding-your-api]
 
+[configuration-loading]: /{{page.kong_version}}/configuration/#configuration-loading
 [CLI]: /{{page.kong_version}}/cli
 [API]: /{{page.kong_version}}/admin-api
 [datastore-section]: /{{page.kong_version}}/configuration/#datastore-section

--- a/app/0.12.x/getting-started/quickstart.md
+++ b/app/0.12.x/getting-started/quickstart.md
@@ -17,32 +17,32 @@ supports PostgreSQL and Cassandra).
 
 ## 1. Start Kong
 
-    Issue the following command to prepare your datastore by running the Kong
-    migrations:
+Issue the following command to prepare your datastore by running the Kong
+migrations:
 
-    ```bash
-    $ kong migrations up [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong migrations up [-c /path/to/kong.conf]
+```
 
-    You should see a message that tells you Kong has successfully migrated your
-    database. If not, you probably incorrectly configured your database
-    connection settings in your configuration file.
+You should see a message that tells you Kong has successfully migrated your
+database. If not, you probably incorrectly configured your database
+connection settings in your configuration file.
 
-    Now let's [start][CLI] Kong:
+Now let's [start][CLI] Kong:
 
-    ```bash
-    $ kong start [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong start [-c /path/to/kong.conf]
+```
 
-    **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to [your own configuration][configuration-loading].
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
-    If everything went well, you should see a message (`Kong started`)
-    informing you that Kong is running.
+If everything went well, you should see a message (`Kong started`)
+informing you that Kong is running.
 
-    By default Kong listens on the following ports:
+By default Kong listens on the following ports:
 
 - `:8000` on which Kong listens for incoming HTTP traffic from your
   clients, and forwards it to your upstream services.
@@ -54,20 +54,20 @@ supports PostgreSQL and Cassandra).
 
 ## 3. Stop Kong
 
-    As needed you can stop the Kong process by issuing the following
-    [command][CLI]:
+As needed you can stop the Kong process by issuing the following
+[command][CLI]:
 
-    ```bash
-    $ kong stop
-    ```
+```bash
+$ kong stop
+```
 
 ## 4. Reload Kong
 
-    Issue the following command to [reload][CLI] Kong without downtime:
+Issue the following command to [reload][CLI] Kong without downtime:
 
-    ```bash
-    $ kong reload
-    ```
+```bash
+$ kong reload
+```
 
 ## Next Steps
 

--- a/app/0.12.x/getting-started/quickstart.md
+++ b/app/0.12.x/getting-started/quickstart.md
@@ -35,7 +35,7 @@ supports PostgreSQL and Cassandra).
     ```
 
     **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to your own configuration.
+    allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
@@ -75,6 +75,7 @@ Now that you have Kong running you can interact with the Admin API.
 
 To begin, go to [Adding your API &rsaquo;][adding-your-api]
 
+[configuration-loading]: /{{page.kong_version}}/configuration/#configuration-loading
 [CLI]: /{{page.kong_version}}/cli
 [API]: /{{page.kong_version}}/admin-api
 [datastore-section]: /{{page.kong_version}}/configuration/#datastore-section

--- a/app/0.13.x/getting-started/quickstart.md
+++ b/app/0.13.x/getting-started/quickstart.md
@@ -35,7 +35,7 @@ supports PostgreSQL and Cassandra).
     ```
 
     **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to your own configuration.
+    allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
@@ -75,6 +75,7 @@ Now that you have Kong running you can interact with the Admin API.
 
 To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
 
+[configuration-loading]: /{{page.kong_version}}/configuration/#configuration-loading
 [CLI]: /{{page.kong_version}}/cli
 [API]: /{{page.kong_version}}/admin-api
 [datastore-section]: /{{page.kong_version}}/configuration/#datastore-section

--- a/app/0.13.x/getting-started/quickstart.md
+++ b/app/0.13.x/getting-started/quickstart.md
@@ -17,32 +17,32 @@ supports PostgreSQL and Cassandra).
 
 ## 1. Start Kong
 
-    Issue the following command to prepare your datastore by running the Kong
-    migrations:
+Issue the following command to prepare your datastore by running the Kong
+migrations:
 
-    ```bash
-    $ kong migrations up [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong migrations up [-c /path/to/kong.conf]
+```
 
-    You should see a message that tells you Kong has successfully migrated your
-    database. If not, you probably incorrectly configured your database
-    connection settings in your configuration file.
+You should see a message that tells you Kong has successfully migrated your
+database. If not, you probably incorrectly configured your database
+connection settings in your configuration file.
 
-    Now let's [start][CLI] Kong:
+Now let's [start][CLI] Kong:
 
-    ```bash
-    $ kong start [-c /path/to/kong.conf]
-    ```
+```bash
+$ kong start [-c /path/to/kong.conf]
+```
 
-    **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-    allowing you to point to [your own configuration][configuration-loading].
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
-    If everything went well, you should see a message (`Kong started`)
-    informing you that Kong is running.
+If everything went well, you should see a message (`Kong started`)
+informing you that Kong is running.
 
-    By default Kong listens on the following ports:
+By default Kong listens on the following ports:
 
 - `:8000` on which Kong listens for incoming HTTP traffic from your
   clients, and forwards it to your upstream services.
@@ -54,20 +54,20 @@ supports PostgreSQL and Cassandra).
 
 ## 3. Stop Kong
 
-    As needed you can stop the Kong process by issuing the following
-    [command][CLI]:
+As needed you can stop the Kong process by issuing the following
+[command][CLI]:
 
-    ```bash
-    $ kong stop
-    ```
+```bash
+$ kong stop
+```
 
 ## 4. Reload Kong
 
-    Issue the following command to [reload][CLI] Kong without downtime:
+Issue the following command to [reload][CLI] Kong without downtime:
 
-    ```bash
-    $ kong reload
-    ```
+```bash
+$ kong reload
+```
 
 ## Next Steps
 

--- a/app/0.14.x/getting-started/quickstart.md
+++ b/app/0.14.x/getting-started/quickstart.md
@@ -33,7 +33,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration][configuration-loading].
 
 [Back to TOC](#table-of-contents)
 
@@ -81,6 +81,7 @@ Now that you have Kong running you can interact with the Admin API.
 
 To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
 
+[configuration-loading]: /{{page.kong_version}}/configuration/#configuration-loading
 [CLI]: /{{page.kong_version}}/cli
 [API]: /{{page.kong_version}}/admin-api
 [datastore-section]: /{{page.kong_version}}/configuration/#datastore-section

--- a/app/1.0.x/getting-started/quickstart.md
+++ b/app/1.0.x/getting-started/quickstart.md
@@ -33,7 +33,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
@@ -73,6 +73,7 @@ Now that you have Kong running you can interact with the Admin API.
 
 To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
 
+[configuration-loading]: /{{page.kong_version}}/configuration/#configuration-loading
 [CLI]: /{{page.kong_version}}/cli
 [API]: /{{page.kong_version}}/admin-api
 [datastore-section]: /{{page.kong_version}}/configuration/#datastore-section

--- a/app/enterprise/0.31-x/getting-started/quickstart.md
+++ b/app/enterprise/0.31-x/getting-started/quickstart.md
@@ -34,7 +34,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration](https://docs.konghq.com/0.12.x/configuration/#configuration-loading).
 
 ## 2. Verify that Kong EE has started successfully
 

--- a/app/enterprise/0.31-x/installation/amazon-linux.md
+++ b/app/enterprise/0.31-x/installation/amazon-linux.md
@@ -46,12 +46,14 @@ $ sudo service postgresql95 restart
 $ sudo vi /etc/kong/license.json
 
 # Uncomment and add 'kong' to pg_password line
-$ sudo vi /etc/kong/kong.conf.default
+$ sudo vi [/path/to/kong.conf]
 
 # Run migrations and start kong
-$ kong migrations up -c /etc/kong/kong.conf.default
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ kong migrations up [-c /path/to/kong.conf]
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
+
+**Note:** You may use `kong.conf.default` or create [your own configuration](https://docs.konghq.com/0.12.x/configuration/#configuration-loading).
 
 ### Test your Kong installation
 
@@ -74,11 +76,11 @@ $ ifconfig
 
 # Uncomment the admin_listen setting, and update to 
 # something like this `admin_listen = 172.31.3.8:8001`
-$ sudo vi /etc/kong/kong.conf.default 
+$ sudo vi [/path/to/kong.conf] 
 
 # Restart kong
 $ sudo /usr/local/bin/kong stop 
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
 
 In a browser, load your server on port `8002`

--- a/app/enterprise/0.32-x/getting-started/quickstart.md
+++ b/app/enterprise/0.32-x/getting-started/quickstart.md
@@ -34,7 +34,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 ## 2. Verify that Kong EE has started successfully
 

--- a/app/enterprise/0.32-x/installation/amazon-linux.md
+++ b/app/enterprise/0.32-x/installation/amazon-linux.md
@@ -42,12 +42,14 @@ $ sudo service postgresql95 restart
 $ sudo vi /etc/kong/license.json
 
 # Uncomment and add 'kong' to pg_password line
-$ sudo vi /etc/kong/kong.conf.default
+$ sudo vi [/path/to/kong.conf]
 
 # Run migrations and start kong
-$ kong migrations up -c /etc/kong/kong.conf.default
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ kong migrations up [-c /path/to/kong.conf]
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
+
+**Note:** You may use `kong.conf.default` or create [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 ## Setup HTTPie to make commands easier
 
@@ -71,11 +73,11 @@ $ http :8000/ip
 $ ifconfig 
 
 # Uncomment the admin_listen setting, and update to something like this `admin_listen = 172.31.3.8:8001`
-$ sudo vi /etc/kong/kong.conf.default 
+$ sudo vi [/path/to/kong.conf] 
 
 # Restart kong
 $ sudo /usr/local/bin/kong stop 
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
 
 In a browser, load your server on port `8002`

--- a/app/enterprise/0.33-x/admin-gui/configuration/getting-started.md
+++ b/app/enterprise/0.33-x/admin-gui/configuration/getting-started.md
@@ -9,9 +9,12 @@ toc: false
 
 Start Kong.
 
-`kong start -c kong.conf.default`
+```bash
+$ kong start [-c /path/to/kong.conf]
+```
 
-> Note: Not all deployments of Kong utilize a configuration file, if this describes you (or you are unsure) please reference the [Kong configuration docs](https://getkong.org/latest/configuration/) in order to implement this step.
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to your own configuration.
 
 Visit the Admin GUI:
 

--- a/app/enterprise/0.33-x/admin-gui/configuration/getting-started.md
+++ b/app/enterprise/0.33-x/admin-gui/configuration/getting-started.md
@@ -14,7 +14,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 Visit the Admin GUI:
 

--- a/app/enterprise/0.33-x/getting-started/quickstart.md
+++ b/app/enterprise/0.33-x/getting-started/quickstart.md
@@ -34,7 +34,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 ## 2. Verify that Kong EE has started successfully
 

--- a/app/enterprise/0.33-x/installation/amazon-linux.md
+++ b/app/enterprise/0.33-x/installation/amazon-linux.md
@@ -42,12 +42,14 @@ $ sudo service postgresql95 restart
 $ sudo vi /etc/kong/license.json
 
 # Uncomment and add 'kong' to pg_password line
-$ sudo vi /etc/kong/kong.conf.default
+$ sudo vi [/path/to/kong.conf]
 
 # Run migrations and start kong
-$ kong migrations up -c /etc/kong/kong.conf.default
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ kong migrations up [-c /path/to/kong.conf]
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
+
+**Note:** You may use `kong.conf.default` or create [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 ## Setup HTTPie to make commands easier
 
@@ -71,11 +73,11 @@ $ http :8000/ip
 $ ifconfig
 
 # Uncomment the admin_listen setting, and update to something like this `admin_listen = 172.31.3.8:8001`
-$ sudo vi /etc/kong/kong.conf.default
+$ sudo vi [/path/to/kong.conf]
 
 # Restart kong
 $ sudo /usr/local/bin/kong stop
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
 
 In a browser, load your server on port `8002`

--- a/app/enterprise/0.34-x/getting-started/quickstart.md
+++ b/app/enterprise/0.34-x/getting-started/quickstart.md
@@ -52,7 +52,7 @@ To set up the first account:
     ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 ## 2. Verify that Kong Enterprise has Started Successfully
 

--- a/app/enterprise/0.34-x/installation/amazon-linux.md
+++ b/app/enterprise/0.34-x/installation/amazon-linux.md
@@ -42,12 +42,14 @@ $ sudo service postgresql95 restart
 $ sudo vi /etc/kong/license.json
 
 # Uncomment and add 'kong' to pg_password line
-$ sudo vi /etc/kong/kong.conf.default
+$ sudo vi [/path/to/kong.conf]
 
 # Run migrations and start kong
-$ kong migrations up -c /etc/kong/kong.conf.default
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ kong migrations up [-c /path/to/kong.conf]
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
+
+**Note:** You may use `kong.conf.default` or create [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading).
 
 ## Install HTTPie to Make Commands more Easily
 
@@ -71,11 +73,11 @@ $ http :8000/ip
 $ ifconfig 
 
 # Uncomment the admin_listen setting, and update to something like this `admin_listen = 172.31.3.8:8001`
-$ sudo vi /etc/kong/kong.conf.default 
+$ sudo vi [/path/to/kong.conf] 
 
 # Restart kong
 $ sudo /usr/local/bin/kong stop 
-$ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf.default
+$ sudo /usr/local/bin/kong start [-c /path/to/kong.conf]
 ```
 
 In a browser, load your server on port `8002`

--- a/app/enterprise/0.34-x/kong-manager/configuration/getting-started.md
+++ b/app/enterprise/0.34-x/kong-manager/configuration/getting-started.md
@@ -9,11 +9,11 @@ chapter: 2
 To start Kong:
 
 ```bash
-$ kong start -c kong.conf.default
+$ kong start [-c /path/to/kong.conf]
 ```
 
-> Note: Not all deployments of Kong use a configuration file, in which case 
-only `kong start` is required.
+**Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+allowing you to point to your own configuration.
 
 Once started, navigate to Kong Manager in the browser at `http://localhost:8002`
 

--- a/app/enterprise/0.34-x/kong-manager/configuration/getting-started.md
+++ b/app/enterprise/0.34-x/kong-manager/configuration/getting-started.md
@@ -13,7 +13,7 @@ $ kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
-allowing you to point to your own configuration.
+allowing you to point to [your own configuration](https://docs.konghq.com/0.13.x/configuration/#configuration-loading)
 
 Once started, navigate to Kong Manager in the browser at `http://localhost:8002`
 


### PR DESCRIPTION
### Summary

Enterprise docs (i.e. Amazon Linux Installation and Kong Manager) mention using `kong.conf.default`. Since users can create their own configuration, it makes more sense to write a generic `path/to/kong.conf`. To better interrelate the docs as part of our new content strategy, the notes now include version-aware links to doc that describes loading configuration files.

### Full changelog

* Replace `-c kong.conf.default` with `[-c /path/to/kong.conf]`
* Add a note about loading different config files
* Provide a link to the correct version of loading config

### Issues resolved

Fix TD-31 (internal)

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] Spellchecked my updates
- [x] Ready to be merged
