### PR TITLE
docs(ee/config) complete property reference for enterprise TD-39

### DIFF
--- a/app/enterprise/0.34-x/admin-api-audit-log.md
+++ b/app/enterprise/0.34-x/admin-api-audit-log.md
@@ -370,49 +370,7 @@ HTTP 200 OK
 
 ### Configuration Reference
 
-#### audit_log 
-
-When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes.
-
-Default: `off`
-
----
-
-#### audit_log_ignore_methods
-
-Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged.
-
-Default: none
-
----
-
-#### audit_log_ignore_paths
-
-Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged.
-
-Default: none
-
----
-
-#### audit_log_ignore_tables
-
-Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term "updates" refers to the creation, update, or deletion of a row).
-
-Default: none
-
----
-
-#### audit_log_record_ttl
-
-Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.
-
-Default: `2592000`
-
----
-
-#### audit_log_signing_key
-Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated.
-
-Default: none
+See the [Data & Admin Audit](/enterprise/{{page.kong_version}}/property-reference#data--admin-audit) 
+section of Kong Enterprise's Configuration Property Reference.
 
 [Back to TOC](#table-of-contents)

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -2,21 +2,55 @@
 title: Configuration Property Reference for Kong Enterprise
 ---
 
-## Kong Manager
+## General
 
 
-### admin_api_uri
+### prefix
 
-**Default:** `NONE` (auto generated)
+See the property description in Kong's configuration reference for 
+[prefix](https://docs.konghq.com/0.13.x/configuration/#prefix)
 
-**Description:**  
 
-Hierarchical part of a URI which is composed 
-optionally of a host, port, and path at which your 
-Admin interface API accepts HTTP or HTTPS traffic. 
-When this config is disabled, the gui will use the 
-window protocol + host and append the resolved 
-admin_gui_listen HTTP/HTTPS port.
+### log_level
+
+See the property description in Kong's configuration reference for 
+[log_level](https://docs.konghq.com/0.13.x/configuration/#log_level)
+
+
+### proxy_access_log
+
+See the property description in Kong's configuration reference for 
+[proxy_access_log](https://docs.konghq.com/0.13.x/configuration/#proxy_access_log)
+
+
+### proxy_error_log 
+
+See the property description in Kong's configuration reference for 
+[proxy_error_log](https://docs.konghq.com/0.13.x/configuration/#proxy_error_log)
+
+
+### adming_access_log
+
+See the property description in Kong's configuration reference for 
+[admin_access_log](https://docs.konghq.com/0.13.x/configuration/#admin_access_log)
+
+
+### admin_error_log
+
+See the property description in Kong's configuration reference for 
+[admin_error_log](https://docs.konghq.com/0.13.x/configuration/#admin_error_log)
+
+
+### custom_plugins 
+
+See the property description in Kong's configuration reference for 
+[custom_plugins](https://docs.konghq.com/0.13.x/configuration/#custom_plugins)
+
+
+### anonymous_reports
+
+See the property description in Kong's configuration reference for 
+[anonymous_reports](https://docs.konghq.com/0.13.x/configuration/#anonymous_reports)
 
 **Example:**
 
@@ -71,6 +105,8 @@ for more details about the `proxy_protocol` parameter.
 proxy_url = https://127.0.0.1:8443
 ```
 
+
+## Kong Manager
 
 ### admin_gui_listen
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -694,6 +694,21 @@ and write source for Vitals data.
 
 ### vitals_statsd_address
 
+**Default:** `NONE` (empty)
+
+**Description:**  
+
+Defines the host and port (and an optional
+protocol) of the StatsD server to which
+Kong should write Vitals metics. This value
+is only applied when the 'vitals_strategy' is
+set to 'prometheus'. This value accepts IPv4,
+IPv6, and, hostnames. Additionally, the suffix
+'tcp' can be specified; doing so will result
+in Kong sending StatsD metrics via TCP
+instead of the UDP (default).
+
+
 ### vitals_statsd_prefix
 
 ### vitals_statsd_udp_packet_size

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -242,6 +242,124 @@ See the property description in Kong's configuration reference for [client_body_
 ### error_default_type
 
 See the property description in Kong's configuration reference for [error_default_type](https://docs.konghq.com/0.13.x/configuration/#error_default_type)
+
+
+## Datastore
+
+
+### database
+
+See the property description in Kong's configuration reference for [database](https://docs.konghq.com/0.13.x/configuration/#database)
+
+
+### pg_host
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### pg_port
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### pg_user
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### pg_password
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### pg_database
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### pg_ssl
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### pg_ssl_verify
+
+See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
+
+### cassandra_contact_points
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_port
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_keyspace
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_timeout
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_ssl
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_ssl_verify
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_username
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_password
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_consistency
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_lb_policy
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_local_datacenter
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_repl_strategy
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_repl_factor
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_data_centers
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+### cassandra_schema_consensus_timeout
+
+See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 ## Kong Manager
 
 ### admin_gui_listen

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -29,8 +29,9 @@ toc: false
 
 **Description:**  
 
-Working directory. Equivalent to Nginx's prefix path, containing temporary files 
-and logs. Each Kong process must have a separate working directory.
+Working directory. Equivalent to Nginx's prefix path, containing 
+temporary files and logs. Each Kong process must have a separate 
+working directory.
 
 
 ### log_level
@@ -39,9 +40,11 @@ and logs. Each Kong process must have a separate working directory.
 
 **Description:**  
 
-Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`.
+Log level of the Nginx server. Logs are found at 
+`<prefix>/logs/error.log`.
 
-**Note:** See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list 
+**Note:** See 
+http://nginx.org/en/docs/ngx_core_module.html#error_log for a list 
 of accepted values.
 
 
@@ -62,8 +65,8 @@ it will be placed under the `prefix` location.
 
 **Description:**
 
-Path for proxy port request error logs. The granularity of these logs 
-is adjusted by the `log_level` directive.
+Path for proxy port request error logs. The granularity of these 
+logs is adjusted by the `log_level` directive.
 
 
 ### admin_access_log
@@ -73,8 +76,8 @@ is adjusted by the `log_level` directive.
 **Description:**
 
 Path for Admin API request access logs. Set this value to `off` to
-disable logging Admin API requests. If this value is a relative path, 
-it will be placed under the `prefix` location.
+disable logging Admin API requests. If this value is a relative 
+path, it will be placed under the `prefix` location.
 
 
 ### admin_error_log
@@ -83,8 +86,8 @@ it will be placed under the `prefix` location.
 
 **Description:**
 
-Path for Admin API request error logs. The granularity of these logs 
-is adjusted by the `log_level` directive.
+Path for Admin API request error logs. The granularity of these 
+logs is adjusted by the `log_level` directive.
 
 
 ### custom_plugins 
@@ -94,8 +97,9 @@ is adjusted by the `log_level` directive.
 **Description:**
 
 Comma-separated list of additional plugins this node should load. 
-Use this property to load custom plugins that are not bundled with Kong. 
-Plugins will be loaded from the `kong.plugins.{name}.*` namespace.
+Use this property to load custom plugins that are not bundled with 
+Kong. Plugins will be loaded from the `kong.plugins.{name}.*` 
+namespace.
 
 
 ### anonymous_reports
@@ -104,7 +108,8 @@ Plugins will be loaded from the `kong.plugins.{name}.*` namespace.
 
 **Description:**
 
-Send anonymous usage data such as error stack traces to help improve Kong.
+Send anonymous usage data such as error stack traces to help 
+improve Kong.
 
 
 ## NGINX

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -17,8 +17,11 @@ and logs. Each Kong process must have a separate working directory.
 
 ### log_level
 
-See the property description in Kong's configuration reference for 
-[log_level](https://docs.konghq.com/0.13.x/configuration/#log_level)
+**Default:** `notice`
+
+**Description:**  
+
+Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`.
 
 
 ### proxy_access_log

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -82,8 +82,11 @@ Plugins will be loaded from the `kong.plugins.{name}.*` namespace.
 
 ### anonymous_reports
 
-See the property description in Kong's configuration reference for 
-[anonymous_reports](https://docs.konghq.com/0.13.x/configuration/#anonymous_reports)
+**Default:** `on`
+
+**Description:**
+
+Send anonymous usage data such as error stack traces to help improve Kong.
 
 
 ## NGINX

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1192,6 +1192,11 @@ Expiration time in seconds for Admin invitation links. Set to zero for no expira
 
 When enabled this flag will only mock the sending of emails and will not attempt to send actual emails. This can be used for testing before the SMTP client is fully configured.
 
+**Examples:**
+
+`smtp_mock = on` Emails will NOT attempt send.
+`smtp_mock = off` Emails will attempt send.
+
 
 ### smtp_host
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -23,14 +23,15 @@ and logs. Each Kong process must have a separate working directory.
 
 Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`.
 
+**Note:** See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list 
+of accepted values.
+
 
 ### proxy_access_log
 
 See the property description in Kong's configuration reference for 
 [proxy_access_log](https://docs.konghq.com/0.13.x/configuration/#proxy_access_log)
 
-**Note:** See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list 
-of accepted values.
 
 ### proxy_error_log 
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -674,6 +674,24 @@ or 'influxdb'.
 
 ### vitals_tsdb_address
 
+**Default:** `NONE` (empty)
+
+**Description:**  
+
+Defines the host and port of the TSDB server
+to which Vitals data is written and read.
+This value is only applied when the
+'vitals_strategy` option is set to
+'prometheus' or 'influxdb'. This value
+accepts IPv4, IPv6, and hostname values.
+If the 'vitals_strategy' is set to
+'prometheus', this value determines the
+address of the Prometheus server from which
+Vitals data will be read. For 'influxdb'
+strategies, this value controls both the read
+and write source for Vitals data.
+
+
 ### vitals_statsd_address
 
 ### vitals_statsd_prefix

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -573,6 +573,7 @@ admin_gui_ssl_key = /path/to/admin_gui_ssl.key
 
 Alters the layout Admin GUI (JSON)
 
+
 ### admin_gui_access_log
 
 **Default:** `logs/admin_gui_access.log`

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1618,8 +1618,9 @@ portal_auth_conf = { "hide_credentials": true }
 
 **Description:**
 
-When this flag is set to 'on', a developer will automatically be marked as "approved" after completing registration. Access can still be revoked through the Kong Manager or Admin API.
-
+When this flag is set to 'on', a developer will automatically be marked as 
+"approved" after completing registration. Access can still be revoked through the 
+Kong Manager or Admin API.
 
 
 ### portal_token_exp
@@ -1628,7 +1629,8 @@ When this flag is set to 'on', a developer will automatically be marked as "appr
 
 **Description:**
 
-Duration in seconds for the expiration of the Dev Portal reset password token. Default `21600` is six hours.
+Duration in seconds for the expiration of the Dev Portal reset password token. 
+Default `21600` is six hours.
 
 
 ## Dev Portal SMTP Configuration

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -40,8 +40,12 @@ it will be placed under the `prefix` location.
 
 ### proxy_error_log 
 
-See the property description in Kong's configuration reference for 
-[proxy_error_log](https://docs.konghq.com/0.13.x/configuration/#proxy_error_log)
+**Default:** `logs/error.log`
+
+**Description:**
+
+Path for proxy port request error logs. The granularity of these logs 
+is adjusted by the `log_level` directive.
 
 
 ### adming_access_log

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1133,15 +1133,6 @@ portal_emails_reply_to: noreply@example.com
 ## Admin SMTP Configuration
 
 
-### admin_invite_email
-
-**Default:** `on`
-
-**Description:**
-
-When enabled invitation emails will be sent to Admins invited to the Kong Manager.
-
-
 ### admin_emails_from
 
 **Default:** `""`

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -559,117 +559,245 @@ same database.
 
 ### database
 
-See the property description in Kong's configuration reference for [database](https://docs.konghq.com/0.13.x/configuration/#database)
+**Default:** `postgres`
+
+**Description:**
+
+Determines which of PostgreSQL or Cassandra
+this node will use as its datastore.
+Accepted values are `postgres` and
+`cassandra`.
 
 
 ### pg_host
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `127.0.0.1 `
+
+**Description:**
+
+The PostgreSQL host to connect to.
 
 
 ### pg_port
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `5432`
+
+**Description:**
+
+The port to connect to.
 
 
 ### pg_user
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `kong`
+
+**Description:**
+
+The username to authenticate if required.
 
 
 ### pg_password
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+The password to authenticate if required.
 
 
 ### pg_database
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `kong`
+
+**Description:**
+
+The database name to connect to.
 
 
 ### pg_ssl
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `off`
+
+**Description:**
+
+Toggles client-server TLS connections
+between Kong and PostgreSQL.
 
 
 ### pg_ssl_verify
 
-See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+**Default:** `off`
 
+**Description:**
+
+Toggles server certificate verification if
+`pg_ssl` is enabled. See the `lua_ssl_trusted_certificate`
+setting to specify a certificate authority.
 
 ### cassandra_contact_points
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `127.0.0.1`
+
+**Description:**
+
+A comma-separated list of contact points to your cluster.
 
 
 ### cassandra_port
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `9042`
+
+**Description:**
+
+The port on which your nodes are listening on. All your nodes and contact 
+points must listen on the same port.
 
 
 ### cassandra_keyspace
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `kong`
+
+**Description:**
+
+The keyspace to use in your cluster.
 
 
 ### cassandra_timeout
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `5000`
+
+**Description:**
+
+Defines the timeout (in ms), for reading and writing.
 
 
 ### cassandra_ssl
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `off`
+
+**Description:**
+
+Toggles client-to-node TLS connections between Kong and Cassandra.
 
 
 ### cassandra_ssl_verify
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `off`
+
+**Description:**
+
+Toggles server certificate verification if
+`cassandra_ssl` is enabled.
+See the `lua_ssl_trusted_certificate`
+setting to specify a certificate authority.
 
 
 ### cassandra_username
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `kong`
+
+**Description:**
+
+Username when using the `PasswordAuthenticator` scheme.
 
 
 ### cassandra_password
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Password when using the `PasswordAuthenticator` scheme.
 
 
 ### cassandra_consistency
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `ONE`
 
+**Description:**
+
+Consistency setting to use when reading/writing to the Cassandra cluster.
 
 ### cassandra_lb_policy
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `RoundRobin`
+
+**Description:**
+
+Load balancing policy to use when
+distributing queries across your Cassandra
+cluster.
+Accepted values are:
+`RoundRobin`, `RequestRoundRobin`,
+`DCAwareRoundRobin`, and
+`RequestDCAwareRoundRobin`.
+Prefer the later if and only if you are
+using a multi-datacenter cluster.
 
 
 ### cassandra_local_datacenter
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+When using the `DCAwareRoundRobin`
+or `RequestDCAwareRoundRobin` load
+balancing policy, you must specify the name
+of the local (closest) datacenter for this
+Kong node.
 
 
 ### cassandra_repl_strategy
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `SimpleStrategy`
 
+**Description:**
+
+When migrating for the first time,
+Kong will use this setting to
+create your keyspace.
+Accepted values are
+`SimpleStrategy` and
+`NetworkTopologyStrategy`.
 
 ### cassandra_repl_factor
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `1`
+
+**Description:**
+
+When migrating for the first time, Kong
+will create the keyspace with this
+replication factor when using the
+`SimpleStrategy`.
 
 
 ### cassandra_data_centers
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `dc1:2,dc2:3`
+
+**Description:**
+
+When migrating for the first time,
+will use this setting when using the
+`NetworkTopologyStrategy`.
+The format is a comma-separated list
+made of <dc_name>:<repl_factor>.
 
 
 ### cassandra_schema_consensus_timeout
 
-See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+**Default:** `10000`
+
+**Description:**
+
+Defines the timeout (in ms) for
+the waiting period to reach a
+schema consensus between your
+Cassandra nodes.
+This value is only used during
+migrations.
 
 
 ## Datastore Cache

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -812,17 +812,53 @@ caching of such configuration entities.
 
 ### db_update_frequency
 
-See the property description in Kong's configuration reference for [db_update_frequency](https://docs.konghq.com/0.13.x/configuration/#db_update_frequency)
+**Default:** `5`
+
+**Description:**
+
+Frequency (in seconds) at which to check for
+updated entities with the datastore.
+When a node creates, updates, or deletes an
+entity via the Admin API, other nodes need
+to wait for the next poll (configured by
+this value) to eventually purge the old
+cached entity and start using the new one.
 
 
 ### db_update_propagation
 
-See the property description in Kong's configuration reference for [db_update_propagation](https://docs.konghq.com/0.13.x/configuration/#db_update_propagation)
+**Default:** `0`
+
+**Description:**
+
+Time (in seconds) taken for an entity in the
+datastore to be propagated to replica nodes
+of another datacenter.
+When in a distributed environment such as
+a multi-datacenter Cassandra cluster, this
+value should be the maximum number of
+seconds taken by Cassandra to propagate a
+row to other datacenters.
+When set, this property will increase the
+time taken by Kong to propagate the change
+of an entity.
+Single-datacenter setups or PostgreSQL
+servers should suffer no such delays, and
+this value can be safely set to 0.
 
 
 ### db_cache_ttl
 
-See the property description in Kong's configuration reference for [db_cache_ttl](https://docs.konghq.com/0.13.x/configuration/#db_cache_ttl)
+**Default:** `3600`
+
+**Description:**
+
+Time-to-live (in seconds) of an entity from
+the datastore when cached by this node.
+Database misses (no entity) are also cached
+according to this setting.
+If set to 0, such cached entities/misses
+never expire.
 
 
 ## DNS Resolver

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -386,25 +386,31 @@ See the property description in Kong's configuration reference for [db_cache_ttl
 
 See the property description in Kong's configuration reference for [dns_resolver](https://docs.konghq.com/0.13.x/configuration/#dns_resolver)
 
+
 ### dns_hostsfile
 
 See the property description in Kong's configuration reference for [dns_hostsfile](https://docs.konghq.com/0.13.x/configuration/#dns_hostsfile)
+
 
 ### dns_order
 
 See the property description in Kong's configuration reference for [dns_order](https://docs.konghq.com/0.13.x/configuration/#dns_order)
 
+
 ### dns_state_ttl
 
 See the property description in Kong's configuration reference for [dns_state_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_state_ttl)
+
 
 ### dns_not_found_ttl
 
 See the property description in Kong's configuration reference for [dns_not_found_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_not_found_ttl)
 
+
 ### dns_error_ttl
 
 See the property description in Kong's configuration reference for [dns_error_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_error_ttl)
+
 
 ### dns_no_sync
 
@@ -418,21 +424,26 @@ See the property description in Kong's configuration reference for [dns_no_sync]
 
 See the property description in Kong's configuration reference for [lua_ssl_trusted_certificate](https://docs.konghq.com/0.13.x/configuration/#lua_ssl_trusted_certificate)
 
+
 ### lua_ssl_verify_depth
 
 See the property description in Kong's configuration reference for [lua_ssl_verify_depth](https://docs.konghq.com/0.13.x/configuration/#lua_ssl_verify_depth)
+
 
 ### lua_package_path
 
 See the property description in Kong's configuration reference for [lua_package_path](https://docs.konghq.com/0.13.x/configuration/#lua_package_path)
 
+
 ### lua_package_cpath
 
 See the property description in Kong's configuration reference for [lua_package_cpath](https://docs.konghq.com/0.13.x/configuration/#lua_package_cpath)
 
+
 ### lua_socket_pool_size
 
 See the property description in Kong's configuration reference for [lua_socket_pool_size](https://docs.konghq.com/0.13.x/configuration/#lua_socket_pool_size)
+
 
 ### enforce_rbac 
 
@@ -454,6 +465,7 @@ token is passed, or the RBAC user with which
 the token is associated does not have
 permissions to access/modify the requested
 resource.
+
 
 ### rbac_auth_header
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1780,7 +1780,9 @@ expiration.
 
 **Description:**
 
-When enabled this flag will only mock the sending of emails and will not attempt to send actual emails. This can be used for testing before the SMTP client is fully configured.
+When enabled this flag will only mock the sending of emails and will not 
+attempt to send actual emails. This can be used for testing before the SMTP 
+client is fully configured.
 
 **Examples:**
 
@@ -1811,7 +1813,8 @@ The port number on SMTP server to connect to.
 
 **Description:**
 
-When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587.
+When set to `on`, STARTTLS is used to encrypt communication with the SMTP 
+server. This is normally used in conjunction with port 587.
 
 
 ### smtp_username
@@ -1838,7 +1841,8 @@ Password used for authentication with the SMTP server.
 
 **Description:**
 
-When set to `on` SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465.
+When set to `on` SMTPS is used to encrypt communication with the SMTP server. 
+This is normally used in conjunction with port 465.
 
 
 ### smtp_auth_type
@@ -1847,7 +1851,8 @@ When set to `on` SMTPS is used to encrypt communication with the SMTP server. Th
 
 **Description:**
 
-The method used to authenticate with the SMTP server. Valid options are `plain`, `login`, or `nil`.
+The method used to authenticate with the SMTP server. Valid options are 
+`plain`, `login`, or `nil`.
 
 
 ### smtp_domain

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -174,8 +174,8 @@ Kong Manager and Dev Portal will use
 the window request host and append the resolved
 listener port depending on the requested protocol.
 
-**Note:** see http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for
-a description of the accepted formats for this and other *_listen values.
+**Note:** see http://nginx.org/en/docs/http/ngx_http_core_module.html#listen 
+for a description of the accepted formats for this and other *_listen values.
 
 **Note:** see https://www.nginx.com/resources/admin-guide/proxy-protocol/
 for more details about the `proxy_protocol` parameter.

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -29,6 +29,8 @@ Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`.
 See the property description in Kong's configuration reference for 
 [proxy_access_log](https://docs.konghq.com/0.13.x/configuration/#proxy_access_log)
 
+**Note:** See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list 
+of accepted values.
 
 ### proxy_error_log 
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -61,8 +61,12 @@ it will be placed under the `prefix` location.
 
 ### admin_error_log
 
-See the property description in Kong's configuration reference for 
-[admin_error_log](https://docs.konghq.com/0.13.x/configuration/#admin_error_log)
+**Default:** `logs/error.log`
+
+**Description:**
+
+Path for Admin API request error logs. The granularity of these logs 
+is adjusted by the `log_level` directive.
 
 
 ### custom_plugins 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1336,7 +1336,8 @@ Prometheus server.
 
 Enable or disable the Dev Portal Interface and API
 
-When enabled, Kong will expose the Kong Dev Portal Files endpoint and the public Dev Portal Files API.
+When enabled, Kong will expose the Kong Dev Portal Files endpoint and the 
+public Dev Portal Files API.
 
 **Example:**
 
@@ -1371,7 +1372,8 @@ portal_gui_listen = 0.0.0.0:8003, 0.0.0.0:8446 ssl
 
 The Dev Portal URL protocol
 
-Provide the protocol used in conjunction with portal_gui_host to construct the lookup, or balancer address for Kong Proxy nodes.
+Provide the protocol used in conjunction with portal_gui_host to construct the 
+lookup, or balancer address for Kong Proxy nodes.
 
 **Example:**
 
@@ -1388,7 +1390,8 @@ portal_gui_protocol = http
 
 Dev Portal GUI Host
 
-Provide the host unsed in conjunction with portal_gui_protocol to construct the lookup, or balancer address for Kong Proxy nodes.
+Provide the host unsed in conjunction with portal_gui_protocol to construct the 
+lookup, or balancer address for Kong Proxy nodes.
 
 **Example:**
 
@@ -1405,7 +1408,9 @@ portal_gui_host = localhost:8003
 
 Enable workspaced Dev Portals to use subdomains
 
-By default the Dev Portal will use the first namespace in the request path to determine the workspace. By enabling subdomains, the Dev Portal will expect the workspace to be included in the request url as a subdomain
+By default the Dev Portal will use the first namespace in the request path to 
+determine the workspace. By enabling subdomains, the Dev Portal will expect the 
+workspace to be included in the request url as a subdomain
 
 **Example**
 
@@ -1426,7 +1431,8 @@ portal_gui_use_subdomains = on
 
 **Description:**  
 
-The absolute path to the SSL certificate for `portal_gui_listen` values with SSL enabled.
+The absolute path to the SSL certificate for `portal_gui_listen` values with 
+SSL enabled.
 
 **Example:**
 
@@ -1529,8 +1535,8 @@ portal_api_ssl_cert_key = /path/to/portal_api_ssl_cert.key
 
 Location of log containing all calls made to the Portal API.
 
-`portal_api_access.log` location can be absolute or relative. When using relative pathing, logs will be placed under
-the `prefix` location.
+`portal_api_access.log` location can be absolute or relative. When using 
+relative pathing, logs will be placed under the `prefix` location.
 
 Setting this value to `off` will disable logging
 Portal API access logs.

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1144,7 +1144,7 @@ When enabled invitation emails will be sent to Admins invited to the Kong Manage
 
 ### admin_emails_from
 
-**Default:** `on`
+**Default:** `""`
 
 **Description:**
 
@@ -1159,7 +1159,7 @@ admin_emails_from = "example@example.com"
 
 ### admin_emails_reply_to
 
-**Default:** `on`
+**Default:** `NONE` (empty)
 
 **Description:**
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1,6 +1,24 @@
 ---
 title: Configuration Property Reference for Kong Enterprise
+toc: false
 ---
+
+##Table of Contents
+
+* [General](#general)
+* [NGINX](#nginx)
+* [Datastore](#datastore)
+* [Datastore Cache](#datastore-cache)
+* [DNS Resolver](#dns-resolver)
+* [Development & Miscellaneous](#development-&-miscellaneous)
+* [Kong Manager](#kong-manager)
+* [Vitals](#vitals)
+* [Dev Portal](#dev-portal)
+* [Dev Portal Authentication](#dev-portal-authentication)
+* [Dev Portal SMTP Configuration](#dev-portal-smtp-configuration)
+* [Admin SMTP Configuration](#admin-smtp-configuration)
+* [General SMTP Configuration](#general-smtp-configuration)
+* [Data & Admin Audit](#data-&-admin-audit)
 
 ## General
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -802,6 +802,13 @@ migrations.
 
 ## Datastore Cache
 
+In order to avoid unecessary communication with the datastore, Kong caches
+entities (e.g., APIs, Consumers, Credentials) for a configurable period
+of time. It also handles invalidations if such an entity is updated.
+
+This section allows for configuring the behavior of Kong regarding the
+caching of such configuration entities.
+
 
 ### db_update_frequency
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -659,6 +659,19 @@ Vitals metrics and visualizations on the dashboard.
 
 ### vitals_strategy
 
+**Default:** `database`
+
+**Description:** 
+
+Determines whether to use the Kong database
+(either PostgreSQL or Cassandra, as defined
+by the 'database' config value above), or a
+separate storage engine, for Vitals metrics.
+
+Accepted values are 'database', 'prometheus',
+or 'influxdb'.
+
+
 ### vitals_tsdb_address
 
 ### vitals_statsd_address

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -735,6 +735,16 @@ This value is defined in bytes.
 
 ### vitals_prometheus_scrape_interval
 
+**Default:** `5`
+
+**Description:**
+
+Defines the scrape_interval query
+parameter sent to the Prometheus
+server when reading Vitals data.
+This should be same as the scrape
+interval (in seconds) of the
+Prometheus server.
 
 ## Dev Portal
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -957,30 +957,70 @@ single query.
 
 ## Development & Miscellaneous
 
+Additional settings inherited from lua-nginx-module allowing for more
+flexibility and advanced usage.
+
+See the lua-nginx-module documentation for more informations:
+https://github.com/openresty/lua-nginx-module
+
 
 ### lua_ssl_trusted_certificate
 
-See the property description in Kong's configuration reference for [lua_ssl_trusted_certificate](https://docs.konghq.com/0.13.x/configuration/#lua_ssl_trusted_certificate)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Absolute path to the certificate
+authority file for Lua cosockets in PEM
+format. This certificate will be the one
+used for verifying Kong's database
+connections, when `pg_ssl_verify` or
+`cassandra_ssl_verify` are enabled.
 
 
 ### lua_ssl_verify_depth
 
-See the property description in Kong's configuration reference for [lua_ssl_verify_depth](https://docs.konghq.com/0.13.x/configuration/#lua_ssl_verify_depth)
+**Default:** `1`
+
+**Description:**
+
+Sets the verification depth in the server
+certificates chain used by Lua cosockets,
+set by `lua_ssl_trusted_certificate`.
+This includes the certificates configured
+for Kong's database connections.
 
 
 ### lua_package_path
 
-See the property description in Kong's configuration reference for [lua_package_path](https://docs.konghq.com/0.13.x/configuration/#lua_package_path)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Sets the Lua module search path (LUA_PATH).
+Useful when developing or using custom
+plugins not stored in the default search
+path.
 
 
 ### lua_package_cpath
 
-See the property description in Kong's configuration reference for [lua_package_cpath](https://docs.konghq.com/0.13.x/configuration/#lua_package_cpath)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Sets the Lua C module search path (LUA_CPATH).
 
 
 ### lua_socket_pool_size
 
-See the property description in Kong's configuration reference for [lua_socket_pool_size](https://docs.konghq.com/0.13.x/configuration/#lua_socket_pool_size)
+**Default:** `30`
+
+**Description:**
+
+Specifies the size limit for every cosocket
+connection pool associated with every remote
+server.
 
 
 ### enforce_rbac 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -360,6 +360,24 @@ See the property description in Kong's configuration reference for [Cassandra se
 ### cassandra_schema_consensus_timeout
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
+
+## Datastore Cache
+
+
+### db_update_frequency
+
+See the property description in Kong's configuration reference for [db_update_frequency](https://docs.konghq.com/0.13.x/configuration/#db_update_frequency)
+
+
+### db_update_propagation
+
+See the property description in Kong's configuration reference for [db_update_propagation](https://docs.konghq.com/0.13.x/configuration/#db_update_propagation)
+
+
+### db_cache_ttl
+
+See the property description in Kong's configuration reference for [db_cache_ttl](https://docs.konghq.com/0.13.x/configuration/#db_cache_ttl)
 ## Kong Manager
 
 ### admin_gui_listen

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -863,40 +863,96 @@ never expire.
 
 ## DNS Resolver
 
+By default the DNS resolver will use the standard configuration files 
+`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be 
+overridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if 
+they have been set.
+
 
 ### dns_resolver
 
-See the property description in Kong's configuration reference for [dns_resolver](https://docs.konghq.com/0.13.x/configuration/#dns_resolver)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Comma separated list of nameservers, each
+entry in `ip[:port]` format to be used by
+Kong. If not specified the nameservers in
+the local `resolv.conf` file will be used.
+Port defaults to 53 if omitted. Accepts
+both IPv4 and IPv6 addresses.
 
 
 ### dns_hostsfile
 
-See the property description in Kong's configuration reference for [dns_hostsfile](https://docs.konghq.com/0.13.x/configuration/#dns_hostsfile)
+**Default:** `/etc/hosts`
+
+**Description:**
+
+The hosts file to use. This file is read
+once and its content is static in memory.
+To read the file again after modifying it,
+Kong must be reloaded.
 
 
 ### dns_order
 
-See the property description in Kong's configuration reference for [dns_order](https://docs.konghq.com/0.13.x/configuration/#dns_order)
+**Default:** `LAST,SRV,A,CNAME`
+
+**Description:**
+
+The order in which to resolve different
+record types. The `LAST` type means the
+type of the last successful lookup (for the
+specified name). The format is a (case
+insensitive) comma separated list.
 
 
 ### dns_state_ttl
 
-See the property description in Kong's configuration reference for [dns_state_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_state_ttl)
+**Default:** `4`
+
+**Description:**
+
+ Defines, in seconds, how long a record will
+remain in cache past its TTL. This value
+will be used while the new DNS record is
+fetched in the background.
+Stale data will be used from expiry of a
+record until either the refresh query
+completes, or the `dns_stale_ttl` number of
+seconds have passed.
 
 
 ### dns_not_found_ttl
 
-See the property description in Kong's configuration reference for [dns_not_found_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_not_found_ttl)
+**Default:** `30`
+
+**Description:**
+
+TTL in seconds for empty DNS responses and "(3) name error" responses.
 
 
 ### dns_error_ttl
 
-See the property description in Kong's configuration reference for [dns_error_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_error_ttl)
+**Default:** `1`
+
+**Description:**
+
+TTL in seconds for error responses.
 
 
 ### dns_no_sync
 
-See the property description in Kong's configuration reference for [dns_no_sync](https://docs.konghq.com/0.13.x/configuration/#dns_no_sync)
+**Default:** `off`
+
+**Description:**
+
+If enabled, then upon a cache-miss every
+request will trigger its own dns query.
+When disabled multiple requests for the
+same name/type will be synchronised to a
+single query.
 
 
 ## Development & Miscellaneous

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1316,12 +1316,53 @@ smtp_admin_emails = admin1@example.com, admin2@example.com
 
 ### audit_log
 
+**Default:** `off`
+
+**Description:**
+
+When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes.
+
+
 ### audit_log_ignore_methods
+
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged.
+
 
 ### audit_log_ignore_paths
 
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged.
+
+
 ### audit_log_ignore_tables
+
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term "updates" refers to the creation, update, or deletion of a row).
+
 
 ### audit_log_record_ttl
 
+**Default:** `2592000`
+
+**Description:**
+
+Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.
+
+
 ### audit_log_signing_key
+
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated.

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1908,6 +1908,12 @@ smtp_admin_emails = admin1@example.com, admin2@example.com
 
 ## Data & Admin Audit
 
+When enabled, Kong will store detailed audit data regarding Admin API and
+database access. In most cases, updates to the database are associated with
+Admin API requests. As such, database object audit log data is tied to a
+given HTTP via a unique identifier, providing built-in association of Admin
+API and database traffic.
+
 
 ### audit_log
 
@@ -1915,7 +1921,8 @@ smtp_admin_emails = admin1@example.com, admin2@example.com
 
 **Description:**
 
-When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes.
+When enabled, Kong will log information about Admin API access and database 
+row insertions, updates, and deletes.
 
 
 ### audit_log_ignore_methods
@@ -1942,7 +1949,9 @@ Comma-separated list of request paths that will not generate audit log entries. 
 
 **Description:**
 
-Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term "updates" refers to the creation, update, or deletion of a row).
+Comma-separated list of database tables that will not generate audit log 
+entries. By default, updates to all database tables will be logged (the 
+term "updates" refers to the creation, update, or deletion of a row).
 
 
 ### audit_log_record_ttl
@@ -1951,7 +1960,8 @@ Comma-separated list of database tables that will not generate audit log entries
 
 **Description:**
 
-Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.
+Length, in seconds, of the TTL for audit log records. Records in the database 
+older than their TTL are automatically purged.
 
 
 ### audit_log_signing_key
@@ -1960,4 +1970,7 @@ Length, in seconds, of the TTL for audit log records. Records in the database ol
 
 **Description:**
 
-Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated.
+Defines the path to a private RSA signing key that can be used to insert a 
+signature of audit records, adjacent to the record. The corresponding public 
+key should be stored offline, and can be used the validate audit entries in 
+the future. If this value is undefined, no signature will be generated.

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -209,7 +209,31 @@ admin_api_uri = https://127.0.0.1:8444
 
 ### admin_listen
 
-See the property description in Kong's configuration reference for [admin_listen](https://docs.konghq.com/0.13.x/configuration/#admin_listen)
+**Default:** `127.0.0.1:8001, 127.0.0.1:8444 ssl`
+
+**Description:**
+
+Comma-separated list of addresses and ports on which the 
+Admin interface should listen. The Admin interface is 
+the API allowing you to configure and manage Kong. 
+Access to this interface should be *restricted* to Kong 
+administrators *only*. This value accepts IPv4, IPv6, 
+and hostnames.
+
+Some suffixes can be specified for each pair:
+- `ssl` will require that all connections made
+  through a particular address/port be made with TLS
+  enabled.
+- `http2` will allow for clients to open HTTP/2
+  connections to Kong's proxy server.
+- Finally, `proxy_protocol` will enable usage of the
+  PROXY protocol for a given address/port.
+
+This value can be set to `off`, thus disabling
+the Admin interface for this node, enabling a
+'data-plane' mode (without configuration
+capabilities) pulling its configuration changes
+from the database.
 
 
 ### nginx_user

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1571,6 +1571,9 @@ directive.
 
 ## Dev Portal Authentication
 
+Referenced on workspace creation to set Dev Portal authentication defaults 
+in the database for that particular workspace.
+
 
 ### portal_auth
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1767,7 +1767,8 @@ admin_emails_reply_to = admin@example.com
 
 **Description:**
 
-Expiration time in seconds for Admin invitation links. Set to zero for no expiration.
+Expiration time in seconds for Admin invitation links. Set to zero for no 
+expiration.
 
 
 ## General SMTP Configuration

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -966,6 +966,24 @@ portal_api_access_log = logs/portal_api_access.log
 
 ### portal_api_error_log
 
+**Default:** `logs/error.log`
+
+**Description:**  
+
+Developer Portal API Error Log location.
+
+Here you can set an absolute or relative path for your
+Portal API access logs.
+
+Setting this value to `off` will disable logging
+Portal API access logs.
+
+When using relative pathing, logs will be placed under
+the `prefix` location.
+
+Granularity can be adjusted through the `log_level`
+directive.
+
 
 ## Dev Portal Authentication
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -71,8 +71,13 @@ is adjusted by the `log_level` directive.
 
 ### custom_plugins 
 
-See the property description in Kong's configuration reference for 
-[custom_plugins](https://docs.konghq.com/0.13.x/configuration/#custom_plugins)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Comma-separated list of additional plugins this node should load. 
+Use this property to load custom plugins that are not bundled with Kong. 
+Plugins will be loaded from the `kong.plugins.{name}.*` namespace.
 
 
 ### anonymous_reports

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -567,6 +567,11 @@ admin_gui_ssl_key = /path/to/admin_gui_ssl.key
 
 ### admin_gui_flags
 
+**Default:** `{}`
+
+**Description:**  
+
+Alters the layout Admin GUI (JSON)
 
 ### admin_gui_access_log
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -117,7 +117,27 @@ improve Kong.
 
 ### proxy_listen
 
-See the property description in Kong's configuration reference for [proxy_listen](https://docs.konghq.com/0.13.x/configuration/#proxy_listen)
+**Default:** `0.0.0.0:8000, 0.0.0.0:8443 ssl`
+
+**Description:**
+
+Comma-separated list of addresses and ports on which the proxy 
+server should listen. The proxy server is the public entrypoint of 
+Kong, which proxies traffic from your consumers to your backend 
+services. This value accepts IPv4, IPv6, and hostnames.
+ 
+Some suffixes can be specified for each pair:
+
+- `ssl` will require that all connections made through a particular 
+  address/port be made with TLS enabled.
+- `http2` will allow for clients to open HTTP/2 connections to Kong's proxy 
+  server.
+- Finally, `proxy_protocol` will enable usage of the PROXY protocol for a given 
+  address/port.
+
+This value can be set to `off`, thus disabling the proxy port for this node, 
+enabling a 'control-plane' mode (without traffic proxying capabilities) which 
+can configure a cluster of nodes connected to the same database.
 
 
 ### proxy_url

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -52,7 +52,6 @@ See the property description in Kong's configuration reference for
 See the property description in Kong's configuration reference for 
 [anonymous_reports](https://docs.konghq.com/0.13.x/configuration/#anonymous_reports)
 
-**Example:**
 
 ## NGINX
 
@@ -128,116 +127,93 @@ admin_gui_listen HTTP/HTTPS port.
 admin_api_uri = https://127.0.0.1:8444
 ```
 
-
 ### admin_listen
 
 See the property description in Kong's configuration reference for [admin_listen](https://docs.konghq.com/0.13.x/configuration/#admin_listen)
-
 
 ### nginx_user
 
 See the property description in Kong's configuration reference for [nginx_user](https://docs.konghq.com/0.13.x/configuration/#nginx_user)
 
-
 ### nginx_worker_processes 
 
 See the property description in Kong's configuration reference for  [nginx_worker_processes](https://docs.konghq.com/0.13.x/configuration/#nginx_worker_processes)
-
 
 ### nginx_daemon
 
 See the property description in Kong's configuration reference for [nginx_daemon](https://docs.konghq.com/0.13.x/configuration/#nginx_daemon)
 
-
 ### mem_cache_size
 
 See the property description in Kong's configuration reference for [mem_cahce_size](https://docs.konghq.com/0.13.x/configuration/#mem_cache_size)
-
 
 ### ssl_cipher_suite
 
 See the property description in Kong's configuration reference for [ssl_cipher_suite](https://docs.konghq.com/0.13.x/configuration/#ssl_cipher_suite)
 
-
 ### ssl_ciphers
 
 See the property description in Kong's configuration reference for [ssl_ciphers](https://docs.konghq.com/0.13.x/configuration/#ssl_ciphers)
-
 
 ### ssl_cert
 
 See the property description in Kong's configuration reference for [ssl_cert](https://docs.konghq.com/0.13.x/configuration/#ssl_cert)
 
-
 ### ssl_cert_key
 
 See the property description in Kong's configuration reference for [ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#ssl_cert_key)
-
 
 ### client_ssl
 
 See the property description in Kong's configuration reference for [client_ssl](https://docs.konghq.com/0.13.x/configuration/#client_ssl)
 
-
 ### client_ssl_cert
 
 See the property description in Kong's configuration reference for [client_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert)
-
 
 ### client_ssl_cert_key
 
 See the property description in Kong's configuration reference for [client_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert_key)
 
-
 ### admin_ssl_cert
 
 See the property description in Kong's configuration reference for [admin_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert)
-
 
 ### admin_ssl_cert_key
 
 See the property description in Kong's configuration reference for [admin_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert_key)
 
-
 ### upstream_keepalive
 
 See the property description in Kong's configuration reference for [upstream_keepalive](https://docs.konghq.com/0.13.x/configuration/#upstream_keepalive)
-
 
 ### server_tokens
 
 See the property description in Kong's configuration reference for [server_tokens](https://docs.konghq.com/0.13.x/configuration/#server_tokens)
 
-
 ### latency_tokens
 
 See the property description in Kong's configuration reference for [latency_tokens](https://docs.konghq.com/0.13.x/configuration/#latency_tokens)
-
 
 ### trusted_ips
 
 See the property description in Kong's configuration reference for [trusted_ips](https://docs.konghq.com/0.13.x/configuration/#trusted_ips)
 
-
 ### real_ip_header
 
 See the property description in Kong's configuration reference for [real_ip_header](https://docs.konghq.com/0.13.x/configuration/#real_ip_header)
-
 
 ### real_ip_recursive
 
 See the property description in Kong's configuration reference for [real_ip_recursive](https://docs.konghq.com/0.13.x/configuration/#real_ip_recursive)
 
-
 ### client_max_body_size
 
 See the property description in Kong's configuration reference for [client_max_body_size](https://docs.konghq.com/0.13.x/configuration/#client_max_body_size)
 
-
 ### client_body_buffer_size
 
 See the property description in Kong's configuration reference for [client_body_buffer_size](https://docs.konghq.com/0.13.x/configuration/#client_body_buffer_size)
-
 
 ### error_default_type
 
@@ -251,111 +227,89 @@ See the property description in Kong's configuration reference for [error_defaul
 
 See the property description in Kong's configuration reference for [database](https://docs.konghq.com/0.13.x/configuration/#database)
 
-
 ### pg_host
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
-
 
 ### pg_port
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
 
-
 ### pg_user
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
-
 
 ### pg_password
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
 
-
 ### pg_database
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
-
 
 ### pg_ssl
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
 
-
 ### pg_ssl_verify
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
-
 
 ### cassandra_contact_points
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_port
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_keyspace
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_timeout
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_ssl
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_ssl_verify
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_username
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_password
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_consistency
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_lb_policy
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_local_datacenter
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_repl_strategy
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_repl_factor
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
-
 ### cassandra_data_centers
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
-
 
 ### cassandra_schema_consensus_timeout
 
@@ -369,16 +323,96 @@ See the property description in Kong's configuration reference for [Cassandra se
 
 See the property description in Kong's configuration reference for [db_update_frequency](https://docs.konghq.com/0.13.x/configuration/#db_update_frequency)
 
-
 ### db_update_propagation
 
 See the property description in Kong's configuration reference for [db_update_propagation](https://docs.konghq.com/0.13.x/configuration/#db_update_propagation)
 
-
 ### db_cache_ttl
 
 See the property description in Kong's configuration reference for [db_cache_ttl](https://docs.konghq.com/0.13.x/configuration/#db_cache_ttl)
+
+
+## DNS Resolver
+
+
+### dns_resolver
+
+See the property description in Kong's configuration reference for [dns_resolver](https://docs.konghq.com/0.13.x/configuration/#dns_resolver)
+
+### dns_hostsfile
+
+See the property description in Kong's configuration reference for [dns_hostsfile](https://docs.konghq.com/0.13.x/configuration/#dns_hostsfile)
+
+### dns_order
+
+See the property description in Kong's configuration reference for [dns_order](https://docs.konghq.com/0.13.x/configuration/#dns_order)
+
+### dns_state_ttl
+
+See the property description in Kong's configuration reference for [dns_state_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_state_ttl)
+
+### dns_not_found_ttl
+
+See the property description in Kong's configuration reference for [dns_not_found_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_not_found_ttl)
+
+### dns_error_ttl
+
+See the property description in Kong's configuration reference for [dns_error_ttl](https://docs.konghq.com/0.13.x/configuration/#dns_error_ttl)
+
+### dns_no_sync
+
+See the property description in Kong's configuration reference for [dns_no_sync](https://docs.konghq.com/0.13.x/configuration/#dns_no_sync)
+
+
+## Development & Miscellaneous
+
+
+### lua_ssl_trusted_certificate
+
+See the property description in Kong's configuration reference for [lua_ssl_trusted_certificate](https://docs.konghq.com/0.13.x/configuration/#lua_ssl_trusted_certificate)
+
+### lua_ssl_verify_depth
+
+See the property description in Kong's configuration reference for [lua_ssl_verify_depth](https://docs.konghq.com/0.13.x/configuration/#lua_ssl_verify_depth)
+
+### lua_package_path
+
+See the property description in Kong's configuration reference for [lua_package_path](https://docs.konghq.com/0.13.x/configuration/#lua_package_path)
+
+### lua_package_cpath
+
+See the property description in Kong's configuration reference for [lua_package_cpath](https://docs.konghq.com/0.13.x/configuration/#lua_package_cpath)
+
+### lua_socket_pool_size
+
+See the property description in Kong's configuration reference for [lua_socket_pool_size](https://docs.konghq.com/0.13.x/configuration/#lua_socket_pool_size)
+
+### enforce_rbac 
+
+**Default:** `off`
+
+**Description:**
+
+Specifies whether Admin API RBAC is enforced;
+accepts one of 'entity', 'both', 'on', or
+'off'. When 'on' is passed, only
+endpoint-level authorization is enforced;
+when 'entity' is passed, entity-level
+authorization applies; 'both' enables both
+endpoint and entity-level authorization;
+'off' disables both. When enabled, Kong will
+deny requests to the Admin API when a
+nonexistent or invalid RBAC authorization
+token is passed, or the RBAC user with which
+the token is associated does not have
+permissions to access/modify the requested
+resource.
+
+### rbac_auth_header
+
+
 ## Kong Manager
+
 
 ### admin_gui_listen
 
@@ -465,6 +499,9 @@ admin_gui_ssl_key = /path/to/admin_gui_ssl.key
 ```
 
 
+### admin_gui_flags
+
+
 ### admin_gui_access_log
 
 **Default:** `logs/admin_gui_access.log`
@@ -508,6 +545,7 @@ authentication plugin you have chosen.
 * For Basic Authentication, set the value to `basic-auth`
 * For LDAP Authentication, set the value to `ldap-auth-advanced`
 
+
 ### admin_gui_auth_conf
 
 **Default:** `NONE` (empty)
@@ -526,26 +564,24 @@ the associated plugin documentation.
 admin_gui_auth_conf = { "hide_credentials": true }
 ```
 
-### enforce_rbac 
 
-**Default:** `off`
+## Vitals
 
-**Description:**
 
-Specifies whether Admin API RBAC is enforced;
-accepts one of 'entity', 'both', 'on', or
-'off'. When 'on' is passed, only
-endpoint-level authorization is enforced;
-when 'entity' is passed, entity-level
-authorization applies; 'both' enables both
-endpoint and entity-level authorization;
-'off' disables both. When enabled, Kong will
-deny requests to the Admin API when a
-nonexistent or invalid RBAC authorization
-token is passed, or the RBAC user with which
-the token is associated does not have
-permissions to access/modify the requested
-resource.
+### vitals
+
+### vitals_strategy
+
+### vitals_tsdb_address
+
+### vitals_statsd_address
+
+### vitals_statsd_prefix
+
+### vitals_statsd_udp_packet_size
+
+### vitals_prometheus_scrape_interval
+
 
 ## Dev Portal
 
@@ -687,6 +723,7 @@ the `admin_listen` directive.
 portal_api_listen = 0.0.0.0:8004, 0.0.0.0:8447 ssl
 ```
 
+
 ### portal_api_url
 
 **Default:** `NONE` (empty)
@@ -763,24 +800,7 @@ portal_api_access_log = logs/portal_api_access.log
 ```
 
 
-### portal_auto_approve
-
-**Default:** `off`
-
-**Description:**  
-
-Dev Portal Auto Approve Access.
-
-When set to `on`, a developer will
-automatically be marked as `approved` after completing
-Dev Portal registration. Access can still be revoked through 
-Kong Manager or API.
-
-**Example:**
-
-```
-portal_auto_approve = on
-```
+### portal_api_error_log
 
 
 ## Dev Portal Authentication
@@ -805,7 +825,7 @@ portal_auth = basic-auth
 ```
 
 
-### portal_auth_config
+### portal_auth_conf
 
 **Default:** `NONE` (empty)
 
@@ -910,6 +930,7 @@ portal_emails_from = Your Name <example@example.com>
 
 ⚠️ **IMPORTANT:** Some SMTP servers may require valid email addresses
 
+
 ### portal_emails_reply_to
 
 **Default:** `nil`
@@ -925,6 +946,7 @@ portal_emails_reply_to: noreply@example.com
 ```
 
 ⚠️ **IMPORTANT:** Some SMTP servers may require valid email addresses
+
 
 ## Admin SMTP Configuration
 
@@ -1100,3 +1122,19 @@ Comma separated list of Admin emails to receive notifications.
 ```
 smtp_admin_emails = admin1@example.com, admin2@example.com
 ```
+
+
+## Data & Admin Audit
+
+
+### audit_log
+
+### audit_log_ignore_methods
+
+### audit_log_ignore_paths
+
+### audit_log_ignore_tables
+
+### audit_log_record_ttl
+
+### audit_log_signing_key

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -469,6 +469,13 @@ resource.
 
 ### rbac_auth_header
 
+**Default:** `Kong-Admin-Token`
+
+**Description:**
+
+Defines the name of the HTTP request header from which the Admin 
+API will attempt to identify the RBAC user.
+
 
 ## Kong Manager
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -642,6 +642,21 @@ admin_gui_auth_conf = { "hide_credentials": true }
 
 ### vitals
 
+**Default:** `on`
+
+**Description:**  
+
+When enabled, Kong will store and report metrics about its performance.                                 
+When running Kong in a multi-node setup, `vitals` entails two 
+separate meanings depending on the node.
+
+On a Proxy-only node, `vitals` determines whether to collect data 
+for Vitals.
+
+On an Admin-only node, `vitals` determines whether to display 
+Vitals metrics and visualizations on the dashboard.
+
+
 ### vitals_strategy
 
 ### vitals_tsdb_address

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -48,10 +48,15 @@ Path for proxy port request error logs. The granularity of these logs
 is adjusted by the `log_level` directive.
 
 
-### adming_access_log
+### admin_access_log
 
-See the property description in Kong's configuration reference for 
-[admin_access_log](https://docs.konghq.com/0.13.x/configuration/#admin_access_log)
+**Default:** `logs/admin_access.log`
+
+**Description:**
+
+Path for Admin API request access logs. Set this value to `off` to
+disable logging Admin API requests. If this value is a relative path, 
+it will be placed under the `prefix` location.
 
 
 ### admin_error_log

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -1635,6 +1635,9 @@ Default `21600` is six hours.
 
 ## Dev Portal SMTP Configuration
 
+Referenced on workspace creation to set SMTP defaults in the database 
+for that particular workspace.
+
 
 ### portal_invite_email
 
@@ -1642,7 +1645,8 @@ Default `21600` is six hours.
 
 **Description:**
 
-When enabled, Admins will be able to invite Developers to a Dev Portal by using the "Invite" button in the Kong Manager.
+When enabled, Admins will be able to invite Developers to a Dev Portal by 
+using the "Invite" button in the Kong Manager.
 
 
 ### portal_access_request_email
@@ -1651,7 +1655,8 @@ When enabled, Admins will be able to invite Developers to a Dev Portal by using 
 
 **Description:**
 
-When enabled, Admins specified by `smtp_admin_emails` will receive an email when a Developer requests access to a Dev Portal.
+When enabled, Admins specified by `smtp_admin_emails` will receive an email 
+when a Developer requests access to a Dev Portal.
 
 
 ### portal_approved_email
@@ -1660,7 +1665,8 @@ When enabled, Admins specified by `smtp_admin_emails` will receive an email when
 
 **Description:**
 
-When enabled, Developers will receive an email when access to a Dev Portal has been approved.
+When enabled, Developers will receive an email when access to a Dev Portal has 
+been approved.
 
 
 ### portal_reset_email
@@ -1669,7 +1675,8 @@ When enabled, Developers will receive an email when access to a Dev Portal has b
 
 **Description:**
 
-When enabled, Developers will be able to use the "Reset Password" flow on a Dev Portal and will receive an email with password reset instructions.
+When enabled, Developers will be able to use the "Reset Password" flow on a 
+Dev Portal and will receive an email with password reset instructions.
 
 When disabled, Developers will *not* be able to reset their account passwords.
 
@@ -1680,9 +1687,11 @@ When disabled, Developers will *not* be able to reset their account passwords.
 
 **Description:**
 
-When enabled, Developers will receive an email after successfully reseting their Dev Portal account password.
+When enabled, Developers will receive an email after successfully reseting 
+their Dev Portal account password.
 
-When disabled, Developers will still be able to reset their account passwords, but will not recieve a confirmation email.
+When disabled, Developers will still be able to reset their account passwords, 
+but will not recieve a confirmation email.
 
 
 ### portal_emails_from

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -127,93 +127,116 @@ admin_gui_listen HTTP/HTTPS port.
 admin_api_uri = https://127.0.0.1:8444
 ```
 
+
 ### admin_listen
 
 See the property description in Kong's configuration reference for [admin_listen](https://docs.konghq.com/0.13.x/configuration/#admin_listen)
+
 
 ### nginx_user
 
 See the property description in Kong's configuration reference for [nginx_user](https://docs.konghq.com/0.13.x/configuration/#nginx_user)
 
+
 ### nginx_worker_processes 
 
 See the property description in Kong's configuration reference for  [nginx_worker_processes](https://docs.konghq.com/0.13.x/configuration/#nginx_worker_processes)
+
 
 ### nginx_daemon
 
 See the property description in Kong's configuration reference for [nginx_daemon](https://docs.konghq.com/0.13.x/configuration/#nginx_daemon)
 
+
 ### mem_cache_size
 
 See the property description in Kong's configuration reference for [mem_cahce_size](https://docs.konghq.com/0.13.x/configuration/#mem_cache_size)
+
 
 ### ssl_cipher_suite
 
 See the property description in Kong's configuration reference for [ssl_cipher_suite](https://docs.konghq.com/0.13.x/configuration/#ssl_cipher_suite)
 
+
 ### ssl_ciphers
 
 See the property description in Kong's configuration reference for [ssl_ciphers](https://docs.konghq.com/0.13.x/configuration/#ssl_ciphers)
+
 
 ### ssl_cert
 
 See the property description in Kong's configuration reference for [ssl_cert](https://docs.konghq.com/0.13.x/configuration/#ssl_cert)
 
+
 ### ssl_cert_key
 
 See the property description in Kong's configuration reference for [ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#ssl_cert_key)
+
 
 ### client_ssl
 
 See the property description in Kong's configuration reference for [client_ssl](https://docs.konghq.com/0.13.x/configuration/#client_ssl)
 
+
 ### client_ssl_cert
 
 See the property description in Kong's configuration reference for [client_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert)
+
 
 ### client_ssl_cert_key
 
 See the property description in Kong's configuration reference for [client_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert_key)
 
+
 ### admin_ssl_cert
 
 See the property description in Kong's configuration reference for [admin_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert)
+
 
 ### admin_ssl_cert_key
 
 See the property description in Kong's configuration reference for [admin_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert_key)
 
+
 ### upstream_keepalive
 
 See the property description in Kong's configuration reference for [upstream_keepalive](https://docs.konghq.com/0.13.x/configuration/#upstream_keepalive)
+
 
 ### server_tokens
 
 See the property description in Kong's configuration reference for [server_tokens](https://docs.konghq.com/0.13.x/configuration/#server_tokens)
 
+
 ### latency_tokens
 
 See the property description in Kong's configuration reference for [latency_tokens](https://docs.konghq.com/0.13.x/configuration/#latency_tokens)
+
 
 ### trusted_ips
 
 See the property description in Kong's configuration reference for [trusted_ips](https://docs.konghq.com/0.13.x/configuration/#trusted_ips)
 
+
 ### real_ip_header
 
 See the property description in Kong's configuration reference for [real_ip_header](https://docs.konghq.com/0.13.x/configuration/#real_ip_header)
+
 
 ### real_ip_recursive
 
 See the property description in Kong's configuration reference for [real_ip_recursive](https://docs.konghq.com/0.13.x/configuration/#real_ip_recursive)
 
+
 ### client_max_body_size
 
 See the property description in Kong's configuration reference for [client_max_body_size](https://docs.konghq.com/0.13.x/configuration/#client_max_body_size)
 
+
 ### client_body_buffer_size
 
 See the property description in Kong's configuration reference for [client_body_buffer_size](https://docs.konghq.com/0.13.x/configuration/#client_body_buffer_size)
+
 
 ### error_default_type
 
@@ -227,89 +250,111 @@ See the property description in Kong's configuration reference for [error_defaul
 
 See the property description in Kong's configuration reference for [database](https://docs.konghq.com/0.13.x/configuration/#database)
 
+
 ### pg_host
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
 
 ### pg_port
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
 
+
 ### pg_user
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
 
 ### pg_password
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
 
+
 ### pg_database
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
 
 ### pg_ssl
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
 
+
 ### pg_ssl_verify
 
 See the property description in Kong's configuration reference for [Postgres settings](https://docs.konghq.com/0.13.x/configuration/#postgres-settings)
+
 
 ### cassandra_contact_points
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_port
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_keyspace
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_timeout
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_ssl
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_ssl_verify
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_username
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_password
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_consistency
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_lb_policy
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_local_datacenter
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_repl_strategy
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_repl_factor
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
 
+
 ### cassandra_data_centers
 
 See the property description in Kong's configuration reference for [Cassandra settings](https://docs.konghq.com/0.13.x/configuration/#cassandra-settings)
+
 
 ### cassandra_schema_consensus_timeout
 
@@ -323,9 +368,11 @@ See the property description in Kong's configuration reference for [Cassandra se
 
 See the property description in Kong's configuration reference for [db_update_frequency](https://docs.konghq.com/0.13.x/configuration/#db_update_frequency)
 
+
 ### db_update_propagation
 
 See the property description in Kong's configuration reference for [db_update_propagation](https://docs.konghq.com/0.13.x/configuration/#db_update_propagation)
+
 
 ### db_cache_ttl
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -723,6 +723,16 @@ exporter or server.
 
 ### vitals_statsd_udp_packet_size
 
+**Default:** `1024`
+
+**Description:**
+
+Defines the maximum buffer size in
+which Vitals statsd metrics will be
+held and sent in batches.
+This value is defined in bytes.
+
+
 ### vitals_prometheus_scrape_interval
 
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -29,8 +29,13 @@ of accepted values.
 
 ### proxy_access_log
 
-See the property description in Kong's configuration reference for 
-[proxy_access_log](https://docs.konghq.com/0.13.x/configuration/#proxy_access_log)
+**Default:** `logs/access.log`
+
+**Description:**  
+
+Path for proxy port request access logs. Set this value to `off` to 
+disable logging proxy requests. If this value is a relative path, 
+it will be placed under the `prefix` location.
 
 
 ### proxy_error_log 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -550,6 +550,12 @@ Accepted values are `text/plain`,
 
 ## Datastore
 
+Kong will store all of its data (such as APIs, consumers, and plugins) in
+either Cassandra or PostgreSQL.
+
+All Kong nodes belonging to the same cluster must connect themselves to the
+same database.
+
 
 ### database
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -711,6 +711,16 @@ instead of the UDP (default).
 
 ### vitals_statsd_prefix
 
+**Default:** `kong`
+
+**Description:**  
+
+Defines the prefix value attached to all
+Vitals StatsD events. This prefix is useful
+when writing metrics to a multi-tenant StatsD
+exporter or server.
+
+
 ### vitals_statsd_udp_packet_size
 
 ### vitals_prometheus_scrape_interval

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -238,112 +238,314 @@ from the database.
 
 ### nginx_user
 
-See the property description in Kong's configuration reference for [nginx_user](https://docs.konghq.com/0.13.x/configuration/#nginx_user)
+**Default:** `nobody nobody`
+
+**Description:**
+
+Defines user and group credentials used by
+worker processes. If group is omitted, a
+group whose name equals that of user is
+used. 
+
+**Example:** `[user] [group]`
 
 
 ### nginx_worker_processes 
 
-See the property description in Kong's configuration reference for  [nginx_worker_processes](https://docs.konghq.com/0.13.x/configuration/#nginx_worker_processes)
+**Default:** `auto`
+
+**Description:**
+
+Determines the number of worker processes spawned by Nginx.
 
 
 ### nginx_daemon
 
-See the property description in Kong's configuration reference for [nginx_daemon](https://docs.konghq.com/0.13.x/configuration/#nginx_daemon)
+**Default:** `on`
+
+**Description:**
+
+Determines wether Nginx will run as a daemon
+or as a foreground process. Mainly useful
+for development or when running Kong inside
+a Docker environment.
 
 
 ### mem_cache_size
 
-See the property description in Kong's configuration reference for [mem_cahce_size](https://docs.konghq.com/0.13.x/configuration/#mem_cache_size)
+**Default:** `128m`
+
+**Description:**
+
+Size of the in-memory cache for database
+entities. The accepted units are `k` and
+`m`, with a minimum recommended value of
+a few MBs.
 
 
 ### ssl_cipher_suite
 
-See the property description in Kong's configuration reference for [ssl_cipher_suite](https://docs.konghq.com/0.13.x/configuration/#ssl_cipher_suite)
+**Default:** `modern`
 
+**Description:**
+
+Defines the TLS ciphers served by Nginx.
+Accepted values are `modern`,
+`intermediate`, `old`, or `custom`.
+
+**Note:** see https://wiki.mozilla.org/Security/Server_Side_TLS for detailed 
+descriptions of each cipher suite.
 
 ### ssl_ciphers
 
-See the property description in Kong's configuration reference for [ssl_ciphers](https://docs.konghq.com/0.13.x/configuration/#ssl_ciphers)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Defines a custom list of TLS ciphers to be
+served by Nginx. This list must conform to
+the pattern defined by `openssl ciphers`.
+This value is ignored if `ssl_cipher_suite`
+is not `custom`.
 
 
 ### ssl_cert
 
-See the property description in Kong's configuration reference for [ssl_cert](https://docs.konghq.com/0.13.x/configuration/#ssl_cert)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+The absolute path to the SSL certificate for
+`proxy_listen` values with SSL enabled.
 
 
 ### ssl_cert_key
 
-See the property description in Kong's configuration reference for [ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#ssl_cert_key)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+The absolute path to the SSL key for
+`proxy_listen` values with SSL enabled.
 
 
 ### client_ssl
 
-See the property description in Kong's configuration reference for [client_ssl](https://docs.konghq.com/0.13.x/configuration/#client_ssl)
+**Default:** `off`
+
+**Description:**
+
+Determines if Nginx should send client-side
+SSL certificates when proxying requests.
 
 
 ### client_ssl_cert
 
-See the property description in Kong's configuration reference for [client_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+If `client_ssl` is enabled, the absolute
+path to the client SSL certificate for the
+`proxy_ssl_certificate` directive. Note that
+this value is statically defined on the
+node, and currently cannot be configured on
+a per-API basis.
 
 
 ### client_ssl_cert_key
 
-See the property description in Kong's configuration reference for [client_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert_key)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+If `client_ssl` is enabled, the absolute
+path to the client SSL key for the
+`proxy_ssl_certificate_key` address. Note
+this value is statically defined on the
+node, and currently cannot be configured on
+a per-API basis.
 
 
 ### admin_ssl_cert
 
-See the property description in Kong's configuration reference for [admin_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+The absolute path to the SSL certificate for
+`admin_listen` values with SSL enabled.
 
 
 ### admin_ssl_cert_key
 
-See the property description in Kong's configuration reference for [admin_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert_key)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+The absolute path to the SSL key for
+`admin_listen` values with SSL enabled.
 
 
 ### upstream_keepalive
 
-See the property description in Kong's configuration reference for [upstream_keepalive](https://docs.konghq.com/0.13.x/configuration/#upstream_keepalive)
+**Default:** `60`
+
+**Description:**
+
+Sets the maximum number of idle keepalive
+connections to upstream servers that are
+preserved in the cache of each worker
+process. When this number is exceeded, the
+least recently used connections are closed.
 
 
 ### server_tokens
 
-See the property description in Kong's configuration reference for [server_tokens](https://docs.konghq.com/0.13.x/configuration/#server_tokens)
+**Default:** `on`
+
+**Description:**
+
+Enables or disables emitting Kong version on
+error pages and in the "Server" or "Via"
+(in case the request was proxied) response
+header field.
 
 
 ### latency_tokens
 
-See the property description in Kong's configuration reference for [latency_tokens](https://docs.konghq.com/0.13.x/configuration/#latency_tokens)
+**Default:** `on`
+
+**Description:**
+
+Enables or disables emitting Kong latency
+information in the "X-Kong-Proxy-Latency"
+and "X-Kong-Upstream-Latency" response
+header fields.
 
 
 ### trusted_ips
 
-See the property description in Kong's configuration reference for [trusted_ips](https://docs.konghq.com/0.13.x/configuration/#trusted_ips)
+**Default:** `NONE` (empty)
+
+**Description:**
+
+Defines trusted IP addresses blocks that are
+known to send correct X-Forwarded-* headers.
+Requests from trusted IPs make Kong forward
+their X-Forwarded-* headers upstream.
+Non-trusted requests make Kong insert its
+own X-Forwarded-* headers.
+
+This property also sets the
+`set_real_ip_from` directive(s) in the Nginx
+configuration. It accepts the same type of
+values (CIDR blocks) but as a
+comma-separated list.
+
+To trust *all* /!\ IPs, set this value to
+`0.0.0.0/0,::/0`.
+
+If the special value `unix:` is specified,
+all UNIX-domain sockets will be trusted.
+
+**Note:** see http://nginx.org/en/docs/http/ngx_http_realip_module.html for 
+examples of accepted values.
 
 
 ### real_ip_header
 
-See the property description in Kong's configuration reference for [real_ip_header](https://docs.konghq.com/0.13.x/configuration/#real_ip_header)
+**Default:** `X-Real-IP`
+
+**Description:**
+
+Defines the request header field whose value
+will be used to replace the client address.
+This value sets the ngx_http_realip_module
+directive of the same name in the Nginx
+configuration.
+
+If set to `proxy_protocol`, then at least
+one of the `proxy_listen` entries must
+have the `proxy_protocol` flag enabled.
+
+**Note:** see 
+http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header 
+for a description of this directive.
 
 
 ### real_ip_recursive
 
-See the property description in Kong's configuration reference for [real_ip_recursive](https://docs.konghq.com/0.13.x/configuration/#real_ip_recursive)
+**Default:** `off`
+
+**Description:**
+
+This value sets the ngx_http_realip_module
+directive of the same name in the Nginx
+configuration.
+
+**Note:** see 
+http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive 
+for a description of this directive.
 
 
 ### client_max_body_size
 
-See the property description in Kong's configuration reference for [client_max_body_size](https://docs.konghq.com/0.13.x/configuration/#client_max_body_size)
+**Default:** `0`
 
+**Description:**
+
+Defines the maximum request body size allowed
+by requests proxied by Kong, specified in
+the Content-Length request header. If a
+request exceeds this limit, Kong will
+respond with a 413 (Request Entity Too
+Large). Setting this value to 0 disables
+checking the request body size.
+
+Note: see 
+http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+for further description of this parameter. Numeric values may be suffixed
+with 'k' or 'm' to denote limits in terms of kilobytes or megabytes.
 
 ### client_body_buffer_size
 
-See the property description in Kong's configuration reference for [client_body_buffer_size](https://docs.konghq.com/0.13.x/configuration/#client_body_buffer_size)
+**Default:** `8k`
+
+**Description:**
+
+Defines the buffer size for reading the
+request body. If the client request body is
+larger than this value, the body will be
+buffered to disk. Note that when the body is
+buffered to disk Kong plugins that access or
+manipulate the request body may not work, so
+it is advisable to set this value as high as
+possible (e.g., set it as high as
+`client_max_body_size` to force request
+bodies to be kept in memory). Do note that
+high-concurrency environments will require
+significant memory allocations to process
+many concurrent large request bodies.
+
+**Note:** see 
+http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+for further description of this parameter. Numeric values may be suffixed
+with 'k' or 'm' to denote limits in terms of kilobytes or megabytes.
 
 
 ### error_default_type
 
-See the property description in Kong's configuration reference for [error_default_type](https://docs.konghq.com/0.13.x/configuration/#error_default_type)
+**Default:** `text/plain`
+
+**Description:**
+
+Default MIME type to use when the request
+`Accept` header is missing and Nginx
+is returning an error for the request.
+Accepted values are `text/plain`,
+`text/html`, `application/json`, and
+`application/xml`.
 
 
 ## Datastore

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -128,93 +128,116 @@ admin_gui_listen HTTP/HTTPS port.
 admin_api_uri = https://127.0.0.1:8444
 ```
 
+
 ### admin_listen
 
 See the property description in Kong's configuration reference for [admin_listen](https://docs.konghq.com/0.13.x/configuration/#admin_listen)
+
 
 ### nginx_user
 
 See the property description in Kong's configuration reference for [nginx_user](https://docs.konghq.com/0.13.x/configuration/#nginx_user)
 
+
 ### nginx_worker_processes 
 
 See the property description in Kong's configuration reference for  [nginx_worker_processes](https://docs.konghq.com/0.13.x/configuration/#nginx_worker_processes)
+
 
 ### nginx_daemon
 
 See the property description in Kong's configuration reference for [nginx_daemon](https://docs.konghq.com/0.13.x/configuration/#nginx_daemon)
 
+
 ### mem_cache_size
 
 See the property description in Kong's configuration reference for [mem_cahce_size](https://docs.konghq.com/0.13.x/configuration/#mem_cache_size)
+
 
 ### ssl_cipher_suite
 
 See the property description in Kong's configuration reference for [ssl_cipher_suite](https://docs.konghq.com/0.13.x/configuration/#ssl_cipher_suite)
 
+
 ### ssl_ciphers
 
 See the property description in Kong's configuration reference for [ssl_ciphers](https://docs.konghq.com/0.13.x/configuration/#ssl_ciphers)
+
 
 ### ssl_cert
 
 See the property description in Kong's configuration reference for [ssl_cert](https://docs.konghq.com/0.13.x/configuration/#ssl_cert)
 
+
 ### ssl_cert_key
 
 See the property description in Kong's configuration reference for [ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#ssl_cert_key)
+
 
 ### client_ssl
 
 See the property description in Kong's configuration reference for [client_ssl](https://docs.konghq.com/0.13.x/configuration/#client_ssl)
 
+
 ### client_ssl_cert
 
 See the property description in Kong's configuration reference for [client_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert)
+
 
 ### client_ssl_cert_key
 
 See the property description in Kong's configuration reference for [client_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert_key)
 
+
 ### admin_ssl_cert
 
 See the property description in Kong's configuration reference for [admin_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert)
+
 
 ### admin_ssl_cert_key
 
 See the property description in Kong's configuration reference for [admin_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert_key)
 
+
 ### upstream_keepalive
 
 See the property description in Kong's configuration reference for [upstream_keepalive](https://docs.konghq.com/0.13.x/configuration/#upstream_keepalive)
+
 
 ### server_tokens
 
 See the property description in Kong's configuration reference for [server_tokens](https://docs.konghq.com/0.13.x/configuration/#server_tokens)
 
+
 ### latency_tokens
 
 See the property description in Kong's configuration reference for [latency_tokens](https://docs.konghq.com/0.13.x/configuration/#latency_tokens)
+
 
 ### trusted_ips
 
 See the property description in Kong's configuration reference for [trusted_ips](https://docs.konghq.com/0.13.x/configuration/#trusted_ips)
 
+
 ### real_ip_header
 
 See the property description in Kong's configuration reference for [real_ip_header](https://docs.konghq.com/0.13.x/configuration/#real_ip_header)
+
 
 ### real_ip_recursive
 
 See the property description in Kong's configuration reference for [real_ip_recursive](https://docs.konghq.com/0.13.x/configuration/#real_ip_recursive)
 
+
 ### client_max_body_size
 
 See the property description in Kong's configuration reference for [client_max_body_size](https://docs.konghq.com/0.13.x/configuration/#client_max_body_size)
 
+
 ### client_body_buffer_size
 
 See the property description in Kong's configuration reference for [client_body_buffer_size](https://docs.konghq.com/0.13.x/configuration/#client_body_buffer_size)
+
 
 ### error_default_type
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -54,9 +54,12 @@ See the property description in Kong's configuration reference for
 
 **Example:**
 
-```
-admin_api_uri = https://127.0.0.1:8444
-```
+## NGINX
+
+
+### proxy_listen
+
+See the property description in Kong's configuration reference for [proxy_listen](https://docs.konghq.com/0.13.x/configuration/#proxy_listen)
 
 
 ### proxy_url
@@ -106,6 +109,116 @@ proxy_url = https://127.0.0.1:8443
 ```
 
 
+### admin_api_uri
+
+**Default:** `NONE` (auto generated)
+
+**Description:**  
+
+Hierarchical part of a URI which is composed 
+optionally of a host, port, and path at which your 
+Admin interface API accepts HTTP or HTTPS traffic. 
+When this config is disabled, the gui will use the 
+window protocol + host and append the resolved 
+admin_gui_listen HTTP/HTTPS port.
+
+**Example:**
+
+```
+admin_api_uri = https://127.0.0.1:8444
+```
+
+### admin_listen
+
+See the property description in Kong's configuration reference for [admin_listen](https://docs.konghq.com/0.13.x/configuration/#admin_listen)
+
+### nginx_user
+
+See the property description in Kong's configuration reference for [nginx_user](https://docs.konghq.com/0.13.x/configuration/#nginx_user)
+
+### nginx_worker_processes 
+
+See the property description in Kong's configuration reference for  [nginx_worker_processes](https://docs.konghq.com/0.13.x/configuration/#nginx_worker_processes)
+
+### nginx_daemon
+
+See the property description in Kong's configuration reference for [nginx_daemon](https://docs.konghq.com/0.13.x/configuration/#nginx_daemon)
+
+### mem_cache_size
+
+See the property description in Kong's configuration reference for [mem_cahce_size](https://docs.konghq.com/0.13.x/configuration/#mem_cache_size)
+
+### ssl_cipher_suite
+
+See the property description in Kong's configuration reference for [ssl_cipher_suite](https://docs.konghq.com/0.13.x/configuration/#ssl_cipher_suite)
+
+### ssl_ciphers
+
+See the property description in Kong's configuration reference for [ssl_ciphers](https://docs.konghq.com/0.13.x/configuration/#ssl_ciphers)
+
+### ssl_cert
+
+See the property description in Kong's configuration reference for [ssl_cert](https://docs.konghq.com/0.13.x/configuration/#ssl_cert)
+
+### ssl_cert_key
+
+See the property description in Kong's configuration reference for [ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#ssl_cert_key)
+
+### client_ssl
+
+See the property description in Kong's configuration reference for [client_ssl](https://docs.konghq.com/0.13.x/configuration/#client_ssl)
+
+### client_ssl_cert
+
+See the property description in Kong's configuration reference for [client_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert)
+
+### client_ssl_cert_key
+
+See the property description in Kong's configuration reference for [client_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#client_ssl_cert_key)
+
+### admin_ssl_cert
+
+See the property description in Kong's configuration reference for [admin_ssl_cert](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert)
+
+### admin_ssl_cert_key
+
+See the property description in Kong's configuration reference for [admin_ssl_cert_key](https://docs.konghq.com/0.13.x/configuration/#admin_ssl_cert_key)
+
+### upstream_keepalive
+
+See the property description in Kong's configuration reference for [upstream_keepalive](https://docs.konghq.com/0.13.x/configuration/#upstream_keepalive)
+
+### server_tokens
+
+See the property description in Kong's configuration reference for [server_tokens](https://docs.konghq.com/0.13.x/configuration/#server_tokens)
+
+### latency_tokens
+
+See the property description in Kong's configuration reference for [latency_tokens](https://docs.konghq.com/0.13.x/configuration/#latency_tokens)
+
+### trusted_ips
+
+See the property description in Kong's configuration reference for [trusted_ips](https://docs.konghq.com/0.13.x/configuration/#trusted_ips)
+
+### real_ip_header
+
+See the property description in Kong's configuration reference for [real_ip_header](https://docs.konghq.com/0.13.x/configuration/#real_ip_header)
+
+### real_ip_recursive
+
+See the property description in Kong's configuration reference for [real_ip_recursive](https://docs.konghq.com/0.13.x/configuration/#real_ip_recursive)
+
+### client_max_body_size
+
+See the property description in Kong's configuration reference for [client_max_body_size](https://docs.konghq.com/0.13.x/configuration/#client_max_body_size)
+
+### client_body_buffer_size
+
+See the property description in Kong's configuration reference for [client_body_buffer_size](https://docs.konghq.com/0.13.x/configuration/#client_body_buffer_size)
+
+### error_default_type
+
+See the property description in Kong's configuration reference for [error_default_type](https://docs.konghq.com/0.13.x/configuration/#error_default_type)
 ## Kong Manager
 
 ### admin_gui_listen

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -7,8 +7,12 @@ title: Configuration Property Reference for Kong Enterprise
 
 ### prefix
 
-See the property description in Kong's configuration reference for 
-[prefix](https://docs.konghq.com/0.13.x/configuration/#prefix)
+**Default:** `/usr/local/kong/`
+
+**Description:**  
+
+Working directory. Equivalent to Nginx's prefix path, containing temporary files 
+and logs. Each Kong process must have a separate working directory.
 
 
 ### log_level

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -746,6 +746,7 @@ This should be same as the scrape
 interval (in seconds) of the
 Prometheus server.
 
+
 ## Dev Portal
 
 


### PR DESCRIPTION
### Summary

Provides a complete property reference for Kong Enterprise; most sections outside of Kong Manager and Dev Portal were missing. Any shared properties with Core have links to the relevant doc.
 
### Full changelog

* Add either a description or a link to all missing properties in Enterprise
* Replace sub-section in Audit Log with a link to the main property reference
* Fix any noticeable formatting issues

### Issues resolved

Fix TD-39 (internal)

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] Spellchecked my updates
- [x] Ready to be merged 
  _Needed in order to merge_:
  - [x] Although we have an entry for `admin_invite_email`, it's nowhere in `kong.conf` and may need to be removed.
  - [x] Write all of the properties instead of linking to Kong reference. This will avoid confusion and improve the reader experience.
  - [x] Remove the ToC for now and create a manual ToC with general sections; this will all be replaced with a left-nav
