### PR TITLE
docs(ce/ee) moving ArecaBay plugin into analytics-monitoring only

### DIFF
--- a/app/_hub/arecabay/ab-microsensor/index.md
+++ b/app/_hub/arecabay/ab-microsensor/index.md
@@ -2,10 +2,8 @@
 name: ArecaBay MicroSensor
 publisher: ArecaBay
 
-categories: 
-  - security
+categories:
   - analytics-monitoring
-  - logging
 
 type: plugin
 


### PR DESCRIPTION
As per commit description.