### PR TITLE
docs(typo) correct property name

### DIFF
--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -311,7 +311,7 @@ portal_gui_host = localhost:8003
 ```
 
 
-### port_gui_use_subdomains
+### portal_gui_use_subdomains
 
 **Default** `Off`
 


### PR DESCRIPTION
### Summary

Corrects `portal_gui_use_subdomains`

### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] Spellchecked my updates
- [x] Ready to be merged
