### PR TITLE
fix(navbar) fix various navbar header styling issues

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -355,6 +355,10 @@ a:focus,a:hover {
     text-decoration: underline
 }
 
+.navbar-nav a:hover,.navbar-nav a:focus {
+    text-decoration: none
+}
+
 a:not([href]):not([tabindex]),a:not([href]):not([tabindex]):focus,a:not([href]):not([tabindex]):hover {
     /* color: inherit; */
     text-decoration: none;

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -42,13 +42,13 @@
       <nav id="navbar" class="navbar-nav">
         <ul>
           <li>
-            <a href="/" class="active">Docs</a>
+            <a href="/" {% if page.layout == 'docs' %}class="active"{% endif %}>Docs</a>
           </li>
           <li>
             <a href="https://konghq.com/about-kong-inc/">About</a>
           </li>
           <li>
-            <a href="/hub/">Hub</a>
+            <a href="/hub/" {% if page.layout == 'extension' or page.url == '/hub/' %}class="active"{% endif %}>Hub</a>
           </li>
           <li>
             <a href="https://konghq.com/community-resources/">Community</a>


### PR DESCRIPTION
* dynamically assign active class again for /docs/ and /hub/ (the only 2
links that stay within the website)
* do not underline navbar links when browing the /hub/