### PR TITLE
feat(autodoc) add an auto-generator for cli.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,24 @@ scraper to test out config changes.
   * Generate documentation for all the modules in your PDK (where possible) and
     put in a folder inside your version docs
 
-## Generating the Admin API Documentation
+## Generating the Admin API and CLI Documentation
 
 - Make sure that `resty` is in your `$PATH` (installing kong installs `resty` as well)
-- Several luarocks are needed. Easiest way to get all of them is to execute `make dev` in the kong folder
+- Several Lua rocks are needed. Easiest way to get all of them is to execute `make dev` in the Kong folder
 - Have a local clone of Kong
 - In the Kong repository, checkout the desired branch/tag/release
-- Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp admin-api-docs`
-- This command will attempt to:
-  * Compare Kong's schemas and Admin API routes with the contents of the file
-    `autodoc-admin-api/data.lua` and error out if there's any mismatches or missing data.
-  * If no errors were found, a new `admin-api.md` file will be generated in the path corresponding
-    to the provided KONG_VERSION.
+- To generate the Admin API docs:
+  - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp admin-api-docs`
+  - This command will attempt to:
+    * Compare Kong's schemas and Admin API routes with the contents of the file
+      `autodoc-admin-api/data.lua` and error out if there's any mismatches or missing data.
+    * If no errors were found, a new `admin-api.md` file will be generated in the path corresponding
+      to the provided KONG_VERSION.
+- To generate the CLI docs:
+  - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp cli-docs`
+  - This command will:
+    * Extract the output of the `--help` for every `kong` CLI subcommand
+    * Generate a new `cli.md` in the path corresponding to the provided KONG_VERSION.
 
 ## Listing Your Extension in the Kong Hub
 

--- a/app/1.0.x/cli.md
+++ b/app/1.0.x/cli.md
@@ -22,6 +22,7 @@ All commands take a set of special, optional flags as arguments:
 
 ## Available commands
 
+
 ### kong check
 
 ```
@@ -29,12 +30,77 @@ Usage: kong check <conf>
 
 Check the validity of a given Kong configuration file.
 
-<conf> (default /etc/kong.conf or /etc/kong/kong.conf) configuration file
+<conf> (default /etc/kong/kong.conf) configuration file
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
+
+
+### kong health
+
+```
+Usage: kong health [OPTIONS]
+
+Check if the necessary services are running for this node.
+
+Options:
+ -p,--prefix      (optional string) prefix at which Kong should be running
+
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+
+### kong migrations
+
+```
+Usage: kong migrations COMMAND [OPTIONS]
+
+Manage database schema migrations.
+
+The available commands are:
+  bootstrap                         Bootstrap the database and run all
+                                    migrations.
+
+  up                                Run any new migrations.
+
+  finish                            Finish running any pending migrations after
+                                    'up'.
+
+  list                              List executed migrations.
+
+  reset                             Reset the database.
+
+Options:
+ -y,--yes                           Assume "yes" to prompts and run
+                                    non-interactively.
+
+ -q,--quiet                         Suppress all output.
+
+ -f,--force                         Run migrations even if database reports
+                                    as already executed.
+
+ --db-timeout     (default 60)      Timeout, in seconds, for all database
+                                    operations (including schema consensus for
+                                    Cassandra).
+
+ --lock-timeout   (default 60)      Timeout, in seconds, for nodes waiting on
+                                    the leader node to finish running
+                                    migrations.
+
+ -c,--conf        (optional string) Configuration file.
+
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
 
 ### kong prepare
 
@@ -48,53 +114,21 @@ be used to start Kong from the nginx binary without using the 'kong start'
 command.
 
 Example usage:
-  kong prepare -p /usr/local/kong -c kong.conf && kong migrations up &&
-    nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf
+  kong migrations up
+  kong prepare -p /usr/local/kong -c kong.conf
+  nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf
 
 Options:
- -c,--conf    (optional string) configuration file
- -p,--prefix  (optional string) override prefix directory
- --nginx-conf (optional string) custom Nginx configuration template
+  -c,--conf       (optional string) configuration file
+  -p,--prefix     (optional string) override prefix directory
+  --nginx-conf    (optional string) custom Nginx configuration template
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
 
-### kong health
-
-```
-Usage: kong health [OPTIONS]
-
-Check if the necessary services are running for this node.
-
-Options:
-  -p,--prefix (optional string) prefix at which Kong should be running
-```
-
-[Back to TOC](#table-of-contents)
-
----
-
-### kong migrations
-
-```
-Usage: kong migrations COMMAND [OPTIONS]
-
-Manage Kong's database migrations.
-
-The available commands are:
-  list   List migrations currently executed.
-  up     Execute all missing migrations up to the latest available.
-  reset  Reset the configured database (irreversible).
-
-Options:
-  -c,--conf (optional string) configuration file
-```
-
-[Back to TOC](#table-of-contents)
-
----
 
 ### kong quit
 
@@ -110,13 +144,15 @@ If the timeout delay is reached, the node will be forcefully
 stopped (SIGTERM).
 
 Options:
-  -p,--prefix  (optional string) prefix Kong is running at
-  -t,--timeout (default 10) timeout before forced shutdown
+ -p,--prefix      (optional string) prefix Kong is running at
+ -t,--timeout     (default 10) timeout before forced shutdown
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
+
 
 ### kong reload
 
@@ -132,35 +168,42 @@ and stop the old ones when they have finished processing
 current requests.
 
 Options:
-  -c,--conf    (optional string) configuration file
-  -p,--prefix  (optional string) prefix Kong is running at
-  --nginx-conf (optional string) custom Nginx configuration template
+ -c,--conf        (optional string) configuration file
+ -p,--prefix      (optional string) prefix Kong is running at
+ --nginx-conf     (optional string) custom Nginx configuration template
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
+
 
 ### kong restart
 
 ```
 Usage: kong restart [OPTIONS]
 
-Restart a Kong node in the given prefix directory.
+Restart a Kong node (and other configured services like Serf)
+in the given prefix directory.
 
 This command is equivalent to doing both 'kong stop' and
 'kong start'.
 
 Options:
-  -c,--conf        (optional string)   configuration file
-  -p,--prefix      (optional string)   prefix at which Kong should be running
-  --nginx-conf     (optional string)   custom Nginx configuration template
-  --run-migrations (optional boolean)  optionally run migrations on the DB
+ -c,--conf        (optional string)   configuration file
+ -p,--prefix      (optional string)   prefix at which Kong should be running
+ --nginx-conf     (optional string)   custom Nginx configuration template
+ --run-migrations (optional boolean)  optionally run migrations on the DB
+ --db-timeout     (default 60)
+ --lock-timeout   (default 60)
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
+
 
 ### kong start
 
@@ -171,15 +214,28 @@ Start Kong (Nginx and other configured services) in the configured
 prefix directory.
 
 Options:
-  -c,--conf        (optional string)   configuration file
-  -p,--prefix      (optional string)   prefix at which Kong should be running
-  --nginx-conf     (optional string)   custom Nginx configuration template
-  --run-migrations (optional boolean)  optionally run migrations on the DB
+ -c,--conf        (optional string)   Configuration file.
+
+ -p,--prefix      (optional string)   Override prefix directory.
+
+ --nginx-conf     (optional string)   Custom Nginx configuration template.
+
+ --run-migrations (optional boolean)  Run migrations before starting.
+
+ --db-timeout     (default 60)        Timeout, in seconds, for all database
+                                      operations (including schema consensus for
+                                      Cassandra).
+
+ --lock-timeout   (default 60)        When --run-migrations is enabled, timeout,
+                                      in seconds, for nodes waiting on the
+                                      leader node to finish running migrations.
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
+
 
 ### kong stop
 
@@ -192,12 +248,14 @@ prefix directory.
 This command sends a SIGTERM signal to Nginx.
 
 Options:
-  -p,--prefix (optional string) prefix Kong is running at
+ -p,--prefix      (optional string) prefix Kong is running at
+
 ```
 
 [Back to TOC](#table-of-contents)
 
 ---
+
 
 ### kong version
 
@@ -208,9 +266,13 @@ Print Kong's version. With the -a option, will print
 the version of all underlying dependencies.
 
 Options:
-  -a,--all    get version of all dependencies
+ -a,--all         get version of all dependencies
+
 ```
 
 [Back to TOC](#table-of-contents)
+
+---
+
 
 [configuration-reference]: /{{page.kong_version}}/configuration

--- a/autodoc-cli/data.lua
+++ b/autodoc-cli/data.lua
@@ -1,0 +1,41 @@
+local data = {}
+
+data.header = [[
+---
+title: CLI Reference
+---
+
+## Introduction
+
+The provided CLI (*Command Line Interface*) allows you to start, stop, and
+manage your Kong instances. The CLI manages your local node (as in, on the
+current machine).
+
+If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
+
+## Global flags
+
+All commands take a set of special, optional flags as arguments:
+
+* `--help`: print the command's help message
+* `--v`: enable verbose mode
+* `--vv`: enable debug mode (noisy)
+
+[Back to TOC](#table-of-contents)
+
+## Available commands
+
+]]
+
+data.command_intro = {
+  ["prepare"] = [[
+    This command prepares the Kong prefix folder, with its sub-folders and files.
+  ]],
+}
+
+data.footer = [[
+
+[configuration-reference]: /{{page.kong_version}}/configuration
+]]
+
+return data

--- a/autodoc-cli/run.lua
+++ b/autodoc-cli/run.lua
@@ -1,0 +1,55 @@
+#!/usr/bin/env resty
+
+local lfs = require("lfs")
+
+local data = require("autodoc-cli.data")
+
+local KONG_PATH = assert(os.getenv("KONG_PATH"))
+local KONG_VERSION = assert(os.getenv("KONG_VERSION"))
+
+package.path = KONG_PATH .. "/?.lua;" .. KONG_PATH .. "/?/init.lua;" .. package.path
+
+local cmds = {}
+for file in lfs.dir(KONG_PATH .. "/kong/cmd") do
+  local cmd = file:match("(.*)%.lua$")
+  if cmd and cmd ~= "roar" and cmd ~= "init" then
+    table.insert(cmds, cmd)
+  end
+end
+table.sort(cmds)
+
+local outpath = "app/" .. KONG_VERSION .. "/cli.md"
+local outfd = assert(io.open(outpath, "w+"))
+
+outfd:write(data.header)
+
+local function write(str)
+  outfd:write(str)
+  outfd:write("\n")
+end
+
+for _, cmd in ipairs(cmds) do
+  write("")
+  write("### kong " .. cmd)
+  write("")
+  if data.command_intro[cmd] then
+    write((("\n"..data.command_intro[cmd]):gsub("\n%s+", "\n"):gsub("^\n", "")))
+  end
+  write("```")
+  local pd = io.popen("cd " .. KONG_PATH .. "; bin/kong " .. cmd .. " --help 2>&1")
+  local info = pd:read("*a")
+  info = info:gsub(" %-%-v[^\n]+\n", "")
+  info = info:gsub("\nOptions:\n$", "")
+  write(info)
+  pd:close()
+  write("```")
+  write("")
+  write("[Back to TOC](#table-of-contents)")
+  write("")
+  write("---")
+  write("")
+end
+
+outfd:write(data.footer)
+
+outfd:close()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -247,6 +247,7 @@ gulp.task('admin-api-docs', function (cb) {
     return cb('No KONG_VERSION environment variable set. Example: 0.14.x')
   }
 
+  // 1 Generate admin-api.md
   cmd = 'resty autodoc-admin-api/run.lua'
   obj = childProcess.spawnSync(cmd, { shell: true })
   errLog = obj.stderr.toString()
@@ -255,6 +256,31 @@ gulp.task('admin-api-docs', function (cb) {
   }
 
   log('Re-generated Admin API docs for ' + KONG_VERSION)
+})
+
+gulp.task('cli-docs', function (cb) {
+  var KONG_PATH, KONG_VERSION, cmd, obj, errLog
+
+  // 0 Obtain "env-var params"
+  KONG_PATH = process.env.KONG_PATH
+  if (KONG_PATH === undefined) {
+    return cb('No KONG_PATH environment variable set')
+  }
+
+  KONG_VERSION = process.env.KONG_VERSION
+  if (KONG_VERSION === undefined) {
+    return cb('No KONG_VERSION environment variable set. Example: 1.0.x')
+  }
+
+  // 1 Generate cli.md
+  cmd = 'resty autodoc-cli/run.lua'
+  obj = childProcess.spawnSync(cmd, { shell: true })
+  errLog = obj.stderr.toString()
+  if (errLog.length > 0) {
+    return cb(errLog)
+  }
+
+  log('Re-generated CLI docs for ' + KONG_VERSION)
 })
 
 gulp.task('clean', function () {


### PR DESCRIPTION
Adds a new script, `autodoc-cli`, which will:
* Extract the output of the `--help` for every `kong` CLI subcommand
* Generate a new `cli.md` in the path corresponding to the provided KONG_VERSION.

Includes a new gulp task to launch it, `cli-docs`.

Also includes the result of running it for Kong 1.0.x. It already paid for itself by catching two flags that we forgot to document. :)