### PR TITLE
docs(ce/conf) add missing guidance for control plane mode

### DIFF
--- a/app/1.0.x/configuration.md
+++ b/app/1.0.x/configuration.md
@@ -483,9 +483,9 @@ Some suffixes can be specified for each pair:
 - Finally, `proxy_protocol` will enable usage of the PROXY protocol for a
   given address/port.
 
-the proxy port for this node, enabling a 'control-plane' mode (without traffic
-proxying capabilities) which can configure a cluster of nodes connected to the
-same database.
+This value can be set to `off`, thus disabling the proxy port for this node, enabling
+a 'control-plane' mode (without traffic proxying capabilities) which can configure a
+cluster of nodes connected to the same database.
 
 See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for
 a description of the accepted formats for this and other `*_listen` values.
@@ -718,7 +718,7 @@ Default: `off`
 Sets the maximum number of idle keepalive connections to upstream servers that
 are preserved in the cache of each worker process. When this number is
 exceeded, the least recently used connections are closed. A value of `0`
-will disable this behavior altogether, forcing each upstream request to open 
+will disable this behavior altogether, forcing each upstream request to open
 a new connection.
 
 Default: `60`


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

The first part of the sentence under the bullets in the `proxy_listen` section of the configuration doc is missing. I took a guess about the correct note here based on my (admittedly poor) understanding of how the configuration options should work. Would be glad for a correction.   

### Full changelog

* Added the option `off` to the notes on `proxy_protocol` in the `proxy_listen` configuration
* Added that setting `off` here should disable the proxy port for the node  

### Issues resolved

Fix #XXX

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
