### PR TITLE
change `up` command to `bootstrap` in docker installation guide

### DIFF
--- a/app/install/docker.md
+++ b/app/install/docker.md
@@ -53,7 +53,7 @@ Here is a quick example showing how to connect a Kong container to a Cassandra o
         -e "KONG_DATABASE=postgres" \
         -e "KONG_PG_HOST=kong-database" \
         -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
-        kong:latest kong migrations up
+        kong:latest kong migrations bootstrap
     ```
 
     In the above example, both Cassandra and PostgreSQL are configured, but you


### PR DESCRIPTION
### Summary

Change command for database migration

### Full changelog

* Edited Docker Installation doc. Replaced `up` with `bootstrap`.

### Issues resolved

If use command `up` then error is thrown `Error: cannot run migrations: database needs bootstrapping; run 'kong migrations bootstrap'`

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
