### PR TITLE
fix(*) anchors with name attrs now properly offset

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -172,7 +172,7 @@ h1, h2, h3, h4, h5, h6, .page-header-section-title {
 
 /* Fix for anchor link h tags being hidden by nav */
 .page-content {
-  h1, h2, h3, h4, h5, h6, .page-header-section-title {
+  h1, h2, h3, h4, h5, h6, .page-header-section-title, a[name] {
     @media (min-width: @navbar-collapse-point) {
       &::before {
         display: block;


### PR DESCRIPTION
### Summary

Browsers will respect the `name` attribute as another way to link to sections of the page. I've limited it to just `a` tags but I'm not sure if other pages use different tags. If others are used, then they'll have to be added too.

### Full changelog

* Have anchor tags with `name` attributes respect the same behavior as headings with `id`s

### Issues resolved

Fix #1039

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
