### PR TITLE
style(install) invert margin for email sign-up

### DIFF
--- a/app/_assets/stylesheets/pages/install-method.less
+++ b/app/_assets/stylesheets/pages/install-method.less
@@ -146,7 +146,7 @@
 
     .update-subscribe {
       display: flex;
-      margin-top: -25px;
+      margin-top: 25px;
       .icon {
         box-sizing: border-box;
         width: 36px;


### PR DESCRIPTION
### Summary

I cannot see why the margin for this element was negative, but inverting it fixes the overlap in #1020

### Full changelog

* Fix overlap of subscribe element

### Issues resolved

Fix #1020

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
