### PR TITLE
docs(ee/dev-portal) fix links to dev status and plugins TD-2

### DIFF
--- a/app/enterprise/0.34-x/developer-portal/configuration/authentication.md
+++ b/app/enterprise/0.34-x/developer-portal/configuration/authentication.md
@@ -7,8 +7,8 @@ title: Authenticating the Dev Portal
 The Dev Portal supports the following authentication plugins:
 
 * [Basic Auth](https://docs.konghq.com/hub/kong-inc/basic-auth/)
-* [Key Authentication](https://docs.konghq.com.org/plugins/key-authentication)
-* [OpenID Connect-EE](https://docs.konghq.com.org/plugins/ee-openid-connect/)
+* [Key Authentication](https://docs.konghq.com/plugins/key-authentication)
+* [OpenID Connect-EE](https://docs.konghq.com/plugins/ee-openid-connect/)
 
 
 ## Enable Authentication
@@ -91,11 +91,11 @@ in plain text, so be careful not to store sensitive information in meta.
 
 Check out the section "**Enabling Authentication"** for a step by step guide on 
 setting up 
-[Basic Authentication](https://docs.konghq.com.org/plugins/basic-authentication).
+[Basic Authentication](https://docs.konghq.com/plugins/basic-authentication).
 
 ### Key Authentication
 
-The [Key Authentication Plugin](https://docs.konghq.com.org/plugins/key-authentication) 
+The [Key Authentication Plugin](https://docs.konghq.com/plugins/key-authentication) 
 allows developers to use API keys to authenticate requests, and can be used to 
 authenticate the Dev Portal. Developers will be able to login with a single API 
 key, rather than a username/password.
@@ -111,12 +111,12 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
 
 ### Open-ID Connect Plugin
 
-The [OpenID Connect Plugin](/plugins/ee-openid-connect/) allows the Dev Portal 
-to hook into existing authentication setups using third-party 
+The [OpenID Connect Plugin](https://docs.konghq.com/hub/kong-inc/openid-connect/) 
+allows the Dev Portal to hook into existing authentication setups using third-party 
 *Identity Providers* (**IdP**) such as Google, Yahoo, Microsoft Azure AD, etc. 
 
-[OIDC](/plugins/ee-openid-connect/) must be used with the `session` method, 
-utilizing cookies for Dev Portal File API requests.
+[OIDC](https://docs.konghq.com/hub/kong-inc/openid-connect/) must be used with 
+the `session` method, utilizing cookies for Dev Portal File API requests.
 
 In the Dev Portal's settings in `Kong Manager` select `Open ID Connect` from the 
 Authentication Plugin dropdown, or run the following cURL command:

--- a/app/enterprise/0.34-x/developer-portal/configuration/authentication.md
+++ b/app/enterprise/0.34-x/developer-portal/configuration/authentication.md
@@ -40,7 +40,7 @@ Developers are now able to request access to the Dev Portal via the
 will be submitted to the `http://127.0.0.1:8000/_kong/portal/register` endpoint 
 and a Developer credential is created upon registration. The Developer will not 
 be able to use this credential until they are approved. See 
-[Approving Developers](/enterprise/{{page.kong_version}}/developer-portal/management/managing-developers#approving-developers).
+[Approving Developers](/enterprise/{{page.kong_version}}/developer-portal/management/developers/#developer-status).
 
 
 Required Registration fields by Authentication plugin:

--- a/app/enterprise/0.34-x/developer-portal/configuration/workspaces.md
+++ b/app/enterprise/0.34-x/developer-portal/configuration/workspaces.md
@@ -58,7 +58,7 @@ the `Settings` page in the `Kong Manager` or by submitting a cURL request
 directly to the Dev Portal's configuration table. More information on these 
 settings can be found in 
 [Getting Started](/enterprise/{{page.kong_version}}/developer-portal/configuration/getting-started) and in the 
-[Dev Portal Property Reference](/enterpise/{{page.kong_version}}/property-reference/#dev-portal)
+[Dev Portal Property Reference](/enterprise/{{page.kong_version}}/property-reference/#dev-portal)
 
 
 ## Files

--- a/app/enterprise/0.34-x/developer-portal/developers/developer-access.md
+++ b/app/enterprise/0.34-x/developer-portal/developers/developer-access.md
@@ -13,7 +13,7 @@ As a Developer, once you are [approved](/enterprise/{{page.kong_version}}/develo
 Current plugins supported:
 
 - [ACL](/plugins/acl/)
-- [Basic Authentication](/plugins/key-authentication/)
+- [Basic Authentication](/plugins/basic-authentication/)
 - [Key Authentication](/plugins/key-authentication/)
 - [OAuth 2.0](/plugins/basic-authentication/)
 - [HMAC Signature Authentication](/plugins/hmac-authentication/)

--- a/app/enterprise/0.34-x/developer-portal/developers/developer-access.md
+++ b/app/enterprise/0.34-x/developer-portal/developers/developer-access.md
@@ -8,7 +8,7 @@ Since [Developers][developers] are a type of [Consumer](/0.13.x/getting-started/
 
 ## How to Manage Your Developer Credentials
 
-As a Developer, once you are [approved](/enterprise/{{page.kong_version}}/developer-portal/managing-developers/#developers-statuses), you can login to the Dev Portal Dashboard and [create](#creating-a-credential), [update](#updating-a-credential), or [delete](#deleting-a-credential) credentials. The credential options available will be based on which authentication plugins the Kong admin has enabled.
+As a Developer, once you are [approved](/enterprise/{{page.kong_version}}/developer-portal/management/developers/#developer-status), you can login to the Dev Portal Dashboard and [create](#creating-a-credential), [update](#updating-a-credential), or [delete](#deleting-a-credential) credentials. The credential options available will be based on which authentication plugins the Kong admin has enabled.
 
 Current plugins supported:
 

--- a/app/enterprise/0.34-x/developer-portal/developers/developer-access.md
+++ b/app/enterprise/0.34-x/developer-portal/developers/developer-access.md
@@ -15,7 +15,7 @@ Current plugins supported:
 - [ACL](/plugins/acl/)
 - [Basic Authentication](/plugins/basic-authentication/)
 - [Key Authentication](/plugins/key-authentication/)
-- [OAuth 2.0](/plugins/basic-authentication/)
+- [OAuth 2.0](/hub/kong-inc/oauth2/)
 - [HMAC Signature Authentication](/plugins/hmac-authentication/)
 - [JWT](/plugins/jwt/)
 

--- a/app/enterprise/0.34-x/developer-portal/introduction.md
+++ b/app/enterprise/0.34-x/developer-portal/introduction.md
@@ -31,7 +31,7 @@ toc: false
     <h3><img src="/assets/images/icons/documentation/icn-window.svg" />
     <a href="/enterprise/{{page.kong_version}}/developer-portal/customization">Customization</a></h3>
     <p>Learn how to customize the look and feel of the Kong Dev Portal.</p>
-    <a href="/enterprise/{{page.kong_version}}/developer-portal/customization">
+    <a href="/enterprise/{{page.kong_version}}/developer-portal/customization/customization">
     Learn More &rarr;</a>
   </div>
 


### PR DESCRIPTION
### Summary

Fix the link to Developer Statuses and various plugin pages.

### Changes
* Fix links to Developer Status by using new path introduced in 0.34
* Fix links to various pages by removing `.org` in URL
* Fix links that redirected by specifying the path

### Issues resolved

Fix (internal) TD-2 and related cases

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
