### PR TITLE
fix(autodoc) replace resty with luajit for cli-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ scraper to test out config changes.
 
 ## Generating the Admin API and CLI Documentation
 
-- Make sure that `resty` is in your `$PATH` (installing kong installs `resty` as well)
+- Make sure that the `resty` and `luajit` executables are in your `$PATH` (installing kong should install them)
 - Several Lua rocks are needed. Easiest way to get all of them is to execute `make dev` in the Kong folder
 - Have a local clone of Kong
 - In the Kong repository, checkout the desired branch/tag/release

--- a/autodoc-cli/run.lua
+++ b/autodoc-cli/run.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/env resty
+#!/usr/bin/env luajit
 
 local lfs = require("lfs")
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,7 +273,7 @@ gulp.task('cli-docs', function (cb) {
   }
 
   // 1 Generate cli.md
-  cmd = 'resty autodoc-cli/run.lua'
+  cmd = 'luajit autodoc-cli/run.lua'
   obj = childProcess.spawnSync(cmd, { shell: true })
   errLog = obj.stderr.toString()
   if (errLog.length > 0) {


### PR DESCRIPTION
The resty executable has trouble dealing with `popen`. On
this particular case, it works on Linux but it throws a
`Interrupted system call` error on mac, when reading the last
line of each popen.

This PR replaces `resty` with `luajit` when generating the
CLI docs, which involve a call to `popen`.

Related with https://github.com/openresty/resty-cli/issues/35