### PR TITLE
style(*) shrink header spacing after small navbar

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -3,6 +3,8 @@
 'use strict'
 
 $(function () {
+  var NAV_HEIGHT = 56
+
   var $window = $(window)
   var $docs = $('#documentation')
 
@@ -15,7 +17,7 @@ $(function () {
     e.preventDefault()
 
     $('html, body').animate({
-      scrollTop: $($(this).attr('href')).offset().top - 107 // Header height
+      scrollTop: $($(this).attr('href')).offset().top - NAV_HEIGHT // Header height
     }, 700)
   })
 
@@ -335,7 +337,7 @@ $(function () {
   // Add Smooth scroll when link with attr clicked
   $('a[data-link="scroll"]').click(function () {
     $('html, body').animate({
-      scrollTop: $($.attr(this, 'href')).offset().top - 150 // Add spacing on top after scroll
+      scrollTop: $($.attr(this, 'href')).offset().top - NAV_HEIGHT // Add spacing on top after scroll
     }, 600) // Adjust scroll speed
     // Remove any active classes that may already be applied
     $('a[data-link="scroll"').removeClass('active')
@@ -348,7 +350,7 @@ $(function () {
   if (window.location.hash) {
     $('html, body').scrollTop(0).show()
     $('html, body').animate({
-      scrollTop: $(window.location.hash).offset().top - 220 // Add spacing on top after scroll
+      scrollTop: $(window.location.hash).offset().top - NAV_HEIGHT // Add spacing on top after scroll
     }, 600) // Adjust scroll speed
   }
 

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1,7 +1,7 @@
 .page-header {
   background-color: #fdfdfd;
   border-bottom: 1px solid @gray;
-  padding: 145px 0 20px;
+  padding: 95px 0 20px;
 
   @media (max-width: 1100px) {
     padding: 50px 0 10px;

--- a/app/_assets/stylesheets/variables.less
+++ b/app/_assets/stylesheets/variables.less
@@ -5,7 +5,7 @@
 @navbar-collapse-point: 1100px;
 
 // Nav
-@nav-header-height: 111px;
+@nav-header-height: 56px;
 
 // Site Fonts
 // -------------------------


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/1246453/52022805-5aa2b480-24af-11e9-9662-c50653b3fc77.png)

![image](https://user-images.githubusercontent.com/1246453/52022677-d4866e00-24ae-11e9-9c09-a70c95f4beed.png)

**After**

![image](https://user-images.githubusercontent.com/1246453/52022813-655d4980-24af-11e9-9f8c-69cb4ab62a1e.png)

![image](https://user-images.githubusercontent.com/1246453/52022722-0697d000-24af-11e9-8104-4fb623d841fd.png)

### Summary

The amount of spacing that currently exists when you click on headers pushes the heading a bit too far down because the old navbar was taller.

### Full changelog

* Pixel height in styles changed

### Issues resolved

None that I'm aware of

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
