### PR TITLE
docs(ee/dev-portal) broken image link

### DIFF
--- a/app/enterprise/0.34-x/developer-portal/configuration/workspaces.md
+++ b/app/enterprise/0.34-x/developer-portal/configuration/workspaces.md
@@ -11,8 +11,7 @@ running multiple instances of the Dev Portal - one for each Workspace. When a
 Workspace is created, that Workspaces Dev Portal will automatically appear on 
 the "Dev Portals Overivew Page"
 
-![Dev Portals Overview Page]
-(https://konghq.com/wp-content/uploads/2018/11/devportals-overview.png)
+![Dev Portals Overview Page](https://konghq.com/wp-content/uploads/2018/11/devportals-overview.png)
 
 Note that Kong Admins will only be able to see the cards for Dev Portals to 
 which they have permissions to edit. 


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Fixed broken image link in Developer portal page

The developer portal overview was supposed to be shown, but seems like the doc generator is not parsing as expected. The whitespace between the text and hyperlinks are causing the issue.

```
![Dev Portals Overview Page] (https://konghq.com/wp-content/uploads/2018/11/devportals-overview.png)
```

### Full changelog

* Fixed broken image link in [developer-portal/configuration/workspaces.md]

### Issues resolved

Fix N/A

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
