### PR TITLE
docs(ee/34/plugins) update video to basic auth

### DIFF
--- a/app/enterprise/0.34-x/getting-started/enabling-plugins.md
+++ b/app/enterprise/0.34-x/getting-started/enabling-plugins.md
@@ -31,7 +31,7 @@ $ curl -i -X POST \
 Or, add your first plugin via Kong Manager on the "Plugins" page:
 
 <video width="100%" autoplay loop controls>
- <source src="https://konghq.com/wp-content/uploads/2018/07/create-keyauth-plugin-ee-0.33.mp4" type="video/mp4">
+ <source src="https://konghq.com/wp-content/uploads/2019/02/add-basic-auth-ent-34.mov" type="video/mp4">
  Your browser does not support the video tag.
 </video>
 


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Update video in Getting Started: Enabling Plugins from using Key Auth in 0.33 to using Basic Auth in 0.34. The main reasons are to (1) show the updated UI and (2) match the new instructions for 0.34.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Preview here: https://5c5b7dd8855af400084e079a--kongdocs.netlify.com/enterprise/0.34-x/getting-started/enabling-plugins/