### PR TITLE
docs(ce/proxy) replace rfc 3986 link

### DIFF
--- a/app/1.0.x/proxy.md
+++ b/app/1.0.x/proxy.md
@@ -515,7 +515,7 @@ local router_matches = ngx.ctx.router_matches
 
 Next, it is worth noting that characters found in regexes are often
 reserved characters according to
-[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+[RFC 3986](https://tools.ietf.org/html/rfc3986) and as such,
 should be percent-encoded. **When configuring Routes with regex paths via the
 Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Replace the broken RFC 3986 link with a working one.

### Issues resolved

Fix #1120 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
