### PR TITLE
Fix z-index of hub version dropdown

### DIFF
--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -3,7 +3,7 @@
   text-align: right;
   top: -100px;
   right: 0;
-  z-index: 1000;
+  z-index: 10;
 
   ul {
     right: 0;


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Lowers the z-index of the version picker on hub plugin pages

_Before_
![](https://cl.ly/4e2e974de2a0/Image%202019-02-20%20at%201.41.31%20PM.png)

_After_
![](https://cl.ly/a692d75a3330/Image%202019-02-20%20at%201.40.59%20PM.png)

### Full changelog

* extenstion.less

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
