### PR TITLE
docs(1.0) remove old modules from plugin dev guide

### DIFF
--- a/app/1.0.x/plugin-development/access-the-datastore.md
+++ b/app/1.0.x/plugin-development/access-the-datastore.md
@@ -14,14 +14,7 @@ Kong supports two primary datastores: [Cassandra
 and [PostgreSQL
 {{site.data.kong_latest.dependencies.postgres}}](http://www.postgresql.org/).
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> As of 0.13.0, Kong is rolling out a new version of
-  the DAO abstraction layer called `kong.db`, which will gradually
-  replace `kong.dao`
-</div>
----
-
-## kong.db and kong.dao
+## kong.db
 
 All entities in Kong are represented by:
 
@@ -34,13 +27,9 @@ All entities in Kong are represented by:
   methods to insert, update, find and delete entities of that type.
 
 The core entities in Kong are: Services, Routes, Consumers and Plugins.
-Services, Routes, and Consumers are available through the new `kong.db`
-singleton. The rest of the entities are available through `kong.dao`. In the
-future, all entities will be gradually migrated to `kong.db`, including custom
-plugins entities (currently relying on `kong.dao`).
+All of them are accessible as Data Access Objects (DAOs),
+through the `kong.db` global singleton:
 
-Both the DAO Factory and the new `db` interface are singleton instances in Kong
-and thus, are accessible through the `kong` global:
 
 ```lua
 -- Core DAOs
@@ -50,8 +39,8 @@ local consumers_dao = kong.db.consumers
 local plugins_dao = kong.dao.plugins
 ```
 
-The `kong` global exposes the [Plugin Development Kit], and its `kong.dao` and
-`kong.db` properties are instances of the DAO and DB singletons.
+Both core entities from Kong and custom entities from plugins are
+available through `kong.db.*`.
 
 ---
 
@@ -62,18 +51,17 @@ the datastore, generally mapping to an entity in Kong. All the underlying
 supported databases (currently Cassandra and PostgreSQL) comply to the same
 interface, thus making the DAO compatible with all of them.
 
-For example, inserting a Service (with `kong.db`) and a Plugin (with
-`kong.dao`) is as easy as:
+For example, inserting a Service and a Plugin is as easy as:
 
 ```lua
 local inserted_service, err = kong.db.services:insert({
   name = "mockbin",
-  url = "http://mockbin.org"
+  url = "http://mockbin.org",
 })
 
-local inserted_plugin, err = kong.dao.plugins:insert({
+local inserted_plugin, err = kong.db.plugins:insert({
   name = "key-auth",
-  service_id = inserted_service.id
+  service_id = { id = inserted_service.id },
 })
 ```
 

--- a/app/1.0.x/plugin-development/entities-cache.md
+++ b/app/1.0.x/plugin-development/entities-cache.md
@@ -179,7 +179,7 @@ Adding this value allows you to use the following function on the DAO of that
 entity:
 
 ```lua
-cache_key = kong.dao:cache_key(arg1, arg2, arg3, ...)
+cache_key = kong.db.<dao>:cache_key(arg1, arg2, arg3, ...)
 ```
 
 Where the arguments must be the attributes specified in your schema's
@@ -189,7 +189,7 @@ computes a string value `cache_key` that is ensured to be unique.
 For example, if we were to generate the cache_key of an API key:
 
 ```lua
-local cache_key = kong.dao.keyauth_credentials:cache_key("abcd")
+local cache_key = kong.db.keyauth_credentials:cache_key("abcd")
 ```
 
 This would produce a cache_key for the API key `"abcd"` (retrieved from one
@@ -198,7 +198,7 @@ cache (or fetch from the database if the cache is a miss):
 
 ```lua
 local apikey = kong.request.get_query().apikey
-local cache_key = kong.dao.keyauth_credentials:cache_key(apikey)
+local cache_key = kong.db.keyauth_credentials:cache_key(apikey)
 
 local credential, err = kong.cache:get(cache_key, nil, load_entity_key, apikey)
 if err then


### PR DESCRIPTION
The Plugin Development Guide had some references to deprecated modules:

* The `kong.dao` module has now been superseeded by `kong.db` for all entities
* The `helpers` parameter on admin apis
is now replaced by the PDK
* The crud_helpers module is now replaced
by kong.api.endpoints
