### PR TITLE
docs(ce/plugin-development) fix broken link

### DIFF
--- a/app/1.0.x/plugin-development/tests.md
+++ b/app/1.0.x/plugin-development/tests.md
@@ -101,7 +101,7 @@ its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
 and Admin API on port 9001.
 
 If you want to see a real-world example, give a look at the
-[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/10-key-auth)
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth)
 
 ---
 


### PR DESCRIPTION
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

The documentation for spec/kong_tests.conf had a broken link to the key-auth plugin

### Full changelog

* Fixed link to the key-auth plugin

### Issues resolved

Fix #1166 

<!-- Have you done all of these things?  -->
### Checklist:

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
