### PR TITLE
hub(key-auth) clarify allowed key characters

### DIFF
--- a/app/_hub/kong-inc/key-auth/0.2-x.md
+++ b/app/_hub/kong-inc/key-auth/0.2-x.md
@@ -53,7 +53,7 @@ params:
       required: false
       default: "`apikey`"
       description: |
-        Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
+        Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-]. Underscores are not permitted for keys in headers due to [additional restrictions in the NGINX defaults](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers).
     - name: key_in_body
       required: false
       default: "`false`"

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -53,7 +53,7 @@ params:
       required: false
       default: "`apikey`"
       description: |
-        Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
+        Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-]. Underscores are not permitted for keys in headers due to [additional restrictions in the NGINX defaults](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers).
     - name: key_in_body
       required: false
       default: "`false`"


### PR DESCRIPTION
### Summary

Clarify allowed key names for key-auth

### Full changelog

* Update key-auth documentation to indicate that there are additional limits on allowed key names if passing the key in a header.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
