### PR TITLE
docs(style) clarify admin, super admin

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -4,7 +4,7 @@
 Use proper case for the Kong entity, lowercase for the RBAC Role
 
 * Invite the Admin using the Organization tab
-* The default roles are `super-admin`, `admin`, and `read-only`
+* The default Roles are `super-admin`, `admin`, and `read-only`
 
 ### Admin API 
 Use proper case

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,7 +1,10 @@
 # Documentation Style Guide
 
-### Admin
-Use proper case
+### Admin, admin
+Use proper case for the Kong entity, lowercase for the RBAC Role
+
+* Invite the Admin using the Organization tab
+* The default roles are `super-admin`, `admin`, and `read-only`
 
 ### Admin API 
 Use proper case
@@ -148,11 +151,11 @@ Joined as a noun/modifier, separated as a phrasal verb, joined as a noun/modifie
 ### Services
 Use proper case
 
-### Super Admin
-Lowercase; no hyphen even as a compound modifier
+### super admin
+Use lowercase, hyphen as a compound modifier. Note that an [Admin](#Admin) is a Kong entity.
 
 * Invite a *super admin*.
-* Grant the new consumer *super admin* permissions.
+* An Admin account may invite others if it has *super-admin* permissions.
 
 ### text in buttons, links
 Maintain the case, surround with double quotes


### PR DESCRIPTION
<!-- 
Thank your for making Kong better! #kongstrong

After creating a pull request, we will automatically generate a preview version of the docs site with your changes. You should see a comment with a link on your PR several minutes after it is created. Please review the generated preview for broken links, formatting issues, etc. if you have not already done so using a local preview.

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

Fixes an issue with the out-of-date, confused Quip doc. Admin should be used for the Kong entity, admin and super admin for the particular Role. The titles of each entry should match the expected use, e.g., 

**Thing One**
Use proper case

**thing two**
Use lowercase

### Full changelog

* Made "super admin" section consistent
* Update "Admin, admin" section with clarification

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
