### PR TITLE
Style/admin api h4s template

### DIFF
--- a/app/1.1.x/admin-api.md
+++ b/app/1.1.x/admin-api.md
@@ -539,7 +539,7 @@ Retrieve generic details about a node.
 
 <div class="endpoint get">/</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -589,7 +589,7 @@ of nginx, every existing nginx monitoring tool or agent can be used.
 
 <div class="endpoint get">/status</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -657,7 +657,7 @@ and examples.
 
 <div class="endpoint post">/config</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -690,7 +690,7 @@ Returns the entities that have been tagged with a provided tag.
 
 <div class="endpoint get">/tags/:tags</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -741,12 +741,12 @@ of how Kong proxies traffic.
 <div class="endpoint post">/services</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.service_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -766,7 +766,7 @@ HTTP 201 Created
 <div class="endpoint get">/services</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -811,7 +811,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -853,12 +853,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.service_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -900,7 +900,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.service_body }}
 
@@ -920,7 +920,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -951,7 +951,7 @@ Attributes | Description
 `route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -993,12 +993,12 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service that should be associated to the newly-created Route.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.route_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1027,7 +1027,7 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service whose Routes are to be retrieved. When using this endpoint, only Routes associated to the specified Service will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1063,7 +1063,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1096,12 +1096,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.route_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1134,7 +1134,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.route_body }}
 
@@ -1154,7 +1154,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1176,7 +1176,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1204,12 +1204,12 @@ datastore.
 <div class="endpoint post">/consumers</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.consumer_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1229,7 +1229,7 @@ HTTP 201 Created
 <div class="endpoint get">/consumers</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1265,7 +1265,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1298,12 +1298,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.consumer_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1336,7 +1336,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.consumer_body }}
 
@@ -1356,7 +1356,7 @@ Notice that specifying a `username` in the URL and a different one in the reques
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1378,7 +1378,7 @@ Attributes | Description
 `username or id`<br>**required** | The unique identifier **or** the username of the Consumer to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1482,12 +1482,12 @@ Attributes | Description
 `consumer id`<br>**required** | The unique identifier of the Consumer that should be associated to the newly-created Plugin.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.plugin_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1534,7 +1534,7 @@ Attributes | Description
 `consumer id`<br>**required** | The unique identifier of the Consumer whose Plugins are to be retrieved. When using this endpoint, only Plugins associated to the specified Consumer will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1561,7 +1561,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to retrieve.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1585,12 +1585,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.plugin_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1614,7 +1614,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to create or update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.plugin_body }}
 
@@ -1634,7 +1634,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1656,7 +1656,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1671,7 +1671,7 @@ Retrieve a list of all installed plugins on the Kong node.
 
 <div class="endpoint get">/plugins/enabled</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1722,7 +1722,7 @@ third-party integrations to the Kong's plugin system.
 
 <div class="endpoint get">/plugins/schema/{plugin name}</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1766,12 +1766,12 @@ tie a cert/key pair to one or more hostnames.
 <div class="endpoint post">/certificates</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.certificate_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1791,7 +1791,7 @@ HTTP 201 Created
 <div class="endpoint get">/certificates</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1818,7 +1818,7 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1842,12 +1842,12 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.certificate_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1871,7 +1871,7 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.certificate_body }}
 
@@ -1891,7 +1891,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1913,7 +1913,7 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1950,12 +1950,12 @@ Attributes | Description
 `certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate that should be associated to the newly-created SNI.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.sni_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1984,7 +1984,7 @@ Attributes | Description
 `certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate whose SNIs are to be retrieved. When using this endpoint, only SNIs associated to the specified Certificate will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2011,7 +2011,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to retrieve.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2035,12 +2035,12 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.sni_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2064,7 +2064,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to create or update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.sni_body }}
 
@@ -2084,7 +2084,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -2106,7 +2106,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2139,12 +2139,12 @@ object, and applies to all of its targets.
 <div class="endpoint post">/upstreams</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.upstream_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -2164,7 +2164,7 @@ HTTP 201 Created
 <div class="endpoint get">/upstreams</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2200,7 +2200,7 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2233,12 +2233,12 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.upstream_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2271,7 +2271,7 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.upstream_body }}
 
@@ -2291,7 +2291,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -2322,7 +2322,7 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2368,7 +2368,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2430,12 +2430,12 @@ Attributes | Description
 `upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.target_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -2459,7 +2459,7 @@ Attributes | Description
 `upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2489,7 +2489,7 @@ Attributes | Description
 `host:port or id`<br>**required** | The host:port combination element of the target to remove, or the `id` of an existing target entry.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2521,7 +2521,7 @@ Attributes | Description
 `target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2559,7 +2559,7 @@ Attributes | Description
 `target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2582,7 +2582,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK

--- a/autodoc-admin-api/run.lua
+++ b/autodoc-admin-api/run.lua
@@ -329,6 +329,16 @@ local function write_entity_templates(outfd, entity)
   outfd:write("\n")
 end
 
+
+local function bold_text_section(outfd, title, content)
+  if not content then
+    return
+  end
+  outfd:write(title and ("*" .. title .. "*\n\n") or "")
+  outfd:write(unindent(content) .. "\n")
+  outfd:write("\n")
+end
+
 local function section(outfd, title, content)
   if not content then
     return
@@ -356,10 +366,10 @@ local function write_endpoint(outfd, endpoint, ep_data)
       for _, fk_endpoint in ipairs(fk_endpoints) do
         section(outfd, nil, fk_endpoint)
       end
-      section(outfd, "Request Querystring Parameters", meth_data.request_query)
-      section(outfd, "Request Body", meth_data.request_body)
+      bold_text_section(outfd, "Request Querystring Parameters", meth_data.request_query)
+      bold_text_section(outfd, "Request Body", meth_data.request_body)
       section(outfd, nil, meth_data.details)
-      section(outfd, "Response", meth_data.response)
+      bold_text_section(outfd, "Response", meth_data.response)
       outfd:write("---\n\n")
     end
   end


### PR DESCRIPTION
The current usage of h4 headers on the Admin API docs makes for an
overloaded Table of Contents, with lots of repeated "Response body"
entries.

This replaces those generated headers by bold text, so they will not
appear on the TOC.