### PR TITLE
Docs(1.0.x) h4s from api docs

### DIFF
--- a/app/1.0.x/admin-api.md
+++ b/app/1.0.x/admin-api.md
@@ -503,7 +503,7 @@ Retrieve generic details about a node.
 
 <div class="endpoint get">/</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -553,7 +553,7 @@ of nginx, every existing nginx monitoring tool or agent can be used.
 
 <div class="endpoint get">/status</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -627,12 +627,12 @@ of how Kong proxies traffic.
 <div class="endpoint post">/services</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.service_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -652,7 +652,7 @@ HTTP 201 Created
 <div class="endpoint get">/services</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -697,7 +697,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -739,12 +739,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.service_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -786,7 +786,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.service_body }}
 
@@ -806,7 +806,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -837,7 +837,7 @@ Attributes | Description
 `route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -879,12 +879,12 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service that should be associated to the newly-created Route.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.route_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -913,7 +913,7 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service whose Routes are to be retrieved. When using this endpoint, only Routes associated to the specified Service will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -949,7 +949,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -982,12 +982,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.route_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1020,7 +1020,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.route_body }}
 
@@ -1040,7 +1040,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1062,7 +1062,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1090,12 +1090,12 @@ datastore.
 <div class="endpoint post">/consumers</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.consumer_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1115,7 +1115,7 @@ HTTP 201 Created
 <div class="endpoint get">/consumers</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1151,7 +1151,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1184,12 +1184,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.consumer_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1222,7 +1222,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.consumer_body }}
 
@@ -1242,7 +1242,7 @@ Notice that specifying a `username` in the URL and a different one in the reques
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1264,7 +1264,7 @@ Attributes | Description
 `username or id`<br>**required** | The unique identifier **or** the username of the Consumer to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1368,12 +1368,12 @@ Attributes | Description
 `consumer id`<br>**required** | The unique identifier of the Consumer that should be associated to the newly-created Plugin.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.plugin_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1420,7 +1420,7 @@ Attributes | Description
 `consumer id`<br>**required** | The unique identifier of the Consumer whose Plugins are to be retrieved. When using this endpoint, only Plugins associated to the specified Consumer will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1447,7 +1447,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to retrieve.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1471,12 +1471,12 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.plugin_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1500,7 +1500,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to create or update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.plugin_body }}
 
@@ -1520,7 +1520,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1542,7 +1542,7 @@ Attributes | Description
 `plugin id`<br>**required** | The unique identifier of the Plugin to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1557,7 +1557,7 @@ Retrieve a list of all installed plugins on the Kong node.
 
 <div class="endpoint get">/plugins/enabled</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1608,7 +1608,7 @@ third-party integrations to the Kong's plugin system.
 
 <div class="endpoint get">/plugins/schema/{plugin name}</div>
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1652,12 +1652,12 @@ tie a cert/key pair to one or more hostnames.
 <div class="endpoint post">/certificates</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.certificate_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1677,7 +1677,7 @@ HTTP 201 Created
 <div class="endpoint get">/certificates</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1704,7 +1704,7 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1728,12 +1728,12 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.certificate_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1757,7 +1757,7 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.certificate_body }}
 
@@ -1777,7 +1777,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1799,7 +1799,7 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -1836,12 +1836,12 @@ Attributes | Description
 `certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate that should be associated to the newly-created SNI.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.sni_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -1870,7 +1870,7 @@ Attributes | Description
 `certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate whose SNIs are to be retrieved. When using this endpoint, only SNIs associated to the specified Certificate will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1897,7 +1897,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to retrieve.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1921,12 +1921,12 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.sni_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -1950,7 +1950,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to create or update.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.sni_body }}
 
@@ -1970,7 +1970,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -1992,7 +1992,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the SNI to delete.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2025,12 +2025,12 @@ object, and applies to all of its targets.
 <div class="endpoint post">/upstreams</div>
 
 
-#### Request Body
+*Request Body*
 
 {{ page.upstream_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -2050,7 +2050,7 @@ HTTP 201 Created
 <div class="endpoint get">/upstreams</div>
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2086,7 +2086,7 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2119,12 +2119,12 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.upstream_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2157,7 +2157,7 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.upstream_body }}
 
@@ -2177,7 +2177,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -2208,7 +2208,7 @@ Attributes | Description
 `target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2254,7 +2254,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2316,12 +2316,12 @@ Attributes | Description
 `upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
 
 
-#### Request Body
+*Request Body*
 
 {{ page.target_body }}
 
 
-#### Response
+*Response*
 
 ```
 HTTP 201 Created
@@ -2345,7 +2345,7 @@ Attributes | Description
 `upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK
@@ -2375,7 +2375,7 @@ Attributes | Description
 `host:port or id`<br>**required** | The host:port combination element of the target to remove, or the `id` of an existing target entry.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2407,7 +2407,7 @@ Attributes | Description
 `target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2445,7 +2445,7 @@ Attributes | Description
 `target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 204 No Content
@@ -2468,7 +2468,7 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
 
 
-#### Response
+*Response*
 
 ```
 HTTP 200 OK

--- a/autodoc-admin-api/run.lua
+++ b/autodoc-admin-api/run.lua
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+require "resty.core"
+
 local lfs = require("lfs")
 local cjson = require("cjson")
 
@@ -327,6 +329,16 @@ local function write_entity_templates(outfd, entity)
   outfd:write("\n")
 end
 
+
+local function bold_text_section(outfd, title, content)
+  if not content then
+    return
+  end
+  outfd:write(title and ("*" .. title .. "*\n\n") or "")
+  outfd:write(unindent(content) .. "\n")
+  outfd:write("\n")
+end
+
 local function section(outfd, title, content)
   if not content then
     return
@@ -354,10 +366,10 @@ local function write_endpoint(outfd, endpoint, ep_data)
       for _, fk_endpoint in ipairs(fk_endpoints) do
         section(outfd, nil, fk_endpoint)
       end
-      section(outfd, "Request Querystring Parameters", meth_data.request_query)
-      section(outfd, "Request Body", meth_data.request_body)
+      bold_text_section(outfd, "Request Querystring Parameters", meth_data.request_query)
+      bold_text_section(outfd, "Request Body", meth_data.request_body)
       section(outfd, nil, meth_data.details)
-      section(outfd, "Response", meth_data.response)
+      bold_text_section(outfd, "Response", meth_data.response)
       outfd:write("---\n\n")
     end
   end


### PR DESCRIPTION
This is a backport of #1194 for the 1.0.x docs.

It modifies the auto-generation template so that several h4-level headers are replaced by plain text. This way they don't clutter the auto-generated TOC.