### PR TITLE
feat(hub) add array examples to template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ the existing plugins for examples, and see additional advice in
     the value to use. A required field with no `value_in_examples` entry
     will resort to the one in `default`.
     * `array_value_in_examples` - an array of values that should appear in
-    examples. This should always be provided if the field is is required,
+    examples. This should always be provided if the field is required,
     as the template does not translate default values into arrays.
     * `description` - description of the field.
     Use YAML's pipe notation if writing longer Markdown text.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,9 @@ the existing plugins for examples, and see additional advice in
     * `value_in_examples` - if the field is to appear in examples, this is
     the value to use. A required field with no `value_in_examples` entry
     will resort to the one in `default`.
+    * `array_value_in_examples` - an array of values that should appear in
+    examples. This should always be provided if the field is is required,
+    as the template does not translate default values into arrays.
     * `description` - description of the field.
     Use YAML's pipe notation if writing longer Markdown text.
 

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -58,7 +58,9 @@ params:
     - name: methods
       required: false
       default: "`GET, HEAD, PUT, PATCH, POST`"
-      value_in_examples: GET, POST
+      array_value_in_examples:
+        - GET
+        - POST
       description:
         Value for the `Access-Control-Allow-Methods` header, expects a comma delimited string (e.g. `GET,POST`).
     - name: headers

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -263,7 +263,7 @@ You can patch an existing jwt plugin:
 ```bash
 # This adds verification for both nbf and exp claims:
 $ curl -X PATCH http://kong:8001/plugins/{jwt plugin id} \
-    --data "config.claims_to_verify=exp,nbf"
+    --data "config.claims_to_verify[]=exp&config.claims_to_verify[]=nbf"
 ```
 
 Supported claims:

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -13,6 +13,10 @@ breadcrumbs:
   for field in page.params.config %}{%
   if field.value_in_examples != nil %} \
     --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ field.value_in_examples }}"{%
+  elsif field.array_value_in_examples != nil %} {%
+    for example in field.array_value_in_examples %} \
+    --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}[]={{ example | markdownify | strip_html | strip }}"{%
+    endfor %} {%
   elsif field.required == true %} \
     --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ field.default | markdownify | strip_html | strip }}"{%
   endif %}{% endfor %}


### PR DESCRIPTION
### Summary

Add support for array examples in Hub and update CORS and JWT plugins to use new syntax.

### Full changelog
* Add a new `array_value_in_examples` field to plugin template. This takes an array of values that are then rendered as separate array data parameters in the cURL example, e.g. `--data foo[]=one --data foo[]=two`.
* Update CORS plugin documentation to use `array_value_in_examples` for its `methods` configuration item.
* Update legacy (not templated) cURL example for JWT plugin to use new syntax.
* Update CONTRIBUTING.md with instructions for new field.

### Issues resolved

Fix #1197

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers << failing to autocomplete for some reason; tagged individuals instead
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Warrants discussion before merger, as that these changes break compatibility with pre-1.0.x releases of Kong (and releases of Kong Enterprise with pre-1.0.x cores). The old syntax (comma-separated strings) is still correct for older versions, but is not covered in examples. How should we handle breaking API changes for plugins?

On a more minor note, did not add a parallel feature for defaults, which are a bit tricky as we use them elsewhere as plain text. It's likely possible to add something that detects if defaults is an array and formats it appropriately when non-example representations are needed, but for now it's just necessary to provide an example array if your plugin needs array config.