### PR TITLE
docs(1.1) add missing plugins in Declarative Config guide

### DIFF
--- a/app/1.1.x/db-less-and-declarative-config.md
+++ b/app/1.1.x/db-less-and-declarative-config.md
@@ -273,7 +273,15 @@ their initial config) so they are fully compatible with DB-less:
 * `datadog`
 * `file-log`
 * `http-log`
+* `tcp-log`
+* `udp-log`
+* `syslog`
 * `ip-restriction`
+* `prometheus`
+* `zipkin`
+* `request-transformer`
+* `response-transformer`
+* `request-termination`
 * `kubernetes-sidecar-injector`
 
 ##### Partial Compatibility


### PR DESCRIPTION
Some plugins were missing due to an oversight. Thanks @hbagdi for the heads up!