### PR TITLE
docs(admin) Update service pagination info

### DIFF
--- a/app/0.14.x/admin-api.md
+++ b/app/0.14.x/admin-api.md
@@ -390,7 +390,7 @@ HTTP 200 OK
         "read_timeout": 60000,
         "write_timeout": 60000
     }],
-    "next": "http://localhost:8001/services?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+    "next": "/services?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
 }
 ```
 


### PR DESCRIPTION
### Summary

While working with pagination in the 0.14.1 version of kong I discovered an inconsistency in behavior between various endpoints that is not reflected by the documentation.

```
r = requests.get(f'{kong_url}/services')
>>> r.json()['next']
'/services?offset=WyJmNmExOWYzNi1hOGYzLTQzYmMtOWNlMy0wZjcyMjk2ZTU0MWUiXQ'
>>> r = requests.get(f'{kong_url}/plugins')
>>> r.json()['next']
'<kong_url_ommitted>/plugins?offset=Mg%3D%3D&size=100'
```

The `/services` endpoint does not include the domain when it returns the url to the next page, but the `/plugins` endpoint does. Presumably this is fixed in later versions of kong, but the documentation for 0.14 should reflect it. I do not know how far back this problem exists. Please let me know if I should update other older documentation.

### Full changelog

* Edited docs to reflect actual pagination behavior of the 0.14.X /services endpoint

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <N/A><!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [ ] Tagged "Team Docs" as reviewers (Do I have to be a member to tag them?)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
