### PR TITLE
docs(*) fix array notation in examples (>= 1.0.0)

### DIFF
--- a/app/1.0.x/admin-api.md
+++ b/app/1.0.x/admin-api.md
@@ -479,6 +479,31 @@ with dotted keys. Example:
 config.limit=10&config.period=seconds
 ```
 
+Arrays and sets can be specified in various ways:
+
+1. Sending same parameter multiple times:
+
+```
+hosts=example.com&hosts=example.org
+```
+
+2. Using array notation:
+
+```
+hosts[1]=example.com&hosts[2]=example.org
+```
+or 
+```
+hosts[]=example.com&hosts[]=example.org
+```
+
+Array and object notation can also be mixed:
+
+```
+config.hosts[1]=example.com&config.hosts[2]=example.org
+```
+
+
 - **application/json**
 
 Handy for complex bodies (ex: complex plugin configuration), in that case simply send
@@ -489,6 +514,18 @@ a JSON representation of the data you want to send. Example:
     "config": {
         "limit": 10,
         "period": "seconds"
+    }
+}
+```
+
+JSON arrays can be specified as well:
+
+```json
+{
+    "config": {
+        "limit": 10,
+        "period": "seconds",
+        "hosts": [ "example.com", "example.org" ]
     }
 }
 ```

--- a/app/1.1.x/admin-api.md
+++ b/app/1.1.x/admin-api.md
@@ -513,6 +513,27 @@ with dotted keys. Example:
 config.limit=10&config.period=seconds
 ```
 
+Arrays and sets can be specified in various ways:
+
+1. Sending same parameter multiple times:
+    ```
+    hosts=example.com&hosts=example.org
+    ```
+2. Using array notation:
+    ```
+    hosts[1]=example.com&hosts[2]=example.org
+    ```
+    or 
+    ```
+    hosts[]=example.com&hosts[]=example.org
+    ```
+    Array and object notation can also be mixed:
+
+    ```
+    config.hosts[1]=example.com&config.hosts[2]=example.org
+    ```
+
+
 - **application/json**
 
 Handy for complex bodies (ex: complex plugin configuration), in that case simply send
@@ -523,6 +544,18 @@ a JSON representation of the data you want to send. Example:
     "config": {
         "limit": 10,
         "period": "seconds"
+    }
+}
+```
+
+JSON arrays can be specified as well:
+
+```json
+{
+    "config": {
+        "limit": 10,
+        "period": "seconds",
+        "hosts": [ "example.com", "example.org" ]
     }
 }
 ```

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -54,14 +54,14 @@ params:
     - name: whitelist
       required: semi
       default:
-      value_in_examples: group1, group2
+      value_in_examples: [ "group1", "group2" ]
       description: |
-        Comma separated list of arbitrary group names that are allowed to consume the Service or Route. One of `config.whitelist` or `config.blacklist` must be specified.
+        Arbitrary group names that are allowed to consume the Service or Route. One of `config.whitelist` or `config.blacklist` must be specified.
     - name: blacklist
       required: semi
       default:
       description: |
-        Comma separated list of arbitrary group names that are not allowed to consume the Service or Route. One of `config.whitelist` or `config.blacklist` must be specified.
+        Arbitrary group names that are not allowed to consume the Service or Route. One of `config.whitelist` or `config.blacklist` must be specified.
     - name: hide_groups_header
       required: false
       default: false

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -38,12 +38,12 @@ params:
       required: false
       default:
       description: |
-        A comma separated array of regular expressions that should be whitelisted. The regular expressions will be checked against the `User-Agent` header.
+        An array of regular expressions that should be whitelisted. The regular expressions will be checked against the `User-Agent` header.
     - name: blacklist
       required: false
       default:
       description: |
-        A comma separated array of regular expressions that should be blacklisted. The regular expressions will be checked against the `User-Agent` header.
+        An array of regular expressions that should be blacklisted. The regular expressions will be checked against the `User-Agent` header.
 
 ---
 

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -54,25 +54,25 @@ params:
       default:
       value_in_examples: http://mockbin.com
       description: |
-        A comma-separated list of allowed domains for the `Access-Control-Allow-Origin` header. If you wish to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes. **NOTE**: Prior to Kong 0.10.x, this parameter was `config.origin` (note the change in trailing `s`), and only accepted a single value, or the `*` special value.
+        List of allowed domains for the `Access-Control-Allow-Origin` header. If you wish to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes. **NOTE**: Prior to Kong 0.10.x, this parameter was `config.origin` (note the change in trailing `s`), and only accepted a single value, or the `*` special value.
     - name: methods
       required: false
       default: "`GET, HEAD, PUT, PATCH, POST`"
-      value_in_examples: GET, POST
+      value_in_examples: [ "GET", "POST" ]
       description:
-        Value for the `Access-Control-Allow-Methods` header, expects a comma delimited string (e.g. `GET,POST`).
+        Value for the `Access-Control-Allow-Methods` header
     - name: headers
       required: false
       default: "Value of the `Access-Control-Request-Headers` request header"
-      value_in_examples: Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Auth-Token
+      value_in_examples: [ "Accept", "Accept-Version", "Content-Length", "Content-MD5", "Content-Type", "Date", "X-Auth-Token" ]
       description: |
-        Value for the `Access-Control-Allow-Headers` header, expects a comma delimited string (e.g. `Origin, Authorization`).
+        Value for the `Access-Control-Allow-Headers` header
     - name: exposed_headers
       required: false
       default:
       value_in_examples: X-Auth-Token
       description: |
-        Value for the `Access-Control-Expose-Headers` header, expects a comma delimited string (e.g. `Origin, Authorization`). If not specified, no custom headers are exposed.
+        Value for the `Access-Control-Expose-Headers` header. If not specified, no custom headers are exposed.
     - name: credentials
       required: false
       default: "`false`"

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -42,14 +42,14 @@ params:
     - name: whitelist
       required: semi
       default:
-      value_in_examples: 54.13.21.1, 143.1.0.0/24
+      value_in_examples: [ "54.13.21.1", "143.1.0.0/24" ]
       description: |
-        Comma separated list of IPs or CIDR ranges to whitelist. One of `config.whitelist` or `config.blacklist` must be specified.
+        List of IPs or CIDR ranges to whitelist. One of `config.whitelist` or `config.blacklist` must be specified.
     - name: blacklist
       required: semi
       default:
       description: |
-        Comma separated list of IPs or CIDR ranges to blacklist. One of `config.whitelist` or `config.blacklist` must be specified.
+        List of IPs or CIDR ranges to blacklist. One of `config.whitelist` or `config.blacklist` must be specified.
 
   extra: |
 

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -53,7 +53,7 @@ params:
       required: false
       default: "`apikey`"
       description: |
-        Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-]. Underscores are not permitted for keys in headers due to [additional restrictions in the NGINX defaults](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers).
+        Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-]. Underscores are not permitted for keys in headers due to [additional restrictions in the NGINX defaults](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers).
     - name: key_in_body
       required: false
       default: "`false`"

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -62,8 +62,8 @@ params:
     - name: scopes
       required: true
       default:
-      value_in_examples: email,phone,address
-      description: Describes an array of comma separated scope names that will be available to the end user
+      value_in_examples: [ "email", "phone", "address" ]
+      description: Describes an array of scope names that will be available to the end user
     - name: mandatory_scope
       required: false
       default: "`false`"
@@ -179,7 +179,7 @@ $ curl -X POST http://kong:8001/consumers/{consumer_id}/oauth2 \
     --data "name=Test%20Application" \
     --data "client_id=SOME-CLIENT-ID" \
     --data "client_secret=SOME-CLIENT-SECRET" \
-    --data "redirect_uris[]=http://some-domain/endpoint/"
+    --data "redirect_uris=http://some-domain/endpoint/"
 ```
 
 `consumer_id`: The [Consumer][consumer-object] entity to associate the credentials to
@@ -200,7 +200,7 @@ If you are migrating your existing OAuth 2.0 applications and access tokens over
 
 ```bash
 $ curl -X POST http://kong:8001/oauth2_tokens \
-    --data 'credential={"id": "KONG-APPLICATION-ID" }' \
+    --data 'credential.id=KONG-APPLICATION-ID' \
     --data "token_type=bearer" \
     --data "access_token=SOME-TOKEN" \
     --data "refresh_token=SOME-TOKEN" \

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -52,15 +52,15 @@ params:
       description: Changes the HTTP method for the upstream request.
     - name: remove.headers
       required: false
-      value_in_examples: "x-toremove, x-another-one"
+      value_in_examples: [ "x-toremove", "x-another-one" ]
       description: List of header names. Unset the header(s) with the given name.
     - name: remove.querystring
       required: false
-      value_in_examples: "qs-old-name:qs-new-name, qs2-old-name:qs2-new-name"
+      value_in_examples: [ "qs-old-name:qs-new-name", "qs2-old-name:qs2-new-name" ]
       description: List of querystring names. Remove the querystring if it is present.
     - name: remove.body
       required: false
-      value_in_examples: "formparam-toremove, formparam-another-one"
+      value_in_examples: [ "formparam-toremove", "formparam-another-one" ]
       description: List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`, `multipart/form-data`,  `application/x-www-form-urlencoded`] and parameter is present.
     - name: replace.headers
       required: false
@@ -70,34 +70,34 @@ params:
       description: List of queryname:value pairs. If and only if the field name is already set, replace its old value with the new one. Ignored if the field name is not already set.
     - name: rename.headers
       required: false
-      value_in_examples: "header-old-name:header-new-name, another-old-name:another-new-name"
+      value_in_examples: [ "header-old-name:header-new-name", "another-old-name:another-new-name" ]
       description: List of headername:value pairs. If and only if the header is already set, rename the header. The value is unchanged. Ignored if the header is not already set.
     - name: rename.querystring
       required: false
-      value_in_examples: "qs-old-name:qs-new-name, qs2-old-name:qs2-new-name"
+      value_in_examples: [ "qs-old-name:qs-new-name", "qs2-old-name:qs2-new-name" ]
       description: List of queryname:value pairs. If and only if the field name is already set, rename the field name. The value is unchanged. Ignored if the field name is not already set.
     - name: rename.body
       required: false
-      value_in_examples: "param-old:param-new, param2-old:param2-new"
+      value_in_examples: [ "param-old:param-new", "param2-old:param2-new" ]
       description: List of parameter name:value pairs. Rename the parameter name if and only if content-type is one the following [`application/json`, `multipart/form-data`,  `application/x-www-form-urlencoded`] and parameter is present.
     - name: append.headers
       required: false
-      value_in_examples: "x-existing-header:some_value, x-another-header:some_value"
+      value_in_examples: [ "x-existing-header:some_value", "x-another-header:some_value" ]
       description: List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
     - name: replace.body
       required: false
       description: List of paramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
     - name: add.headers
       required: false
-      value_in_examples: "x-new-header:value,x-another-header:something"
+      value_in_examples: [ "x-new-header:value", "x-another-header:something" ]
       description: List of headername:value pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
     - name: add.querystring
       required: false
-      value_in_examples: "new-param:some_value, another-param:some_value"
+      value_in_examples: [ "new-param:some_value", "another-param:some_value" ]
       description: List of queryname:value pairs. If and only if the querystring is not already set, set a new querystring with the given value. Ignored if the header is already set.
     - name: add.body
       required: false
-      value_in_examples: "new-form-param:some_value, another-form-param:some_value"
+      value_in_examples: [ "new-form-param:some_value", "another-form-param:some_value" ]
       description: List of pramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is not present, add a new parameter with the given value to form-encoded body. Ignored if the parameter is already present.
     - name: append.headers
       required: false

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -11,8 +11,14 @@ breadcrumbs:
 
 {% capture config_required_fields %}{%
   for field in page.params.config %}{%
-  if field.value_in_examples != nil %} \
+  if field.value_in_examples != nil  %}{%
+  if field.value_in_examples.first %}{%
+  for value in field.value_in_examples %} \
+    --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ value }}"{%
+  endfor %}{%
+  else %} \
     --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ field.value_in_examples }}"{%
+  endif %}{%
   elsif field.required == true %} \
     --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ field.default | markdownify | strip_html | strip }}"{%
   endif %}{% endfor %}


### PR DESCRIPTION
### Summary

Fixes array notation in documentation examples, also removes the `comma separated` advice.

See:
- https://github.com/Kong/kong/issues/4445
- https://discuss.konghq.com/t/cors-plugin-issue-with-v1-0-3/2838
- https://github.com/Kong/docs.konghq.com/issues/1197