### PR TITLE
fix(hub): serverless-fn remove backslash in code

### DIFF
--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -80,7 +80,7 @@ different priority in the plugin chain.
     -- Terminate request early if our custom authentication header
     -- does not exist
     if not custom_auth then
-      return kong.response.exit(401\, "Invalid Credentials")
+      return kong.response.exit(401, "Invalid Credentials")
     end
 
     -- Remove custom authentication header from request


### PR DESCRIPTION
### Summary

The backslash is only required when directly submitting code, not when using the file upload in curl.

### Checklist:

- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers
- [x] Ready to be merged
