### PR TITLE
Fix configuration typo in db-less docs

### DIFF
--- a/app/1.1.x/db-less-and-declarative-config.md
+++ b/app/1.1.x/db-less-and-declarative-config.md
@@ -196,7 +196,7 @@ parse successful
 
 ## Loading The Declarative Configuration File
 
-There are two ways to load a declarative configuartion into Kong: via
+There are two ways to load a declarative configuration into Kong: via
 `kong.conf` and via the Admin API.
 
 To load a declarative configuration at Kong start-up, use the


### PR DESCRIPTION
### Summary

Fixes a small spelling error / typo

### Full changelog

* Spelling error on the db-less config docs

### Issues resolved

None

### Checklist:

I have done no checks on the checklist.

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [ ] Spellchecked my updates
- [ ] Tagged "Team Docs" as reviewers
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
