### PR TITLE
Docs/plugin compatibility matrix

### DIFF
--- a/app/1.1.x/db-less-and-declarative-config.md
+++ b/app/1.1.x/db-less-and-declarative-config.md
@@ -196,7 +196,7 @@ parse successful
 
 ## Loading The Declarative Configuration File
 
-There are two ways to load a declarative configuartion into Kong: via
+There are two ways to load a declarative configuration into Kong: via
 `kong.conf` and via the Admin API.
 
 To load a declarative configuration at Kong start-up, use the
@@ -209,7 +209,7 @@ $ export KONG_DECLARATIVE_CONFIG=kong.yml
 $ kong start -c kong.conf
 ```
 
-Alternatively, you can load a declarative config into a running
+Alternatively, you can load a declarative configuration into a running
 Kong node via its Admin API, using the `/config` endpoint. The 
 following example loads `kong.yml` using HTTPie:
 
@@ -243,7 +243,7 @@ nodes, since they have no knowledge of each other.
 
 #### Read-Only Admin API
 
-Since the only way to configure entities is via declarative config,
+Since the only way to configure entities is via declarative configuration,
 the endpoints for CRUD operations on entities are effectively read-only
 in the Admin API when running Kong in DB-less mode. `GET` operations
 for inspecting entities work as usual, but attempts to `POST`, `PATCH`

--- a/app/_hub/_init/my-extension/index.md
+++ b/app/_hub/_init/my-extension/index.md
@@ -147,6 +147,16 @@ params: # metadata about your plugin
   route_id:
     # whether this plugin can be applied to a Route.
     # Affects generation of examples and config table.
+  protocols:
+    # List of protocols this plugin is compatible with.
+    # Valid values: "http", "https", "tcp", "tls"
+    # Example: ["http", "https"]
+  dbless_compatible:
+    # Degree of compatibility with DB-less mode. Three values allowed:
+    # 'yes', 'no' or 'partially'
+  dbless_explanation:
+    # Optional free-text explanation, usually containing details about the degree of
+    # compatibility with DB-less.
 
   config: # Configuration settings for your plugin
     - name: # setting name

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -50,6 +50,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: whitelist
       required: semi

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -51,6 +51,11 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    Consumers and ACLs can be created with declarative config.
+
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on ACLs will not work on db-less mode.
   config:
     - name: whitelist
       required: semi

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -54,9 +54,9 @@ params:
   protocols: ["http", "https"]
   dbless_compatible: partially
   dbless_explanation: |
-    Consumers and ACLs can be created with declarative config.
+    Consumers and ACLs can be created with declarative configuration.
 
-    Admin API endpoints which do POST, PUT, PATCH or DELETE on ACLs will not work on db-less mode.
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on ACLs will not work on DB-less mode.
   config:
     - name: whitelist
       required: semi

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -44,6 +44,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: aws_key
       required: true

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -43,6 +43,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: aws_key
       required: true

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -30,6 +30,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: functionname
       required: true

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -19,6 +19,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
     enterprise_edition:

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -29,6 +29,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: functionname
       required: true

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -52,9 +52,9 @@ params:
   protocols: ["http", "https"]
   dbless_compatible: partially
   dbless_explanation: |
-    Consumers and Credentials can be created with declarative config.
+    Consumers and Credentials can be created with declarative configuration.
 
-    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials are not available on db-less mode.
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials are not available on DB-less mode.
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -49,6 +49,11 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    Consumers and Credentials can be created with declarative config.
+
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials are not available on db-less mode.
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -48,6 +48,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -34,6 +34,7 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: whitelist
       required: false

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -33,6 +33,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: whitelist
       required: false

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -34,6 +34,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: header_name
       required: false

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -35,6 +35,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: header_name
       required: false

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -48,6 +48,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: origins
       required: false

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -49,6 +49,7 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: origins
       required: false

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -23,6 +23,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -46,6 +46,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: host
       required: false

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -45,6 +45,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: host
       required: false

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -53,6 +53,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: path
       required: true

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -54,6 +54,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: path
       required: true

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -51,6 +51,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -55,9 +55,9 @@ params:
   protocols: ["http", "https"]
   dbless_compatible: partially
   dbless_explanation: |
-    Consumers and Credentials can be created with declarative config.
+    Consumers and Credentials can be created with declarative configuration.
 
-    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials will not work on db-less mode.
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials will not work on DB-less mode.
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -52,6 +52,11 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    Consumers and Credentials can be created with declarative config.
+
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials will not work on db-less mode.
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -47,6 +47,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: http_endpoint
       required: true

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -48,6 +48,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: http_endpoint
       required: true

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -38,6 +38,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: whitelist
       required: semi

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -39,6 +39,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: whitelist
       required: semi

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -51,6 +51,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: uri_param_names
       required: false

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -52,6 +52,11 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    Consumers and JWT secrets can be created with declarative config.
+
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on secrets are not available on db-less mode.
   config:
     - name: uri_param_names
       required: false

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -55,9 +55,9 @@ params:
   protocols: ["http", "https"]
   dbless_compatible: partially
   dbless_explanation: |
-    Consumers and JWT secrets can be created with declarative config.
+    Consumers and JWT secrets can be created with declarative configuration.
 
-    Admin API endpoints which do POST, PUT, PATCH or DELETE on secrets are not available on db-less mode.
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on secrets are not available on DB-less mode.
   config:
     - name: uri_param_names
       required: false

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -49,6 +49,11 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    Consumers and Credentials can be created with declarative config.
+
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials are not available on db-less mode.
   config:
     - name: key_names
       required: false

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -48,6 +48,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: key_names
       required: false

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -52,9 +52,9 @@ params:
   protocols: ["http", "https"]
   dbless_compatible: partially
   dbless_explanation: |
-    Consumers and Credentials can be created with declarative config.
+    Consumers and Credentials can be created with declarative configuration.
 
-    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials are not available on db-less mode.
+    Admin API endpoints which do POST, PUT, PATCH or DELETE on Credentials are not available on DB-less mode.
   config:
     - name: key_names
       required: false

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -43,6 +43,7 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -42,6 +42,7 @@ params:
   service_id: false
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: hide_credentials
       required: false

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -37,6 +37,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: host
       required: false

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -36,6 +36,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: host
       required: false

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -34,6 +34,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -62,9 +62,9 @@ params:
   protocols: ["http", "https"]
   dbless_compatible: no
   dbless_explanation: |
-    For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with db-less.
+    For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with DB-less.
 
-    In addition to this, its Admin API endpoints offer several POST, PATCH, PUT and DELETE methods for tokens and credentials. None of them would work on db-less.
+    In addition to this, its Admin API endpoints offer several POST, PATCH, PUT and DELETE methods for tokens and credentials. None of them would work on DB-less.
   config:
     - name: scopes
       required: true

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -59,6 +59,11 @@ params:
   route_id: false
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: no
+  dbless_explanation: |
+    For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with db-less.
+
+    In addition to this, its Admin API endpoints offer several POST, PATCH, PUT and DELETE methods for tokens and credentials. None of them would work on db-less.
   config:
     - name: scopes
       required: true

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -58,6 +58,7 @@ params:
   service_id: true
   route_id: false
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: scopes
       required: true

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -23,6 +23,7 @@ params:
   name: prometheus
   service_id: true
   route_id: false
+  protocols: ["http", "https", "tcp", "tls"]
 
 ---
 

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
     enterprise_edition:

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -27,7 +27,7 @@ params:
   protocols: ["http", "https", "tcp", "tls"]
   dbless_compatible: yes
   dbless_explanation: |
-    The database will always be reported as “reachable” in prometheus with db-less.
+    The database will always be reported as “reachable” in prometheus with DB-less.
 
 ---
 

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -24,6 +24,9 @@ params:
   service_id: true
   route_id: false
   protocols: ["http", "https", "tcp", "tls"]
+  dbless_compatible: yes
+  dbless_explanation: |
+    The database will always be reported as “reachable” in prometheus with db-less.
 
 ---
 

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -52,7 +52,7 @@ params:
   dbless_compatible: partially
   dbless_explanation: |
     The plugin will run fine with the `local` policy (which doesn't use the database) or
-    the `redis` policy (which uses an independent Redis, so it is compatible with db-less).
+    the `redis` policy (which uses an independent Redis, so it is compatible with DB-less).
 
     The plugin will not work with the `cluster` policy, which requires writes to the database.
 

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -48,6 +48,13 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    The plugin will run fine with the `local` policy (which doesn't use the database) or
+    the `redis` policy (which uses an independent Redis, so it is compatible with db-less).
+
+    The plugin will not work with the `cluster` policy, which requires writes to the database.
+
   config:
     - name: second
       required: semi

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -47,6 +47,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: second
       required: semi

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -51,6 +51,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: allowed_payload_size
       required: true

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -52,6 +52,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: allowed_payload_size
       required: true

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -33,6 +33,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: status_code
       required: false

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -34,6 +34,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: status_code
       required: false

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -46,6 +46,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: http_method
       required: false
@@ -246,10 +247,10 @@ $ curl -X POST http://localhost:8001/services/example-service/plugins \
   </tr>
 </table>
 
-|incoming request querystring | upstream proxied querystring 
-|---           | --- 
-| ?q1=v1       |  ?q1=v1&q2=v1 
-|              |  ?q1=v2&q2=v1 
+|incoming request querystring | upstream proxied querystring
+|---           | ---
+| ?q1=v1       |  ?q1=v1&q2=v1
+|              |  ?q1=v2&q2=v1
 
 - Append multiple headers and remove a body parameter:
 
@@ -276,10 +277,10 @@ $ curl -X POST http://localhost:8001/services/example-service/plugins \
   </tr>
 </table>
 
-|incoming url encoded body | upstream proxied url encoded body: 
-|---           | --- 
-|p1=v1&p2=v1   | p2=v1 
-|p2=v1         | p2=v1 
+|incoming url encoded body | upstream proxied url encoded body:
+|---           | ---
+|p1=v1&p2=v1   | p2=v1
+|p2=v1         | p2=v1
 
 [api-object]: /latest/admin-api/#api-object
 [consumer-object]: /latest/admin-api/#consumer-object

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -47,6 +47,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: http_method
       required: false

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -49,6 +49,13 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    The plugin will run fine with the `local` policy (which doesn't use the database) or
+    the `redis` policy (which uses an independent Redis, so it is compatible with db-less).
+
+    The plugin will not work with the `cluster` policy, which requires writes to the database.
+
   config:
     - name: limits.{limit_name}
       required: true

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -53,7 +53,7 @@ params:
   dbless_compatible: partially
   dbless_explanation: |
     The plugin will run fine with the `local` policy (which doesn't use the database) or
-    the `redis` policy (which uses an independent Redis, so it is compatible with db-less).
+    the `redis` policy (which uses an independent Redis, so it is compatible with DB-less).
 
     The plugin will not work with the `cluster` policy, which requires writes to the database.
 

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -48,6 +48,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: limits.{limit_name}
       required: true

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -42,6 +42,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: remove.headers
       required: false

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -41,6 +41,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: remove.headers
       required: false

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -18,6 +18,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -30,6 +30,9 @@ params:
   route_id: true
   consumer_id: false
   protocols: ["http", "https"]
+  dbless_compatible: partially
+  dbless_explanation: |
+    The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.
   config:
     - name: functions
       required: true

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -29,6 +29,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  protocols: ["http", "https"]
   config:
     - name: functions
       required: true

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
     enterprise_edition:

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -46,6 +46,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: host
       required: false

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -47,6 +47,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: host
       required: false

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -37,6 +37,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: successful_severity
       required: false

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -36,6 +36,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: successful_severity
       required: false

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -49,6 +49,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: host
       required: true

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -48,6 +48,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: host
       required: true

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -41,6 +41,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: host
       required: true

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
         - 0.13.x

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -40,6 +40,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
   config:
     - name: host
       required: true

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -37,6 +37,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https", "tcp", "tls"]
   config:
     - name: http_endpoint
       required: true

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.1.x
         - 1.0.x
         - 0.14.x
     enterprise_edition:

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -38,6 +38,7 @@ params:
   route_id: true
   consumer_id: true
   protocols: ["http", "https", "tcp", "tls"]
+  dbless_compatible: yes
   config:
     - name: http_endpoint
       required: true

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -259,6 +259,27 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 
       {% if page.type == "plugin" %}
         <h2 id="configuration">Configuration</h2>
+        {% if page.params.protocols %}
+          <p>This plugin is compatible with requests with the following protocols:</p>
+          <ul>
+            {% for protocol in page.params.protocols %}
+              <li><code>{{ protocol }}</code></li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+
+        {% if page.params.dbless_compatible == true %}
+          <p>This plugin is <strong>compatible</strong> with DB-less mode.</p>
+        {% elsif page.params.dbless_compatible == "partially" %}
+          <p>This plugin is <strong>partially compatible</strong> with DB-less mode.</p>
+        {% elsif page.params.dbless_compatible != nil %}
+          <p>This plugin is <strong>not compatible</strong> with DB-less mode.</p>
+        {% endif %}
+
+        {% if page.params.dbless_explanation %}
+          {{ page.params.dbless_explanation | mardownify }}
+        {% endif %}
+
         {% if page.params.service_id %}
           {{ plugin_config_for_service | markdownify }}
         {% endif %}


### PR DESCRIPTION
This PR contains 3 things:
* 3 new params for plugins (`protocols`, `db_less_compatible` & `db_less_explanation`) which are understood and rendered by the extension
* The bundled plugins have been filled up in Kong's default bundled plugins
* Documented compatibility with Kong 1.1 to Kong's default bundled plugins

This is an example of how the new fields are rendered:

![Screenshot 2019-04-25 at 16 24 05](https://user-images.githubusercontent.com/63131/56743773-8912f180-6777-11e9-9cbf-0ae7e2cdf67a.png)
