### PR TITLE
conditionally displaay install button on main nav

### DIFF
--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -219,7 +219,7 @@
           </div>
           </div>
         </li>
-        <li class="kong-navbar_nav_link kong-navbar_nav_link--cta">{% if page.edition=='community' %}<a class="nav-link btn btn-outline-secondary transparent" href="http://konghq.com/install">Install Kong</a>{% endif %}{% if page.edition=='enterprise' %}<a class="nav-link btn btn-outline-secondary transparent" href="http://konghq.com/request-demo">Request Demo</a>{% endif %}</li>
+        <li class="kong-navbar_nav_link kong-navbar_nav_link--cta">{% if page.edition=='enterprise' %}<a class="nav-link btn btn-outline-secondary transparent" href="http://konghq.com/request-demo">Request Demo</a>{% else %}<a class="nav-link btn btn-outline-secondary transparent" href="http://konghq.com/install">Install Kong</a>{% endif %}</li>
       </ul>
     </nav>
     <button class="navbar-toggler align-self-center" type="button" data-toggle="kong-expand" data-target="#pagesNav" aria-controls="pagesNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION


Show "Install Kong" CTA on all hub pages

### Full changelog

* update template conditionals to display install cta on hub & plugin pages


<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [N/A] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
