### PR TITLE
Corrected Grammer Mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the scraper to test out config changes.
 - Have a local clone of Kong
 - In the Kong repository, check out the desired branch/tag/release
 - To generate the Admin API docs:
-  - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp admin-API-docs`
+  - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp admin-api-docs`
   - This command will attempt to:
     * Compare Kong's schemas and Admin API routes with the contents of the file
       `autodoc-admin-api/data.lua` and error out if there's any mismatches or missing data.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ docs.konghq.com and can be found [here](https://github.com/algolia/docsearch-con
 To update the scraper config, you can submit a pull request to the config. To
 test a config change locally, you will need to run their open source
 [scraper](https://github.com/algolia/docsearch-scraper) against your own
-scraper to test out config changes.
+the scraper to test out config changes.
 
 ## Generating the Plugin Development Kit documentation
 
 - Have a local clone of Kong
 - Install Luarocks (comes with Kong)
 - Install `ldoc` using Luarocks: `luarocks install ldoc 1.4.6`
-- In the Kong repository, checkout the desired branch/tag/release
+- In the Kong repository, check out the desired branch/tag/release
 - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp pdk-docs`
 - This command will attempt to:
   * Obtain an updated list of modules from your local PDK and put it inside
@@ -74,11 +74,11 @@ scraper to test out config changes.
 ## Generating the Admin API, CLI and Configuration Documentation
 
 - Make sure that the `resty` and `luajit` executables are in your `$PATH` (installing kong should install them)
-- Several Lua rocks are needed. Easiest way to get all of them is to execute `make dev` in the Kong folder
+- Several Lua rocks are needed. The easiest way to get all of them is to execute `make dev` in the Kong folder
 - Have a local clone of Kong
-- In the Kong repository, checkout the desired branch/tag/release
+- In the Kong repository, check out the desired branch/tag/release
 - To generate the Admin API docs:
-  - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp admin-api-docs`
+  - Run: `KONG_PATH=path/to/your/kong/folder KONG_VERSION=0.14.x gulp admin-API-docs`
   - This command will attempt to:
     * Compare Kong's schemas and Admin API routes with the contents of the file
       `autodoc-admin-api/data.lua` and error out if there's any mismatches or missing data.

--- a/templates/how-to.md
+++ b/templates/how-to.md
@@ -14,7 +14,7 @@
 
 ### Introduction
 
-This is an introduction to this how-to guide. It should be limited to a few
+Use this section to provide an introduction to the how-to guide and provide the user with context for the guide. It should be limited to a few succinct sentences and provide a clear end-goal or outline of what the user will accomplish by following the guide
 succinct sentences that introduce what the user will be learning to do. A
 The how-to guide should provide an end-goal or something that the user will accomplish by following the steps. 
 

--- a/templates/how-to.md
+++ b/templates/how-to.md
@@ -21,7 +21,7 @@ The how-to guide should provide an end-goal or something that the user will acco
 ### Prerequisites
 
 - A bulleted list of everything a user needs to complete the How-to guide
-- Maybe broken into multiple sections for additional clarity
+- May be broken into multiple sections for additional clarity
 
 **Prereq Section 1** (optional)
 

--- a/templates/how-to.md
+++ b/templates/how-to.md
@@ -14,15 +14,14 @@
 
 ### Introduction
 
-This is an introduction to this how to guide. It should be limited to a few
-succinct sentences that introduces what the user will be learning to do. A
-How-to guide should provide an end-goal, or something that the user will 
-accomplish by following the steps. 
+This is an introduction to this how-to guide. It should be limited to a few
+succinct sentences that introduce what the user will be learning to do. A
+The how-to guide should provide an end-goal or something that the user will accomplish by following the steps. 
 
 ### Prerequisites
 
 - A bulleted list of everything a user needs to complete the How-to guide
-- May be broken into multiple sections for additional clarity
+- Maybe broken into multiple sections for additional clarity
 
 **Prereq Section 1** (optional)
 


### PR DESCRIPTION
Corrected Some Grammer Mistake now docs look much better to read

### Full changelog

* [Edited docs too...]
* [Added cool new feature ...]
* ...

### Issues resolved

Fix #XXX

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
