### PR TITLE
docs(1.2.x/admin-api) add description on using certificate object wit…

### DIFF
--- a/app/1.2.x/admin-api.md
+++ b/app/1.2.x/admin-api.md
@@ -225,7 +225,7 @@ certificate_body: |
     `cert` | PEM-encoded public certificate of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
     `tags`<br>*optional* |  An optional set of strings associated with the Certificate, for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. 
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
 
 certificate_json: |
     {
@@ -256,7 +256,7 @@ sni_body: |
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
     `tags`<br>*optional* |  An optional set of strings associated with the SNIs, for grouping and filtering. 
-    `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname  With form-encoded, the notation is `certificate.id=<certificate_id>`. With JSON, use `"certificate":{"id":"<certificate_id>"}`.
+    `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.  With form-encoded, the notation is `certificate.id=<certificate_id>`. With JSON, use `"certificate":{"id":"<certificate_id>"}`.
 
 sni_json: |
     {
@@ -1871,9 +1871,10 @@ HTTP 200 OK
 
 ## Certificate Object
 
-A certificate object represents a public certificate/private key pair for an SSL
-certificate. These objects are used by Kong to handle SSL/TLS termination for
-encrypted requests. Certificates are optionally associated with SNI objects to
+A certificate object represents a public certificate, and can be optionally paired with the
+corresponding private key. These objects are used by Kong to handle SSL/TLS termination for
+encrypted requests, or for use as a trusted CA store when validating peer certificate of
+client/service. Certificates are optionally associated with SNI objects to
 tie a cert/key pair to one or more hostnames.
 
 Certificates can be both [tagged and filtered by tags](#tags).

--- a/app/1.2.x/db-less-admin-api.md
+++ b/app/1.2.x/db-less-admin-api.md
@@ -225,7 +225,7 @@ certificate_body: |
     `cert` | PEM-encoded public certificate of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
     `tags`<br>*optional* |  An optional set of strings associated with the Certificate, for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. 
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
 
 certificate_json: |
     {
@@ -256,7 +256,7 @@ sni_body: |
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
     `tags`<br>*optional* |  An optional set of strings associated with the SNIs, for grouping and filtering. 
-    `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname  With form-encoded, the notation is `certificate.id=<certificate_id>`. With JSON, use `"certificate":{"id":"<certificate_id>"}`.
+    `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.  With form-encoded, the notation is `certificate.id=<certificate_id>`. With JSON, use `"certificate":{"id":"<certificate_id>"}`.
 
 sni_json: |
     {
@@ -1328,9 +1328,10 @@ HTTP 200 OK
 
 ## Certificate Object
 
-A certificate object represents a public certificate/private key pair for an SSL
-certificate. These objects are used by Kong to handle SSL/TLS termination for
-encrypted requests. Certificates are optionally associated with SNI objects to
+A certificate object represents a public certificate, and can be optionally paired with the
+corresponding private key. These objects are used by Kong to handle SSL/TLS termination for
+encrypted requests, or for use as a trusted CA store when validating peer certificate of
+client/service. Certificates are optionally associated with SNI objects to
 tie a cert/key pair to one or more hostnames.
 
 Certificates can be both [tagged and filtered by tags](#tags).

--- a/autodoc-admin-api/data.lua
+++ b/autodoc-admin-api/data.lua
@@ -895,9 +895,10 @@ return {
 
     certificates = {
       description = [[
-        A certificate object represents a public certificate/private key pair for an SSL
-        certificate. These objects are used by Kong to handle SSL/TLS termination for
-        encrypted requests. Certificates are optionally associated with SNI objects to
+        A certificate object represents a public certificate, and can be optionally paired with the
+        corresponding private key. These objects are used by Kong to handle SSL/TLS termination for
+        encrypted requests, or for use as a trusted CA store when validating peer certificate of
+        client/service. Certificates are optionally associated with SNI objects to
         tie a cert/key pair to one or more hostnames.
       ]],
       fields = {
@@ -928,7 +929,8 @@ return {
             An array of zero or more hostnames to associate with this
             certificate as SNIs. This is a sugar parameter that will, under the
             hood, create an SNI object and associate it with this certificate
-            for your convenience.
+            for your convenience. To set this attribute this certificate must
+            have a valid private key associated with it.
           ]]
         } },
       },
@@ -953,7 +955,9 @@ return {
         name = { description = [[The SNI name to associate with the given certificate.]] },
         certificate = {
           description = [[
-            The id (a UUID) of the certificate with which to associate the SNI hostname
+            The id (a UUID) of the certificate with which to associate the SNI hostname.
+            The Certificate must have a valid private key associated with it to be used
+            by the SNI object.
           ]]
         },
         tags = {


### PR DESCRIPTION
…hout private key

In Kong 1.2.x we will be supporting not specifying private key while creating a new
certificate object, objects created this way can not be used for TLS termination but
can be used as CA store for verification purpose.