### PR TITLE
fix(autodoc-admin-api) add newly needed boilerplate

### DIFF
--- a/autodoc-admin-api/run.lua
+++ b/autodoc-admin-api/run.lua
@@ -137,6 +137,9 @@ kong = require("kong.global").new()   -- luacheck: ignore
 kong.db = require("kong.db").new({    -- luacheck: ignore
   database = "postgres",
 })
+kong.configuration = { -- luacheck: ignore
+  loaded_plugins = {}
+}
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is needed for autodoc-admin-api to generate correctly with current
`master` and `next` of kong/kong.
