### PR TITLE
docs(route) add description for https_redirect_status_code

### DIFF
--- a/autodoc-admin-api/data.lua
+++ b/autodoc-admin-api/data.lua
@@ -541,6 +541,15 @@ return {
             This is where the Route proxies traffic to.
           ]]
         },
+        https_redirect_status_code = {
+          description = [[
+            The status code Kong responds with when all properties of a Route
+            match except the protocol i.e. if the protocol of the request
+            is `HTTP` instead of `HTTPS`.
+            `Location` header is injected by Kong if the field is set
+            to 301, 302, 307 or 308.
+          ]]
+        },
         tags = {
           description = [[
             An optional set of strings associated with the Route, for grouping and filtering.


### PR DESCRIPTION
`https_redirect_status_code` is a new property on route introduced in
Kong 1.2.0.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [ ] Tagged "Team Docs" as reviewers
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
