### PR TITLE
downgrade bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^3.3.5",
     "browser-sync": "^2.9.1",
     "cloudflare": "2.4.1",
     "del": "^4.1.0",


### PR DESCRIPTION
Downgrades bootstrap back down to 3.3.5 as our styles do not support bootstrap 4