### PR TITLE
docs(35/migrations) cover upgrade paths from Core

### DIFF
--- a/app/enterprise/0.35-x/deployment/migrations.md
+++ b/app/enterprise/0.35-x/deployment/migrations.md
@@ -5,8 +5,8 @@ title: Migrating to 0.35
 ### Prerequisites for Migrating to 0.35
 
 * If running a version of Kong Enterprise earlier than 0.34, it is necessary to [upgrade to 0.34](/enterprise/0.34-x/deployment-guide/#upgrading-to-034) first before migrating to 0.35.
-* If running Kong Core versions 0.14 or 0.15, you must [upgrade to Core 1.0](/1.0.x/upgrading/) before upgrading to Enterprise 0.35. You cannot upgrade to Enterprise 0.34 first.
-* If running Kong Core versions 0.13 or older, you can either upgrade to Core 1.0 or Enterprise 0.34 before upgrading to Enterprise 0.35.
+* If running Kong versions 0.14 or 0.15, you must [upgrade to Kong 1.0](/1.0.x/upgrading/) before upgrading to Kong Enterprise 0.35. You cannot upgrade to Kong Enterprise 0.34 first.
+* If running Kong version 0.13 or older, you can either upgrade to Kong 1.0 or Kong Enterprise 0.34 before upgrading to Kong Enterprise 0.35.
 * If the datastore still has `API` entities instead of `Services` and `Routes`, upgrading to 0.35 will not be possible. `APIs` were deprecated in release 0.32 and are now removed from Kong. It is possible to convert `APIs` to `Services` and `Routes` and then remove the `APIs` on the 0.34 node.
 
 ### Changes and Configuration to Consider before Upgrading

--- a/app/enterprise/0.35-x/deployment/migrations.md
+++ b/app/enterprise/0.35-x/deployment/migrations.md
@@ -4,7 +4,9 @@ title: Migrating to 0.35
 
 ### Prerequisites for Migrating to 0.35
 
-* If running a version earlier than 0.34, it is necessary to [upgrade to 0.34](/enterprise/0.34-x/deployment-guide/#upgrading-to-034) first before migrating to 0.35.
+* If running a version of Kong Enterprise earlier than 0.34, it is necessary to [upgrade to 0.34](/enterprise/0.34-x/deployment-guide/#upgrading-to-034) first before migrating to 0.35.
+* If running Kong Core versions 0.14 or 0.15, you must [upgrade to Core 1.0](/1.0.x/upgrading/) before upgrading to Enterprise 0.35. You cannot upgrade to Enterprise 0.34 first.
+* If running Kong Core versions 0.13 or older, you can either upgrade to Core 1.0 or Enterprise 0.34 before upgrading to Enterprise 0.35.
 * If the datastore still has `API` entities instead of `Services` and `Routes`, upgrading to 0.35 will not be possible. `APIs` were deprecated in release 0.32 and are now removed from Kong. It is possible to convert `APIs` to `Services` and `Routes` and then remove the `APIs` on the 0.34 node.
 
 ### Changes and Configuration to Consider before Upgrading


### PR DESCRIPTION
### Summary

Add upgrade instructions for users going from Kong Core to Kong Enterprise 0.35.

The 0.35 upgrade viability checker relies on either the presence of all 0.34 migrations or the absence of the `schema_migrations` table, which 1.0 removes. Because of this, 0.14 and 0.15 fail 0.35's upgrade check. These versions cannot be upgraded to 0.34, as 0.34 is based on Core 0.13. As such, the only viable upgrade path is to first upgrade them to 1.0.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->