### PR TITLE
docs(35/start) provide default ports for enterprise

### DIFF
--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -10,6 +10,7 @@ toc: false
 - [Step 2](#step-2)
 - [Step 3](#step-3)
 - [Step 4](#step-4)
+- [Default Ports](#default-ports)
 - [Next Steps](#next-steps)
 
 ### Introduction
@@ -95,10 +96,25 @@ allowing you to point to [your own configuration](/1.0.x/configuration/#configur
 ## Step 4
 
 To test that Kong Enterprise has successfully started with a **Super Admin**, 
-visit Kong Manager's URL. By default, it is `http://localhost:8002`. 
+visit Kong Manager's URL. By [default](#default-ports), it is on port `:8002`. 
 
 The username is `kong_admin` and the password is the one set in 
 [Step 1](#step-1).
+
+### Default Ports
+
+By default Kong listens on the following ports:
+
+- `:8000`: incoming HTTP traffic from Consumers, and forwarded to Upstream 
+  Services.
+- `:8443`: incoming HTTPS traffic. This port behaves similarly to the `:8000` 
+  port, except that it expects HTTPS traffic only. 
+- `:8003`: Dev Portal traffic, assuming the Dev Portal is enabled.
+- `:8004`: Dev Portal `/files` traffic, assuming the Dev Portal is enabled.
+- `:8001`: Admin API listens for HTTP traffic.
+- `:8444`: Admin API listens for HTTPS traffic.
+- `:8002`: Kong Manager listens for HTTP traffic.
+- `:8445`: Kong Manager listens for HTTPS traffic.
 
 ### Next Steps
 

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -107,7 +107,7 @@ By default, Kong Enterprise listens on the following ports:
 
 - [`:8000`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen): incoming HTTP traffic from **Consumers**, and forwarded to upstream 
   **Services**.
-- [`:8443`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)): incoming HTTPS traffic. This port behaves similarly to the `:8000` 
+- [`:8443`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen): incoming HTTPS traffic. This port behaves similarly to the `:8000` 
   port, except that it expects HTTPS traffic only. 
 - [`:8003`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen): Dev Portal listens for HTTP traffic, assuming Dev Portal is **enabled**.
 -[`:8446`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen): Dev Portal listens for HTTPS traffic, assuming Dev Portal is **enabled**.

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -109,8 +109,10 @@ By default, Kong Enterprise listens on the following ports:
   **Services**.
 - [`:8443`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)): incoming HTTPS traffic. This port behaves similarly to the `:8000` 
   port, except that it expects HTTPS traffic only. 
-- `:8003`: Dev Portal traffic, assuming the Dev Portal is **enabled**.
-- `:8004`: Dev Portal **`/files` traffic**, assuming the Dev Portal is **enabled**.
+- [`:8003`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen): Dev Portal listens for HTTP traffic, assuming Dev Portal is **enabled**.
+-[`:8446`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen): Dev Portal listens for HTTPS traffic, assuming Dev Portal is **enabled**.
+- [`:8004`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen): Dev Portal **`/files`** traffic over HTTP, assuming the Dev Portal is **enabled**.
+- [`:8447`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen): Dev Portal **`/files`** traffic over HTTPS, assuming the Dev Portal is **enabled**.
 - `:8001`: Admin API listens for HTTP traffic.
 - `:8444`: Admin API listens for HTTPS traffic.
 - `:8002`: Kong Manager listens for HTTP traffic.

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -105,12 +105,12 @@ The username is `kong_admin` and the password is the one set in
 
 By default, Kong Enterprise listens on the following ports:
 
-- `:8000`: incoming HTTP traffic from Consumers, and forwarded to Upstream 
-  Services.
+- `:8000`: incoming HTTP traffic from **Consumers**, and forwarded to upstream 
+  **Services**.
 - `:8443`: incoming HTTPS traffic. This port behaves similarly to the `:8000` 
   port, except that it expects HTTPS traffic only. 
-- `:8003`: Dev Portal traffic, assuming the Dev Portal is enabled.
-- `:8004`: Dev Portal `/files` traffic, assuming the Dev Portal is enabled.
+- `:8003`: Dev Portal traffic, assuming the Dev Portal is **enabled**.
+- `:8004`: Dev Portal **`/files` traffic**, assuming the Dev Portal is **enabled**.
 - `:8001`: Admin API listens for HTTP traffic.
 - `:8444`: Admin API listens for HTTPS traffic.
 - `:8002`: Kong Manager listens for HTTP traffic.

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -105,9 +105,9 @@ The username is `kong_admin` and the password is the one set in
 
 By default, Kong Enterprise listens on the following ports:
 
-- `:8000`: incoming HTTP traffic from **Consumers**, and forwarded to upstream 
+- [`:8000`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen): incoming HTTP traffic from **Consumers**, and forwarded to upstream 
   **Services**.
-- `:8443`: incoming HTTPS traffic. This port behaves similarly to the `:8000` 
+- [`:8443`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen)): incoming HTTPS traffic. This port behaves similarly to the `:8000` 
   port, except that it expects HTTPS traffic only. 
 - `:8003`: Dev Portal traffic, assuming the Dev Portal is **enabled**.
 - `:8004`: Dev Portal **`/files` traffic**, assuming the Dev Portal is **enabled**.

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -103,7 +103,7 @@ The username is `kong_admin` and the password is the one set in
 
 ### Default Ports
 
-By default Kong listens on the following ports:
+By default, Kong Enterprise listens on the following ports:
 
 - `:8000`: incoming HTTP traffic from Consumers, and forwarded to Upstream 
   Services.

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -113,8 +113,8 @@ By default, Kong Enterprise listens on the following ports:
 -[`:8446`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen): Dev Portal listens for HTTPS traffic, assuming Dev Portal is **enabled**.
 - [`:8004`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen): Dev Portal **`/files`** traffic over HTTP, assuming the Dev Portal is **enabled**.
 - [`:8447`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen): Dev Portal **`/files`** traffic over HTTPS, assuming the Dev Portal is **enabled**.
-- `:8001`: Admin API listens for HTTP traffic.
-- `:8444`: Admin API listens for HTTPS traffic.
+- [`:8001`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri): Admin API listens for HTTP traffic.
+- [`:8444`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri): Admin API listens for HTTPS traffic.
 - `:8002`: Kong Manager listens for HTTP traffic.
 - `:8445`: Kong Manager listens for HTTPS traffic.
 

--- a/app/enterprise/0.35-x/getting-started/start-kong.md
+++ b/app/enterprise/0.35-x/getting-started/start-kong.md
@@ -115,8 +115,8 @@ By default, Kong Enterprise listens on the following ports:
 - [`:8447`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen): Dev Portal **`/files`** traffic over HTTPS, assuming the Dev Portal is **enabled**.
 - [`:8001`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri): Admin API listens for HTTP traffic.
 - [`:8444`](/enterprise/{{page.kong_version}}/property-reference/#admin_api_uri): Admin API listens for HTTPS traffic.
-- `:8002`: Kong Manager listens for HTTP traffic.
-- `:8445`: Kong Manager listens for HTTPS traffic.
+- [`:8002`](/enterprise/{{page.kong_version}}/property-reference/#admin_gui_listen): Kong Manager listens for HTTP traffic.
+- [`:8445`](/enterprise/{{page.kong_version}}/property-reference/#admin_gui_listen): Kong Manager listens for HTTPS traffic.
 
 ### Next Steps
 


### PR DESCRIPTION
### Summary

In the Getting Started guide, once a user has started Kong, they have a list of default ports used with Kong Enterprise. 

Each port listing will also link to the related configuration property in case the organization wants to know where to change the ports used or to deactivate unused ones. 

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
For this PR:
- [x] Update entity names with SG
- [x] Check accuracy of ports (some may have changed since 0.31)
- [x] Link to Configuration Property Reference 