### PR TITLE
docs(ldap-auth-advanced) `consumer_by` takes an array and the default…

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -115,10 +115,10 @@ params:
         Whether consumer is optional
     - name: consumer_by
       required: false
-      default: "`username`"
+      default: "`{ "username", "custom_id" }`"
       value_in_examples:
       description: |
-        Whether to authenticate consumer based on `username` or `custom_id`
+        Whether to authenticate consumer based on `username` and/or `custom_id`
     - name: hide_credentials
       required: false
       default: "`false`"


### PR DESCRIPTION
… value was

incorrect