### PR TITLE
docs(rate-limiting-advanced) note unit for timeout

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -92,7 +92,7 @@ params:
       default: 2000
       value_in_examples:
       description: |
-        Connection timeout to use for Redis connection when the `redis` strategy is defined
+        Connection timeout (in milliseconds) to use for Redis connection when the `redis` strategy is defined
     - name: redis.password
       required: semi
       default:


### PR DESCRIPTION
### Summary

Note that the Redis timeout in the plugin configuration is measured in milliseconds.

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? --> N/A
- [x] [Adheres to Kong style guide](https://github.com/Kong/docs.konghq.com/blob/master/STYLEGUIDE.md)
- [x] Spellchecked my updates
- [x] Tagged "Team Docs" as reviewers
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->