### PR TITLE
docs(plugins) add new tls field in *current* versions of the plugins

### DIFF
--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -88,6 +88,12 @@ Every request will be logged separately in a JSON object separated by a new line
             "accept": "*/*",
             "host": "httpbin.org",
             "user-agent": "curl/7.37.1"
+        },
+        "tls": {
+            "version": "TLSv1.2",
+            "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "supported_client_ciphers": "ECDHE-RSA-AES256-GCM-SHA384",
+            "client_verify": "NONE"
         }
     },
     "upstream_uri": "/",

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -96,6 +96,12 @@ Every request will be logged separately in a JSON object, with the following for
             "accept": "*/*",
             "host": "httpbin.org",
             "user-agent": "curl/7.37.1"
+        },
+        "tls": {
+            "version": "TLSv1.2",
+            "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "supported_client_ciphers": "ECDHE-RSA-AES256-GCM-SHA384",
+            "client_verify": "NONE"
         }
     },
     "upstream_uri": "/",

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -76,6 +76,12 @@ Every request will be logged to System log in [SYSLOG](https://en.wikipedia.org/
             "accept": "*/*",
             "host": "httpbin.org",
             "user-agent": "curl/7.37.1"
+        },
+        "tls": {
+            "version": "TLSv1.2",
+            "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "supported_client_ciphers": "ECDHE-RSA-AES256-GCM-SHA384",
+            "client_verify": "NONE"
         }
     },
     "upstream_uri": "/",

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -88,6 +88,12 @@ Every request will be logged separately in a JSON object, separated by a new lin
             "accept": "*/*",
             "host": "httpbin.org",
             "user-agent": "curl/7.37.1"
+        },
+        "tls": {
+            "version": "TLSv1.2",
+            "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "supported_client_ciphers": "ECDHE-RSA-AES256-GCM-SHA384",
+            "client_verify": "NONE"
         }
     },
     "upstream_uri": "/",

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -77,7 +77,14 @@ Every request will be logged separately in a JSON object with the following form
             "accept": "*/*",
             "host": "httpbin.org",
             "user-agent": "curl/7.37.1"
+        },
+        "tls": {
+            "version": "TLSv1.2",
+            "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "supported_client_ciphers": "ECDHE-RSA-AES256-GCM-SHA384",
+            "client_verify": "NONE"
         }
+
     },
     "upstream_uri": "/",
     "response": {


### PR DESCRIPTION
This is a continuation of #1251.

On that PR the TLS field was added to the docs of *older versions of the
plugins* (`0.1-x`, etc) but not to the *current* ones (`index.md`). This PR fixes that problem.
