### PR TITLE
hotfix(hub/ldap-adv) fix yaml formatting

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -115,7 +115,7 @@ params:
         Whether consumer is optional
     - name: consumer_by
       required: false
-      default: "`[ "username", "custom_id" ]`"
+      default: '`[ "username", "custom_id" ]`'
       value_in_examples:
       description: |
         Whether to authenticate consumer based on `username` and/or `custom_id`


### PR DESCRIPTION
Fixes issue where all declared content in YAML front matter was broken due to the outside quotes. Long term solution would be to flag a failure in Travis CI. Incidentally, the error message stated an incorrect line number--said line 116, whereas error was on line 118. 