### PR TITLE
docs(0.34-x/rbac-admin-api) Fix response when deleting a Role Entity …

### DIFF
--- a/app/enterprise/0.34-x/rbac/admin-api.md
+++ b/app/enterprise/0.34-x/rbac/admin-api.md
@@ -528,21 +528,7 @@ HTTP 200 OK
 **Response**
 
 ```
-HTTP 200 OK
-```
-
-```json
-{
-  "endpoint": "/routes",
-  "created_at": 1529052518000,
-  "role_id": "22ffce18-afef-4f19-a1b2-2071f52e2f30",
-  "actions": [
-    "create",
-    "read"
-  ],
-  "negative": false,
-  "workspace": "default"
-}
+HTTP 204 No Content
 ```
 
 ---


### PR DESCRIPTION
…Permission

The response when deleting a RBAC Role Endpoint Permission via Admin API should be '_204_' instead of '_200_'.

### Summary

The response when deleting a RBAC Role Endpoint Permission should be '204' instead of '200'.

### Full changelog

* [app/enterprise/0.34-x/rbac/admin-api.md]: modified _Response_ when deleting a RBAC Role Endpoint Permission