### PR TITLE
docs(0.35-x/conf-ref) fix a typo of configuration directive

### DIFF
--- a/app/enterprise/0.35-x/property-reference.md
+++ b/app/enterprise/0.35-x/property-reference.md
@@ -1263,7 +1263,7 @@ Kong Manager.
 admin_gui_session_conf = { "cookie_name": "kookie", "secret": "changeme"}
 ```
 
-### admin)gui_auth_header
+### admin_gui_auth_header
 
 **Default:** `Kong-Admin-User`
 


### PR DESCRIPTION
Original: admin)gui_auth_header
Fixed: admin_gui_auth_header

### Summary

Fix a typo of configuration directive.
* Original: admin)gui_auth_header
* Fixed: admin_gui_auth_header

### Full changelog

* [app/enterprise/0.35-x/property-reference.md]: fix typo

