### PR TITLE
fix(docs): Proxy Cache examples

### DIFF
--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -80,7 +80,7 @@ params:
     - name: strategy
       required:
       default:
-      value_in_examples:
+      value_in_examples: memory
       description: |
         The backing data store in which to hold cache entities. Accepted values are; `memory`, and `redis`.
     - name: memory.dictionary_name


### PR DESCRIPTION
### Summary

Adds `memory` as the example value for `config.strategy` in the **Proxy Cache** plugin

## Issues resolved

Fix #1344 
