### PR TITLE
docs(*) mention rbac/users and consumers for admins are not listed

### DIFF
--- a/app/1.0.x/admin-api.md
+++ b/app/1.0.x/admin-api.md
@@ -1130,6 +1130,10 @@ HTTP 200 OK
 }
 ```
 
+⚠️ **Note**: **Consumers** associated with **Admins** will _not_ be 
+listed with **`GET`** `/consumers`. Instead, use 
+[**`GET`** `/admins`](/enterprise/0.35-x/admin-api/admins/reference/#list-admins) 
+to list all **Admins**.
 
 ---
 

--- a/app/enterprise/0.35-x/admin-api/rbac/reference.md
+++ b/app/enterprise/0.35-x/admin-api/rbac/reference.md
@@ -121,6 +121,11 @@ HTTP 200 OK
   "next": null
 }
 ```
+
+⚠️ **Note**: **RBAC Users** associated with **Admins** will _not_ be listed with **`GET`** `/rbac/users`. Instead, use 
+[**`GET`** `/admins`](/enterprise/{{page.kong_version}}/admin-api/admins/reference/#list-admins) 
+to list all **Admins**.
+
 ___
 
 ## Update a User

--- a/app/enterprise/0.35-x/admin-api/rbac/reference.md
+++ b/app/enterprise/0.35-x/admin-api/rbac/reference.md
@@ -122,7 +122,8 @@ HTTP 200 OK
 }
 ```
 
-⚠️ **Note**: **RBAC Users** associated with **Admins** will _not_ be listed with **`GET`** `/rbac/users`. Instead, use 
+⚠️ **Note**: **RBAC Users** associated with **Admins** will _not_ be 
+listed with **`GET`** `/rbac/users`. Instead, use 
 [**`GET`** `/admins`](/enterprise/{{page.kong_version}}/admin-api/admins/reference/#list-admins) 
 to list all **Admins**.
 


### PR DESCRIPTION
### Summary

GET `/rbac/users` and `/consumers` lists all respective entities except those associated with Admin accounts. This leads to confusion when users can't find the entities they'd expect.

### Full changelog

* Added a note under List Users (for RBAC in Enterprise)
* Added a note under List Consumers (Core entities that are tied to Enterprise Admins)

@kikito , please note that (1) there is a requested change outside of Enterprise, and (2) the Kong Enterprise version is hardcoded in the link since there is not a dynamic way to connect Kong and Kong Enterprise versions.