### PR TITLE
doc(k8s) re-do and update the Kong w\ k8s installation docs

### DIFF
--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -165,7 +165,7 @@ Now deploy the Kong dataplane using the `kong-dbless.yaml` file from this reposi
 $ kubectl apply -f kong-dbless.yaml
 ```
 
-### **Using Declarative / DB Less Backed Kong**
+### Using Declarative / DB Less Backed Kong
 
 To update declarative / db-less Kong edit the declarative file and then replace the config map
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -143,7 +143,7 @@ pod/kong-control-plane         1/1     Running
 pod/kong-ingress-data-plane    1/1     Running
 ```
 
-Export the Kong host, admin api and proxy ports
+Export the Kong host, Admin API and proxy ports
 
 ```bash
 $ export HOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -80,7 +80,7 @@ For Postgres, continue to [Postgres Backed Kong](#postgres-backed-kong)
 
 For DB-less mode, continue to [Using Kong without a Database](#using-kong-without-a-database)
 
-### **Cassandra Backed Kong**
+### Cassandra Backed Kong
 
 Use the `cassandra-service.yaml` and `cassandra-statefulset.yaml`
 file from this repository to deploy a Cassandra `Service` and a `StatefulSet` in the cluster.

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -6,10 +6,8 @@ header_icon: /assets/images/icons/icn-installation.svg
 breadcrumbs:
   Installation: /install
 links:
-  gcloud: "https://cloud.google.com/sdk/"
   kubectl: "https://cloud.google.com/container-engine/docs/quickstart#install_the_gcloud_command-line_interface"
   gh_tag: "https://github.com/Kong/kong-dist-kubernetes/tree/1.0.0"
-  minikube: "https://github.com/Kong/kong-dist-kubernetes/blob/master/minikube/README.md"
   kubeapps_hub: "https://hub.kubeapps.com/charts/stable/kong"
   gh_repo: "https://github.com/Kong/kong-dist-kubernetes/"
   az: "https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest"
@@ -20,7 +18,7 @@ links:
 <!-- FIXME the list below should be an unordered list, but currently those do not render correctly in this section of the Docs site - depends on https://github.com/Kong/docs.konghq.com/issues/917 -->
 1. [Kubernetes Ingress Controller for Kong](#kubernetes-ingress-controller-for-kong)
 1. [Kong via Google Cloud Platform Marketplace](#kong-via-google-cloud-platform-marketplace)
-1. [Kong via Helm or Minikube](#kong-via-helm-or-minikube)
+1. [Kong via Helm](#kong-via-helm)
 1. [Kong via Manifest Files](#kong-via-manifest-files)
 1. [Additional Steps for Kong Enterprise Trial Users](#additional-steps-for-kong-enterprise-trial-users)
 
@@ -30,7 +28,7 @@ Install Kong or Kong Enterprise using the official
 <a href="https://github.com/Kong/kubernetes-ingress-controller">Kubernetes Ingress Controller</a>.
 
 Learn more via the <a href="https://github.com/Kong/kubernetes-ingress-controller/blob/master/README.md">README
-</a>. To get up and running quickly, follow the
+</a>. To run a local proof of concept, follow the
 <a href="https://github.com/Kong/kubernetes-ingress-controller/tree/master/deploy">Minikube and Minishift tutorials</a>.
 
 The [Kubernetes Ingress Controller for Kong launch announcement](https://konghq.com/blog/kubernetes-ingress-controller-for-kong/)
@@ -66,134 +64,131 @@ For questions and discussion, please visit [Kong Nation](https://discuss.konghq.
 
 Kong, or the trial version of Kong Enterprise, can be provisioned
 on a Kubernetes cluster via the manifest files provided
-in the [repo]({{ page.links.gh_repo }}).
+in the [Kong Kubernetes repository]({{ page.links.gh_repo }}).
 
-## 1. **Initial setup**
+## **Prerequisites**
 
-Download or clone the following repo:
+1. Download or clone the [Kong Kubernetes repository]({{ page.links.gh_repo }})
+2. A Kubernetes cluster
 
+## **Installation Steps**
+
+The [Kong Kubernetes repository]({{ page.links.gh_repo }}) includes Make tasks `run_cassandra`,
+`run_postgres` and `run_dbless` for ease of use but we'll detail the specific yaml files the tasks use here.
+
+For all variations create the Kong namespace
 ```bash
-$ git clone git@github.com:Kong/kong-dist-kubernetes.git
-$ cd kong-dist-kubernetes
+$ kubectl apply -f kong-namespace.yaml
 ```
 
-Skip to step 3 if you have already provisioned a cluster and registered it
-with Kubernetes.
+### **Cassandra Backed Kong**
 
-## 2.  **Deploy a cluster**
-
-### [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
-
-You need [gcloud]({{ page.links.gcloud }}) and [kubectl]({{ page.links.kubectl }})
-command-line tools installed and set up to run deployment commands. Also
-make sure your Google Cloud account has `STATIC_ADDRESSES` available for
-the external access of Kong services.
-
-Using the `cluster.yaml` file from this repo, deploy a
-GKE cluster. Provide the following information before deploying:
-
-1. Desired cluster name
-2. Zone in which to run the cluster
-3. A basicauth username and password for authenticating the access to the
-cluster
+Use the `cassandra-service.yaml` and `cassandra-statefulset.yaml`
+file from this repository to deploy a Cassandra `Service` and a `StatefulSet` in the cluster.
 
 ```bash
-$ gcloud deployment-manager deployments \
-    create cluster --config cluster.yaml
+$ kubectl apply -f cassandra-service.yaml
+$ kubectl apply -f cassandra-statefulset.yaml
 ```
 
-### [Azure Kubernetes Cluster (AKS)](https://docs.microsoft.com/en-us/azure/aks/)
-
-You need [az]({{ page.links.az }}) command-line tools installed and set up to run deployment commands.
-
-1. **Create a Resource Group**
-
-    ```bash
-    $ az group create --name myAKSCluster --location eastus
-    ```
-
-2. **Install kubectl**
-
-    If you already have [kubectl]({{ page.links.kubectl }}) installed, you can skip this step.
-
-    ```bash
-    $ az aks install-cli
-    ```
-
-3. **Configure kubectl**
-
-    ```bash
-    $ az aks get-credentials --resource-group myAKSCluster --name myAKSCluster
-    ```
-
-## 3. **Deploy a datastore**
-
-Before deploying Kong, you need to provision a Cassandra or PostgreSQL pod.
-
-For Cassandra, use the `cassandra.yaml` file from this repo to deploy a
-Cassandra `Service` and a `StatefulSet` in the cluster.
+Use the `kong-control-plane-cassandra.yaml` file from this repository to run required migrations
+and deploy Kong control plane node including the Kong admin api
 
 ```bash
-$ kubectl create -f cassandra.yaml
+$ kubectl -n kong apply -f kong-control-plane-cassandra.yaml
 ```
 
-For PostgreSQL, use the `postgres.yaml` file from the kong-dist-kubernetes
-repo to deploy a PostgreSQL `Service` and a `ReplicationController` in the
-cluster:
+Use the `kong-ingress-data-plane-cassandra.yaml` file from this repository to run the Kong data
+plane node
+
+``` bash
+$ kubectl -n kong apply -f kong-ingress-data-plane-cassandra.yaml
+```
+
+Continue to [Using Datastore Backed Kong](#using-datastore-backed-kong)
+
+### **PostgreSQL Backed Kong**
+
+Use the `postgres.yaml` file from the repository to deploy a  PostgreSQL `Service` and a 
+`ReplicationController` in the cluster:
 
 ```bash
 $ kubectl create -f postgres.yaml
 ```
 
-**Kong Enterprise trial users** should complete the steps in the
-**Additional Steps for Kong Enterprise Trial Users** section below before proceeding.
-
-## 4. **Prepare database**
-
-Using the `kong_migration_<postgres|cassandra>.yaml` file,
-run the migration job:
+Use the `kong-control-plane-postgres.yaml` file from this repository to run required migrations
+and deploy Kong control plane node including the Kong admin api
 
 ```bash
-$ kubectl create -f kong_migration_<postgres|cassandra>.yaml
+$ kubectl -n kong apply -f kong-control-plane-postgres.yaml
 ```
-Once the job completes, you can remove the pod by running following command:
+
+Use the `kong-ingress-data-plane-postgres.yaml` file from this repository to run the Kong data
+plane node
+
+``` bash
+$ kubectl -n kong apply -f kong-ingress-data-plane-postgres.yaml
+```
+
+Continue to [Using Datastore Backed Kong](#using-datastore-backed-kong)
+
+### **Using Datastore Backed Kong**
+
+First let's ensure the Kong control plane and data plane are successfully running
 
 ```bash
-$ kubectl delete -f kong_migration_<postgres|cassandra>.yaml
+kubectl get all -n kong
+NAME                           READY   STATUS
+pod/kong-control-plane         1/1     Running
+pod/kong-ingress-data-plane    1/1     Running
 ```
 
-## 5. **Deploy Kong**
-
-Using the `kong_<postgres|cassandra>.yaml` file from this
-repo, deploy Kong admin, proxy services, and a `Deployment` controller to
-the cluster:
+Export the Kong host, admin api and proxy ports
 
 ```bash
-$ kubectl create -f kong_<postgres|cassandra>.yaml
+$ export HOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')
+$ export ADMIN_PORT=$(kubectl get svc --namespace kong kong-control-plane  -o jsonpath='{.spec.ports[0].nodePort}')
+$ export PROXY_PORT=$(kubectl get svc --namespace kong kong-ingress-data-plane -o jsonpath='{.spec.ports[0].nodePort}')
 ```
 
-## 6. **Verify your deployments**
+Continue to [configuring a service](/latest/getting-started/configuring-a-service/).
 
-You can now see the resources that have been deployed using `kubectl`:
+### **Declarative / No Datastore**
+
+For declarative / db-less, create a config map using the `declarative.yaml` sample file from
+this repository
+```bash
+$ kubectl create configmap kongdeclarative -n kong --from-file=declarative.yaml
+```
+
+Now deploy the Kong dataplane using the `kong-dbless.yaml` file from this repository
 
 ```bash
-$ kubectl get all
+$ kubectl apply -f kong-dbless.yaml
 ```
 
-Once the `EXTERNAL_IP` is available for Kong Proxy and Admin services, you
-can test Kong by making the following requests:
+### **Using Declarative / DB Less Backed Kong**
+
+To update declarative / db-less Kong edit the declarative file and then replace the config map
 
 ```bash
-$ curl <kong-admin-ip-address>:8001
-$ curl https://<admin-ssl-ip-address>:8444
-$ curl <kong-proxy-ip-address>:8000
-$ curl https://<kong-proxy-ssl-ip-address>:8443
+$ kubectl create configmap kongdeclarative -n kong --from-file=declarative.yaml -o yaml --dry-run | kubectl replace -n kong -f -
 ```
 
-## 7. **Get Started with Kong**
+Now do a rolling deployment using the `md5sum` of the declarative Kong yaml file
 
-Quickly learn how to use Kong with the
-[5-minute Quickstart](/latest/getting-started/quickstart/).
+```bash
+$ kubectl patch deployment kong-dbless -n kong -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"declarative\":\"`md5sum declarative.yaml | awk '{ print $$1 }'`\"}}}}}}"
+```
+
+Export the Kong host, and proxy port
+
+```bash
+$ export HOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')
+$ export PROXY_PORT=$(kubectl get svc --namespace kong kong-dbless -o jsonpath='{.spec.ports[0].nodePort}')
+```
+
+Continue to [db-less and declarative configuration documentation page](/latest/db-less-and-declarative-config/)
 
 # Additional Steps for Kong Enterprise Trial Users
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -131,7 +131,7 @@ $ kubectl -n kong apply -f kong-ingress-data-plane-postgres.yaml
 
 Continue to [Using Datastore Backed Kong](#using-datastore-backed-kong)
 
-### **Using Datastore Backed Kong**
+### Using Datastore Backed Kong
 
 First let's ensure the Kong control plane and data plane are successfully running
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -139,12 +139,11 @@ pod/kong-control-plane         1/1     Running
 pod/kong-ingress-data-plane    1/1     Running
 ```
 
-Export the Kong host, Admin API and proxy ports
+Get access to the Kong Admin API port (if running minikube the below should work):
 
 ```bash
 $ export HOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')
 $ export ADMIN_PORT=$(kubectl get svc --namespace kong kong-control-plane  -o jsonpath='{.spec.ports[0].nodePort}')
-$ export PROXY_PORT=$(kubectl get svc --namespace kong kong-ingress-data-plane -o jsonpath='{.spec.ports[0].nodePort}')
 ```
 
 Continue to [configuring a service](/latest/getting-started/configuring-a-service/).
@@ -177,11 +176,11 @@ Now do a rolling deployment using the `md5sum` of the declarative Kong yaml file
 $ kubectl patch deployment kong-dbless -n kong -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"declarative\":\"`md5sum declarative.yaml | awk '{ print $$1 }'`\"}}}}}}"
 ```
 
-Export the Kong host, and proxy port
+Get access to the Kong Admin API port (if running minikube the below should work):
 
 ```bash
-$ export HOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')
-$ export PROXY_PORT=$(kubectl get svc --namespace kong kong-dbless -o jsonpath='{.spec.ports[0].nodePort}')
+$ export HOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')=
+$ export ADMIN_PORT=$(kubectl get svc --namespace kong kong-control-plane  -o jsonpath='{.spec.ports[0].nodePort}')
 ```
 
 Continue to [db-less and declarative configuration documentation page](/latest/db-less-and-declarative-config/)

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -61,7 +61,7 @@ in the [Kong Kubernetes repository]({{ page.links.gh_repo }}).
 1. Download or clone the [Kong Kubernetes repository]({{ page.links.gh_repo }})
 2. A Kubernetes cluster
 
-## **Installation Steps**
+## Installation Steps
 
 The [Kong Kubernetes repository]({{ page.links.gh_repo }}) includes Make tasks `run_cassandra`,
 `run_postgres` and `run_dbless` for ease of use, but we'll detail the specific YAML files the tasks use here.

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -153,7 +153,7 @@ $ export PROXY_PORT=$(kubectl get svc --namespace kong kong-ingress-data-plane -
 
 Continue to [configuring a service](/latest/getting-started/configuring-a-service/).
 
-### **Declarative / No Datastore**
+### **Using Kong without a Database**
 
 For declarative / db-less, create a config map using the `declarative.yaml` sample file from
 this repository

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -117,7 +117,7 @@ $ kubectl create -f postgres.yaml
 ```
 
 Use the `kong-control-plane-postgres.yaml` file from this repository to run required migrations
-and deploy Kong control plane node including the Kong admin api
+and deploy Kong control plane node including the Kong Admin API:
 
 ```bash
 $ kubectl -n kong apply -f kong-control-plane-postgres.yaml

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -56,7 +56,7 @@ once you've completed your experiment to avoid on-going Google Cloud usage charg
 
 # Kong via Helm
 
-Install Kong or Kong Enterprise using the official [Helm chart]({{ page.links.kubeapps_hub }})
+Install Kong or Kong Enterprise using the official [Helm chart]({{ page.links.kubeapps_hub }}).
 
 For questions and discussion, please visit [Kong Nation](https://discuss.konghq.com/c/kubernetes).
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -74,7 +74,7 @@ in the [Kong Kubernetes repository]({{ page.links.gh_repo }}).
 ## **Installation Steps**
 
 The [Kong Kubernetes repository]({{ page.links.gh_repo }}) includes Make tasks `run_cassandra`,
-`run_postgres` and `run_dbless` for ease of use but we'll detail the specific yaml files the tasks use here.
+`run_postgres` and `run_dbless` for ease of use, but we'll detail the specific YAML files the tasks use here.
 
 For all variations create the Kong namespace
 ```bash

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -151,7 +151,7 @@ $ export ADMIN_PORT=$(kubectl get svc --namespace kong kong-control-plane  -o js
 
 Continue to [configuring a service](/latest/getting-started/configuring-a-service/).
 
-### **Using Kong without a Database**
+### Using Kong without a Database
 
 For declarative / db-less, create a config map using the `declarative.yaml` sample file from
 this repository

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -56,7 +56,7 @@ Kong, or the trial version of Kong Enterprise, can be provisioned
 on a Kubernetes cluster via the manifest files provided
 in the [Kong Kubernetes repository]({{ page.links.gh_repo }}).
 
-### **Prerequisites**
+### Prerequisites
 
 1. Download or clone the [Kong Kubernetes repository]({{ page.links.gh_repo }})
 2. A Kubernetes cluster

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -56,12 +56,11 @@ once you've completed your experiment to avoid on-going Google Cloud usage charg
 
 <iframe width="660" height="400" src="https://www.youtube-nocookie.com/embed/MPlSyWDAOpw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
-# Kong via Helm or Minikube
+# Kong via Helm
 
-An easy way to deploy Kong on Kubernetes is via [Helm]({{ page.links.kubeapps_hub }}).
+Install Kong or Kong Enterprise using the official [Helm chart]({{ page.links.kubeapps_hub }})
 
-Kong can also be deployed on minikube - please follow the [README]({{ page.links.minikube }})
-and use the manifest files provided in `minikube` directory.
+For questions and discussion, please visit [Kong Nation](https://discuss.konghq.com/c/kubernetes).
 
 # Kong via Manifest Files
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -106,7 +106,7 @@ $ kubectl -n kong apply -f kong-ingress-data-plane-cassandra.yaml
 
 Continue to [Using Datastore Backed Kong](#using-datastore-backed-kong)
 
-### **PostgreSQL Backed Kong**
+### PostgreSQL Backed Kong
 
 Use the `postgres.yaml` file from the repository to deploy a  PostgreSQL `Service` and a 
 `ReplicationController` in the cluster:

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -73,9 +73,12 @@ $ kubectl apply -f kong-namespace.yaml
 
 The next step depends on whether you are going to use Kong with Cassandra, Postgres or without a datastore:
 
-* For Cassandra, continue to [Cassandra Backed Kong](#cassandra-backed-kong)
-* For Postgres, continue to [Postgres Backed Kong](#postgres-backed-kong)
-* For DB-less mode, continue to [Using Kong without a Database](#using-kong-without-a-database)
+
+For Cassandra, continue to [Cassandra Backed Kong](#cassandra-backed-kong)
+
+For Postgres, continue to [Postgres Backed Kong](#postgres-backed-kong)
+
+For DB-less mode, continue to [Using Kong without a Database](#using-kong-without-a-database)
 
 ### **Cassandra Backed Kong**
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -16,11 +16,10 @@ links:
 ## Kubernetes Ingress Controller for Kong
 
 Install Kong or Kong Enterprise using the official
-<a href="https://github.com/Kong/kubernetes-ingress-controller">Kubernetes Ingress Controller</a>.
+[Kubernetes Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller).
 
-Learn more via the <a href="https://github.com/Kong/kubernetes-ingress-controller/blob/master/README.md">README
-</a>. To run a local proof of concept, follow the
-<a href="https://github.com/Kong/kubernetes-ingress-controller/tree/master/deploy">Minikube and Minishift tutorials</a>.
+Learn more via the [README](https://github.com/Kong/kubernetes-ingress-controller/blob/master/README.md). 
+To run a local proof of concept, follow the [Minikube and Minishift tutorials](https://github.com/Kong/kubernetes-ingress-controller/tree/master/deploy).
 
 The [Kubernetes Ingress Controller for Kong launch announcement](https://konghq.com/blog/kubernetes-ingress-controller-for-kong/)
 is on the [Kong Blog](https://konghq.com/blog/).
@@ -47,7 +46,7 @@ once you've completed your experiment to avoid on-going Google Cloud usage charg
 
 ## Kong via Helm
 
-Install Kong or Kong Enterprise using the official [Helm chart]({{ page.links.kubeapps_hub }}).
+Install **Kong** or **Kong Enterprise** using the official [Helm chart]({{ page.links.kubeapps_hub }}).
 
 For questions and discussion, please visit [Kong Nation](https://discuss.konghq.com/c/kubernetes).
 

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -81,6 +81,11 @@ For all variations create the Kong namespace
 $ kubectl apply -f kong-namespace.yaml
 ```
 
+The next step depends on whether you are going to use Kong with Cassandra, Postgres or without a datastore:
+
+* For Cassandra, continue to [Cassandra Backed Kong](#cassandra-backed-kong)
+* For Postgres, continue to [Postgres Backed Kong](#postgres-backed-kong)
+* For DB-less mode, continue to [Using Kong without a Database](#using-kong-without-a-database)
 ### **Cassandra Backed Kong**
 
 Use the `cassandra-service.yaml` and `cassandra-statefulset.yaml`


### PR DESCRIPTION
- mention the existence of the Make tasks in kong-dist-kubernetes
- change k8s cluster to a prerequisite don't document how to provision one
- similarly let's not document how to use minikube
- demonstrate how to access the admin-api / proxy and continue the getting started tutorial at adding a configuring a service

To do but out of scope is we need to duplicate all relevant admin api examples for declarative. Right now it's not clear where best to direct folks after they finish setting up declarative / db-less Kong

To do in the a PR to follow this one is continue the k8s w\ datastore examples to include setting up https://github.com/Kong/kubernetes-sidecar-injector and running bookinfo.yaml