### PR TITLE
docs(35/km/auth) stop implying password = token

### DIFF
--- a/app/enterprise/0.35-x/kong-manager/authentication/super-admin.md
+++ b/app/enterprise/0.35-x/kong-manager/authentication/super-admin.md
@@ -49,8 +49,6 @@ be enabled. Follow the instructions on
 
 3. Paste the URL in your browser and you will be asked to create a password for 
 the newly defined **Super Admin** user on the Kong Manager. 
-**Note:** In addition to Kong Manager, this password will also be used as the 
-`Kong-Admin-Token` needed to utilize the Admin API.
 
 4. Go to the Kong Manager homepage and you will be prompted to login with the 
 new ***Super Admin*** credentials.


### PR DESCRIPTION
The previous note suggested that setting a password would also create an RBAC token with the same value. (That is only true for the Super Admin created at the time of migration using the env var, whereas this guide pertains to creating SAs after installation.) 0.35 is the only version affected.