### PR TITLE
fix(docs): fix url typo

### DIFF
--- a/app/enterprise/0.35-x/kong-manager/administration/workspaces/workspaces.md
+++ b/app/enterprise/0.35-x/kong-manager/administration/workspaces/workspaces.md
@@ -39,4 +39,4 @@ a **Workspace**, the **Admin** assigned to that **Role** will not be
 able to see the related navigation links.
 
 For more information about **Admins** and **Roles**, see 
-[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-mananger/administration/rbac/rbac). 
+[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac). 


### PR DESCRIPTION

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md

### Summary

changes "mananger" to "manger" in url

### Full changelog

[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-mananger/administration/rbac/rbac). 	
to
[RBAC in Kong Manager](/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac). 


### Issues resolved

Fixes dead link