### PR TITLE
fix(js): Fix smooth scrolling

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -15,9 +15,13 @@ $(function () {
 
   $('.scroll-to').on('click', function (e) {
     e.preventDefault()
-
+    if ($(window).width() <= 1000) {
+      var offset = NAV_HEIGHT + 40
+    } else {
+      var offset = NAV_HEIGHT
+    }
     $('html, body').animate({
-      scrollTop: $($(this).attr('href')).offset().top - NAV_HEIGHT // Header height
+      scrollTop: $($(this).attr('href')).offset().top - offset // Header height
     }, 700)
   })
 
@@ -357,9 +361,14 @@ $(function () {
 
   // Smooth scroll if hash in URL
   if (window.location.hash) {
+    if ($(window).width() <= 1000) {
+      var offset = NAV_HEIGHT + 40
+    } else {
+      var offset = NAV_HEIGHT
+    }
     $('html, body').scrollTop(0).show()
     $('html, body').animate({
-      scrollTop: $(window.location.hash).offset().top - NAV_HEIGHT // Add spacing on top after scroll
+      scrollTop: $(window.location.hash).offset().top - offset // Add spacing on top after scroll
     }, 600) // Adjust scroll speed
   }
 

--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -126,7 +126,7 @@ id: documentation
           {% if page.toc == true or
           page.toc != false and filename != "index.md" %}
           <h2 id="table-of-contents">Table of Contents</h2>
-          {% include toc.html html=content %}
+          {% include toc.html html=content anchor_class="scroll-to" %}
           {% endif %}
 
           {{ content }}


### PR DESCRIPTION
### Summary

Fixes smooth scrolling when clicking on a Table of Contents link on documentation pages

### Full changelog

* Adds `anchor_class="scroll-to"` to toc call in doc.html (documentation layout) so that the smooth scrolling JS works (this was apparently broken)
* Adds a window width check to smooth-scrolling to reduce offset for smaller screens - this fixes the anchor-links cutting off the heading on screens smaller than 1000px wide
