### PR TITLE
fix(install): Fix generated TOC styling

### DIFF
--- a/app/_assets/stylesheets/pages/install-method.less
+++ b/app/_assets/stylesheets/pages/install-method.less
@@ -47,167 +47,167 @@
     }
   }
 
-  .content {
+  .page-content {
     padding: 50px 0;
+    .content {
 
-    h3 {
-      font-size: 22px;
-      margin-bottom: 1em;
-    }
-
-    pre {
-      margin: 1em 0;
-    }
-
-    hr {
-      margin: 1.5em 0px;
-    }
-
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-
-      li {
-        margin-right: 10px;
-
-        display: inline-flex;
-        align-items: center;
-
-        a {
-          display: flex;
+      h3 {
+        font-size: 22px;
+        margin-bottom: 1em;
+      }
+  
+      pre {
+        margin: 1em 0;
+      }
+  
+      hr {
+        margin: 1.5em 0px;
+      }
+  
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+  
+        li {
+          margin-right: 10px;
+          display: inline-flex;
           align-items: center;
-
-          &:extend(.button all);
-          border-color: #d4d7d9;
-          background-image: linear-gradient(to top, #f7f9fa, #fcfcfc);
-          color: @gray-dark;
-          font-size: 14px;
-          line-height: 39px;
-          height: 40px;
-
-          em {
-            margin-left: 5px;
-            font-style: normal;
-            color: #aab0b2;
+  
+          a {
+            display: flex;
+            align-items: center;
+  
+            &:extend(.button all);
+            border-color: #d4d7d9;
+            background-image: linear-gradient(to top, #f7f9fa, #fcfcfc);
+            color: @gray-dark;
+            font-size: 14px;
+            line-height: 39px;
+            height: 40px;
+  
+            em {
+              margin-left: 5px;
+              font-style: normal;
+              color: #aab0b2;
+            }
+  
+            &:active {
+              background: #f7f9fa;
+            }
+  
+            &:before {
+              content: '';
+              display: inline-block;
+              width: 16px;
+              height: 16px;
+              background-image: url('/assets/images/icons/icn-download.svg');
+              background-size: 16px;
+              background-repeat: no-repeat;
+              margin-right: 5px;
+            }
           }
-
-          &:active {
-            background: #f7f9fa;
-          }
-
-          &:before {
+  
+          &:not(:last-of-type):after {
             content: '';
             display: inline-block;
-            width: 16px;
-            height: 16px;
-            background-image: url('/assets/images/icons/icn-download.svg');
-            background-size: 16px;
-            background-repeat: no-repeat;
-            margin-right: 5px;
+            width: 1px;
+            height: 30px;
+            margin-left: 10px;
+  
+            border-right: 1px solid #d4d7d9;
           }
         }
-
-        &:not(:last-of-type):after {
-          content: '';
-          display: inline-block;
-          width: 1px;
-          height: 30px;
-          margin-left: 10px;
-
-          border-right: 1px solid #d4d7d9;
+      }
+  
+      ol {
+        &:extend(.instructions-steps);
+        padding-left: 19px;
+  
+        & > li {
+          &:extend(.instructions-steps .instructions-step-item all);
+          padding: 7px 0 15px 35px;
+  
+          &:last-child {
+            padding-bottom: 15px;
+            border-left: 1px solid #ebebeb;
+          }
+  
+          &:before {
+            color: @font-color;
+            font-size: 13px;
+            width: 36px;
+            height: 36px;
+            line-height: 36px;
+            left: -19px;
+          }
         }
       }
-    }
-
-    ol {
-      &:extend(.instructions-steps);
-      padding-left: 19px;
-
-      & > li {
-        &:extend(.instructions-steps .instructions-step-item all);
-        padding: 7px 0 15px 35px;
-
-        &:last-child {
-          padding-bottom: 15px;
-          border-left: 1px solid #ebebeb;
-        }
-
-        &:before {
-          color: @font-color;
-          font-size: 13px;
+  
+      .update-subscribe {
+        display: flex;
+        margin-top: 25px;
+        .icon {
+          box-sizing: border-box;
           width: 36px;
           height: 36px;
           line-height: 36px;
-          left: -19px;
+          text-align: center;
+          border-radius: 50%;
+          border: 1px solid #ebebeb;
+          background-color: #fff;
+          font-weight: 600;
+          position: relative;
+          display: inline-flex;
+          justify-content: center;
         }
-      }
-    }
-
-    .update-subscribe {
-      display: flex;
-      margin-top: 25px;
-      .icon {
-        box-sizing: border-box;
-        width: 36px;
-        height: 36px;
-        line-height: 36px;
-        text-align: center;
-        border-radius: 50%;
-        border: 1px solid #ebebeb;
-        background-color: #fff;
-        font-weight: 600;
-        position: relative;
-        display: inline-flex;
-        justify-content: center;
-      }
-      .update-content {
-        display: inline-block;
-        margin-left: 20px;
-        width: 80%;
-        max-width: 450px;
-        input {
-          width: 100%;
-          margin-bottom: 5px;
-          &.error {
-            border-color: @red;
-            background-image: url('/assets/images/icons/error.png');
-            background-repeat: no-repeat;
-            background-position: center;
-            background-position-x: 95%;
+        .update-content {
+          display: inline-block;
+          margin-left: 20px;
+          width: 80%;
+          max-width: 450px;
+          input {
+            width: 100%;
+            margin-bottom: 5px;
+            &.error {
+              border-color: @red;
+              background-image: url('/assets/images/icons/error.png');
+              background-repeat: no-repeat;
+              background-position: center;
+              background-position-x: 95%;
+            }
+          }
+          .button {
+            background: @green;
+            color: @white-90;
+            margin-top: 1rem;
+          }
+          .form {
+            margin-bottom: 1rem;
           }
         }
-        .button {
-          background: @green;
-          color: @white-90;
-          margin-top: 1rem;
+        .card {
+          border: 1px solid #ebebeb;
+          border-radius: 3px;
+          padding: 10px;
         }
-        .form {
-          margin-bottom: 1rem;
+        .success-message {
+          color: @green;
+          display: block;
         }
+  
+        .error-message {
+          color: @red;
+          display: block;
+        }
+  
       }
-      .card {
-        border: 1px solid #ebebeb;
-        border-radius: 3px;
-        padding: 10px;
-      }
-      .success-message {
-        color: @green;
-        display: block;
-      }
-
-      .error-message {
-        color: @red;
-        display: block;
-      }
-
-    }
-    .help {
-      a {
-        margin: 0px 5px;
+      .help {
+        a {
+          margin: 0px 5px;
+        }
       }
     }
-
   }
 }
 

--- a/app/_assets/stylesheets/pages/install-method.less
+++ b/app/_assets/stylesheets/pages/install-method.less
@@ -55,29 +55,29 @@
         font-size: 22px;
         margin-bottom: 1em;
       }
-  
+
       pre {
         margin: 1em 0;
       }
-  
+
       hr {
         margin: 1.5em 0px;
       }
-  
+
       ul {
         list-style: none;
         padding: 0;
         margin: 0;
-  
+
         li {
           margin-right: 10px;
           display: inline-flex;
           align-items: center;
-  
+
           a {
             display: flex;
             align-items: center;
-  
+
             &:extend(.button all);
             border-color: #d4d7d9;
             background-image: linear-gradient(to top, #f7f9fa, #fcfcfc);
@@ -85,17 +85,17 @@
             font-size: 14px;
             line-height: 39px;
             height: 40px;
-  
+
             em {
               margin-left: 5px;
               font-style: normal;
               color: #aab0b2;
             }
-  
+
             &:active {
               background: #f7f9fa;
             }
-  
+
             &:before {
               content: '';
               display: inline-block;
@@ -107,32 +107,32 @@
               margin-right: 5px;
             }
           }
-  
+
           &:not(:last-of-type):after {
             content: '';
             display: inline-block;
             width: 1px;
             height: 30px;
             margin-left: 10px;
-  
+
             border-right: 1px solid #d4d7d9;
           }
         }
       }
-  
+
       ol {
         &:extend(.instructions-steps);
         padding-left: 19px;
-  
+
         & > li {
           &:extend(.instructions-steps .instructions-step-item all);
           padding: 7px 0 15px 35px;
-  
+
           &:last-child {
             padding-bottom: 15px;
             border-left: 1px solid #ebebeb;
           }
-  
+
           &:before {
             color: @font-color;
             font-size: 13px;
@@ -143,7 +143,6 @@
           }
         }
       }
-  
       .update-subscribe {
         display: flex;
         margin-top: 25px;
@@ -195,12 +194,10 @@
           color: @green;
           display: block;
         }
-  
         .error-message {
           color: @red;
           display: block;
         }
-  
       }
       .help {
         a {

--- a/app/_layouts/install.html
+++ b/app/_layouts/install.html
@@ -56,6 +56,11 @@ layout: default
 
     <div class="page-content-container">
       <div class="page-content">
+          {% if page.toc == true or
+            page.toc != false and filename != "index.md" %}
+            <h2 id="table-of-contents">Table of Contents</h2>
+            {% include toc.html html=content class="inline-toc" anchor_class="scroll-to" h_max=2 %}
+            {% endif %}
         <div class="content">
           {{ content }}
 

--- a/app/install/aws-cloudformation.md
+++ b/app/install/aws-cloudformation.md
@@ -17,15 +17,13 @@ links:
     kong-dbless-pv : "https://s3.amazonaws.com/kong-cf-templates/latest/kong-elb-dbless-vpc-optional-pv.template"
 ---
 
-### Templates
-
-#### Kong with Cassandra
+## Kong with Cassandra
 
 This template will provision Kong instances in a new or existing VPC. You will
 need to provide the contact points of your Cassandra cluster during the
 deployment process.
 
-##### HVM AMI
+### HVM AMI
 
 - [us-east-1]({{ page.links.aws }}?region=us-east-1#/stacks/new?stackName=kong-elb-hvm&templateURL={{ page.links.templates.kong-hvm }})
 - [us-west-1]({{ page.links.aws }}?region=us-west-1#/stacks/new?stackName=kong-elb-hvm&templateURL={{ page.links.templates.kong-hvm }})
@@ -36,7 +34,7 @@ deployment process.
 - [ap-southeast-2]({{ page.links.aws }}?region=ap-southeast-2#/stacks/new?stackName=kong-elb-hvm&templateURL={{ page.links.templates.kong-hvm }})
 - [sa-east-1]({{ page.links.aws }}?region=sa-east-1#/stacks/new?stackName=kong-elb-hvm&templateURL={{ page.links.templates.kong-hvm }})
 
-##### PV AMI
+### PV AMI
 
 - [us-east-1]({{ page.links.aws }}?region=us-east-1#/stacks/new?stackName=kong-elb-pv&templateURL={{ page.links.templates.kong-pv }})
 - [us-west-1]({{ page.links.aws }}?region=us-west-1#/stacks/new?stackName=kong-elb-pv&templateURL={{ page.links.templates.kong-pv }})
@@ -47,13 +45,13 @@ deployment process.
 - [ap-southeast-2]({{ page.links.aws }}?region=ap-southeast-2#/stacks/new?stackName=kong-elb-pv&templateURL={{ page.links.templates.kong-pv }})
 - [sa-east-1]({{ page.links.aws }}?region=sa-east-1#/stacks/new?stackName=kong-elb-pv&templateURL={{ page.links.templates.kong-pv }})
 
-#### Kong with PostgreSQL
+## Kong with PostgreSQL
 
 This template will provision Kong instances in a new or existing VPC. You can
 provide your own PostgreSQL instance, or if not, the template will create one
 on AWS RDS for you.
 
-##### HVM AMI
+### HVM AMI
 
 - [us-east-1]({{ page.links.aws }}?region=us-east-1#/stacks/new?stackName=kong-elb-postgres-hvm&templateURL={{ page.links.templates.kong-postgres-hvm }})
 - [us-west-1]({{ page.links.aws }}?region=us-west-1#/stacks/new?stackName=kong-elb-postgres-hvm&templateURL={{ page.links.templates.kong-postgres-hvm }})
@@ -64,7 +62,7 @@ on AWS RDS for you.
 - [ap-southeast-2]({{ page.links.aws }}?region=ap-southeast-2#/stacks/new?stackName=kong-elb-postgres-hvm&templateURL={{ page.links.templates.kong-postgres-hvm }})
 - [sa-east-1]({{ page.links.aws }}?region=sa-east-1#/stacks/new?stackName=kong-elb-hvm&templateURL={{ page.links.templates.kong-postgres-hvm }})
 
-##### PV AMI
+### PV AMI
 
 - [us-east-1]({{ page.links.aws }}?region=us-east-1#/stacks/new?stackName=kong-elb-postgres-pv&templateURL={{ page.links.templates.kong-postgres-pv }})
 - [us-west-1]({{ page.links.aws }}?region=us-west-1#/stacks/new?stackName=kong-elb-postgres-pv&templateURL={{ page.links.templates.kong-postgres-pv }})
@@ -75,14 +73,14 @@ on AWS RDS for you.
 - [ap-southeast-2]({{ page.links.aws }}?region=ap-southeast-2#/stacks/new?stackName=kong-elb-postgres-pv&templateURL={{ page.links.templates.kong-postgres-pv }})
 - [sa-east-1]({{ page.links.aws }}?region=sa-east-1#/stacks/new?stackName=kong-elb-postgres-pv&templateURL={{ page.links.templates.kong-postgres-pv }})
 
-#### Kong in DB-less mode
+## Kong in DB-less mode
 
 Provisions Kong resources in a new VPC or existing VPC. 
 
 Note: User would need to provide an S3 bucket location where `kong.yml` is
 stored with the declarative configuration to bootstrap all the Kong instances.
 
-##### HVM AMI
+### HVM AMI
 
 - [us-east-1]({{ page.links.aws }}?region=us-east-1#/stacks/new?stackName=kong-elb-dbless-hvm&templateURL={{ page.links.templates.kong-dbless-hvm }})
 - [us-west-1]({{ page.links.aws }}?region=us-west-1#/stacks/new?stackName=kong-elb-dbless-hvm&templateURL={{ page.links.templates.kong-dbless-hvm }})
@@ -93,7 +91,7 @@ stored with the declarative configuration to bootstrap all the Kong instances.
 - [ap-southeast-2]({{ page.links.aws }}?region=ap-southeast-2#/stacks/new?stackName=kong-elb-dbless-hvm&templateURL={{ page.links.templates.kong-dbless-hvm }})
 - [sa-east-1]({{ page.links.aws }}?region=sa-east-1#/stacks/new?stackName=kong-elb-dbless-hvm&templateURL={{ page.links.templates.kong-dbless-hvm }})
 
-##### PV AMI
+### PV AMI
 
 - [us-east-1]({{ page.links.aws }}?region=us-east-1#/stacks/new?stackName=kong-elb-dbless-pv&templateURL={{ page.links.templates.kong-dbless-pv }})
 - [us-west-1]({{ page.links.aws }}?region=us-west-1#/stacks/new?stackName=kong-elb-dbless-pv&templateURL={{ page.links.templates.kong-dbless-pv }})
@@ -106,12 +104,12 @@ stored with the declarative configuration to bootstrap all the Kong instances.
 
 
 ----
-### Recommended usage
+#### Recommended usage
 
-  <B>Use this cloud formation as a basis for your own, adjust the variables and template to better suit your needs.</B>
+  Use this cloud formation as a basis for your own, adjust the variables and template to better suit your needs.
 ----
 
-### Instructions
+## Setup Instructions
 
 1. **Initial Setup**
 

--- a/app/install/aws-linux.md
+++ b/app/install/aws-linux.md
@@ -5,9 +5,10 @@ header_title: Amazon Linux
 header_icon: /assets/images/icons/icn-installation.svg
 breadcrumbs:
   Installation: /install
+
 ---
 
-### Packages
+## Packages
 
 Start by downloading the following package specifically built for the Amazon Linux AMI:
 
@@ -15,7 +16,7 @@ Start by downloading the following package specifically built for the Amazon Lin
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 
-### YUM Repositories
+## YUM Repositories
 
 You can also install Kong via YUM; follow the instructions on the "Set Me Up"
 section on the page below.
@@ -31,7 +32,7 @@ baseurl=https://kong.bintray.com/kong-rpm/amazonlinux/amazonlinux
 
 ----
 
-### Installation
+## Installation
 
 1. **Install Kong**
 

--- a/app/install/aws-marketplace.md
+++ b/app/install/aws-marketplace.md
@@ -7,6 +7,7 @@ breadcrumbs:
   Installation: /install
 links:
   market: "https://aws.amazon.com/marketplace/pp/B06WP4TNKL"
+toc: false
 ---
 
 Kong 64-bit Amazon Machine Image (AMI) is available on the AWS Marketplace, with 1-Click Launch, or manually With EC2 Console, APIs or CLI:

--- a/app/install/centos.md
+++ b/app/install/centos.md
@@ -7,7 +7,7 @@ breadcrumbs:
   Installation: /install
 ---
 
-### Packages
+## Packages
 
 Start by downloading the corresponding package for your configuration:
 
@@ -37,7 +37,7 @@ baseurl=https://kong.bintray.com/kong-rpm/centos/7
 
 ----
 
-### Installation
+## Installation
 
 1. **Install Kong**
 

--- a/app/install/dcos.md
+++ b/app/install/dcos.md
@@ -5,6 +5,7 @@ header_title: Kong deployment on DC/OS cluster
 header_icon: /assets/images/icons/icn-installation.svg
 breadcrumbs:
   Installation: /install
+toc: false
 links:
   mesos-aws: "https://dcos.io/docs/1.9/installing/oss/cloud/aws/"
   mesos-cli: "https://dcos.io/docs/1.9/cli/"

--- a/app/install/debian.md
+++ b/app/install/debian.md
@@ -7,7 +7,7 @@ breadcrumbs:
   Installation: /install
 ---
 
-### Packages
+## Packages
 
 Start by downloading the corresponding package for your configuration:
 
@@ -17,7 +17,7 @@ Start by downloading the corresponding package for your configuration:
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 
-### APT Repositories
+## APT Repositories
 
 You can also install Kong via APT; follow the instructions on the "Set Me Up"
 section on the page below, setting  *distribution* to the appropriate value
@@ -27,7 +27,7 @@ section on the page below, setting  *distribution* to the appropriate value
 
 ----
 
-### Installation
+## Installation
 
 1. **Install Kong**
 

--- a/app/install/google-cloud.md
+++ b/app/install/google-cloud.md
@@ -5,6 +5,7 @@ header_title: Google Cloud
 header_icon: /assets/images/icons/icn-installation.svg
 breadcrumbs:
   Installation: /install
+toc: false
 ---
 
 There currently are two options for installing Kong from the Google Cloud

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -15,16 +15,7 @@ links:
   az: "https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest"
 ---
 
-## Table of Contents
-
-<!-- FIXME the list below should be an unordered list, but currently those do not render correctly in this section of the Docs site - depends on https://github.com/Kong/docs.konghq.com/issues/917 -->
-1. [Kubernetes Ingress Controller for Kong](#kubernetes-ingress-controller-for-kong)
-1. [Kong via Google Cloud Platform Marketplace](#kong-via-google-cloud-platform-marketplace)
-1. [Kong via Helm or Minikube](#kong-via-helm-or-minikube)
-1. [Kong via Manifest Files](#kong-via-manifest-files)
-1. [Additional Steps for Kong Enterprise Trial Users](#additional-steps-for-kong-enterprise-trial-users)
-
-# Kubernetes Ingress Controller for Kong
+## Kubernetes Ingress Controller for Kong
 
 Install Kong or Kong Enterprise using the official
 <a href="https://github.com/Kong/kubernetes-ingress-controller">Kubernetes Ingress Controller</a>.
@@ -39,7 +30,7 @@ is on the [Kong Blog](https://konghq.com/blog/).
 For questions and discussion, please visit [Kong Nation](https://discuss.konghq.com/c/kubernetes). For bug reports,
 please [open a new issue on GitHub](https://github.com/Kong/kubernetes-ingress-controller/issues).
 
-# Kong via Google Cloud Platform Marketplace
+## Kong via Google Cloud Platform Marketplace
 
 Perhaps the fastest way to try Kong on Kubernetes is via the Google Cloud
 Platform Marketplace and [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) -
@@ -56,20 +47,20 @@ once you've completed your experiment to avoid on-going Google Cloud usage charg
 
 <iframe width="660" height="400" src="https://www.youtube-nocookie.com/embed/MPlSyWDAOpw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
-# Kong via Helm or Minikube
+## Kong via Helm or Minikube
 
 An easy way to deploy Kong on Kubernetes is via [Helm]({{ page.links.kubeapps_hub }}).
 
 Kong can also be deployed on minikube - please follow the [README]({{ page.links.minikube }})
 and use the manifest files provided in `minikube` directory.
 
-# Kong via Manifest Files
+## Kong via Manifest Files
 
 Kong, or the trial version of Kong Enterprise, can be provisioned
 on a Kubernetes cluster via the manifest files provided
 in the [repo]({{ page.links.gh_repo }}).
 
-## 1. **Initial setup**
+### 1. **Initial setup**
 
 Download or clone the following repo:
 
@@ -81,9 +72,9 @@ $ cd kong-dist-kubernetes
 Skip to step 3 if you have already provisioned a cluster and registered it
 with Kubernetes.
 
-## 2.  **Deploy a cluster**
+### 2.  **Deploy a cluster**
 
-### [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
+#### [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
 
 You need [gcloud]({{ page.links.gcloud }}) and [kubectl]({{ page.links.kubectl }})
 command-line tools installed and set up to run deployment commands. Also
@@ -103,7 +94,7 @@ $ gcloud deployment-manager deployments \
     create cluster --config cluster.yaml
 ```
 
-### [Azure Kubernetes Cluster (AKS)](https://docs.microsoft.com/en-us/azure/aks/)
+#### [Azure Kubernetes Cluster (AKS)](https://docs.microsoft.com/en-us/azure/aks/)
 
 You need [az]({{ page.links.az }}) command-line tools installed and set up to run deployment commands.
 
@@ -127,7 +118,7 @@ You need [az]({{ page.links.az }}) command-line tools installed and set up to ru
     $ az aks get-credentials --resource-group myAKSCluster --name myAKSCluster
     ```
 
-## 3. **Deploy a datastore**
+### 3. **Deploy a datastore**
 
 Before deploying Kong, you need to provision a Cassandra or PostgreSQL pod.
 
@@ -149,7 +140,7 @@ $ kubectl create -f postgres.yaml
 **Kong Enterprise trial users** should complete the steps in the
 **Additional Steps for Kong Enterprise Trial Users** section below before proceeding.
 
-## 4. **Prepare database**
+### 4. **Prepare database**
 
 Using the `kong_migration_<postgres|cassandra>.yaml` file,
 run the migration job:
@@ -163,7 +154,7 @@ Once the job completes, you can remove the pod by running following command:
 $ kubectl delete -f kong_migration_<postgres|cassandra>.yaml
 ```
 
-## 5. **Deploy Kong**
+### 5. **Deploy Kong**
 
 Using the `kong_<postgres|cassandra>.yaml` file from this
 repo, deploy Kong admin, proxy services, and a `Deployment` controller to
@@ -173,7 +164,7 @@ the cluster:
 $ kubectl create -f kong_<postgres|cassandra>.yaml
 ```
 
-## 6. **Verify your deployments**
+### 6. **Verify your deployments**
 
 You can now see the resources that have been deployed using `kubectl`:
 
@@ -191,12 +182,12 @@ $ curl <kong-proxy-ip-address>:8000
 $ curl https://<kong-proxy-ssl-ip-address>:8443
 ```
 
-## 7. **Get Started with Kong**
+### 7. **Get Started with Kong**
 
 Quickly learn how to use Kong with the
 [5-minute Quickstart](/latest/getting-started/quickstart/).
 
-# Additional Steps for Kong Enterprise Trial Users
+## Additional Steps for Kong Enterprise Trial Users
 
 1. **Publish a Kong Enterprise Docker image to your container registry**
 

--- a/app/install/macos.md
+++ b/app/install/macos.md
@@ -7,13 +7,13 @@ breadcrumbs:
   Installation: /install
 ---
 
-### Packages
+## Packages
 
 - [Homebrew Formula]({{ site.repos.homebrew }})
 
 ----
 
-### Installation
+## Installation
 
 
 

--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -9,7 +9,7 @@ breadcrumbs:
 
 {% capture cassandra_version %}{{site.data.kong_latest.dependencies.cassandra}}{% endcapture %}
 
-### Packages
+## Packages
 
 Start by downloading the corresponding package for your configuration:
 
@@ -18,7 +18,7 @@ Start by downloading the corresponding package for your configuration:
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 
-### YUM Repositories
+## YUM Repositories
 
 You can also install Kong via YUM; follow the instructions on the "Set Me Up"
 section on the page below.
@@ -39,7 +39,7 @@ baseurl=https://kong.bintray.com/kong-rpm/rhel/7
 
 ----
 
-### Installation
+## Installation
 
 1. **Enable the EPEL repository**
 

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -7,7 +7,7 @@ breadcrumbs:
   Installation: /install
 ---
 
-### Packages
+## Packages
 
 Start by downloading the corresponding package for your configuration:
 
@@ -19,7 +19,7 @@ Start by downloading the corresponding package for your configuration:
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 
-### APT Repositories
+## APT Repositories
 
 You can also install Kong via APT; follow the instructions on the "Set Me Up"
 section on the page below, setting  *distribution* to the appropriate value ( lsb_release -sc )
@@ -29,7 +29,7 @@ section on the page below, setting  *distribution* to the appropriate value ( ls
 
 ----
 
-### Installation
+## Installation
 
 1. **Install Kong**
 

--- a/app/install/vagrant.md
+++ b/app/install/vagrant.md
@@ -5,6 +5,7 @@ header_title: Vagrant Installation
 header_icon: /assets/images/icons/icn-installation.svg
 breadcrumbs:
   Installation: /install
+toc: false
 ---
 
 Vagrant can be used to create an isolated environment for Kong and its


### PR DESCRIPTION
### Summary

Allow core installation docs to use the Table of Contents extension 

### Full changelog

* Adds call to toc.html in install page layout, moves it out of main content section to ensure it displays correctly
* Updates all installation pages to use the new TOC

### Issues resolved

Fix #917
