### PR TITLE
Kong 0.35 changes the db_cache_ttl value to 0

### DIFF
--- a/app/enterprise/0.35-x/property-reference.md
+++ b/app/enterprise/0.35-x/property-reference.md
@@ -864,7 +864,7 @@ this value can be safely set to 0.
 
 ### db_cache_ttl
 
-**Default:** `3600`
+**Default:** `0`
 
 **Description:**
 


### PR DESCRIPTION
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

