### PR TITLE
docs(*) fix declarative configuration array notation

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -11,7 +11,7 @@ breadcrumbs:
 
 {% capture config_required_fields %}{%
   for field in page.params.config %}{%
-  if field.value_in_examples != nil  %}{%
+  if field.value_in_examples != nil %}{%
   if field.value_in_examples.first %}{%
   for value in field.value_in_examples %} \
     --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ value }}"{%
@@ -27,8 +27,15 @@ breadcrumbs:
 {% capture config_required_fields_yaml
   %}config: {%
   for field in page.params.config %}{%
-  if field.value_in_examples != nil %}
+  if field.value_in_examples != nil %}{%
+    if field.value_in_examples.first %}
+    {{ field.name }}:{%
+    for value in field.value_in_examples %}
+    - {{ value }}{%
+    endfor %}{%
+    else %}
     {{ field.name }}: {{ field.value_in_examples }}{%
+    endif %}{%
   elsif field.required == true %}
     {{ field.name }}: {{ field.default | markdownify | strip_html | strip }}{%
   endif %}{% endfor


### PR DESCRIPTION
### Summary

Fixes declarative configuration array notation examples, e.g.:

```yaml
plugins:
- name: cors
  config: 
    methods: GETPOST
```

to:

```yaml
plugins:
- name: cors
  config: 
    methods:
    - GET
    - POST
```

See the problem here:
https://docs.konghq.com/hub/kong-inc/cors/