### PR TITLE
docs(35/km/security) add TLS and localhost explanations and references

### DIFF
--- a/app/enterprise/0.35-x/kong-manager/networking/configuration.md
+++ b/app/enterprise/0.35-x/kong-manager/networking/configuration.md
@@ -78,8 +78,8 @@ admin_gui_url = https://test.com:8445
 
 ### Using `https://localhost`
 
-If using `localhost` for testing, it may be preferrable to just use HTTP as the protocol and, if using RBAC, 
-to set `cookie_secure=false` in Session configuration. The reason to use HTTP for `localhost` is that 
+If serving Kong Manager on localhost, it may be preferable to use HTTP as the protocol. If also using RBAC,
+set cookie_secure=false in admin_gui_session_conf.". The reason to use HTTP for `localhost` is that 
 creating TLS certificates for `localhost` requires more effort and configuration, and there may not be any 
 reason to use it. The adequate use cases for TLS are (1) when data is in transit between hosts, or (2) 
 when testing an application with [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)

--- a/app/enterprise/0.35-x/kong-manager/networking/configuration.md
+++ b/app/enterprise/0.35-x/kong-manager/networking/configuration.md
@@ -79,7 +79,7 @@ admin_gui_url = https://test.com:8445
 ### Using `https://localhost`
 
 If serving Kong Manager on localhost, it may be preferable to use HTTP as the protocol. If also using RBAC,
-set cookie_secure=false in admin_gui_session_conf.". The reason to use HTTP for `localhost` is that 
+set `cookie_secure=false` in `admin_gui_session_conf`. The reason to use HTTP for `localhost` is that 
 creating TLS certificates for `localhost` requires more effort and configuration, and there may not be any 
 reason to use it. The adequate use cases for TLS are (1) when data is in transit between hosts, or (2) 
 when testing an application with [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)

--- a/app/enterprise/0.35-x/kong-manager/networking/configuration.md
+++ b/app/enterprise/0.35-x/kong-manager/networking/configuration.md
@@ -70,10 +70,10 @@ admin_gui_ssl_cert = /path/to/test.crt
 admin_gui_ssl_cert_key = /path/to/test.key
 ```
 
-3) Ensure that `admin_gui_url` is prefixed with `https` to use TLS, e.g.
+3) Ensure that `admin_gui_url` is prefixed with `https` to use TLS, e.g.,
 
 ```
-admin_gui_url = https://test.com:844
+admin_gui_url = https://test.com:8445
 ```
 
 ### Using `https://localhost`

--- a/app/enterprise/0.35-x/kong-manager/networking/configuration.md
+++ b/app/enterprise/0.35-x/kong-manager/networking/configuration.md
@@ -52,7 +52,49 @@ To enable authentication, configure the following properties:
 on to enforce authorization rules. Otherwise, whoever can log in 
 to Kong Manager can perform any operation available on the Admin API.
 
+## TLS Certificates
+
+By default, if Kong Manager’s URL is accessed over HTTPS _without_ a certificate issued by a CA, it will 
+receive  a self-signed certificate that modern web browsers will not trust, preventing the application 
+from accessing the Admin API.
+
+In order to serve Kong Manager over HTTPS,  use a trusted certificate authority to issue TLS certificates, 
+and have the resulting `.crt` and `.key` files ready for the next step.
+
+1) Move `.crt` and `.key` files into the desired directory of the Kong node.
+
+2) Point [`admin_gui_ssl_cert`] and [`admin_gui_ssl_cert_key`] at the absolute paths of the certificate and key.
+
+```
+admin_gui_ssl_cert = /path/to/test.crt
+admin_gui_ssl_cert_key = /path/to/test.key
+```
+
+3) Ensure that `admin_gui_url` is prefixed with `https` to use TLS, e.g.
+
+```
+admin_gui_url = https://test.com:844
+```
+
+### Using `https://localhost`
+
+If using `localhost` for testing, it may be preferrable to just use HTTP as the protocol and, if using RBAC, 
+to set `cookie_secure=false` in Session configuration. The reason to use HTTP for `localhost` is that 
+creating TLS certificates for `localhost` requires more effort and configuration, and there may not be any 
+reason to use it. The adequate use cases for TLS are (1) when data is in transit between hosts, or (2) 
+when testing an application with [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
+(which Kong Manager does not use).
+
+External CAs cannot provide a certificate since no one uniquely owns `localhost`, nor is it rooted in a top-level 
+domain (e.g., `.com`, `.org`). Likewise, self-signed certificates will not be trusted in modern browsers. Instead, 
+it is necessary to use a private CA that allows you to issue your own certificates. Also ensure that the SSL state 
+is cleared from the browser after testing to prevent stale certificates from interfering with future access to 
+`localhost`.
+
+
 [`admin_gui_auth`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_auth
+[`admin_gui_ssl_cert`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_ssl_cert
+[`admin_gui_ssl_cert_key`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_ssl_cert_key
 [`default_ports`]: /enterprise/{{page.kong_version}}/getting-started/start-kong/#default-ports
 [`admin_api_uri`]: /enterprise/{{page.kong_version}}/property-reference/#admin_api_uri
 [`admin_gui_auth_conf`]: /enterprise/{{page.kong_version}}/property-reference/#admin_gui_auth_conf

--- a/app/enterprise/0.35-x/kong-manager/security.md
+++ b/app/enterprise/0.35-x/kong-manager/security.md
@@ -1,6 +1,7 @@
 ---
 title: Securing Kong Manager
 book: admin_gui
+toc: false
 ---
 #### Table of Contents
 

--- a/app/enterprise/0.35-x/kong-manager/security.md
+++ b/app/enterprise/0.35-x/kong-manager/security.md
@@ -1,13 +1,7 @@
 ---
 title: Securing Kong Manager
 book: admin_gui
-toc: false
 ---
-#### Table of Contents
-
-- [What Can Admins Do in Kong Manager?](#what-can-admins-do-in-kong-manager)
-- [Configuring Authentication](#configuring-authentication)
-- [Access Control with RBAC and Workspaces](#access-control-with-roles-and-workspaces)
 
 ## What Can Admins Do in Kong Manager?
 

--- a/app/enterprise/0.35-x/kong-manager/security.md
+++ b/app/enterprise/0.35-x/kong-manager/security.md
@@ -2,6 +2,12 @@
 title: Securing Kong Manager
 book: admin_gui
 ---
+#### Table of Contents
+
+- [What Can Admins Do in Kong Manager?](#what-can-admins-do-in-kong-manager)
+- [Configuring Authentication](#configuring-authentication)
+- [Access Control with RBAC and Workspaces](#access-control-with-roles-and-workspaces)
+
 ## What Can Admins Do in Kong Manager?
 
 Kong Manager enables users with **Admin** accounts to access Kong entities such 
@@ -10,7 +16,7 @@ as **Services**, **Plugins**, and **Consumers.**
 The following document summarizes Kong Manager's controls for *authentication* 
 and *authorization*.
 
-## Authentication with Plugins
+## Configuring Authentication
 
 Kong Enterprise comes packaged with **Authentication Plugins** that can be used 
 to secure Kong Manager. Unlike enabling a **Plugin** on an entity or cluster, 


### PR DESCRIPTION
* Adds a new section to Networking about configuring TLS and the problem posed by self-signed certs with localhost
* Change the title of the Authentication section to clearly emphasize that it is accomplished through configuring Kong a certain way, and not through enabling plugins globally
* Add a table of contents to the Securing Kong Manager page

TODO:
* Turn TLS section into a page
* Add a link to the new TLS page on the Networking page
* Provide an introduction to the Networking section
* Move Securing KM to a higher position, pre-networking
* Divide Securing KM into subsections: Secure Networking and Identity and Access Management