### PR TITLE
docs(hub/proxy-cache) clarify content-type matching

### DIFF
--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -44,7 +44,7 @@ params:
       default: text/plain
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable
+        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned
     - name: cache_ttl
       required:
       default: 300

--- a/app/_hub/kong-inc/proxy-cache/0.32-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.32-x.md
@@ -44,7 +44,7 @@ params:
       default: text/plain
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable
+        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned
     - name: vary_headers
       required:
       default:

--- a/app/_hub/kong-inc/proxy-cache/0.33-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.33-x.md
@@ -44,7 +44,7 @@ params:
       default: text/plain
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable
+        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned
     - name: vary_headers
       required:
       default:

--- a/app/_hub/kong-inc/proxy-cache/0.34-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.34-x.md
@@ -44,7 +44,7 @@ params:
       default: text/plain, application/json
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable
+        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned
     - name: vary_headers
       required: false
       default:

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -46,7 +46,7 @@ params:
       default: text/plain, application/json
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable
+        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned
     - name: vary_headers
       required: false
       default:


### PR DESCRIPTION
### Summary

Clarify `proxy-cache` plugin content-type matching.