### PR TITLE
fix(styling): Fix table styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .ruby-version
 .ruby-gemset
 *.log
+.vscode/
 yarn.lock
 
 # jekyll

--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -7810,7 +7810,7 @@ a.bg-inverse:focus,a.bg-inverse:hover {
 }
 
 .text-right {
-    text-align: right!important
+    !important
 }
 
 .text-center {

--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -7810,7 +7810,7 @@ a.bg-inverse:focus,a.bg-inverse:hover {
 }
 
 .text-right {
-    !important
+    text-align: right!important
 }
 
 .text-center {

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -405,16 +405,28 @@ $(function () {
   })
 
   // Responsive Tables
-  $('table').each(function (index, value) {
-    var headerCount = $(this).find('thead th').length
+   if($window.width() <= 1099) {
+     mobileTable()
+  }
 
-    for (i = 0; i <= headerCount; i++) {
-      var headerLabel = $(this).find('thead th:nth-child(' + i + ')').text()
-
-      $(this).find('tr td:not([colspan]):nth-child(' + i + ')').replaceWith(
-        function () {
-          return $('<td data-label="' + headerLabel + '">').append($(this).contents())
-        })
+  $window.resize(function (){
+    if($window.width() <= 1099) {
+      mobileTable()
     }
   })
+
+  function mobileTable () {
+    $('table').each(function (index, value) {
+      var headerCount = $(this).find('thead th').length
+
+      for (i = 0; i <= headerCount; i++) {
+        var headerLabel = $(this).find('thead th:nth-child(' + i + ')').text()
+
+        $(this).find('tr td:not([colspan]):nth-child(' + i + ')').replaceWith(
+          function () {
+            return $('<td data-label="' + headerLabel + '">').append($(this).contents())
+          })
+      }
+    })
+  }
 })

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -405,8 +405,8 @@ $(function () {
   })
 
   // Responsive Tables
-   if($window.width() <= 1099) {
-     mobileTable()
+  if($window.width() <= 1099) {
+    mobileTable()
   }
 
   $window.resize(function (){

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -403,4 +403,18 @@ $(function () {
       })
     }
   })
+
+  // Responsive Tables
+  $('table').each(function (index, value) {
+    var headerCount = $(this).find('thead th').length
+
+    for (i = 0; i <= headerCount; i++) {
+      var headerLabel = $(this).find('thead th:nth-child(' + i + ')').text()
+
+      $(this).find('tr td:not([colspan]):nth-child(' + i + ')').replaceWith(
+        function () {
+          return $('<td data-label="' + headerLabel + '">').append($(this).contents())
+        })
+    }
+  })
 })

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -434,7 +434,7 @@
   {
     table, thead, tbody, th, td, tr {
       display: block;
-      text-align: left !important;
+      text-align: left;
     }
 
     table {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -440,7 +440,7 @@
     table {
         /* Hide table headers  */
       thead tr {
-       display: none;
+        display: none;
       }
 
       tr { border: 1px solid #ccc; }

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -405,63 +405,62 @@
     font-style: italic;
   }
 
-    /* 
-  Generic Styling, for Desktops/Laptops 
+    /*
+  Generic Styling for Desktop
   */
-  table { 
-    width: 100%; 
-    border-collapse: collapse; 
+  table {
+    width: 100%;
+    border-collapse: collapse;
     font-size: 14px;
   }
   code {
     font-size: 14px;
   }
   /* Zebra striping */
-  tr:nth-of-type(odd) { 
-    background: @gray-light; 
+  tr:nth-of-type(odd) {
+    background: @gray-light;
   }
-  th { 
-    font-weight: bold; 
+  th {
+    font-weight: bold;
   }
-  td, th { 
-    padding: 6px; 
-    border: 1px solid #ccc; 
-    text-align: left; 
+  td, th {
+    padding: 6px;
+    border: 1px solid #ccc;
+    text-align: left;
   }
 
   @media
   only screen and (max-width: 1099px)
   {
-    table, thead, tbody, th, td, tr { 
-      display: block; 
+    table, thead, tbody, th, td, tr {
+      display: block;
     }
 
     table {
         /* Hide table headers (but not display: none;, for accessibility) */
-      thead tr { 
+      thead tr {
         position: absolute;
         top: -9999px;
         left: -9999px;
       }
-      
+
       tr { border: 1px solid #ccc; }
-      
-      td { 
+
+      td {
         /* Behave  like a "row" */
         border: none;
-        border-bottom: 1px solid #eee; 
+        border-bottom: 1px solid #eee;
         position: relative;
-       // padding-left: 50%; 
       }
-      
-      td:before { 
+
+      td:before {
         /* Now like a table header */
         position: absolute;
         /* Top/left values mimic padding */
         top: 6px;
         left: 6px;
-        width: 45%; 
-        padding-right: 10px; 
+        width: 45%;
+        padding-right: 10px;
         white-space: nowrap;
       }
     }

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -408,10 +408,12 @@
     /*
   Generic Styling for Desktop
   */
+
   table {
     width: 100%;
     border-collapse: collapse;
     font-size: 14px;
+
   }
   code {
     font-size: 14px;
@@ -426,22 +428,19 @@
   td, th {
     padding: 6px;
     border: 1px solid #ccc;
-    text-align: left;
   }
 
-  @media
-  only screen and (max-width: 1099px)
+  @media only screen and (max-width: 1099px)
   {
     table, thead, tbody, th, td, tr {
       display: block;
+      text-align: left !important;
     }
 
     table {
-        /* Hide table headers (but not display: none;, for accessibility) */
+        /* Hide table headers  */
       thead tr {
-        position: absolute;
-        top: -9999px;
-        left: -9999px;
+       display: none;
       }
 
       tr { border: 1px solid #ccc; }
@@ -454,14 +453,12 @@
       }
 
       td:before {
-        /* Now like a table header */
-        position: absolute;
-        /* Top/left values mimic padding */
-        top: 6px;
-        left: 6px;
-        width: 45%;
         padding-right: 10px;
         white-space: nowrap;
+
+        content: attr(data-label);
+        font-size: 14px;
+
       }
     }
   }

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -273,11 +273,6 @@
     color: #505659;
   }
 
-  p {
-    line-height: 1.5;
-    font-size: 16px;
-  }
-
   h1, h2, h3, h4 {
     margin-bottom: 1em;
     font-weight: 600;
@@ -410,50 +405,64 @@
     font-style: italic;
   }
 
-  table {
-    width: 100%;
-    border: 1px solid @gray;
+    /* 
+  Generic Styling, for Desktops/Laptops 
+  */
+  table { 
+    width: 100%; 
+    border-collapse: collapse; 
+    font-size: 14px;
+  }
+  code {
+    font-size: 14px;
+  }
+  /* Zebra striping */
+  tr:nth-of-type(odd) { 
+    background: @gray-light; 
+  }
+  th { 
+    font-weight: bold; 
+  }
+  td, th { 
+    padding: 6px; 
+    border: 1px solid #ccc; 
+    text-align: left; 
+  }
 
-    th, td {
-      .font-source-sans();
-      font-size: 14px;
-      vertical-align: top;
+  @media
+  only screen and (max-width: 1099px)
+  {
+    table, thead, tbody, th, td, tr { 
+      display: block; 
     }
 
-    th {
-      text-transform: lowercase;
-      .font-source-sans-sc();
-      font-size: 14px;
-      text-align: left !important;
-      background: @gray-light;
-      border-bottom: 1px solid @gray;
-      color: lighten(@gray-dark, 30%);
-      padding: 10px;
-    }
-
-    td {
-      padding: 10px;
-      &:first-child {
-        white-space: nowrap;
-
-        code {
-          padding: 3px 9px;
-        }
-
-        br {
-          & + em,
-          & + strong,
-          & + b {
-            display: inline-block;
-            margin-top: 3px;
-          }
-        }
+    table {
+        /* Hide table headers (but not display: none;, for accessibility) */
+      thead tr { 
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
       }
-      &:nth-child(2) {
-        word-wrap: break-word;
-        code {
-          white-space: normal;
-        }
+      
+      tr { border: 1px solid #ccc; }
+      
+      td { 
+        /* Behave  like a "row" */
+        border: none;
+        border-bottom: 1px solid #eee; 
+        position: relative;
+       // padding-left: 50%; 
+      }
+      
+      td:before { 
+        /* Now like a table header */
+        position: absolute;
+        /* Top/left values mimic padding */
+        top: 6px;
+        left: 6px;
+        width: 45%; 
+        padding-right: 10px; 
+        white-space: nowrap;
       }
     }
   }

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -42,22 +42,6 @@
       font-size: 17px;
     }
 
-    table {
-      font-size: 13px;
-
-      th {
-        padding: 8px 15px;
-      }
-
-      th {
-        .font-source-sans-sc();
-      }
-
-      td {
-        padding: 15px;
-      }
-    }
-
     h2, h4, p, table, .highlight {
       margin: 0 0 2.5rem 0;
     }

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -42,7 +42,7 @@
       font-size: 17px;
     }
 
-    h2, h4, p, table, .highlight {
+    h2, h4, p .highlight {
       margin: 0 0 2.5rem 0;
     }
   }

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -175,31 +175,31 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 {% capture params_table %}
 <table>
   <thead>
-    <tr><th>form parameter</th><th>default</th><th>description</th></tr>
+    <tr><th>form parameter</th><th>description</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>name</code></td><td></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code></td></tr>
+    <tr><td><code>name</code></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code></td></tr>
 
     {% if page.params.service_id %}
-      <tr><td><code>service_id</code></td><td></td><td>The id of the Service which this plugin will target.</td></tr>
+      <tr><td><code>service_id</code></td><td>The id of the Service which this plugin will target.</td></tr>
     {% endif %}
     {% if page.params.route_id %}
-      <tr><td><code>route_id</code></td><td></td><td>The id of the Route which this plugin will target.</td></tr>
+      <tr><td><code>route_id</code></td><td>The id of the Route which this plugin will target.</td></tr>
     {% endif %}
-      <tr><td><code>enabled</code></td><td><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
+      <tr><td><code>enabled</code><br><br><strong>default value: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
     {% if page.params.consumer_id %}
-      <tr><td><code>consumer_id</code></td><td></td><td>The id of the Consumer which this plugin will target.</td></tr>
+      <tr><td><code>consumer_id</code></td><td>The id of the Consumer which this plugin will target.</td></tr>
     {% endif %}
     {% if page.params.api_id %}
-    <tr><td><code>api_id</code></td><td></td><td>The id of the API which this plugin will target. <strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
+    <tr><td><code>api_id</code></td><td>The id of the API which this plugin will target. <strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
     {% endif %}
     {% for field in page.params.config %}
       <tr>
         <td><code>config.{{ field.name }}</code>
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
+          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default | markdownify }}{% endif %}
         </td>
-        <td>{% if field.default != nil %}{{ field.default | markdownify }}{% endif %}</td>
         <td>{{ field.description | markdownify }}</td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
Changes table layout on plugin / extension pages so it no longer overflows main body

Fixes Issue #835 

## Changes

### Desktop
- In `extensions.html`, moves `default` column in Plugin data tables to be nested under the property name, this helps prevent overflowing content
- Fixes overlapping styles causing some table text sizes to exceed 14px 
- Adds zebra-stripping for readability

<img width="1010" alt="Screen Shot 2019-07-08 at 9 46 58 PM" src="https://user-images.githubusercontent.com/8921227/60860209-6ca92180-a1ca-11e9-8a2d-1aa47aee7b40.png">

### Mobile:
- Collapses tables on mobile for readability
- Hides table headers on mobile
- JQuery adds the `data-label` attribute to table elements
- CSS shows `data-label` attr on mobile to make mobile tables more readable.
- Forces all text-alignment to `left` only on mobile -- allows authors to still use Markdown content alignment on Desktop

Before:
<img width="350" alt="Screen Shot 2019-07-08 at 9 46 40 PM" src="https://user-images.githubusercontent.com/8921227/60860196-58fdbb00-a1ca-11e9-81ec-f0482703109f.png">

After:
![Screen Shot 2019-07-09 at 4 31 16 PM](https://user-images.githubusercontent.com/8921227/60929640-03c3b700-a267-11e9-9ea1-4ca07e7be3c2.png)

