### PR TITLE
fix(doc): Edit consumer_by to be array

### DIFF
--- a/app/enterprise/0.35-x/kong-manager/authentication/ldap.md
+++ b/app/enterprise/0.35-x/kong-manager/authentication/ldap.md
@@ -33,7 +33,7 @@ admin_gui_auth_conf = {
     "start_tls":false,                                        \
     "timeout":10000,                                          \
     "verify_ldap_host":true                                   \
-    "consumer_by":"username",                                 \
+    "consumer_by":["username", "custom_id"],                  \
 }
 ```
 


### PR DESCRIPTION
Fixes internal issue TD-311

LDAP example in Kong Manager authentication doc shows the field `consumer_by` as a string vs an array - this will result in an error if one tries to implement it.
