### PR TITLE
docs(plugins) Status code correction

### DIFF
--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -281,7 +281,7 @@ has no JWT                     | no                       | 401
 missing or invalid `iss` claim | no                       | 401
 invalid signature              | no                       | 403
 valid signature                | yes                      | from the upstream service
-valid signature, invalid verified claim (**option**) | no                       | 401
+valid signature, invalid verified claim _optional_ | no                       | 401
 
 <div class="alert alert-warning">
   <strong>Note:</strong> When the JWT is valid and proxied to the upstream service, Kong makes no modification to the request other than adding headers identifying the Consumer. The JWT will be forwarded to your upstream service, which can assume its validity. It is now the role of your service to base64 decode the JWT claims and make use of them.

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -281,7 +281,7 @@ has no JWT                     | no                       | 401
 missing or invalid `iss` claim | no                       | 401
 invalid signature              | no                       | 403
 valid signature                | yes                      | from the upstream service
-valid signature, invalid verified claim (**option**) | no                       | 403
+valid signature, invalid verified claim (**option**) | no                       | 401
 
 <div class="alert alert-warning">
   <strong>Note:</strong> When the JWT is valid and proxied to the upstream service, Kong makes no modification to the request other than adding headers identifying the Consumer. The JWT will be forwarded to your upstream service, which can assume its validity. It is now the role of your service to base64 decode the JWT claims and make use of them.


### PR DESCRIPTION
Original: 403
Fixed: 401

### Summary

Per FT-471 commented by @bungle , it appears that the status code of invalid verified claims should be 401 instead of 403.

* Original: 403
* Fixed: 401

### Full changelog

* [app/_hub/kong-inc/jwt/index.md]: fix status code