### PR TITLE
docs(zipkin) add docs for include_credential config option

### DIFF
--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -56,6 +56,12 @@ params:
       description: |
         How often to sample requests that do not contain trace ids.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests.
+    - name: include_credential
+      required: true
+      default: true
+      value_in_examples: true
+      description: |
+        Should the credential of the currently authenticated consumer be included in metadata sent to the Zipkin server?
 
 ---
 


### PR DESCRIPTION
Tied to https://github.com/Kong/kong-plugin-zipkin/pull/37
