### PR TITLE
docs(admin-api) redirect index to ref

### DIFF
--- a/app/enterprise/0.35-x/admin-api/admins/index.md
+++ b/app/enterprise/0.35-x/admin-api/admins/index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /enterprise/0.35-x/admin-api/admins
+---


### PR DESCRIPTION
KM currently links to `/admin-api/admins`. There will eventually be an explanatory doc for this path. For now, it should redirect to the API reference since otherwise it 404s.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

