### PR TITLE
feat(install) prepare for multi-arch releases

### DIFF
--- a/app/install/aws-linux.md
+++ b/app/install/aws-linux.md
@@ -12,7 +12,7 @@ breadcrumbs:
 
 Start by downloading the following package specifically built for the Amazon Linux AMI:
 
-- [Download]({{ site.links.download }}/kong-rpm/download_file?file_path=amazonlinux/amazonlinux/kong-{{site.data.kong_latest.version}}.aws.rpm)
+- [Download]({{ site.links.download }}/kong-rpm/download_file?file_path=amazonlinux/amazonlinux/kong-{{site.data.kong_latest.version}}.aws.amd64.rpm)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/centos.md
+++ b/app/install/centos.md
@@ -11,8 +11,8 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [CentOS 6]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/6/kong-{{site.data.kong_latest.version}}.el6.noarch.rpm)
-- [CentOS 7]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/7/kong-{{site.data.kong_latest.version}}.el7.noarch.rpm)
+- [CentOS 6]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/6/kong-{{site.data.kong_latest.version}}.el6.amd64.rpm)
+- [CentOS 7]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/7/kong-{{site.data.kong_latest.version}}.el7.amd64.rpm)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/debian.md
+++ b/app/install/debian.md
@@ -11,9 +11,9 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [7 Wheezy]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.wheezy.all.deb)
-- [8 Jessie]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.jessie.all.deb)
-- [9 Stretch]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.stretch.all.deb)
+- [7 Wheezy]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.wheezy.amd64.deb)
+- [8 Jessie]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.jessie.amd64.deb)
+- [9 Stretch]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.stretch.amd64.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -13,8 +13,8 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [RHEL 6]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/6/kong-{{site.data.kong_latest.version}}.rhel6.noarch.rpm)
-- [RHEL 7]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/7/kong-{{site.data.kong_latest.version}}.rhel7.noarch.rpm)
+- [RHEL 6]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/6/kong-{{site.data.kong_latest.version}}.rhel6.amd64.rpm)
+- [RHEL 7]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/7/kong-{{site.data.kong_latest.version}}.rhel7.amd64.rpm)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -11,11 +11,11 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [12.04 Precise]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.precise.all.deb)
-- [14.04 Trusty]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.trusty.all.deb)
-- [16.04 Xenial]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.xenial.all.deb)
-- [17.04 Zesty]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.zesty.all.deb)
-- [18.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.bionic.all.deb)
+- [12.04 Precise]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.precise.amd64.deb)
+- [14.04 Trusty]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.trusty.amd64.deb)
+- [16.04 Xenial]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.xenial.amd64.deb)
+- [17.04 Zesty]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.zesty.amd64.deb)
+- [18.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.bionic.amd64.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 


### PR DESCRIPTION
When https://github.com/Kong/kong/pull/4868 is merged the next subsequent release will be tagged by architecture (ideally Kong@1.3.0)