### PR TITLE
docs(key-auth) remove the underscore in key name restriction from doc

### DIFF
--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -64,7 +64,7 @@ params:
       required: false
       default: "`apikey`"
       description: |
-        Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-]. Underscores are not permitted for keys in headers due to [additional restrictions in the NGINX defaults](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers).
+        Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
     - name: key_in_body
       required: false
       default: "`false`"


### PR DESCRIPTION
because it no longer applies

See: https://github.com/Kong/kong/pull/4896