### PR TITLE
docs(zipkin) add `default_service_name` configuration parameter to docs

### DIFF
--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -57,6 +57,10 @@ params:
       description: |
         How often to sample requests that do not contain trace ids.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests.
+    - name: default_service_name
+      required: false
+      description: |
+        The default service name to override the unknown-service-name spans.
 
 ---
 


### PR DESCRIPTION
### Summary

The default service name can be used to override the
unknown-service-name spans.