### PR TITLE
fix(travis-ci) expand memory limit for css removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ cache:
 before_install:
   - rvm install 2.3.3
   - npm install -g yarn
+env:
+  - NODE_OPTIONS=--max_old_space_size=8192
 install:
   - bundle install
   - yarn


### PR DESCRIPTION
Fixes issue where, as unused CSS is removed, the build hits a memory limit causing a failure.

Note the following:

- Netlify was fixed separately by adding `NODE_OPTIONS=--max_old_space_size=8192` to  https://app.netlify.com/sites/kongdocs/settings/deploys#environment

- With local development, writers still need to manually use `export NODE_OPTIONS=--max_old_space_size=8192`; ideally we can include this out of the box, but this PR only addresses Travis CI.