### PR TITLE
docs(enterprise/*) fix typo on deployment page

### DIFF
--- a/app/enterprise/0.35-x/index.md
+++ b/app/enterprise/0.35-x/index.md
@@ -18,7 +18,7 @@ title: Kong Enterprise Documentation
   <div class="docs-grid-block">
     <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="/enterprise/{{page.kong_version}}/deployment/installation/overview">Install Kong Enterprise</a></h3>
     <p>Learn how to install Kong Enterprise with your chosen deployment method.</p>
-    <a href="/enterprise/{{page.kong_version}}/deployment/installation/overview">Chose Deployment Method &rarr;</a>
+    <a href="/enterprise/{{page.kong_version}}/deployment/installation/overview">Choose Deployment Method &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/enterprise/0.36-x/index.md
+++ b/app/enterprise/0.36-x/index.md
@@ -18,7 +18,7 @@ title: Kong Enterprise Documentation
   <div class="docs-grid-block">
     <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="/enterprise/{{page.kong_version}}/deployment/installation/overview">Install Kong Enterprise</a></h3>
     <p>Learn how to install Kong Enterprise with your chosen deployment method.</p>
-    <a href="/enterprise/{{page.kong_version}}/deployment/installation/overview">Chose Deployment Method &rarr;</a>
+    <a href="/enterprise/{{page.kong_version}}/deployment/installation/overview">Choose Deployment Method &rarr;</a>
   </div>
 
   <div class="docs-grid-block">


### PR DESCRIPTION
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

0.35 and 0.36 are the only versions affected.