### PR TITLE
chore(ee/*) remove leftover front matter

### DIFF
--- a/app/enterprise/0.35-x/admin-api/index.md
+++ b/app/enterprise/0.35-x/admin-api/index.md
@@ -3,7 +3,6 @@ title: Admin API
 redirect_from:
   - /0.35-x/admin-api/
 toc: false
----
 
 service_body: |
     Attributes | Description


### PR DESCRIPTION
Removes duplicated front matter that caused all of the content in YAML to not render at all.