### PR TITLE
fix(passwords) use anchor links for page sections

### DIFF
--- a/app/enterprise/0.35-x/kong-manager/reset-password.md
+++ b/app/enterprise/0.35-x/kong-manager/reset-password.md
@@ -5,10 +5,10 @@ toc: false
 
 ### Table of contents
 
-* [Passwords and RBAC Tokens](passwords-and-rbac-tokens)
-* [How to Reset a Forgotten Password in Kong Manager](how-to-reset-a-forgotten-password-in-kong-manager)
-* [How to Reset a Password from within Kong Manager](how-to-reset-a-password-from-within-kong-manager)
-* [How to Reset an RBAC Token in Kong Manager](how-to-reset-an-rbac-token-in-kong-manager)
+* [Passwords and RBAC Tokens](#passwords-and-rbac-tokens)
+* [How to Reset a Forgotten Password in Kong Manager](#how-to-reset-a-forgotten-password-in-kong-manager)
+* [How to Reset a Password from within Kong Manager](#how-to-reset-a-password-from-within-kong-manager)
+* [How to Reset an RBAC Token in Kong Manager](#how-to-reset-an-rbac-token-in-kong-manager)
 
 ## Passwords and RBAC Tokens
 

--- a/app/enterprise/0.36-x/kong-manager/reset-password.md
+++ b/app/enterprise/0.36-x/kong-manager/reset-password.md
@@ -5,10 +5,10 @@ toc: false
 
 ### Table of contents
 
-* [Passwords and RBAC Tokens](passwords-and-rbac-tokens)
-* [How to Reset a Forgotten Password in Kong Manager](how-to-reset-a-forgotten-password-in-kong-manager)
-* [How to Reset a Password from within Kong Manager](how-to-reset-a-password-from-within-kong-manager)
-* [How to Reset an RBAC Token in Kong Manager](how-to-reset-an-rbac-token-in-kong-manager)
+* [Passwords and RBAC Tokens](#passwords-and-rbac-tokens)
+* [How to Reset a Forgotten Password in Kong Manager](#how-to-reset-a-forgotten-password-in-kong-manager)
+* [How to Reset a Password from within Kong Manager](#how-to-reset-a-password-from-within-kong-manager)
+* [How to Reset an RBAC Token in Kong Manager](#how-to-reset-an-rbac-token-in-kong-manager)
 
 ## Passwords and RBAC Tokens
 


### PR DESCRIPTION
Fix Kong Manager password/token reset instructions to point to appropriate anchors within the page, rather than non-existent off-page links.