### PR TITLE
docs(ce/rate-limiting) fix-config-policy

### DIFF
--- a/app/_hub/kong-inc/rate-limiting/0.1-x.md
+++ b/app/_hub/kong-inc/rate-limiting/0.1-x.md
@@ -74,10 +74,11 @@ params:
       description: |
         The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.
     - name: policy
-      required: false
+      required: semi
+      value_in_examples: "local"
       default: "`cluster`"
       description: |
-        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes).
+        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or 'redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
     - name: fault_tolerant
       required: false
       default: "`true`"

--- a/app/_hub/kong-inc/rate-limiting/0.1-x.md
+++ b/app/_hub/kong-inc/rate-limiting/0.1-x.md
@@ -78,7 +78,7 @@ params:
       value_in_examples: "local"
       default: "`cluster`"
       description: |
-        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or 'redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
+        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or `redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
     - name: fault_tolerant
       required: false
       default: "`true`"

--- a/app/_hub/kong-inc/rate-limiting/0.1-x.md
+++ b/app/_hub/kong-inc/rate-limiting/0.1-x.md
@@ -78,7 +78,7 @@ params:
       value_in_examples: "local"
       default: "`cluster`"
       description: |
-        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or `redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
+        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, at least one of `local` or `redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
     - name: fault_tolerant
       required: false
       default: "`true`"

--- a/app/_hub/kong-inc/rate-limiting/0.1-x.md
+++ b/app/_hub/kong-inc/rate-limiting/0.1-x.md
@@ -74,7 +74,7 @@ params:
       description: |
         The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.
     - name: policy
-      required: semi
+      required: false
       value_in_examples: "local"
       default: "`cluster`"
       description: |

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -89,10 +89,11 @@ params:
       description: |
         The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.
     - name: policy
-      required: false
+      required: semi
+      value_in_examples: "local"
       default: '`cluster`'
       description: |
-        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes).
+        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or 'redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
     - name: fault_tolerant
       required: false
       default: '`true`'

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -89,7 +89,7 @@ params:
       description: |
         The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.
     - name: policy
-      required: semi
+      required: false
       value_in_examples: "local"
       default: '`cluster`'
       description: |

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -93,7 +93,7 @@ params:
       value_in_examples: "local"
       default: '`cluster`'
       description: |
-        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or 'redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
+        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or `redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
     - name: fault_tolerant
       required: false
       default: '`true`'

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -93,7 +93,7 @@ params:
       value_in_examples: "local"
       default: '`cluster`'
       description: |
-        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, atleast one of `local` or `redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
+        The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes). In case of DB-less mode, at least one of `local` or `redis` must be specified. Please refer <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a> for details on which policy should be used.
     - name: fault_tolerant
       required: false
       default: '`true`'


### PR DESCRIPTION
* made policy param semi-required
* added example value
* added explaination in description for semi-optional

Please refer Kong/kong#4965 for issues due to this.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

The docs page for rate-limiting currently does not list policy in config in the examples which cause issues to people who are using the same declarative configuration file in DB-less mode.