### PR TITLE
docs(readme) fix-bundler-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make develop
 ### Prerequisites
 
 - [npm](https://www.npmjs.com/)
-- [Bundler](https://bundler.io/)
+- [Bundler](https://bundler.io/) (< 2.0.0) 
 - [Ruby](https://www.ruby-lang.org) (>= 2.0, < 2.3)
 - [Python](https://www.python.org) (>= 2.7.X, < 3)
 


### PR DESCRIPTION
* added upper version for bundler

Since bundler has dropped support for ruby < 2.3 starting from version 2.0.0 we should update the version to be installed in the README file.
Please refer https://github.com/bundler/bundler/releases/tag/v2.0.0 for more details.
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

