### PR TITLE
remove purifycss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,22 +54,22 @@ gulp.task('styles', function () {
     .pipe($.if(dev, $.sourcemaps.init()))
     .pipe($.less())
     .pipe($.autoprefixer())
-    .pipe($.purifycss([dest.html], {
-      whitelist: [
-        '.affix',
-        '.alert',
-        '.close',
-        '.collaps',
-        '.fade',
-        '.has',
-        '.help',
-        '.in',
-        '.modal',
-        '.open',
-        '.popover',
-        '.tooltip'
-      ]
-    }))
+    // .pipe($.purifycss([dest.html], {
+    //   whitelist: [
+    //     '.affix',
+    //     '.alert',
+    //     '.close',
+    //     '.collaps',
+    //     '.fade',
+    //     '.has',
+    //     '.help',
+    //     '.in',
+    //     '.modal',
+    //     '.open',
+    //     '.popover',
+    //     '.tooltip'
+    //   ]
+    // }))
     .pipe($.cleanCss({ compatibility: 'ie8' }))
     .pipe($.rename('styles.css'))
     .pipe($.if(dev, $.sourcemaps.write()))

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "gulp-load-plugins": "1.6.0",
     "gulp-minify": "3.1.0",
     "gulp-plumber": "1.2.1",
-    "gulp-purifycss": "0.2.0",
     "gulp-rename": "1.4.0",
     "gulp-resource-hints": "0.2.1",
     "gulp-size": "3.0.0",


### PR DESCRIPTION
Removes `purifycss` as it is an unmaintained project causing memory leak issues in the repo. 

Looking into alternative packages, but lets remove this for now. 
