### PR TITLE
Update Amazon instructions

### DIFF
--- a/app/enterprise/0.35-x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/0.35-x/deployment/installation/amazon-linux.md
@@ -19,9 +19,9 @@ baseurl=https://<BINTRAY_USER>:<BINTRAY_API_KEY>@kong.bintray.com/kong-enterpris
 
 ```bash
 $ sudo yum install kong-enterprise-edition
-$ sudo yum install postgresql95 postgresql95-server
-$ sudo service postgresql95 initdb
-$ sudo service postgresql95 start
+$ sudo yum install postgresql postgresql-server
+$ sudo service postgresql initdb
+$ sudo service postgresql start
 $ sudo -i -u postgres (puts you into new shell)
 ```
 


### PR DESCRIPTION
After working with a customer, it seems that the package with the 95 suffix no longer exists in Amazon's Repo.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

