### PR TITLE
docs(config) add warnings about character escaping

### DIFF
--- a/app/1.0.x/configuration.md
+++ b/app/1.0.x/configuration.md
@@ -896,6 +896,10 @@ datastore. Accepted values are `postgres` and `cassandra`.
 
 Default: `postgres`
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+</div>
+
 ---
 
 #### Postgres settings

--- a/app/1.1.x/configuration.md
+++ b/app/1.1.x/configuration.md
@@ -889,6 +889,10 @@ Accepted values are `postgres` and `cassandra`.
 
 Default: `postgres`
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+</div>
+
 ---
 
 

--- a/app/1.2.x/configuration.md
+++ b/app/1.2.x/configuration.md
@@ -900,6 +900,10 @@ Accepted values are `postgres`, `cassandra`, and `off`.
 
 Default: `postgres`
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+</div>
+
 ---
 
 

--- a/app/1.3.x/configuration.md
+++ b/app/1.3.x/configuration.md
@@ -1005,6 +1005,10 @@ Accepted values are `postgres`, `cassandra`, and `off`.
 
 Default: `postgres`
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+</div>
+
 ---
 
 

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -873,6 +873,10 @@ The username to authenticate if required.
 
 The password to authenticate if required.
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
+
 
 ### pg_database
 
@@ -977,6 +981,10 @@ Username when using the `PasswordAuthenticator` scheme.
 **Description:**
 
 Password when using the `PasswordAuthenticator` scheme.
+
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
 
 
 ### cassandra_consistency
@@ -2102,6 +2110,10 @@ Username used for authentication with the SMTP server.
 **Description:**
 
 Password used for authentication with the SMTP server.
+
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
 
 
 ### smtp_ssl

--- a/app/enterprise/0.35-x/property-reference.md
+++ b/app/enterprise/0.35-x/property-reference.md
@@ -696,6 +696,10 @@ The username to authenticate if required.
 
 The password to authenticate if required.
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
+
 
 ### pg_database
 
@@ -800,6 +804,10 @@ Username when using the `PasswordAuthenticator` scheme.
 **Description:**
 
 Password when using the `PasswordAuthenticator` scheme.
+
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
 
 
 ### cassandra_consistency
@@ -2015,6 +2023,10 @@ Username used for authentication with the SMTP server.
 **Description:**
 
 Password used for authentication with the SMTP server.
+
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
 
 
 ### smtp_ssl

--- a/app/enterprise/0.36-x/property-reference.md
+++ b/app/enterprise/0.36-x/property-reference.md
@@ -697,6 +697,10 @@ The username to authenticate if required.
 
 The password to authenticate if required.
 
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
+
 
 ### pg_database
 
@@ -801,6 +805,10 @@ Username when using the `PasswordAuthenticator` scheme.
 **Description:**
 
 Password when using the `PasswordAuthenticator` scheme.
+
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
 
 
 ### cassandra_consistency
@@ -2026,6 +2034,10 @@ Username used for authentication with the SMTP server.
 **Description:**
 
 Password used for authentication with the SMTP server.
+
+<div class="alert alert-warning">
+  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+</div>
 
 
 ### smtp_ssl


### PR DESCRIPTION
Add warning boxes instructing users to escape "#" characters in configuration. Though technically applicable everywhere, this typically comes up in the context of database and SMTP passwords.

See also: https://github.com/Kong/kong/commit/a185dd954c839e8830759efec2d769856e8842e3