### PR TITLE
fix(config) fix warning box formatting

### DIFF
--- a/app/1.0.x/configuration.md
+++ b/app/1.0.x/configuration.md
@@ -897,7 +897,7 @@ datastore. Accepted values are `postgres` and `cassandra`.
 Default: `postgres`
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your database password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 ---

--- a/app/1.1.x/configuration.md
+++ b/app/1.1.x/configuration.md
@@ -890,7 +890,7 @@ Accepted values are `postgres` and `cassandra`.
 Default: `postgres`
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your database password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 ---

--- a/app/1.2.x/configuration.md
+++ b/app/1.2.x/configuration.md
@@ -901,7 +901,7 @@ Accepted values are `postgres`, `cassandra`, and `off`.
 Default: `postgres`
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your database password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 ---

--- a/app/1.3.x/configuration.md
+++ b/app/1.3.x/configuration.md
@@ -1006,7 +1006,7 @@ Accepted values are `postgres`, `cassandra`, and `off`.
 Default: `postgres`
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your database password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your database password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 ---

--- a/app/enterprise/0.34-x/property-reference.md
+++ b/app/enterprise/0.34-x/property-reference.md
@@ -874,7 +874,7 @@ The username to authenticate if required.
 The password to authenticate if required.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 
@@ -983,7 +983,7 @@ Username when using the `PasswordAuthenticator` scheme.
 Password when using the `PasswordAuthenticator` scheme.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 
@@ -2112,7 +2112,7 @@ Username used for authentication with the SMTP server.
 Password used for authentication with the SMTP server.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 

--- a/app/enterprise/0.35-x/property-reference.md
+++ b/app/enterprise/0.35-x/property-reference.md
@@ -697,7 +697,7 @@ The username to authenticate if required.
 The password to authenticate if required.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 
@@ -806,7 +806,7 @@ Username when using the `PasswordAuthenticator` scheme.
 Password when using the `PasswordAuthenticator` scheme.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 
@@ -2025,7 +2025,7 @@ Username used for authentication with the SMTP server.
 Password used for authentication with the SMTP server.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 

--- a/app/enterprise/0.36-x/property-reference.md
+++ b/app/enterprise/0.36-x/property-reference.md
@@ -698,7 +698,7 @@ The username to authenticate if required.
 The password to authenticate if required.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 
@@ -807,7 +807,7 @@ Username when using the `PasswordAuthenticator` scheme.
 Password when using the `PasswordAuthenticator` scheme.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 
@@ -2036,7 +2036,7 @@ Username used for authentication with the SMTP server.
 Password used for authentication with the SMTP server.
 
 <div class="alert alert-warning">
-  Kong's configuration parser treats `#` characters as comments. If your password contains a `#` character, escape it with `\#`.
+  Kong's configuration parser treats <code class="highlighter-rouge">#</code> characters as comments. If your password contains a <code class="highlighter-rouge">#</code> character, escape it with <code class="highlighter-rouge">\#</code>.
 </div>
 
 


### PR DESCRIPTION
Aron was too quick for me on https://github.com/Kong/docs.konghq.com/pull/1499 and I hadn't checked formatting before it was merged.

Turns out you can't use Markdown inside warning boxes. Applying the appropriate code class manually instead.