### PR TITLE
docs(ce/logging) fixes in Logging Reference doc

### DIFF
--- a/app/0.14.x/logging.md
+++ b/app/0.14.x/logging.md
@@ -21,7 +21,7 @@ With new regulations surrounding protecting private data like GDPR, there is a c
 
 For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/apiname/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong) or copied from below
 
 ```
 # ---------------------

--- a/app/1.0.x/logging.md
+++ b/app/1.0.x/logging.md
@@ -3,12 +3,6 @@ title: Logging Reference
 toc: false
 ---
 
-## Removing Certain Elements From Your Kong Logs
-
-With new regulations surrounding protecting private data like GDPR, there is a chance you may need to change your logging habits. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your APIs. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
-
-For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/apiname/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
-
 ## Log Levels
 
 Log levels are set in [Kong's configuration](/{{page.kong_version}}/configuration/#log_level). Following are the log levels in increasing order of their severity, `debug`, `info`,
@@ -28,7 +22,7 @@ With new regulations surrounding protecting private data like GDPR, there is a c
 
 For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong) or copied from below
 
 ```
 # ---------------------

--- a/app/1.1.x/logging.md
+++ b/app/1.1.x/logging.md
@@ -3,12 +3,6 @@ title: Logging Reference
 toc: false
 ---
 
-## Removing Certain Elements From Your Kong Logs
-
-With new regulations surrounding protecting private data like GDPR, there is a chance you may need to change your logging habits. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your APIs. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
-
-For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/apiname/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
-
 ## Log Levels
 
 Log levels are set in [Kong's configuration](/{{page.kong_version}}/configuration/#log_level). Following are the log levels in increasing order of their severity, `debug`, `info`,
@@ -28,7 +22,7 @@ With new regulations surrounding protecting private data like GDPR, there is a c
 
 For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong) or copied from below
 
 ```
 # ---------------------

--- a/app/1.2.x/logging.md
+++ b/app/1.2.x/logging.md
@@ -3,12 +3,6 @@ title: Logging Reference
 toc: false
 ---
 
-## Removing Certain Elements From Your Kong Logs
-
-With new regulations surrounding protecting private data like GDPR, there is a chance you may need to change your logging habits. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your APIs. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
-
-For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/apiname/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
-
 ## Log Levels
 
 Log levels are set in [Kong's configuration](/{{page.kong_version}}/configuration/#log_level). Following are the log levels in increasing order of their severity, `debug`, `info`,
@@ -28,7 +22,7 @@ With new regulations surrounding protecting private data like GDPR, there is a c
 
 For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong) or copied from below
 
 ```
 # ---------------------

--- a/app/1.3.x/logging.md
+++ b/app/1.3.x/logging.md
@@ -3,12 +3,6 @@ title: Logging Reference
 toc: false
 ---
 
-## Removing Certain Elements From Your Kong Logs
-
-With new regulations surrounding protecting private data like GDPR, there is a chance you may need to change your logging habits. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your APIs. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
-
-For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/apiname/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
-
 ## Log Levels
 
 Log levels are set in [Kong's configuration](/{{page.kong_version}}/configuration/#log_level). Following are the log levels in increasing order of their severity, `debug`, `info`,
@@ -28,7 +22,7 @@ With new regulations surrounding protecting private data like GDPR, there is a c
 
 For this example, let’s say you want to remove any instances of an email address from your kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+To start using a custom NGINX template, first get a copy of our template. This can be found [https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong](https://docs.konghq.com/latest/configuration/#custom-nginx-templates--embedding-kong) or copied from below
 
 ```
 # ---------------------


### PR DESCRIPTION
This PR fix following problems in Logging Reference documentation:

- remove duplicated "Removing Certain Elements From Your Kong Logs"
- fix url to "custom NGINX template"


