### PR TITLE
docs(changelog) note missing 1.2 features in 0.36

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -51,6 +51,10 @@ layout: changelog
 
 ## 0.36
 
+### Notifications
+- **Kong Enterprise 0.36** inherits from **Kong 1.2.1** with some exceptions:
+  * Declarative Configuration and DB-less mode of Kong Gateway is designed for limited scenarios that do not allow for the Kong Enterprise to function as-is. As such the mode is not available in Kong Enterprise today.
+
 **Release Date:** 2019/8/5
 
 ### Features


### PR DESCRIPTION
In order to avoid confusion, describe the Gateway version Enterprise is based on and mention the missing features.

**Note:** Once the messaging is approved, I will copy it for 0.36-1 and 0.36-2. I left them blank to avoid needing to make duplicate changes.