### PR TITLE
chores(links) -  fix got github broken links

### DIFF
--- a/app/1.0.x/plugin-development/tests.md
+++ b/app/1.0.x/plugin-development/tests.md
@@ -101,7 +101,7 @@ its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
 and Admin API on port 9001.
 
 If you want to see a real-world example, give a look at the
-[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/10-key-auth)
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth)
 
 ---
 

--- a/app/1.3.x/plugin-development/tests.md
+++ b/app/1.3.x/plugin-development/tests.md
@@ -101,7 +101,7 @@ its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
 and Admin API on port 9001.
 
 If you want to see a real-world example, give a look at the
-[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/10-key-auth)
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth)
 
 ---
 

--- a/app/_hub/qnap/api-transformer/index.md
+++ b/app/_hub/qnap/api-transformer/index.md
@@ -184,7 +184,7 @@ This table `ngx.ctx` can be used to store per-request Lua context data and has a
 
 ### Convensions in writing the transformer
 
-In the transformer, we need to return a Lua tuple: `(f_status, body_or_err)`, please check the detail via [test case](https://github.com/qnap-dev/kong-plugin-api-transformer/tree/master/spechttps://github.com/qnap-dev/kong-plugin-api-transformer/tree/master/spec).
+In the transformer, we need to return a Lua tuple: `(f_status, body_or_err)`, please check the detail via [test case](https://github.com/qnap-dev/kong-plugin-api-transformer/tree/master/spec).
 
 ```
 if f_status == true then

--- a/app/enterprise/0.35-x/plugin-development/tests.md
+++ b/app/enterprise/0.35-x/plugin-development/tests.md
@@ -101,7 +101,7 @@ its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
 and Admin API on port 9001.
 
 If you want to see a real-world example, give a look at the
-[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/10-key-auth)
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth)
 
 ---
 

--- a/app/enterprise/0.36-x/plugin-development/tests.md
+++ b/app/enterprise/0.36-x/plugin-development/tests.md
@@ -101,7 +101,7 @@ its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
 and Admin API on port 9001.
 
 If you want to see a real-world example, give a look at the
-[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/10-key-auth)
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth)
 
 ---
 


### PR DESCRIPTION
In addition to CI - broken links checker, a human one.

1) remove url to qnap github, with kong api in lua
2) changed spec reference broken by Kong/kong@5c24e507

