### PR TITLE
chores(links): broken links to rfc 1386

### DIFF
--- a/app/0.11.x/proxy.md
+++ b/app/0.11.x/proxy.md
@@ -452,7 +452,7 @@ local router_matches = ngx.ctx.router_matches
 
 Next, it is worth noting that characters found in regexes are often
 reserved characters according to
-[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+[RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) and as such,
 should be percent-encoded. **When configuring APIs with regex URIs via the
 Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:

--- a/app/0.12.x/proxy.md
+++ b/app/0.12.x/proxy.md
@@ -452,7 +452,7 @@ local router_matches = ngx.ctx.router_matches
 
 Next, it is worth noting that characters found in regexes are often
 reserved characters according to
-[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+[RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) and as such,
 should be percent-encoded. **When configuring APIs with regex URIs via the
 Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:

--- a/app/0.13.x/proxy.md
+++ b/app/0.13.x/proxy.md
@@ -516,7 +516,7 @@ local router_matches = ngx.ctx.router_matches
 
 Next, it is worth noting that characters found in regexes are often
 reserved characters according to
-[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+[RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) and as such,
 should be percent-encoded. **When configuring Routes with regex paths via the
 Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:

--- a/app/0.14.x/proxy.md
+++ b/app/0.14.x/proxy.md
@@ -519,7 +519,7 @@ local router_matches = ngx.ctx.router_matches
 
 Next, it is worth noting that characters found in regexes are often
 reserved characters according to
-[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+[RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) and as such,
 should be percent-encoded. **When configuring Routes with regex paths via the
 Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:

--- a/app/enterprise/0.34-x/proxy.md
+++ b/app/enterprise/0.34-x/proxy.md
@@ -516,7 +516,7 @@ local router_matches = ngx.ctx.router_matches
 
 Next, it is worth noting that characters found in regexes are often
 reserved characters according to
-[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+[RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) and as such,
 should be percent-encoded. **When configuring Routes with regex paths via the
 Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:


### PR DESCRIPTION
link replaces to a source website link
https://www.ietf.org/rfc/rfc3986.txt

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

