### PR TITLE
style(aws-lambda) fix formatting issues

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -171,13 +171,13 @@ params:
 Any form parameter sent along with the request, will be also sent as an
 argument to the AWS Lambda function.
 
-### Known Issues
-
 ### Notes
 
 If you do not provide `aws.key` or `aws.secret`, the plugin uses an IAM role inherited from the instance running Kong. 
 
 First, the plugin will try ECS metadata to get the role. If no ECS metadata is available, the plugin will fall back on EC2 metadata.
+
+### Known Issues
 
 #### Use a fake upstream service
 


### PR DESCRIPTION
We accidentally added the 'Notes' section inside the 'Known issues' section: https://github.com/Kong/docs.konghq.com/pull/1549/files#diff-e1db400f86ea82db8db667114dd7927eL149-R181

<img width="885" alt="Screen Shot 2019-10-25 at 15 47 53" src="https://user-images.githubusercontent.com/17624339/67596312-d3812500-f73e-11e9-8c53-926c1933a55c.png">

