### PR TITLE
docs(*) missing docs for the 1.4.0 release

### DIFF
--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -88,7 +88,7 @@ params:
       required: false
       default: '`consumer`'
       description: |
-        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.
+        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`. If the `consumer`, the `credential` or the `service` cannot be determined, the system will always fallback to `ip`.
     - name: policy
       required: false
       value_in_examples: "local"

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -58,6 +58,9 @@ params:
       required: false
       value_in_examples: "json-key-toremove, another-json-key"
       description: List of property names. Remove the property from the JSON body if it is present.
+    - name: rename.headers
+      required: false
+      description: List of original_header_name:new_header_name pairs. If the header `original_headername` is already set, rename it to `new_headername`. Ignored if the header is not already set.
     - name: replace.headers
       required: false
       description: List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
@@ -88,7 +91,7 @@ Note: if the value contains a `,` then the comma separated format for lists cann
 
 Plugin performs the response transformation in following order
 
-remove --> replace --> add --> append
+remove --> rename --> replace --> add --> append
 
 ## Examples
 


### PR DESCRIPTION
docs(rate-limiting) new `limit_by` value (`service`)
docs(response-transformer) new `headers.rename` param