### PR TITLE
fix(migrations) correct 1.3 links

### DIFF
--- a/app/enterprise/1.3-x/deployment/migrations.md
+++ b/app/enterprise/1.3-x/deployment/migrations.md
@@ -4,8 +4,8 @@ title: Migrating to 1.3
 
 ### Prerequisites for Migrating to 1.3
 
-* If running a version of **Kong Enterprise** earlier than 0.36, [migrate to 0.36](/enterprise/0.35-x/deployment/migrations/) first.
-* If running a version of **Kong** earlier than 1.3, [upgrade to Kong 1.3](/1.2.x/upgrading/) before upgrading to Kong Enterprise 1.3.
+* If running a version of **Kong Enterprise** earlier than 0.36, [migrate to 0.36](/enterprise/0.36-x/deployment/migrations/) first.
+* If running a version of **Kong** earlier than 1.3, [upgrade to Kong 1.3](/1.3.x/upgrading/) before upgrading to Kong Enterprise 1.3.
 
 ### Changes and Configuration to Consider before Upgrading
 


### PR DESCRIPTION
Use correct target for Enterprise 1.3 migration links. Links previously targeted guides for versions older than the prerequisite version.

