### PR TITLE
doc(portal): add javascript asset docs

### DIFF
--- a/app/_data/docs_nav_ee_1.3-x.yml
+++ b/app/_data/docs_nav_ee_1.3-x.yml
@@ -239,11 +239,15 @@
           url: /developer-portal/administration/managing-developers
         - text: Developer Roles and Content Permissions
           url: /developer-portal/administration/developer-permissions
-    - text: Theme Customization
+    - text: Customization
       url: /developer-portal/theme-customization/easy-theme-editing
       items:
         - text: Easy Theme Editing
           url: /developer-portal/theme-customization/easy-theme-editing
+        - text: Adding and Using Javascript Assets
+          url: /developer-portal/theme-customization/adding-javascript-assets
+        - text: Single Page App in Dev Portal
+          url: /developer-portal/theme-customization/single-page-app
     - text: Helpers
       url: /developer-portal/helpers/cli
       items:

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -6,18 +6,18 @@ title: Adding and Using Javascript Assets in Kong Dev Portal
 
 The Kong Developer Portal ships with Vue, React, and jQuery already loaded. In order to write custom interactive webpages, you may wish to make use of these libraries, or load additional javascript.
 
-Note: This guide is for adding/using javascript assets without changing server-side routing. [Learn more about a SPA to the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/single-page-app).
+> Note: This guide is for adding/using javascript assets without changing server-side routing. [Learn more about a SPA to the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/single-page-app).
 
 ### Prerequisites
 
 * Kong Enterprise 1.3 or later
 * Portal Legacy is turned off
-* The Developer Portal is enabled and running
-* kong-portal-cli tool is installed locally
+* The Kong Developer Portal is enabled and running
+* The [kong-portal-cli tool](/enterprise/{{page.kong_version}}/developer-portal/helpers/cli) is installed locally
 
 
 ### Adding JS Assets
-Warning: Due to compatibility issues, avoid using any React other than React 15 on the `layouts/system/spec-render.html` layout. We recommend if using react, to use the version of react included by the default base theme. If using a different version of react, be sure not to load it on to `layouts/system/spec-render.html`
+> Warning: Due to compatibility issues, avoid using any React version other than React 15 on the `layouts/system/spec-render.html` layout. We recommend using the version of React included by the default base theme. 
 
 To add javascript assets:
 1. Clone down the kong-portal-templates repo.
@@ -33,7 +33,6 @@ By default React is only loaded on `layouts/system/spec-render.html`
 
 if you want to load React or any custom javascript asset on all pages, you can edit `themes/partial/foot.html`
 
-For example if you want to load react on every page, change `themes/partial/foot.html` to be:
 
 {% raw %}
 ```

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -1,0 +1,56 @@
+---
+title: Adding and Using Javascript Assets in Kong Dev Portal
+---
+
+### Introduction
+
+The Kong Developer Portal ships with Vue, React, and jQuery already loaded. In order to write custom interactive webpages, you may wish to make use of these libraries, or load additional javascript.
+
+Note: This guide is for adding/using javascript assets without changing server-side routing. [Learn more about a SPA to the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/single-page-app).
+
+### Prerequisites
+
+* Kong Enterprise 1.3 or later
+* Portal Legacy is turned off
+* The Developer Portal is enabled and running
+* kong-portal-cli tool is installed locally
+
+
+### Adding JS Assets
+Warning: Due to compatibility issues, avoid using any React other than React 15 on the `layouts/system/spec-render.html` layout. We recommend if using react, to use the version of react included by the default base theme. If using a different version of react, be sure not to load it on to `layouts/system/spec-render.html`
+
+To add javascript assets:
+1. Clone down the kong-portal-templates repo.
+2. Add any javascript files to the `themes/base/js` folder.
+3. Deploy using the kong-portal-cli-tool.
+
+
+### Loading JS Assets
+
+You can make use of the existing Vue, and jQuery in any layout/partial that includes `partials/theme/required-scripts.html` where the these scripts are loaded.
+
+By default React is only loaded on `layouts/system/spec-render.html`
+
+if you want to load React or any custom javascript asset on all pages, you can edit `themes/partial/foot.html`
+
+For example if you want to load react on every page, change `themes/partial/foot.html` to be:
+
+{% raw %}
+```
+{% layout = "layouts/_base.html" %}
+
+{-main-}
+  {(partials/header.html)}
+
+  <div class="page">
+    {* blocks.content *}
+  </div>
+
+  {(partials/footer.html)}
+  <script src="assets/js/third-party/react.min.js"></script>
+
+{-main-}
+```
+{% endraw %}
+
+Alternatively you can load the script you need on the specific layout for each content page as needed.

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -20,7 +20,7 @@ The Kong Developer Portal ships with Vue, React, and jQuery already loaded. In o
 > Warning: Due to compatibility issues, avoid using any React version other than React 15 on the `layouts/system/spec-render.html` layout. We recommend using the version of React included by the default base theme. 
 
 To add javascript assets:
-1. Clone down the kong-portal-templates repo.
+1. Clone the [kong-portal-templates](https://github.com/Kong/kong-portal-templates) repo.
 2. Add any javascript files to the `themes/base/js` folder.
 3. Deploy using the kong-portal-cli-tool.
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -6,7 +6,7 @@ title: Hosting Single Page App out of Kong Dev Portal
 
 The Kong Developer Portal ships with a default server side rendered theme, however it is possible to replace this with a Single Page App (SPA). Our example is in Angular using the Angular CLI Tool, but you can follow along with any other javascript framework with just a few tweaks.
 
-To view the basic example Angular template from this this guide view the [`example/spa-angular` branch from the kong-portal-templates branch](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular).
+To view the basic example Angular template from this guide visit the [`example/spa-angular`](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular) branch from the kong-portal-templates branch.
 
 ### Prerequisites
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -53,7 +53,7 @@ In the `router.conf.yaml` example below, we are hardcoding routing for all kong 
 
 ```
 
-### Creating Your SPA
+#### 1. Creating Your SPA
 
 Create SPA app in the javascript framework of your choice
 As a example, we will be using angular.
@@ -74,7 +74,7 @@ Copy the build output JS and CSS files to a folder inside `workspaces/default/th
 
 For this example we placed the angular build inside a `workspaces/default/themes/assets/js/ng`
 
-### Mounting a SPA
+#### 2. Mounting a SPA
 
 In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example we will call it `spa.html`
 
@@ -117,7 +117,7 @@ This is what our layout ended up as:
 
 If your SPA build process creates a css file edit the head.html partial to include your css file.
 
-### Loading your layout
+#### 3. Loading your layout
 
 In order to use our layout modify `workspaces/default/content/index.txt` to use our layout,
 The title we set here will be the one that displays until the JS set title loads.
@@ -131,6 +131,7 @@ title: Home
 ```
 {% endraw %}
 
+#### 4. Deploy the Portal
 
 Now using the kong-portal-cli tool we can deploy this portal
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -17,7 +17,7 @@ To view the basic example Angular template from this this guide view the [`examp
 
 ### What is a SPA
 
-A Single Page App(SPA) is a website that loads all the HTML, Javascript, and CSS on the first load. Instead of loading subsequent pages from the server, javascript is used to dynamically change the page content. You may wish to use a SPA in Dev Portal if you have a preexisting SPA you want to integrate with portal, or you are trying to achieve a more application like experience across many pages. A SPA takes control of routing from the server, and handles it client side instead.
+A Single Page App (SPA) is a website that loads all HTML, Javascript, and CSS on the first load. Instead of loading subsequent pages from the server, javascript is used to dynamically change the page content. You may wish to use a SPA in Dev Portal if you have a preexisting SPA you want to integrate with portal, or you are trying to achieve a more application like experience across many pages. A SPA takes control of routing from the server, and handles it client-side instead.
 
 If you simplify wish to add interactive javascript to a few pages, it may make more sense to add the javascript to only layouts that require it, and maintain server side rendering. [Learn more about adding Javascipt to a layout without implementing a SPA.](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets)
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -4,7 +4,7 @@ title: Hosting Single Page App out of Kong Dev Portal
 
 ### Introduction
 
-The Kong Developer Portal ships with a default server side rendered theme, however it is possible to replace this with a Single Page App(SPA). Our example is in Angular using the Angular CLI Tool, but you can follow along with any other javascript framework, with just a few tweaks.
+The Kong Developer Portal ships with a default server side rendered theme, however it is possible to replace this with a Single Page App (SPA). Our example is in Angular using the Angular CLI Tool, but you can follow along with any other javascript framework with just a few tweaks.
 
 To view the basic example Angular template from this this guide view the [`example/spa-angular` branch from the kong-portal-templates branch](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular).
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -1,0 +1,143 @@
+---
+title: Hosting Single Page App out of Kong Dev Portal
+---
+
+### Introduction
+
+The Kong Developer Portal ships with a default server side rendered theme, however it is possible to replace this with a Single Page App(SPA). Our example is in Angular using the Angular CLI Tool, but you can follow along with any other javascript framework, with just a few tweaks.
+
+To view the basic example Angular template from this this guide view the [`example/spa-angular` branch from the kong-portal-templates branch](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular).
+
+### Prerequisites
+
+* Kong Enterprise 1.3 or later
+* Portal Legacy is turned off
+* The Developer Portal is enabled and running
+* kong-portal-cli tool is installed locally
+
+### What is a SPA
+
+A Single Page App(SPA) is a website that loads all the HTML, Javascript, and CSS on the first load. Instead of loading subsequent pages from the server, javascript is used to dynamically change the page content. You may wish to use a SPA in Dev Portal if you have a preexisting SPA you want to integrate with portal, or you are trying to achieve a more application like experience across many pages. A SPA takes control of routing from the server, and handles it client side instead.
+
+If you simplify wish to add interactive javascript to a few pages, it may make more sense to add the javascript to only layouts that require it, and maintain server side rendering. [Learn more about adding Javascipt to a layout without implementing a SPA.](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets)
+
+### Making Choices
+
+Decide what pages routing should be handled by SPA and what is handled by content files.
+
+We recommend Catalog and Spec routes not be handled by SPA
+If you are using Authentication, then you probably also want to leave server-side rendering for any account pages
+
+### Getting Started
+1. Clone down the portal-templates repo
+
+2. Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via javascript.
+
+`router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing from content/spec path or set in headmatter.
+
+The following example `router.conf.yaml` will route all paths to the `content/index.txt`, other then routes needed for authentication and spec handling.
+
+```
+/login: content/login.txt
+/logout: content/logout.txt
+/register: content/register.txt
+/settings: content/settings.txt
+/reset-password: content/reset-password.txt
+/account/invalidate-verification: content/account/invalidate-verification.txt
+/account/resend-verification: content/account/resend-verification.txt
+/account/verify: content/account/resend-verification.txt
+/documentation: content/documentation/index.txt
+/documentation/httpbin: specs/httpbin.json
+/documentation/petstore: specs/petstore.yaml
+/*: content/index.txt
+
+```
+
+### Creating Your SPA
+
+Create SPA app in the javascript framework of your choice
+As a example, we will be using angular.
+```
+ng new
+```
+
+Make sure to include a 404 route, as well as all routes you want to have on the Portal (excluding the routes handled by server-side rendering we excluded above)
+
+Run the build process
+
+For angular:
+```
+ng build
+```
+
+Copy the build output JS and CSS files to a folder inside `workspaces/default/themes/assets/js`
+
+For this example we placed the angular build inside a `workspaces/default/themes/assets/js/ng`
+
+### Mounting a SPA
+
+In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example we will call it `spa.html`
+
+Create a file called `spa.html` in `workspaces/default/themes/layouts`
+
+This file will need to contain the html element that our SPA will mount to as well as the scripts necessary to do this.
+For reference view the index.html inside the build folder created by the build step of our SPA.
+
+We will be using `layouts/_base.html` as the base for layout template, this way we get the <head> element handled the same way other pages in the portal do, as well as the same CSS and scripts.
+
+If you want to have the top nav bar and bottom nav bar, be sure to include them in your layout.
+
+This is what our layout ended up as:
+{% raw %}
+```
+{% layout = "layouts/_base.html" %}
+{-main-}
+
+    {(partials/header.html)}
+    <div class="page">
+        <app-root></app-root>
+    </div>
+    {(partials/footer.html)}
+
+
+    <script src="assets/js/ng/runtime-es2015.js" type="module"></script>
+    <script src="assets/js/ng/runtime-es5.js" nomodule defer></script>
+    <script src="assets/js/ng/polyfills-es5.js" nomodule defer></script>
+    <script src="assets/js/ng/polyfills-es2015.js" type="module"></script>
+    <script src="assets/js/ng/styles-es2015.js" type="module"></script>
+    <script src="assets/js/ng/styles-es5.js" nomodule defer></script>
+    <script src="assets/js/ng/vendor-es2015.js" type="module"></script>
+    <script src="assets/js/ng/vendor-es5.js" nomodule defer></script>
+    <script src="assets/js/ng/main-es2015.js" type="module"></script>
+    <script src="assets/js/ng/main-es5.js" nomodule defer></script>
+
+{-main-}
+```
+{% endraw %}
+
+If your SPA build process creates a css file edit the head.html partial to include your css file.
+
+### Loading your layout
+
+In order to use our layout modify `workspaces/default/content/index.txt` to use our layout,
+The title we set here will be the one that displays until the JS set title loads.
+
+{% raw %}
+```
+---
+layout: spa.html
+title: Home
+---
+```
+{% endraw %}
+
+
+Now using the kong-portal-cli tool we can deploy this portal
+
+From the root folder of the templates repo
+```
+portal deploy default
+```
+
+
+

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -19,7 +19,7 @@ To view the basic example Angular template from this this guide view the [`examp
 
 A Single Page App (SPA) is a website that loads all HTML, Javascript, and CSS on the first load. Instead of loading subsequent pages from the server, javascript is used to dynamically change the page content. You may wish to use a SPA in Dev Portal if you have a preexisting SPA you want to integrate with portal, or you are trying to achieve a more application like experience across many pages. A SPA takes control of routing from the server, and handles it client-side instead.
 
-If you simplify wish to add interactive javascript to a few pages, it may make more sense to add the javascript to only layouts that require it, and maintain server side rendering. [Learn more about adding Javascipt to a layout without implementing a SPA.](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets)
+If you simply wish to add interactive javascript to a few pages, it may make more sense to add the javascript to only layouts that require it, and maintain server side rendering. [Learn more](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding Javascipt to a layout without implementing a SPA.
 
 ### Making Choices
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -34,7 +34,7 @@ If you are using Authentication, then you probably also want to leave server-sid
 
 `router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing set by collections or set in headmatter.
 
-The following example `router.conf.yaml` will route all paths to the `content/index.txt`, other then routes needed for authentication and spec handling.
+In the `router.conf.yaml` example below, we are hardcoding routing for all kong related functionality and deferring to SPA routing for all other routes.  The `/*` route at the bottom of the file is a wildcard route. The wildcard route, in this case, tells Kong to serve `content/index.txt' for any request that is not handled by the route declarations above.
 
 ```
 /login: content/login.txt

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -23,7 +23,6 @@ If you simply wish to add interactive javascript to a few pages, it may make mor
 
 ### Making Choices
 
-Decide what pages routing should be handled by SPA and what is handled by content files.
 
 We recommend Catalog and Spec routes not be handled by SPA
 If you are using Authentication, then you probably also want to leave server-side rendering for any account pages

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -35,7 +35,7 @@ Create a file called `router.conf.yaml` in `workspaces/default` This file will o
 
 `router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing set by collections or set in headmatter.
 
-In the `router.conf.yaml` example below, we are hardcoding routing for all kong related functionality and deferring to SPA routing for all other routes.  The `/*` route at the bottom of the file is a wildcard route. The wildcard route, in this case, tells Kong to serve `content/index.txt' for any request that is not handled by the route declarations above.
+In the `router.conf.yaml` example below, we are hardcoding routing for all kong related functionality and deferring to SPA routing for all other routes.  The `/*` route at the bottom of the file is a wildcard route. The wildcard route, in this case, tells Kong to serve `content/index.txt` for any request that is not handled by the route declarations above.
 
 ```
 /login: content/login.txt

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -28,9 +28,9 @@ We recommend Catalog and Spec routes not be handled by SPA
 If you are using Authentication, then you probably also want to leave server-side rendering for any account pages
 
 ### Getting Started
-1. Clone down the portal-templates repo
+Clone down the portal-templates repo
 
-2. Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via javascript.
+Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via javascript.
 
 `router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing set by collections or set in headmatter.
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -32,7 +32,7 @@ If you are using Authentication, then you probably also want to leave server-sid
 
 2. Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via javascript.
 
-`router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing from content/spec path or set in headmatter.
+`router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing set by collections or set in headmatter.
 
 The following example `router.conf.yaml` will route all paths to the `content/index.txt`, other then routes needed for authentication and spec handling.
 

--- a/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.3-x/developer-portal/theme-customization/single-page-app.md
@@ -19,7 +19,7 @@ To view the basic example Angular template from this guide visit the [`example/s
 
 A Single Page App (SPA) is a website that loads all HTML, Javascript, and CSS on the first load. Instead of loading subsequent pages from the server, javascript is used to dynamically change the page content. You may wish to use a SPA in Dev Portal if you have a preexisting SPA you want to integrate with portal, or you are trying to achieve a more application like experience across many pages. A SPA takes control of routing from the server, and handles it client-side instead.
 
-If you simply wish to add interactive javascript to a few pages, it may make more sense to add the javascript to only layouts that require it, and maintain server side rendering. [Learn more](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding Javascipt to a layout without implementing a SPA.
+Custom javascript can also be added to run only on specific layouts, allowing you to maintain server-side rendering. [Learn more](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding javascript to a layout without implementing a SPA.
 
 ### Making Choices
 
@@ -28,7 +28,8 @@ We recommend Catalog and Spec routes not be handled by SPA
 If you are using Authentication, then you probably also want to leave server-side rendering for any account pages
 
 ### Getting Started
-Clone down the portal-templates repo
+
+Clone the [portal-templates](https://github.com/Kong/kong-portal-templates) repo
 
 Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via javascript.
 
@@ -137,6 +138,4 @@ From the root folder of the templates repo
 ```
 portal deploy default
 ```
-
-
 


### PR DESCRIPTION
This PR adds docs for SPA served out of portal, as well as how to add custom javascript assets.