### PR TITLE
chore(config) make Levi and Aron code owners for master (WIP)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @levfishbluefish @h3xar0n


### PR DESCRIPTION
Goal is to ensure that Team Docs are the only ones who can
approve PRs.

