### PR TITLE
chore(config) explain why CODEOWNERS = Team Docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# Team Docs own all the things, should be tagged in PRs
 *    @Kong/team-docs


### PR DESCRIPTION
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

