### PR TITLE
docs(1.4.x) added `host_header` and `cassandra_refresh_frequency`

### DIFF
--- a/app/1.4.x/clustering.md
+++ b/app/1.4.x/clustering.md
@@ -216,6 +216,9 @@ Additionally, you might want to configure `cassandra_consistency` to a value
 like `QUORUM` or `LOCAL_QUORUM`, to ensure that values being cached by your
 Kong nodes are up-to-date values from your database.
 
+Setting the `cassandra_refresh_frequency` option to `0` is not advised, as a Kong
+restart will be required to discover any changes to the Cassandra cluster topology.
+
 [Back to TOC](#table-of-contents)
 
 ## Interacting with the cache via the Admin API

--- a/app/1.4.x/loadbalancing.md
+++ b/app/1.4.x/loadbalancing.md
@@ -120,9 +120,10 @@ entities.
 
 Each upstream gets its own ring-balancer. Each `upstream` can have many
 `target` entries attached to it, and requests proxied to the 'virtual hostname'
-will be load balanced over the targets. A ring-balancer has a pre-defined
-number of slots, and based on the target weights the slots get assigned to the
-targets of the upstream.
+(which can be overwritten before proxying, using `upstream`'s property
+`host_header`) will be load balanced over the targets. A ring-balancer has a
+pre-defined number of slots, and based on the target weights the slots get
+assigned to the targets of the upstream.
 
 Adding and removing targets can be done with a simple HTTP request on the
 Admin API. This operation is relatively cheap. Changing the upstream


### PR DESCRIPTION
Added `upstream`'s new property `host_header` to load balancing guide.
Added `cassandra_refresh_frequency` to clustering guide.
