### PR TITLE
remove link to index

### DIFF
--- a/app/_data/docs_nav_studio_1.0.x.yml
+++ b/app/_data/docs_nav_studio_1.0.x.yml
@@ -1,5 +1,4 @@
 - title: Kong Studio
-  url: /index
   items:
     - text: Release Notes
       url: /release-notes


### PR DESCRIPTION
Remove `/index` from Kong Studio navigation

