### PR TITLE
docs(ce/nav) add link to grpc guide

### DIFF
--- a/app/_data/docs_nav_1.3.x.yml
+++ b/app/_data/docs_nav_1.3.x.yml
@@ -10,6 +10,9 @@
     - text: Configuring a Service
       url: /getting-started/configuring-a-service
 
+    - text: Configuring a gRPC Service
+      url: /getting-started/configuring-a-grpc-service
+
     - text: Enabling Plugins
       url: /getting-started/enabling-plugins
 

--- a/app/_data/docs_nav_1.4.x.yml
+++ b/app/_data/docs_nav_1.4.x.yml
@@ -10,6 +10,9 @@
     - text: Configuring a Service
       url: /getting-started/configuring-a-service
 
+    - text: Configuring a gRPC Service
+      url: /getting-started/configuring-a-grpc-service
+
     - text: Enabling Plugins
       url: /getting-started/enabling-plugins
 


### PR DESCRIPTION
### Summary

Add missing links to gRPC guide, currently unreachable - unless one uses the search feature.
