### PR TITLE
docs(statsd) fix mismatch in metric namespace

### DIFF
--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -87,12 +87,12 @@ Metric                     | description | namespace
 `request_size`             | tracks the request's body size in bytes | kong.\<service_name>.request.size
 `response_size`            | tracks the response's body size in bytes | kong.\<service_name>.response.size
 `latency`                  | tracks the time interval between the request started and response received from the upstream server | kong.\<service_name>.latency
-`status_count`             | tracks each status code returned in a response | kong.\<service_name>.status.\<status>.count and kong.\<service_name>.status.\<status>.total
+`status_count`             | tracks each status code returned in a response | kong.\<service_name>.request.status.\<status>.count and kong.\<service_name>.request.status.\<status>.total
 `unique_users`             | tracks unique users who made a requests to the underlying Service/Route | kong.\<service_name>.user.uniques
-`request_per_user`         | tracks request/user | kong.\<service_name>.user.\<consumer_id>.count
+`request_per_user`         | tracks request/user | kong.\<service_name>.user.\<consumer_id>.request.count
 `upstream_latency`         | tracks the time it took for the final service to process the request | kong.\<service_name>.upstream_latency
 `kong_latency`             | tracks the internal Kong latency that it took to run all the plugins | kong.\<service_name>.kong_latency
-`status_count_per_user`    | tracks request/status/user | kong.\<service_name>.user.\<customer_id>.status.\<status> and kong.\<service_name>.user.\<customer_id>.status.total
+`status_count_per_user`    | tracks request/status/user | kong.\<service_name>.user.\<customer_id>.request.status.\<status> and kong.\<service_name>.user.\<customer_id>.request.status.total
 
 ### Metric Fields
 


### PR DESCRIPTION
documented namespaces for statsd metrics are mismatching current implementation
metrics for user request `.count`/`.status` and service `.status` have a prefix `.request` that is missing in the doc

References:
- ["%s.user.%s.request.count"](https://github.com/Kong/kong/blob/master/kong/plugins/statsd/handler.lua#L57)
- ["%s.user.%s.request.status"](https://github.com/Kong/kong/blob/master/kong/plugins/statsd/handler.lua#L68) 
- ["%s.request.status](https://github.com/Kong/kong/blob/master/kong/plugins/statsd/handler.lua#L33)