### PR TITLE
provide redirect to new terraform module page

### DIFF
--- a/app/_hub/zillowgroup/kong-terraform/index.md
+++ b/app/_hub/zillowgroup/kong-terraform/index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /hub/kong-inc/kong-terraform-aws
+---


### PR DESCRIPTION
Currently, there are old links to this page that 404.