### PR TITLE
fix(hub) use Kong repo for Terraform

### DIFF
--- a/app/_hub/kong-inc/kong-terraform-aws/index.md
+++ b/app/_hub/kong-inc/kong-terraform-aws/index.md
@@ -12,7 +12,7 @@ desc: Terraform module to provision Kong and Kong Enterprise clusters on Amazon 
 description: |
   Terraform module to provision Kong clusters in Amazon Web Service (AWS) using AWS best practices for architecture and security. Both Kong and Kong Enterprise are supported. Available under the Apache License 2.0 license. 
 
-support_url: https://github.com/zillowgroup/kong-terraform/issues
+support_url: https://github.com/Kong/kong-terraform-aws/issues
 
 source_url: https://github.com/kong/kong-terraform-aws
 


### PR DESCRIPTION
Update the support URL to use the Kong repository rather than the old third-party repository.