### PR TITLE
add red-alert box

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -474,6 +474,12 @@
       background-color: hsl(51, 100%, 96%);
     }
 
+    &.alert-red {
+      color: red;
+      border-color: red;
+      background-color: #fdf3f2;
+    }
+
     ol {
       list-style: none;
       margin-bottom: 0;


### PR DESCRIPTION
Adds CSS for a red alert box:

`<div class="alert alert-red">`

<img width="760" alt="Screen Shot 2019-12-17 at 1 36 45 AM" src="https://user-images.githubusercontent.com/8921227/70983624-e690e100-206d-11ea-93a4-76e131425713.png">


