### PR TITLE
remove Kafka Upstream installation instructions

### DIFF
--- a/app/_hub/kong-inc/kafka-upstream/index.md
+++ b/app/_hub/kong-inc/kafka-upstream/index.md
@@ -121,35 +121,6 @@ params:
 
 ---
 
-## Installation
-
-Manually download and install:
-
-```
-$ git clone https://github.com/kong/kong-plugin-kafka-upstream.git /path/to/kong/plugins/kong-plugin-kafka-upstream
-$ cd /path/to/kong/plugins/kong-plugin-kafka-upstream
-$ luarocks make *.rockspec
-```
-
-In both cases, you need to change your Kong [`plugins` configuration option](https://docs.konghq.com/1.3.x/configuration/#plugins)
-to include this plugin:
-
-```
-plugins = bundled,kafka-upstream
-```
-
-Or, if you don't want to activate any of the bundled plugins:
-
-```
-plugins = kafka-upstream
-```
-
-Then reload kong:
-
-```
-kong reload
-```
-
 ## Configuration
 
 


### PR DESCRIPTION
Kafka Upstream is packaged with Kong Enterprise, and customers do not have access to the Git repo, so these instructions are purely internal for developers.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

