### PR TITLE
Fix URL that was pointing to a 404

### DIFF
--- a/app/enterprise/1.3-x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.3-x/kong-for-kubernetes/install.md
@@ -19,7 +19,7 @@ Before installing Kong for Kubernetes Enterprise, be sure you have the following
   * If you have a license, continue to [Step 1. Set Kong Enterprise License](#step-1-set-kong-enterprise-license) below. If you need your license file information, contact Kong Support. 
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page. 
   * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-- [Kong Enterprise Docker registry access](https://github.com/Kong/kubernetes-ingress-controller-private/blob/kong-for-kubernetes/docs/deployment/k4k8s-enterprise.md#kong-enterprise-docker-registry-access)
+- Kong Enterprise Docker registry access
 
 
 ## Installing Kong for Kubernetes Enterprise


### PR DESCRIPTION
Removed URL that was pointing to a 404. It was pointing to some non-existing URL.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

