### PR TITLE
fix(serverless) correct example code

### DIFF
--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -87,7 +87,6 @@ different priority in the plugin chain.
 1. Create a file named `custom-auth.lua` with the following content:
 
     ```lua
-    return function()
       -- Get list of request headers
       local custom_auth = kong.request.get_header("x-custom-auth")
 
@@ -99,7 +98,6 @@ different priority in the plugin chain.
 
       -- Remove custom authentication header from request
       kong.service.request.clear_header('x-custom-auth')
-    end
     ```
 
 4. Ensure the file contents:
@@ -156,19 +154,17 @@ different priority in the plugin chain.
     - name: pre-function
       config:
         functions: |
-          return function()
-            -- Get list of request headers
-            local custom_auth = kong.request.get_header("x-custom-auth")
+          -- Get list of request headers
+          local custom_auth = kong.request.get_header("x-custom-auth")
 
-            -- Terminate request early if our custom authentication header
-            -- does not exist
-            if not custom_auth then
-              return kong.response.exit(401, "Invalid Credentials")
-            end
-
-            -- Remove custom authentication header from request
-            kong.service.request.clear_header('x-custom-auth')
+          -- Terminate request early if our custom authentication header
+          -- does not exist
+          if not custom_auth then
+            return kong.response.exit(401, "Invalid Credentials")
           end
+
+          -- Remove custom authentication header from request
+          kong.service.request.clear_header('x-custom-auth')
     ```
 
 2. Test that our Lua code will terminate the request when no header is passed:


### PR DESCRIPTION
Remove wrapping function from serverless plugin code examples. This reapplies parts of 8cdcfd8c5e57aaa56d2ebf3d3fb50cd9ffa3072c that appear to have been accidentally clobbered by d55c2dbbda9b4eb020ba218b7e255e5ee4848998 for the 1.3 docs release.

