### PR TITLE
docs(hub) update cors methods defaults

### DIFF
--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -66,7 +66,7 @@ params:
         List of allowed domains for the `Access-Control-Allow-Origin` header. If you wish to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes. **NOTE**: Prior to Kong 0.10.x, this parameter was `config.origin` (note the change in trailing `s`), and only accepted a single value, or the `*` special value.
     - name: methods
       required: false
-      default: "`GET, HEAD, PUT, PATCH, POST`"
+      default: "`GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS, TRACE, CONNECT`"
       value_in_examples: [ "GET", "POST" ]
       description:
         Value for the `Access-Control-Allow-Methods` header


### PR DESCRIPTION
As per: https://github.com/Kong/kong/blob/master/kong/plugins/cors/handler.lua#L218 , the defaults list has grown much larger.
