### PR TITLE
docs(cli/changelog) mention db_import limitations

### DIFF
--- a/app/enterprise/1.3-x/cli.md
+++ b/app/enterprise/1.3-x/cli.md
@@ -52,10 +52,9 @@ The available commands are:
                                       get you started.
 
   db_import <file>                    Import a declarative config file into
-                                      the Kong database.
-                                      
-  db_export <file>                    Export the Kong database into a
-                                      declarative config file.
+                                      the Kong database. db_import supports 
+                                      most Admin API entities except for Admins,
+                                      RBAC users, roles, and permissions. 
 
   parse <file>                        Parse a declarative config file (check
                                       its syntax) but do not load it into Kong.
@@ -65,6 +64,8 @@ Options:
  -p,--prefix      (optional string)   Override prefix directory.
 
 ```
+
+*Note:* `db_export` is not currently supported in Kong Enterprise.
 
 [Back to TOC](#table-of-contents)
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -44,7 +44,6 @@ layout: changelog
 
 * Fixes issue where settings in the kong configuration file did not always update `.kong_env `
 * Fixes issue where updating a plugin with a similar payload as its initial configuration resulted in a schema violation
-* Fixes issue where `db_export` erred on exporting the `keyauth_credentials` table
 * Fixes issue where `db_import` would fail due to missing libraries
 
 #### Kong Developer Portal
@@ -686,7 +685,10 @@ attempting to fetch headers during the ssl_cert phase.
 - **Bulk database import** using the same declarative
   configuration format as the in-memory mode, using the new command:
   `kong config db_import kong.yml`. This command upserts all
-  entities specified in the given `kong.yml` file in bulk
+  entities specified in the given `kong.yml` file in bulk.
+   * Known issue for db_import/db_export in Kong Enterprise
+      - `db_import` supports all API Gateway entities, with the exception of Admins and RBAC users and roles. This limitation is because credentials are hashed.
+      - `db_export` is not supported at all.
 - New command: `kong config init` to generate a template `kong.yml`
   file to get you started
 - New command: `kong config parse kong.yml` to verify the syntax of


### PR DESCRIPTION
Warns against using `db_import` and mentions that we don't support `db_export` for Enterprise. 