### PR TITLE
docs(vitals) simplify influx vitals docs

### DIFF
--- a/app/enterprise/1.3-x/admin-api/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/1.3-x/admin-api/vitals/vitals-influx-strategy.md
@@ -26,19 +26,12 @@ local InfluxDB instance is possible via Docker:
 ```bash
 $ docker run -p 8086:8086 \
       -v $PWD:/var/lib/influxdb \
+      -e INFLUXDB_DB=kong \
       influxdb
 ```
 
-Writing Vitals data to InfluxDB requires that the `kong` database is created.
-Currently, this operation must be done manually. This can be done via the
-`influx` CLI:
-
-```bash
-influx> create database kong;
-```
-
-Alternatively the [InfluxDB API](https://docs.influxdata.com/influxdb/v1.7/tools/api/#query-http-endpoint)
-may be queried directly to create the database.
+Writing Vitals data to InfluxDB requires that the `kong` database is created, 
+this is done using the `INFLUXDB_DB` variable.
 
 ### Configuring Kong
 


### PR DESCRIPTION
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->
When following these docs, for [this spike](https://github.com/Kong/kong-collector/pull/382/files) I stumbled over the process of creating the initial influxdb kong database. It appears that adding an environment variable to the docker environment allows us to remove 10 lines of docs.