### PR TITLE
Update property-reference.md

### DIFF
--- a/app/enterprise/1.3-x/property-reference.md
+++ b/app/enterprise/1.3-x/property-reference.md
@@ -2422,7 +2422,7 @@ Different strategies are available to tune
 how to enforce splitting traffic of
 workspaces.
 
-- 'smart' is the default option and uses the algorithm described in
+- 'smart' is the default option and uses the algorithm described in [this example](https://docs.konghq.com/enterprise/1.3-x/admin-api/workspaces/examples/#important-note-conflicting-apis-or-routes-in-workspaces)
 - 'off' disables any check
 - 'path' enforces routes to comply with the pattern described in config enforce_route_path_pattern
 
@@ -2454,7 +2454,7 @@ The strategy used to validate routes when creating or updating them.
 Different strategies are available to tune how to enforce splitting
 traffic of workspaces.
 
-- `smart` is the default option and uses the algorithm described in [this example](https://docs.konghq.com/enterprise/0.37-x/workspaces/examples/#important-note-conflicting-apis-or-routes-in-workspaces)
+- `smart` is the default option and uses the algorithm described in [this example](https://docs.konghq.com/enterprise/1.3-x/admin-api/workspaces/examples/#important-note-conflicting-apis-or-routes-in-workspaces)
 
 - `off` disables all checks.
 


### PR DESCRIPTION
Fixed the link destination in "Workspaces" and added the missing link to the "Route Collision Detection and Prevention"

The "Route Collision Detection and Prevention" section is followed by the "Workspaces" section which has duplicated the same information. Should the Workspaces section be deleted?

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

