### PR TITLE
Removing Host header known issue from CORS plugin

### DIFF
--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -104,19 +104,3 @@ params:
 ## Known issues
 
 Below is a list of known issues or limitations for this plugin.
-
-### CORS Limitations
-
-If the client is a browser, there is a known issue with this plugin caused by a
-limitation of the CORS specification that doesn't allow to specify a custom
-`Host` header in a preflight `OPTIONS` request.
-
-Because of this limitation, this plugin will only work for Routes that have been
-configured with a `paths` setting, and it will not work for Routes that
-are being resolved using a custom DNS (the `hosts` property).
-
-To learn how to configure `paths` for a Route, please read the [Proxy
-Reference][proxy-reference].
-
-[configuration]: /latest/configuration
-[proxy-reference]: /0.12.x/proxy#request-uri


### PR DESCRIPTION
Since most browsers do send the Host header, the known issue in CORS plugin is outdated.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS

![image](https://user-images.githubusercontent.com/6049847/73948327-9993f300-48d7-11ea-8e7c-496b23f3f02a.png)
