### PR TITLE
Update JWT plugin docs

### DIFF
--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -8,7 +8,7 @@ description: |
 
   - a query string parameter,
   - a cookie,
-  - or the Authorization header.
+  - or HTTP request headers
 
   Kong will either proxy the request to your upstream services if the token's signature is verified, or discard the request if not. Kong can also perform verifications on some of the registered claims of RFC 7519 (exp and nbf).
 
@@ -73,6 +73,10 @@ params:
       required: false
       default:
       description: A list of cookie names that Kong will inspect to retrieve JWTs.
+    - name: header_names
+      required: false
+      default: "`Authorization`"
+      description: A list of HTTP header names that Kong will inspect to retrieve JWTs.
     - name: claims_to_verify
       required: false
       default:
@@ -258,7 +262,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMzZjMzA0OWIzNjI0OWEzYzlmODg5MWN
 
 ### Send a request with the JWT
 
-The JWT can now be included in a request to Kong by adding it to the `Authorization` header:
+The JWT can now be included in a request to Kong by adding it as a header, if configured in `config.header_names` (which contains `Authorization` by default):
 
 ```bash
 $ curl http://kong:8000/{route path} \


### PR DESCRIPTION
Adding documentation for custom header names for the JWT plugin via `config.header_names` (which was added in [this commit](https://github.com/Kong/kong/commit/25638a606186a4561a04d228c78b7c315a2dffc9#diff-c0d3a6670f6b464eda1575b4489b4bb4) back in June 2019).