### PR TITLE
docs(ce/2.0/nav) add grpc getting started link

### DIFF
--- a/app/_data/docs_nav_2.0.x.yml
+++ b/app/_data/docs_nav_2.0.x.yml
@@ -10,6 +10,9 @@
     - text: Configuring a Service
       url: /getting-started/configuring-a-service
 
+    - text: Configuring a gRPC Service
+      url: /getting-started/configuring-a-grpc-service
+
     - text: Enabling Plugins
       url: /getting-started/enabling-plugins
 


### PR DESCRIPTION
Adds a link to the gRPC topic in the CE Getting Started section.
