### PR TITLE
docs(plugins) add Kubernetes info for request-transformer-advanced

### DIFF
--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -145,7 +145,7 @@ params:
 
 ### Template as Value
 
-User can use any of the the current request headers, query params, and captured URI named groups as template to populate above supported config fields.
+User can use any of the the current request headers, query params, and captured URI groups as template to populate above supported config fields.
 
 | Request Param | Template
 | --------- | -----------
@@ -169,6 +169,14 @@ $ curl -X POST http://localhost:8001/apis \
     --data-urlencode 'uris=/requests/user/(?<user_id>\w+)' \
     --data "strip_uri=false"
 ```
+
+<div class="alert alert-info.blue" role="alert">
+  **Kubernetes users:** version `v1beta1` of the Ingress specification does not
+  allow the use of named regex capture groups in paths. If you use the ingress
+  controller, you should use unnamed groups, e.g. `(\w+)/` instead of
+  `(?<user_id>\w+)`. You can access these based on their order in the URL path,
+  e.g. `$(uri_captures[1])` will obtain the value of the first capture group.
+</div>
 
 Enable the ‘request-transformer-advanced’ plugin to add a new header `x-consumer-id`
 and its value is being set with the value sent with header `x-user-id` or

--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -171,11 +171,12 @@ $ curl -X POST http://localhost:8001/apis \
 ```
 
 <div class="alert alert-info.blue" role="alert">
-  **Kubernetes users:** version `v1beta1` of the Ingress specification does not
-  allow the use of named regex capture groups in paths. If you use the ingress
-  controller, you should use unnamed groups, e.g. `(\w+)/` instead of
-  `(?<user_id>\w+)`. You can access these based on their order in the URL path,
-  e.g. `$(uri_captures[1])` will obtain the value of the first capture group.
+  <strong>Kubernetes users:</strong> version <code>v1beta1</code> of the Ingress
+  specification does not allow the use of named regex capture groups in paths.
+  If you use the ingress controller, you should use unnamed groups, e.g.
+  <code>(\w+)/</code> instead of <code>(?<user_id>\w+)</code>. You can access
+  these based on their order in the URL path, e.g. <code>$(uri_captures[1])</code>
+  will obtain the value of the first capture group.
 </div>
 
 Enable the ‘request-transformer-advanced’ plugin to add a new header `x-consumer-id`

--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -174,7 +174,7 @@ $ curl -X POST http://localhost:8001/apis \
   <strong>Kubernetes users:</strong> version <code>v1beta1</code> of the Ingress
   specification does not allow the use of named regex capture groups in paths.
   If you use the ingress controller, you should use unnamed groups, e.g.
-  <code>(\w+)/</code> instead of <code>(?<user_id>\w+)</code>. You can access
+  <code>(\w+)/</code> instead of <code>(?&lt;user_id&gt;\w+)</code>. You can access
   these based on their order in the URL path, e.g. <code>$(uri_captures[1])</code>
   will obtain the value of the first capture group.
 </div>

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -141,11 +141,12 @@ remove --> rename --> replace --> add --> append
 ## Examples
 
 <div class="alert alert-info.blue" role="alert">
-  **Kubernetes users:** version `v1beta1` of the Ingress specification does not
-  allow the use of named regex capture groups in paths. If you use the ingress
-  controller, you should use unnamed groups, e.g. <code>(\w+)/</code> instead of
-  <code>(?<user_id>\w+)</code>. You can access these based on their order in the URL path,
-  e.g. <code>$(uri_captures[1])</code> will obtain the value of the first capture group.
+  <strong>Kubernetes users:</strong> version <code>v1beta1</code> of the Ingress
+  specification does not allow the use of named regex capture groups in paths.
+  If you use the ingress controller, you should use unnamed groups, e.g.
+  <code>(\w+)/</code> instead of <code>(?<user_id>\w+)</code>. You can access
+  these based on their order in the URL path, e.g. <code>$(uri_captures[1])</code>
+  will obtain the value of the first capture group.
 </div>
 
 In these examples we have the plugin enabled on a Service. This would work

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -140,6 +140,14 @@ remove --> rename --> replace --> add --> append
 
 ## Examples
 
+<div class="alert alert-info.blue" role="alert">
+  **Kubernetes users:** version `v1beta1` of the Ingress specification does not
+  allow the use of named regex capture groups in paths. If you use the ingress
+  controller, you should use unnamed groups, e.g. <code>(\w+)/</code> instead of
+  <code>(?<user_id>\w+)</code>. You can access these based on their order in the URL path,
+  e.g. <code>$(uri_captures[1])</code> will obtain the value of the first capture group.
+</div>
+
 In these examples we have the plugin enabled on a Service. This would work
 similarly for Routes.
 

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -144,7 +144,7 @@ remove --> rename --> replace --> add --> append
   <strong>Kubernetes users:</strong> version <code>v1beta1</code> of the Ingress
   specification does not allow the use of named regex capture groups in paths.
   If you use the ingress controller, you should use unnamed groups, e.g.
-  <code>(\w+)/</code> instead of <code>(?<user_id>\w+)</code>. You can access
+  <code>(\w+)/</code> instead of <code>(?&lt;user_id&gt;\w+)</code>. You can access
   these based on their order in the URL path, e.g. <code>$(uri_captures[1])</code>
   will obtain the value of the first capture group.
 </div>


### PR DESCRIPTION
Add Kubernetes-specific guidance for the request-transformer-advanced plugin's capture group functionality.

See https://kubernetes.slack.com/archives/CDCA87FRD/p1581616660335200 for context.