### PR TITLE
docs(prometheus) update the custom server block snippet

### DIFF
--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -198,8 +198,8 @@ allow access to the `/metrics` endpoint to Prometheus.
         location / {
             default_type text/plain;
             content_by_lua_block {
-                local serve = require "kong.plugins.prometheus.serve"
-                serve.prometheus_server()
+                local prometheus = require "kong.plugins.prometheus.exporter"
+                prometheus:collect()
             }
         }
 


### PR DESCRIPTION
Assuming `app/_hub/kong-inc/prometheus/index.md` refers to the latest plugin version, the changes of #1227 should have been made to that file instead of `app/_hub/kong-inc/prometheus/0.1-x.md`

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

