### PR TITLE
Updated 1301 changelog, removed alpha tag

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -75,8 +75,8 @@ layout: changelog
 ### Features
 
 * Kong Enterprise now officially supports RHEL 8
+* Kong Enterprise now has a License Reports module for customers to view current usage metrics. For more information, contact your Kong Account Executive.
 * (Alpha feature) Kong Enterprise can now perform encryption-at-rest for sensitive fields within the data store (Postgres or Cassandra).
-* (Alpha feature) Kong Enterprise now has a License Reports module for customers to view current usage metrics. For more information, contact your Kong Account Executive.
 
 #### Kong Developer Portal:
 


### PR DESCRIPTION
Removed "alpha" tag for license report feature in 1.3.0.1 changelog, as it's not an alpha feature, and we now have a topic in the docs. https://docs.konghq.com/enterprise/1.3-x/deployment/licenses/report/. While the topic applies to 1.3.0.2, the 1.3.0.1 license report info is valid and works, so not considered alpha. Our only hesitation is how Kong helps the user to run this report, and how we track info.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

