### PR TITLE
Invalid example, postgresql -> postgres

### DIFF
--- a/app/2.0.x/plugin-development/custom-entities.md
+++ b/app/2.0.x/plugin-development/custom-entities.md
@@ -90,7 +90,7 @@ A migration file is a Lua file which returns a table with the following structur
 ``` lua
 -- `<plugin_name>/migrations/000_base_my_plugin.lua`
 return {
-  postgresql = {
+  postgres = {
     up = [[
       CREATE TABLE IF NOT EXISTS "my_plugin_table" (
         "id"           UUID                         PRIMARY KEY,
@@ -123,7 +123,7 @@ return {
 
 -- `<plugin_name>/migrations/001_100_to_110.lua`
 return {
-  postgresql = {
+  postgres = {
     up = [[
       DO $$
       BEGIN


### PR DESCRIPTION
Example is invalid. Should be postgres, see for another example: https://github.com/Kong/kong/blob/2.0.1/kong/plugins/basic-auth/migrations/000_base_basic_auth.lua

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

