### PR TITLE
fix(distributions) adjust the CE supported distributions install links

### DIFF
--- a/app/install/centos.md
+++ b/app/install/centos.md
@@ -13,6 +13,7 @@ Start by downloading the corresponding package for your configuration:
 
 - [CentOS 6]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/6/kong-{{site.data.kong_latest.version}}.el6.amd64.rpm)
 - [CentOS 7]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/7/kong-{{site.data.kong_latest.version}}.el7.amd64.rpm)
+- [CentOS 8]({{ site.links.download }}/kong-rpm/download_file?file_path=centos/8/kong-{{site.data.kong_latest.version}}.el8.amd64.rpm)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/debian.md
+++ b/app/install/debian.md
@@ -11,9 +11,10 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [7 Wheezy]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.wheezy.amd64.deb)
 - [8 Jessie]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.jessie.amd64.deb)
 - [9 Stretch]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.stretch.amd64.deb)
+- [10 Buster]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.buster.amd64.deb)
+- [11 Bullseye]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.bullseye.amd64.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -13,8 +13,8 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [RHEL 6]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/6/kong-{{site.data.kong_latest.version}}.rhel6.amd64.rpm)
 - [RHEL 7]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/7/kong-{{site.data.kong_latest.version}}.rhel7.amd64.rpm)
+- [RHEL 8]({{ site.links.download }}/kong-rpm/download_file?file_path=rhel/7/kong-{{site.data.kong_latest.version}}.rhel8.amd64.rpm)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -11,10 +11,7 @@ breadcrumbs:
 
 Start by downloading the corresponding package for your configuration:
 
-- [12.04 Precise]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.precise.amd64.deb)
-- [14.04 Trusty]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.trusty.amd64.deb)
 - [16.04 Xenial]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.xenial.amd64.deb)
-- [17.04 Zesty]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.zesty.amd64.deb)
 - [18.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.bionic.amd64.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.


### PR DESCRIPTION
when we released 2.0 we pruned some EOL (or near EOL) distributions and added a few new options