### PR TITLE
docs(autodoc/api) make it clear that the database status info

### DIFF
--- a/autodoc-admin-api/data.lua
+++ b/autodoc-admin-api/data.lua
@@ -245,8 +245,9 @@ return {
                   connections waiting for a request.
             * `database`: Metrics about the database.
                 * `reachable`: A boolean value reflecting the state of the
-                  database connection. Please note that this flag **does not**
-                  reflect the health of the database itself.
+                  main database connection. Please note that this flag **does not**
+                  reflect the health of the database itself nor does it reflect the
+                  state of the read-only connection (if enabled).
           ]],
         },
       }


### PR DESCRIPTION
returned by `/status` endpoint does not reflect the status of
read-only database connections yet
