### PR TITLE
Removed KeyConcepts from GetStarted Overview

### DIFF
--- a/app/enterprise/1.3-x/getting-started/index.md
+++ b/app/enterprise/1.3-x/getting-started/index.md
@@ -18,40 +18,6 @@ Each guide also contains links to more in-depth material. Note that Kong
 [contact Support](https://support.konghq.com/support/s/) and they will be happy
  to help.
 
-### Key Concepts
-
-The following concepts have a special meaning in Kong Enterprise:
-
-* **Plugin**: a plugin executing actions inside Kong before or after a request
- has been proxied to the upstream API.
-
-* **Workspace**: a private, segmented part of a shared Kong cluster that allows
-a particular team to access its own Admin API entities separately from other teams.
-
-* **Admin**: a Kong Enterprise user capable of accessing Admin API entities based
- on a set of **Permissions**.
-
-* **Permission**: an ability to create, read, update, or destroy an Admin API
- entity defined by endpoints.
-
-* **Role**: a set of **Permissions** that may be reused and assigned to **Admins**.
-
-* **Super Admin**: an **Admin** whose **Role** has the **Permission** to:
-  * invite and disable other **Admin** accounts
-  * assign and revoke **Roles**
-  * create new **Roles** with custom **Permissions**
-  * create new **Workspaces**
-
-* **Service**: the Admin API entity representing an external _upstream_ API or
- microservice.
-
-* **Route**: the Admin API entity representing a way to map downstream requests
- to upstream services.
-
-* **Consumer**: the Admin API entity representing a developer or machine using
- the API. When using Kong, a Consumer only communicates with Kong which proxies
- every call to the said upstream API.
-
 ## Get Started
 
 <div class="docs-grid">


### PR DESCRIPTION
We now have a Concepts section in the front of the Getting Started Guide.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

