### PR TITLE
Removing duplicate entries for RBAC and workspaces

### DIFF
--- a/app/_data/docs_nav_ee_1.3-x.yml
+++ b/app/_data/docs_nav_ee_1.3-x.yml
@@ -124,10 +124,6 @@
     url: /admin-api/#upstream-object
   - text: Target Object
     url: /admin-api/#target-object
-  - text: Workspace Object routes
-    url: /admin-api/workspaces/reference
-  - text: RBAC Object routes
-    url: /admin-api/rbac/reference
   - text: Workspaces
     url: /admin-api/workspaces/reference
   - text: RBAC


### PR DESCRIPTION
ToC has two entries for RBAC and workspaces just one space apart, and the links are the same. Looks like a holdover from a previous release. Removing the extras.