### PR TITLE
Fixing steps for ubuntu

### DIFF
--- a/app/enterprise/1.3-x/deployment/installation/ubuntu.md
+++ b/app/enterprise/1.3-x/deployment/installation/ubuntu.md
@@ -138,31 +138,26 @@ PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu "snap
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 
-1. Create an environment variable with the desired **Super Admin** password and keep password in a safe place:
+1. Create an environment variable with the desired **Super Admin** password and keep password in a safe place.  Run migrations to prepare the Kong database.
+:
 
     ```bash
-    $ export KONG_PASSWORD=<password-only-you-know>
+    $ sudo KONG_PASSWORD=<password-only-you-know> /usr/local/bin/kong migrations bootstrap -c /etc/kong/kong.conf
     ```
 
-2. Run migrations to prepare the Kong database.
-
-    ```bash
-    $ sudo /usr/local/bin/kong migrations bootstrap -c /etc/kong/kong.conf
-    ```
-
-3. Start Kong Enterprise:
+2. Start Kong Enterprise:
 
     ```bash
     $ sudo /usr/local/bin/kong start -c /etc/kong/kong.conf
     ```
 
-4. Verify Kong Enterprise is working:
+3. Verify Kong Enterprise is working:
 
     ```bash
     $ curl -i -X GET --url http://localhost:8001/services
     ```
 
-5. You should receive a `HTTP/1.1 200 OK` message.
+4. You should receive a `HTTP/1.1 200 OK` message.
 
 ## Step 6. Finalize your Configuration and Verify Kong was Successfully installed:
 

--- a/app/enterprise/1.3-x/deployment/installation/ubuntu.md
+++ b/app/enterprise/1.3-x/deployment/installation/ubuntu.md
@@ -138,7 +138,7 @@ PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu "snap
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 
-1. Create an environment variable with the desired **Super Admin** password and keep password in a safe place.  Run migrations to prepare the Kong database.
+1. Create an environment variable with the desired **Super Admin** password and store the password in a safe place. Run migrations to prepare the Kong database:
 :
 
     ```bash

--- a/app/enterprise/1.3-x/deployment/installation/ubuntu.md
+++ b/app/enterprise/1.3-x/deployment/installation/ubuntu.md
@@ -139,7 +139,6 @@ PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu "snap
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 
 1. Create an environment variable with the desired **Super Admin** password and store the password in a safe place. Run migrations to prepare the Kong database:
-:
 
     ```bash
     $ sudo KONG_PASSWORD=<password-only-you-know> /usr/local/bin/kong migrations bootstrap -c /etc/kong/kong.conf


### PR DESCRIPTION
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->
Hi team 👋 

I ran into an issue that `kong migrations bootstrap` command didn't seed a password properly for `kong_admin`.

I realized the issue is coming from that we need to make sure the `KONG_PASSWORD` envvar is attached to the user that runs `kong migrations bootstrap` command.

I've confirmed with @felderi to run through this fix will seed a password properly.

Thanks!
