### PR TITLE
Corrected the header for debugging route

### DIFF
--- a/app/enterprise/1.3-x/proxy.md
+++ b/app/enterprise/1.3-x/proxy.md
@@ -479,7 +479,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 


### PR DESCRIPTION
X-Kong-Debug is incorrect it doesn't work for returning the routeid in response header, correct name for header is Kong-Debug

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

