### PR TITLE
docs (plugins) Fixing table styling in plugins

### DIFF
--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -45,6 +45,14 @@
     h2, h4, p .highlight {
       margin: 0 0 2.5rem 0;
     }
+    table {
+      p {
+        font-size: 14px;
+      }
+      code {
+        font-size: 13px;
+      }
+    }
   }
 
   .alert-info {

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -227,16 +227,16 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
     {% endif %}
       <tr><td><code>enabled</code><br><br><strong>default value: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
     {% if page.params.api_id %}
-    <tr><td><code>api_id</code></td><td>The id of the API which this plugin will target. <strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
+    <tr><td><code>api_id</code></td><td>The id of the API which this plugin will target. <br><br><strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
     {% endif %}
     {% for field in page.params.config %}
       <tr>
         <td><code>config.{{ field.name }}</code>
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default }}{% endif %}
+          {% if field.default != nil %}<br><br><strong>default value: </strong><code>{{ field.default }}</code>{% endif %}
         </td>
-        <td>{{ field.description }}</td>
+        <td>{{ field.description | markdownify }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -211,7 +211,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 {% capture params_table %}
 <table>
   <thead>
-    <tr><th>form parameter</th><th>description</th></tr>
+    <tr><th>Form Parameter</th><th>Description</th></tr>
   </thead>
   <tbody>
     <tr><td><code>name</code></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code></td></tr>
@@ -234,9 +234,9 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
         <td><code>config.{{ field.name }}</code>
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default | markdownify }}{% endif %}
+          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default }}{% endif %}
         </td>
-        <td>{{ field.description | markdownify }}</td>
+        <td>{{ field.description }}</td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
Plugin parameter tables were pulling in two different styles depending on the source of the value. This change makes them consistent with the styling in the rest of the docs. 

Old table formatting: https://docs.konghq.com/hub/kong-inc/forward-proxy/#parameters
Fixed formatting preview: https://deploy-preview-1877--kongdocs.netlify.com/hub/kong-inc/forward-proxy/#parameters