### PR TITLE
docs(plugins) Changing color of plugin version checkmark

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -8640,7 +8640,7 @@ a.text-gray-dark:focus,a.text-gray-dark:hover {
 }
 
 .fa-check:before {
-    content: "";
+    content: ""
 }
 
 .fa-close:before,.fa-remove:before,.fa-times:before {

--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -8640,7 +8640,8 @@ a.text-gray-dark:focus,a.text-gray-dark:hover {
 }
 
 .fa-check:before {
-    content: ""
+    content: "";
+    color: #21A959
 }
 
 .fa-close:before,.fa-remove:before,.fa-times:before {

--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -8641,7 +8641,6 @@ a.text-gray-dark:focus,a.text-gray-dark:hover {
 
 .fa-check:before {
     content: "";
-    color: #21A959
 }
 
 .fa-close:before,.fa-remove:before,.fa-times:before {

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -25,6 +25,10 @@
   }
 }
 
+.fa-check:before {
+    color: #21A959
+  }
+
 .page-extension-profile {
   .content {
     padding-top: 35px;


### PR DESCRIPTION
Plugin pages list versions in their sidebar, with a checkmark or an x to indicate support. Changing the checkmark to green to make it stand out from the x. 

Old doc example: https://docs.konghq.com/hub/okta/okta/
Preview: https://deploy-preview-1878--kongdocs.netlify.com/hub/okta/okta/