### PR TITLE
Move db_export note in kong config doc

### DIFF
--- a/app/enterprise/1.3-x/cli.md
+++ b/app/enterprise/1.3-x/cli.md
@@ -41,7 +41,7 @@ Check the validity of a given Kong configuration file.
 
 
 ### kong config
-
+*Note:* `db_export` is not currently supported in Kong Enterprise.
 ```
 Usage: kong config COMMAND [OPTIONS]
 
@@ -65,7 +65,6 @@ Options:
 
 ```
 
-*Note:* `db_export` is not currently supported in Kong Enterprise.
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
Moved the "db_export" note from after the table to before the table for the kong config param. Needed to make more visible.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

