### PR TITLE
updated oidc.md

### DIFF
--- a/app/enterprise/1.3-x/developer-portal/configuration/authentication/oidc.md
+++ b/app/enterprise/1.3-x/developer-portal/configuration/authentication/oidc.md
@@ -73,7 +73,7 @@ Example:
   "scopes": ["openid","profile","email","offline_access"],
   "logout_query_arg": "logout",
   "client_id": ["<CLIENT_ID>"],
-  "login_redirect_uri": ["https://example.portal.com],
+  "login_redirect_uri": ["https://example.portal.com"],
   "login_action": "redirect",
   "logout_redirect_uri": ["https://example.portal.com"],
   "ssl_verify": false,


### PR DESCRIPTION
missing closing quotes on the ODIC config
 "login_redirect_uri": ["https://example.portal.com"],

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

