### PR TITLE
fix(ldap) indent code to to render pipe-character properly

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/0.33-x.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/0.33-x.md
@@ -132,7 +132,7 @@ params:
 In order to authenticate the user, client must set credentials in
 `Proxy-Authorization` or `Authorization` header in following format:
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the
 credential for future requests for the duration specified in

--- a/app/_hub/kong-inc/ldap-auth-advanced/0.34-x.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/0.34-x.md
@@ -132,7 +132,7 @@ params:
 In order to authenticate the user, client must set credentials in
 `Proxy-Authorization` or `Authorization` header in following format:
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the
 credential for future requests for the duration specified in

--- a/app/_hub/kong-inc/ldap-auth-advanced/0.35-x.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/0.35-x.md
@@ -140,7 +140,7 @@ params:
 In order to authenticate the user, client must set credentials in
 `Proxy-Authorization` or `Authorization` header in following format:
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the
 credential for future requests for the duration specified in

--- a/app/_hub/kong-inc/ldap-auth-advanced/0.36-x.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/0.36-x.md
@@ -141,7 +141,7 @@ params:
 In order to authenticate the user, client must set credentials in
 `Proxy-Authorization` or `Authorization` header in following format:
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the
 credential for future requests for the duration specified in

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -161,7 +161,7 @@ params:
 In order to authenticate the user, client must set credentials in
 `Proxy-Authorization` or `Authorization` header in following format:
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the
 credential for future requests for the duration specified in

--- a/app/_hub/kong-inc/ldap-auth/0.1-x.md
+++ b/app/_hub/kong-inc/ldap-auth/0.1-x.md
@@ -112,7 +112,7 @@ params:
 
 In order to authenticate the user, client must set credentials in `Proxy-Authorization` or `Authorization` header in following format
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the credential for future requests for the duration specified in `config.cache_ttl`.
 

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -127,7 +127,7 @@ params:
 
 In order to authenticate the user, client must set credentials in `Proxy-Authorization` or `Authorization` header in following format
 
-credentials := [ldap | LDAP] base64(username:password)
+    credentials := [ldap | LDAP] base64(username:password)
 
 The plugin will validate the user against the LDAP server and cache the credential for future requests for the duration specified in `config.cache_ttl`.
 


### PR DESCRIPTION
The pipe character `|` gets interpreted as a table separator when
rendered. By indenting we can prevent this.
