### PR TITLE
chore(gh): add actions to update indices

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -1,0 +1,27 @@
+on:
+  schedules:
+  - cron: 0 0 * * *
+name: Update indices every day
+jobs:
+  updateAlgoliaIndexKongEE:
+    name: Index Kong EE Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run docsearch for Kong EE Docs
+      uses: Embraser01/docsearch-scraper-action@v0.1.0
+      with:
+        apiKey: ${{ secrets.API_KEY }}
+        applicationId: ${{ secrets.APPLICATION_ID }}
+        file: /github/workspace/algolia/config-ee.json
+  updateAlgoliaIndexKongStudio:
+    name: Index Kong Studio Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run docsearch for Kong Studio Docs
+      uses: Embraser01/docsearch-scraper-action@v0.1.0
+      with:
+        apiKey: ${{ secrets.API_KEY }}
+        applicationId: ${{ secrets.APPLICATION_ID }}
+        file: /github/workspace/algolia/config-studio.json

--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -12,7 +12,7 @@ jobs:
       uses: Embraser01/docsearch-scraper-action@v0.1.0
       with:
         apiKey: ${{ secrets.API_KEY }}
-        applicationId: ${{ secrets.APPLICATION_ID }}
+        applicationId: ${{ secrets.ALGOLIA_APPLICATION_ID }}
         file: /github/workspace/algolia/config-ee.json
   updateAlgoliaIndexKongStudio:
     name: Index Kong Studio Docs
@@ -23,5 +23,5 @@ jobs:
       uses: Embraser01/docsearch-scraper-action@v0.1.0
       with:
         apiKey: ${{ secrets.API_KEY }}
-        applicationId: ${{ secrets.APPLICATION_ID }}
+        applicationId: ${{ secrets.ALGOLIA_APPLICATION_ID }}
         file: /github/workspace/algolia/config-studio.json

--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -1,6 +1,6 @@
 on:
-  schedules:
-  - cron: 0 0 * * *
+  schedule:
+  - cron: '0 0 * * *'
 name: Update indices every day
 jobs:
   updateAlgoliaIndexKongEE:


### PR DESCRIPTION
Adds gh-actions cron to update the indices. We need to add

`ALGOLIA_API_KEY`
`ALGOLIA_APPLICATION_ID`

to this repo's setting for this to work. I was not able to test this out so no idea if it actually works. Author of action is no longer maintaining it (https://github.com/Embraser01/docsearch-scraper-action/issues/1#issuecomment-584523791)