### PR TITLE
chore(algolia): add custom action

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -9,19 +9,19 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Run docsearch for Kong EE Docs
-      uses: Embraser01/docsearch-scraper-action@v0.1.0
+      uses: darrenjennings/algolia-docsearch-action@master
       with:
-        apiKey: ${{ secrets.API_KEY }}
-        applicationId: ${{ secrets.ALGOLIA_APPLICATION_ID }}
-        file: /github/workspace/algolia/config-ee.json
+        algolia_api_key: ${{ secrets.API_KEY }}
+        algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+        file: algolia/config-ee.json
   updateAlgoliaIndexKongStudio:
     name: Index Kong Studio Docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Run docsearch for Kong Studio Docs
-      uses: Embraser01/docsearch-scraper-action@v0.1.0
+      uses: darrenjennings/algolia-docsearch-action@master
       with:
-        apiKey: ${{ secrets.API_KEY }}
-        applicationId: ${{ secrets.ALGOLIA_APPLICATION_ID }}
-        file: /github/workspace/algolia/config-studio.json
+        algolia_api_key: ${{ secrets.API_KEY }}
+        algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+        file: algolia/config-studio.json

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ test a config change locally, you will need to run their open source
 [scraper](https://github.com/algolia/docsearch-scraper) against your own
 scraper to test out config changes.
 
+The Enterprise documentation uses paid algolia indices, which auto-update every
+24 hours via a [github action here](/.github/workflows/algolia.yml)
+
 ## Generating the Plugin Development Kit documentation
 
 - Have a local clone of Kong.


### PR DESCRIPTION
The gh action was failing because the author is not supporting it anymore. I've created a new custom gh action and updated our usage.

Custom action:
https://github.com/darrenjennings/algolia-docsearch-action