### PR TITLE
added correlation-id to plugin priority list

### DIFF
--- a/app/enterprise/1.5.x/plugin-development/custom-logic.md
+++ b/app/enterprise/1.5.x/plugin-development/custom-logic.md
@@ -313,7 +313,6 @@ kafka-log                   | 5
 syslog                      | 4
 collector                   | 3
 request-termination         | 2
-correlation-id              | 1
 post-function               | -1000
 
 ---

--- a/app/enterprise/1.5.x/plugin-development/custom-logic.md
+++ b/app/enterprise/1.5.x/plugin-development/custom-logic.md
@@ -262,6 +262,7 @@ The current order of execution for the bundled plugins is:
 Plugin                      | Priority
 ----------------------------|----------
 pre-function                | `+inf`
+correlation-id              | 100001
 zipkin                      | 100000
 exit-transformer            | 9999
 bot-detection               | 2500


### PR DESCRIPTION
added correlation-id to plugin priority list as 100001

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

