### PR TITLE
Fixed the order for 1.5

### DIFF
--- a/app/enterprise/1.5.x/plugin-development/custom-logic.md
+++ b/app/enterprise/1.5.x/plugin-development/custom-logic.md
@@ -262,17 +262,20 @@ The current order of execution for the bundled plugins is:
 Plugin                      | Priority
 ----------------------------|----------
 pre-function                | `+inf`
+correlation-id              | 100001
 zipkin                      | 100000
 exit-transformer            | 9999
 bot-detection               | 2500
 cors                        | 2000
 session                     | 1900
 oauth2-introspection        | 1700
+application-registration    | 1007
 mtls-auth                   | 1006
 kubernetes-sidecar-injector | 1006
 jwt                         | 1005
 degraphql                   | 1005
 oauth2                      | 1004
+vault-auth                  | 1003
 key-auth                    | 1003
 key-auth-enc                | 1003
 ldap-auth                   | 1002
@@ -285,6 +288,7 @@ jwt-signer                  | 999
 ip-restriction              | 990
 request-size-limiting       | 951
 acl                         | 950
+collector                   | 903
 rate-limiting-advanced      | 902
 graphql-rate-limiting-advanced | 902
 rate-limiting               | 901
@@ -292,11 +296,14 @@ response-ratelimiting       | 900
 request-transformer-advanced | 802
 request-transformer         | 801
 response-transformer-advanced | 800
+route-transformer-advanced  | 800
 response-transformer        | 800
 kafka-upstream              | 751
 aws-lambda                  | 750
 azure-functions             | 749
 graphql-proxy-cache-advanced | 100
+proxy-cache-advanced        | 100
+proxy-cache                 | 100
 forward-proxy               | 50
 prometheus                  | 13
 canary                      | 13
@@ -310,9 +317,7 @@ tcp-log                     | 7
 loggly                      | 6
 kafka-log                   | 5
 syslog                      | 4
-collector                   | 3
 request-termination         | 2
-correlation-id              | 1
 post-function               | -1000
 
 ---


### PR DESCRIPTION
👋 @Kong/team-docs 

I've checked the plugins execution order in the fresh Kong EE 1.5 installation.

```bash
$ kong version
Kong Enterprise 1.5.0.0
$ cd /usr/local/share/lua/5.1/kong/plugins/
$ find . | xargs grep  \.PRIORITY |  sort -k 3 -t " " -n -r
./correlation-id/handler.lua:CorrelationIdHandler.PRIORITY = 100001
./exit-transformer/handler.lua:_M.PRIORITY = 9999
./bot-detection/handler.lua:BotDetectionHandler.PRIORITY = 2500
./cors/handler.lua:CorsHandler.PRIORITY = 2000
./oauth2-introspection/handler.lua:OAuth2Introspection.PRIORITY = 1700
./application-registration/handler.lua:PortalAppHandler.PRIORITY = 1007
./mtls-auth/handler.lua:MtlsAuthHandler.PRIORITY = 1006
./jwt/handler.lua:JwtHandler.PRIORITY = 1005
./degraphql/handler.lua:_M.PRIORITY = 1005
./oauth2/handler.lua:OAuthHandler.PRIORITY = 1004
./vault-auth/handler.lua:VaultAuthHandler.PRIORITY = 1003
./key-auth/handler.lua:KeyAuthHandler.PRIORITY = 1003
./key-auth-enc/handler.lua:KeyAuthHandler.PRIORITY = 1003
./ldap-auth/handler.lua:LdapAuthHandler.PRIORITY = 1002
./ldap-auth-advanced/handler.lua:LdapAuthHandler.PRIORITY = 1002
./basic-auth/handler.lua:BasicAuthHandler.PRIORITY = 1001
./hmac-auth/handler.lua:HMACAuthHandler.PRIORITY = 1000
./request-validator/handler.lua:RequestValidator.PRIORITY = 999
./ip-restriction/handler.lua:IpRestrictionHandler.PRIORITY = 990
./request-size-limiting/handler.lua:RequestSizeLimitingHandler.PRIORITY = 951
./acl/handler.lua:ACLHandler.PRIORITY = 950
./collector/handler.lua:CollectorHandler.PRIORITY = 903
./rate-limiting-advanced/handler.lua:NewRLHandler.PRIORITY = 902
./graphql-rate-limiting-advanced/handler.lua:NewRLHandler.PRIORITY = 902
./rate-limiting/handler.lua:RateLimitingHandler.PRIORITY = 901
./response-ratelimiting/handler.lua:ResponseRateLimitingHandler.PRIORITY = 900
./request-transformer-advanced/handler.lua:RequestTransformerHandler.PRIORITY = 802
./response-transformer/handler.lua:ResponseTransformerHandler.PRIORITY = 800
./response-transformer-advanced/handler.lua:ResponseTransformerHandler.PRIORITY = 800
./kafka-upstream/handler.lua:KafkaUpstreamHandler.PRIORITY = 751
./aws-lambda/handler.lua:AWSLambdaHandler.PRIORITY = 750
./request-validator/handler.lua:RequestValidator.PRIORITY = 200
./graphql-proxy-cache-advanced/handler.lua:_GqlCacheHandler.PRIORITY = 100
./forward-proxy/handler.lua:ForwardProxyHandler.PRIORITY = 50
./canary/handler.lua:Canary.PRIORITY = 13
./http-log/handler.lua:HttpLogHandler.PRIORITY = 12
./statsd/handler.lua:StatsdHandler.PRIORITY = 11
./statsd-advanced/handler.lua:StatsdHandler.PRIORITY = 11
./datadog/handler.lua:DatadogHandler.PRIORITY = 10
./file-log/handler.lua:FileLogHandler.PRIORITY = 9
./udp-log/handler.lua:UdpLogHandler.PRIORITY = 8
./tcp-log/handler.lua:TcpLogHandler.PRIORITY = 7
./loggly/handler.lua:LogglyLogHandler.PRIORITY = 6
./kafka-log/handler.lua:KafkaLogHandler.PRIORITY = 5
./syslog/handler.lua:SysLogHandler.PRIORITY = 4
./request-termination/handler.lua:RequestTerminationHandler.PRIORITY = 2
./zipkin/handler.lua:  PRIORITY = 100000,
./session/handler.lua:  PRIORITY = 1900,
./route-transformer-advanced/handler.lua:  PRIORITY = 800,
./request-transformer/handler.lua:  PRIORITY = 801,
./proxy-cache/handler.lua:  PRIORITY = 100,
./proxy-cache-advanced/handler.lua:  PRIORITY = 100,
./prometheus/handler.lua:  PRIORITY = 13,
./pre-function/_handler.lua:    PRIORITY = priority,
./openid-connect/handler.lua:  PRIORITY = 1000,
./kubernetes-sidecar-injector/handler.lua:  PRIORITY = 1006,
./jwt-signer/handler.lua:  PRIORITY = 999,
./azure-functions/handler.lua:  PRIORITY = 749,
```
