### PR TITLE
fix(plugin template) Removing code formatting from plugin default values

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -234,7 +234,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
         <td><code>config.{{ field.name }}</code>
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default }}{% endif %}
+          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default | markdownify }}{% endif %}
         </td>
         <td>{{ field.description | markdownify }}</td>
       </tr>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -234,7 +234,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
         <td><code>config.{{ field.name }}</code>
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default value: </strong><code>{{ field.default }}</code>{% endif %}
+          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default }}{% endif %}
         </td>
         <td>{{ field.description | markdownify }}</td>
       </tr>


### PR DESCRIPTION
Most plugin values are entered in backticks in the individual plugin pages, so having code formatting applied on top adds backticks to the output. Removing that formatting for cleaner output.
