### PR TITLE
Add KONG_PG_USER

### DIFF
--- a/app/install/docker.md
+++ b/app/install/docker.md
@@ -56,6 +56,7 @@ Here is a quick example showing how to connect a Kong container to a Cassandra o
         --network=kong-net \
         -e "KONG_DATABASE=postgres" \
         -e "KONG_PG_HOST=kong-database" \
+        -e "KONG_PG_USER=kong" \
         -e "KONG_PG_PASSWORD=kong" \
         -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
         kong:latest kong migrations bootstrap
@@ -82,6 +83,7 @@ Here is a quick example showing how to connect a Kong container to a Cassandra o
         --network=kong-net \
         -e "KONG_DATABASE=postgres" \
         -e "KONG_PG_HOST=kong-database" \
+        -e "KONG_PG_USER=kong" \
         -e "KONG_PG_PASSWORD=kong" \
         -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
         -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \


### PR DESCRIPTION
We need to add the missing `KONG_PG_USER` for environment variables. Otherwise, we will encounter a `connection refused` error

> Error: [PostgreSQL error] failed to retrieve PostgreSQL server_version_num: connection refused

