### PR TITLE
docs(gsg/expose-services) Fixing port number and tab headings

### DIFF
--- a/app/getting-started-guide/latest/expose-services.md
+++ b/app/getting-started-guide/latest/expose-services.md
@@ -124,12 +124,12 @@ Using the Admin API, issue the following:
 
 *Using cURL*:
 ```
-$ http :8000/mock
+$ curl -i -X GET http://<admin-hostname>:8000/mock
 ```
 
 *Or using HTTPie*:
 ```
-$ curl -i -X GET http://<admin-hostname>:8001/mock
+$ http :8000/mock
 ```
 
 {% endnavtab %}


### PR DESCRIPTION
* Switching the content under "Using cURL" and "Using HTTPie" - it was backwards
* Fixing port number for verifying route