### PR TITLE
Datatdog version updates

### DIFF
--- a/app/_data/extensions/kong-inc/datadog/versions.yml
+++ b/app/_data/extensions/kong-inc/datadog/versions.yml
@@ -1,2 +1,3 @@
+- release: 3.0.x
 - release: 1.0-x
 - release: 0.1-x

--- a/app/_hub/kong-inc/datadog/1.0-x.md
+++ b/app/_hub/kong-inc/datadog/1.0-x.md
@@ -1,7 +1,7 @@
 ---
 name: Datadog
 publisher: Kong Inc.
-version: 3.0.0
+version: 1.0-x
 
 desc: Visualize metrics on Datadog
 description: |
@@ -10,7 +10,7 @@ description: |
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled
-    with versions of Kong prior to 1.4.0 differs from what is documented herein.
+    with versions of Kong prior to 0.11.0 differs from what is documented herein.
     Refer to the
     <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
     for details.
@@ -41,7 +41,6 @@ kong_version_compatibility:
         - 0.6.x
     enterprise_edition:
       compatible:
-        - 1.5.x
         - 1.3-x
         - 0.36-x
         - 0.35-x
@@ -81,18 +80,21 @@ params:
 ---
 
 ## Metrics
-Plugin currently logs the following metrics to the Datadog server about a Service or Route.
+
+Plugin currently logs following metrics to the Datadog server about a Service or Route.
 
 Metric                     | description | namespace
 ---                        | ---         | ---
-`request_count`            | tracks the request | kong.request.count
-`request_size`             | tracks the request's body size in bytes | kong.request.size
-`response_size`            | tracks the response's body size in bytes | kong.response.size
-`latency`                  | tracks the time interval between the request started and response received from the upstream server | kong.latency
-`upstream_latency`         | tracks the time it took for the final service to process the request | kong.upstream\_latency
-`kong_latency`             | tracks the internal Kong latency that it took to run all the plugins | kong.kong\_latency
-
-The metrics will be sent with the tags `name` and `status` carrying the API name and HTTP status code respectively. If you specify `consumer_identifier` with the metric, a tag `consumer` will be added.
+`request_count`            | tracks the request | kong.\<service_name>.request.count
+`request_size`             | tracks the request's body size in bytes | kong.\<service_name>.request.size
+`response_size`            | tracks the response's body size in bytes | kong.\<service_name>.response.size
+`latency`                  | tracks the time interval between the request started and response received from the upstream server | kong.\<service_name>.latency
+`status_count`             | tracks each status code returned as response | kong.\<service_name>.status.\<status>.count and kong.\<service_name>.status.\<status>.total
+`unique_users`             | tracks unique users made a request | kong.\<service_name>.user.uniques
+`request_per_user`         | tracks request/user | kong.\<service_name>.user.\<consumer_id>.count
+`upstream_latency`         | tracks the time it took for the final service to process the request | kong.\<service_name>.upstream_latency
+`kong_latency`             | tracks the internal Kong latency that it took to run all the plugins | kong.\<service_name>.kong_latency
+`status_count_per_user`    | tracks request/status/user | kong.\<service_name>.user.\<customer_id>.status.\<status> and kong.\<service_name>.user.\<customer_id>.status.total
 
 ### Metric fields
 
@@ -110,20 +112,10 @@ Field           | description                                           | allowe
 
 1.  by default all metrics get logged.
 2.  metric with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
+3.  `unique_users` metric only works with `stat_type` as `set`.
+4.  `status_count`, `status_count_per_user` and `request_per_user` work only with `stat_type`  as `counter`.
+5.  `status_count_per_user`, `request_per_user` and `unique_users` must have `customer_identifier` defined.
 
-## Migrating Datadog queries
-The plugin updates replace the api, status, and consumer-specific metrics with a generic metric name.
-You have to change your Datadog queries in dashboards and alerts to reflect the metrics updates.
-
-For example, the following query:
-```
-avg:kong.sample_service.latency.avg{*}
-```
-would need to change to:
-
-```
-avg:kong.latency.avg{name:sample-service}
-```
 
 ## Kong Process Errors
 


### PR DESCRIPTION
Bumping Datadog plugin version to its current actual version 3.0. Also adding in missing 1.0.x file based on its state on February 14th, 2020 prior to the 3.0 updates done by a patch in https://github.com/Kong/docs.konghq.com/pull/1551. Skipping 2.0.x per Lena.

Direct link for review: https://deploy-preview-1988--kongdocs.netlify.app/hub/kong-inc/datadog/