### PR TITLE
docs/add new param config.redis.sentinel_password

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -124,7 +124,7 @@ params:
       value_in_examples:
       description: |
             Sentinel password to authenticate with a Redis Sentinel instance.
-            **Note:** This parameter is only available for {{site.ee_product_name}} versions
+            **Note:** This parameter is only available for Kong Enterprise versions
             1.3.0.2 and later.
     - name: redis.sentinel_role
       required: semi

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -124,7 +124,7 @@ params:
       value_in_examples:
       description: |
             Sentinel password to authenticate with a Redis Sentinel instance.
-            **Note:** This parameter is only available for versions
+            **Note:** This parameter is only available for {{site.ee_product_name}} versions
             1.3.0.2 and later.
     - name: redis.sentinel_role
       required: semi

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -118,6 +118,14 @@ params:
       value_in_examples:
       description: |
         Sentinel master to use for Redis connection when the `redis` strategy is defined. Defining this value implies using Redis Sentinel.
+    - name: redis.sentinel_password
+      required: semi
+      default:
+      value_in_examples:
+      description: |
+            Sentinel password to authenticate with a Redis Sentinel instance.
+            **Note:** This parameter is only available for versions
+            1.3.0.2 and later.
     - name: redis.sentinel_role
       required: semi
       default:


### PR DESCRIPTION
Add new config to adv rate limiting plugin per tickets:

https://konghq.atlassian.net/browse/DOCS-963
https://konghq.atlassian.net/browse/FTI-1113

When a Sentinel node has auth enabled, this pw is required for successful auth between Kong and Sentinel nodes.

@kallecaco3 I took a stab at a description. Please review. Thank you for your assistance. I am also updating the GraphQL plugin per DOCS-998 GraphQL Rate Limiting Advanced errors https://konghq.atlassian.net/browse/DOCS-998; does this option needed to be added there as well? Answer is yes per Karl; will do.

Direct link to generated output for review:

https://deploy-preview-1993--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/#parameters

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

