### PR TITLE
fix(plugins) Approov plugin fixes

### DIFF
--- a/app/_hub/critical-blue/approov/index.md
+++ b/app/_hub/critical-blue/approov/index.md
@@ -4,7 +4,6 @@ publisher: CriticalBlue Ltd
 
 categories:
   - authentication
-  - security
 
 type: integration
 
@@ -22,16 +21,12 @@ source_url: https://github.com/approov/kong_approov-plugin
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 0.14.x
-      - 0.13.x
-      - 0.12.x
-      - 0.11.x
-      - 0.10.x
+      - 1.5.x
+      - 1.4.x
+      - 1.3.x
   enterprise_edition:
     compatible:
-      - 0.34-x
-      - 0.33-x
-      - 0.32-x
+      - 1.5.x
 
 ---
 


### PR DESCRIPTION
Relates to https://konghq.atlassian.net/browse/DOCS-1021. 

* Removed from "security" category and left it in "authentication"; plugin template is misleading, plugin should only be in one category.
* Changed supported versions to versions that were actually tested by the plugin developer

Preview: https://deploy-preview-1998--kongdocs.netlify.app/hub/critical-blue/approov/