### PR TITLE
Algolia workflow: removing Studio index

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -14,14 +14,3 @@ jobs:
         algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
         algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}
         file: algolia/config-ee.json
-  updateAlgoliaIndexKongStudio:
-    name: Index Kong Studio Docs
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Run docsearch for Kong Studio Docs
-      uses: darrenjennings/algolia-docsearch-action@master
-      with:
-        algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
-        algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}
-        file: algolia/config-studio.json


### PR DESCRIPTION
Studio docs got moved into Enterprise so there's no need for a separate index anymore
