### PR TITLE
docs(oauth2-introspection) Note and link to OpenID Connect plugin

### DIFF
--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -12,6 +12,12 @@ description: |
   the Consumer already has an access token that will be validated against a
   third-party OAuth 2.0 server.
 
+  **Note**: The [OpenID Connect Plugin][oidcplugin] supports
+  OAuth 2.0 Token Introspection as well and offers functionality beyond
+  this plugin such as restricting access by scope.
+
+  [oidcplugin]: /hub/kong-inc/openid-connect/
+
 enterprise: true
 type: plugin
 categories:

--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -14,7 +14,7 @@ description: |
 
   **Note**: The [OpenID Connect Plugin][oidcplugin] supports
   OAuth 2.0 Token Introspection as well and offers functionality beyond
-  this plugin such as restricting access by scope.
+  this plugin, such as restricting access by scope.
 
   [oidcplugin]: /hub/kong-inc/openid-connect/
 


### PR DESCRIPTION
I have been asked recently about how to limit access to a scope when using the OAuth 2.0 Introspection plugin. This is not possible, however, the OpenID Connect plugin supports OAuth 2.0 Token Introspection as well and can be used instead.

This adds a note with a link to the OpenID Connect plugin to the documentation for the OAuth 2.0 Introspection plugin.

<img width="786" alt="Screenshot 2020-05-07 at 13 56 04" src="https://user-images.githubusercontent.com/694597/81297205-d607f400-906a-11ea-9528-dabfc3a825d8.png">
 