### PR TITLE
Add overview of Kong for Kubernetes deployment options

### DIFF
--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -313,6 +313,8 @@
       url: /kong-for-kubernetes/install
     - text: Using Kong for Kubernetes
       url: /kong-for-kubernetes/using-kong-for-kubernetes
+    - text: Deployment Options
+      url: /kong-for-kubernetes/deployment-options
     - text: Changelog
       url: /kong-for-kubernetes/changelog
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -1,0 +1,179 @@
+---
+title: Kong for Kubernetes deployment options
+---
+
+- [Deployment options](#deployment-options)
+- [DB-less versus database-backed deployments](#db-less-versus-database-backed-deployments)
+- [Choosing between DB-less or database-backed deployments](#choosing-between-db-less-or-database-backed-deployments)
+  * [Feature availability](#feature-availability)
+  * [Plugin compatibility](#plugin-compatibility)
+  * [Manual configuration](#manual-configuration)
+- [Migrating between deployment types](#migrating-between-deployment-types)
+
+# Deployment options
+
+Kong for Kubernetes provides two options for its Kong Enterprise container
+image:
+
+* [kong-enterprise-k8s][k8s-bintray] (Kong for Kubernetes Enterprise)
+* [kong-enterprise-edition][enterprise-bintray] (Kong for Kubernetes with Kong
+  Enterprise)
+
+_These repositories require a login. If you see a 404, log in through the [Kong
+repository home page](https://bintray.com/kong) first._
+
+The `kong-enterprise-k8s` image is recommended for most deployments. It
+provides most Kong Enterprise plugins and runs without a database, but does not
+provide other Kong Enterprise features (Kong Manager, Dev Portal, Vitals,
+etc.).
+
+The `kong-enterprise-edition` image is recommended for deployments that require
+features not supported by `kong-enterprise-k8s`. It supports all Kong
+Enterprise plugins and features, but cannot run without a database.
+
+# DB-less versus database-backed deployments
+
+When using Kong for Kubernetes, the source of truth for Kong's configuration is
+the Kubernetes configuration in etcd: Kong's custom Kubernetes resources,
+ingresses, and services provide the information necessary for the ingress
+controller to configure Kong. This differs from Kong deployments that do not
+use an ingress controller, where configuration in the database or DB-less
+config file is the source of truth.
+
+In traditional deployments, Kong's database (PostgreSQL or Cassandra) provides
+a persistent store of configuration available to all Kong nodes to ensure
+consistent proxy behavior across the cluster that is not affected by node
+restarts. Because etcd provides this functionality in Kong for Kubernetes
+deployments, it is not necessary to run an additional database, reducing
+maintenance and infrastructure requirements.
+
+While Kong for Kubernetes does not require a database, it is fully compatible
+with PostgreSQL and requires it for some features. etcd remains the source of
+truth, but controller can translate Kubernetes resources there into either
+DB-less or database configuration.
+
+# Choosing between DB-less or database-backed deployments
+
+In general, DB-less deployments are simpler to maintain and require less
+resources to run, and as such are the preferred option for Kong for Kubernetes.
+These deployments use the `kong-enterprise-k8s` image and must set
+`KONG_DATABASE=off` in their environment variables.
+
+Database-backed deployments offer a wider range of features using the
+`kong-enterprise-edition` image. Review the sections below to determine if your
+use case requires a feature that is not available in DB-less deployments.
+
+## Feature availability
+
+Some Kong Enterprise features are not available in DB-less deployments. Users
+should use the `kong-enterprise-edition` image and a database-backed deployment
+if they wish to use:
+
+* Kong Manager
+* Dev Portal
+* Brain
+* Immunity
+* Teams (RBAC)
+* Vitals
+* Workspaces
+
+Because Kong for Kubernetes is configured by the ingress controller, some
+functionality in these features is different from traditional deployments:
+
+* Users will not typically create proxy configuration through Kong Manager;
+  proxy configuration is normally managed by the controller and users provide
+  configuration via Kubernetes resources.
+* Because the controller creates proxy configuration on behalf of users, users
+  do not need to interact with the Admin API directly. Typical Kong for
+  Kubernetes deployments do not expose the Admin API to protect it in lieu of
+  RBAC: only the controller can access it. Kubernetes-level RBAC rules and
+  namespaces should be used to restrict what configuration administrators can
+  create.
+* Ingress controller instances create configuration in a single workspace only
+  (`default` by default). To use multiple workspaces, users should deploy
+  multiple controller instances, setting the `CONTROLLER_KONG_WORKSPACE`
+  environment variable to the workspace that instance should use. These
+  instances should set `CONTROLLER_INGRESS_CLASS` to unique values, to avoid
+  creating duplicate configuration in workspaces. Note that if controller
+  instances are deployed outside the Kong pod the Admin API must be exposed,
+  and users should enable RBAC with workspace admin users for the controllers.
+  Set `CONTROLLER_KONG_ADMIN_TOKEN` to the RBAC user's token.
+* The controller cannot manage configuration for the features above: it cannot
+  create workspaces, Dev Portal content, admins, etc. These features must be
+  configured manually through the Admin API.
+
+## Plugin compatibility
+
+Not all plugins are compatible with DB-less operation, and as such not all
+plugins are available in the `kong-enterprise-k8s` image. In addition to the
+[compatible core plugins][core-plugins], the `kong-enterprise-k8s` image
+includes the following Enterprise plugins:
+
+* canary release
+* collector
+* degraphql
+* forward-proxy
+* graphql-proxy-cache-advanced
+* graphql-rate-limiting-advanced
+* jwt-signer
+* kafka-log
+* kafka-upstream
+* ldap-auth-advanced
+* mtls-auth
+* oauth2-introspection
+* openid-connect
+* proxy-cache-advanced
+* rate-limiting-advanced
+* request-validator
+* response-transformer-advanced
+* vault-auth
+
+The following Enterprise plugins are not included:
+
+* application-registration (only used with Dev Portal)
+* exit-transformer
+* key-auth-enc
+* request-transformer-advanced (request-transformer now has the same feature
+  set)
+* route-transformer-advanced
+* statsd-advanced (only used with Vitals)
+
+Third-party plugins are generally compatible with DB-less as long as they do
+not create custom entities (i.e. they do not add new entities that users can
+create and modify through the Admin API).
+
+## Manual configuration
+
+DB-less configuration must be supplied as a complete unit: it is not possible
+to add or modify entities individually through the Admin API, or provide
+partial configuration that is added to existing configuration. As such, all
+configuration must be sourced from Kubernetes resources so that the ingress
+controller can render it into a complete configuration.
+
+On database-backed deployments, users can create or modify configuration
+through the Admin API. The ingress controller uses a tag (set by the
+`CONTROLLER_KONG_ADMIN_FILTER_TAG` environment variable) to to identify
+configuration that it manages. While the controller will revert changes to
+configuration with its tag, other configuration is left as-is.
+
+Although database-backed deployments can use controller-generated and
+manually-added configuration simultaneously, Kong's recommended best practice
+is to still manage as much configuration through Kubernetes resources as
+possible, primarily using manual configuration for temporary or test resources.
+
+# Migrating between deployment types
+
+Because etcd is the source of truth for Kong's configuration, the ingress
+controller can re-create Kong's proxy configuration even if the underlying
+datastore changes.
+
+While most Kubernetes resources can be left unchanged when migrating between
+deployment types, users must remove any KongPlugin resources that use
+unavailable plugins when migrating from a database-backed deployment using the
+`kong-enterprise-edition` image to a DB-less deployment using the
+`kong-enterprise-k8s` image. No changes to Kubernetes resources are required if
+migrating in the opposite direction.
+
+[k8s-bintray]: https://bintray.com/kong/kong-enterprise-k8s
+[enterprise-bintray]: https://bintray.com/kong/kong-enterprise-edition-docker
+[core-plugins]: /latest/db-less-and-declarative-config/#plugin-compatibility

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -73,9 +73,8 @@ if you want to use:
 Because Kong for Kubernetes is configured by the ingress controller, some
 functionality in these features is different from traditional deployments:
 
-* Users will not typically create proxy configuration through Kong Manager;
-  proxy configuration is normally managed by the controller and users provide
-  configuration via Kubernetes resources.
+* Instead of using Kong Manager, proxy configuration is normally managed by the
+  controller, and you would provide configuration via Kubernetes resources.
 * Because the controller creates proxy configuration on behalf of users, you do
   not need to interact with the Admin API directly. Kong's own RBAC
   implementation isn't required for typical Kong for Kubernetes deployments, as
@@ -97,39 +96,10 @@ functionality in these features is different from traditional deployments:
 
 ### Plugin compatibility
 
-Not all plugins are compatible with DB-less operation, and as such not all
-plugins are available in the `kong-enterprise-k8s` image. In addition to the
-[compatible core plugins][core-plugins], the `kong-enterprise-k8s` image
-includes the following Enterprise plugins:
-
-* canary release
-* collector
-* degraphql
-* forward-proxy
-* graphql-proxy-cache-advanced
-* graphql-rate-limiting-advanced
-* jwt-signer
-* kafka-log
-* kafka-upstream
-* ldap-auth-advanced
-* mtls-auth
-* oauth2-introspection
-* openid-connect
-* proxy-cache-advanced
-* rate-limiting-advanced
-* request-validator
-* response-transformer-advanced
-* vault-auth
-
-The following Enterprise plugins are not included:
-
-* application-registration (only used with Dev Portal)
-* exit-transformer
-* key-auth-enc
-* request-transformer-advanced (request-transformer now has the same feature
-  set)
-* route-transformer-advanced
-* statsd-advanced (only used with Vitals)
+Not all plugins are compatible with DB-less operation. and as such not all
+plugins are available in the `kong-enterprise-k8s` image. Review the [list of
+supported plugins][supported-plugins] to see if you require a plugin that needs
+a database.
 
 Third-party plugins are generally compatible with DB-less as long as they do
 not create custom entities (i.e. they do not add new entities that users can
@@ -178,6 +148,6 @@ migrating in the opposite direction.
 
 [k8s-bintray]: https://bintray.com/kong/kong-enterprise-k8s
 [enterprise-bintray]: https://bintray.com/kong/kong-enterprise-edition-docker
-[core-plugins]: /latest/db-less-and-declarative-config/#plugin-compatibility
 [admission-webhook]: https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/deployment/admission-webhook.md
 [route-validation]: /enterprise/1.5.x/property-reference/#route_validation_strategy
+[supported-plugins]: https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/plugin-compatibility.md

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -40,9 +40,10 @@ deployments, it is not necessary to run an additional database, reducing
 maintenance and infrastructure requirements.
 
 While Kong for Kubernetes does not require a database, it is fully compatible
-with PostgreSQL and requires it for some features. etcd remains the source of
-truth, but the controller can translate Kubernetes resources from etcd into either
-DB-less or database configuration.
+with PostgreSQL and requires it for some features. etcd still remains the
+source of truth in database-backed deployments: the controller translate
+Kubernetes resources from etcd into Kong configuration and inserts them into
+the database via the Admin API.
 
 ## Choosing between DB-less or database-backed deployments
 
@@ -150,8 +151,17 @@ configuration with its tag, other configuration is left as-is.
 
 Although database-backed deployments can use controller-generated and
 manually-added configuration simultaneously, Kong's recommended best practice
-is to still manage as much configuration through Kubernetes resources as
-possible, primarily using manual configuration for temporary or test resources.
+is to manage as much configuration through Kubernetes resources as possible.
+Using both controller-managed and manual configuration can result in conflicts
+between the two, and conflicts will prevent the controller from applying its
+configuration. To minimize this risk:
+
+* Use the [admission webhook][admission-webhook]
+  to reject Kubernetes resources that conflict with other configuration, or are
+  otherwise invalid.
+* Manually create configuration in a workspace that is not managed by the
+  controller. This avoids most conflicts, but not all: routes may still
+  conflict depending on your [route validation][route-validation] setting.
 
 ## Migrating between deployment types
 
@@ -169,3 +179,5 @@ migrating in the opposite direction.
 [k8s-bintray]: https://bintray.com/kong/kong-enterprise-k8s
 [enterprise-bintray]: https://bintray.com/kong/kong-enterprise-edition-docker
 [core-plugins]: /latest/db-less-and-declarative-config/#plugin-compatibility
+[admission-webhook]: https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/deployment/admission-webhook.md
+[route-validation]: /enterprise/1.5.x/property-reference/#route_validation_strategy

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -10,7 +10,7 @@ title: Kong for Kubernetes deployment options
   * [Manual configuration](#manual-configuration)
 - [Migrating between deployment types](#migrating-between-deployment-types)
 
-# Deployment options
+## Deployment options
 
 Kong for Kubernetes provides two options for its Kong Enterprise container
 image:
@@ -31,7 +31,7 @@ The `kong-enterprise-edition` image is recommended for deployments that require
 features not supported by `kong-enterprise-k8s`. It supports all Kong
 Enterprise plugins and features, but cannot run without a database.
 
-# DB-less versus database-backed deployments
+## DB-less versus database-backed deployments
 
 When using Kong for Kubernetes, the source of truth for Kong's configuration is
 the Kubernetes configuration in etcd: Kong's custom Kubernetes resources,
@@ -49,10 +49,10 @@ maintenance and infrastructure requirements.
 
 While Kong for Kubernetes does not require a database, it is fully compatible
 with PostgreSQL and requires it for some features. etcd remains the source of
-truth, but controller can translate Kubernetes resources there into either
+truth, but the controller can translate Kubernetes resources from etcd into either
 DB-less or database configuration.
 
-# Choosing between DB-less or database-backed deployments
+## Choosing between DB-less or database-backed deployments
 
 In general, DB-less deployments are simpler to maintain and require less
 resources to run, and as such are the preferred option for Kong for Kubernetes.
@@ -63,11 +63,11 @@ Database-backed deployments offer a wider range of features using the
 `kong-enterprise-edition` image. Review the sections below to determine if your
 use case requires a feature that is not available in DB-less deployments.
 
-## Feature availability
+### Feature availability
 
-Some Kong Enterprise features are not available in DB-less deployments. Users
-should use the `kong-enterprise-edition` image and a database-backed deployment
-if they wish to use:
+Some Kong Enterprise features are not available in DB-less deployments.
+Use the `kong-enterprise-edition` image and a database-backed deployment
+if you want to use:
 
 * Kong Manager
 * Dev Portal
@@ -90,7 +90,7 @@ functionality in these features is different from traditional deployments:
   namespaces should be used to restrict what configuration administrators can
   create.
 * Ingress controller instances create configuration in a single workspace only
-  (`default` by default). To use multiple workspaces, users should deploy
+  (`default` by default). To use multiple workspaces, deploy
   multiple controller instances, setting the `CONTROLLER_KONG_WORKSPACE`
   environment variable to the workspace that instance should use. These
   instances should set `CONTROLLER_INGRESS_CLASS` to unique values, to avoid
@@ -102,7 +102,7 @@ functionality in these features is different from traditional deployments:
   create workspaces, Dev Portal content, admins, etc. These features must be
   configured manually through the Admin API.
 
-## Plugin compatibility
+### Plugin compatibility
 
 Not all plugins are compatible with DB-less operation, and as such not all
 plugins are available in the `kong-enterprise-k8s` image. In addition to the
@@ -142,7 +142,7 @@ Third-party plugins are generally compatible with DB-less as long as they do
 not create custom entities (i.e. they do not add new entities that users can
 create and modify through the Admin API).
 
-## Manual configuration
+### Manual configuration
 
 DB-less configuration must be supplied as a complete unit: it is not possible
 to add or modify entities individually through the Admin API, or provide
@@ -161,7 +161,7 @@ manually-added configuration simultaneously, Kong's recommended best practice
 is to still manage as much configuration through Kubernetes resources as
 possible, primarily using manual configuration for temporary or test resources.
 
-# Migrating between deployment types
+## Migrating between deployment types
 
 Because etcd is the source of truth for Kong's configuration, the ingress
 controller can re-create Kong's proxy configuration even if the underlying

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -96,7 +96,7 @@ functionality in these features is different from traditional deployments:
 
 ### Plugin compatibility
 
-Not all plugins are compatible with DB-less operation. and as such not all
+Not all plugins are compatible with DB-less operation, therefore not all
 plugins are available in the `kong-enterprise-k8s` image. Review the [list of
 supported plugins][supported-plugins] to see if you require a plugin that needs
 a database.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -75,21 +75,21 @@ functionality in these features is different from traditional deployments:
 * Users will not typically create proxy configuration through Kong Manager;
   proxy configuration is normally managed by the controller and users provide
   configuration via Kubernetes resources.
-* Because the controller creates proxy configuration on behalf of users, users
-  do not need to interact with the Admin API directly. Typical Kong for
-  Kubernetes deployments do not expose the Admin API to protect it in lieu of
-  RBAC: only the controller can access it. Kubernetes-level RBAC rules and
-  namespaces should be used to restrict what configuration administrators can
-  create.
+* Because the controller creates proxy configuration on behalf of users, you do
+  not need to interact with the Admin API directly. Kong's own RBAC
+  implementation isn't required for typical Kong for Kubernetes deployments, as
+  they do not expose the Admin API; only the controller can access it.
+  Kubernetes-level RBAC rules and namespaces should be used to restrict what
+  configuration administrators can create.
 * Ingress controller instances create configuration in a single workspace only
   (`default` by default). To use multiple workspaces, deploy
   multiple controller instances, setting the `CONTROLLER_KONG_WORKSPACE`
   environment variable to the workspace that instance should use. These
-  instances should set `CONTROLLER_INGRESS_CLASS` to unique values, to avoid
-  creating duplicate configuration in workspaces. Note that if controller
-  instances are deployed outside the Kong pod the Admin API must be exposed,
-  and users should enable RBAC with workspace admin users for the controllers.
-  Set `CONTROLLER_KONG_ADMIN_TOKEN` to the RBAC user's token.
+  instances should set `CONTROLLER_INGRESS_CLASS` to unique values for each
+  instance to avoid creating duplicate configuration in workspaces. Note that
+  if controller instances are deployed outside the Kong pod the Admin API must
+  be exposed, and users should enable RBAC with workspace admin users for the
+  controllers.  Set `CONTROLLER_KONG_ADMIN_TOKEN` to the RBAC user's token.
 * The controller cannot manage configuration for the features above: it cannot
   create workspaces, Dev Portal content, admins, etc. These features must be
   configured manually through the Admin API.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -4,12 +4,14 @@ title: Kong for Kubernetes deployment options
 
 ## Deployment options
 
-Kong for Kubernetes provides two options for its Kong Enterprise container
-image:
+Kong for Kubernetes consists of a controller, which translates Kubernetes
+resources into Kong configuration, and a proxy, which uses that configuration
+to route and control traffic. There are two options for the proxy image:
 
-* [kong-enterprise-k8s][k8s-bintray] ([Kong for Kubernetes Enterprise][k4k8s-enterprise-install])
-* [kong-enterprise-edition][enterprise-bintray] ([Kong for Kubernetes with Kong
-  Enterprise][k4k8s-with-enterprise-install])
+* [Kong for Kubernetes Enterprise][k4k8s-enterprise-install]
+  (the [kong-enterprise-k8s][k8s-bintray] image)
+* [Kong for Kubernetes with Kong Enterprise][k4k8s-with-enterprise-install]
+  (the [kong-enterprise-edition][enterprise-bintray] image)
 
 _These repositories require a login. If you see a 404, log in through the [Kong
 repository home page](https://bintray.com/kong) first._
@@ -132,6 +134,11 @@ configuration. To minimize this risk:
 * Manually create configuration in a workspace that is not managed by the
   controller. This avoids most conflicts, but not all: routes may still
   conflict depending on your [route validation][route-validation] setting.
+
+Large numbers of consumers (and associated credentials) are the exception to
+this rule: if your consumer count is in the tens of thousands, we recommend
+that you create them and their credentials through the Admin API to reduce etcd
+load.
 
 ## Migrating between deployment types
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -7,9 +7,9 @@ title: Kong for Kubernetes deployment options
 Kong for Kubernetes provides two options for its Kong Enterprise container
 image:
 
-* [kong-enterprise-k8s][k8s-bintray] (Kong for Kubernetes Enterprise)
-* [kong-enterprise-edition][enterprise-bintray] (Kong for Kubernetes with Kong
-  Enterprise)
+* [kong-enterprise-k8s][k8s-bintray] ([Kong for Kubernetes Enterprise][k4k8s-enterprise-install])
+* [kong-enterprise-edition][enterprise-bintray] ([Kong for Kubernetes with Kong
+  Enterprise][k4k8s-with-enterprise-install])
 
 _These repositories require a login. If you see a 404, log in through the [Kong
 repository home page](https://bintray.com/kong) first._
@@ -149,5 +149,7 @@ migrating in the opposite direction.
 [k8s-bintray]: https://bintray.com/kong/kong-enterprise-k8s
 [enterprise-bintray]: https://bintray.com/kong/kong-enterprise-edition-docker
 [admission-webhook]: https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/deployment/admission-webhook.md
-[route-validation]: /enterprise/1.5.x/property-reference/#route_validation_strategy
+[route-validation]: /enterprise/{{page.kong_version}}/property-reference/#route_validation_strategy
 [supported-plugins]: https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/plugin-compatibility.md
+[k4k8s-enterprise-install]: /enterprise/{{page.kong_version}}/kong-for-kubernetes/install.md
+[k4k8s-with-enterprise-install]: /enterprise/{{page.kong_version}}/kong-for-kubernetes/install-on-kubernetes.md

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -2,14 +2,6 @@
 title: Kong for Kubernetes deployment options
 ---
 
-- [Deployment options](#deployment-options)
-- [DB-less versus database-backed deployments](#db-less-versus-database-backed-deployments)
-- [Choosing between DB-less or database-backed deployments](#choosing-between-db-less-or-database-backed-deployments)
-  * [Feature availability](#feature-availability)
-  * [Plugin compatibility](#plugin-compatibility)
-  * [Manual configuration](#manual-configuration)
-- [Migrating between deployment types](#migrating-between-deployment-types)
-
 ## Deployment options
 
 Kong for Kubernetes provides two options for its Kong Enterprise container

--- a/app/enterprise/k8s-changelog.md
+++ b/app/enterprise/k8s-changelog.md
@@ -23,8 +23,8 @@ Please review the changelog for
 The following plugins are included in this release:
 
 * degraphql
-* graphql-rate-limiting-advanced
 * graphql-proxy-cache-advanced
+* graphql-rate-limiting-advanced
 
 ## 1.4.2.0
 
@@ -61,17 +61,18 @@ Please review the changelog for
 
 The following plugins are included with this release:
 
+* canary release
+* collector
+* forward-proxy
+* jwt-signer
+* kafka-log
+* kafka-upstream
+* ldap-auth-advanced
+* mtls-auth
 * oauth2-introspection
 * openid-connect
 * proxy-cache-advanced
 * rate-limiting-advanced
-* response-transformer-advanced
-* kafka-log
-* kafka-upstream
-* canary release
-* ldap-auth-advanced
-* forward-proxy
-* jwt-signer
-* collector
-* mtls-auth
 * request-validator
+* response-transformer-advanced
+* vault-auth


### PR DESCRIPTION
This document provides an overview of the two Enterprise image options for Kong for Kubernetes geared towards helping users decide which option fits their use case. It compares the features available in both, explains how database-backed Kong for Kubernetes deployments differ from non-controller-managed deployments, and provides basic information about migrating between the deployment types.