### PR TITLE
docs(install) Instructions for installing Kong Enterprise on Kubernetes

### DIFF
--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -17,8 +17,10 @@
       items:
         - text: Docker
           url: /deployment/installation/docker
-        - text: Kubernetes
+        - text: Kong for Kubernetes Enteprise
           url: /kong-for-kubernetes/install
+        - text: Kong Enterprise on Kubernetes
+          url: /kong-for-kubernetes/install-on-kubernetes
         - text: Ubuntu
           url: /deployment/installation/ubuntu
         - text: CentOS
@@ -331,8 +333,10 @@
   items:
     - text: Overview
       url:  /kong-for-kubernetes
-    - text: Installation
+    - text: Install Kong for Kubernetes Enterprise
       url: /kong-for-kubernetes/install
+    - text: Install Kong Enterprise on Kubernetes
+      url: /kong-for-kubernetes/install-on-kubernetes
     - text: Using Kong for Kubernetes
       url: /kong-for-kubernetes/using-kong-for-kubernetes
     - text: Changelog

--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -17,7 +17,7 @@
       items:
         - text: Docker
           url: /deployment/installation/docker
-        - text: Kong for Kubernetes Enteprise
+        - text: Kong for Kubernetes Enterprise
           url: /kong-for-kubernetes/install
         - text: Kong Enterprise on Kubernetes
           url: /kong-for-kubernetes/install-on-kubernetes

--- a/app/enterprise/1.5.x/deployment/installation/overview.md
+++ b/app/enterprise/1.5.x/deployment/installation/overview.md
@@ -33,7 +33,12 @@ skip_read_time: true
 
   <a href="/enterprise/{{page.kong_version}}/kong-for-kubernetes/install" class="docs-grid-install-block">
     <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/kubernetes.png" alt="kubernetes" />
-    <div class="install-text">Kong for Kubernetes</div>
+    <div class="install-text">Kong for Kubernetes Enterprise</div>
+  </a>
+
+  <a href="/enterprise/{{page.kong_version}}/kong-for-kubernetes/install-on-kubernetes" class="docs-grid-install-block">
+    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/kubernetes.png" alt="kubernetes" />
+    <div class="install-text">Kong Enterprise on Kubernetes</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/rhel" class="docs-grid-install-block">

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -236,8 +236,11 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
 
+    > **Note:** Do not use IPs with RBAC. If you want to use RBAC, you need to set
+    up a DNS hostname first, instead of directly specifying an IP.
+
     ```
-    admin_api_uri: <your-ip>
+    admin_api_uri: <your-DNSorIP>
     ```
 
 3. Clean up:
@@ -271,8 +274,11 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
 
+    > **Note:** Do not use IPs with RBAC. If you want to use RBAC, you need to set
+    up a DNS hostname first, instead of directly specifying an IP.
+
     ```
-    admin_api_uri: <your-ip>
+    admin_api_uri: <your-DNSorIP>
     ```
 
 3. Clean up:

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -166,9 +166,7 @@ In the following steps, replace `<your-password>` with a secure password.
     |`image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
 
-3. (Optional) If not using the Kong Ingress Controller, remove the entire section of `Ingress Controller parameters`.
-
-4. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
+3. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
 
     For example:
     ```
@@ -193,7 +191,7 @@ In the following steps, replace `<your-password>` with a secure password.
         servicePort: 8446
     ```
 
-5. Fill in the rest of the parameters as they fit your implementation. Use the comments in the sample file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
+4. Fill in the rest of the parameters as they fit your implementation. Use the comments in the sample file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
 
 ## Step 8. Deploy Kong Enterprise on Kubernetes
 The steps in this section show you how to install Kong Enterprise on Kubernetes using Helm.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -1,0 +1,307 @@
+---
+title: Installing Kong Enterprise on Kubernetes
+---
+
+## Introduction
+
+Kong Enterprise on Kubernetes is recommended for deployments that require features not supported by Kong for Kubernetes Enterprise. It supports all Kong Enterprise plugins and features, but can't run in DB-less mode. See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for more information.
+
+You can use kubectl or OpenShift oc to configure Kong Enterprise on Kubernetes, then deploy it using Helm.
+
+<img src="https://doc-assets.konghq.com/kubernetes/Kong-Enterprise-on-Kubernetes.png">
+
+## Prerequisites
+Before starting installation, be sure you have the following:
+
+- **Kubernetes cluster with load balancer**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
+- **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
+- A valid Kong Enterprise License:
+  * If you have a license, continue to [Set Up Kong Enterprise License](#set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
+  * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
+  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
+- Kong Enterprise Docker registry access on Bintray.
+- Helm installed.
+
+## Step 1. Provision a namespace
+
+In order to create the secrets for license and Docker registry access,
+first provision the `kong` namespace:
+
+{% navtabs %}
+{% navtab kubectl %}
+```bash
+$ kubectl create namespace kong
+```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+```bash
+$ oc new-project kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Step 2. Set Up Kong Enterprise license
+Running Kong Enterprise on Kubernetes requires a valid license.
+
+As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
+
+> Note:
+* There is no `.json` extension in the `--from-file` parameter.
+* `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
+
+{% navtabs %}
+{% navtab kubectl %}
+```
+$ kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+```
+$ oc create secret generic kong-enterprise-license --from-file=./license -n kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Step 3. Set up Helm
+
+1. Add the Kong charts repository:
+    ```
+    $ helm repo add kong https://charts.konghq.com
+    ```
+2. Update Helm:
+    ```
+    $ helm repo update
+    ```
+
+## Step 4. Configure Kong Enterprise Docker registry access
+Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted in a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
+
+{% navtabs %}
+{% navtab kubectl %}
+Set up the credentials:
+```
+$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
+    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
+    --docker-username=<your-bintray-username> \
+    --docker-password=<your-bintray-api-key>
+```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+Set up the credentials:
+```
+$ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
+    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \      
+    --docker-username=<your-bintray-username> \
+    --docker-password=<your-bintray-api-key>
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Step 5. Seed the Super Admin password
+{% navtabs %}
+{% navtab kubectl %}
+(Optional) Create a password for the super admin:
+```
+kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
+```
+Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
+{% endnavtab %}
+{% navtab OpenShift oc %}
+(Optional) Create a password for the super admin:
+```
+oc create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
+```
+Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
+{% endnavtab %}
+{% endnavtabs %}
+
+## Step 6. Prepare the sessions plugin for Manager and Dev Portal
+In the following steps, replace `<your-password>` with a secure password.
+
+{% navtabs %}
+{% navtab kubectl %}
+
+1. Create a sessions config file for Kong Manager:
+    ```
+    $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
+    ```
+2. Create a sessions config file for Kong Dev Portal:
+    ```
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    ```
+3. Create secret:
+    ```
+    kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf=<manager-config-filename> --from-file=portal_session_conf=<portal-config-filename>
+    ```
+
+{% endnavtab %}
+{% navtab OpenShift oc %}
+
+1. Create a sessions config file for Kong Manager:
+    ```
+    $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
+    ```
+2. Create a sessions config file for Kong Dev Portal:
+    ```
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    ```
+3. Create secret:
+    ```
+    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf=<manager-config-filename> --from-file=portal_session_conf=<portal-config-filename>
+    ```
+{% endnavtab %}
+{% endnavtabs %}
+## Step 7. Prepare Kong's configuration file
+
+1. Create a `values.yaml` file based on the sample in the [Kong charts repository](https://github.com/Kong/charts/blob/master/charts/kong/values.yaml). This file sets all the necessary parameters for your Kong environment.
+
+2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
+
+    Parameter | Value  
+    ----------|-------
+    `env.database` | `"postgres"` or `"cassandra"`
+    `env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`.
+    `env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`.
+    `image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`.
+    `image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`.
+    `ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you
+    don't want to install it.
+
+3. (Optional) If not using the Kong Ingress Controller, remove the entire section of `Ingress Controller parameters`.
+
+4. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
+
+    For example:
+    ```
+    manager:
+      enabled: true
+      type: LoadBalancer
+      http:
+        enabled: true
+        servicePort: 8002
+      tls:
+        enabled: true
+        servicePort: 8445
+
+    portal:
+      enabled: true
+      type: LoadBalancer
+      http:
+        enabled: true
+        servicePort: 8003
+      tls:
+        enabled: true
+        servicePort: 8446
+    ```
+
+5. Fill in the rest of the parameters as they fit your implementation. Use the comments in the sample file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
+
+## Step 8. Deploy Kong Enterprise on Kubernetes
+The steps in this section show you how to install Kong Enterprise on Kubernetes using Helm.
+>Note: the following instructions assume that you're running Helm 3.
+
+{% navtabs %}
+{% navtab kubectl %}
+1. Run:
+    ```
+    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+    This may take some time.
+
+2. Check pod status:
+    ```
+    $ kubectl get pods -n kong
+    ```
+    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
+{% endnavtab %}
+{% navtab OpenShift oc %}
+1. Run:
+    ```
+    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+    This may take some time.
+
+2. Check pod status:
+    ```
+    $ oc get pods -n kong
+    ```
+    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
+{% endnavtab %}
+{% endnavtabs %}
+
+## Step 9. Finalize Configuration and Verify Installation
+{% navtabs %}
+{% navtab kubectl %}
+1. Run:
+    ```
+    $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ```
+
+2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
+
+    ```
+    admin_api_uri: <your-ip>
+    ```
+
+3. Clean up:
+    ```
+    $ kubectl delete jobs -n kong --all
+    ```
+
+4. Update Kong to use the changed `values.yaml`:
+    ```
+    $ helm upgrade my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+
+6. Once the upgrade is complete, you can log into Kong Manager. Run:
+    ```
+    kubectl get svc -n kong
+    ```
+
+    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong services, including Kong Manager and Kong Dev Portal:
+
+    ```
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
+    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
+    my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
+    ```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+1. Run:
+    ```
+    $ oc get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ```
+
+2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
+
+    ```
+    admin_api_uri: <your-ip>
+    ```
+
+3. Clean up:
+    ```
+    $ oc delete jobs -n kong --all
+    ```
+
+4. Update Kong to use the changed `values.yaml`:
+    ```
+    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+
+6. Once the upgrade is complete, you can log into Kong Manager. Run:
+    ```
+    oc get svc -n kong
+    ```
+
+    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong services, including Kong Manager and Kong Dev Portal:
+
+    ```
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
+    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
+    my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
+    ```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Next steps...
+See [Using Kong for Kubernetes Enterprise](/enterprise/{{page.kong_version}}/kong-for-kubernetes/using-kong-for-kubernetes) for information about concepts, how-to guides, reference guides, and using plugins.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -24,7 +24,7 @@ Before starting installation, be sure you have the following:
 
 ## Step 1. Provision a namespace
 
-In order to create the secrets for license and Docker registry access,
+To create the secrets for license and Docker registry access,
 first provision the `kong` namespace:
 
 {% navtabs %}
@@ -104,18 +104,18 @@ $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
 ```
 kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
 ```
-Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
+⚠️**Important:** Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
 {% endnavtab %}
 {% navtab OpenShift oc %}
 (Optional) Create a password for the super admin:
 ```
 oc create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
 ```
-Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
+⚠️**Important:** Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
 {% endnavtab %}
 {% endnavtabs %}
 
-## Step 6. Prepare the sessions plugin for Manager and Dev Portal
+## Step 6. Prepare the sessions plugin for Kong Manager and Dev Portal
 In the following steps, replace `<your-password>` with a secure password.
 
 {% navtabs %}
@@ -191,7 +191,7 @@ In the following steps, replace `<your-password>` with a secure password.
         servicePort: 8446
     ```
 
-4. Fill in the rest of the parameters as they fit your implementation. Use the comments in the sample file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
+4. Fill in the rest of the parameters as appropriate for your implementation. Use the comments in the sample file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
 
 ## Step 8. Deploy Kong Enterprise on Kubernetes
 The steps in this section show you how to install Kong Enterprise on Kubernetes using Helm.
@@ -209,7 +209,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     ```
     $ kubectl get pods -n kong
     ```
-    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
+    After migrations are complete and the `my-kong-kong-<ID>` pod is running, continue to the next section.
 {% endnavtab %}
 {% navtab OpenShift oc %}
 1. Run:
@@ -222,7 +222,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     ```
     $ oc get pods -n kong
     ```
-    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
+    After migrations are complete and the `my-kong-kong-<ID>` pod is running, continue to the next section.
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -253,7 +253,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     $ helm upgrade my-kong kong/kong --namespace kong --values ~/values.yaml
     ```
 
-6. Once the upgrade is complete, run:
+6. After the upgrade is complete, run:
     ```
     kubectl get svc -n kong
     ```
@@ -291,7 +291,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
     ```
 
-6. Once the upgrade is complete, run:
+6. After the upgrade is complete, run:
     ```
     oc get svc -n kong
     ```

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -16,7 +16,7 @@ Before starting installation, be sure you have the following:
 - **Kubernetes cluster with load balancer**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
 - A valid Kong Enterprise License:
-  * If you have a license, continue to [Set Up Kong Enterprise License](#set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
+  * If you have a license, continue to [Set Up Kong Enterprise License](#step-2-set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
   * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
 - Kong Enterprise Docker registry access on Bintray.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -157,15 +157,14 @@ In the following steps, replace `<your-password>` with a secure password.
 
 2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
 
-    Parameter | Value  
-    ----------|-------
-    `env.database` | `"postgres"` or `"cassandra"`
-    `env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`.
-    `env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`.
-    `image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`.
-    `image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`.
-    `ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you
-    don't want to install it.
+    |Parameter      | Value                         |
+    |---------------|-------------------------------|
+    |`env.database` | `"postgres"` or `"cassandra"` |
+    |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
+    |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
+    |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/ kong-enterprise-edition`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`. |
+    |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
 
 3. (Optional) If not using the Kong Ingress Controller, remove the entire section of `Ingress Controller parameters`.
 
@@ -253,15 +252,15 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     $ helm upgrade my-kong kong/kong --namespace kong --values ~/values.yaml
     ```
 
-6. Once the upgrade is complete, you can log into Kong Manager. Run:
+6. Once the upgrade is complete, run:
     ```
     kubectl get svc -n kong
     ```
 
-    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong services, including Kong Manager and Kong Dev Portal:
+    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong features, including Kong Manager and Kong Dev Portal:
 
     ```
-    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                            AGE
     my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
     my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
     ```
@@ -288,15 +287,15 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
     ```
 
-6. Once the upgrade is complete, you can log into Kong Manager. Run:
+6. Once the upgrade is complete, run:
     ```
     oc get svc -n kong
     ```
 
-    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong services, including Kong Manager and Kong Dev Portal:
+    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong features, including Kong Manager and Kong Dev Portal:
 
     ```
-    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                            AGE
     my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    8002:31308/TCP,8445:32420/TCP      24m
     my-kong-kong-portal           LoadBalancer   10.101.251.123   10.101.251.123  8003:31609/TCP,8446:32002/TCP      24m
     ```

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -1,16 +1,13 @@
 ---
-title: Installing Kong Enterprise with Kubernetes
+title: Installing Kong for Kubernetes Enteprise
 ---
 
 ## Introduction
-Kong for Kubernetes provides two options for its Kong Enterprise container image:
+Kong for Kubernetes Enterprise provides most Kong Enterprise plugins and runs without a database, but does not include other Kong Enterprise features (Kong Manager, Dev Portal, Vitals, etc). See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for more information.
 
-* Kong for Kubernetes Enterprise (`kong-enterprise-k8s`): provides most Kong Enterprise plugins and runs without a database, but does not include other Kong Enterprise features (Kong Manager, Dev Portal, Vitals, etc).
-* Kong Enterprise on Kubernetes (`kong-enterprise-edition`): recommended for deployments that require features not supported by `kong-enterprise-k8s`. It supports all Kong Enterprise plugins and features, but cannot run without a database. This package does not require the Kong Ingress Controller.
+You can install Kong for Kubernetes Enterprise using YAML with kubectl, or with OpenShift oc. Other deployment options, such as using Helm Chart and Kustomize, will be available at a later time.
 
-You can install `kong-enterprise-k8s` using YAML with kubectl, or with OpenShift oc. Other deployment options, such as using Helm Chart and Kustomize, will be available at a later time.
-
-You can also use kubectl or oc to configure `kong-enterprise-edition`, but it has to be deployed using Helm.
+<img src="https://doc-assets.konghq.com/kubernetes/K4K8S-Enterprise-Diagram.png" alt="Kong for Kubernetes Enterprise control diagram">
 
 ## Prerequisites
 Before starting installation, be sure you have the following:
@@ -22,11 +19,8 @@ Before starting installation, be sure you have the following:
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
   * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
 - Kong Enterprise Docker registry access on Bintray.
-- **For installations of Kong Enterprise on Kubernetes**: Helm is installed.
 
-## Prepare for Installation
-
-### Provision a Namespace
+## Step 1. Provision a Namespace
 
 In order to create the secrets for license and Docker registry access,
 first provision the `kong` namespace:
@@ -44,10 +38,10 @@ $ oc new-project kong
 {% endnavtab %}
 {% endnavtabs %}
 
-## Set Up Kong Enterprise License
-Running Kong Enterprise requires a valid license.
+## Step 2. Set Up Kong Enterprise License
+Running Kong for Kubernetes Enterprise requires a valid license.
 
-As part of sign up for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
+As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales represenative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
 > Note: There is no `.json` extension in the `--from-file` parameter.
 > `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
@@ -65,16 +59,9 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% endnavtab %}
 {% endnavtabs %}
 
-Next, choose an installation option: [Kong for Kubernetes Enteprise](#option-1-install-kong-for-kubernetes-enterprise) or [Kong Enterprise on Kubernetes](#option-2-install-kong-enterprise-on-kubernetes).
+## Step 3. Configure Kong Enterprise Docker registry access
 
-## Option 1: Install Kong for Kubernetes Enterprise
-The steps in this section show you how to install Kong for Kubernetes Enterprise using YAML.
-
-<img src="https://doc-assets.konghq.com/kubernetes/K4K8S-Enterprise-Diagram.png" alt="Kong for Kubernetes Enterprise control diagram">
-
-### Configure Kong Enterprise Docker registry access
-
-Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted as a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
+Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted in a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -95,7 +82,8 @@ $ oc create secret -n kong docker-registry kong-enterprise-k8s-docker \
 {% endnavtab %}
 {% endnavtabs %}
 
-### Deploy Kong for Kubernetes Enteprise
+## Step 4. Deploy Kong for Kubernetes Enteprise
+The steps in this section show you how to install Kong for Kubernetes Enterprise using YAML.
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -152,223 +140,5 @@ $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip
 It might take a while for your cloud provider to associate the IP address to the `kong-proxy` service.
 Once you have installed Kong, see the [getting started tutorial](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/guides/getting-started.md).
 
-## Option 2: Install Kong Enterprise on Kubernetes
-
-The steps in this section show you how to install Kong Enterprise on Kubernetes using Helm.
->Note: the following instructions assume that you're running Helm 3.
-
-<img src="https://doc-assets.konghq.com/kubernetes/Kong-Enterprise-on-Kubernetes.png">
-
-### Set up Helm
-
-1. Add the Kong charts repository:
-    ```
-    $ helm repo add kong https://charts.konghq.com
-    ```
-2. Update Helm:
-    ```
-    $ helm repo update
-    ```
-
-### Configure Kong Enterprise Docker registry access
-Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted as a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
-
-{% navtabs %}
-{% navtab kubectl %}
-1. Set up the credentials:
-    ```
-    $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
-        --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
-        --docker-username=<your-bintray-username> \
-        --docker-password=<your-bintray-api-key>
-    ```
-
-2. (Optional) Create a password for the super admin:
-    ```
-    kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
-    ```
-    Though not required, this is recommended for users that wish to use RBAC, as it cannot be done after initial setup.
-{% endnavtab %}
-{% navtab OpenShift oc %}
-1. Set up the credentials:
-    ```
-    $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
-        --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
-        --docker-username=<your-bintray-username> \
-        --docker-password=<your-bintray-api-key>
-    ```
-
-2. (Optional) Create a password for the super admin:
-    ```
-    oc create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
-    ```
-    Though not required, this is recommended for users that wish to use RBAC, as it cannot be done after initial setup.
-{% endnavtab %}
-{% endnavtabs %}
-### Enable the sessions plugin for Manager and Dev Portal
-In the following steps, replace `<your-password>` with a secure password.
-
-{% navtabs %}
-{% navtab kubectl %}
-
-1. Create a sessions config file for Kong Manager:
-    ```
-    $ cat > admin_gui_session_conf
-    {"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
-    ```
-2. Create a sessions config file for Kong Dev Portal:
-    ```
-    $ cat > portal_session_conf
-    {"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
-    ```
-
-3. Create secret:
-    ```
-    $ kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
-    ```
-{% endnavtab %}
-{% navtab OpenShift oc %}
-
-1. Create a sessions config file for Kong Manager:
-    ```
-    $ cat > admin_gui_session_conf
-    {"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
-    ```
-2. Create a sessions config file for Kong Dev Portal:
-    ```
-    $ cat > portal_session_conf
-    {"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
-    ```
-
-3. Create secret:
-    ```
-    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
-    ```
-{% endnavtab %}
-{% endnavtabs %}
-### Prepare the values.yaml
-
-1. Create a `values.yaml` file based on the sample in the [Kong charts repository](https://github.com/Kong/charts/blob/master/charts/kong/values.yaml). This file sets all the necessary parameters for your Kong environment.
-
-2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
-
-    Parameter | Value  
-    ----------|-------
-    `env.database` | `"postgres"` or `"cassandra"`
-    `env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`.
-    `env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`.
-    `image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`
-    `image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`
-    `ingressController.enabled` | `false`
-
-3. Remove the entire section of `Ingress Controller parameters`. Since this installation enables other features such as Kong Manager and Kong Dev Portal, there is no need for a separate ingress controller.
-
-4. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
-
-5. Fill in the rest of the parameters as they fit your implementation. Use the comments in the file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
-
-### Deploy Kong Enterprise on Kubernetes
-{% navtabs %}
-{% navtab kubectl %}
-1. Run:
-    ```
-    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
-    ```
-    This may take some time.
-
-2. Check pod status:
-    ```
-    $ kubectl get pods -n kong
-    ```
-    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
-{% endnavtab %}
-{% navtab OpenShift oc %}
-1. Run:
-    ```
-    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
-    ```
-    This may take some time.
-
-2. Check pod status:
-    ```
-    $ oc get pods -n kong
-    ```
-    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
-{% endnavtab %}
-{% endnavtabs %}
-
-### Set up Kong Manager
-{% navtabs %}
-{% navtab kubectl %}
-1. Run:
-    ```
-    $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    ```
-
-2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
-
-    ```
-    admin_api_uri: <your-ip>
-    ```
-
-3. Clean up:
-    ```
-    $ kubectl delete jobs -n kong --all
-    ```
-
-4. Update Kong to use the changed `values.yaml`:
-    ```
-    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
-    ```
-
-6. Once the upgrade is complete, you can log into Kong Manager. Run:
-    ```
-    kubectl get svc -n kong
-    ```
-
-    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong Manager:
-
-    ```
-    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
-    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    80:31308/TCP,443:32420/TCP      24m
-    ```
-    You can also access the Kong Dev Portal directly using its IP from this list, or log into Kong Manager and access the Dev Portal for an individual workspace from there.
-{% endnavtab %}
-{% navtab OpenShift oc %}
-1. Run:
-    ```
-    $ oc get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    ```
-
-2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
-
-    ```
-    admin_api_uri: <your-ip>
-    ```
-
-3. Clean up:
-    ```
-    $ oc delete jobs -n kong --all
-    ```
-
-4. Update Kong to use the changed `values.yaml`:
-    ```
-    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
-    ```
-
-6. Once the upgrade is complete, you can log into Kong Manager. Run:
-    ```
-    oc get svc -n kong
-    ```
-
-    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong Manager:
-
-    ```
-    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
-    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    80:31308/TCP,443:32420/TCP      24m
-    ```
-    You can also access the Kong Dev Portal directly using its IP from this list, or log into Kong Manager and access the Dev Portal for an individual workspace from there.
-{% endnavtab %}
-{% endnavtabs %}
-## Next steps...
+### Next steps...
 See [Using Kong for Kubernetes Enterprise](/enterprise/{{page.kong_version}}/kong-for-kubernetes/using-kong-for-kubernetes) for information about concepts, how-to guides, reference guides, and using plugins.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -1,33 +1,32 @@
 ---
-title: Installing Kong for Kubernetes Enterprise
+title: Installing Kong Enterprise with Kubernetes
 ---
 
 ## Introduction
-This installation topic guides you through installing and deploying Kong for Kubernetes Enterprise (K4K8S-Enterprise), then directs you to the documentation for configuring and using the product.
+Kong for Kubernetes provides two options for its Kong Enterprise container image:
 
- You can install Kong for Kubernetes Enterprise using YAML with kubectl, or with OpenShift oc. Other deployment options, such as using Helm Chart and Kustomize, will be available at a later time.
+* Kong for Kubernetes Enterprise (`kong-enterprise-k8s`): provides most Kong Enterprise plugins and runs without a database, but does not include other Kong Enterprise features (Kong Manager, Dev Portal, Vitals, etc).
+* Kong Enterprise on Kubernetes (`kong-enterprise-edition`): recommended for deployments that require features not supported by `kong-enterprise-k8s`. It supports all Kong Enterprise plugins and features, but cannot run without a database. This package does not require the Kong Ingress Controller.
 
-<img src="https://doc-assets.konghq.com/kubernetes/K4K8S-Enterprise-Diagram.png" alt="Kong for Kubernetes Enterprise control diagram">
+You can install `kong-enterprise-k8s` using YAML with kubectl, or with OpenShift oc. Other deployment options, such as using Helm Chart and Kustomize, will be available at a later time.
 
-### Prerequisites
-Before installing Kong for Kubernetes Enterprise, be sure you have the following:
+You can also use kubectl or oc to configure `kong-enterprise-edition`, but it has to be deployed using Helm.
+
+## Prerequisites
+Before starting installation, be sure you have the following:
 
 - **Kubernetes cluster**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
 - A valid Kong Enterprise License
-  * If you have a license, continue to [Step 1. Set Kong Enterprise License](#step-1-set-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
+  * If you have a license, continue to [Set Up Kong Enterprise License](#set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
   * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-- Kong Enterprise Docker registry access.
+- Kong Enterprise Docker registry access on Bintray.
+- **For installations of Kong Enterprise on Kubernetes**: Helm is installed.
 
+## Prepare for Installation
 
-## Installing Kong for Kubernetes Enterprise
-The steps in this section include installing Kong for Kubernetes Enterprise using YAML.
-
-Installation steps include:
-- [Step 1. Set Kong Enterprise License ](#step-1-set-kong-enterprise-license)
-- [Step 2. Configure Kong Enterprise Docker registry access](#step-2-configure-kong-enterprise-docker-registry-access)
-- [Step 3. Deploy Kong for Kubernetes Enterprise](#step-3-deploy-kong-for-kubernetes-enterprise)
+### Provision a Namespace
 
 In order to create the secrets for license and Docker registry access,
 first provision the `kong` namespace:
@@ -45,13 +44,13 @@ $ oc new-project kong
 {% endnavtab %}
 {% endnavtabs %}
 
-### Step 1. Set Kong Enterprise License
-Kong for Kubernetes Enterprise requires a valid license.
+## Set Up Kong Enterprise License
+Running Kong Enterprise requires a valid license.
 
 As part of sign up for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
-> Note: There is no .json extension in the --from-file parameter.
-> -n kong specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
+> Note: There is no `.json` extension in the `--from-file` parameter.
+> `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -66,7 +65,15 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% endnavtab %}
 {% endnavtabs %}
 
-### Step 2. Configure Kong Enterprise Docker registry access
+Next, choose an installation option: [Kong for Kubernetes Enteprise](#option-1-install-kong-for-kubernetes-enterprise) or [Kong Enterprise on Kubernetes](#option-2-install-kong-enterprise-on-kubernetes).
+
+## Option 1: Install Kong for Kubernetes Enterprise
+The steps in this section show you how to install Kong for Kubernetes Enterprise using YAML.
+
+<img src="https://doc-assets.konghq.com/kubernetes/K4K8S-Enterprise-Diagram.png" alt="Kong for Kubernetes Enterprise control diagram">
+
+### Configure Kong Enterprise Docker registry access
+
 Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted as a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
 
 {% navtabs %}
@@ -74,12 +81,7 @@ Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterp
 ```
 $ kubectl create secret -n kong docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
-    --docker-username=<your-bintray-username@kong> \
-    --docker-password=<your-bintray-api-key>
-
-$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
-    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
-    --docker-username=<your-bintray-username@kong> \
+    --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
 ```
 {% endnavtab %}
@@ -87,22 +89,14 @@ $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
 ```
 $ oc create secret -n kong docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
-    --docker-username=<your-bintray-username@kong> \
-    --docker-password=<your-bintray-api-key>
-
-$ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
-    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
-    --docker-username=<your-bintray-username@kong> \
+    --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
 ```
 {% endnavtab %}
 {% endnavtabs %}
 
-For future reference, make a note of the namespace in which you are deploying Kong.
-Once these credentials are created, you are ready to deploy Kong Enterprise Ingress Controller.
+### Deploy Kong for Kubernetes Enteprise
 
-
-### Step 3. Deploy Kong for Kubernetes Enterprise
 {% navtabs %}
 {% navtab kubectl %}
 ```
@@ -158,13 +152,223 @@ $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip
 It might take a while for your cloud provider to associate the IP address to the `kong-proxy` service.
 Once you have installed Kong, see the [getting started tutorial](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/guides/getting-started.md).
 
-## Next steps...
-See [Using Kong for Kubernetes Enterprise](/enterprise/{{page.kong_version}}/kong-for-kubernetes/using-kong-for-kubernetes) for information about concepts, how-to guides, reference guides, and using plugins.
+## Option 2: Install Kong Enterprise on Kubernetes
 
-## Optional: Installing Kong Enterprise on Kubernetes
-
-> Note: The recommended installation is [Kong for Kubernetes Enterprise](#introduction).
-
-To install Kong Enterprise on Kubernetes, instead of installing Kong for Kubernetes, see the following diagram. (Steps to be provided at a later time.)
+The steps in this section show you how to install Kong Enterprise on Kubernetes using Helm.
+>Note: the following instructions assume that you're running Helm 3.
 
 <img src="https://doc-assets.konghq.com/kubernetes/Kong-Enterprise-on-Kubernetes.png">
+
+### Set up Helm
+
+1. Add the Kong charts repository:
+    ```
+    $ helm repo add kong https://charts.konghq.com
+    ```
+2. Update Helm:
+    ```
+    $ helm repo update
+    ```
+
+### Configure Kong Enterprise Docker registry access
+Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted as a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
+
+{% navtabs %}
+{% navtab kubectl %}
+1. Set up the credentials:
+    ```
+    $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
+        --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
+        --docker-username=<your-bintray-username> \
+        --docker-password=<your-bintray-api-key>
+    ```
+
+2. (Optional) Create a password for the super admin:
+    ```
+    kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
+    ```
+    Though not required, this is recommended for users that wish to use RBAC, as it cannot be done after initial setup.
+{% endnavtab %}
+{% navtab OpenShift oc %}
+1. Set up the credentials:
+    ```
+    $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
+        --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
+        --docker-username=<your-bintray-username> \
+        --docker-password=<your-bintray-api-key>
+    ```
+
+2. (Optional) Create a password for the super admin:
+    ```
+    oc create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
+    ```
+    Though not required, this is recommended for users that wish to use RBAC, as it cannot be done after initial setup.
+{% endnavtab %}
+{% endnavtabs %}
+### Enable the sessions plugin for Manager and Dev Portal
+In the following steps, replace `<your-password>` with a secure password.
+
+{% navtabs %}
+{% navtab kubectl %}
+
+1. Create a sessions config file for Kong Manager:
+    ```
+    $ cat > admin_gui_session_conf
+    {"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
+    ```
+2. Create a sessions config file for Kong Dev Portal:
+    ```
+    $ cat > portal_session_conf
+    {"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
+    ```
+
+3. Create secret:
+    ```
+    $ kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
+    ```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+
+1. Create a sessions config file for Kong Manager:
+    ```
+    $ cat > admin_gui_session_conf
+    {"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
+    ```
+2. Create a sessions config file for Kong Dev Portal:
+    ```
+    $ cat > portal_session_conf
+    {"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}
+    ```
+
+3. Create secret:
+    ```
+    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
+    ```
+{% endnavtab %}
+{% endnavtabs %}
+### Prepare the values.yaml
+
+1. Create a `values.yaml` file based on the sample in the [Kong charts repository](https://github.com/Kong/charts/blob/master/charts/kong/values.yaml). This file sets all the necessary parameters for your Kong environment.
+
+2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
+
+    Parameter | Value  
+    ----------|-------
+    `env.database` | `"postgres"` or `"cassandra"`
+    `env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`.
+    `env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`.
+    `image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`
+    `image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`
+    `ingressController.enabled` | `false`
+
+3. Remove the entire section of `Ingress Controller parameters`. Since this installation enables other features such as Kong Manager and Kong Dev Portal, there is no need for a separate ingress controller.
+
+4. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
+
+5. Fill in the rest of the parameters as they fit your implementation. Use the comments in the file to guide you, and see the documentation on [Kong Enterprise parameters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-parameters) for more details.
+
+### Deploy Kong Enterprise on Kubernetes
+{% navtabs %}
+{% navtab kubectl %}
+1. Run:
+    ```
+    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+    This may take some time.
+
+2. Check pod status:
+    ```
+    $ kubectl get pods -n kong
+    ```
+    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
+{% endnavtab %}
+{% navtab OpenShift oc %}
+1. Run:
+    ```
+    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+    This may take some time.
+
+2. Check pod status:
+    ```
+    $ oc get pods -n kong
+    ```
+    Once migrations are complete and the `my-kong-kong-<ID>` pod is running, move on to the next section.
+{% endnavtab %}
+{% endnavtabs %}
+
+### Set up Kong Manager
+{% navtabs %}
+{% navtab kubectl %}
+1. Run:
+    ```
+    $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ```
+
+2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
+
+    ```
+    admin_api_uri: <your-ip>
+    ```
+
+3. Clean up:
+    ```
+    $ kubectl delete jobs -n kong --all
+    ```
+
+4. Update Kong to use the changed `values.yaml`:
+    ```
+    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+
+6. Once the upgrade is complete, you can log into Kong Manager. Run:
+    ```
+    kubectl get svc -n kong
+    ```
+
+    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong Manager:
+
+    ```
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
+    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    80:31308/TCP,443:32420/TCP      24m
+    ```
+    You can also access the Kong Dev Portal directly using its IP from this list, or log into Kong Manager and access the Dev Portal for an individual workspace from there.
+{% endnavtab %}
+{% navtab OpenShift oc %}
+1. Run:
+    ```
+    $ oc get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ```
+
+2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
+
+    ```
+    admin_api_uri: <your-ip>
+    ```
+
+3. Clean up:
+    ```
+    $ oc delete jobs -n kong --all
+    ```
+
+4. Update Kong to use the changed `values.yaml`:
+    ```
+    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
+    ```
+
+6. Once the upgrade is complete, you can log into Kong Manager. Run:
+    ```
+    oc get svc -n kong
+    ```
+
+    In the output, the IP in the `EXTERNAL_IP` column is your access point for Kong Manager:
+
+    ```
+    NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                         AGE
+    my-kong-kong-manager          LoadBalancer   10.96.61.116     10.96.61.116    80:31308/TCP,443:32420/TCP      24m
+    ```
+    You can also access the Kong Dev Portal directly using its IP from this list, or log into Kong Manager and access the Dev Portal for an individual workspace from there.
+{% endnavtab %}
+{% endnavtabs %}
+## Next steps...
+See [Using Kong for Kubernetes Enterprise](/enterprise/{{page.kong_version}}/kong-for-kubernetes/using-kong-for-kubernetes) for information about concepts, how-to guides, reference guides, and using plugins.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -15,7 +15,7 @@ Before starting installation, be sure you have the following:
 - **Kubernetes cluster**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
 - A valid Kong Enterprise License
-  * If you have a license, continue to [Set Up Kong Enterprise License](#set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
+  * If you have a license, continue to [Set Up Kong Enterprise License](#step-2-set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
   * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
 - Kong Enterprise Docker registry access on Bintray.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -41,7 +41,7 @@ $ oc new-project kong
 ## Step 2. Set Up Kong Enterprise License
 Running Kong for Kubernetes Enterprise requires a valid license.
 
-As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales represenative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
+As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
 > Note: There is no `.json` extension in the `--from-file` parameter.
 > `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Kong for Kubernetes Enteprise
+title: Installing Kong for Kubernetes Enterprise
 ---
 
 ## Introduction
@@ -22,7 +22,7 @@ Before starting installation, be sure you have the following:
 
 ## Step 1. Provision a Namespace
 
-In order to create the secrets for license and Docker registry access,
+To create the secrets for license and Docker registry access,
 first provision the `kong` namespace:
 
 {% navtabs %}
@@ -82,7 +82,7 @@ $ oc create secret -n kong docker-registry kong-enterprise-k8s-docker \
 {% endnavtab %}
 {% endnavtabs %}
 
-## Step 4. Deploy Kong for Kubernetes Enteprise
+## Step 4. Deploy Kong for Kubernetes Enterprise
 The steps in this section show you how to install Kong for Kubernetes Enterprise using YAML.
 
 {% navtabs %}
@@ -138,7 +138,7 @@ $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip
 ```
 
 It might take a while for your cloud provider to associate the IP address to the `kong-proxy` service.
-Once you have installed Kong, see the [getting started tutorial](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/guides/getting-started.md).
+After you have installed Kong, see the [getting started tutorial](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/guides/getting-started.md).
 
-### Next steps...
+## Next steps...
 See [Using Kong for Kubernetes Enterprise](/enterprise/{{page.kong_version}}/kong-for-kubernetes/using-kong-for-kubernetes) for information about concepts, how-to guides, reference guides, and using plugins.


### PR DESCRIPTION
*  Adding descriptions of packages to intro based on https://github.com/Kong/docs.konghq.com/pull/2015
* Splitting out instructions for `kong-kubernetes-install` into separate section
* Rearranging topic to fit new instructions

Previews:
https://deploy-preview-2019--kongdocs.netlify.app/enterprise/1.5.x/kong-for-kubernetes/install/
https://deploy-preview-2019--kongdocs.netlify.app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes/

