### PR TITLE
more info on cookie_domain in dev portal auth sessions

### DIFF
--- a/app/_hub/kong-inc/session/index.md
+++ b/app/_hub/kong-inc/session/index.md
@@ -8,11 +8,14 @@ redirect_from:
 
 desc: Support sessions for Kong Authentication Plugins.
 description: |
-  The Kong Session Plugin can be used to manage browser sessions for APIs proxied 
+  The Kong Session Plugin can be used to manage browser sessions for APIs proxied
   through the Kong API Gateway. It provides configuration and management for
   session data storage, encryption, renewal, expiry, and sending browser cookies.
   It is built using
-  <a href="https://github.com/bungle/lua-resty-session">lua-resty-session</a>
+  <a href="https://github.com/bungle/lua-resty-session">lua-resty-session</a>.
+
+  For information about configuring and using the Sessions plugin with the Dev
+  Portal, see [Sessions in the Dev Portal](/enterprise/latest/developer-portal/configuration/authentication/sessions/#configuration-to-use-the-sessions-plugin-with-the-dev-portal).
 
 type: plugin
 categories:
@@ -352,9 +355,9 @@ the `access` and `header_filter` phases in the plugin.
 
 ### Groups
 
-Authenticated groups are stored on `ngx.ctx.authenticated_groups` from other 
-authentication plugins and the session plugin will store them in the data of 
-the current session. Since the session plugin runs before authentication 
+Authenticated groups are stored on `ngx.ctx.authenticated_groups` from other
+authentication plugins and the session plugin will store them in the data of
+the current session. Since the session plugin runs before authentication
 plugins, it will also set `authenticated_groups` associated headers.
 
 ## Kong Storage Adapter

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -21,8 +21,9 @@ portal_session_conf = {
     "cookie_name":"<SET_COOKIE_NAME>",
     "storage":"kong",
     "cookie_lifetime":<NUMBER_OF_SECONDS_TO_LIVE>,
-    "cookie_renew":<NUMBER_OF_SECONDS_LEFT_TO_RENEW>
-    "cookie_secure":<SET_DEPENDING_ON_PROTOCOL>
+    "cookie_renew":<NUMBER_OF_SECONDS_LEFT_TO_RENEW>,
+    "cookie_secure":<SET_DEPENDING_ON_PROTOCOL>,
+    "cookie_domain":"<SET_DEPENDING_ON_DOMAIN>",
     "cookie_samesite":"<SET_DEPENDING_ON_DOMAIN>"
 }
 ```

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -90,8 +90,8 @@ portal_session_conf = {
 
 ### Domains
 
-The dev portal `portal_api_url` and the dev
-portal api `portal_gui_host` must share a domain or subdomain. The following
+The dev portal `portal_gui_host` and the dev
+portal api `portal_api_url` must share a domain or subdomain. The following
 example assumes subdomains of `portal.xyz.com` and `portalapi.xyz.com`.
 Set a subdomain such as ``"cookie_domain": ".xyz.com"`` and set
 `cookie_samesite` to `off`.

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -62,7 +62,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ## Example Configurations
 
-### HTTPS and same domain
+### HTTPS with the same domain for API and GUI
 
 If using HTTPS and hosting Dev Portal API and the Dev Portal GUI from the same domain, the following configuration could be used for Basic Auth:
 
@@ -90,8 +90,8 @@ portal_session_conf = {
 
 ### Domains
 
-There is a dependency that the dev portal `portal_api_url` and the dev
-portal api `portal_gui_host` need to share a domain or subdomain. The following
+The dev portal `portal_api_url` and the dev
+portal api `portal_gui_host` must share a domain or subdomain. The following
 example assumes subdomains of `portal.xyz.com` and `portalapi.xyz.com`.
 Set a subdomain such as ``"cookie_domain": ".xyz.com"`` and set
 `cookie_samesite` to `off`.

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -2,7 +2,7 @@
 title: Sessions in the Dev Portal
 ---
 
-⚠️**Important:** Portal Session Configuration does not apply when using [OpenID Connect](/hub/kong-inc/openid-connect) for Dev Portal authentication. The following information assumes that the Dev Portal is configured with `portal_auth` other than `openid-connect`, for example `key-auth` or `basic-auth`.
+⚠️**Important:** Portal Session Configuration does not apply when using [OpenID Connect](/hub/kong-inc/openid-connect) for Dev Portal authentication. The following information assumes that the Dev Portal is configured with `portal_auth` other than `openid-connect`; for example, `key-auth` or `basic-auth`.
 
 ## How does the Sessions Plugin work in the Dev Portal?
 
@@ -39,6 +39,7 @@ portal_session_conf = {
    the Plugin renews the session; 600 by default.
 * `"cookie_secure":<SET_DEPENDING_ON_PROTOCOL>`: `true` by default. See [Session Security](#session-security) for
     exceptions.
+* `"cookie_domain":<SET_DEPENDING_ON_DOMAIN>:` Optional. See [Session Security](#session-security) for exceptions.
 * `"cookie_samesite":"<SET_DEPENDING_ON_DOMAIN>"`: `"Strict"` by default. See [Session Security](#session-security) for
     exceptions.
 
@@ -60,6 +61,8 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ## Example Configurations
 
+### HTTPS and same domain
+
 If using HTTPS and hosting Dev Portal API and the Dev Portal GUI from the same domain, the following configuration could be used for Basic Auth:
 
 ```
@@ -68,6 +71,7 @@ portal_session_conf = {
     "cookie_name":"$4m04$"
     "secret":"change-this-secret"
     "storage":"kong"
+    "cookie_secure":true
 }
 ```
 
@@ -80,5 +84,26 @@ portal_session_conf = {
     "secret":"change-this-secret"
     "storage":"kong"
     "cookie_secure":false
+}
+```
+
+### Domains
+
+There is a dependency that the dev portal `portal_api_url` and the dev
+portal api `portal_gui_host` need to share a domain or subdomain. The following
+example assumes subdomains of `portal.xyz.com` and `portalapi.xyz.com`.
+Set a subdomain such as ``"cookie_domain": ".xyz.com"`` and set
+`cookie_samesite` to `off`.
+
+```
+portal_auth = basic-auth
+portal_session_conf = {
+    "storage":"kong"
+    "cookie_name":"portal_session"
+    "cookie_domain": ".xyz.com"
+    "secret":"super-secret"
+    "cookie_secure":false
+    "cookie_lifetime":31557600,
+    "cookie_samesite":"off"
 }
 ```


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1045

Direct review links:

https://deploy-preview-2022--kongdocs.netlify.app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions/#configuration-to-use-the-sessions-plugin-with-the-dev-portal

https://deploy-preview-2022--kongdocs.netlify.app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions/#domains

Link in first paragraph of Session plugin back to Dev Portal auth session:

https://deploy-preview-2022--kongdocs.netlify.app/hub/kong-inc/session/