### PR TITLE
fix(build workflow) Removing review_requested

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: ready_for_review
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Testing out another method of building previews: disabling the "review_requested" flag, as it's building every time you add a reviewer or re-request a review.
