### PR TITLE
docs(nav) Fix link to CA certificate object in 1.5.x nav

### DIFF
--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -137,7 +137,7 @@
   - text: Certificate Object
     url: /admin-api/#certificate-object
   - text: CA Certificate Object
-    urk: /admin-api/#ca-certificate-object
+    url: /admin-api/#ca-certificate-object
   - text: SNI Object
     url: /admin-api/#sni-object
   - text: Upstream Object


### PR DESCRIPTION
Link is already fixed in 1.3-x
