### PR TITLE
docs(rate-limiting) Moving rate limiting reference 

### DIFF
--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -96,8 +96,7 @@
     - text: CLI Reference
       url: /cli
     - text: Rate Limiting Library
-      url: /enterprise/references/rate-limiting
-      absolute_url: true
+      url: /rate-limiting
     - text: Proxy Reference
       url: /proxy
     - text: Authentication Reference

--- a/app/enterprise/1.5.x/rate-limiting.md
+++ b/app/enterprise/1.5.x/rate-limiting.md
@@ -1,7 +1,6 @@
 ---
 title: Enterprise Rate Limiting Library
 ---
-<!--- This page remains unversioned for Kong Enterprise 1.3-x and earlier; for later versions, edit /app/enterprise/<version-folder>/rate-limiting --->
 
 ## Overview
 This library is designed to provide an efficient, scalable, eventually-consistent sliding window rate limiting library. It relies on atomic operations in shared ngx memory zones to track window counters within a given node, periodically syncing this data to a central data store (current Cassandra, Postgres, and Redis).


### PR DESCRIPTION
Rate limiting reference exists outside of the doc versioning structure, so it doesn't pick up the ToC and floats on its own. 

* Adding the rate limiting reference into ee-1.5.x and updating nav accordingly
* Leaving it as is for previous versions to avoid unnecessary topic duplication
* Changing the layout to the (new) default docs layout instead of a reference-specific one
