### PR TITLE
docs(plugins) DB-less config cleanup for examples and global plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -143,7 +143,7 @@ Configure this plugin on a [Consumer](/latest/admin-api/#Consumer-object) with:
 
 ```bash
 $ curl -X POST http://kong:8001/consumers/{consumer}/plugins \
-   --data "name={{page.params.name}}" {{ config_required_fields }}
+    --data "name={{page.params.name}}" {{ config_required_fields }}
 ```
 {% endcapture %}
 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -56,11 +56,11 @@ $ curl -X POST http://kong:8001/services/{service}/plugins \
 {% capture plugin_config_for_service %}
 ### Enabling the plugin on a Service
 
-{% if page.enterprise %}
+{% if page.enterprise or page.params.dbless_compatible == false or page.params.dbless_compatible == nil %}
 
 {{ plugin_config_for_service_with_db }}
 
-{% else %}
+{% elsif page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
 
 {% navtabs %}
 {% navtab With a database %}
@@ -104,11 +104,11 @@ $ curl -X POST http://kong:8001/routes/{route}/plugins \
 {% capture plugin_config_for_route %}
 ### Enabling the plugin on a Route
 
-{% if page.enterprise %}
+{% if page.enterprise or page.params.dbless_compatible == false or page.params.dbless_compatible == nil %}
 
 {{ plugin_config_for_route_with_db }}
 
-{% else %}
+{% elsif page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
 
 {% navtabs %}
 {% navtab With a database %}
@@ -139,8 +139,7 @@ plugins:
 {% if page.params.consumer_id %}
 {% capture plugin_config_for_consumer_with_db %}
 
-You can use the `http://localhost:8001/plugins` endpoint to enable this plugin
-on specific [Consumers](/latest/admin-api/#Consumer-object):
+Configure this plugin on a [Consumer](/latest/admin-api/#Consumer-object) with:
 
 ```bash
 $ curl -X POST http://kong:8001/consumers/{consumer}/plugins \
@@ -152,11 +151,11 @@ $ curl -X POST http://kong:8001/consumers/{consumer}/plugins \
 {% capture plugin_config_for_consumer %}
 ### Enabling the plugin on a Consumer
 
-{% if page.enterprise %}
+{% if page.enterprise or page.params.dbless_compatible == false or page.params.dbless_compatible == nil %}
 
 {{ plugin_config_for_consumer_with_db }}
 
-{% else %}
+{% elsif page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
 {% navtabs %}
 
 {% navtab With a database %}
@@ -410,17 +409,20 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
         {% endif %}
 
         <h3 id="global-plugins">Global plugins</h3>
-
-        <ul>
-          <li><strong>Using a database</strong>, all plugins can be configured using the <code>http://kong:8001/plugins/</code> endpoint.</li>
-          <li><strong>Without a database</strong>, all plugins can be configured via the <code>plugins:</code> entry on the declarative configuration file.</li>
-        </ul>
-
         <p>A plugin which is not associated to any Service, Route, or Consumer (or API, if you are using an older
         version of Kong) is considered "global", and will be run on every request.
         Read the <a href="/latest/admin-api/#add-plugin">Plugin Reference</a> and the
         <a href="/latest/admin-api/#precedence">Plugin Precedence</a> sections for more information.
         </p>
+        {% if page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
+        <ul>
+          <li><strong>Using a database</strong>, all plugins can be configured using the <code>http://kong:8001/plugins/</code> endpoint.</li>
+          <li><strong>Without a database</strong>, all plugins can be configured via the <code>plugins:</code> entry on the declarative configuration file.</li>
+        </ul>
+        {% else %}
+        <p>Plugins can be configured using the <code>http://kong:8001/plugins/</code> endpoint.
+        </p>
+        {% endif %}
 
         <h3 id="parameters">Parameters</h3>
 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -143,8 +143,7 @@ Configure this plugin on a [Consumer](/latest/admin-api/#Consumer-object) with:
 
 ```bash
 $ curl -X POST http://kong:8001/consumers/{consumer}/plugins \
-    --data "name={{page.params.name}}" \
-    {{ config_required_fields }}
+   --data "name={{page.params.name}}" {{ config_required_fields }}
 ```
 {% endcapture %}
 


### PR DESCRIPTION
The plugins layout doesn't account for a few different use-cases when it comes to db-less config. It also assumes that if a plugin is a core plugin, then it has db-less support.

* Changed example settings so that layout would look for other permutations of the dbless_compatibility setting, including times when the parameter doesn't exist. This fixes OAuth2, which isn't db-less compatible.
* Conditionalized the "Global Plugins" section to display info on db-less only when a plugin supports it.
* Removed info about enabling a plugin on a consumer through `http://localhost:8001/plugins`

Previews:
OAuth2: https://deploy-preview-2039--kongdocs.netlify.app/hub/kong-inc/oauth2/
Any Kong Inc plugin: https://deploy-preview-2039--kongdocs.netlify.app/hub/