### PR TITLE
fix(proxy) add missing link tag

### DIFF
--- a/app/2.0.x/proxy.md
+++ b/app/2.0.x/proxy.md
@@ -1332,6 +1332,7 @@ just covered.
 [plugin-configuration-object]: /{{page.kong_version}}/admin-api#plugin-object
 [plugin-development-guide]: /{{page.kong_version}}/plugin-development
 [plugin-association-rules]: /{{page.kong_version}}/admin-api/#precedence
+[proxy-websocket]: /{{page.kong_version}}/proxy/#proxy-websocket-traffic
 [load-balancing-reference]: /{{page.kong_version}}/loadbalancing
 [configuration-reference]: /{{page.kong_version}}/configuration/
 [configuration-trusted-ips]: /{{page.kong_version}}/configuration/#trusted_ips

--- a/app/enterprise/1.5.x/proxy.md
+++ b/app/enterprise/1.5.x/proxy.md
@@ -1113,6 +1113,7 @@ just covered.
 [plugin-configuration-object]: /enterprise/{{page.kong_version}}/admin-api#plugin-object
 [plugin-development-guide]: /enterprise/{{page.kong_version}}/plugin-development
 [plugin-association-rules]: /enterprise/{{page.kong_version}}/admin-api/#precedence
+[proxy-websocket]: /{{page.kong_version}}/proxy/#proxy-websocket-traffic
 [load-balancing-reference]: /enterprise/{{page.kong_version}}/loadbalancing
 [configuration-reference]: /enterprise/{{page.kong_version}}/property-reference
 [configuration-trusted-ips]: /enterprise/{{page.kong_version}}/property-reference/#trusted_ips

--- a/app/enterprise/1.5.x/proxy.md
+++ b/app/enterprise/1.5.x/proxy.md
@@ -1113,7 +1113,7 @@ just covered.
 [plugin-configuration-object]: /enterprise/{{page.kong_version}}/admin-api#plugin-object
 [plugin-development-guide]: /enterprise/{{page.kong_version}}/plugin-development
 [plugin-association-rules]: /enterprise/{{page.kong_version}}/admin-api/#precedence
-[proxy-websocket]: /{{page.kong_version}}/proxy/#proxy-websocket-traffic
+[proxy-websocket]: /enterprise/{{page.kong_version}}/proxy/#proxy-websocket-traffic
 [load-balancing-reference]: /enterprise/{{page.kong_version}}/loadbalancing
 [configuration-reference]: /enterprise/{{page.kong_version}}/property-reference
 [configuration-trusted-ips]: /enterprise/{{page.kong_version}}/property-reference/#trusted_ips


### PR DESCRIPTION
Currently this tag is referenced at the end of https://docs.konghq.com/2.0.x/proxy/#3-proxying--upstream-timeouts (https://github.com/Kong/docs.konghq.com/blame/e94866bcd0ac3c3020a230803433947805308ae1/app/2.0.x/proxy.md#L959 in source), but was not present in the bottom matter.