### PR TITLE
fix(renovate-bot) Setting bot to ignore jekyll and bootstrap dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,9 @@
     "config:base"
   ],
   "schedule": "every weekend",
-  "bundler": {"enabled": true}
+  "bundler": {"enabled": true},
+  "ignoreDeps": [
+    "jekyll",
+    "bootstrap"
+  ]
 }


### PR DESCRIPTION
Based on the docs found here: https://konghq.atlassian.net/wiki/spaces/KD/pages/1123156059/Renovate-bot

Particularly:
> The docs site currently runs on Jekyll 3.8.6 and Bootstrap 3 - updating these two packages will break the site, renovate-bot has been told not to try to update these but be on the lookout in-case it does!

Renovate-bot has recently tried to open PRs twice to update jekyll to 3.8.7, even though closing the PR should tell it to ignore the update. Changing settings to ignore both jekyll and bootstrap updates.
