### PR TITLE
docs(plugins) Proxy-cache supports db-less

### DIFF
--- a/app/1.2.x/db-less-and-declarative-config.md
+++ b/app/1.2.x/db-less-and-declarative-config.md
@@ -271,6 +271,7 @@ their initial config) so they are fully compatible with DB-less:
 - `datadog`
 - `file-log`
 - `http-log`
+- `proxy-cache`
 - `tcp-log`
 - `udp-log`
 - `syslog`

--- a/app/1.3.x/db-less-and-declarative-config.md
+++ b/app/1.3.x/db-less-and-declarative-config.md
@@ -91,7 +91,7 @@ Server: kong/1.1.0
 }
 ```
 
-Kong is running, but no declarative configuration was loaded yet. This 
+Kong is running, but no declarative configuration was loaded yet. This
 means that the configuration of this node is empty. There are no Routes,
 Services or entities of any kind:
 
@@ -107,7 +107,7 @@ Date: Wed, 27 Mar 2019 15:30:02 GMT
 Server: kong/1.1.0
 
 {
-    "data": [], 
+    "data": [],
     "next": null
 }
 ```
@@ -210,7 +210,7 @@ $ kong start -c kong.conf
 ```
 
 Alternatively, you can load a declarative configuration into a running
-Kong node via its Admin API, using the `/config` endpoint. The 
+Kong node via its Admin API, using the `/config` endpoint. The
 following example loads `kong.yml` using HTTPie:
 
 ```
@@ -273,6 +273,7 @@ their initial config) so they are fully compatible with DB-less:
 * `datadog`
 * `file-log`
 * `http-log`
+* `proxy-cache`
 * `tcp-log`
 * `udp-log`
 * `syslog`
@@ -289,7 +290,7 @@ their initial config) so they are fully compatible with DB-less:
 Authentication plugins can be used insofar as the set of credentials
 used is static and specified as part of the declarative configuration.
 Admin API endpoints to dynamically create, update or delete credentials
-are not available in DB-less mode. Plugins that fall into this 
+are not available in DB-less mode. Plugins that fall into this
 category are:
 
 * `acl`

--- a/app/1.4.x/db-less-and-declarative-config.md
+++ b/app/1.4.x/db-less-and-declarative-config.md
@@ -91,7 +91,7 @@ Server: kong/1.1.0
 }
 ```
 
-Kong is running, but no declarative configuration was loaded yet. This 
+Kong is running, but no declarative configuration was loaded yet. This
 means that the configuration of this node is empty. There are no Routes,
 Services or entities of any kind:
 
@@ -107,7 +107,7 @@ Date: Wed, 27 Mar 2019 15:30:02 GMT
 Server: kong/1.1.0
 
 {
-    "data": [], 
+    "data": [],
     "next": null
 }
 ```
@@ -210,7 +210,7 @@ $ kong start -c kong.conf
 ```
 
 Alternatively, you can load a declarative configuration into a running
-Kong node via its Admin API, using the `/config` endpoint. The 
+Kong node via its Admin API, using the `/config` endpoint. The
 following example loads `kong.yml` using HTTPie:
 
 ```
@@ -273,6 +273,7 @@ their initial config) so they are fully compatible with DB-less:
 * `datadog`
 * `file-log`
 * `http-log`
+* `proxy-cache`
 * `tcp-log`
 * `udp-log`
 * `syslog`
@@ -289,7 +290,7 @@ their initial config) so they are fully compatible with DB-less:
 Authentication plugins can be used insofar as the set of credentials
 used is static and specified as part of the declarative configuration.
 Admin API endpoints to dynamically create, update or delete credentials
-are not available in DB-less mode. Plugins that fall into this 
+are not available in DB-less mode. Plugins that fall into this
 category are:
 
 * `acl`

--- a/app/1.5.x/db-less-and-declarative-config.md
+++ b/app/1.5.x/db-less-and-declarative-config.md
@@ -91,7 +91,7 @@ Server: kong/1.1.0
 }
 ```
 
-Kong is running, but no declarative configuration was loaded yet. This 
+Kong is running, but no declarative configuration was loaded yet. This
 means that the configuration of this node is empty. There are no Routes,
 Services or entities of any kind:
 
@@ -107,7 +107,7 @@ Date: Wed, 27 Mar 2019 15:30:02 GMT
 Server: kong/1.1.0
 
 {
-    "data": [], 
+    "data": [],
     "next": null
 }
 ```
@@ -210,7 +210,7 @@ $ kong start -c kong.conf
 ```
 
 Alternatively, you can load a declarative configuration into a running
-Kong node via its Admin API, using the `/config` endpoint. The 
+Kong node via its Admin API, using the `/config` endpoint. The
 following example loads `kong.yml` using HTTPie:
 
 ```
@@ -273,6 +273,7 @@ their initial config) so they are fully compatible with DB-less:
 * `datadog`
 * `file-log`
 * `http-log`
+* `proxy-cache`
 * `tcp-log`
 * `udp-log`
 * `syslog`
@@ -282,14 +283,13 @@ their initial config) so they are fully compatible with DB-less:
 * `request-transformer`
 * `response-transformer`
 * `request-termination`
-* `kubernetes-sidecar-injector`
 
 ##### Partial Compatibility
 
 Authentication plugins can be used insofar as the set of credentials
 used is static and specified as part of the declarative configuration.
 Admin API endpoints to dynamically create, update or delete credentials
-are not available in DB-less mode. Plugins that fall into this 
+are not available in DB-less mode. Plugins that fall into this
 category are:
 
 * `acl`

--- a/app/2.0.x/db-less-and-declarative-config.md
+++ b/app/2.0.x/db-less-and-declarative-config.md
@@ -273,6 +273,7 @@ their initial config) so they are fully compatible with DB-less:
 * `datadog`
 * `file-log`
 * `http-log`
+* `proxy-cache`
 * `tcp-log`
 * `udp-log`
 * `syslog`
@@ -282,7 +283,6 @@ their initial config) so they are fully compatible with DB-less:
 * `request-transformer`
 * `response-transformer`
 * `request-termination`
-* `kubernetes-sidecar-injector`
 
 ##### Partial Compatibility
 

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -43,13 +43,13 @@ params:
         Upstream response status code considered cacheable.
     - name: request_method
       required:
-      default: "`GET,HEAD`"
+      default: '`["GET","HEAD"]`'
       value_in_examples:
       description: |
         Downstream request methods considered cacheable.
     - name: content_type
       required:
-      default: "`text/plain,application/json`"
+      default: '`["text/plain", "application/json"]`'
       value_in_examples:
       description: |
         Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned.

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -30,29 +30,29 @@ kong_version_compatibility:
 
 params:
   name: proxy-cache
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true
+  dbless_compatible: yes
   config:
     - name: response_code
       required:
       default: 200, 301, 404
       value_in_examples:
       description: |
-        Upstream response status code considered cacheable
+        Upstream response status code considered cacheable.
     - name: request_method
       required:
-      default: GET, HEAD
+      default: "`GET,HEAD`"
       value_in_examples:
       description: |
-        Downstream request methods considered cacheable
+        Downstream request methods considered cacheable.
     - name: content_type
       required:
-      default: text/plain, application/json
+      default: "`text/plain,application/json`"
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned
+        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned.
     - name: vary_headers
       required: false
       default:
@@ -68,15 +68,15 @@ params:
     - name: cache_ttl
       required:
       default: 300
-      value_in_examples:
+      value_in_examples: 300
       description: |
-        TTL, in seconds, of cache entities
+        TTL, in seconds, of cache entities.
     - name: cache_control
       required:
-      default: false
+      default: "`false`"
       value_in_examples:
       description: |
-        When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2)
+        When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
     - name: storage_ttl
       required: false
       default:
@@ -84,14 +84,14 @@ params:
       description: |
         Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors.
     - name: strategy
-      required:
+      required: true
       default:
       value_in_examples: memory
       description: |
-        The backing data store in which to hold cache entities. Accepted values are; `memory`.
+        The backing data store in which to hold cache entities. The only accepted value is `memory`.
     - name: memory.dictionary_name
       required:
-      default: kong_cache
+      default: "`kong_cache`"
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.


### PR DESCRIPTION
As an OSS plugin, proxy-cache has db-less support. 

* Added the plugin to db-less support lists going back to 1.2.x based on https://github.com/Kong/kong/blob/master/CHANGELOG.md
* Removed sidecar injector plugin from 2.0.x and 1.5.x lists as it was deprecated in 1.5.x (https://github.com/Kong/docs.konghq.com/pull/1817)  
* Set `dbless_compatibility` to true to generate examples and accurate descriptions

Previews: https://deploy-preview-2049--kongdocs.netlify.app/hub/kong-inc/proxy-cache
https://deploy-preview-2049--kongdocs.netlify.app/2.0.x/db-less-and-declarative-config/