### PR TITLE
Added 0.35-5 release

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -1040,6 +1040,7 @@ not able to access the **Workspace** that the **Role** was assigned to.
 ### Fixes
 - Reverted breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
 - Reverted service mesh changes affecting `proxy_ssl_*` directives.
+- Removed service mesh to fix upstream TLS issues.
 
 ## 0.35-4
 **Release Date:** 2019/08/19

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -1038,7 +1038,7 @@ not able to access the **Workspace** that the **Role** was assigned to.
 **Release Date:** 2020/05/14
 
 ### Fixes
-- Reverted some breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
+- Reverted breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
 - Reverted service mesh changes affecting proxy_ssl_* directives.
 
 ## 0.35-4

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -1039,7 +1039,7 @@ not able to access the **Workspace** that the **Role** was assigned to.
 
 ### Fixes
 - Reverted breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
-- Reverted service mesh changes affecting proxy_ssl_* directives.
+- Reverted service mesh changes affecting `proxy_ssl_*` directives.
 
 ## 0.35-4
 **Release Date:** 2019/08/19

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -1034,6 +1034,13 @@ not able to access the **Workspace** that the **Role** was assigned to.
 - **Brain**
   - Renames **Brain** to **Collector**
 
+## 0.35-5
+**Release Date:** 2020/05/14
+
+### Fixes
+- Reverted some breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
+- Reverted service mesh changes affecting proxy_ssl_* directives.
+
 ## 0.35-4
 **Release Date:** 2019/08/19
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -1040,7 +1040,6 @@ not able to access the **Workspace** that the **Role** was assigned to.
 ### Fixes
 - Reverted breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
 - Reverted service mesh changes affecting `proxy_ssl_*` directives.
-- Removed service mesh to fix upstream TLS issues.
 
 ## 0.35-4
 **Release Date:** 2019/08/19


### PR DESCRIPTION
Worked with Arturas M to update the changelog. 

## 0.35-5
**Release Date:** 2020/05/14
### Fixes
- Reverted some breaking changes introduced by [PR #3780](https://github.com/Kong/kong/pull/3780) involving the handling of slashes inside the router.
- Reverted service mesh changes affecting proxy_ssl_* directives.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

