### PR TITLE
docs(brain) Fixes for Auto-Generated Specs page

### DIFF
--- a/app/enterprise/1.5.x/brain-immunity/auto-generated-specs.md
+++ b/app/enterprise/1.5.x/brain-immunity/auto-generated-specs.md
@@ -3,7 +3,7 @@ title: Auto-Generated Specs
 ---
 
 ## Introduction
-Writing API documentations and keeping them up to date is often the easiest, most important task that either doesn't happen or doesn't happen enough.  Having great API specifications is especially difficult for organizations with legacy APIs that were never documented to begin with.
+Writing API documentation and keeping them up to date is often the easiest, most important task that either doesn't happen or doesn't happen enough. Having great API specifications is especially difficult for organizations with legacy APIs that were never documented to begin with.
 
 Being able to use seen traffic to auto-generate OpenAPI/Swagger specifications is a crucial first step towards having and maintaining accurate API docs.
 
@@ -15,7 +15,7 @@ Being able to use seen traffic to auto-generate OpenAPI/Swagger specifications i
 * Dev Portal enabled for all workspaces that need auto-generated specifications
 
 
-For more information, see the [Kong Brain and Kong Immunity Installation and Configuration Guide](/enterprise/{{page.kong_version}}/brain-immunity/install-configure).
+For more information, see the [Kong Brain and Kong Immunity Installation and Configuration](/enterprise/{{page.kong_version}}/brain-immunity/install-configure) topic.
 
 
 ### Setup

--- a/app/enterprise/1.5.x/brain-immunity/auto-generated-specs.md
+++ b/app/enterprise/1.5.x/brain-immunity/auto-generated-specs.md
@@ -3,9 +3,9 @@ title: Auto-Generated Specs
 ---
 
 ## Introduction
-Writing API documentation and keeping them up to date is often the easiest, most important task that either doesn't happen or doesn't happen enough.  Having great API specs is especially difficult for organizations with legacy APIs that were never documented to begin with.
+Writing API documentations and keeping them up to date is often the easiest, most important task that either doesn't happen or doesn't happen enough.  Having great API specifications is especially difficult for organizations with legacy APIs that were never documented to begin with.
 
-Being able to use seen traffic to auto-generated Swagger and Open API specs is a crucial first step towards having and maintaining accurate API docs.
+Being able to use seen traffic to auto-generate OpenAPI/Swagger specifications is a crucial first step towards having and maintaining accurate API docs.
 
 
 ### Prerequisites
@@ -20,13 +20,19 @@ For more information, see the [Kong Brain and Kong Immunity Installation and Con
 
 ### Setup
 
-Once you have the Collector plugin and infrastructure up and running with Dev Portal enabled, Kong Brain does not require additional configuration as it is automatically enabled. Once data is flowing through the Collector system, Brain starts generating swagger files and service-maps as displayed on the Dev Portal.
+Once you have the Collector plugin and infrastructure up and running with Dev Portal enabled, Kong Brain does not require additional configuration as it is automatically enabled. Once data is flowing through the Collector system, Brain starts generating and uploading OpenAPI/Swagger specifications to the Kong Dev Portal and populating the Service Map in Kong Manager.
 
 
-#### Retrieve Open-Spec Files from Collector Backend
+#### Retrieve OpenAPI/Swagger specifications from the Collector backend
 
-Open-spec files can also be retrieved via the Collector App endpoint on **<COLLECTOR_APP_ENDPOINT>/swagger**.  The **/swagger** endpoint returns a swagger file, generated considering traffic that match the submitted filter parameters: `host`, `route_id`, `service_id` and `workspace_name`. Also, it fills the fields `title`, `version` and `description` within the swagger file with the respective submitted parameters.
+The generated OpenAPI/Swagger specifications can also be retrieved via the Collector App endpoint at `http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/swagger`.
+
+The `/swagger` endpoint returns an OpenAPI/Swagger file, generated based on traffic matching the submitted filter parameters: `host`, `route_id`, `service_id`, and `workspace_name`.
+
+In the specification, the fields `title`, `version`, and `description` are filled with the submitted URL parameters.
+
+Use the parameter `openapi_version` to specify which version of the OpenAPI specification to use - possible values are `2` (default) and `3`.
 
 ```
-http://<COLLECTOR_APP_ENDPOINT>/swagger?host=<request_host>&openapi_version=<2|3>&route_id=<route_id>&service_id=<service_id>&workspace_name=<workspace_name>?title=
+http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/swagger?openapi_version=<2|3>&host=<request_host>&route_id=<route_id>&service_id=<service_id>&workspace_name=<workspace_name>&title=<title>&version=<version>&description=<description>
 ```


### PR DESCRIPTION
Fixes several bugs with https://docs.konghq.com/enterprise/1.5.x/brain-immunity/auto-generated-specs/:

1. The formatting of the last section is currently broken because of unescaped angle brackets that cause text to be interpreted as HTML tags
2. The URL at the end contains two `?` which would cause it to fail if used as-is
3. The parameter `openapi_version` is not explained (though it appears in the URL format).

In addition to fixing these, some general tidying up - using the same wording everywhere, aligning with other parts of the docs (e.g. using `<COLLECTOR_HOST>:<COLLECTOR_PORT>`).