### PR TITLE
docs(plugin-mtls_auth) Added known issue for revocation_check_mode

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -53,7 +53,9 @@ params:
     - name: revocation_check_mode
       default: "`IGNORE_CA_ERROR`"
       description: |
-        ***Known Issue: The default value `IGNORE_CA_ERROR` has a known issue in versions 1.5.0.0 and later. To workaround, manually set the value to `SKIP`***.  Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR` or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
+        >**Known Issue:** The default value `IGNORE_CA_ERROR` has a known issue in versions 1.5.0.0 and later. As a workaround, manually set the value to `SKIP`.
+
+        Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR` or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
     - name: http_timeout
       default: "30000"
       description: |
@@ -167,7 +169,7 @@ certificate property being set in `authenticated_group_by`.
 
 ### Troubleshooting
 
-When authentication fails, the client does not have access to any details explaining the 
+When authentication fails, the client does not have access to any details explaining the
 failure. The security reason for this omission is to prevent malicious reconnaissance.
 Instead, the details are recorded inside Kong's error logs under the `[mtls-auth]`
 filter.

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -55,7 +55,7 @@ params:
       description: |
         >**Known Issue:** The default value `IGNORE_CA_ERROR` has a known issue in versions 1.5.0.0 and later. As a workaround, manually set the value to `SKIP`.
 
-        Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR` or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
+        Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR`, or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
     - name: http_timeout
       default: "30000"
       description: |

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -53,7 +53,7 @@ params:
     - name: revocation_check_mode
       default: "`IGNORE_CA_ERROR`"
       description: |
-        Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR` or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
+        ***Known Issue: The default value `IGNORE_CA_ERROR` has a known issue in versions 1.5.0.0 and later. To workaround, manually set the value to `SKIP`***.  Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR` or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
     - name: http_timeout
       default: "30000"
       description: |


### PR DESCRIPTION
- Added known issue for param "revocation_check_mode", as default IGNORE_CA_ERROR" does not work in version 1.5.0.0 and later. 
- Workaround is to set value to "SKIP"
- Did not want to change default value to Skip, so opted for known issue note. 
- See https://konghq.atlassian.net/browse/FTI-1509
- Need to remove this note when issue is fixed.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

