### PR TITLE
docs(plugins) Added KE 1.5.x to Sessions plugin bundle/version support

### DIFF
--- a/app/_hub/kong-inc/session/index.md
+++ b/app/_hub/kong-inc/session/index.md
@@ -33,7 +33,8 @@ kong_version_compatibility:
       - 1.2.x
   enterprise_edition:
     compatible:
-      - 1.3.x
+      - 1.5.x
+      - 1.3-x
       - 0.36-x
       - 0.35-x
 


### PR DESCRIPTION
* Added KE 1.5.x version to "bundled-with" for Ldap Auth plugin
* This version info hasn't been updated since 1.3-x
* Confirmed with Rob S to look at https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule to confirm plugins bundled with release versions.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

