### PR TITLE
Dev portal copy edits

### DIFF
--- a/app/enterprise/1.5.x/developer-portal/administration/developer-permissions.md
+++ b/app/enterprise/1.5.x/developer-portal/administration/developer-permissions.md
@@ -22,7 +22,7 @@ newly created role as well as any other previously defined roles.
 
 Clicking View displays the Role Details page with a list of developers assigned.
 
-From the Role Details page, click the Edit button to make changes to the role. You can also access this page from the Roles List Edit button. Here we can change the name and comment of the role, assign or remove developers, or delete the role.
+From the Role Details page, click the Edit button to make changes to the role. You can also access this page from the Roles List Edit button. Here you can change the name and comment of the role, assign or remove developers, or delete the role.
 
 Deleting a role will remove it from any developers assigned the role and remove
 the role restriction from any content files it is applied to.

--- a/app/enterprise/1.5.x/developer-portal/administration/developer-permissions.md
+++ b/app/enterprise/1.5.x/developer-portal/administration/developer-permissions.md
@@ -4,31 +4,55 @@ title: Developer Roles and Content Permissions
 
 ## Introduction
 
-Access to the Developer Portal can be fine-tuned with the use of Developer Roles and Content Permissions, managed through the Dev Portal Permissions page of Kong Manager. This page can be found by clicking on the **Permissions** link under **Dev Portal** in the Kong Manager side navigation.
+Access to the Developer Portal can be fine-tuned with the use of Developer
+Roles and Content Permissions, managed through the Dev Portal Permissions page
+of Kong Manager. This page can be found by clicking the **Permissions** link
+under **Dev Portal** in the Kong Manager side navigation.
 
 ## Roles
 
-The Roles Tab contains a list of available developer roles as well as the ability to create and edit roles.
+The Roles Tab contains a list of available developer roles as well as providing
+the ability to create and edit roles.
 
-Selecting "Create Role" will allow us to enter the unique role name, as well as a comment to provide context for the nature of the role. We can assign the role to existing developers from within the role creation page. Clicking "Create" will save the role and return us to the Roles List view. Here we can see our newly created role as well as any other previously defined roles.
+Selecting Create Role allows you to enter a unique role name, as well as a
+comment to provide context for the nature of the role. You can assign the role
+to existing developers from within the role creation page. Clicking Create
+saves the role and returns you to the Roles List view. There you can see your
+newly created role as well as any other previously defined roles.
 
-Clicking "View" will show us the Role Details page with a list of developers assigned.
+Clicking View displays the Role Details page with a list of developers assigned.
 
-From the Role Details page, we can click the "Edit" button to make changes to the role. We can also access this page from the Roles List "Edit" button. Here we can change the name and comment of the role, assign or remove developers, or delete the role.
+From the Role Details page, click the Edit button to make changes to the role. You can also access this page from the Roles List Edit button. Here we can change the name and comment of the role, assign or remove developers, or delete the role.
 
-Deleting a role will remove it from any developers assigned the role and remove the role restriction from any content files it is applied to.
+Deleting a role will remove it from any developers assigned the role and remove
+the role restriction from any content files it is applied to.
 
 ## Content
 
-The Content Tab shows the list of content files used by the Dev Portal. Here we can apply roles to our content files, restricting access to  developers who posess certain roles. Selecting an individual content file displays a dropdown of availabled developer roles. Here we can choose which role has accese to the file. Unchecking all availabled roles will leave the file unauthenticated.
+The Content Tab shows the list of content files used by the Dev Portal. You can
+apply roles to your content files, restricting access only to developers who
+possess certain roles. Selecting an individual content file displays a
+dropdown of available developer roles where you can choose which role has
+access to the file. Unchecking all available roles will leave the file
+unauthenticated.
 
-An additional option is preset in the list: the `*` role. This predefined role behaves differently from other roles. When a content file has the `*` role attached to it, any developer may view the page as long as they are authenticated. Additionally, the `*` role may not be used in conjunction with other user defined roles and will deselect these roles when `*` is selected
+An additional option, the `*` role, is preset in the list. This predefined role
+behaves differently from other roles. When a content file has the `*` role
+attached to it, any developer may view the page as long as they are
+authenticated. Additionally, the `*` role may not be used in conjunction with
+other user-defined roles and will deselect those roles when `*` is selected.
 
-⚠️**Important:** `dashboard.txt` and `settings.txt` content files are assigned the `*` role by default. All other content files have no roles by default. This means that until a role is added, the file is unauthenticated even if Dev Portal Authentication is enabled. Content Permissions are ignored when Dev Portal Authentication is disabled. For more information visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication">Dev Portal Authentication</a> section.
+⚠️**Important:** The `dashboard.txt` and `settings.txt` content files are
+assigned the `*` role by default. All other content files have no roles by
+default. This means that until a role is added, the file is unauthenticated
+even if Dev Portal Authentication is enabled. Content Permissions are ignored
+when Dev Portal Authentication is disabled. For more information, visit the
+<a href="/enterprise/{{page.kong_version}}/developer-portal/configuration/authentication">Dev Portal Authentication</a> section.
 
 ## readable_by attribute
 
-When a role is applied to a content file via the Content Tab, a special attribute `readable_by` is added to the headmatter of the file.
+When a role is applied to a content file using the Content Tab, a special
+attribute `readable_by` is added to the headmatter of the file.
 
 ```
 ---
@@ -47,10 +71,18 @@ x-headmatter:
     - another_role_name
 ```
 
-The value of `readable_by` is an array of string role names that have access to view the content file. The exception is when the `*` role is applied to the file. In this case, the value of `readable_by` is no longer an array, but the single string character `*`.
+The value of `readable_by` is an array of string role names that have access to
+view the content file. An exception is when the `*` role is applied to the
+file. In this case, the value of `readable_by` is no longer an array, because
+it contains the single string character `*`.
 
 ```
 readable_by: "*"
 ```
 
-⚠️**Important:** Please note that if you manually remove or edit the `readable_by` attribute, it will modify the permissions of the file. Attempting to save a content file with a `readable_by` array containing an nonexistent role name will result in an error. Additionally, if you make changes to permissions in the Content Tab or via the Portal Editor, be sure to sync any local files so that permissions are not overwritten next time you push changes.
+⚠️**Important:** If you manually remove or edit the `readable_by` attribute, it
+will modify the permissions of the file. Attempting to save a content file with
+a `readable_by` array containing a nonexistent role name will result in an
+error. Additionally, if you make changes to permissions in the Content Tab or
+the Portal Editor, be sure to sync any local files so that permissions are not
+overwritten the next time you push changes.

--- a/app/enterprise/1.5.x/developer-portal/administration/managing-developers.md
+++ b/app/enterprise/1.5.x/developer-portal/administration/managing-developers.md
@@ -5,17 +5,17 @@ title: Managing Developers
 ### Developer Status
 
 A status represents the state of a developer and the access they have to the Dev
- Portal and APIs.
+ Portal and APIs:
 
 * **Approved**
-  * A Developer who can access the Dev Portal. Approved Developers can create 
+  * A developer who can access the Dev Portal. Approved developers can create
   credentials &amp; access **all** APIs that allow those credentials.
 * **Requested**
-  * A Developer who has requested access but has not yet been Approved.
+  * A developer who has requested access but has not yet been Approved.
 * **Rejected**
-  * A Developer who has had their request denied by a Kong Admin.
+  * A developer who has had their request denied by a Kong admin.
 * **Revoked**
-  * A Developer who once had access to the Dev Portal but has since had access 
+  * A developer who once had access to the Dev Portal but has since had access
   Revoked.
 
 
@@ -23,36 +23,38 @@ A status represents the state of a developer and the access they have to the Dev
 
 ### Approving Developers
 
-Developers who have requested access to a Dev Portal will appear under the 
-**Requested Access** tab. From this tab you can choose to *Accept* or *Reject* 
-the developer from the actions in the table row. After selecting an action the 
-corresponding tab will update.
+Developers who have requested access to a Dev Portal will appear under the
+**Requested Access** tab. From this tab, you can choose to *Accept* or *Reject*
+the developer from the actions in the table row. After selecting an action, the
+corresponding tab is updated.
 
 
 ### Viewing Approved Developers
 
-To view all currently approved developers choose the **Approved** tab. From here you can choose to *Revoke* or *Delete* a particular developer. Additionally you can use this view to send an email to a developer with the **Email Developer** `mailto` link. See [Emailing Developers](#emailing-developers) for more info.
+To view all currently approved developers, click the **Approved** tab. From here, you can choose to *Revoke* or *Delete* a particular developer. Additionally, you can use this view to send an email to a developer with the **Email Developer** `mailto` link. See [Emailing Developers](#emailing-developers) for more info.
 
 
 ### Viewing Revoked Developers
 
-To view all currently revoked developers choose the **Revoked** tab. From here you can choose to *Re-approve* or *Delete* a developer.
+To view all currently revoked developers, click the **Revoked** tab. From here, you can choose to *Re-approve* or *Delete* a developer.
 
 
 ### Viewing Rejected Developers
 
-To view all currently rejected developers choose the **Rejected** tab. Rejected developers completed the registration flow on your Dev Portal but were rejected from the **Request Access** tab. You may *Approve* or *Delete* a developer from this tab.
+To view all currently rejected developers, click the **Rejected** tab. Rejected developers completed the registration flow on your Dev Portal but were rejected from the **Request Access** tab. You may *Approve* or *Delete* a developer from this tab.
 
 
 ### Emailing Developers
 
 #### Inviting Developers to Register
 
-To invite a single or set of developers...
+To invite a single or multiple developers:
 
-1. Click the **Invite Developers** button from the top right corner above the tabs
-2. Use the popup modal to enter email addresses separated by commas
-3. After all emails have been added click **Invite**. This will open a pre-filled message in your default email client with a link to the registration page for your Dev Portal
+1. Click **Invite Developers**.
+2. Use the popup modal to enter email addresses separated by commas.
+3. After all emails have been added, click **Invite**. A pre-filled message
+opens in your default email client with a link to the registration page for
+your Dev Portal.
 
 Each developer is bcc'd by default for privacy. You may choose to edit the message or send as is.
 
@@ -69,12 +71,12 @@ Each developer is bcc'd by default for privacy. You may choose to edit the messa
 **Description:**
 Dev Portal Auto Approve Access.
 
-When set to `on`, a developer will automatically be marked as `approved` after 
-completing Dev Portal registration. Access can still be revoked through 
-Kong Manager or API.
+When set to `on`, a developer will automatically be marked as `approved` after
+completing Dev Portal registration. Access can still be revoked through
+Kong Manager or the API.
 
-When set to `off`, a Kong Admin will have to manually approve the Developer via
-the Kong Manager or API.
+When set to `off`, a Kong admin will have to manually approve the Developer
+using Kong Manager or the API.
 
 
 #### portal_invite_email
@@ -82,8 +84,8 @@ the Kong Manager or API.
 **Default:** `on`
 
 **Description:**
-When enabled, Admins will be able to invite Developers to a Dev Portal by using
- the "Invite" button in the Kong Manager.
+When enabled, Kong admins can invite developers to a Dev Portal by using
+the Invite button in Kong Manager.
 
 
 #### portal_access_request_email
@@ -91,10 +93,10 @@ When enabled, Admins will be able to invite Developers to a Dev Portal by using
 **Default:** `on`
 
 **Description:**
-When enabled, Kong Admins specified by `smtp_admin_emails` will receive an email
- when a Developer requests access to a Dev Portal.
+When enabled, Kong admins specified by `smtp_admin_emails` will receive an email
+when a developer requests access to a Dev Portal.
 
-When disabled, Kong Admins will have to manually check the Kong Manager to view 
+When disabled, Kong admins will have to manually check the Kong Manager to view
 any requests.
 
 
@@ -103,11 +105,11 @@ any requests.
 **Default:** `on`
 
 **Description:**
-When enabled, Developers will receive an email when access to a Dev Portal has 
+When enabled, developers will receive an email when access to a Dev Portal has
 been approved.
 
-When disabled, Developers will receive no indication that they have been 
-approved. It is suggested to only disable this feature if`portal_auto_approve` 
+When disabled, developers will receive no indication that they have been
+approved. It is suggested to only disable this feature if `portal_auto_approve`
 is enabled.
 
 
@@ -116,11 +118,11 @@ is enabled.
 **Default:** `on`
 
 **Description:**
-When enabled, Developers will be able to use the "Reset Password" flow on a Dev 
+When enabled, developers will be able to use the Reset Password flow on a Dev
 Portal and will receive an email with password reset instructions.
 
-When disabled, Developers will *not* be able to reset their account passwords.
-Kong Admins will have to manually create new credentials for the Developer in 
+When disabled, developers will *not* be able to reset their account passwords.
+Kong Admins will have to manually create new credentials for the Developer in
 the Kong Manager.
 
 #### portal_token_exp
@@ -128,8 +130,8 @@ the Kong Manager.
 **Default:** `21600`
 
 **Description:**
-Duration in seconds for the expiration of the Dev Portal reset password token. 
-Default `21600` is six hours.
+Duration in seconds for the expiration of the Dev Portal reset password token.
+Default is `21600` (six hours).
 
 
 #### portal_reset_success_email
@@ -137,8 +139,8 @@ Default `21600` is six hours.
 **Default:** `on`
 
 **Description:**
-When enabled, Developers will receive an email after successfully resetting their
- Dev Portal account password. 
- 
-When disabled, Developers will still be able to reset their account passwords, 
+When enabled, developers will receive an email after successfully resetting
+their Dev Portal account password.
+
+When disabled, developers will still be able to reset their account passwords,
 but will not receive a confirmation email.

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/adding-registration-fields.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/adding-registration-fields.md
@@ -1,30 +1,26 @@
 ---
-title: Adding New Dev Portal Registration Fields
+title: Adding Dev Portal Registration Fields
 ---
 
 
 ### Introduction
 
-By default, when authentication is enabled for a Dev Portal the only required
-fields are **full name**, **email**, and **password**. However, additional fields can be added
-to this form.
+When authentication is enabled for a Dev Portal, the only required
+fields by default are **full name**, **email**, and **password**. However, you
+can add custom fields to this form and indicate whether the fields are
+required. Adding custom required fields will not affect existing registered
+users until they choose to edit their profile.
 
+### Adding Custom Registration Fields
 
-### Adding Additional Registration Fields
+1. In Kong Manager, navigate to the Workspace's Dev Portal **Settings** page.
 
-1. In Kong Manager, navigate to the desired Workspace's Dev Portal **Settings** page.
-
-2. Click the **Developer Meta Fields** tab on the **Settings Page**
+2. Click the **Developer Meta Fields** tab.
 
 3. Click **+ Add Field** to add a new field object to the form.
 
-4. Give the new field a label, field name, and select the type of input
+4. Enter a label, field name, and select the type of input.
 
-5. Select the checkbox **Required** to require this field for registration
+5. Select the **Required** checkbox to require the new field for registration.
 
-6. Click the **Save Changes** button a the bottom of the form.
-
-
-Once saved, the new field will automatically be added to the registration form.
-
-Adding new required fields will not affect existing registered users until they choose to edit their profile.
+6. Click the **Save Changes**. The field is automatically added to the registration form.

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/adding-registration-fields.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/adding-registration-fields.md
@@ -23,4 +23,4 @@ users until they choose to edit their profile.
 
 5. Select the **Required** checkbox to require the new field for registration.
 
-6. Click the **Save Changes**. The field is automatically added to the registration form.
+6. Click **Save Changes**. The field is automatically added to the registration form.

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/basic-auth.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/basic-auth.md
@@ -19,7 +19,7 @@ Basic Authentication for the Dev Portal can be enabled in three ways:
 
 ### Enable Portal Session Config
 
-In the the Kong configuration file set the `portal_session_conf` property:
+In the Kong configuration file, set the `portal_session_conf` property:
 
 ```
 portal_session_conf={ "cookie_name": "portal_session", "secret": "CHANGE_THIS", "storage": "kong" }
@@ -33,16 +33,16 @@ portal_session_conf={ "cookie_name": "portal_session", "secret": "CHANGE_THIS", 
 
 ### Enable Basic Auth via Kong Manager
 
-1. Navigate to the Dev Portal's **Settings** page
-2. Find **Authentication plugin** under the **Authentication** tab
-3. Select **Basic Authentication** from the drop down
-4. Click the **Save Changes** button at the bottom of the form
+1. Navigate to the Dev Portal's **Settings** page.
+2. Find **Authentication plugin** under the **Authentication** tab.
+3. Select **Basic Authentication** from the drop down.
+4. Click the **Save Changes**.
 
 >**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
 ### Enable Basic Auth via the Command Line
 
-To patch a Dev Portal's authentication property directly run:
+To patch a Dev Portal's authentication property directly, run:
 
 ```
 curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
@@ -56,7 +56,7 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
 Kong allows for a `default authentication plugin` to be set in the Kong
 configuration file with the `portal_auth` property.
 
-In your `kong.conf` file set the property as follows:
+In your `kong.conf` file, set the property as follows:
 
 ```
 portal_auth="basic-auth"

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/basic-auth.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/basic-auth.md
@@ -36,7 +36,7 @@ portal_session_conf={ "cookie_name": "portal_session", "secret": "CHANGE_THIS", 
 1. Navigate to the Dev Portal's **Settings** page.
 2. Find **Authentication plugin** under the **Authentication** tab.
 3. Select **Basic Authentication** from the drop down.
-4. Click the **Save Changes**.
+4. Click **Save Changes**.
 
 >**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/key-auth.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/key-auth.md
@@ -32,16 +32,16 @@ portal_session_conf={ "cookie_name": "portal_session", "secret": "CHANGE_THIS", 
 
 ### Enable Key Auth via Kong Manager
 
-1. Navigate to the Dev Portal's **Settings** page
-2. Find **Authentication plugin** under the **Authentication** tab
-3. Select **Key Authentication** from the drop down
-4. Click the **Save Changes** button at the bottom of the form
+1. Navigate to the Dev Portal's **Settings** page.
+2. Find **Authentication plugin** under the **Authentication** tab.
+3. Select **Key Authentication** from the drop down.
+4. Click **Save Changes**.
 
 >**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
 ### Enable Key Auth via the Command Line
 
-To patch a Dev Portal's authentication property directly run:
+To patch a Dev Portal's authentication property directly, run:
 
 ```
 curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
@@ -55,7 +55,7 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
 Kong allows for a `default authentication plugin` to be set in the Kong
 configuration file with the `portal_auth` property.
 
-In your `kong.conf` file set the property as follows:
+In your `kong.conf` file, set the property as follows:
 
 ```
 portal_auth="key-auth"

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/oidc.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/oidc.md
@@ -11,7 +11,7 @@ allows the Kong Developer Portal to hook into existing authentication setups usi
 [OIDC](/hub/kong-inc/openid-connect/) must be used with
 the `session` method, utilizing cookies for Dev Portal File API requests.
 
-In addition, a configuration object is required to enable OIDC, please refer to the
+In addition, a configuration object is required to enable OIDC. Refer to the
 [Sample Configuration Object](#/sample-configuration-object) section of this
 document for more information.
 
@@ -29,7 +29,7 @@ Session Plugin Config does not apply when using OpenID Connect.
 ### Sample Configuration Object
 
 Below is a sample configuration JSON object for using *Google* as the Identity
-Provder:
+Provider:
 
 ```
 {
@@ -61,7 +61,7 @@ OIDC configuration:
   - `<CLIENT_SECRET>` - Client secret provided by IdP
 
 If `portal_gui_host` and `portal_api_url` are set to share a domain but differ
-in regards to subdomain, `redirect_uri` and `session_cookie_domain` need to be
+with regard to subdomain, `redirect_uri` and `session_cookie_domain` need to be
 configured to allow OpenID-Connect to apply the session correctly.
 
 Example:
@@ -91,19 +91,19 @@ Example:
 
 ### Enable OIDC via Kong Manager
 
-1. Navigate to the Dev Portal's **Settings** page
-2. Find **Authentication plugin** under the **Authentication** tab
-3. Select **OpenId  Connect** from the drop down
-4. Select **Custom** from the **Auth Config (JSON)** field drop down
+1. Navigate to the Dev Portal's **Settings** page.
+2. Find **Authentication plugin** under the **Authentication** tab.
+3. Select **OpenId  Connect** from the drop down.
+4. Select **Custom** from the **Auth Config (JSON)** field drop down.
 5. Enter your customized [**Configuration JSON Object**](#/sample-configuration-object)
 into the provided text area.
-4. Click the **Save Changes** button at the bottom of the form
+4. Click **Save Changes**.
 
 >**Warning** When Dev Portal Authentication is enabled, content files will remain unauthenticated until a role is applied to them. The exception to this is `settings.txt` and `dashboard.txt` which begin with the `*` role. Please visit the <a href="/enterprise/{{page.kong_version}}/developer-portal/administration/developer-permissions">Developer Roles and Content Permissions</a> section for more info.
 
 ### Enable OIDC via the Command Line
 
-To patch a Dev Portal's authentication property directly run:
+To patch a Dev Portal's authentication property directly, run:
 
 ```
 curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
@@ -118,14 +118,14 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
 Kong allows for a `default authentication plugin` to be set in the Kong
 configuration file with the `portal_auth` property.
 
-In your `kong.conf` file set the property as follows:
+In your `kong.conf` file, set the property as follows:
 
 ```
 portal_auth="openid-connect"
 ```
 
 Then set `portal_auth_conf` property to your
-customized [**Configuration JSON Object**](#/sample-configuration-object)
+customized [**Configuration JSON Object**](#/sample-configuration-object).
 
 This will set every Dev Portal to use Key Authentication by default when
 initialized, regardless of Workspace.

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -50,7 +50,7 @@ portal_session_conf = {
 * `logout_query_arg`
 * `logout_post_arg`
 
-For detailed descriptions of each configuration property, learn more in the [Session Plugin documentation](/enterprise/{{page.kong_version}}/plugins/session).
+For detailed descriptions of each configuration property, see the [Session Plugin documentation](/enterprise/{{page.kong_version}}/plugins/session).
 
 ## Session Security
 

--- a/app/enterprise/1.5.x/developer-portal/configuration/smtp.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/smtp.md
@@ -4,9 +4,9 @@ title: Dev Portal SMTP Configuration
 
 ### Introduction
 
-The following property reference outlines each email and email variable used by the Dev Portal to send emails to Kong Admins and Developers.
+The following property reference outlines each email and email variable used by the Dev Portal to send emails to Kong admins and developers.
 
-These settings can be modified in the `Kong Manager` under the Dev Portal `Settings / Email` tab. Or by running the following command:
+These settings can be modified in the `Kong Manager` under the Dev Portal `Settings / Email` tab, or by running the following command:
 
 ```
 curl http://localhost:8001/workspaces/<WORKSPACE_NAME> \
@@ -15,7 +15,7 @@ curl http://localhost:8001/workspaces/<WORKSPACE_NAME> \
 
 If they are not modified manually, the Dev Portal will use the default value defined in the Kong Configuration file.
 
-In 1.3.0.1 or greater [Developer Portal email content and styling can be customized via template files](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/emails/)
+In 1.3.0.1 or greater, [Developer Portal email content and styling can be customized via template files](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/emails/)
 
 
 ### portal_invite_email
@@ -23,7 +23,7 @@ In 1.3.0.1 or greater [Developer Portal email content and styling can be customi
 **Default:** `on`
 
 **Description:**
-When enabled, Kong Admins will be able to invite Developers to a Dev Portal by using the "Invite" button in the Kong Manager.
+When enabled, Kong admins will be able to invite developers to a Dev Portal by using the Invite button in the Kong Manager.
 
 **Email:**
 ```
@@ -41,7 +41,7 @@ Please visit `<DEV_PORTAL_URL/register>` to create your account.
 **Default:** `off`
 
 **Description:**
-When enabled Developers will receive an email upon registration to verify their account. Developers will not be able to use the Dev Portal until their account is verified, even if auto-approve is enabled.
+When enabled, developers will receive an email upon registration to verify their account. Developers will not be able to use the Dev Portal until their account is verified, even if auto-approve is enabled.
 
 
 ### portal_access_request_email
@@ -66,7 +66,7 @@ Please visit <KONG_MANAGER_URL/developers/requested> to review this request.
 **Default:** `on`
 
 **Description:**
-When enabled, Developers will receive an email when access to a Dev Portal has been approved.
+When enabled, developers will receive an email when access to a Dev Portal has been approved.
 
 ```
 Subject: Developer Portal access approved
@@ -82,9 +82,9 @@ Please visit <DEV PORTAL URL/login> to login.
 **Default:** `on`
 
 **Description:**
-When enabled, Developers will be able to use the "Reset Password" flow on a Dev Portal and will receive an email with password reset instructions.
+When enabled, developers will be able to use the Reset Password flow on a Dev Portal and will receive an email with password reset instructions.
 
-When disabled, Developers will *not* be able to reset their account passwords.
+When disabled, developers will *not* be able to reset their account passwords.
 
 ```
 Subject: Password Reset Instructions for Developer Portal <WORKSPACE_NAME>.
@@ -106,9 +106,9 @@ the link above to change your password.
 **Default:** `on`
 
 **Description:**
-When enabled, Developers will receive an email after successfully reseting their Dev Portal account password.
+When enabled, developers will receive an email after successfully reseting their Dev Portal account password.
 
-When disabled, Developers will still be able to reset their account passwords, but will not recieve a confirmation email.
+When disabled, developers will still be able to reset their account passwords, but will not receive a confirmation email.
 
 ```
 Subject: Developer Portal password change success

--- a/app/enterprise/1.5.x/developer-portal/configuration/workspaces.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/workspaces.md
@@ -40,7 +40,7 @@ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE_NAME> \
  --data "config.portal=true"
 ```
 
-On intialization, Kong will populate the new Dev Portal with the [**Default Settings**](#defining-dev-portals-default-settings) defined in Kong's configuration file.
+On initialization, Kong will populate the new Dev Portal with the [**Default Settings**](#defining-dev-portals-default-settings) defined in Kong's configuration file.
 
 >*Note* A Workspace can only enable a Dev Portal if the Dev Portal feature has been enabled in Kong's configuration.
 
@@ -71,7 +71,7 @@ in the Kong Manager or by patching the setting directly.
 
 ### Workspace Files
 
-On initialization of a Workspace's Dev Portal a copy of the **default** Dev Portal files will be made and inserted into the new Dev Portal. This allows for the easy transference of a customized Dev Portal theme and allows **default** to act as a 'master template' -- however the Dev Portal will not continue to sync changes from the **default** Dev Portal after it is first enabled.
+On initialization of a Workspace's Dev Portal, a copy of the **default** Dev Portal files will be made and inserted into the new Dev Portal. This allows for the easy transference of a customized Dev Portal theme and allows **default** to act as a 'master template' -- however, the Dev Portal will not continue to sync changes from the **default** Dev Portal after it is first enabled.
 
 ### Developer Access
 

--- a/app/enterprise/1.5.x/developer-portal/structure-and-file-types.md
+++ b/app/enterprise/1.5.x/developer-portal/structure-and-file-types.md
@@ -6,25 +6,25 @@ chapter: 4
 
 ## Introduction
 
-The Kong Portal templates have been completely revamped to allow for easier customization, clearer separation of concerns between content and layouts, and more powerful hooks into Kong lifecycle/data.  Under the hood we have implemented a flat file CMS built on top of the `https://github.com/bungle/lua-resty-template` library.  This system should feel familiar for anyone who has worked with projects like `jekyll`, `kirby cms`, or `vuepress` in the past.
+The Kong Portal templates have been completely revamped to allow for easier customization, clearer separation of concerns between content and layouts, and more powerful hooks into Kong lifecycle/data.  Under the hood, we have implemented a flat file CMS built on top of the `https://github.com/bungle/lua-resty-template` library.  This system should feel familiar for anyone who has worked with projects like `jekyll`, `kirby cms`, or `vuepress` in the past.
 
 >Note: To follow along with this guide, it is best to clone the [kong-portal-templates repo](https://github.com/Kong/kong-portal-templates) and check out the `master` branch. This guide makes the assumption that you are working within a single workspace (the templates repo can host many different sets of portal files per workspace).  Navigate to the `workspaces/default` directory from root to view the default workspaces portal files.
 
 ## Directory Structure
 
-Navigate to `workspaces/default` from the kong-portal-templates root directory to access the default portals template files. The relative file structure in this directory directly maps to the file `path` schema attribute.  (`content/homepage.txt` here maps to `content/homepage.txt` in Kong).
+Navigate to `workspaces/default` from the `kong-portal-templates` root directory to access the default portals template files. The relative file structure in this directory directly maps to the file `path` schema attribute.  (`content/homepage.txt` here maps to `content/homepage.txt` in Kong).
 
-From `workspaces/default` we can see the different elements that make up a single instance of the kong developer portal:
+From `workspaces/default`, you can see the different elements that make up a single instance of the kong developer portal:
 - **content/**
   - The content directory contains files that determine both site structure of the Kong Dev Portal as well as the dynamic content that renders within each page.
 - **specs/**
-  - Specs are similar to content in that they contain the data needed to render dynamic content on the page.  In the case of `specs` the files contain valid OAS or Swagger to be rendered as a spec.
+  - Specs are similar to content in that they contain the data needed to render dynamic content on the page.  In the case of `specs`, the files contain valid OAS or Swagger to be rendered as a spec.
 - **themes/**
-  - The theme directory contains different themes to be applied to the content of the portal.  Each theme contains html templates, assets, and a config file which sets global styles available to the theme.
+  - The theme directory contains different themes to be applied to the content of the portal. Each theme contains html templates, assets, and a config file that sets global styles available to the theme.
 - **portal.conf.yaml**
   - This config file determines which theme the portal uses to render, the name of the portal, as well configuration for special behavior such as redirect paths for user actions like login/logout.
 - **router.conf.yaml (optional)**
-  - This optional config file overrides the portals default routing system with hardcoded values.  This is useful for implementing single page applications, as well as for setting a static site structure.
+  - This optional config file overrides the portals default routing system with hardcoded values. This is useful for implementing single page applications, as well as for setting a static site structure.
 
 ## Portal Configuration File
 
@@ -33,7 +33,7 @@ From `workspaces/default` we can see the different elements that make up a singl
 - **file extensions:** `.yaml`
 
 #### Description
-The Portal Configuration File determines which theme the portal uses to render, the name of the portal, as well as configuration for special behavior such as redirect paths for user actions like login/logout.  It is required in the root of every portal.  There can only be one Portal Configuration File, it must be named `portal.conf.yaml`, and it must be a direct child of the root directory. 
+The Portal Configuration File determines which theme the portal uses to render, the name of the portal, as well as configuration for special behavior such as redirect paths for user actions like login/logout. It is required in the root of every portal. There can only be one Portal Configuration File, it must be named `portal.conf.yaml`, and it must be a direct child of the root directory.
 
 #### Example
 
@@ -67,7 +67,7 @@ collections:
 - `redirect`
   - **required**: true
   - **type**: `object`
-  - **description**: The redirect object informs kong how to redirect the user after certain actions. If one of these values is not set, Kong serves a default template based off of the action. Each key represents the name of the action taking place, the value represents the route to which the application redirects the user. 
+  - **description**: The redirect object informs kong how to redirect the user after certain actions. If one of these values is not set, Kong serves a default template based off of the action. Each key represents the name of the action taking place, the value represents the route to which the application redirects the user.
 - `collections`
   - **required**: false
   - **type**: `object`
@@ -81,10 +81,10 @@ collections:
 - **file extensions:** `.yaml`
 
 #### Description
-This optional config file overrides the portals default routing system with hardcoded values.  This is useful for implementing single page applications, as well as for setting a static site structure.  There can only be one Router Configuration File, it must be named `router.conf.yaml`, and it must be a direct child of the root directory.
+This optional config file overrides the portals default routing system with hardcoded values.  This is useful for implementing single page applications, as well as for setting a static site structure. There can only be one Router Configuration File, it must be named `router.conf.yaml`, and it must be a direct child of the root directory.
 
 #### Example
-The `router.conf.yaml` file expects sets of key value pairs.  The key should be the route you wish to set, the value should be the content file path you wish that route to resolve to. Routes should begin with a backslash.  `/*` is a reserved route and acts as a catchall/wildcard, if the requested route is not explicitly defined in the config file the portal will resolve to the wildcard route if present.
+The `router.conf.yaml` file expects sets of key-value pairs. The key should be the route you want to set; the value should be the content file path you want that route to resolve to. Routes should begin with a backslash.  `/*` is a reserved route and acts as a catchall/wildcard. If the requested route is not explicitly defined in the config file, the portal will resolve to the wildcard route if present.
 
 ```yaml
 /*: content/index.txt
@@ -121,21 +121,21 @@ readable_by: [red, blue]
 Welcome to the homepage!
 ```
 
-File contents can be broken down into two parts: `headmatter` and `body`
+File contents can be broken down into two parts: `headmatter` and `body`.
 
 ##### headmatter
 
-The first thing to notice in the example files contents are the two sets of `---` delimiters at the start.  The text contained within these markers is called `headmatter` and always gets parsed and validated as valid `yaml`.  `headmatter` contains information necessary for a file to render successfully, as well as any information you would like to access within a template.  Kong parses any valid `yaml` key-value pair and becomes available within the content's coinciding HTML template. There are a few reserved attributes that have special meaning to Kong at the time of render. They are as follows:
+The first thing to notice in the example files contents are the two sets of `---` delimiters at the start.  The text contained within these markers is called `headmatter` and always gets parsed and validated as valid `yaml`.  `headmatter` contains information necessary for a file to render successfully, as well as any information you would like to access within a template.  Kong parses any valid `yaml` key-value pair and becomes available within the content's corresponding HTML template. There are a few reserved attributes that have special meaning to Kong at the time of render:
 
 - `title`:
   - **required**: false
   - **type**: `string`
-  - **description**: The title attribute is not necessary but is recommended. When set this will set the title of a page in the browser tab.
+  - **description**: The title attribute is not necessary but is recommended. When set, this will set the title of a page in the browser tab.
   - **example**: `homepage`
 - `layout`
   - **required**: true
   - **type**: `string`
-  - **description**: The layout attribute is required for each piece of content, and determines what html layout to use in order to render the page.  This attribute assumes  a root of the current themes layout directory (`themes/<theme-name>/layouts`).
+  - **description**: The layout attribute is required for each piece of content, and determines what html layout to use in order to render the page.  This attribute assumes a root of the current themes layout directory (`themes/<theme-name>/layouts`).
   - **example**: `bio.html` or `team/about.html`
 - `readable_by`
   - **required**: false
@@ -147,19 +147,19 @@ The first thing to notice in the example files contents are the two sets of `---
   - **required**: false
   - **type**: `string`
   - **description**: This optional attribute overrides the generated route Kong assigns to content, and replaces it with the route included here.
-  - **example**: `route: /example/dog` renders the example page above at `<url>/example/dog` instead of the auto generated `/homepage` route.
+  - **example**: `route: /example/dog` renders the example page above at `<url>/example/dog` instead of the autogenerated `/homepage` route.
 - `output`
   - **required**: false
   - **type**: `boolean`
   - **default**: `true`
-  - **description**: This optional attribute is `true` by default and determines whether a piece of content should be rendered. (no route or page gets created when this value is set to `false`)
+  - **description**: This optional attribute is `true` by default and determines whether a piece of content should be rendered. No route or page gets created when this value is set to `false`.
 - `stub`
   - **required**: false
   - **type**: `string`
   - **description**: Used by `collection` config to determine custom routing.  You can read more about Collections in the collections section of the _working with templates_ guide.
 
 ##### body
-The information located under headmatter represents the content body.  Body content is freeform and gets parsed as by the file extension included in the file path.  In the case of the example above, the file is `.txt` and is available in the template as such.
+The information located under headmatter represents the content body. Body content is freeform and gets parsed as by the file extension included in the file path. In the case of the example above, the file is `.txt` and is available in the template as such.
 
 ## Spec Files
 
@@ -168,7 +168,7 @@ The information located under headmatter represents the content body.  Body cont
 - **file extensions:** `.yaml`, `.json`
 
 #### Description
-Specs are similar to `content` files in that they provide the dynamic data needed to render a page, as well as any metadata a user wishes to provide as `headmatter`.  The format in which these are provided to the Portal differs from `content` files, which can be seen in the example below.
+Specs are similar to `content` files in that they provide the dynamic data needed to render a page, as well as any metadata a user wants to provide as `headmatter`.  The format in which these are provided to the Portal differs from `content` files, which can be seen in the example below.
 
 >It is recommended to keep spec folder structure flat.  Spec files must be valid OAS or Swagger `.yaml`/`.yml` or `.json` files.
 
@@ -189,7 +189,7 @@ x-headmatter
 ...
 ```
 
-Spec file contents themselves should be valid OAS or Swagger specifications.  If you would like to inject headmatter into the specification, you can do so by including an `x-headmatter` key to the root of the spec object.  This may be useful if you wanted to for example provide your own renderer template via `x-headmatter.layout` or override the specs default route via `x-headmatter.route`. 
+Spec file contents themselves should be valid OAS or Swagger specifications.  If you would like to inject headmatter into the specification, you can do so by including an `x-headmatter` key to the root of the spec object. This may be useful if you wanted to for example provide your own renderer template via `x-headmatter.layout` or override the specs default route via `x-headmatter.route`.
 
 Example:
 ```
@@ -207,21 +207,21 @@ x-headmatter:
 ...
 ```
 
-Specs are a collection meaning their `layout` and `route` are determined by the portal configuration and not the file itself.  Specs are rendered by default by the `system/spec-renderer.html` layout, under the route pattern `/documentation/:name` where name is the name of the particular spec file.  So a spec with a path of `specs/myfirstspec.json` renders in the portal as `/documentation/myfirstspec`.  If you would like to overwrite the hardcoded spec collection config, you can do so by including your own in `portal.conf.yaml`.  Check out the Collections section of our `Working with Templates` guide to learn more.
+Specs are a collection meaning their `layout` and `route` are determined by the portal configuration and not the file itself. Specs are rendered by default by the `system/spec-renderer.html` layout, under the route pattern `/documentation/:name` where name is the name of the particular spec file. So a spec with a path of `specs/myfirstspec.json` renders in the portal as `/documentation/myfirstspec`.  If you want to overwrite the hardcoded spec collection config, you can do so by including your own in `portal.conf.yaml`. Check out the Collections section of our `Working with Templates` guide to learn more.
 
 ## Theme Files
 #### Themes Directory Structure
-The theme directory contains different instances of portal themes, each one of which determines the look and feel of the developer portal via html/css/js.  Which theme is used at time of render is determined by setting `theme.name` within `portal.conf.yaml`.  (setting `theme.name` to `best-theme` causes the portal to load theme files under `themes/best-theme/**`).
+The theme directory contains different instances of portal themes, each one of which determines the look and feel of the developer portal via html/css/js.  Which theme is used at time of render is determined by setting `theme.name` within `portal.conf.yaml`. Setting `theme.name` to `best-theme` causes the portal to load theme files under `themes/best-theme/**`.
 
-Each theme file is compromised of a few different folders:
+Each theme file is composed of a few different folders:
 - **assets/**
-  - The assets directory contains static assets that layouts/partials will reference at time of render.  Includes CSS, JS, font, and image files.
+  - The assets directory contains static assets that layouts/partials will reference at time of render. Includes CSS, JS, font, and image files.
 - **layouts/**
   - The layouts directory contains html page templates that `content` reference via the `layout` attribute in headmatter (see `content` section).
 - **partials/**
-  - The partials directory contains html partials to be referenced by layouts. Can be compared to how layouts and partials interacted in the legacy portal. 
+  - The partials directory contains html partials to be referenced by layouts. Can be compared to how layouts and partials interacted in the legacy portal.
 - **theme.conf.yaml**
-  - This config file sets color and font defaults available to templates for reference as css variables.  It also determines what options are available in the Kong Manager Appearance page.
+  - This config file sets color and font defaults available to templates for reference as css variables. It also determines what options are available in the Kong Manager Appearance page.
 
 #### Theme Assets
 
@@ -248,7 +248,7 @@ To access asset files from your templates, keep in mind that Kong assumes a path
 - **file extensions:** `.html`
 
 ##### Description
-Layouts act as the html skeleton of the page you wish to render.  Each file within the layouts directory must have an `html` filetype.  They can exist as vanilla `html`, or can reference partials and parent layouts via the portals templating syntax.  Layouts also have access to the `headmatter` and `body` attributes set in `content`.
+Layouts act as the html skeleton of the page you want to render. Each file within the layouts directory must have an `html` filetype. They can exist as vanilla `html`, or can reference partials and parent layouts via the portals templating syntax. Layouts also have access to the `headmatter` and `body` attributes set in `content`.
 
 The example below shows what a typical layout could look like.
 
@@ -269,7 +269,7 @@ The example below shows what a typical layout could look like.
 ```
 {% endraw %}
 
-To learn more about the templating syntax used in this example check out our [templating guide](/enterprise/{{page.kong_version}}/developer-portal/working-with-templates).
+To learn more about the templating syntax used in this example, check out our [templating guide](/enterprise/{{page.kong_version}}/developer-portal/working-with-templates).
 
 #### Theme Partials
 
@@ -278,7 +278,7 @@ To learn more about the templating syntax used in this example check out our [te
 - **file extensions:** `.html`
 
 ##### Description
-Partials are very similar to layouts: they share the same syntax, can call other partials within themselves, and have access to the same data/helpers at time of render.  The thing that differentiates partials from layouts it that layouts call on partials to build the page, but partials cannot call on layouts.
+Partials are very similar to layouts: they share the same syntax, can call other partials within themselves, and have access to the same data/helpers at time of render. The thing that differentiates partials from layouts it that layouts call on partials to build the page, but partials cannot call on layouts.
 
 The example below shows the `header.html` partial referenced from the example above:
 
@@ -304,7 +304,4 @@ The example below shows the `header.html` partial referenced from the example ab
 - **file extensions:** `.yaml`
 
 ##### Description
-The Theme Configuration File determines color/font/image values a theme makes available for templates/CSS at the time of render.  It is required in the root of every theme.  There can only be one Theme Configuration File, it must be named `theme.conf.yaml`, and it must be a direct child of the themes root directory.
-
-
-
+The Theme Configuration File determines color/font/image values a theme makes available for templates/CSS at the time of render. It is required in the root of every theme. There can only be one Theme Configuration File, it must be named `theme.conf.yaml`, and it must be a direct child of the themes root directory.

--- a/app/enterprise/1.5.x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/enterprise/1.5.x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -1,10 +1,10 @@
 ---
-title: Adding and Using Javascript Assets in Kong Dev Portal
+title: Adding and Using JavaScript Assets in Kong Dev Portal
 ---
 
 ### Introduction
 
-The Kong Developer Portal ships with Vue, React, and jQuery already loaded. In order to write custom interactive webpages, you may wish to make use of these libraries, or load additional javascript.
+The Kong Developer Portal ships with Vue, React, and jQuery already loaded. In order to write custom interactive webpages, you may want to make use of these libraries, or load additional JavaScript.
 
 > Note: This guide is for adding/using javascript assets without changing server-side routing. [Learn more about a SPA to the Dev Portal](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/single-page-app).
 
@@ -17,7 +17,7 @@ The Kong Developer Portal ships with Vue, React, and jQuery already loaded. In o
 
 
 ### Adding JS Assets
-> Warning: Due to compatibility issues, avoid using any React version other than React 15 on the `layouts/system/spec-render.html` layout. We recommend using the version of React included by the default base theme. 
+> Warning: Due to compatibility issues, avoid using any React version other than React 15 on the `layouts/system/spec-render.html` layout. We recommend using the version of React included by the default base theme.
 
 To add javascript assets:
 1. Clone the [kong-portal-templates](https://github.com/Kong/kong-portal-templates) repo.
@@ -27,11 +27,11 @@ To add javascript assets:
 
 ### Loading JS Assets
 
-You can make use of the existing Vue, and jQuery in any layout/partial that includes `partials/theme/required-scripts.html` where the these scripts are loaded.
+You can make use of the existing Vue and jQuery in any layout/partial that includes `partials/theme/required-scripts.html` where these scripts are loaded.
 
-By default React is only loaded on `layouts/system/spec-render.html`
+By default, React is only loaded on `layouts/system/spec-render.html`.
 
-if you want to load React or any custom javascript asset on all pages, you can edit `themes/partial/foot.html`
+If you want to load React or any custom JavaScript asset on all pages, you can edit `themes/partial/foot.html`.
 
 
 {% raw %}
@@ -52,4 +52,4 @@ if you want to load React or any custom javascript asset on all pages, you can e
 ```
 {% endraw %}
 
-Alternatively you can load the script you need on the specific layout for each content page as needed.
+Alternatively, you can load the script you need on the specific layout for each content page as needed.

--- a/app/enterprise/1.5.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/enterprise/1.5.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -15,7 +15,7 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 ### The Appearance Tab
 
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
-This will open the Developer Portals theme editor. From this page the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
+This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
 ![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
 
@@ -29,6 +29,6 @@ Hovering over an element will show a color picker, as well as a list of predefin
 
 ## Editing Theme Files with the Editor
 
-The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the theme.conf.yaml file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor) for more information on how to edit, preview, and save files in the Editor.
+The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor) for more information on how to edit, preview, and save files in the Editor.
 
 ![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/enterprise/1.5.x/developer-portal/theme-customization/emails.md
+++ b/app/enterprise/1.5.x/developer-portal/theme-customization/emails.md
@@ -12,11 +12,11 @@ Editable email templates are loaded as files similar to content files for portal
 Email files can be managed in the same way as other files for rendering, via editor or via the Portal CLI Tool.
 This feature is **not** supported on legacy portal mode.
 
-If no email templates are loaded, Kong will fall back to the same emails as Kong Enterprise 1.3.0.0
-By default on 1.3.0.1 and newer enabling a non-legacy portal on new workspaces loads default editable email templates.
+If no email templates are loaded, Kong will fall back to the same emails as Kong Enterprise 1.3.0.0.
+By default on 1.3.0.1 and newer, enabling a non-legacy portal on new workspaces loads default editable email templates.
 For existing non-legacy Portals, editable email templates must be loaded manually.
 
-Email specific values are templated in via tokens that work similarly to templating in portal layouts and partials.
+Email-specific values are templated in tokens that work similarly to templating in portal layouts and partials.
 Not all tokens are supported on all emails.
 
 
@@ -55,7 +55,7 @@ Like other content files, these files have a headmatter between the two `---` . 
 - `subject` sets the subject line for email.
 - `heading` is an optional value that by default is rendered as a h3
 
-The body of the email is HTML content. You can reference the tokens allowed for the email in the table below. In this case {% raw %}`{{portal.url}}`{% endraw %} is used to access the portal url
+The body of the email is HTML content. You can reference the tokens allowed for the email in the table below. In this case, {% raw %}`{{portal.url}}`{% endraw %} is used to access the portal url
 
 ## Supported Emails and Tokens
 
@@ -94,7 +94,7 @@ The body of the email is HTML content. You can reference the tokens allowed for 
 
 ## Editing Email Templates
 
-The default email templates will be automatically loaded into the Kong Developer Portal's file system when the Dev Portal is activated. These templates can now be edited in Kong Manager via the **Portal Editor** or via the **Portal CLI** tool. 
+The default email templates will be automatically loaded into the Kong Developer Portal's file system when the Dev Portal is activated. These templates can now be edited in Kong Manager via the **Portal Editor** or via the **Portal CLI** tool.
 **Note:** If you are using a Dev Portal initiated in a Kong Enterprise version prior to 1.3.0.1, you will need to manually load the email templates into the file system. Follow the steps in [Loading Email Templates on Existing Dev Portals](#loading-email-templates-on-existing-dev-portals).
 
 ### Editing via the Portal Editor
@@ -102,7 +102,7 @@ The default email templates will be automatically loaded into the Kong Developer
 Email templates can now be edited in the Portal Editor along with the rest of the files in the Kong Developer Portal file system. To view and edit these files:
 
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
-2. Select the **Editor** from the sidebar under **Dev Portal**
+2. Select the **Editor** from the sidebar under **Dev Portal**.
 
 The email templates can be found under the **Emails** section in the Portal Editor sidebar:
 
@@ -110,18 +110,18 @@ The email templates can be found under the **Emails** section in the Portal Edit
 
 ### Editing via the Portal CLI Tool
 
-1. Clone [https://github.com/Kong/kong-portal-templates] master branch, and navigate into its directory
-2. If you have any customizations or permissions changes that you wish to keep:
+1. Clone [https://github.com/Kong/kong-portal-templates] master branch, and navigate into its directory.
+2. If you have any customizations or permissions changes that you want to keep:
     Run `portal fetch <workspacename>` This will pull in your modifications locally.
-3.  After making any changes  `portal deploy <workspacename>` to deploy all files.
+3.  After making any changes, `portal deploy <workspacename>` to deploy all files.
 
 
 ## Editing Email Appearance
 
 To edit the appearance of emails, you can change the layout file emails use.
-By default emails are set to use the layout `emails/email_base.html` if this file does not exist in side your theme(default theme is `base`) then a hardcoded fallback will be used.
+By default, emails are set to use the layout `emails/email_base.html`. If this file does not exist inside your theme (default theme is `base`), then a hardcoded fallback will be used.
 
-You can edit the layout this layout file via the Portal Editor or locally with the Portal CLI tool, follow the instructions for the editing email text, but instead modifying the layout file.
+You can edit the layout this layout file via the Portal Editor or locally with the Portal CLI tool. Follow the instructions for the editing email text, but modifying the layout file instead.
 
 If you want different emails to have a different appearance, you can set different layout files for each email file.
 
@@ -158,32 +158,31 @@ By modifying the html of this file, you can change the appearance of your emails
 Be sure to keep in mind the html support limitations of the email clients you plan to support.
 
 
-
 ## Loading Email Templates on Existing Dev Portals
 
-**Note:** This is only necessary for existing Dev Portals created on Kong Enterprise 1.3.0, new Portals created in 1.3.0.1 and later will have these files already loaded, unless manually deleted.
+**Note:** This is only necessary for existing Dev Portals created on Kong Enterprise 1.3.0. New Portals created in 1.3.0.1 and later will have these files already loaded, unless manually deleted.
 
 Editable email templates can be loaded either via the editor or via the `kong-portal-cli` tool.
 
 ### Load Email Templates via the Portal Editor
 
 1. Log into Kong Manager and navigate to the workspace you want to edit. Click on **Editor** in the sidebar.
-2. Press the “New File+” button in the top left.
-3. Select Content type “email”
-4. Type in one of the supported paths from above
-5. Press create File, this will generate a default email template that is valid for that email.
-6. Do this for emails you wish to edit.
+2. Click **New File+**.
+3. Select Content type `email`.
+4. Type in one of the supported paths from above.
+5. Click **Create File** to generate a default email template that is valid for that email.
+6. Do this for emails you want to edit.
 
-    Note: By default these emails you create will have layout key set:  `layout: emails/email_base.html`
+    Note: By default, these emails you create will have layout key set:  `layout: emails/email_base.html`.
     If you don’t create this layout file, all emails fallback to a default layout.
     You will want to create this layout if you want to customize the Appearance of emails in addition to message.
 
 To create an email layout:
 
-1. Press the “New File+” button in the top left.
-2. Select Content type “theme”
+1. Click **New File+**.
+2. Select Content type `theme`.
 3. Type in the path for the layout, `themes/<THEME_NAME>/layouts/email_base.html`. The default theme name is base.
-    The layout that loads in the new portals in 1.3.0.1 is the following, (this adds the logo image that can be set in the appearance tab in the manager):
+    The layout that loads in the new portals in 1.3.0.1 is the following (this adds the logo image that can be set in the appearance tab in the manager):
 
 {% raw %}
 ```html
@@ -206,13 +205,13 @@ To create an email layout:
 ```
 {% endraw %}
 
-Find out more about customizing the email layout in the section below
+Find out more about customizing the email layout in the section below.
 
 ### Load Email Templates via the Portal CLI Tool
 
-1. Clone [https://github.com/Kong/kong-portal-templates] master branch and navigate into the folder you cloned
-2. If you have any customizations or permissions changes that you wish to keep:
-    -  Run `portal fetch <workspacename>` This will pull in your modifications locally.
+1. Clone [https://github.com/Kong/kong-portal-templates] master branch and navigate into the folder you cloned.
+2. If you have any customizations or permissions changes that you want to keep:
+    -  Run `portal fetch <workspacename>`. This will pull in your modifications locally.
     -  Merge in master branch of [https://github.com/Kong/kong-portal-templates] to apply changes for 1.3.0.1 including emails.
 
-3.  Run `portal deploy <workspacename>` This will deploy all files.
+3.  Run `portal deploy <workspacename>`. This will deploy all files.

--- a/app/enterprise/1.5.x/developer-portal/theme-customization/single-page-app.md
+++ b/app/enterprise/1.5.x/developer-portal/theme-customization/single-page-app.md
@@ -4,9 +4,9 @@ title: Hosting Single Page App out of Kong Dev Portal
 
 ### Introduction
 
-The Kong Developer Portal ships with a default server side rendered theme, however it is possible to replace this with a Single Page App (SPA). Our example is in Angular using the Angular CLI Tool, but you can follow along with any other javascript framework with just a few tweaks.
+The Kong Developer Portal ships with a default server-side rendered theme; however, it is possible to replace this with a Single Page App (SPA). This example is in Angular using the Angular CLI Tool, but you can follow along with any other JavaScript framework with just a few tweaks.
 
-To view the basic example Angular template from this guide visit the [`example/spa-angular`](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular) branch from the kong-portal-templates branch.
+To view the basic example Angular template from this guide, visit the [`example/spa-angular`](https://github.com/Kong/kong-portal-templates/tree/example/spa-angular) branch from the `kong-portal-templates branch`.
 
 ### Prerequisites
 
@@ -17,21 +17,21 @@ To view the basic example Angular template from this guide visit the [`example/s
 
 ### What is a SPA
 
-A Single Page App (SPA) is a website that loads all HTML, Javascript, and CSS on the first load. Instead of loading subsequent pages from the server, javascript is used to dynamically change the page content. You may wish to use a SPA in Dev Portal if you have a preexisting SPA you want to integrate with portal, or you are trying to achieve a more application like experience across many pages. A SPA takes control of routing from the server, and handles it client-side instead.
+A Single Page App (SPA) is a website that loads all HTML, JavaScript, and CSS on the first load. Instead of loading subsequent pages from the server, JavaScript is used to dynamically change the page content. You may want to use an SPA in Dev Portal if you have a preexisting SPA you want to integrate with the portal, or you are trying to achieve a more application-like experience across many pages. An SPA takes control of routing from the server, and handles it client-side instead.
 
-Custom javascript can also be added to run only on specific layouts, allowing you to maintain server-side rendering. [Learn more](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding javascript to a layout without implementing a SPA.
+Custom JavaScript can also be added to run only on specific layouts, allowing you to maintain server-side rendering. [Learn more](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/adding-javascript-assets) about adding JavaScript to a layout without implementing an SPA.
 
 ### Making Choices
 
 
-We recommend Catalog and Spec routes not be handled by SPA
-If you are using Authentication, then you probably also want to leave server-side rendering for any account pages
+We recommend Catalog and Spec routes not be handled by SPA.
+If you are using Authentication, then you probably also want to leave server-side rendering for any account pages.
 
 ### Getting Started
 
 Clone the [portal-templates](https://github.com/Kong/kong-portal-templates) repo
 
-Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via javascript.
+Create a file called `router.conf.yaml` in `workspaces/default` This file will override the default routing, allowing you to control routing via JavaScript.
 
 `router.conf.yaml` must be a yaml file, where the key is each route, and the value a content or spec path. `/*` Is a catch-all wildcard for all routes not specified in `router.conf.yaml`, it will overwrite all default routing set by collections or set in headmatter.
 
@@ -53,41 +53,45 @@ In the `router.conf.yaml` example below, we are hardcoding routing for all kong 
 
 ```
 
-#### 1. Creating Your SPA
+#### 1. Create your SPA
 
-Create SPA app in the javascript framework of your choice
-As a example, we will be using angular.
+Create an SPA app in the JavaScript framework of your choice. This
+example uses angular.
+
 ```
 ng new
 ```
 
-Make sure to include a 404 route, as well as all routes you want to have on the Portal (excluding the routes handled by server-side rendering we excluded above)
+Make sure to include a 404 route, as well as all routes you want to have on the Portal (excluding the routes handled by server-side rendering excluded above).
 
 Run the build process
 
 For angular:
+
 ```
 ng build
 ```
 
-Copy the build output JS and CSS files to a folder inside `workspaces/default/themes/assets/js`
+Copy the build output JS and CSS files to a folder inside `workspaces/default/themes/assets/js`.
 
-For this example we placed the angular build inside a `workspaces/default/themes/assets/js/ng`
+For this example, place the angular build inside a `workspaces/default/themes/assets/js/ng`.
 
-#### 2. Mounting a SPA
+#### 2. Mounting an SPA
 
-In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example we will call it `spa.html`
+In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example, call it `spa.html`.
 
-Create a file called `spa.html` in `workspaces/default/themes/layouts`
+Create a file called `spa.html` in `workspaces/default/themes/layouts`.
 
-This file will need to contain the html element that our SPA will mount to as well as the scripts necessary to do this.
-For reference view the index.html inside the build folder created by the build step of our SPA.
+This file will need to contain the html element that the SPA will mount to as well as the scripts necessary to do this.
+For reference, view the `index.html` inside the build folder created by the build step of the SPA.
 
-We will be using `layouts/_base.html` as the base for layout template, this way we get the <head> element handled the same way other pages in the portal do, as well as the same CSS and scripts.
+The example uses `layouts/_base.html` as the base for the layout template.
+By doing so, the <head> element is handled the same way as other pages in the portal, as well as the same CSS and scripts.
 
 If you want to have the top nav bar and bottom nav bar, be sure to include them in your layout.
 
-This is what our layout ended up as:
+This is the resulting layout:
+
 {% raw %}
 ```
 {% layout = "layouts/_base.html" %}
@@ -115,12 +119,12 @@ This is what our layout ended up as:
 ```
 {% endraw %}
 
-If your SPA build process creates a css file edit the head.html partial to include your css file.
+If the SPA build process creates a css file, edit the `head.html` partial to include your css file.
 
 #### 3. Loading your layout
 
-In order to use our layout modify `workspaces/default/content/index.txt` to use our layout,
-The title we set here will be the one that displays until the JS set title loads.
+Modify `workspaces/default/content/index.txt` to use your layout.
+The title you set here will be the one that displays until the JS set title loads.
 
 {% raw %}
 ```
@@ -133,10 +137,10 @@ title: Home
 
 #### 4. Deploy the Portal
 
-Now using the kong-portal-cli tool we can deploy this portal
+Now using the kong-portal-cli tool, deploy the portal.
 
-From the root folder of the templates repo
+From the root folder of the templates repo:
+
 ```
 portal deploy default
 ```
-

--- a/app/enterprise/1.5.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/1.5.x/developer-portal/using-the-editor.md
@@ -28,7 +28,7 @@ This will launch the **Editor Mode**:
 ![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
 
 
->Note: Editor Mode is a *live* editor. After changes are saved, changes to files will propagate to the Dev Portal *immediately*.
+>Note: After changes are saved, changes to files will propagate to the Dev Portal *immediately*.
 
 
 ### Navigating the Editor

--- a/app/enterprise/1.5.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/1.5.x/developer-portal/using-the-editor.md
@@ -4,7 +4,7 @@ title: Using the Editor
 
 ### Introduction
 
-Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser. 
+Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
 ![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
 
@@ -14,11 +14,11 @@ Kong Manager offers a robust file editor for editing the template files of the D
 * Access to Kong Manager
 * The Kong Developer Portal is **enabled** and **running**
 
->NOTE: Editor Mode is *not* available when running the Dev Portal in **legacy** mode
+>NOTE: Editor Mode is *not* available when running the Dev Portal in **legacy** mode.
 
 ### Enter Editor Mode
 
-From the **Kong Manager** dashboard of your **Workspace**, click “Editor” under “Dev Portal” in the sidebar.
+From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
 ![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
 
@@ -28,24 +28,24 @@ This will launch the **Editor Mode**:
 ![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
 
 
->Note: Editor Mode is a *live* editor - once Saved, changes to files will propagate to the Dev Portal *immediately*. 
+>Note: Editor Mode is a *live* editor. After changes are saved, changes to files will propagate to the Dev Portal *immediately*.
 
 
 ### Navigating the Editor
 
-When enabled, the Dev Portal is pre-populated with Kong's default theme. The file editor exposes these files to the UI, allowing them to be edited quickly and easily from inside the browser. When you first open the editor you will be presented with a list of files on the left, and a blank editing form. 
+When enabled, the Dev Portal is pre-populated with Kong's default theme. The file editor exposes these files to the UI, allowing them to be edited quickly and easily from inside the browser. When you first open the editor, you will be presented with a list of files on the left, and a blank editing form.
 
-1. Create new files for the Dev Portal right from the Editor by clicking `New File+`
-2. List of all exposed template files in the Dev Portal, separated by Content / Spec / Themes
-3. Code View - Select a file from the sidebar to show the code here
-4. Portal Preview - a live preview of the selected Dev Portal file
-5. Toggle View - Choose between three different views, full screen code, a split view, and full screen preview mode
+1. Create new files for the Dev Portal right from the Editor by clicking `New File+`.
+2. List of all exposed template files in the Dev Portal, separated by Content / Spec / Themes.
+3. Code View - Select a file from the sidebar to show the code here.
+4. Portal Preview - View a live preview of the selected Dev Portal file.
+5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
 ![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
 
 ### Editing Files
 
-Select a file from the sidebar to open it for editing - this will expose the file to the Code View and show a live update in the Portal Preview. Clicking “Save” in the top right corner will save the updates to the database and update the file on the Dev Portal.
+Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
 ![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
 
@@ -53,24 +53,25 @@ Select a file from the sidebar to open it for editing - this will expose the fil
 
 ### Adding new files
 
-Clicking the `New File +` button will open the New File Dialog.
+Clicking the `New File +` button opens the New File Dialog.
 
 ![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
 
-### Authenticating Files
+### Authenticating files
 
-Authentication is handled by readable_by value on content pages (for gui view go to permissions page)
+Authentication is handled by `readable_by` value on content pages (for gui view, go to permissions page)
     - set readable_by: '*' to equal old authenticated
-    - to restrict access to certain roles, set readably to an array of accepted roles (must create roles first on permissions page)
-    - on specs readable_by is set inside "x-headmatter" object
+    - to restrict access to certain roles, set readable_by to an array of accepted roles (you must first create roles on the permissions page)
+    - on specs, readable_by is set inside "x-headmatter" object
 
 
 ### Deleting files
 
-To delete a file from within the Editor, right click on the file name and select `Delete` from the pop-up menu. 
-**NOTE** This action cannot be undone.
+To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
+
+**NOTE:** This action cannot be undone.
 
 ![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/enterprise/1.5.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/1.5.x/developer-portal/using-the-editor.md
@@ -28,7 +28,6 @@ This will launch the **Editor Mode**:
 ![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
 
 
->Note: After changes are saved, changes to files will propagate to the Dev Portal *immediately*.
 
 
 ### Navigating the Editor

--- a/app/enterprise/1.5.x/developer-portal/working-with-templates.md
+++ b/app/enterprise/1.5.x/developer-portal/working-with-templates.md
@@ -4,7 +4,7 @@ title: Working with Templates
 
 ### Introduction
 
-Kong Portal 1.3 is built on top of the `lua-resty-template` templating library which can be viewed here: https://github.com/bungle/lua-resty-template. Basic usage of the library will be described below, reference the source documentation for a more in-depth look at what it can accomplish.
+Kong Portal 1.3 is built on top of the `lua-resty-template` templating library, which can be viewed here: https://github.com/bungle/lua-resty-template. Basic usage of the library will be described below. Refer to the source documentation for a more in-depth look at what it can accomplish.
 
 ### Syntax
 ***(excerpt from lua-resty-templates documentation)***
@@ -18,7 +18,7 @@ You may use the following tags in templates:
 
 * `{-block-}...{-block-}`, wraps inside of a `{-block-}` to a value stored in a `blocks` table with a key `block` (in this case), see [using blocks](https://github.com/bungle/lua-resty-template#using-blocks). Don't use predefined block names `verbatim` and `raw`.
 * `{-verbatim-}...{-verbatim-}` and `{-raw-}...{-raw-}` are predefined blocks whose inside is not processed by the `lua-resty-template` but the content is outputted as is.
-* `{# comments #}` everything between `{#` and `#}` is considered to be commented out (i.e. not outputted or executed)
+* `{# comments #}` everything between `{#` and `#}` is considered to be commented out (i.e., not outputted or executed).
 {% endraw %}
 
 ### Using Partials
@@ -129,9 +129,9 @@ hero_description: Partials are wicked sick!
 
 ### Using Blocks
 
-Blocks can be used to embed a view or partial into another template. Blocks are particularly useful when you would like different templates to share a common wrapper.
+Blocks can be used to embed a view or partial into another template. Blocks are particularly useful when you want different templates to share a common wrapper.
 
-In the example below notice that the content file is referencing `index.html`, and not `wrapper.html`.
+In the example below, notice that the content file is referencing `index.html`, and not `wrapper.html`.
 
 ##### content/index.txt
 
@@ -209,7 +209,7 @@ description: Blocks are the future!
 {% endraw %}
 
 ### collections
-Collections are a powerful tool enabling you to render sets of content as a group.  Content rendered as a collection share a configurable route pattern, as well as a layout.  Collections are configured in you portals `portal.conf.yaml` file.
+Collections are a powerful tool enabling you to render sets of content as a group.  Content rendered as a collection share a configurable route pattern, as well as a layout. Collections are configured in your portals `portal.conf.yaml` file.
 
 The example below shows all the necessary configuration/files needed to render a basic `blog` collection made up of individual `posts`.
 
@@ -228,28 +228,28 @@ collections:
 ```
 {% endraw %}
 
-Above you can see we have declared a `collections` object which is made up of individual collection configurations.  In this example, we are configuring a collection called `posts`.  The renderer looks for a root directory called `_posts` within the `content` folder for individual pages to render.  If we created another collection conf called `animals`, the renderer would look for a directory called `_animals` for content files to render.
+Above you can see a `collections` object was declared, which is made up of individual collection configurations. In this example, you are configuring a collection called `posts`.  The renderer looks for a root directory called `_posts` within the `content` folder for individual pages to render.  If you created another collection conf called `animals`, the renderer would look for a directory called `_animals` for content files to render.
 
 Each configuration item is made up of a few parts:
 - ###### `output`
   - **required**: false
   - **type**: `boolean`
-  - **description**: This optional attribute determines whether the collections should render or not.  When set to `false` virtual routes for the collection are not created.
+  - **description**: This optional attribute determines whether the collections should render or not. When set to `false`, virtual routes for the collection are not created.
 - ###### `route`
   - **required**: true
   - **type**: `string`
   - **default**: `none`
   - **description**: The `route` attribute is required and tells the renderer what pattern to generate collection routes from. A collection route should always include at least one valid dynamic namespace that uniquely identifies each collection member.
     - Any namespace in the route declaration which begins with `:` is considered dynamic.
-    - Only certain dynamic namespaces are recognized by kong as valid:
-      - `:title`: Replaces namespac with a contents `title`, declared in headmatter.
+    - Only certain dynamic namespaces are recognized by Kong as valid:
+      - `:title`: Replaces namespace with a contents `title`, declared in headmatter.
       - `:name`: Replaces namespace with the filename of a piece of content.
       - `:collection`: Replaces namespace with name of current collection.
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
 - ###### `route`
     - **required**: true
       - **type**: `boolean`
-      - **description**: The `layout` attribute determines what HTML layout the collections use to render.  The path root is assessed from within the current themes `layouts` directory.
+      - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
 ##### `content/_posts/post1.md`
 


### PR DESCRIPTION
Quick copy edit to clean up dev portal content.

The landing pages and the migration topics are not included in this PR. App portal registration is also not included. Those will be separate PRs. There are some navigation issues that will be addressed with forthcoming site improvements.

Because much of the content was/is on one code line, it is sometimes difficult for git to show a proper diff. That also makes it difficult to make granular suggested edits.

Direct review link entry point:

https://deploy-preview-2075--kongdocs.netlify.app/enterprise/1.5.x/developer-portal/