### PR TITLE
docs(images) Disabling image expand on icons

### DIFF
--- a/app/enterprise/1.3-x/deployment/installation/overview.md
+++ b/app/enterprise/1.3-x/deployment/installation/overview.md
@@ -2,6 +2,7 @@
 title: Install Kong Enterprise
 toc: false
 skip_read_time: true
+disable_image_expand: true
 ---
 
 <div class="docs-grid-install">

--- a/app/enterprise/1.3-x/getting-started/index.md
+++ b/app/enterprise/1.3-x/getting-started/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started with Kong Enterprise
 toc: false
+disable_image_expand: true
 ---
 
 ### Introduction

--- a/app/enterprise/1.3-x/kong-manager/administration/rbac/index.md
+++ b/app/enterprise/1.3-x/kong-manager/administration/rbac/index.md
@@ -5,62 +5,62 @@ book: admin_gui
 
 ### Introduction to RBAC in Kong Manager
 
-In addition to authenticating **Admins** and segmenting **Workspaces**, 
-Kong Enterprise has the ability to enforce Role-Based Access Control 
-(RBAC) for all resources with the use of **Roles** assigned to **Admins**. 
+In addition to authenticating **Admins** and segmenting **Workspaces**,
+Kong Enterprise has the ability to enforce Role-Based Access Control
+(RBAC) for all resources with the use of **Roles** assigned to **Admins**.
 
-As the **Super Admin** (or any **Role** with **read** and **write** 
-access to the `/admins` and `/rbac` endpoints), it is possible to 
+As the **Super Admin** (or any **Role** with **read** and **write**
+access to the `/admins` and `/rbac` endpoints), it is possible to
 create new **Roles** and customize **Permissions**.
 
-In Kong Manager, RBAC affects how **Admins** are able to navigate 
+In Kong Manager, RBAC affects how **Admins** are able to navigate
 through the application.
 
 ### Default Roles
 
-Kong includes Role-Based Access Control (RBAC). Every **Admin** using Kong Manager 
+Kong includes Role-Based Access Control (RBAC). Every **Admin** using Kong Manager
 will need an assigned **Role** based on the resources they have **Permission** to access.
 
-When a **Super Admin** starts Kong for the first time, the `default` **Workspace** will 
-include three default **Roles**: `read-only`, `admin`, and `super-admin`. The three 
+When a **Super Admin** starts Kong for the first time, the `default` **Workspace** will
+include three default **Roles**: `read-only`, `admin`, and `super-admin`. The three
 **Roles** have **Permissions** related to every **Workspace** in the cluster.
 
-Similarly, if a **Role** is confined to certain **Workspaces**, the **Admin** assigned to it 
+Similarly, if a **Role** is confined to certain **Workspaces**, the **Admin** assigned to it
 will not be able to see either the overview or links to other **Workspaces**.
 
-⚠️ **IMPORTANT**: Although a default **Admin** has full permissions with every 
-endpoint in Kong, only a **Super Admin** has the ability to assign and modify RBAC 
-**Permissions**. An **Admin** is not able to modify their own **Permissions** or delimit a 
+⚠️ **IMPORTANT**: Although a default **Admin** has full permissions with every
+endpoint in Kong, only a **Super Admin** has the ability to assign and modify RBAC
+**Permissions**. An **Admin** is not able to modify their own **Permissions** or delimit a
 **Super Admin's** **Permissions**.
 
-⚠️ **IMPORTANT**: If a **Role** does not have **Permission** to access entire endpoints, 
+⚠️ **IMPORTANT**: If a **Role** does not have **Permission** to access entire endpoints,
 the **Admin** assigned to the **Role** will not be able to see the related navigation links.
 
 ### RBAC in Workspaces
 
-RBAC **Roles** and **Permissions** will be specific to a **Workspace** if they are assigned 
-from within one. For example, if there are two **Workspaces**, **Payments** and 
-**Deliveries**, an **Admin** created in **Payments** will not have access to any 
+RBAC **Roles** and **Permissions** will be specific to a **Workspace** if they are assigned
+from within one. For example, if there are two **Workspaces**, **Payments** and
+**Deliveries**, an **Admin** created in **Payments** will not have access to any
 endpoints in **Deliveries**.
 
-When a **Super Admin** creates a new **Workspace**, there are three default **Roles** that 
-mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**: 
-`workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and 
+When a **Super Admin** creates a new **Workspace**, there are three default **Roles** that
+mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
+`workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
 `workspace-portal-admin`.
 
 These roles can be viewed in the **Teams** tab under **Roles**
 
 ![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
 
-⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have 
-**Permissions** applied to all subsequently created **Workspaces**. A **Super Admin** in 
+⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have
+**Permissions** applied to all subsequently created **Workspaces**. A **Super Admin** in
 in `default` has RBAC **Permissions** across all **Workspaces**.
 
 
 <div class="docs-grid">
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/new-role">Create a New Role</a>
     </h3>
     <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/new-role">
@@ -70,7 +70,7 @@ in `default` has RBAC **Permissions** across all **Workspaces**.
 
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/add-user">Create RBAC Users</a>
     </h3>
     <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/add-user">

--- a/app/enterprise/1.3-x/kong-manager/overview.md
+++ b/app/enterprise/1.3-x/kong-manager/overview.md
@@ -10,7 +10,7 @@ toc: false
 <div class="docs-grid">
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/networking/configuration">Networking</a>
     </h3>
     <p>Check and customize Kong Manager's networking configuration.</p>
@@ -21,7 +21,7 @@ toc: false
 
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/security">Security</a>
     </h3>
     <p>Authenticate Kong Admins with Basic Auth, OIDC, LDAP, and Sessions. Authorize Admins with RBAC and Workspaces.</p>
@@ -32,7 +32,7 @@ toc: false
 
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/workspaces/workspaces">Workspaces</a>
     </h3>
     <p>Segment your cluster into Workspaces for specific teams.</p>
@@ -41,7 +41,7 @@ toc: false
 
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/rbac/rbac">
           RBAC Roles and Permissions</a>
     </h3>
@@ -51,7 +51,7 @@ toc: false
 
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/administration/admins/invite">Managing Admins</a>
     </h3>
     <p>Invite and keep track of every team member, all from one place</p>
@@ -60,7 +60,7 @@ toc: false
 
   <div class="docs-grid-block">
     <h3>
-        <img src="/assets/images/icons/documentation/icn-window.svg" />
+        <img class="no-image-expand" src="/assets/images/icons/documentation/icn-window.svg" />
         <a href="/enterprise/{{page.kong_version}}/kong-manager/vitals">Vitals</a>
     </h3>
     <p>Feel the pulse of all Workspaces with health charts and performance metrics.</p>

--- a/app/enterprise/1.5.x/deployment/installation/overview.md
+++ b/app/enterprise/1.5.x/deployment/installation/overview.md
@@ -2,6 +2,7 @@
 title: Install Kong Enterprise
 toc: false
 skip_read_time: true
+disable_image_expand: true
 ---
 
 <div class="docs-grid-install">

--- a/app/getting-started-guide/latest/dev-portal.md
+++ b/app/getting-started-guide/latest/dev-portal.md
@@ -2,7 +2,7 @@
 title: Publish, Locate, and Consume Services
 ---
 <div class="alert alert-ee">
-<img src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This feature is only available with a Kong Enterprise subscription.
+<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This feature is only available with a Kong Enterprise subscription.
 </div>
 
 The Kong Developer Portal (Dev Portal) provides a single source of truth for all developers to locate, access, and consume services. With intuitive content management for documentation, streamlined developer onboarding, and role-based access control (RBAC), Kong’s Developer Portal provides a comprehensive solution for creating and customizing a unified developer experience.

--- a/app/getting-started-guide/latest/manage-teams.md
+++ b/app/getting-started-guide/latest/manage-teams.md
@@ -2,7 +2,7 @@
 title: Manage Administrative Teams
 ---
 <div class="alert alert-ee">
-<img src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This feature is only available with a Kong Enterprise subscription.
+<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This feature is only available with a Kong Enterprise subscription.
 </div>
 
 In this topic, you’ll learn how to manage and configure user authorization using workspaces and teams in Kong Enterprise.

--- a/app/getting-started-guide/latest/overview.md
+++ b/app/getting-started-guide/latest/overview.md
@@ -19,7 +19,7 @@ In this guide, you will:
 
 ### {{site.ee_product_name}} and free trials
 <div class="alert alert-ee">
-<img src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This guide also includes some features specific to {{site.ee_product_name}} and the {{site.ee_gateway_name}}. They'll be called out in blue blocks like this, or in their own Kong Manager tabs.
+<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This guide also includes some features specific to {{site.ee_product_name}} and the {{site.ee_gateway_name}}. They'll be called out in blue blocks like this, or in their own Kong Manager tabs.
 <br/><br/>
 {{site.ee_product_name}} extends the {{site.ce_product_name}} with enterprise features and support. It provides advanced functionality using plugins for security, collaboration, performance at scale, and use of advanced protocols.
 <br/><br/>

--- a/app/getting-started-guide/latest/prepare.md
+++ b/app/getting-started-guide/latest/prepare.md
@@ -13,7 +13,7 @@ Before you start this section, make sure that:
 In this guide, an instance of Kong Gateway is referenced via `<admin-hostname>`. Make sure to replace `<admin-hostname>` with the hostname of your control plane instance.
 
 <div class="alert alert-ee">
-<h5><img src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for Kong Enterprise free trial users</h5>
+<h5><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for Kong Enterprise free trial users</h5>
 If you are trying out Kong Enterprise using a hosted free trial, you can go through this guide to experience some of this enhanced functionality. However, you need to enable access to the Admin API first.
   <ol>
     <li>Open the Kong Manager using the link provided in your free trial welcome email.</li>

--- a/app/getting-started-guide/latest/protect-services.md
+++ b/app/getting-started-guide/latest/protect-services.md
@@ -10,7 +10,7 @@ If you are following the getting started workflow, make sure you have completed 
 Rate Limiting lets you restrict how many requests your upstream services receive from your API consumers, or how often each user can call the API.
 
 <div class="alert alert-ee">
-<img src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> For Kong Enterprise, the Rate Limiting Advanced plugin provides support for the sliding window algorithm to prevent the API from being overloaded near the window boundaries, and adds Redis support for greater performance.
+<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> For Kong Enterprise, the Rate Limiting Advanced plugin provides support for the sliding window algorithm to prevent the API from being overloaded near the window boundaries, and adds Redis support for greater performance.
 </div>
 
 ## Why Use Rate Limiting?
@@ -23,7 +23,7 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 {% navtab Using the Admin API %}
 
 <div class="alert alert-ee">
-<img src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have Kong Enterprise or free trial access, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced instead.
+<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have Kong Enterprise or free trial access, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced instead.
 </div>
 
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.


### PR DESCRIPTION
Issues: images are set to expand on click across the site, icons and linked images included. This PR disables that for Enterprise 1.3-x and 1.5.x and the getting started guide.

Current behavior: https://docs.konghq.com/enterprise/1.5.x/deployment/installation/overview/