### PR TITLE
docs(nav) Add missing navigation items to Admin API and Guides

### DIFF
--- a/app/_data/docs_nav_ee_0.35-x.yml
+++ b/app/_data/docs_nav_ee_0.35-x.yml
@@ -73,8 +73,54 @@
       url: /secure-admin-api
     - text: Plugin Development Guide
       url: /plugin-development
+      items:
+        - text: Introduction
+          url: /plugin-development
+        - text: File structure
+          url: /plugin-development/file-structure
+        - text: Implementing custom logic
+          url: /plugin-development/custom-logic
+        - text: Plugin configuration
+          url: /plugin-development/plugin-configuration
+        - text: Accessing the datastore
+          url: /plugin-development/access-the-datastore
+        - text: Storing custom entities
+          url: /plugin-development/custom-entities
+        - text: Caching custom entities
+          url: /plugin-development/entities-cache
+        - text: Extending the Admin API
+          url: /plugin-development/admin-api
+        - text: Writing tests
+          url: /plugin-development/tests
+        - text: (un)Installing your plugin
+          url: /plugin-development/distribution
     - text: Plugin Development Kit
       url: /pdk
+      items:
+        - text: kong.client
+          url: /pdk/kong.client
+        - text: kong.ctx
+          url: /pdk/kong.ctx
+        - text: kong.ip
+          url: /pdk/kong.ip
+        - text: kong.log
+          url: /pdk/kong.log
+        - text: kong.node
+          url: /pdk/kong.node
+        - text: kong.request
+          url: /pdk/kong.request
+        - text: kong.response
+          url: /pdk/kong.response
+        - text: kong.router
+          url: /pdk/kong.router
+        - text: kong.service
+          url: /pdk/kong.service
+        - text: kong.service.request
+          url: /pdk/kong.service.request
+        - text: kong.service.response
+          url: /pdk/kong.service.response
+        - text: kong.table
+          url: /pdk/kong.table
 
 - title: Admin API
   url: /admin-api
@@ -103,8 +149,18 @@
     url: /admin-api/#target-object
   - text: Workspace Object routes
     url: /admin-api/workspaces/reference
+    items:
+      - text: Workspaces Reference
+        url: /admin-api/workspaces/reference
+      - text: Workspace Examples
+        url: /admin-api/workspaces/examples
   - text: RBAC Object routes
     url: /admin-api/rbac/reference
+    items:
+      - text: RBAC Reference
+        url: /admin-api/rbac/reference
+      - text: RBAC Examples
+        url: /admin-api/rbac/examples
   - text: Admins
     url: /admin-api/admins/reference
     items:

--- a/app/_data/docs_nav_ee_0.36-x.yml
+++ b/app/_data/docs_nav_ee_0.36-x.yml
@@ -74,8 +74,54 @@
       url: /secure-admin-api
     - text: Plugin Development Guide
       url: /plugin-development
+      items:
+        - text: Introduction
+          url: /plugin-development
+        - text: File structure
+          url: /plugin-development/file-structure
+        - text: Implementing custom logic
+          url: /plugin-development/custom-logic
+        - text: Plugin configuration
+          url: /plugin-development/plugin-configuration
+        - text: Accessing the datastore
+          url: /plugin-development/access-the-datastore
+        - text: Storing custom entities
+          url: /plugin-development/custom-entities
+        - text: Caching custom entities
+          url: /plugin-development/entities-cache
+        - text: Extending the Admin API
+          url: /plugin-development/admin-api
+        - text: Writing tests
+          url: /plugin-development/tests
+        - text: (un)Installing your plugin
+          url: /plugin-development/distribution
     - text: Plugin Development Kit
       url: /pdk
+      items:
+        - text: kong.client
+          url: /pdk/kong.client
+        - text: kong.ctx
+          url: /pdk/kong.ctx
+        - text: kong.ip
+          url: /pdk/kong.ip
+        - text: kong.log
+          url: /pdk/kong.log
+        - text: kong.node
+          url: /pdk/kong.node
+        - text: kong.request
+          url: /pdk/kong.request
+        - text: kong.response
+          url: /pdk/kong.response
+        - text: kong.router
+          url: /pdk/kong.router
+        - text: kong.service
+          url: /pdk/kong.service
+        - text: kong.service.request
+          url: /pdk/kong.service.request
+        - text: kong.service.response
+          url: /pdk/kong.service.response
+        - text: kong.table
+          url: /pdk/kong.table
     - text : OpenAPI Spec to Kong Entities
       url: /oasconfig
 
@@ -108,8 +154,18 @@
     url: /admin-api/#target-object
   - text: Workspace Object routes
     url: /admin-api/workspaces/reference
+    items:
+      - text: Workspaces Reference
+        url: /admin-api/workspaces/reference
+      - text: Workspace Examples
+        url: /admin-api/workspaces/examples
   - text: RBAC Object routes
     url: /admin-api/rbac/reference
+    items:
+      - text: RBAC Reference
+        url: /admin-api/rbac/reference
+      - text: RBAC Examples
+        url: /admin-api/rbac/examples
   - text: Admins
     url: /admin-api/admins/reference
     items:

--- a/app/_data/docs_nav_ee_1.3-x.yml
+++ b/app/_data/docs_nav_ee_1.3-x.yml
@@ -91,8 +91,54 @@
       url: /secure-admin-api
     - text: Plugin Development Guide
       url: /plugin-development
+      items:
+        - text: Introduction
+          url: /plugin-development
+        - text: File structure
+          url: /plugin-development/file-structure
+        - text: Implementing custom logic
+          url: /plugin-development/custom-logic
+        - text: Plugin configuration
+          url: /plugin-development/plugin-configuration
+        - text: Accessing the datastore
+          url: /plugin-development/access-the-datastore
+        - text: Storing custom entities
+          url: /plugin-development/custom-entities
+        - text: Caching custom entities
+          url: /plugin-development/entities-cache
+        - text: Extending the Admin API
+          url: /plugin-development/admin-api
+        - text: Writing tests
+          url: /plugin-development/tests
+        - text: (un)Installing your plugin
+          url: /plugin-development/distribution
     - text: Plugin Development Kit
       url: /pdk
+      items:
+        - text: kong.client
+          url: /pdk/kong.client
+        - text: kong.ctx
+          url: /pdk/kong.ctx
+        - text: kong.ip
+          url: /pdk/kong.ip
+        - text: kong.log
+          url: /pdk/kong.log
+        - text: kong.node
+          url: /pdk/kong.node
+        - text: kong.request
+          url: /pdk/kong.request
+        - text: kong.response
+          url: /pdk/kong.response
+        - text: kong.router
+          url: /pdk/kong.router
+        - text: kong.service
+          url: /pdk/kong.service
+        - text: kong.service.request
+          url: /pdk/kong.service.request
+        - text: kong.service.response
+          url: /pdk/kong.service.response
+        - text: kong.table
+          url: /pdk/kong.table
     - text : Control Kong through systemd
       url: /systemd
     - text : Keyring and Data Encryption
@@ -130,8 +176,18 @@
     url: /admin-api/#target-object
   - text: Workspaces
     url: /admin-api/workspaces/reference
+    items:
+      - text: Workspaces Reference
+        url: /admin-api/workspaces/reference
+      - text: Workspace Examples
+        url: /admin-api/workspaces/examples
   - text: RBAC
     url: /admin-api/rbac/reference
+    items:
+      - text: RBAC Reference
+        url: /admin-api/rbac/reference
+      - text: RBAC Examples
+        url: /admin-api/rbac/examples
   - text: Admins
     url: /admin-api/admins/reference
     items:

--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -115,8 +115,54 @@
       url: /network
     - text: Plugin Development Guide
       url: /plugin-development
+      items:
+        - text: Introduction
+          url: /plugin-development
+        - text: File structure
+          url: /plugin-development/file-structure
+        - text: Implementing custom logic
+          url: /plugin-development/custom-logic
+        - text: Plugin configuration
+          url: /plugin-development/plugin-configuration
+        - text: Accessing the datastore
+          url: /plugin-development/access-the-datastore
+        - text: Storing custom entities
+          url: /plugin-development/custom-entities
+        - text: Caching custom entities
+          url: /plugin-development/entities-cache
+        - text: Extending the Admin API
+          url: /plugin-development/admin-api
+        - text: Writing tests
+          url: /plugin-development/tests
+        - text: (un)Installing your plugin
+          url: /plugin-development/distribution
     - text: Plugin Development Kit
       url: /pdk
+      items:
+        - text: kong.client
+          url: /pdk/kong.client
+        - text: kong.ctx
+          url: /pdk/kong.ctx
+        - text: kong.ip
+          url: /pdk/kong.ip
+        - text: kong.log
+          url: /pdk/kong.log
+        - text: kong.node
+          url: /pdk/kong.node
+        - text: kong.request
+          url: /pdk/kong.request
+        - text: kong.response
+          url: /pdk/kong.response
+        - text: kong.router
+          url: /pdk/kong.router
+        - text: kong.service
+          url: /pdk/kong.service
+        - text: kong.service.request
+          url: /pdk/kong.service.request
+        - text: kong.service.response
+          url: /pdk/kong.service.response
+        - text: kong.table
+          url: /pdk/kong.table
     - text : Control Kong Enterprise through systemd
       url: /systemd
 
@@ -152,8 +198,18 @@
     url: /admin-api/#target-object
   - text: Workspaces
     url: /admin-api/workspaces/reference
+    items:
+      - text: Workspaces Reference
+        url: /admin-api/workspaces/reference
+      - text: Workspace Examples
+        url: /admin-api/workspaces/examples
   - text: RBAC
     url: /admin-api/rbac/reference
+    items:
+      - text: RBAC Reference
+        url: /admin-api/rbac/reference
+      - text: RBAC Examples
+        url: /admin-api/rbac/examples
   - text: Admins
     url: /admin-api/admins/reference
     items:

--- a/app/enterprise/0.35-x/admin-api/workspaces/examples.md
+++ b/app/enterprise/0.35-x/admin-api/workspaces/examples.md
@@ -8,33 +8,33 @@ book: workspaces
 This chapter aims to provide a step-by-step tutorial on how to set up
 workspaces, entities, and see it in action.
 
-## Important Note: Conflicting APIs or Routes in workspaces
+## Important Note: Conflicting Services or Routes in workspaces
 
 Workspaces provide a way to segment Kong entities—entities in a workspace
 are isolated from those in other workspaces. That said, entities
-such as APIs and Routes have "routing rules", which are pieces of info
-attached to APIs or Routes—such as HTTP method, URI, or host—that allow a
+such as Services and Routes have "routing rules", which are pieces of info
+attached to Services or Routes—such as HTTP method, URI, or host—that allow a
 given proxy-side request to be routed to its corresponding upstream service.
 
-Admins configuring APIs (or Routes) in their workspaces do not want traffic
-directed to their APIs or Routes to be swallowed by APIs or Routes in other
+Admins configuring Services (or Routes) in their workspaces do not want traffic
+directed to their Services or Routes to be swallowed by Services or Routes in other
 workspaces; Kong allows them to prevent such undesired behavior—as long as
 certain measures are taken. Below we outline the conflict detection algorithm
 used by Kong to determine if a conflict occurs.
 
-* At API or Route **creation or modification** time, Kong runs its internal
+* At Service or Route **creation or modification** time, Kong runs its internal
 router:
-  - If no APIs or Routes are found with matching routing rules, the creation
+  - If no Services or Routes are found with matching routing rules, the creation
   or modification proceeds
-  - If APIs or Routes with matching routing rules are found **within the same
+  - If Services or Routes with matching routing rules are found **within the same
   workspace**, proceed
-  - If APIs or Routes are found **in a different workspace**:
-    * If the matching API or Route **does not have an associated
+  - If Services or Routes are found **in a different workspace**:
+    * If the matching Service or Route **does not have an associated
       `host` value**—`409 Conflict`
-    * If the matching API or Route's `host` is a wildcard
+    * If the matching Service or Route's `host` is a wildcard
       - If they are the same, a conflict is reported—`409 Conflict`
       - If they are not equal, proceed
-    * If the matching API or Route's `host` is an absolute value, a
+    * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 
 ## The Default workspace

--- a/app/enterprise/0.36-x/admin-api/workspaces/examples.md
+++ b/app/enterprise/0.36-x/admin-api/workspaces/examples.md
@@ -8,33 +8,33 @@ book: workspaces
 This chapter aims to provide a step-by-step tutorial on how to set up
 workspaces, entities, and see it in action.
 
-## Important Note: Conflicting APIs or Routes in workspaces
+## Important Note: Conflicting Services or Routes in workspaces
 
 Workspaces provide a way to segment Kong entities—entities in a workspace
 are isolated from those in other workspaces. That said, entities
-such as APIs and Routes have "routing rules", which are pieces of info
-attached to APIs or Routes—such as HTTP method, URI, or host—that allow a
+such as Services and Routes have "routing rules", which are pieces of info
+attached to Services or Routes—such as HTTP method, URI, or host—that allow a
 given proxy-side request to be routed to its corresponding upstream service.
 
-Admins configuring APIs (or Routes) in their workspaces do not want traffic
-directed to their APIs or Routes to be swallowed by APIs or Routes in other
+Admins configuring Services (or Routes) in their workspaces do not want traffic
+directed to their Services or Routes to be swallowed by Services or Routes in other
 workspaces; Kong allows them to prevent such undesired behavior—as long as
 certain measures are taken. Below we outline the conflict detection algorithm
 used by Kong to determine if a conflict occurs.
 
-* At API or Route **creation or modification** time, Kong runs its internal
+* At Service or Route **creation or modification** time, Kong runs its internal
 router:
-  - If no APIs or Routes are found with matching routing rules, the creation
+  - If no Services or Routes are found with matching routing rules, the creation
   or modification proceeds
-  - If APIs or Routes with matching routing rules are found **within the same
+  - If Services or Routes with matching routing rules are found **within the same
   workspace**, proceed
-  - If APIs or Routes are found **in a different workspace**:
-    * If the matching API or Route **does not have an associated
+  - If Services or Routes are found **in a different workspace**:
+    * If the matching Service or Route **does not have an associated
       `host` value**—`409 Conflict`
-    * If the matching API or Route's `host` is a wildcard
+    * If the matching Service or Route's `host` is a wildcard
       - If they are the same, a conflict is reported—`409 Conflict`
       - If they are not equal, proceed
-    * If the matching API or Route's `host` is an absolute value, a
+    * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 
 ## The Default workspace

--- a/app/enterprise/1.3-x/admin-api/rbac/examples.md
+++ b/app/enterprise/1.3-x/admin-api/rbac/examples.md
@@ -151,7 +151,7 @@ http :8001/workspaces name=teamC Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7
 **NOTE**: this is the RBAC Super Admin creating workspaces—note his
 token being passed in through the `Kong-Admin-Token` HTTP header.
 
-## Super Admin Creates one Admin for each Team:
+## Super Admin Creates one Admin for each Team
 
 **Team A**:
 
@@ -436,7 +436,7 @@ http :8001/teamA/rbac/roles/users/endpoints/ endpoint=/workspaces/* workspace=te
 }
 ```
 
-**IMPORTANT**: as explained in the [Wildcards in Permissions][rbac-wildcards]
+**IMPORTANT**: as explained in the [Wildcards in Permissions](#wildcards-in-permissions)
 section, the meaning of `*` is not the expected generic globbing one might
 be used to. As such, `/rbac/*` or `/workspaces/*` do not match all of the
 RBAC and Workspaces endpoints. For example, to cover all of the RBAC API,
@@ -575,7 +575,7 @@ http :8001/teamA/rbac/users/bazgineer/roles roles=users Kong-Admin-Token:n5bhjgv
 }
 ```
 
-## Regular Team Users use their tokens!
+## Regular Team Users use their tokens
 
 foogineer, bargineer, and bazgineer all have gotten their RBAC user tokens
 from their Team A admin, and are now allowed to explore Kong—within the
@@ -642,14 +642,14 @@ This ends our use case tutorial; it demonstrates the power of RBAC and
 workspaces with a real-world scenario. Following, we will approach **Entity-Level
 RBAC**, an extension of our powerful access control to entity-level granularity.
 
-# Entity-Level RBAC: a Primer
+## Entity-Level RBAC: a Primer
 
 Kong Enterprise's new RBAC implementation goes one step further in permissions
 granularity: in addition to "endpoint" permissions, it supports entity-level
 permissions, meaning that particular entities, identified by their unique ID,
 can be allowed or disallowed access in a role.
 
-Refreshing our minds, RBAC is [enforced][rbac-enforce] with the `enforce_rbac`
+Refreshing our minds, RBAC is [enforced](#enforcing-rbac) with the `enforce_rbac`
 configuration directive—or with its `KONG_ENFORCE_RBAC` environment variable
 counterpart. Such directive is an enum, with 4 possible values:
 
@@ -663,7 +663,7 @@ If one sets it to either `entity` or `both`, Kong will enforce entity-level
 access control. However, as with endpoint-level access control, permissions
 must be bootstrapped before enforcement is enabled.
 
-## Creating Entity-Level Permissions
+### Creating Entity-Level Permissions
 
 Team A just got one new, temporary, team member: qux. Admin A, the admin of
 Team A, has already created his qux RBAC user; he needs, however, to limit
@@ -830,7 +830,7 @@ That is, 2 entities permissions and no endpoint permissions.
 Admin A is done setting up qux, and qux can now use his user token to read
 his two entities over Kong's admin API.
 
-We will assume that Admin A [enabled entity-level enforcement][rbac-enforce].
+We will assume that Admin A [enabled entity-level enforcement](#enforcing-rbac).
 Note that as qux has **no endpoint-level permissions**, if both endpoint and
 entity-level enforcement is enabled, he will not be able to read his entities -
 endpoint-level validation comes before entity-level.
@@ -903,7 +903,7 @@ http :8001/teamA/routes/3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 Kong-Admin-Token:sU
 
 We will end this chapter with a few closing remarks.
 
-## Wildcards in Permissions
+### Wildcards in Permissions
 
 RBAC supports the use of wildcards—represented by the `*` character—in many
 aspects of permissions:
@@ -938,7 +938,7 @@ character:
 
 - `entity_id`: `*` matches **any entity ID**
 
-## Entities Concealing in Entity-Level RBAC
+### Entities Concealing in Entity-Level RBAC
 
 With Entity-Level RBAC enabled, endpoints that list all entities of a
 particular collection will only list entities that the user has access to;
@@ -1006,7 +1006,7 @@ http :8001/teamA/plugins Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
 
 Notice the `total` field is 2, but qux only got one entity in the response.
 
-## Creating Entities in Entity-Level RBAC
+### Creating Entities in Entity-Level RBAC
 
 As entity-level RBAC provides access control to individual existing entities,
 it does not apply to creation of new entities; for that, endpoint-level
@@ -1042,9 +1042,7 @@ he created.
 
 ---
 
-[rbac-overview]: /enterprise/{{page.kong_version}}/rbac/overview
-[rbac-enforce]: /enterprise/{{page.kong_version}}/rbac/overview#enforcing-rbac
-[rbac-wildcard]: /enterprise/{{page.kong_version}}/rbac/examples/#wildcards-in-permissions
-[rbac-admin]: /enterprise/{{page.kong_version}}/rbac/admin-api
-[workspaces-examples]: /enterprise/{{page.kong_version}}/rbac/examples
+[rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
+[rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
+[workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
 [getting-started-guide]: /enterprise/{{page.kong_version}}/getting-started

--- a/app/enterprise/1.3-x/admin-api/workspaces/examples.md
+++ b/app/enterprise/1.3-x/admin-api/workspaces/examples.md
@@ -8,33 +8,33 @@ book: workspaces
 This chapter aims to provide a step-by-step tutorial on how to set up
 workspaces, entities, and see it in action.
 
-## Important Note: Conflicting APIs or Routes in workspaces
+## Important Note: Conflicting Services or Routes in workspaces
 
 Workspaces provide a way to segment Kong entities—entities in a workspace
 are isolated from those in other workspaces. That said, entities
-such as APIs and Routes have "routing rules", which are pieces of info
-attached to APIs or Routes—such as HTTP method, URI, or host—that allow a
+such as Services and Routes have "routing rules", which are pieces of info
+attached to Services or Routes—such as HTTP method, URI, or host—that allow a
 given proxy-side request to be routed to its corresponding upstream service.
 
-Admins configuring APIs (or Routes) in their workspaces do not want traffic
-directed to their APIs or Routes to be swallowed by APIs or Routes in other
+Admins configuring Services (or Routes) in their workspaces do not want traffic
+directed to their Services or Routes to be swallowed by Services or Routes in other
 workspaces; Kong allows them to prevent such undesired behavior—as long as
 certain measures are taken. Below we outline the conflict detection algorithm
 used by Kong to determine if a conflict occurs.
 
-* At API or Route **creation or modification** time, Kong runs its internal
+* At Service or Route **creation or modification** time, Kong runs its internal
 router:
-  - If no APIs or Routes are found with matching routing rules, the creation
+  - If no Services or Routes are found with matching routing rules, the creation
   or modification proceeds
-  - If APIs or Routes with matching routing rules are found **within the same
+  - If Services or Routes with matching routing rules are found **within the same
   workspace**, proceed
-  - If APIs or Routes are found **in a different workspace**:
-    * If the matching API or Route **does not have an associated
+  - If Services or Routes are found **in a different workspace**:
+    * If the matching Service or Route **does not have an associated
       `host` value**—`409 Conflict`
-    * If the matching API or Route's `host` is a wildcard
+    * If the matching Service or Route's `host` is a wildcard
       - If they are the same, a conflict is reported—`409 Conflict`
       - If they are not equal, proceed
-    * If the matching API or Route's `host` is an absolute value, a
+    * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 
 ## The Default workspace

--- a/app/enterprise/1.5.x/admin-api/rbac/examples.md
+++ b/app/enterprise/1.5.x/admin-api/rbac/examples.md
@@ -151,7 +151,7 @@ http :8001/workspaces name=teamC Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7
 **NOTE**: this is the RBAC Super Admin creating workspaces—note his
 token being passed in through the `Kong-Admin-Token` HTTP header.
 
-## Super Admin Creates one Admin for each Team:
+## Super Admin Creates one Admin for each Team
 
 **Team A**:
 
@@ -436,7 +436,7 @@ http :8001/teamA/rbac/roles/users/endpoints/ endpoint=/workspaces/* workspace=te
 }
 ```
 
-**IMPORTANT**: as explained in the [Wildcards in Permissions][rbac-wildcards]
+**IMPORTANT**: as explained in the [Wildcards in Permissions](#wildcards-in-permissions)
 section, the meaning of `*` is not the expected generic globbing one might
 be used to. As such, `/rbac/*` or `/workspaces/*` do not match all of the
 RBAC and Workspaces endpoints. For example, to cover all of the RBAC API,
@@ -575,7 +575,7 @@ http :8001/teamA/rbac/users/bazgineer/roles roles=users Kong-Admin-Token:n5bhjgv
 }
 ```
 
-## Regular Team Users use their tokens!
+## Regular Team Users use their tokens
 
 foogineer, bargineer, and bazgineer all have gotten their RBAC user tokens
 from their Team A admin, and are now allowed to explore Kong—within the
@@ -642,14 +642,14 @@ This ends our use case tutorial; it demonstrates the power of RBAC and
 workspaces with a real-world scenario. Following, we will approach **Entity-Level
 RBAC**, an extension of our powerful access control to entity-level granularity.
 
-# Entity-Level RBAC: a Primer
+## Entity-Level RBAC: a Primer
 
 Kong Enterprise's new RBAC implementation goes one step further in permissions
 granularity: in addition to "endpoint" permissions, it supports entity-level
 permissions, meaning that particular entities, identified by their unique ID,
 can be allowed or disallowed access in a role.
 
-Refreshing our minds, RBAC is [enforced][rbac-enforce] with the `enforce_rbac`
+Refreshing our minds, RBAC is [enforced](#enforcing-rbac) with the `enforce_rbac`
 configuration directive—or with its `KONG_ENFORCE_RBAC` environment variable
 counterpart. Such directive is an enum, with 4 possible values:
 
@@ -663,7 +663,7 @@ If one sets it to either `entity` or `both`, Kong will enforce entity-level
 access control. However, as with endpoint-level access control, permissions
 must be bootstrapped before enforcement is enabled.
 
-## Creating Entity-Level Permissions
+### Creating Entity-Level Permissions
 
 Team A just got one new, temporary, team member: qux. Admin A, the admin of
 Team A, has already created his qux RBAC user; he needs, however, to limit
@@ -830,7 +830,7 @@ That is, 2 entities permissions and no endpoint permissions.
 Admin A is done setting up qux, and qux can now use his user token to read
 his two entities over Kong's admin API.
 
-We will assume that Admin A [enabled entity-level enforcement][rbac-enforce].
+We will assume that Admin A [enabled entity-level enforcement](#enforcing-rbac).
 Note that as qux has **no endpoint-level permissions**, if both endpoint and
 entity-level enforcement is enabled, he will not be able to read his entities -
 endpoint-level validation comes before entity-level.
@@ -903,7 +903,7 @@ http :8001/teamA/routes/3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 Kong-Admin-Token:sU
 
 We will end this chapter with a few closing remarks.
 
-## Wildcards in Permissions
+### Wildcards in Permissions
 
 RBAC supports the use of wildcards—represented by the `*` character—in many
 aspects of permissions:
@@ -938,7 +938,7 @@ character:
 
 - `entity_id`: `*` matches **any entity ID**
 
-## Entities Concealing in Entity-Level RBAC
+### Entities Concealing in Entity-Level RBAC
 
 With Entity-Level RBAC enabled, endpoints that list all entities of a
 particular collection will only list entities that the user has access to;
@@ -1006,7 +1006,7 @@ http :8001/teamA/plugins Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
 
 Notice the `total` field is 2, but qux only got one entity in the response.
 
-## Creating Entities in Entity-Level RBAC
+### Creating Entities in Entity-Level RBAC
 
 As entity-level RBAC provides access control to individual existing entities,
 it does not apply to creation of new entities; for that, endpoint-level
@@ -1042,9 +1042,7 @@ he created.
 
 ---
 
-[rbac-overview]: /enterprise/{{page.kong_version}}/rbac/overview
-[rbac-enforce]: /enterprise/{{page.kong_version}}/rbac/overview#enforcing-rbac
-[rbac-wildcard]: /enterprise/{{page.kong_version}}/rbac/examples/#wildcards-in-permissions
-[rbac-admin]: /enterprise/{{page.kong_version}}/rbac/admin-api
-[workspaces-examples]: /enterprise/{{page.kong_version}}/rbac/examples
+[rbac-overview]: /enterprise/{{page.kong_version}}/kong-manager/administration/rbac
+[rbac-admin]: /enterprise/{{page.kong_version}}/admin-api/rbac/reference
+[workspaces-examples]: /enterprise/{{page.kong_version}}/admin-api/workspaces/examples
 [getting-started-guide]: /enterprise/{{page.kong_version}}/getting-started

--- a/app/enterprise/1.5.x/admin-api/workspaces/examples.md
+++ b/app/enterprise/1.5.x/admin-api/workspaces/examples.md
@@ -8,33 +8,33 @@ book: workspaces
 This chapter aims to provide a step-by-step tutorial on how to set up
 workspaces, entities, and see it in action.
 
-## Important Note: Conflicting APIs or Routes in workspaces
+## Important Note: Conflicting Services or Routes in workspaces
 
 Workspaces provide a way to segment Kong entities—entities in a workspace
 are isolated from those in other workspaces. That said, entities
-such as APIs and Routes have "routing rules", which are pieces of info
-attached to APIs or Routes—such as HTTP method, URI, or host—that allow a
+such as Services and Routes have "routing rules", which are pieces of info
+attached to Services or Routes—such as HTTP method, URI, or host—that allow a
 given proxy-side request to be routed to its corresponding upstream service.
 
-Admins configuring APIs (or Routes) in their workspaces do not want traffic
-directed to their APIs or Routes to be swallowed by APIs or Routes in other
+Admins configuring Services (or Routes) in their workspaces do not want traffic
+directed to their Services or Routes to be swallowed by Services or Routes in other
 workspaces; Kong allows them to prevent such undesired behavior—as long as
 certain measures are taken. Below we outline the conflict detection algorithm
 used by Kong to determine if a conflict occurs.
 
-* At API or Route **creation or modification** time, Kong runs its internal
+* At Service or Route **creation or modification** time, Kong runs its internal
 router:
-  - If no APIs or Routes are found with matching routing rules, the creation
+  - If no Services or Routes are found with matching routing rules, the creation
   or modification proceeds
-  - If APIs or Routes with matching routing rules are found **within the same
+  - If Services or Routes with matching routing rules are found **within the same
   workspace**, proceed
-  - If APIs or Routes are found **in a different workspace**:
-    * If the matching API or Route **does not have an associated
+  - If Services or Routes are found **in a different workspace**:
+    * If the matching Service or Route **does not have an associated
       `host` value**—`409 Conflict`
-    * If the matching API or Route's `host` is a wildcard
+    * If the matching Service or Route's `host` is a wildcard
       - If they are the same, a conflict is reported—`409 Conflict`
       - If they are not equal, proceed
-    * If the matching API or Route's `host` is an absolute value, a
+    * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 
 ## The Default workspace


### PR DESCRIPTION
I noticed there are a few documentation pages that do not appear in the navigation of the Enterprise docs. Some can be reached through links on other pages, but some only through the search. Some of these pages contain important information, e.g. about conflict resolution between workspaces.

This PR adds them to the navigation as far back as `0.35` (when it seems a lot of the docs were reorganized).

It also replaces the old `API(s)` with the new `Service(s)` on one of those pages.

