### PR TITLE
docs(dev portal) Copying changes to template docs from 1.3-x to 1.5.x

### DIFF
--- a/app/enterprise/1.5.x/developer-portal/working-with-templates.md
+++ b/app/enterprise/1.5.x/developer-portal/working-with-templates.md
@@ -302,3 +302,1181 @@ This is my second post!
 <h1>Post Two</h1>
 <p>This is my second post!</p>
 ```
+
+
+### List of Helper Functions
+
+# Kong Template Helpers - Lua API
+Kong Template Helpers are a collection of objects that give access to your portal data at the time of render and provide powerful integrations into Kong.
+
+
+## Globals
+
+- [`l`](#lkey-fallback) - Locale helper, first version, gets values from the currently active page.
+- [`each`](#eachlist_or_table) - Commonly used helper to iterate over lists or tables.
+- [`print`](#printany) - Commonly used helper to print lists / tables.
+- [`markdown`](#printany) - Commonly used helper to print lists / tables.
+- [`json_decode`](#json_decode) - Decode JSON to Lua table.
+- [`json_encode`](#json_encode) - Encode Lua table to JSON.
+
+
+## Objects
+
+- [`portal`](#portal) - The portal object refers to the current workspace portal being accessed.
+- [`page`](#page) - The page object refers to the currently active page and its contents.
+- [`user`](#user) - The user object represents the currently logged in developer accessing the Kong Portal.
+- [`theme`](#theme) - The theme object represents the currently active theme and its variables.
+- [`tbl`](#tbl) = Table helper methods. Examples: `map`, `filter`, `find`, `sort`.
+- [`str`](#str) = String helper methods. Examples: `lower`, `upper`, `reverse`, `endswith`.
+- [`helpers`](#helpers) - Helper functions simplify common tasks or provide easy shortcuts to Kong Portal methods.
+
+
+## Terminology / Definitions
+
+- `list` - Also referred to commonly as an array (`[1, 2, 3]`) in Lua is a table-like object (`{1, 2, 3}`). Lua list index starts at `1` not `0`. Values can be accessed by array notation (`list[1]`).
+- `table` - Also commonly known as an object or hashmap (`{1: 2}`) in Lua looks like (`{1 = 2}`). Values can be accessed by array or dot notation (`table.one or table["one"]`).
+
+# Globals
+## `l(key, fallback)`
+
+#### Description
+
+> Returns the current translation by key from the currently active page.
+
+#### Return Type
+{% raw %}
+
+```lua
+string
+```
+{% endraw %}
+#### Usage
+
+
+##### `content/en/example.txt`
+
+{% raw %}
+```yaml
+---
+layout: example.html
+
+locale:
+  title: Welcome to {{portal.name}}
+  slogan: The best developer portal ever created.
+---
+```
+{% endraw %}
+
+
+##### `content/es/example.txt`
+
+{% raw %}
+```yaml
+---
+layout: example.html
+
+locale:
+  title: Bienvenido a {{portal.name}}
+  slogan: El mejor portal para desarrolladores jamás creado.
+---
+```
+{% endraw %}
+
+
+##### `layouts/example.html`
+
+{% raw %}
+```lua
+<h1>{* l("title", "Welcome to" .. portal.name) *}</h1>
+<p>{* l("slogan", "My amazing developer portal!") *}</p>
+<p>{* l("powered_by", "Powered by Kong.") *}</p>
+```
+{% endraw %}
+
+
+##### Output when on `en/example`
+
+{% raw %}
+```html
+<h1>Welcome to Kong Portal</h1>
+<p>The best developer portal ever created.</p>
+<p>Powered by Kong.</p>
+```
+{% endraw %}
+
+
+##### Output when on `es/example`
+
+{% raw %}
+```html
+<h1>Bienvenido a Kong Portal</h1>
+<p>El mejor portal para desarrolladores jamás creado.</p>
+<p>Powered by Kong.</p>
+```
+{% endraw %}
+
+
+#### Notes
+
+- `l(...)` is a helper from the `page` object. It can be also accessed via `page.l`. However, `page.l` does not support template interpolation (for example, `{{portal.name}}` will not work.)
+
+## `each(list_or_table)`
+
+#### Description
+
+> Returns the appropriate iterator depending on what type of argument is passed.
+
+#### Return Type
+
+```lua
+Iterator
+```
+
+#### Usage
+
+##### Template (List)
+
+{% raw %}
+```lua
+{% for index, value in each(table) do %}
+<ul>
+  <li>Index: {{index}}</li>
+  <li>Value: {{ print(value) }}</li>
+</ul>
+{% end %}
+```
+{% endraw %}
+
+
+##### Template (Table)
+
+{% raw %}
+```lua
+{% for key, value in each(table) do %}
+<ul>
+  <li>Key: {{key}}</li>
+  <li>Value: {{ print(value) }}</li>
+</ul>
+{% end %}
+```
+{% endraw %}
+
+## `print(any)`
+
+#### Description
+
+> Returns stringified output of input value.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template (Table)
+
+{% raw %}
+```lua
+<pre>{{print(page)}}</pre>
+```
+{% endraw %}
+
+## `markdown(string)`
+
+#### Description
+
+> Returns HTML from the markdown string passed as an argument. If a string argument is not valid markdown, the function will return the string as is. To render properly, the helper should be used with raw "{* *}" delimiters.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template (string as arg)
+
+{% raw %}
+```lua
+<pre>{* markdown("##This is Markdown") *}</pre>
+```
+{% endraw %}
+
+##### Template (content val as arg)
+
+{% raw %}
+```lua
+<pre>{* markdown(page.description) *)</pre>
+```
+{% endraw %}
+
+## `json_encode(object)`
+
+#### Description
+
+> JSON encodes Lua table passed as argument
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```lua
+<pre>{{ json_encode({ dog = cat }) }}</pre>
+```
+{% endraw %}
+
+## `json_decode(string)`
+
+#### Description
+
+> Decodes JSON string argument to Lua table
+
+#### Return Type
+
+```lua
+table
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```lua
+<pre>{{ print(json_encode('{"dog": "cat"}')) }}</pre>
+```
+{% endraw %}
+
+
+# `portal`
+
+> `portal` gives access to data relating to the current portal, this includes things like portal configuration, content, specs, and layouts.
+
+---
+
+- [How To Access Config Values](#how-to-access-config-values)
+- [Portal Members](#portal-members)
+  - [`portal.workspace`](#portalworkspace)
+  - [`portal.url`](#portalurl)
+  - [`portal.api_url`](#portalapi_url)
+  - [`portal.auth`](#portalauth)
+  - [`portal.specs`](#portalspecs)
+  - [`portal.specs_by_tag`](#portalspecs_by_tag)
+  - [`portal.developer_meta_fields`](#portaldeveloper_meta_fields)
+
+---
+
+## How To Access Config Values
+
+You can access the current workspace's portal config directly on the `portal` object like so:
+
+```lua
+portal[config_key] or portal.config_key
+```
+
+For example `portal.auth` is a portal config value. You can find a list of config values by reading the portal section of `kong.conf`.
+
+### From `kong.conf`
+
+The portal only exposes config values that start with  `portal_`, and they can be access by removing the `portal_` prefix.
+
+> Some configuration values are modified or customized, these customizations are documented under the [Portal Members](#portal-members) section.
+
+## Portal Members
+
+### `portal.workspace`
+
+#### Description
+
+> Returns the current portal's workspace.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{portal.workspace}}
+```
+{% endraw %}
+
+##### Output
+
+```html
+default
+```
+
+### `portal.url`
+
+#### Description
+
+> Returns the current portal's url with workspace.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{portal.url}}
+```
+{% endraw %}
+
+##### Output
+
+```html
+http://127.0.0.1:8003/default
+```
+
+## `portal.api_url`
+
+#### Description
+
+> Returns the configuration value for `portal_api_url` with
+> the current workspace appended.
+
+#### Return Type
+
+```lua
+string or nil
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{portal.api_url}}
+```
+{% endraw %}
+
+##### Output when `portal_api_url = http://127.0.0.1:8004`
+
+```html
+http://127.0.0.1:8004/default
+```
+
+### `portal.auth`
+
+#### Description
+
+> Returns the current portal's authentication type.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+#### Printing Value
+
+###### Input
+
+{% raw %}
+```hbs
+{{portal.auth}}
+```
+{% endraw %}
+
+###### Output when `portal_auth = basic-auth`
+
+```html
+basic-auth
+```
+
+#### Checking Authentication Enabled
+
+###### Input
+
+{% raw %}
+```hbs
+{% if portal.auth then %}
+  Authentication is enabled!
+{% end %}
+```
+{% endraw %}
+
+###### Output when `portal_auth = basic-auth`
+
+```html
+Authentication is endabled!
+```
+
+### `portal.specs`
+
+#### Description
+
+Returns an array of specification files contained within the current portal.
+
+#### Return type
+
+```lua
+array
+```
+
+#### Usage
+
+##### Viewing content value
+
+###### Template
+
+{% raw %}
+```hbs
+<pre>{{ print(portal.specs) }}</pre>
+```
+{% endraw %}
+
+###### Output
+
+```lua
+{
+  {
+    "path" = "content/example1_spec.json",
+    "content" = "..."
+  },
+  {
+    "path" = "content/documentation/example1_spec.json",
+    "content" = "..."
+  },
+  ...
+}
+```
+
+##### Looping through values
+
+###### Template
+
+{% raw %}
+```hbs
+{% for _, spec in each(portal.specs) %}
+  <li>{{spec.path}}</li>
+{% end %}
+```
+{% endraw %}
+
+###### Output
+
+```hbs
+  <li>content/example1_spec.json</li>
+  <li>content/documentation/example1_spec.json</li>
+```
+
+##### Filter by path
+
+###### Template
+
+{% raw %}
+```hbs
+{% for _, spec in each(helpers.filter_by_path(portal.specs, "content/documentation")) %}
+  <li>{{spec.path}}</li>
+{% end %}
+```
+{% endraw %}
+###### Output
+
+```hbs
+  <li>content/documentation/example1_spec.json</li>
+```
+
+### `portal.developer_meta_fields`
+
+#### Description
+
+Returns an array of developer meta fields available/required by Kong to register a developer.
+
+#### Return Type
+
+```lua
+array
+```
+
+#### Usage
+
+##### Printing
+
+###### Template
+
+{% raw %}
+```hbs
+{{ print(portal.developer_meta_fields) }}
+```
+{% endraw %}
+
+###### Output
+
+{% raw %}
+```lua
+{
+  {
+    label    = "Full Name",
+    name     = "full_name",
+    type     = "text",
+    required = true,
+  },
+  ...
+}
+```
+{% endraw %}
+
+#### Looping
+
+###### Template
+
+{% raw %}
+```hbs
+{% for i, field in each(portal.developer_meta_fields) do %}
+<ul>
+  <li>Label: {{field.label}}</li>
+  <li>Name: {{field.name}}</li>
+  <li>Type: {{field.type}}</li>
+  <li>Required: {{field.required}}</li>
+</ul>
+{% end %}
+```
+{% endraw %}
+
+###### Output
+
+```html
+<ul>
+  <li>Label: Full Name</li>
+  <li>Name: full_name</li>
+  <li>Type: text</li>
+  <li>Required: true</li>
+</ul>
+...
+```
+
+# `page`
+
+> `page` gives access to data relating to the current page, which includes things like page url, path, breadcrumbs, and more.
+
+---
+
+- [How to access content values](#how-to-access-content-values)
+- [Page Members](#page-members)
+  - [`page.route`](#pageroute)
+  - [`page.url`](#pageurl)
+  - [`page.breadcrumbs`](#pagebreadcrumbs)
+  - [`page.body`](#pagebody)
+  - [`page.parsed_body`](#parsedbody)
+---
+
+## How to access content values
+
+When you create a new content page, you are able to define key-values. Here you are going to learn how to access those values and a few other interesting things.
+
+You can access the key-values you define directly on the `page` object like so:
+
+{% raw %}
+```lua
+page[key_name] or page.key_name
+```
+{% endraw %}
+
+You can also access nested keys like so:
+
+```lua
+page.key_name.nested_key
+```
+{% raw %}
+> Be careful! To avoid output errors, make sure that the `key_name` exists before accessing `nested_key` as shown below:
+> ```hbs
+> {{page.key_name and page.key_name.nested_key}}
+> ```
+{% endraw %}
+
+## Page Members
+### `page.route`
+
+#### Description
+
+> Returns the current page's route/path.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{page.route}}
+```
+{% endraw %}
+
+##### Output given url is `http://127.0.0.1:8003/default/guides/getting-started`
+
+```html
+guides/getting-started
+```
+
+### `page.url`
+
+#### Description
+
+> Returns the current page's url.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{page.url}}
+```
+{% endraw %}
+
+##### Output given url is `http://127.0.0.1:8003/default/guides/getting-started`
+
+```html
+http://127.0.0.1:8003/default/guides/getting-started
+```
+
+### `page.breadcrumbs`
+
+#### Description
+
+> Returns the current page's breadcrumb collection.
+
+#### Return Type
+
+```lua
+table[]
+```
+
+#### Item Properties
+
+- `item.path` - Full path to item, no forward-slash prefix.
+- `item.display_name` - Formatted name.
+- `item.is_first` - Is this the first item in the list?
+- `item.is_last` - Is this the last item in the list?
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+<div id="breadcrumbs">
+  <a href="">Home</a>
+  {% for i, crumb in each(page.breadcrumbs) do %}
+    {% if crumb.is_last then %}
+      / {{ crumb.display_name }}
+    {% else %}
+      / <a href="{{crumb.path}}">{{ crumb.display_name }}</a>
+    {% end %}
+  {% end %}
+</div>
+```
+{% endraw %}
+
+### `page.body`
+
+#### Description
+
+> Returns the body of the current page as a string. If the route's content file has a `.md` or `.markdown` extension, the body will be parsed from markdown to html.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage for .txt, .json, .yaml, .yml templates
+
+##### index.txt
+```hbs
+This is text content.
+```
+
+{% raw %}
+##### Template
+```hbs
+<h1>This is a title</h1>
+<p>{{ page.body) }}</p>
+```
+{% endraw %}
+
+##### Output
+> # This is a title
+> This is text content.
+
+#### Usage for .md, .markdown templates
+
+##### Template (markdown)
+You must use the raw delimiter syntax `{* *}` to render markdown within a template.
+
+##### index.txt
+```hbs
+# This is a title
+This is text content.
+```
+
+##### Template
+```hbs
+{* page.body *}
+```
+
+##### Output
+> # This is a title
+> This is text content.
+
+# `user`
+
+> `user` gives access to data relating to the currently authenticated user.  User object is only applicable when `KONG_PORTAL_AUTH` is enabled.
+
+---
+
+- [User Members](#user-members)
+  - [`user.is_authenticated`](#useris_authenticated)
+  - [`user.has_role`](#userhas_role)
+  - [`user.get`](#userget)
+
+---
+
+## User Members
+
+### `user.is_authenticated`
+
+#### Description
+
+> Returns `boolean` value as to the current user's authentication status.
+
+#### Return Type
+
+```lua
+boolean
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{print(user.is_authenticated)}}
+```
+{% endraw %}
+
+##### Output
+
+```html
+true
+```
+
+### `user.has_role`
+
+#### Description
+
+> Returns `true` if a user has a role given as an argument.
+
+#### Return Type
+
+```lua
+boolean
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{print(user.has_role("blue"))}}
+```
+{% endraw %}
+
+##### Output
+
+```html
+true
+```
+
+### `user.get`
+
+#### Description
+
+> Takes developer attribute as an argument and returns value if present.
+
+#### Return Type
+
+```lua
+any
+```
+
+#### Usage
+
+##### Template
+
+{% raw %}
+```hbs
+{{user.get("email")}}
+{{print(user.get("meta"))}}
+```
+{% endraw %}
+
+##### Output
+
+```html
+example123@konghq.com
+{ "full_name" = "example" }
+```
+
+
+# `theme`
+
+> The `theme` object exposes values set in your `theme.conf.yaml` file.  In addition, any variable overrides contained in `portal.conf.yaml` will be included as well.
+
+---
+
+- [Theme Members](#theme-members)
+  - [`theme.colors`](#usercolors)
+  - [`theme.color`](#usercolor)
+  - [`theme.fonts`](#userfonts)
+  - [`theme.font`](#userfont)
+
+---
+
+## Theme Members
+
+### `theme.colors`
+
+#### Description
+
+> Returns a table of color variables and their values as key-value pairs.
+
+#### Return Type
+
+```lua
+table
+```
+
+#### Usage
+
+##### theme.conf.yaml
+```yaml
+name: Kong
+colors:
+  primary:
+    value: '#FFFFFF'
+    description: 'Primary Color'
+  secondary:
+    value: '#000000'
+    description: 'Secondary Color'
+  tertiary:
+    value: '#1DBAC2'
+    description: 'Tertiary Color'
+```
+
+##### Template
+
+{% raw %}
+```lua
+{% for k,v in each(theme.colors) do %}
+  <p>{{k}}: {{v}}</p>
+{% end %}
+```
+{% endraw %}
+
+##### Output
+
+```html
+<p>primary: #FFFFFF</p>
+<p>secondary: #000000</p>
+<p>tertiary: #1DBAC2</p>
+```
+
+### `theme.color`
+
+#### Description
+
+> Takes color var by string argument, returns value.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### theme.conf.yaml
+```yaml
+name: Kong
+colors:
+  primary:
+    value: '#FFFFFF'
+    description: 'Primary Color'
+  secondary:
+    value: '#000000'
+    description: 'Secondary Color'
+  tertiary:
+    value: '#1DBAC2'
+    description: 'Tertiary Color'
+```
+
+##### Template
+
+{% raw %}
+```lua
+<p>primary: {{theme.color("primary")}}</p>
+<p>secondary: {{theme.color("secondary")}}</p>
+<p>tertiary: {{theme.color("tertiary")}}</p>
+```
+{% endraw %}
+
+##### Output
+
+```html
+<p>primary: #FFFFFF</p>
+<p>secondary: #000000</p>
+<p>tertiary: #1DBAC2</p>
+```
+
+
+### `theme.fonts`
+
+#### Description
+
+> Returns table of font vars and their values as key-value pairs.
+
+#### Return Type
+
+```lua
+table
+```
+
+#### Usage
+
+##### theme.conf.yaml
+```yaml
+name: Kong
+fonts:
+  base: Roboto
+  code: Roboto Mono
+  headings: Lato
+```
+
+##### Template
+
+{% raw %}
+```lua
+{% for k,v in each(theme.fonts) do %}
+  <p>{{k}}: {{v}}</p>
+{% end %}
+```
+{% endraw %}
+
+##### Output
+
+```html
+<p>base: Roboto</p>
+<p>code: Roboto Mono</p>
+<p>headings: Lato</p>
+```
+
+### `theme.font`
+
+#### Description
+
+> Takes font name by string argument, returns value.
+
+#### Return Type
+
+```lua
+string
+```
+
+#### Usage
+
+##### theme.conf.yaml
+```yaml
+name: Kong
+fonts:
+  base: Roboto
+  code: Roboto Mono
+  headings: Lato
+```
+
+##### Template
+
+{% raw %}
+```lua
+<p>base: {{theme.font("base")}}</p>
+<p>code: {{theme.font("code")}}</p>
+<p>headings: {{theme.font("headings")}}</p>
+```
+{% endraw %}
+
+##### Output
+
+```html
+<p>base: #FFFFFF</p>
+<p>code: #000000</p>
+<p>headings: #1DBAC2</p>
+```
+
+## `str`
+
+#### Description
+
+> Table containing useful string helper methods.
+
+#### Usage
+
+{% raw %}
+##### _.upper()_ example
+```lua
+<pre>{{ str.upper("dog") }}</pre>
+```
+{% endraw %}
+
+#### Methods
+##### str.[byte](https://www.gammon.com.au/scripts/doc.php?lua=string.byte)
+##### str.[char](https://www.gammon.com.au/scripts/doc.php?lua=string.char)
+##### str.[dump](https://www.gammon.com.au/scripts/doc.php?lua=string.dump)
+##### str.[find](https://www.gammon.com.au/scripts/doc.php?lua=string.find)
+##### str.[format](https://www.gammon.com.au/scripts/doc.php?lua=string.format)
+##### str.[gfind](https://www.gammon.com.au/scripts/doc.php?lua=string.gfind)
+##### str.[gmatch](https://www.gammon.com.au/scripts/doc.php?lua=string.gmatch)
+##### str.[gsub](https://www.gammon.com.au/scripts/doc.php?lua=string.gsub)
+##### str.[len](https://www.gammon.com.au/scripts/doc.php?lua=string.len)
+##### str.[lower](https://www.gammon.com.au/scripts/doc.php?lua=string.lower)
+##### str.[match](https://www.gammon.com.au/scripts/doc.php?lua=string.match)
+##### str.[rep](https://www.gammon.com.au/scripts/doc.php?lua=string.rep)
+##### str.[reverse](https://www.gammon.com.au/scripts/doc.php?lua=string.reverse)
+##### str.[sub](https://www.gammon.com.au/scripts/doc.php?lua=string.sub)
+##### str.[upper](https://www.gammon.com.au/scripts/doc.php?lua=string.upper)
+##### str.[isalpha](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#isalpha)
+##### str.[isdigit](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#isdigit)
+##### str.[isalnum](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#isalnum)
+##### str.[isspace](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#isspace)
+##### str.[islower](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#islower)
+##### str.[isupper](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#isupper)
+##### str.[startswith](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#startswith)
+##### str.[endswith](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#endswith)
+##### str.[join](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#join)
+##### str.[splitlines](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#splitlines)
+##### str.[split](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#split)
+##### str.[expandtabs](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#expandtabs)
+##### str.[lfind](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#lfind)
+##### str.[rfind](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#rfind)
+##### str.[replace](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#replace)
+##### str.[count](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#count)
+##### str.[ljust](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#ljust)
+##### str.[rjust](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#rjust)
+##### str.[center](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#center)
+##### str.[lstrip](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#lstrip)
+##### str.[rstrip](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#rstrip)
+##### str.[strip](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#strip)
+##### str.[splitv](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#splitv)
+##### str.[partition](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#partition)
+##### str.[rpartition](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#rpartition)
+##### str.[at](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#at)
+##### str.[lines](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#lines)
+##### str.[title](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#title)
+##### str.[shorten](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#shorten)
+##### str.[quote_string](https://stevedonovan.github.io/Penlight/api/libraries/pl.stringx.html#quote_string)
+
+
+## `tbl`
+
+#### Description
+
+> Table containing useful table helper methods
+
+#### Usage
+
+##### _.map()_ example
+{% raw %}
+```lua
+{% tbl.map({"dog", "cat"}, function(item) %}
+  {% if item ~= "dog" then %}
+    {% return true %}
+  {% end %}
+{% end) %}
+```
+{% endraw %}
+
+#### Methods
+##### tbl.[getn](https://www.gammon.com.au/scripts/doc.php?lua=table.getn)
+##### tbl.[setn](https://www.gammon.com.au/scripts/doc.php?lua=table.setn)
+##### tbl.[maxn](https://www.gammon.com.au/scripts/doc.php?lua=table.maxn)
+##### tbl.[insert](https://www.gammon.com.au/scripts/doc.php?lua=table.insert)
+##### tbl.[remove](https://www.gammon.com.au/scripts/doc.php?lua=table.remove)
+##### tbl.[concat](https://www.gammon.com.au/scripts/doc.php?lua=table.concat)
+##### tbl.[map](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#map)
+##### tbl.[foreach](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#foreach)
+##### tbl.[foreachi](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#foreachi)
+##### tbl.[sort](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#sort)
+##### tbl.[sortv](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#sortv)
+##### tbl.[filter](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#filter)
+##### tbl.[size](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#size)
+##### tbl.[index_by](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#index_by)
+##### tbl.[transform](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#transform)
+##### tbl.[range](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#range)
+##### tbl.[reduce](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#reduce)
+##### tbl.[index_map](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#index_map)
+##### tbl.[makeset](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#makeset)
+##### tbl.[union](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#union)
+##### tbl.[intersection](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#intersection)
+##### tbl.[count_map](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#count_map)
+##### tbl.[set](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#set)
+##### tbl.[new](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#new)
+##### tbl.[clear](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#clear)
+##### tbl.[removevalues](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#removevalues)
+##### tbl.[readonly](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#readonly)
+##### tbl.[update](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#update)
+##### tbl.[copy](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#copy)
+##### tbl.[deepcopy](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#deepcopy)
+##### tbl.[icopy](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#icopy)
+##### tbl.[move](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#move)
+##### tbl.[insertvalues](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#insertvalues)
+##### tbl.[deepcompare](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#deepcompare)
+##### tbl.[compare](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#compare)
+##### tbl.[compare_no_order](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#compare_no_order)
+##### tbl.[find](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#find)
+##### tbl.[find_if](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#find_if)
+##### tbl.[search](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#search)
+##### tbl.[keys](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#keys)
+##### tbl.[values](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#values)
+##### tbl.[sub](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#sub)
+##### tbl.[merge](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#merge)
+##### tbl.[difference](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#difference)
+##### tbl.[zip](https://stevedonovan.github.io/Penlight/api/libraries/pl.tablex.html#zip)


### PR DESCRIPTION
This PR is a straight copy/paste. 

@tlblessing this page definitely needs reformatting, it's very hard to use right now. We can go one of two ways:
- The easy(ish) solution is to follow the styling we have in the Admin API docs. This is literally an API doc as well, and should be presented as such: https://docs.konghq.com/enterprise/1.5.x/admin-api/
- The tougher (but better in the long run) solution is to work with the DevX team to create API docs using our own product.  

Solution #1 is definitely a temp solution (though it might be necessary for now). The real solution would require a rework of all of our API docs, not just these. 