### PR TITLE
docs(ee-kubernetes) Cleaning Kubernetes topics and nav tweak

### DIFF
--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -390,15 +390,15 @@
   url: /kong-for-kubernetes/
   items:
     - text: Overview
-      url:  /kong-for-kubernetes
+      url: /kong-for-kubernetes
+    - text: Deployment Options
+      url: /kong-for-kubernetes/deployment-options
     - text: Install Kong for Kubernetes Enterprise
       url: /kong-for-kubernetes/install
     - text: Install Kong Enterprise on Kubernetes
       url: /kong-for-kubernetes/install-on-kubernetes
     - text: Using Kong for Kubernetes
       url: /kong-for-kubernetes/using-kong-for-kubernetes
-    - text: Deployment Options
-      url: /kong-for-kubernetes/deployment-options
     - text: Changelog
       url: /kong-for-kubernetes/changelog
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/changelog.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/changelog.md
@@ -2,14 +2,12 @@
 title: Kong for Kubernetes Enterprise Changelog
 ---
 
-Kong for Kubernetes comprises of two components:
+Kong for Kubernetes consists of two components:
 
 * Kong Enterprise k8s, a package that includes Enterprise plugins, in addition to Kong OSS Gateway and comes with Enterprise support
 * Controller, which actively configures Kong based on the configuration defined in Kubernetes
 
+The changelogs for these can be found at:
 
-The changelog for these can be found at:
-
-* [Kong Enterprise k8s Changelog](/enterprise/k8s-changelog)
-* Controller: <https://github.com/Kong/kubernetes-ingress-controller/blob/master/CHANGELOG.md>
-
+* [Kong Enterprise k8s changelog](/enterprise/k8s-changelog)
+* [Kong Ingress Controller changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/master/CHANGELOG.md)

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -147,7 +147,7 @@ controller can re-create Kong's proxy configuration even if the underlying
 datastore changes.
 
 While most Kubernetes resources can be left unchanged when migrating between
-deployment types, users must remove any KongPlugin resources that use
+deployment types, users must remove any Kong Plugin resources that use
 unavailable plugins when migrating from a database-backed deployment using the
 `kong-enterprise-edition` image to a DB-less deployment using the
 `kong-enterprise-k8s` image. No changes to Kubernetes resources are required if

--- a/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/deployment-options.md
@@ -147,7 +147,7 @@ controller can re-create Kong's proxy configuration even if the underlying
 datastore changes.
 
 While most Kubernetes resources can be left unchanged when migrating between
-deployment types, users must remove any Kong Plugin resources that use
+deployment types, users must remove any KongPlugin resources that use
 unavailable plugins when migrating from a database-backed deployment using the
 `kong-enterprise-edition` image to a DB-less deployment using the
 `kong-enterprise-k8s` image. No changes to Kubernetes resources are required if

--- a/app/enterprise/1.5.x/kong-for-kubernetes/index.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/index.md
@@ -1,14 +1,17 @@
 ---
 title: Kong for Kubernetes Enterprise
+toc: false
 ---
 
-Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes Ingress Controller. A Kubernetes Ingress Controller is a proxy that exposes Kubernetes services from applications (e.g., Deployments, RepliaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster.
+Kong for Kubernetes Enterprise is a deployment of {{site.ee_gateway_name}} onto Kubernetes with an ingress controller, which is responsible for configuring Kong. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (e.g., Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an ingress controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster.
 
-For example, in a common use case, if an application deployed to Kubernetes exposes an API that needs to be used by Web or mobile-client applications or services in another cluster, then a Kubernetes Ingress Controller is required. It is important for the Ingress Controller to secure and manage traffic according to various policies that can be changed on the fly based on the use-case and application.
+For example, here's a common use case: an application deployed to Kubernetes exposes an API that needs to be used by Web or mobile-client applications or services in another cluster. It uses a Kubernetes ingress controller, which can secure and manage traffic according to various policies that can be changed on the fly based on the use case and application.
 
-Kong for Kubernetes Enterprise stores all of the configuration in the Kubernetes datastore (etcd) using Custom Resource Definitions (CRDs), meaning you can use Kubernetes' native tools to manage Kong and benefit from Kubernetes' declarative configuration, RBAC, namespacing, and scalability. Also, because the configuration is stored in Kubernetes, no database needs to be deployed for Kong. Kong runs in in-memory mode, making it operationally easy to run, upgrade, and backup Kong.
+Here are some benefits of using Kong for Kubernetes Enterprise:
+* It stores all of the configuration in the Kubernetes datastore (etcd) using Custom Resource Definitions (CRDs), meaning you can use Kubernetes' native tools to manage Kong and benefit from Kubernetes' declarative configuration, RBAC, namespacing, and scalability.
+* Because the configuration is stored in Kubernetes, no database needs to be deployed for Kong. Kong runs in in-memory mode, making it operationally easy to run, upgrade, and back up.
+* It natively integrates with the Cloud Native Computing Foundation (CNCF) eco-system to provide out of the box monitoring, logging, certificate management, tracing, and scaling.
 
-Kong for Kubernetes Enterprise natively integrates with the Cloud Native Computing Foundation (CNCF) eco-system to provide out of the box monitoring, logging, certificate management, tracing, and scaling.
-
+Alternatively, you can also deploy Kong Enterprise on Kubernetes to use features such as Kong Manager, Kong Developer Portal, and others. For a comparison of the options, see [Deployment Options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options).
 
 <img src="https://doc-assets.konghq.com/kubernetes/K4K8S-Enterprise-Diagram.png" alt="Kong for Kubernetes Enterprise control diagram">

--- a/app/enterprise/1.5.x/kong-for-kubernetes/index.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/index.md
@@ -3,7 +3,7 @@ title: Kong for Kubernetes Enterprise
 toc: false
 ---
 
-Kong for Kubernetes Enterprise is a deployment of {{site.ee_gateway_name}} onto Kubernetes with an ingress controller, which is responsible for configuring Kong. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (e.g., Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an ingress controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster.
+Kong for Kubernetes Enterprise is a deployment of {{site.ee_gateway_name}} onto Kubernetes as an ingress controller. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (e.g., Deployments, StatefulSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an ingress controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster.
 
 For example, here's a common use case: an application deployed to Kubernetes exposes an API that needs to be used by Web or mobile-client applications or services in another cluster. It uses a Kubernetes ingress controller, which can secure and manage traffic according to various policies that can be changed on the fly based on the use case and application.
 
@@ -13,5 +13,7 @@ Here are some benefits of using Kong for Kubernetes Enterprise:
 * It natively integrates with the Cloud Native Computing Foundation (CNCF) ecosystem to provide out of the box monitoring, logging, certificate management, tracing, and scaling.
 
 Alternatively, you can also deploy Kong Enterprise on Kubernetes to use features such as Kong Manager, Kong Developer Portal, and others. For a comparison of the options, see [Deployment Options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options).
+
+For more information about the architecture, see [Kong Ingress Controller Design](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/design.md).
 
 <img src="https://doc-assets.konghq.com/kubernetes/K4K8S-Enterprise-Diagram.png" alt="Kong for Kubernetes Enterprise control diagram">

--- a/app/enterprise/1.5.x/kong-for-kubernetes/index.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/index.md
@@ -9,8 +9,8 @@ For example, here's a common use case: an application deployed to Kubernetes exp
 
 Here are some benefits of using Kong for Kubernetes Enterprise:
 * It stores all of the configuration in the Kubernetes datastore (etcd) using Custom Resource Definitions (CRDs), meaning you can use Kubernetes' native tools to manage Kong and benefit from Kubernetes' declarative configuration, RBAC, namespacing, and scalability.
-* Because the configuration is stored in Kubernetes, no database needs to be deployed for Kong. Kong runs in in-memory mode, making it operationally easy to run, upgrade, and back up.
-* It natively integrates with the Cloud Native Computing Foundation (CNCF) eco-system to provide out of the box monitoring, logging, certificate management, tracing, and scaling.
+* Because the configuration is stored in Kubernetes, no database needs to be deployed for Kong. Kong runs in DB-less mode, making it operationally easy to run, upgrade, and back up.
+* It natively integrates with the Cloud Native Computing Foundation (CNCF) ecosystem to provide out of the box monitoring, logging, certificate management, tracing, and scaling.
 
 Alternatively, you can also deploy Kong Enterprise on Kubernetes to use features such as Kong Manager, Kong Developer Portal, and others. For a comparison of the options, see [Deployment Options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options).
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -4,7 +4,9 @@ title: Installing Kong Enterprise on Kubernetes
 
 ## Introduction
 
-Kong Enterprise on Kubernetes is recommended for deployments that require features not supported by Kong for Kubernetes Enterprise. It supports all Kong Enterprise plugins and features, but can't run in DB-less mode. See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for more information.
+Kong Enterprise on Kubernetes is recommended for deployments that require features not supported by Kong for Kubernetes Enterprise. It supports all Kong Enterprise plugins and features, but can't run in DB-less mode.
+
+> Note: See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for a feature breakdown and image comparison.
 
 You can use kubectl or OpenShift oc to configure Kong Enterprise on Kubernetes, then deploy it using Helm.
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -3,7 +3,9 @@ title: Installing Kong for Kubernetes Enterprise
 ---
 
 ## Introduction
-Kong for Kubernetes Enterprise provides most Kong Enterprise plugins and runs without a database, but does not include other Kong Enterprise features (Kong Manager, Dev Portal, Vitals, etc). See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for more information.
+Kong for Kubernetes Enterprise provides most Kong Enterprise plugins and runs without a database, but does not include other Kong Enterprise features (Kong Manager, Dev Portal, Vitals, etc).
+
+>Note: See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for a feature breakdown and image comparison.
 
 You can install Kong for Kubernetes Enterprise using YAML with kubectl, or with OpenShift oc. Other deployment options, such as using Helm Chart and Kustomize, will be available at a later time.
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/using-kong-for-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/using-kong-for-kubernetes.md
@@ -2,56 +2,54 @@
 title: Using Kong for Kubernetes Enterprise
 ---
 
-For information about using Kong for Kubernetes Enterprise, see the documentation listed below that is available on Github at https://github.com/Kong/kubernetes-ingress-controller/tree/master/docs.
+For information about using Kong for Kubernetes Enterprise, see the documentation breakdown below. Most of this documentation is available on Github at [kubernetes-ingress-controller/docs](https://github.com/Kong/kubernetes-ingress-controller/tree/master/docs).
 
-### Concepts
+## Concepts
 
-#### Architecture
+### Architecture
 The [design](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/design.md) document explains how Kong Ingress Controller works inside a Kubernetes cluster and configures Kong to proxy traffic as per rules defined in the Ingress resources.
 
-#### Custom Resources
-The Ingress resource in Kubernetes is a fairly narrow and ambiguous API, and does not offer resources to describe the specifics of proxying. To overcome this limitation, the KongIngress Custom resource is used as an "extension" to the existing Ingress API.
+### Custom resources
+The Ingress resource in Kubernetes is a fairly narrow and ambiguous API, and does not offer resources to describe the specifics of proxying. To overcome this limitation, the KongIngress custom resource is used as an "extension" to the existing Ingress API.
 
 A few custom resources are bundled with Kong Ingress Controller to configure settings that are specific to Kong and provide fine-grained control over the proxying behavior.
 
-See [custom resources](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/custom-resources.md) concept document for more details.
+See the [custom resources](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/custom-resources.md) concept document for more details.
 
-#### Deployment Methods
-Kong Ingress Controller can be deployed in a variety of deployment patterns. See the [deployment](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md) documentation, which explains all of the components involved and different ways of deploying them based on the use-case.
+### Deployment options
+Kong Ingress Controller can be deployed in a variety of deployment patterns.
+- See the [deployment](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) documentation, which compares the main deployment options for {{site.ee_product_name}}.
+- Or, for information on all of the components involved and different ways of deploying them based on the use case, see the [deployment documentation](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md) in the Kong Ingress Controller repository.
 
-#### High-availability and Scaling
-The Kong Ingress Controller is designed to scale with your traffic and infrastructure. See [High-availability and Scaling](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/ha-and-scaling.md) to understand failure scenarios, recovery methods, as well as scaling considerations.
+### Compatibility
+- For a list of which plugins are compatible with the different distributions of {{site.ee_product_name}}, see [Plugin Compatibility](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/plugin-compatibility.md#kong-enterprise).
+- For compatibility between the versions of {{site.ee_product_name}} distributions and the Kong Ingress Controller, see [Version Compatibility](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/version-compatibility.md).
 
-#### Security
+### High-availability and scaling
+The Kong Ingress Controller is designed to scale with your traffic and infrastructure. See [High-availability and Scaling](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/ha-and-scaling.md) to understand failure scenarios, recovery methods, and scaling considerations.
+
+### Security
 See the [Security](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/security.md) document to understand the default security settings and how to further secure the Ingress Controller.
 
-
-
-### Guides and Tutorials
+## Guides and tutorials
 Browse through [guides](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/guides) to get started or understand how to configure a specific setting with Kong Ingress Controller.
 
-### Configuration Reference
-
-The configurations in the Kong Ingress Controller can be customized using Custom Resources and annotations. See the following documents detailing this process:
+## Configuration reference
+The configurations in the Kong Ingress Controller can be customized using custom resources and annotations. See the following documents detailing this process:
 
 - [Custom Resource Definitions](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/custom-resources.md)
 - [Annotations](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/annotations.md)
 - [CLI arguments](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/cli-arguments.md)
 
-
-
-### FAQs
+## FAQs
 [FAQs](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/faq.md) are available to help find answers to quickly resolve common problems. Feel free to open Pull Requests to contribute to the list.
 
-
-
-### Troubleshooting
+## Troubleshooting
 See the [deployment guide](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/deployment) for a detailed understanding of how Kong Ingress Controller is designed and deployed along alongside Kong.
 
 Other resources include:
 - [FAQs](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/faq.md)
 - The [Troubleshooting guide](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/troubleshooting.md) can help resolve some issues.
 
-
-### Contribute to the Community
+## Contribute to the community
 For a place to discuss and share Kong knowledge with the community, visit [Kong Nation](https://discuss.konghq.com/c/kubernetes).


### PR DESCRIPTION
* Adding a compatibility links section to "Using Kong for Kubernetes"
* Minor edits for typos, grammar, and header depth 
* Based on feedback from team, moving deployment topic up in the nav
* Rephrasing and some cleanup on intro page - @rainest can you look over the changes to /kong-for-kubernetes/index.md and let me know if this content is accurate? It doesn't seem to fully line up with your deployment topic.
