### PR TITLE
Added a parameter that's needed to enable Enterprise

### DIFF
--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -161,6 +161,7 @@ In the following steps, replace `<your-password>` with a secure password.
 
     |Parameter      | Value                         |
     |---------------|-------------------------------|
+    |`enterprise.enabled` | `true` |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |


### PR DESCRIPTION
Added a parameter (enterprise.enabled) that's needed to enable Enterprise to the table.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

