### PR TITLE
Add OIDC integration guide links to Hub

### DIFF
--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -2806,26 +2806,26 @@ Provider                                                                        
 [Auth0](https://auth0.com/)                                                      | [Docs](https://auth0.com/docs/protocols/oidc) / [Discovery](https://demo.auth0.com/.well-known/openid-configuration) / [Keys](https://demo.auth0.com/.well-known/jwks.json) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-auth0) |
 [Google](https://www.google.com/)                                                | [Docs](https://developers.google.com/identity/protocols/OpenIDConnect) / [Discovery](https://accounts.google.com/.well-known/openid-configuration) / [Keys](https://www.googleapis.com/oauth2/v3/certs) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-google/) |
 [Microsoft](https://www.microsoft.com/) Azure AD                                 | [Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oidc) / [Discovery](https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration) / [Keys](https://login.microsoftonline.com/organizations/discovery/v2.0/keys) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-azuread) |
-[Microsoft](https://www.microsoft.com/) Live Connect                             | Docs / [Discovery](https://login.live.com/.well-known/openid-configuration) / [Keys](https://nexus.passport.com/public/partner/discovery/key) ||
+[Microsoft](https://www.microsoft.com/) Live Connect                             | Docs / [Discovery](https://login.live.com/.well-known/openid-configuration) / [Keys](https://nexus.passport.com/public/partner/discovery/key) | - |
 [Okta](https://www.okta.com/)                                                    | [Docs](https://developer.okta.com/docs/api/resources/oidc.html) / [Discovery](https://demo.oktapreview.com/.well-known/openid-configuration) / [Keys](https://demo.oktapreview.com/oauth2/v1/keys) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-okta) |
-[OneLogin](https://www.onelogin.com/)                                            | [Docs](https://developers.onelogin.com/openid-connect) / [Discovery](https://openid-connect.onelogin.com/oidc/.well-known/openid-configuration) / [Keys](https://openid-connect.onelogin.com/oidc/certs) ||
-[Paypal](https://www.paypal.com/)                                                | [Docs](https://developer.paypal.com/docs/integration/direct/identity/log-in-with-paypal/) / [Discovery](https://www.paypal.com/.well-known/openid-configuration) / [Keys](https://api.paypal.com/v1/oauth2/certs) ||
-[Salesforce](https://www.salesforce.com/f)                                       | [Docs](https://developer.salesforce.com/page/Inside_OpenID_Connect_on_Force.com) / [Discovery](https://test.salesforce.com/.well-known/openid-configuration) / [Keys](https://test.salesforce.com/id/keys) ||
-[Yahoo!](https://www.yahoo.com/)                                                 | [Docs](https://developer.yahoo.com/oauth2/guide/openid_connect/) / [Discovery](https://api.login.yahoo.com/.well-known/openid-configuration) / [Keys](https://login.yahoo.com/openid/v1/certs) ||
+[OneLogin](https://www.onelogin.com/)                                            | [Docs](https://developers.onelogin.com/openid-connect) / [Discovery](https://openid-connect.onelogin.com/oidc/.well-known/openid-configuration) / [Keys](https://openid-connect.onelogin.com/oidc/certs) | - |
+[Paypal](https://www.paypal.com/)                                                | [Docs](https://developer.paypal.com/docs/integration/direct/identity/log-in-with-paypal/) / [Discovery](https://www.paypal.com/.well-known/openid-configuration) / [Keys](https://api.paypal.com/v1/oauth2/certs) | - |
+[Salesforce](https://www.salesforce.com/f)                                       | [Docs](https://developer.salesforce.com/page/Inside_OpenID_Connect_on_Force.com) / [Discovery](https://test.salesforce.com/.well-known/openid-configuration) / [Keys](https://test.salesforce.com/id/keys) | - |
+[Yahoo!](https://www.yahoo.com/)                                                 | [Docs](https://developer.yahoo.com/oauth2/guide/openid_connect/) / [Discovery](https://api.login.yahoo.com/.well-known/openid-configuration) / [Keys](https://login.yahoo.com/openid/v1/certs) | - |
 
 
 ### On Premises
 
 Provider                                                        | Information  | Kong integration guide |
 ----------------------------------------------------------------|:------------:|:----------------------:|
-[Connect2id](https://connect2id.com/)                           | [Docs](https://connect2id.com/products/server) / [Discovery](https://demo.c2id.com/c2id/.well-known/openid-configuration) / [Keys](https://demo.c2id.com/c2id/jwks.json) ||
-[Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) ||
-[Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) ||
-[IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks) ||
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) ||
-[OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) ||
-[PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/) ||
-[WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect) ||
+[Connect2id](https://connect2id.com/)                           | [Docs](https://connect2id.com/products/server) / [Discovery](https://demo.c2id.com/c2id/.well-known/openid-configuration) / [Keys](https://demo.c2id.com/c2id/jwks.json) | - |
+[Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) | - |
+[Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) | - |
+[IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks) | - |
+[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) | - |
+[OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) | - |
+[PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/) | - |
+[WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect) | - |
 
 
 ## Enterprise Support & Demo

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -2800,32 +2800,32 @@ well.
 
 ### Cloud Providers
 
-Provider                                                                         | Information
----------------------------------------------------------------------------------|:------------:
-[Amazon AWS](https://aws.amazon.com/) [Cognito](https://aws.amazon.com/cognito/) | [Docs](https://aws.amazon.com/cognito/getting-started/) / [Discovery](https://cognito-idp.us-east-2.amazonaws.com/us-east-2_XEXO5iUSL/.well-known/openid-configuration) / [Keys](https://cognito-idp.us-east-2.amazonaws.com/us-east-2_XEXO5iUSL/.well-known/jwks.json)
-[Auth0](https://auth0.com/)                                                      | [Docs](https://auth0.com/docs/protocols/oidc) / [Discovery](https://demo.auth0.com/.well-known/openid-configuration) / [Keys](https://demo.auth0.com/.well-known/jwks.json)
-[Google](https://www.google.com/)                                                | [Docs](https://developers.google.com/identity/protocols/OpenIDConnect) / [Discovery](https://accounts.google.com/.well-known/openid-configuration) / [Keys](https://www.googleapis.com/oauth2/v3/certs)
-[Microsoft](https://www.microsoft.com/) Azure AD                                 | [Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oidc) / [Discovery](https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration) / [Keys](https://login.microsoftonline.com/organizations/discovery/v2.0/keys)
-[Microsoft](https://www.microsoft.com/) Live Connect                             | Docs / [Discovery](https://login.live.com/.well-known/openid-configuration) / [Keys](https://nexus.passport.com/public/partner/discovery/key)
-[Okta](https://www.okta.com/)                                                    | [Docs](https://developer.okta.com/docs/api/resources/oidc.html) / [Discovery](https://demo.oktapreview.com/.well-known/openid-configuration) / [Keys](https://demo.oktapreview.com/oauth2/v1/keys)
-[OneLogin](https://www.onelogin.com/)                                            | [Docs](https://developers.onelogin.com/openid-connect) / [Discovery](https://openid-connect.onelogin.com/oidc/.well-known/openid-configuration) / [Keys](https://openid-connect.onelogin.com/oidc/certs)
-[Paypal](https://www.paypal.com/)                                                | [Docs](https://developer.paypal.com/docs/integration/direct/identity/log-in-with-paypal/) / [Discovery](https://www.paypal.com/.well-known/openid-configuration) / [Keys](https://api.paypal.com/v1/oauth2/certs)
-[Salesforce](https://www.salesforce.com/f)                                       | [Docs](https://developer.salesforce.com/page/Inside_OpenID_Connect_on_Force.com) / [Discovery](https://test.salesforce.com/.well-known/openid-configuration) / [Keys](https://test.salesforce.com/id/keys)
-[Yahoo!](https://www.yahoo.com/)                                                 | [Docs](https://developer.yahoo.com/oauth2/guide/openid_connect/) / [Discovery](https://api.login.yahoo.com/.well-known/openid-configuration) / [Keys](https://login.yahoo.com/openid/v1/certs)
+Provider                                                                         | Information  | Kong integration guide |
+---------------------------------------------------------------------------------|:------------:|:----------------------:|
+[Amazon AWS](https://aws.amazon.com/) [Cognito](https://aws.amazon.com/cognito/) | [Docs](https://aws.amazon.com/cognito/getting-started/) / [Discovery](https://cognito-idp.us-east-2.amazonaws.com/us-east-2_XEXO5iUSL/.well-known/openid-configuration) / [Keys](https://cognito-idp.us-east-2.amazonaws.com/us-east-2_XEXO5iUSL/.well-known/jwks.json) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-cognito/) |
+[Auth0](https://auth0.com/)                                                      | [Docs](https://auth0.com/docs/protocols/oidc) / [Discovery](https://demo.auth0.com/.well-known/openid-configuration) / [Keys](https://demo.auth0.com/.well-known/jwks.json) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-auth0) |
+[Google](https://www.google.com/)                                                | [Docs](https://developers.google.com/identity/protocols/OpenIDConnect) / [Discovery](https://accounts.google.com/.well-known/openid-configuration) / [Keys](https://www.googleapis.com/oauth2/v3/certs) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-google/) |
+[Microsoft](https://www.microsoft.com/) Azure AD                                 | [Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oidc) / [Discovery](https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration) / [Keys](https://login.microsoftonline.com/organizations/discovery/v2.0/keys) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-azuread) |
+[Microsoft](https://www.microsoft.com/) Live Connect                             | Docs / [Discovery](https://login.live.com/.well-known/openid-configuration) / [Keys](https://nexus.passport.com/public/partner/discovery/key) ||
+[Okta](https://www.okta.com/)                                                    | [Docs](https://developer.okta.com/docs/api/resources/oidc.html) / [Discovery](https://demo.oktapreview.com/.well-known/openid-configuration) / [Keys](https://demo.oktapreview.com/oauth2/v1/keys) | [Guide](https://docs.konghq.com/enterprise/latest/plugins/oidc-okta) |
+[OneLogin](https://www.onelogin.com/)                                            | [Docs](https://developers.onelogin.com/openid-connect) / [Discovery](https://openid-connect.onelogin.com/oidc/.well-known/openid-configuration) / [Keys](https://openid-connect.onelogin.com/oidc/certs) ||
+[Paypal](https://www.paypal.com/)                                                | [Docs](https://developer.paypal.com/docs/integration/direct/identity/log-in-with-paypal/) / [Discovery](https://www.paypal.com/.well-known/openid-configuration) / [Keys](https://api.paypal.com/v1/oauth2/certs) ||
+[Salesforce](https://www.salesforce.com/f)                                       | [Docs](https://developer.salesforce.com/page/Inside_OpenID_Connect_on_Force.com) / [Discovery](https://test.salesforce.com/.well-known/openid-configuration) / [Keys](https://test.salesforce.com/id/keys) ||
+[Yahoo!](https://www.yahoo.com/)                                                 | [Docs](https://developer.yahoo.com/oauth2/guide/openid_connect/) / [Discovery](https://api.login.yahoo.com/.well-known/openid-configuration) / [Keys](https://login.yahoo.com/openid/v1/certs) ||
 
 
 ### On Premises
 
-Provider                                                        | Information
-----------------------------------------------------------------|:------------:
-[Connect2id](https://connect2id.com/)                           | [Docs](https://connect2id.com/products/server) / [Discovery](https://demo.c2id.com/c2id/.well-known/openid-configuration) / [Keys](https://demo.c2id.com/c2id/jwks.json)
-[Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md)
-[Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/)
-[IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks)
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html)
-[OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect)
-[PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/)
-[WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect)
+Provider                                                        | Information  | Kong integration guide |
+----------------------------------------------------------------|:------------:|:----------------------:|
+[Connect2id](https://connect2id.com/)                           | [Docs](https://connect2id.com/products/server) / [Discovery](https://demo.c2id.com/c2id/.well-known/openid-configuration) / [Keys](https://demo.c2id.com/c2id/jwks.json) ||
+[Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) ||
+[Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) ||
+[IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks) ||
+[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) ||
+[OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) ||
+[PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/) ||
+[WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect) ||
 
 
 ## Enterprise Support & Demo


### PR DESCRIPTION
Add links to Kong Enterprise detailed integration guides for providers where available, for improved discovery.

May have some rendering errors to start--I'm having issues with getting the local Docker compose image to start, so relying on netlify.

An aside, I've added these to https://docs.konghq.com/hub/kong-inc/openid-connect/#compatibility, but there's a duplicate of the compatibility list near the bottom of the intro section. I believe that's sourced from upstream, so I didn't modify it, but we should probably look at consolidating on or the other.