### PR TITLE
docs(request-validator) Add verbose_response parameter

### DIFF
--- a/app/_hub/kong-inc/request-validator/index.md
+++ b/app/_hub/kong-inc/request-validator/index.md
@@ -60,7 +60,7 @@ params:
       value_in_examples:
       description: |
         If enabled, the plugin returns more verbose and detailed validation errors
-        (e.g. the name of the required field that is missing).
+        (e.g., the name of the required field that is missing).
 
 ---
 

--- a/app/_hub/kong-inc/request-validator/index.md
+++ b/app/_hub/kong-inc/request-validator/index.md
@@ -54,6 +54,14 @@ params:
       value_in_examples:
       description: Array of parameter validator specifications
 
+    - name: verbose_response
+      required: false
+      default: false
+      value_in_examples:
+      description: |
+        If enabled, the plugin returns more verbose and detailed validation errors
+        (e.g. the name of the required field that is missing).
+
 ---
 
 ## Examples


### PR DESCRIPTION
The Request Validator plugin gained a very useful `verbose_response` parameter [in version 1.3.0.2](https://docs.konghq.com/enterprise/changelog/#plugins-4).

This adds it to the plugin documentation.