### PR TITLE
docs(0.36-6 changelog) Updated changelog

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -733,6 +733,7 @@ repository will allow you to do both easily.
 
 ### Fixes
 - Fixes Kong PDK `get_method()` function to return a correct HTTP method when there are connectivity issues with the Upstream.
+- Reverted Service Mesh changes which affect `proxy_ssl_*` directives.
 
 
 ## 0.36-5

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -732,7 +732,7 @@ repository will allow you to do both easily.
 **Release Date:** 2020-06-15
 
 ### Fixes
-- Fixes Kong PDK `get_method()` function to return a correct HTTP method when there are connectivity issues with the upstream.
+- Fixes Kong PDK `get_method()` function to return a correct HTTP method when there are connectivity issues with the Upstream.
 
 
 ## 0.36-5

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -727,6 +727,14 @@ repository will allow you to do both easily.
 - Fixes: centos and alpine images did not work on some OpenShift setups with relaxed anyuid SCC settings.
 
 
+## 0.36-6
+
+**Release Date:** 2020-06-15
+
+### Fixes
+- Fixes Kong PDK `get_method()` function to return a correct HTTP method when there are connectivity issues with the upstream.
+
+
 ## 0.36-5
 
 **Release Date:** 2020-04-02


### PR DESCRIPTION
- Updated changelog to add 0.36-6 fix "Fixed Kong PDK `get_method()` function to return a correct HTTP method when there are connectivity issues with the upstream."

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

