### PR TITLE
docs(changelog-update) Change release date for 0.36-6

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -729,7 +729,7 @@ repository will allow you to do both easily.
 
 ## 0.36-6
 
-**Release Date:** 2020-06-15
+**Release Date:** 2020-06-18
 
 ### Fixes
 - Fixes Kong PDK `get_method()` function to return a correct HTTP method when there are connectivity issues with the Upstream.


### PR DESCRIPTION
- Changed release date for 0.36-6 from 2020-06-15 to 2020-06-18

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

