### PR TITLE
fix(toc) Fixing broken links in Admin API ToC

### DIFF
--- a/app/_includes/docs-sidebar-item.html
+++ b/app/_includes/docs-sidebar-item.html
@@ -10,9 +10,11 @@
   {% else %}
   {% assign url = include.docs_url | append: item.url %}
   {% assign last_url_char = item.url | slice: -1, 1 %}
+  {% unless item.url contains '#' %}
   {% if last_url_char != '/' %}
   {% assign url = url | append: '/' %}
   {% endif %}
+  {% endunless %}
   <li>
     <a {% if item.absolute_url %}href="{{item.url}}" {% else %}href="{{include.docs_url | append: item.url}}" {% endif %} {% if page.url==url %}class="active"{% endif %}>
       {{item.text}}
@@ -32,9 +34,11 @@
 {% else %}
 {% assign item_url = include.docs_url | append: include.url %}
 {% assign last_url_char = include.url | slice: -1, 1 %}
+{% unless include.url contains '#' %}
 {% if last_url_char != '/' %}
 {% assign item_url = item_url | append: '/' %}
 {% endif %}
+{% endunless %}
 {% endif %}
 {% if page.url == item_url %}{% assign item_active = true %}{% endif %}
 {% else %}


### PR DESCRIPTION
Adding an exception for links with anchors. 

Looks like there's some weird behaviour remaining (ToC doesn't set anchor links to active when they're clicked), but that's more of a visual consistency issue and can try to fix that in the future. 