### PR TITLE
fix(distributions) add focal link for Kong CE

### DIFF
--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -13,6 +13,7 @@ Start by downloading the corresponding package for your configuration:
 
 - [16.04 Xenial]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.xenial.amd64.deb)
 - [18.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.bionic.amd64.deb)
+- [20.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.focal.amd64.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -13,7 +13,7 @@ Start by downloading the corresponding package for your configuration:
 
 - [16.04 Xenial]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.xenial.amd64.deb)
 - [18.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.bionic.amd64.deb)
-- [20.04 Bionic]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.focal.amd64.deb)
+- [20.04 Focal]({{ site.links.download }}/kong-deb/download_file?file_path=kong-{{site.data.kong_latest.version}}.focal.amd64.deb)
 
 **Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
 


### PR DESCRIPTION
Kong CE focal package won't be available at the linked location until 2.1.0 GA as such please do not merge / deploy this until after 2.1.0 final