### PR TITLE
release(k8s) add k8s 2.0.4.2 changelog info

### DIFF
--- a/app/enterprise/k8s-changelog.md
+++ b/app/enterprise/k8s-changelog.md
@@ -2,6 +2,15 @@
 title: Kong Enterprise k8s Changelog
 ---
 
+## 2.0.4.2
+
+> Released on 2020/06/29
+
+### Fixed
+
+- Resolve an incompatibility between LuaRocks and a dependency that prevented
+  installing custom plugins in custom images.
+
 ## 2.0.4.1
 
 > Released on 2020/05/05


### PR DESCRIPTION
Add changelog entries for today's release of kong-enterprise-k8s 2.0.4.2.