### PR TITLE
chore(hub) update plugins' compatibility matrix

### DIFF
--- a/app/_hub/cleafy/cleafy/index.md
+++ b/app/_hub/cleafy/cleafy/index.md
@@ -38,6 +38,7 @@ kong_version_compatibility:
       - 1.4.x
       - 1.5.x
       - 2.0.x
+      - 2.1.x
   enterprise_edition:
     compatible:
       - 0.33-x

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -19,6 +19,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x      
         - 1.4.x

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -23,6 +23,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x      
         - 1.4.x

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x      
         - 1.4.x

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -19,6 +19,7 @@ license_type: MIT
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x      
         - 1.4.x

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x      
         - 1.4.x

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -15,6 +15,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x      
         - 1.4.x

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -18,6 +18,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/session/index.md
+++ b/app/_hub/kong-inc/session/index.md
@@ -26,6 +26,7 @@ source_url: https://github.com/Kong/kong-plugin-session
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.1.x
         - 2.0.x
         - 1.5.x
         - 1.4.x

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x

--- a/app/_hub/seifchen/kong-path-allow/index.md
+++ b/app/_hub/seifchen/kong-path-allow/index.md
@@ -21,6 +21,7 @@ license_type: Apache-2.0
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x

--- a/app/_hub/signal_sciences/signal-sciences/index.md
+++ b/app/_hub/signal_sciences/signal-sciences/index.md
@@ -62,6 +62,7 @@ privacy_policy_url: https://www.signalsciences.com/privacy/
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x

--- a/app/_hub/yesinteractive/kong-jwt2header/index.md
+++ b/app/_hub/yesinteractive/kong-jwt2header/index.md
@@ -31,6 +31,7 @@ license_type: MIT
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
   enterprise_edition:

--- a/app/_hub/yesinteractive/kong-log-google/index.md
+++ b/app/_hub/yesinteractive/kong-log-google/index.md
@@ -26,6 +26,7 @@ license_type: MIT
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x


### PR DESCRIPTION
### Summary

Updates compatibility matrix on those plugins that previously had `2.0.x` as supported. Other 3rd party plugins should probably be checked by hand.