### PR TITLE
docs(nav) Add Upgrade guide to CE navigation

### DIFF
--- a/app/_data/docs_nav_1.0.x.yml
+++ b/app/_data/docs_nav_1.0.x.yml
@@ -47,6 +47,9 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:

--- a/app/_data/docs_nav_1.1.x.yml
+++ b/app/_data/docs_nav_1.1.x.yml
@@ -47,6 +47,9 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:

--- a/app/_data/docs_nav_1.2.x.yml
+++ b/app/_data/docs_nav_1.2.x.yml
@@ -48,6 +48,9 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:

--- a/app/_data/docs_nav_1.3.x.yml
+++ b/app/_data/docs_nav_1.3.x.yml
@@ -51,6 +51,9 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:

--- a/app/_data/docs_nav_1.4.x.yml
+++ b/app/_data/docs_nav_1.4.x.yml
@@ -51,6 +51,9 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:

--- a/app/_data/docs_nav_1.5.x.yml
+++ b/app/_data/docs_nav_1.5.x.yml
@@ -52,6 +52,9 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:

--- a/app/_data/docs_nav_2.0.x.yml
+++ b/app/_data/docs_nav_2.0.x.yml
@@ -83,6 +83,9 @@
     - text : Control Kong Community Gateway through systemd
       url: /systemd
 
+    - text: Upgrade guide
+      url: /upgrading
+
     - text: Plugin Development Guide
       url: /plugin-development
       items:


### PR DESCRIPTION
Adds the upgrade guide to the navigation items for CE all the way back to 1.0. Seems it was never included. 