### PR TITLE
docs(hub) update prometheus docs to match version 0.9.0

### DIFF
--- a/app/_data/extensions/kong-inc/prometheus/versions.yml
+++ b/app/_data/extensions/kong-inc/prometheus/versions.yml
@@ -1,2 +1,3 @@
-- release: 1.0-x
+- release: 0.9.x
+- release: 0.8.x
 - release: 0.1-x

--- a/app/_hub/kong-inc/prometheus/0.8.x.md
+++ b/app/_hub/kong-inc/prometheus/0.8.x.md
@@ -1,11 +1,11 @@
 ---
 name: Prometheus
 publisher: Kong Inc.
-version: 0.9.0
+version: 1.0.0
 
-desc: Expose metrics related to Kong and proxied Upstream services in Prometheus exposition format
+desc: Expose metrics related to Kong and proxied upstream services in Prometheus exposition format
 description: |
-    Expose metrics related to Kong and proxied Upstream services in [Prometheus](https://prometheus.io/docs/introduction/overview/) exposition format, which can be scraped by a Prometheus Server.
+    Expose metrics related to Kong and proxied upstream services in [Prometheus](https://prometheus.io/docs/introduction/overview/) exposition format, which can be scraped by a Prometheus Server.
 
 type: plugin
 categories:
@@ -14,9 +14,8 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.1.x
         - 2.0.x
-        - 1.5.x
+        - 1.5.x      
         - 1.4.x
         - 1.3.x
         - 1.2.x
@@ -36,18 +35,18 @@ params:
   protocols: ["http", "https", "tcp", "tls", "grpc", "grpcs"]
   dbless_compatible: yes
   dbless_explanation: |
-    The database will always be reported as reachable in Prometheus with DB-less.
+    The database will always be reported as “reachable” in prometheus with DB-less.
 
 ---
 
 Metrics are available on the Admin API at the `http://localhost:8001/metrics`
 endpoint. Note that the URL to the Admin API will be specific to your
-installation; see [Accessing the metrics](#accessing-the-metrics) below.
+installation; see _Accessing the metrics_ below.
 
-This plugin records and exposes metrics at the node level. Your Prometheus
+This plugin records and exposes metrics at the node-level. Your Prometheus
 server will need to discover all Kong nodes via a service discovery mechanism,
 and consume data from each node's configured `/metric` endpoint. Kong nodes
-that are set to proxy only (that is, their Admin API has been disabled by
+that are set to proxy only (that is their Admin API has been disabled by
 specifying `admin_listen = off`) will need to use a [custom Nginx
 configuration template](/latest/configuration/#custom-nginx-configuration)
 to expose the metrics data.
@@ -59,30 +58,28 @@ dashboard: [https://grafana.com/dashboards/7424](https://grafana.com/dashboards/
 
 ### Available metrics
 
-- **Status codes**: HTTP status codes returned by Upstream services.
+- **Status codes**: HTTP status codes returned by upstream services.
   These are available per service and across all services.
 - **Latencies Histograms**: Latency as measured at Kong:
-   - **Request**: Total time taken by Kong and Upstream services to serve
+   - **Request**: Total time taken by Kong and upstream services to serve
      requests.
    - **Kong**: Time taken for Kong to route a request and run all configured
      plugins.
-   - **Upstream**: Time taken by the Upstream service to respond to requests.
+   - **Upstream**: Time taken by the upstream service to respond to requests.
 - **Bandwidth**: Total Bandwidth (egress/ingress) flowing through Kong.
   This metric is available per service and as a sum across all services.
-- **DB reachability**: A gauge type with a value of 0 or 1, which represents
-  whether DB can be reached by a Kong node.
+- **DB reachability**: A gauge type with a value of 0 or 1, representing if DB
+  can be reached by a Kong node or not.
 - **Connections**: Various Nginx connection metrics like active, reading,
   writing, and number of accepted connections.
-- **Target Health**: The healthiness status (`healthchecks_off`, `healthy`, `unhealthy`, or `dns_error`) of Targets
-  belonging to a given Upstream.
 
 Here is an example of output you could expect from the `/metrics` endpoint:
 
 ```bash
 $ curl -i http://localhost:8001/metrics
 HTTP/1.1 200 OK
-Server: openresty/1.15.8.3
-Date: Tue, 7 Jun 2020 16:35:40 GMT
+Server: openresty/1.11.2.5
+Date: Mon, 11 Jun 2018 01:39:38 GMT
 Content-Type: text/plain; charset=UTF-8
 Transfer-Encoding: chunked
 Connection: keep-alive
@@ -165,18 +162,13 @@ kong_nginx_http_current_connections{state="writing"} 1
 # HELP kong_nginx_metric_errors_total Number of nginx-lua-prometheus errors
 # TYPE kong_nginx_metric_errors_total counter
 kong_nginx_metric_errors_total 0
-# HELP kong_upstream_target_health Health status of targets of upstream. States = healthchecks_off|healthy|unhealthy|dns_error, value is 1 when state is populated.
-kong_upstream_target_health{upstream="<upstream_name>",target="<target>",address="<ip>:<port>",state="healthchecks_off"} 0
-kong_upstream_target_health{upstream="<upstream_name>",target="<target>",address="<ip>:<port>",state="healthy"} 1
-kong_upstream_target_health{upstream="<upstream_name>",target="<target>",address="<ip>:<port>",state="unhealthy"} 0
-kong_upstream_target_health{upstream="<upstream_name>",target="<target>",address="<ip>:<port>",state="dns_error"} 0
 ```
 
 ### Accessing the metrics
 
 In most configurations, the Kong Admin API will be behind a firewall or would
-need to be set up to require authentication. Here are a couple of options to
-allow access to the `/metrics` endpoint to Prometheus:
+need to be set up to require authentication, here are a couple of options to
+allow access to the `/metrics` endpoint to Prometheus.
 
 
 1. Kong Enterprise users can protect the admin `/metrics` endpoint with an
@@ -187,15 +179,16 @@ allow access to the `/metrics` endpoint to Prometheus:
 2. You can proxy the Admin API through Kong itself then use plugins to limit
    access. For example, you can create a route `/metrics` endpoint and have
    Prometheus access this endpoint to slurp in the metrics while preventing
-   others from accessing it. The specifics of how this is configured will depend
-   on your specific setup. For details, see [Securing the Admin
-   API](https://docs.konghq.com/latest/secure-admin-api/#kong-api-loopback).
+   others from access it. The specifics of how this is configured will depend
+   on your specific setup. Read the docs [Securing the Admin
+   API](https://docs.konghq.com/latest/secure-admin-api/#kong-api-loopback) for
+   details.
 
 3. Finally, you could serve the content on a different port with a custom server
    block using a [custom Nginx
    template](/latest/configuration/#custom-nginx-configuration) with Kong.
 
-    The following block is an example custom nginx template that can be used
+    The following block is an example custom nginx template which can be used
     by Kong:
 
     ```


### PR DESCRIPTION
Update Prometheus plugin docs to match current version (0.9.0). Please review `index.md`, which contains the latest version of the docs.