### PR TITLE
docs(hub) add zipkin 1.1.0 docs

### DIFF
--- a/app/_data/extensions/kong-inc/zipkin/versions.yml
+++ b/app/_data/extensions/kong-inc/zipkin/versions.yml
@@ -1,2 +1,3 @@
-- release: 1.0-x
+- release: 1.1.x
+- release: 1.0.x
 - release: 0.1-x

--- a/app/_hub/kong-inc/zipkin/1.0.x.md
+++ b/app/_hub/kong-inc/zipkin/1.0.x.md
@@ -3,7 +3,7 @@ name: Zipkin
 publisher: Kong Inc.
 redirect_from:
   - /hub/kong-inc/zipkin/http-log/
-version: 1.1.0
+version: 1.0.0
 
 source_url: https://github.com/Kong/kong-plugin-zipkin
 
@@ -26,7 +26,6 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 2.1.x
       - 2.0.x
       - 1.5.x
       - 1.4.x
@@ -76,27 +75,6 @@ params:
       value_in_examples: true
       description: |
         Should the credential of the currently authenticated consumer be included in metadata sent to the Zipkin server?
-    - name: traceid_byte_count
-      required: true
-      default: 16
-      description: |
-        The length in bytes of each request's Trace ID.
-    - name: header_type
-      required: true
-      default: preserve
-      description: |
-        All HTTP requests going through the plugin will be tagged with a tracing HTTP request.
-        This property codifies what kind of tracing header the plugin expects on incoming requests.
-        Possible values are `b3`, `b3-single`, `w3c`, or `preserve`. The `b3` option means that
-        the plugin expects [Zipkin's B3 multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers)
-        on incoming requests, and will add them to the transmitted requests if they are missing from it.
-        The `b3-single` option expects or adds Zipkin's B3 single-header tracing headers.
-        The `w3c` option expects or adds W3C's traceparent tracing header. The `preserve` option
-        does not expect any format, and will  transmit whatever header is recognized or present,
-        defaulting to `b3` if none is found. In case of mismatch between the expected and incoming
-        tracing headers (for example, when `header_type` is set to `b3` but a w3c-style tracing header is
-        found in the incoming request), then the plugin will add both kinds of tracing headers
-        to the request and generate a mismatch warning in the logs.
 
 ---
 
@@ -107,9 +85,24 @@ When enabled, [this plugin](https://github.com/Kong/kong-plugin-zipkin) traces r
 The code is structured around an [opentracing](http://opentracing.io/) core using the [opentracing-lua library](https://github.com/Kong/opentracing-lua) to collect timing data of a request in each of Kong's phases.
 The plugin uses opentracing-lua compatible extractor, injector, and reporters to implement Zipkin's protocols.
 
+### Extractor and Injector
+
+An opentracing "extractor" collects information from an incoming request.
+If no trace ID is present in the incoming request, then one is probabilistically generated based on the `sample_ratio` configuration value.
+
+An opentracing "injector" adds trace information to an outgoing request. Currently, the injector is only called for the request proxied by kong; it is **not** yet used for requests to the database or by other plugins (such as the [http-log plugin](./http-log/)).
+
+This plugin follows Zipkin's ["B3" specification](https://github.com/openzipkin/b3-propagation/) as to which HTTP headers to use. Additionally, it supports [Jaegar](http://jaegertracing.io/)-style `uberctx-` headers for propagating [baggage](https://github.com/opentracing/specification/blob/master/specification.md#set-a-baggage-item).
+
 ### Reporter
 
 An opentracing "reporter" is how tracing data is reported to another system.
 This plugin records tracing data for a given request, and sends it as a batch to a Zipkin server using [the Zipkin v2 API](https://zipkin.io/zipkin-api/#/default/post_spans). Note that zipkin version 1.31 or higher is required.
 
 The `http_endpoint` configuration variable must contain the full uri including scheme, host, port and path sections (i.e. your uri likely ends in `/api/v2/spans`).
+
+## FAQ
+
+### Can I use this plugin with other tracing systems, like Jaeger?
+
+Probably! Jaeger accepts spans in Zipkin format - see https://www.jaegertracing.io/docs/features/#backwards-compatibility-with-zipkin for more information.


### PR DESCRIPTION
Add zipkin 1.1.0 docs.

**NOTE**: please focus review on `index.md`, which contains newly added docs. 