### PR TITLE
Updated download link to latest decK version

### DIFF
--- a/app/_hub/kong-inc/deck/index.md
+++ b/app/_hub/kong-inc/deck/index.md
@@ -118,7 +118,7 @@ the Github [release page](https://github.com/hbagdi/deck/releases)
 or install by downloading the binary:
 
 ```shel
-$ curl -sL https://github.com/hbagdi/deck/releases/download/v0.4.0/deck_0.4.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/hbagdi/deck/releases/download/v1.1.0/deck_1.1.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ cp /tmp/deck /usr/local/bin/
 ```


### PR DESCRIPTION
Very outdated link to 0.4 before - changed to 1.1.0
Please automate that it is always the latest link!

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

