### PR TITLE
docs(plugins) Fixing filtering for enterprise plugins

### DIFF
--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -35,7 +35,7 @@ body_id: page-hub
               </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" data-filter="pub-konghq">
+              <a class="nav-link" data-filter="ee-compat">
                 Bundled with Kong Enterprise
               </a>
             </li>

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -11,7 +11,7 @@
   {% endif %}
   {% assign extn_slug_array = extn_slug | split: "-" %}
   <div class="col-12 col-md-6 col-lg-4 my-1x card-group">
-    <div class="card plugin-card align-items-center {{ extn.type }} {{ extn.categories | join: ' ' }} {% if extn_publisher == 'kong-inc' %}pub-konghq {% if extn.enterprise %}enterprise{% else %}open-source{% endif %} {% else %}pub-not-konghq pub-{{extn_publisher}}{% endif %}">
+    <div class="card plugin-card align-items-center {{ extn.type }} {{ extn.categories | join: ' ' }} {% if extn_publisher == 'kong-inc' %}pub-konghq {% if extn.kong_version_compatibility.enterprise_edition.compatible != nil %}ee-compat {% endif %}{% if extn.enterprise %}enterprise{% else %}open-source{% endif %} {% else %}pub-not-konghq pub-{{extn_publisher}}{% endif %}">
       <a href="{{ extn.url | remove: '/index' }}">
         <div>
           <div class="name-desc">


### PR DESCRIPTION
Based on slack thread in `#docs`, mainly:
> Our hub lists ACME as being bundled with Kong Enterprise https://docs.konghq.com/hub/ - but it is not in the package.

Also happens with grpc-web and grpc-gateway plugins.

Filter tweak fixes the Enterprise plugin selector. Test by clicking "Bundled with Kong Enterprise".

Preview: https://deploy-preview-2166--kongdocs.netlify.app/hub/