### PR TITLE
Update migrate/upgrade for Dev Portal to beta placeholder

### DIFF
--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -349,8 +349,8 @@
       url: /developer-portal/
     - text: Enable the Dev Portal
       url: /developer-portal/enable-dev-portal
-    - text: Migrating to 1.5
-      url: /developer-portal/migrating-to-1.5
+    - text: Migrating to Latest Release
+      url: /deployment/migrations/
     - text: Migrating from Legacy
       url: /developer-portal/legacy-migration
     - text: Structure and File Types


### PR DESCRIPTION
This PR updates the following obsolete TOC entry:

![image](https://user-images.githubusercontent.com/3756245/87809645-55f7ca80-c821-11ea-8884-fee6ffcc41b3.png)

![image](https://user-images.githubusercontent.com/3756245/87809229-a9b5e400-c820-11ea-8dc7-32b4c28915df.png)

This TOC entry will eventually link to the content @Jlawlzz and I will produce for 2.1 Dev Portal migration https://konghq.atlassian.net/browse/DOCS-1139.

Direct review link: https://deploy-preview-2177--kongdocs.netlify.app/enterprise/2.1.x/deployment/migrations/