### PR TITLE
docs(styles) Adjust scroll button position

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1529,7 +1529,7 @@ Generic Styling for Desktop
 #scroll-to-top-button {
   position: fixed;
   bottom: 12px;
-  right: 50%;
+  right: 24%;
   z-index: 10;
   cursor: pointer;
   background: #e3e3e3;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1552,4 +1552,8 @@ Generic Styling for Desktop
   &.visible {
     transform: translateY(0);
   }
+
+  @media (max-width: 600px) {
+    right: 50%;
+  }
 }


### PR DESCRIPTION
Got feedback that it's distracting to have the button dead center. This adjustment will work for the majority of screens, though it isn't as well-positioned at very high resolutions.