### PR TITLE
Docs(plugins) grpc-gateway alpha banner

### DIFF
--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -1,6 +1,7 @@
 ---
 name: gRPC-gateway
 publisher: Kong Inc.
+beta: true
 
 categories:
   - transformations
@@ -18,6 +19,9 @@ license_type: MIT
 
 kong_version_compatibility:
   community_edition:
+    compatible:
+      - 2.1.x
+  enterprise_edition:
     compatible:
       - 2.1.x
 

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -4,13 +4,12 @@ publisher: Kong Inc.
 
 categories:
   - transformations
-alpha: true
 type: plugin
 
 desc: Access gRPC services through HTTP REST
 description: |
   A Kong plugin to allow access to a gRPC service via HTTP REST requests
-  and translate requests and responses in a JSON format. Similar to 
+  and translate requests and responses in a JSON format. Similar to
   [gRPC-gateway](https://grpc-ecosystem.github.io/grpc-gateway/).
 
 source_url: https://github.com/Kong/kong-plugin-grpc-gateway

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -334,8 +334,10 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
       {% endif %}
       {% if page.alpha %}
       <div class="alert alert-ee red condensed margin-bigger">
+        <div class="alert-body">
           <div class="tag red">ALPHA</div>
           <p><strong>WARNING:</strong> This plugin is released as <a href="/enterprise/latest/introduction/key-concepts/#alpha">ALPHA</a> and should not be deployed in a production environment.</p>
+          </div>
       </div>
       {% endif %}
       {% if page.beta %}


### PR DESCRIPTION
- Fixing broken alpha banner
- Replacing alpha banner with beta for grpc-gateway plugin: Community 2.1 is GA, Enterprise 2.1 is in beta.
- Adding Enterprise 2.1 to "bundled with" versions

@fffonion is this plugin supposed to be available in Enterprise? I'm seeing it in Kong Manager in a 2.1.0.0 beta build, though the "bundled with" section on this page only mentions Community.

Preview: https://deploy-preview-2180--kongdocs.netlify.app/hub/kong-inc/grpc-gateway/