### PR TITLE
docs(layout) Adjustment to mobile banner

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -412,9 +412,6 @@
     background-image: linear-gradient(to bottom, #ffffff, 40%, transparent), url("/assets/images/docs/banner-bkg.png");
     transform: translateX(-50%);
 
-    @media (max-width: 1100px) {
-      display: none;
-    }
   }
 }
 


### PR DESCRIPTION
Mobile banner was still defaulting to blue gradient. Adjusting CSS to use the banner on mobile as well.

To test, open the Netlify preview from a mobile device; or, in Chrome:
1. Open the dev tools (Right-click anywhere on the page > Inspect).
2. Turn on the device toolbar with Cmd+shift+M.
3. In the dropdown that appears, switch from "Responsive" to any mobile device.

The geometric banner should remain visible in all sizes.