### PR TITLE
Make sure the image points to the 2.1

### DIFF
--- a/app/enterprise/2.1.x/deployment/installation/docker.md
+++ b/app/enterprise/2.1.x/deployment/installation/docker.md
@@ -38,7 +38,7 @@ To complete this installation you will need:
 
 ```bash
 $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kong-docker-kong-enterprise-edition-docker.bintray.io
-$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.1.0.0-beta1-alpine
 ```
 
 You should now have your Kong Enterprise image locally.


### PR DESCRIPTION
👋 
when pulling the docker image, the version should be explicitly set. Because currently, the `latest` tag points to 1.5.x, if you don't specify the version.

