### PR TITLE
docs(plugins) Feedback widget for plugin docs

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -585,11 +585,9 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
       </div>
     </div>
   </div>
-</div>
-</div>
-{% if page.feedback != false %}
-{% include feedback-widget.html %}
-{% endif %}
+  {% if page.feedback != false %}
+  {% include feedback-widget.html %}
+  {% endif %}
 </div>
 
 <!-- {% include intercom.html %} -->

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -586,5 +586,10 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
     </div>
   </div>
 </div>
+</div>
+{% if page.feedback != false %}
+{% include feedback-widget.html %}
+{% endif %}
+</div>
 
 <!-- {% include intercom.html %} -->


### PR DESCRIPTION
Adding feedback widget to plugin doc pages.

Note: Widget will not appear on the Hub landing page, but will appear on anything under the /hub/ directory. This is to mirror the rest of the docs.

Sample preview: https://deploy-preview-2197--kongdocs.netlify.app/hub/kong-inc/application-registration/