### PR TITLE
docs(github) Updates to doc contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,7 +417,7 @@ Use variables for product names and release versions.
 
 - `{{page.kong_version}}` - Outputs the version of the current page
 - `{{site.ee_product_name}}` - Kong Enterprise
-- `{{site.ee_product_name}}` - Kong Gateway
+- `{{site.ce_product_name}}` - Kong Gateway
 
 
 #### Links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Consult the Table of Contents below, and jump to the desired section.
     - [Links](#links)
     - [Info Blocks](#info-blocks)
     - [Table of Contents generator](#table-of-contents-generator)
-    - [Using tabs within topics](#using-tabs-within-topics)
+    - [Using navtabs within topics](#using-navtabs-within-topics)
   - [Contributor T-shirt](#contributor-t-shirt)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Consult the Table of Contents below, and jump to the desired section.
     - [Linting](#linting)
   - [Contributing images, videos, etc](#contributing-images-videos-etc)
   - [Formatting Documentation](#formatting-documentation)
+    - [Markdown Front Matter](#markdown-front-matter)
     - [Variables](#variables)
     - [Links](#links)
     - [Info Blocks](#info-blocks)
@@ -374,6 +375,11 @@ Instead, please:
 The Kong docs site has a number of features built in to better display content.
 
 #### Markdown Front Matter
+
+Markdown files on the doc site (excluding `docs.konghq.com/hub/`) must have a
+yaml front matter section with at least one parameter (`title`). You can also
+specify additional parameters to change how your doc will display.
+
 **Required:**
 ```yaml
 title: Page Title
@@ -391,6 +397,10 @@ skip_read_time: true
 beta: true
 alpha: true
 # Labels the page as beta or alpha, adds a banner to the top of the page.
+disable_image_expand: true
+# Stops images from expanding in a modal on click. Sets it for the entire page.
+class: no-copy-code
+# Disables the copy code button in any code blocks on the page.
 ```
 
 #### Variables

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,12 @@ Consult the Table of Contents below, and jump to the desired section.
     - [Commit message format](#commit-message-format)
     - [Linting](#linting)
   - [Contributing images, videos, etc](#contributing-images-videos-etc)
-  - [Table of Contents generator](#table-of-contents-generator)
-  - [Using tabs within topics](#using-tabs-within-topics)
+  - [Formatting Documentation](#formatting-documentation)
+    - [Variables](#variables)
+    - [Links](#links)
+    - [Info Blocks](#info-blocks)
+    - [Table of Contents generator](#table-of-contents-generator)
+    - [Using tabs within topics](#using-tabs-within-topics)
   - [Contributor T-shirt](#contributor-t-shirt)
 
 
@@ -61,7 +65,7 @@ you may find on this website. Please read the below section about
 
 Adding and improving listings in the Kong Hub is also encouraged! Please
 read the below section
-about [Kong Hub contributions](#kong-hub-contributions)
+about [Kong Hub contributions](#kong-hub-contributions).
 
 If you wish to contribute to Kong itself (as opposed to the documentation
 website), then please consult the [Kong Contributing
@@ -105,8 +109,9 @@ to verify a few things:
   `git rebase`; this is important to ensure your commit history is clean and
    linear)
 - The linting is succeeding: run `npm run test` (see the development
-  documentation for additional details)
-- You've tagged "Team Docs" as reviewers
+  documentation for additional details).
+  _Note: The linter won't catch most errors in Plugin Hub documentation. You
+  need to check for any errors manually, with a [local build](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md)._
 
 If the above guidelines are respected, your Pull Request has all its chances
 to be considered and will be reviewed by a maintainer.
@@ -136,7 +141,7 @@ Adding a new listing to the Kong Hub may be proposed by:
     ```
     git clone https://github.com/Kong/docs.konghq.com.git
     ```
-1. Move into the repo's directory
+2. Move into the repo's directory
     ```
     cd docs.konghq.com
     ```
@@ -347,7 +352,6 @@ $ npm run test
 
 [Back to TOC](#table-of-contents)
 
-
 ### Contributing images, videos, etc
 
 Binary files like images and videos should not be included in your pull
@@ -365,18 +369,90 @@ Instead, please:
 
 [Back to TOC](#table-of-contents)
 
+### Formatting Documentation
 
-### Table of Contents generator
+The Kong docs site has a number of features built in to better display content.
+
+#### Markdown Front Matter
+**Required:**
+```yaml
+title: Page Title
+```
+
+**Optional:**
+```yaml
+no_search: true
+# Disables search for the page.
+toc: false
+# Disables the right-hand nav for the page; useful is the page is short and has
+# one or no headers.
+skip_read_time: true
+# Disables estimated read time; useful for long reference content.
+beta: true
+alpha: true
+# Labels the page as beta or alpha, adds a banner to the top of the page.
+```
+
+#### Variables
+Use variables for product names and release versions.
+
+`{{page.kong_version}}` - Outputs the version of the current page
+`{{site.ee_product_name}}` - Kong Enterprise
+`{{site.ee_product_name}}` - Kong Gateway
+
+#### Links
+ In markdown(`.md`) files, use relative links with a version variable.
+	* For Community: `/{{page.kong_version}}/file`
+  * For Enterprise: `/enterprise/{{page.kong_version}}/file`
+
+If you're adding a new topic, you also need to add it to the nav file for its
+version. These are located under `app/_data`. In these files, the path is
+relative to the versioned folder.
+
+For example, if the project path is `app/enterprise/2.1.x/overview`, the path in
+the nav file would be `/overview`.
+
+#### Info Blocks
+
+Info blocks are HTML divs that follow this basic format:
+```
+<div class="alert alert-type">
+   Some text.
+</div>
+```
+
+For a basic info block, use:
+```
+<div class="alert alert-ee blue">
+Some text.
+</div>
+```
+
+For a warning, use:
+```
+<div class="alert alert-warning">
+   Some text.
+</div>
+```
+
+For a breaking issue or notice of alpha/beta, use:
+```
+<div class="alert alert-ee red">
+   Some text.
+</div>
+```
+
+#### Table of Contents generator
 
 Almost all pages have an automatic Table of Contents (ToC) added to the right of
 the page.
 
 To inhibit the automatic addition of ToC (such as on API reference pages),
-add the following to the front-matter: `toc: false`
+add the following to the front-matter: `toc: false`.
 
 This ToC generator depends on headings being correctly coded in the markdown
 portion of the doc site files, and will only pick up H2 and H3 level headings.
-If a page has an incorrectly-formatted ToC, be sure to check:
+If a page has an incorrectly-formatted ToC, be sure to check the following:
 
 - Heading levels must be correctly nested. Thus, heading levels like this:
 
@@ -397,7 +473,7 @@ will cause the first H3 to be skipped, and should be corrected to:
 [Back to TOC](#table-of-contents)
 
 
-### Using tabs within topics
+#### Using tabs within topics
 
 If your topic provides instructions for two or more methods of completing a
 task, you can nest them inside `navtabs`. For example, this topic
@@ -423,6 +499,9 @@ Here's some more content.
 
 On initial page load, the first tab ("<your title here>" in the example above)
 will be the one displayed.
+
+> **Note:** You can’t nest tabs within tabs.
+
 
 [Back to TOC](#table-of-contents)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Consult the Table of Contents below, and jump to the desired section.
   - [Submitting a patch](#submitting-a-patch)
   - [Kong Hub contributions](#kong-hub-contributions)
   - [Writing plugin documentation](#writing-plugin-documentation)
+  - [Git Best Practices](#git-best-practices)
     - [Git branches](#git-branches)
     - [Commit atomicity](#commit-atomicity)
     - [Commit message format](#commit-message-format)
@@ -223,6 +224,7 @@ the existing plugins for examples, and see additional advice in
 
 [Back to TOC](#table-of-contents)
 
+### Git Best Practices
 
 #### Git branches
 
@@ -372,13 +374,12 @@ Instead, please:
 
 ### Formatting Documentation
 
-The Kong docs site has a number of features built in to better display content.
-
 #### Markdown Front Matter
 
 Markdown files on the doc site (excluding `docs.konghq.com/hub/`) must have a
 yaml front matter section with at least one parameter (`title`). You can also
-specify additional parameters to change how your doc will display.
+specify additional parameters to change how the doc source renders in the
+output.
 
 **Required:**
 
@@ -391,16 +392,21 @@ title: Page Title
 ``` yaml
 no_search: true
 # Disables search for the page.
+
 toc: false
-# Disables the right-hand nav for the page; useful is the page is short and has
+# Disables the right-hand nav for the page; useful if the page is short and has
 # one or no headers.
+
 skip_read_time: true
 # Disables estimated read time; useful for long reference content.
+
 beta: true
 alpha: true
-# Labels the page as beta or alpha, adds a banner to the top of the page.
+# Labels the page as beta or alpha; adds a banner to the top of the page.
+
 disable_image_expand: true
 # Stops images from expanding in a modal on click. Sets it for the entire page.
+
 class: no-copy-code
 # Disables the copy code button in any code blocks on the page.
 ```
@@ -409,13 +415,13 @@ class: no-copy-code
 #### Variables
 Use variables for product names and release versions.
 
-`{{page.kong_version}}` - Outputs the version of the current page
-`{{site.ee_product_name}}` - Kong Enterprise
-`{{site.ee_product_name}}` - Kong Gateway
+- `{{page.kong_version}}` - Outputs the version of the current page
+- `{{site.ee_product_name}}` - Kong Enterprise
+- `{{site.ee_product_name}}` - Kong Gateway
 
 
 #### Links
- In markdown(`.md`) files, use relative links with a version variable.
+In markdown(`.md`) files, use relative links with a version variable.
 - For Community: `/{{page.kong_version}}/file`
 - For Enterprise: `/enterprise/{{page.kong_version}}/file`
 
@@ -487,7 +493,7 @@ will cause the first H3 to be skipped, and should be corrected to:
 [Back to TOC](#table-of-contents)
 
 
-#### Using tabs within topics
+#### Using navtabs within topics
 
 If your topic provides instructions for two or more methods of completing a
 task, you can nest them inside `navtabs`. For example, this topic
@@ -514,7 +520,7 @@ Here's some more content.
 On initial page load, the first tab ("<your title here>" in the example above)
 will be the one displayed.
 
-> **Note:** You can’t nest tabs within tabs.
+> **Note:** You can’t nest navtabs within navtabs.
 
 
 [Back to TOC](#table-of-contents)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,12 +381,14 @@ yaml front matter section with at least one parameter (`title`). You can also
 specify additional parameters to change how your doc will display.
 
 **Required:**
-```yaml
+
+``` yaml
 title: Page Title
 ```
 
 **Optional:**
-```yaml
+
+``` yaml
 no_search: true
 # Disables search for the page.
 toc: false
@@ -403,6 +405,7 @@ class: no-copy-code
 # Disables the copy code button in any code blocks on the page.
 ```
 
+
 #### Variables
 Use variables for product names and release versions.
 
@@ -410,10 +413,11 @@ Use variables for product names and release versions.
 `{{site.ee_product_name}}` - Kong Enterprise
 `{{site.ee_product_name}}` - Kong Gateway
 
+
 #### Links
  In markdown(`.md`) files, use relative links with a version variable.
-	* For Community: `/{{page.kong_version}}/file`
-  * For Enterprise: `/enterprise/{{page.kong_version}}/file`
+- For Community: `/{{page.kong_version}}/file`
+- For Enterprise: `/enterprise/{{page.kong_version}}/file`
 
 If you're adding a new topic, you also need to add it to the nav file for its
 version. These are located under `app/_data`. In these files, the path is

--- a/README.md
+++ b/README.md
@@ -7,25 +7,44 @@ This repository is the source code for [Kong](https://github.com/Kong/kong)'s do
 Not sure where to start? Head on over to the `issues` tab to and look for the `good first issue` label. These are issues Kong has identified as beginner friendly. Many of these can be addressed through Github and do not require pulling the repository and building locally.
 
 
-## Develop Locally With Docker
+## Develop Locally with Docker
+
+```
+make install-prerequisites
+```
 
 >
 ```bash
 make develop
 ```
 
-### Testing Links With Docker
+### Running a Local Build with Docker
 
->
+Install tools:
+```
+make install
+```
+
+Run the build:
+```
+make run
+```
+
+Check the build output at http://localhost:3000.
+
+### Testing Links with Docker
+
 ```
 make check-links
 ```
 
-## Develop Locally Without Docker
+## Develop Locally without Docker
 
 ### Prerequisites
 
-- [npm](https://www.npmjs.com/)
+- [node and npm](https://www.npmjs.com/get-npm)
+- [yarn](https://classic.yarnpkg.com)
+- [gulp](https://gulpjs.com/docs/en/getting-started/quick-start/)
 - [Bundler](https://bundler.io/) (< 2.0.0)
 - [Ruby](https://www.ruby-lang.org) (>= 2.0, < 2.3)
 - [Python](https://www.python.org) (>= 2.7.X, < 3)

--- a/templates/how-to.md
+++ b/templates/how-to.md
@@ -2,14 +2,14 @@
 title: Page title here
 ---
 
-### Introduction
+## Introduction
 
 This section is the introduction to the how-to guide. It should be limited to a few
 succinct sentences that introduce what the user will be learning to do. A
 how-to guide should provide an end-goal or otherwise indicate that the user will
 accomplish by following the steps.
 
-### Prerequisites
+## Prerequisites
 
 - A bulleted list of everything a user needs to complete the how-to guide
 - May be broken into multiple sections for additional clarity
@@ -50,6 +50,6 @@ accomplish by following the steps.
 ## Title for Step 5
 
 
-### Next Steps
+## Next Steps
 
 <!-- Keep newline at end of file -->


### PR DESCRIPTION
Adding a bunch of missing info for creating docs. 
* https://github.com/Kong/docs.konghq.com/blob/docs/instructions/README.md
* https://github.com/Kong/docs.konghq.com/blob/docs/instructions/CONTRIBUTING.md#formatting-documentation

Note: None of these pages will build with Netlify, so don't refer to the to build preview. 