### PR TITLE
docs(plugins/oauth) Fix version

### DIFF
--- a/app/_hub/kong-inc/oauth2/1.0-x.md
+++ b/app/_hub/kong-inc/oauth2/1.0-x.md
@@ -1,6 +1,7 @@
 ---
 name: OAuth 2.0 Authentication
 publisher: Kong Inc.
+version: 1.0-x
 
 desc: Add OAuth 2.0 authentication to your Services
 description: |


### PR DESCRIPTION
Plugin filename uses the incorrect version, so the version selector dropdown was throwing a 404 (check by selecting 1.0-x from the dropdown [here](https://docs.konghq.com/hub/kong-inc/oauth2/)).

This change fixes the filename and adds the version to the plugin metadata.

Preview: https://deploy-preview-2202--kongdocs.netlify.app/hub/kong-inc/oauth2/1.0-x.html