### PR TITLE
Docs/grpc plugins

### DIFF
--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -519,6 +519,13 @@
           url: /plugins/kafka-log
         - text: Kafka Upstream Plugin
           url: /plugins/kafka-upstream
+    - text: gRPC
+      url: /plugins/grpc
+      items:
+        - text: gRPC-Gateway Plugin
+          url: /plugins/grpc-gateway
+        - text: gRPC-Web Plugin
+          url: /plugins/grpc-web
     - text: Proxy Cache Advanced Plugin
       url: /plugins/proxy-cache-advanced
     - text: Canary Release Plugin

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -523,10 +523,10 @@
       url: /plugins/grpc
       items:
         - text: gRPC-Gateway Plugin
-          url: /plugins/grpc-gateway
+          url: /hub/kong-inc/plugins/grpc-gateway
           absolute_url: true
         - text: gRPC-Web Plugin
-          url: /plugins/grpc-web
+          url: /hub/kong-inc/plugins/grpc-web
           absolute_url: true
     - text: Proxy Cache Advanced Plugin
       url: /plugins/proxy-cache-advanced

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -524,8 +524,10 @@
       items:
         - text: gRPC-Gateway Plugin
           url: /plugins/grpc-gateway
+          absolute_url: true
         - text: gRPC-Web Plugin
           url: /plugins/grpc-web
+          absolute_url: true
     - text: Proxy Cache Advanced Plugin
       url: /plugins/proxy-cache-advanced
     - text: Canary Release Plugin

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -523,10 +523,10 @@
       url: /plugins/grpc
       items:
         - text: gRPC-Gateway Plugin
-          url: /hub/kong-inc/plugins/grpc-gateway
+          url: /hub/kong-inc/grpc-gateway
           absolute_url: true
         - text: gRPC-Web Plugin
-          url: /hub/kong-inc/plugins/grpc-web
+          url: /hub/kong-inc/grpc-web
           absolute_url: true
     - text: Proxy Cache Advanced Plugin
       url: /plugins/proxy-cache-advanced

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -54,7 +54,8 @@ Image credit: [grpc-gateway](https://grpc-ecosystem.github.io/grpc-gateway/)
 
 ## Usage
 
-This plugin should be enabled on a Kong `Route` that serves the `http(s)` protocol but proxies to a `Service` with the `grpc(s)` protocol.
+This plugin should be enabled on a Kong `Route` that serves the `http(s)` protocol
+but proxies to a `Service` with the `grpc(s)` protocol.
 
 Sample configuration via declarative (YAML):
 
@@ -96,7 +97,8 @@ $ curl -XPOST localhost:8001/routes/web-service/plugins \
   --data name=grpc-gateway
 ```
 
-The proto file must contain the [HTTP REST to gRPC mapping rule](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto).
+The proto file must contain the
+[HTTP REST to gRPC mapping rule](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto).
 
 The example uses the following mapping:
 
@@ -132,7 +134,8 @@ message HelloReply {
 
 Note the `option (google.api.http) = {}` section is required.
 
-You can send following requests to Kong that translates to corresponding gRPC requests:
+You can send the following requests to Kong that translate to the corresponding
+gRPC requests:
 
 ```bash
 curl -XGET localhost:8000/v1/messages/Kong2.0

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -151,3 +151,7 @@ curl -XPOST localhost:8000/v1/messages/Kong2.0 -d '{"name":"kong2.0"}'
 All syntax defined in [Path template syntax](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto#L225) is supported.
 
 Currently only unary requests are supported; streaming requests are not supported.
+
+## See also
+
+[Introduction to Kong gRPC plugins](/enterprise/2.1.x/plugins/grpc)

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -23,7 +23,11 @@ kong_version_compatibility:
       - 2.0.x
       - 1.5.x
       - 1.4.x
-
+  enterprise_edition:
+    compatible:
+      - 2.1.x
+      - 1.5.x
+      - 1.3.x
 
 params:
   name: grpc-web

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -10,7 +10,7 @@ type: plugin
 desc: Allow browser clients to call gRPC services
 description: |
   A Kong plugin to allow access to a gRPC service via the [gRPC-Web protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2).
-  Primarily, this means JS browser apps using the [gRPC-Web](https://github.com/grpc/grpc-web) library.
+  Primarily, this means JavaScript browser applications using the [gRPC-Web](https://github.com/grpc/grpc-web) library.
 
 source_url: https://github.com/Kong/kong-plugin-grpc-web
 
@@ -50,8 +50,9 @@ params:
 ## Purpose
 
 A service that presents a gRPC API can be used by clients written in many languages,
-but the network specifications are oriented primarily to connections within a datacenter.
-[gRPC-Web] lets you expose this API to the Internet so that it can be consumed by browser-based JS apps.
+but the network specifications are oriented primarily to connections within a
+datacenter. [gRPC-Web] lets you expose the gRPC API to the Internet so
+that it can be consumed by browser-based JavaScript applications.
 
 This plugin translates requests and responses between [gRPC-Web] and
 [gRPC](https://github.com/grpc/grpc). The plugin supports both HTTP/1.1

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -168,7 +168,7 @@ to the full [gRPC protocol]. The [gRPC-Web] library performs this framing as exp
 
 As an extension, this plugin also allows naked JSON requests with the POST method and
 `Content-Type: application/json` header. These requests are encoded to ProtocolBuffer,
-framed, and forwarded to the gRPC service.  Likewise, the responses are transformed
+framed, and forwarded to the gRPC service. Likewise, the responses are transformed
 on the way back, allowing any HTTP client to use a gRPC service without special
 libraries. This feature is limited to unary (non-streaming) requests. Streaming
 responses are encoded into multiple JSON objects; it's up to the client to split into

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -175,7 +175,7 @@ libraries. This feature is limited to unary (non-streaming) requests. Streaming
 responses are encoded into multiple JSON objects; it's up to the client to split into
 separate records if it has to support multiple response messages.
 
-
+## Related information
 [Kong]: https://konghq.com
 [gRPC protocol]: https://github.com/grpc/grpc
 [gRPC-Web]: https://github.com/grpc/grpc-web

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -11,7 +11,7 @@ desc: Allow browser clients to call gRPC services.
 description: |
   A Kong plugin to allow access to a gRPC service via the [gRPC-Web protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2).
   Primarily, this means JS browser apps using the [gRPC-Web](https://github.com/grpc/grpc-web) library.
-  
+
 source_url: https://github.com/Kong/kong-plugin-grpc-web
 
 license_type: MIT
@@ -157,3 +157,7 @@ As an extension, this plugin also allows "naked" JSON requests with POST method 
 [lua-protobuf]: https://github.com/starwing/lua-protobuf
 [lua-cjson]: https://github.com/openresty/lua-cjson
 [lua-pack]: https://github.com/Kong/lua-pack
+
+## See also
+
+[Introduction to Kong gRPC plugins](/enterprise/2.1.x/plugins/grpc)

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -54,13 +54,13 @@ but the network specifications are oriented primarily to connections within a da
 [gRPC-Web] lets you expose this API to the Internet so that it can be consumed by browser-based JS apps.
 
 This plugin translates requests and responses between [gRPC-Web] and
-["real" gRPC](https://github.com/grpc/grpc). The plugin supports both HTTP/1.1
+[gRPC](https://github.com/grpc/grpc). The plugin supports both HTTP/1.1
 and HTTP/2, over plaintext (HTTP) and TLS (HTTPS) connections.
 
 ## Usage
 
-This plugin should be enabled on a Kong `Route` that serves the `http(s)` protocol
-but proxies to a `Service` with the `grpc(s)` protocol.
+This plugin should be enabled on a Kong Route that serves the `http(s)` protocol
+but proxies to a Service with the `grpc(s)` protocol.
 
 Sample configuration via declarative (YAML):
 
@@ -109,7 +109,7 @@ for binary, and `application/grpc-web-text` or `application/grpc-web-text+proto`
 If you want to use JSON encoding, you have to provide the gRPC specification in
 a `.proto` file, which needs to be installed in the Kong node running the plugin.
 A path starting with a `/` is considered absolute; otherwise, it will be interpreted
-relative to the Kong's prefix (`/usr/local/kong/` by default). For example:
+relative to the Kong node's prefix (`/usr/local/kong/` by default). For example:
 
 ```protobuf
 syntax = "proto2";

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -7,7 +7,7 @@ categories:
 
 type: plugin
 
-desc: Allow browser clients to call gRPC services.
+desc: Allow browser clients to call gRPC services
 description: |
   A Kong plugin to allow access to a gRPC service via the [gRPC-Web protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2).
   Primarily, this means JS browser apps using the [gRPC-Web](https://github.com/grpc/grpc-web) library.
@@ -49,13 +49,18 @@ params:
 
 ## Purpose
 
-A service that presents a gRPC API can be used by clients written in many languages, but the network specifications are oriented primarily to connections within a datacenter. [gRPC-Web] lets you expose this API to the Internet so that it can be consumed by browser-based JS apps.
+A service that presents a gRPC API can be used by clients written in many languages,
+but the network specifications are oriented primarily to connections within a datacenter.
+[gRPC-Web] lets you expose this API to the Internet so that it can be consumed by browser-based JS apps.
 
-This plugin translates requests and responses between [gRPC-Web] and ["real" gRPC](https://github.com/grpc/grpc).  Supports both HTTP/1.1 and HTTP/2, over plaintext (HTTP) and TLS (HTTPS) connections.
+This plugin translates requests and responses between [gRPC-Web] and
+["real" gRPC](https://github.com/grpc/grpc). The plugin supports both HTTP/1.1
+and HTTP/2, over plaintext (HTTP) and TLS (HTTPS) connections.
 
 ## Usage
 
-This plugin should be enabled on a Kong `Route` that serves the `http(s)` protocol but proxies to a `Service` with the `grpc(s)` protocol.
+This plugin should be enabled on a Kong `Route` that serves the `http(s)` protocol
+but proxies to a `Service` with the `grpc(s)` protocol.
 
 Sample configuration via declarative (YAML):
 
@@ -95,9 +100,16 @@ $ curl -XPOST localhost:8001/routes/web-service/plugins \
   --data name=grpc-web
 ```
 
-In these examples we don't set any configuration for the plugin.  This minimal setup works for the default varieties of the [gRPC-Web protocol], which use ProtocolBuffer messages either directly in binary or with base64 encoding.  The related `Content-Type` headers are `application/grpc-web` or `application/grpc-web+proto` for binary and `application/grpc-web-text` or `application/grpc-web-text+proto`.
+In these examples, we don't set any configuration for the plugin.
+This minimal setup works for the default varieties of the [gRPC-Web protocol],
+which use ProtocolBuffer messages either directly in binary or with base64-encoding.
+The related `Content-Type` headers are `application/grpc-web` or `application/grpc-web+proto`
+for binary, and `application/grpc-web-text` or `application/grpc-web-text+proto` for text.
 
-If we wish to use JSON encoding, we have to provide the gRPC specification in a .proto file, which needs to be installed in the Kong node running the plugin.  A path starting with a `/` is considered absolute, otherwise it will be interpreted relative to the Kong's prefix (`/usr/local/kong/` by default).  For example:
+If you want to use JSON encoding, you have to provide the gRPC specification in
+a `.proto` file, which needs to be installed in the Kong node running the plugin.
+A path starting with a `/` is considered absolute; otherwise, it will be interpreted
+relative to the Kong's prefix (`/usr/local/kong/` by default). For example:
 
 ```protobuf
 syntax = "proto2";
@@ -147,11 +159,20 @@ $ curl -XPOST localhost:8001/routes/web-service/plugins \
   --data proto=path/to/hello.proto
 ```
 
-With this setup, we can support gRPC-Web/JSON clients using `Content-Type` headers like `application/grpc-web+json` or `application/grpc-web-text+json`.
+With this setup, we can support gRPC-Web/JSON clients using `Content-Type` headers
+like `application/grpc-web+json` or `application/grpc-web-text+json`.
 
-Note that, even using JSON encoding, the [gRPC-Web protocol] specifies that both request and response data consist of a series of frames, in a similar way to the full [gRPC protocol].  The [gRPC-Web] library performs this framing as expected.
+Note that even when using JSON encoding, the [gRPC-Web protocol] specifies that
+both request and response data consist of a series of frames, in a similar way
+to the full [gRPC protocol]. The [gRPC-Web] library performs this framing as expected.
 
-As an extension, this plugin also allows "naked" JSON requests with POST method and `Content-Type: application/json` header.  These requests are encoded to ProtocolBuffer, framed, and forwarded to the gRPC service.  Likewise, the responses are transformed on the way back, allowing any HTTP client to use a gRPC service without special libraries.  This feature is limited to unary (non-streaming) requests.  Streaming responses are encoded into multiple JSON objects; it's up to the client to split into separate records if it has to support multiple response messages.
+As an extension, this plugin also allows naked JSON requests with the POST method and
+`Content-Type: application/json` header. These requests are encoded to ProtocolBuffer,
+framed, and forwarded to the gRPC service.  Likewise, the responses are transformed
+on the way back, allowing any HTTP client to use a gRPC service without special
+libraries. This feature is limited to unary (non-streaming) requests. Streaming
+responses are encoded into multiple JSON objects; it's up to the client to split into
+separate records if it has to support multiple response messages.
 
 
 [Kong]: https://konghq.com

--- a/app/enterprise/2.1.x/plugins/grpc.md
+++ b/app/enterprise/2.1.x/plugins/grpc.md
@@ -3,14 +3,14 @@ title: Introduction to Kong gRPC Plugins
 ---
 
 Before we dive into the specifics of how to configure Kong's gRPC plugins, let's
-first discuss the advantages of the protocol. Unlike JSON, [gRPC](https://en.wikipedia.org/wiki/GRPC) 
-is a binary protocol, using protobuf definitions to instruct how the data will
-be marshalled and unmarshalled. Because binary data is used instead of text, it's
-a more efficient way to transmit data over a network. But this also makes it
-harder to work with because inspecting what went wrong is more challenging.
-Additionally, few clients natively handle gRPC.
+first discuss the advantages of the protocol. Unlike JSON, [gRPC](https://en.wikipedia.org/wiki/GRPC)
+is a binary protocol, using [protobuf](https://en.wikipedia.org/wiki/Protocol_Buffers)
+definitions to instruct how the data is marshalled and unmarshalled. Because
+binary data is used instead of text, it's a more efficient way to transmit data
+over a network. But this also makes gRPC harder to work with because inspecting
+what went wrong is more challenging. Additionally, few clients natively handle gRPC.
 
-To alleviate the challenges of working with gRPC, Kong has two plugins:
+To help alleviate the challenges of working with gRPC, Kong has two plugins:
 - [gRPC-Gateway](/hub/kong-inc/grpc-gateway)
 - [gRPC-Web](/hub/kong-inc/grpc-web)
 
@@ -89,7 +89,7 @@ message HelloResponse {
 }
 ```
 
-Upload the protobuf to your Kong Node:
+Upload the protobuf definition to your Kong Node:
 
 ```
 docker cp hello-gateway.proto kong-dp-host:/usr/local/kong/
@@ -130,7 +130,7 @@ curl -X POST kong-cp-host:8001/routes/grpcbin-post-route/plugins \
 --data 'config.proto=/usr/local/kong/hello.proto'
 ```
 
-Protobuf definition (hello.proto):
+Protobuf definition (`hello.proto`):
 
 ```
 syntax = "proto2";
@@ -153,7 +153,7 @@ message HelloResponse {
 }
 ```
 
-Upload the protobuf to your Kong Node:
+Upload the protobuf definition to your Kong Node:
 
 ```
 docker cp hello.proto kong-dp-host:/usr/local/kong/

--- a/app/enterprise/2.1.x/plugins/grpc.md
+++ b/app/enterprise/2.1.x/plugins/grpc.md
@@ -1,0 +1,169 @@
+---
+title: Introduction to Kong gRPC Plugins
+---
+
+Before we dive into the specifics of how to configure Kong's gRPC plugins, let's
+first discuss the advantages of the protocol. Unlike JSON, [gRPC](https://en.wikipedia.org/wiki/GRPC) 
+is a binary protocol, using protobuf definitions to instruct how the data will
+be marshalled and unmarshalled. Because binary data is used instead of text, it's
+a more efficient way to transmit data over a network. But this also makes it
+harder to work with because inspecting what went wrong is more challenging.
+Additionally, few clients natively handle gRPC.
+
+To alleviate the challenges of working with gRPC, Kong has two plugins:
+- [gRPC-Gateway](/hub/kong-inc/grpc-gateway)
+- [gRPC-Web](/hub/kong-inc/grpc-web)
+
+The gRPC-Gateway plugin allows you to send JSON requests to a gRPC service. A
+specially configured `.proto` file handles the conversion of the JSON request
+into one that the gRPC service can handle. This allows you to expose RESTful-style
+interfaces that talk to a gRPC service.
+
+The gRPC-Web plugin allows you to interact with a gRPC service from a browser.
+Instead of presenting a RESTful-type call, however, you POST data to the same
+gRPC service endpoint that the protobuf defines.
+
+For flexibility and compatibility with RESTful expectations, the gRPC-Gateway
+plugin offers more configurability, whereas the gRPC-Web plugin adheres more
+directly to the protobuf specification.
+
+Let's walk through setting up each plugin so you can see how they work.
+
+## gRPC-Gateway plugin configuration
+
+Set up a Service:
+
+```
+curl -X POST kong-cp-host:8001/services \
+--data 'name=grpcbin-service' \
+--data 'url=grpc://grpcb.in:9000'
+```
+
+Set up the Route to the Service:
+
+```
+curl -X POST kong-cp-host:8001/services/grpcbin-service/routes \
+--data 'name=grpcbin-get-route' \
+--data 'paths=/' \
+--data 'methods=GET' \
+--data 'headers.x-grpc=true'
+```
+
+Set up the gRPC-Web plugin:
+
+```
+curl -X POST kong-cp-host:8001/routes/grpcbin-get-route/plugins \
+--data 'name=grpc-gateway' \
+--data 'config.proto=/usr/local/kong/hello-gateway.proto'
+```
+
+Protobuf definition (`hello-gateway.proto`):
+
+```
+syntax = "proto3";
+
+package hello;
+
+service HelloService {
+  rpc SayHello(HelloRequest) returns (HelloResponse) {
+    option (google.api.http) = {
+      get: "/v1/messages/{name}"
+      additional_bindings {
+        get: "/v1/messages/legacy/{name=**}"
+      }
+      post: "/v1/messages/"
+      body: "*"
+    }
+  }
+}
+
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloResponse {
+  string message = 1;
+}
+```
+
+Upload the protobuf to your Kong Node:
+
+```
+docker cp hello-gateway.proto kong-dp-host:/usr/local/kong/
+```
+
+Test your setup:
+
+```
+curl -X GET kong-dp-host:8000/v1/messages/kong2.1 \
+--header 'x-grpc: true'
+```
+
+## gRPC-Web plugin configuration
+
+Set up a Service:
+
+```
+curl -X POST kong-cp-host:8001/services \
+--data 'name=grpcbin-service' \
+--data 'url=grpc://grpcb.in:9000'
+```
+
+Set up the Route to the Service:
+
+```
+curl -X POST kong-cp-host:8001/services/grpcbin-service/routes \
+--data 'name=grpcbin-post-route' \
+--data 'paths=/' \
+--data 'methods=POST' \
+--data 'headers.x-grpc=true'
+```
+
+Set up the gRPC-Web plugin:
+
+```
+curl -X POST kong-cp-host:8001/routes/grpcbin-post-route/plugins \
+--data 'name=grpc-web' \
+--data 'config.proto=/usr/local/kong/hello.proto'
+```
+
+Protobuf definition (hello.proto):
+
+```
+syntax = "proto2";
+
+package hello;
+
+service HelloService {
+  rpc SayHello(HelloRequest) returns (HelloResponse);
+  rpc LotsOfReplies(HelloRequest) returns (stream HelloResponse);
+  rpc LotsOfGreetings(stream HelloRequest) returns (HelloResponse);
+  rpc BidiHello(stream HelloRequest) returns (stream HelloResponse);
+}
+
+message HelloRequest {
+  optional string greeting = 1;
+}
+
+message HelloResponse {
+  required string reply = 1;
+}
+```
+
+Upload the protobuf to your Kong Node:
+
+```
+docker cp hello.proto kong-dp-host:/usr/local/kong/
+```
+
+Test your setup:
+
+```
+curl -X POST kong-dp-host:8000/hello.HelloService/SayHello \
+--header 'x-grpc: true' \
+--header 'Content-Type: application/json' \
+--data '{"greeting":"kong2.1"}'
+```

--- a/app/enterprise/2.1.x/plugins/grpc.md
+++ b/app/enterprise/2.1.x/plugins/grpc.md
@@ -2,8 +2,9 @@
 title: Introduction to Kong gRPC Plugins
 ---
 
-Before we dive into the specifics of how to configure Kong's gRPC plugins, let's
-first discuss the advantages of the protocol. Unlike JSON, [gRPC](https://en.wikipedia.org/wiki/GRPC)
+Before going into the specifics of configuring Kong's gRPC plugins, let's
+discuss the advantages of the gRPC protocol. Unlike JSON,
+[gRPC](https://en.wikipedia.org/wiki/GRPC)
 is a binary protocol, using [protobuf](https://en.wikipedia.org/wiki/Protocol_Buffers)
 definitions to instruct how the data is marshalled and unmarshalled. Because
 binary data is used instead of text, it's a more efficient way to transmit data

--- a/app/enterprise/2.1.x/plugins/grpc.md
+++ b/app/enterprise/2.1.x/plugins/grpc.md
@@ -7,7 +7,7 @@ first discuss the advantages of the protocol. Unlike JSON, [gRPC](https://en.wik
 is a binary protocol, using [protobuf](https://en.wikipedia.org/wiki/Protocol_Buffers)
 definitions to instruct how the data is marshalled and unmarshalled. Because
 binary data is used instead of text, it's a more efficient way to transmit data
-over a network. But this also makes gRPC harder to work with because inspecting
+over a network. However, this also makes gRPC harder to work with, because inspecting
 what went wrong is more challenging. Additionally, few clients natively handle gRPC.
 
 To help alleviate the challenges of working with gRPC, Kong has two plugins:
@@ -20,7 +20,7 @@ into one that the gRPC service can handle. This allows you to expose RESTful-sty
 interfaces that talk to a gRPC service.
 
 The gRPC-Web plugin allows you to interact with a gRPC service from a browser.
-Instead of presenting a RESTful-type call, however, you POST data to the same
+Instead of presenting a RESTful-type call, you POST data to the same
 gRPC service endpoint that the protobuf defines.
 
 For flexibility and compatibility with RESTful expectations, the gRPC-Gateway


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1158

This PR adds a deep dive comparison of the Kong gRPC plugins written by Aaron Miller and other dev SMEs. The topic is in the Plugins TOC in the KE TOC. There isn't a Plugins section in the CE docs (non-hub) TOC. Added See also links to plugin hub docs to new intro topic that compares the gRPC plugins and walks through their set up and testing.

This PR does not address the specific issues mentioned for the gateway plugin in https://konghq.atlassian.net/browse/FTI-1750. That should be addressed in a subsequent PR.

Old ticket also addressed:

https://konghq.atlassian.net/browse/DOCS-625

Note that there doesn't seem to be a logical order for the nav plugin TOC, most of which links to plugin hub docs. Need to discuss with PM as to plugin docs overhaul and centralization.

Direct review links:

https://deploy-preview-2215--kongdocs.netlify.app/enterprise/2.1.x/plugins/grpc/

plugin hub docs:

https://deploy-preview-2215--kongdocs.netlify.app/hub/kong-inc/grpc-gateway/#see-also
https://deploy-preview-2215--kongdocs.netlify.app/hub/kong-inc/grpc-web/#see-also