### PR TITLE
docs(deck) Fix typo in export example

### DIFF
--- a/app/deck/guides/getting-started.md
+++ b/app/deck/guides/getting-started.md
@@ -103,7 +103,7 @@ Export Kong's configuration:
 $ deck dump
 
 # look at the kong.yaml file that is generated:
-$ cat kong.yamz
+$ cat kong.yaml
 _format_version: "1.1"
 services:
 - connect_timeout: 60000


### PR DESCRIPTION
`yaml` was accidentally entered as `yamz`, fixing it.

Preview: https://deploy-preview-2216--kongdocs.netlify.app/deck/guides/getting-started/