### PR TITLE
fix(css) Add Firefox styling for hero image

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -410,6 +410,7 @@
     min-width: 1500px;
     background-size: cover;
     background-image: linear-gradient(to bottom, #ffffff, 40%, transparent), url("/assets/images/docs/banner-bkg.png");
+    background-image: -moz-linear-gradient(bottom, rgba(255,255,255,0) 40%, #ffffff), url("/assets/images/docs/banner-bkg.png");
     transform: translateX(-50%);
 
   }


### PR DESCRIPTION
Hero image for docs site isn't picking up the gradient properly in Firefox. Adjusting CSS to fix that.

Broken banner:
![Screen Shot 2020-08-13 at 10 07 50 AM](https://user-images.githubusercontent.com/54370747/90170138-6afa4780-dd54-11ea-8fce-944b5e79f1bb.png)

Fixed banner: 
![Screen Shot 2020-08-13 at 11 03 21 AM](https://user-images.githubusercontent.com/54370747/90170259-9ed56d00-dd54-11ea-811d-b9c336e8dc46.png)
