### PR TITLE
removed serve command; update params doc on latest version

### DIFF
--- a/app/enterprise/1.3-x/developer-portal/helpers/cli.md
+++ b/app/enterprise/1.3-x/developer-portal/helpers/cli.md
@@ -33,9 +33,9 @@ The easiest way to start is by cloning the [portal-templates repo][templates] ma
 
 Then edit `workspaces/default/cli.conf.yaml` to set `kong_admin_uri` and `kong_admin_token` to match your setup.
 
-Make sure Kong is running and portal is on:
+Make sure Kong is running and portal is on.
 
-Now from root folder of the templates repo you can run:
+Now from root folder of the templates repo, you can run:
 
 ```portal <command> <workspace>```
 
@@ -45,7 +45,6 @@ Where `<command>` is one of:
  - `disable`   Disable the portal on the given workspace.
  - `enable`    Enable the portal on the given workspace.
  - `fetch`     Fetches content and themes from the given workspace.
- - `serve`     Run the portal of a given workspace locally.
  - `wipe`      Deletes all content and themes from upstream workspace.
 
  Where `<workspace>` indicates the directory/workspace pairing you would like to operate on.
@@ -73,7 +72,7 @@ Available environment variables include:
 [clipanion]: https://github.com/arcanis/clipanion
 [sync-script]: https://github.com/Kong/kong-portal-templates/blob/81382f2c7887cf57bb040a6af5ca716b83cc74f3/bin/sync.js
 [cli-support]: https://github.com/Kong/kong-portal-cli/issues/new
-[cli-license]: https://github.com/Kong/kong-portal-cli/blob/master/LICENSE	
+[cli-license]: https://github.com/Kong/kong-portal-cli/blob/master/LICENSE
 [cli-contributors]: (https://github.com/Kong/kong-portal-cli/contributors)
-[kong-support]: https://support.konghq.com/support/s/	
+[kong-support]: https://support.konghq.com/support/s/
 [templates]: https://github.com/Kong/kong-portal-templates

--- a/app/enterprise/1.3-x/developer-portal/helpers/cli.md
+++ b/app/enterprise/1.3-x/developer-portal/helpers/cli.md
@@ -35,7 +35,7 @@ Then edit `workspaces/default/cli.conf.yaml` to set `kong_admin_uri` and `kong_a
 
 Make sure Kong is running and portal is on.
 
-Now from root folder of the templates repo, you can run:
+Now, from the root folder of the templates repo, you can run:
 
 ```portal <command> <workspace>```
 

--- a/app/enterprise/1.3-x/developer-portal/helpers/cli.md
+++ b/app/enterprise/1.3-x/developer-portal/helpers/cli.md
@@ -37,24 +37,38 @@ Make sure Kong is running and portal is on.
 
 Now, from the root folder of the templates repo, you can run:
 
-```portal <command> <workspace>```
+```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
 
 Where `<command>` is one of:
- - `config`    Output or change configuration of the portal on the given workspace.
- - `deploy`    Deploy changes made locally under the given workspace upstream.
- - `disable`   Disable the portal on the given workspace.
- - `enable`    Enable the portal on the given workspace.
- - `fetch`     Fetches content and themes from the given workspace.
- - `wipe`      Deletes all content and themes from upstream workspace.
 
- Where `<workspace>` indicates the directory/workspace pairing you would like to operate on.
+* `config`   Output or change configuration of the portal on the given
+`workspace`, locally.
+* `deploy`   Deploy changes made locally under the given workspace upstream.
+* `disable`  Enable the portal on the given workspace.
+* `enable`   Enable the portal on the given workspace.
+* `fetch`    Fetches content and themes from the given workspace.
+* `wipe`     Deletes all content and themes from upstream workspace
 
-### For `deploy`
+Where <workspace> indicates the directory/workspace pairing you would like to operate on.
+
+#### For `deploy`
 - Add `-W` or `--watch` to make changes reactive.
 - Add `-P` or `--preserve` to avoid deleting files upstream that you do not have locally.
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
 
-### For `fetch`
-- Add `-K` or `--keep-encode` to keep binary assets as base64 encoded strings locally.
+#### For `fetch`
+- Add `-K` or `--keep-encode` to keep binary assets as base64-encoded strings locally.
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
+
+#### For `wipe`
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
+
+#### For `enable` and `disable`
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+
 
 ### Using Environment Variables
 You can override config values set in `cli.conf.yaml` via environment variables.  If you wanted to override the kong admin url for example, you can run:

--- a/app/enterprise/1.5.x/developer-portal/helpers/cli.md
+++ b/app/enterprise/1.5.x/developer-portal/helpers/cli.md
@@ -37,19 +37,37 @@ Make sure Kong is running and portal is on.
 
 Now, from the root folder of the templates repo, you can run:
 
-```portal [-h,--help] [--config PATH] [-v,--verbose] <command>```
+```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
 
 Where `<command>` is one of:
 
 * `config`   Output or change configuration of the portal on the given
-* `workspace`, locally.
+`workspace`, locally.
 * `deploy`   Deploy changes made locally under the given workspace upstream.
 * `disable`  Enable the portal on the given workspace.
 * `enable`   Enable the portal on the given workspace.
 * `fetch`    Fetches content and themes from the given workspace.
 * `wipe`     Deletes all content and themes from upstream workspace
 
-Add `--watch` to make changes reactive
+Where <workspace> indicates the directory/workspace pairing you would like to operate on.
+
+#### For `deploy`
+- Add `-W` or `--watch` to make changes reactive.
+- Add `-P` or `--preserve` to avoid deleting files upstream that you do not have locally.
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
+
+#### For `fetch`
+- Add `-K` or `--keep-encode` to keep binary assets as base64-encoded strings locally.
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
+
+#### For `wipe`
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
+
+#### For `enable` and `disable`
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
 
 
 [clipanion]: https://github.com/arcanis/clipanion

--- a/app/enterprise/1.5.x/developer-portal/helpers/cli.md
+++ b/app/enterprise/1.5.x/developer-portal/helpers/cli.md
@@ -35,7 +35,7 @@ Then edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_t
 
 Make sure Kong is running and portal is on.
 
-Now from root folder of the templates repo, you can run:
+Now, from the root folder of the templates repo, you can run:
 
 ```portal [-h,--help] [--config PATH] [-v,--verbose] <command>```
 

--- a/app/enterprise/1.5.x/developer-portal/helpers/cli.md
+++ b/app/enterprise/1.5.x/developer-portal/helpers/cli.md
@@ -33,9 +33,9 @@ The easiest way to start is by cloning the [portal-templates repo][templates] ma
 
 Then edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token` to match your setup.
 
-Make sure Kong is running and portal is on:
+Make sure Kong is running and portal is on.
 
-Now from root folder of the templates repo you can run:
+Now from root folder of the templates repo, you can run:
 
 ```portal [-h,--help] [--config PATH] [-v,--verbose] <command>```
 
@@ -47,7 +47,6 @@ Where `<command>` is one of:
 * `disable`  Enable the portal on the given workspace.
 * `enable`   Enable the portal on the given workspace.
 * `fetch`    Fetches content and themes from the given workspace.
-* `serve`    Run the portal of a given workspace locally.
 * `wipe`     Deletes all content and themes from upstream workspace
 
 Add `--watch` to make changes reactive

--- a/app/enterprise/2.1.x/developer-portal/helpers/cli.md
+++ b/app/enterprise/2.1.x/developer-portal/helpers/cli.md
@@ -25,32 +25,33 @@ For Kong Enterprise `<= 0.36`, or for `legacy mode` on Kong Enterprise `>= 1.3` 
 > npm install -g kong-portal-cli
 ```
 
-
-
 ### Usage
 
-The easiest way to start is by cloning the [portal-templates repo][templates] master branch locally.
+The easiest way to start is by cloning the [portal-templates repo][templates]
+master branch locally.
 
-Then edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token` to match your setup.
+Then edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token`
+to match your setup.
 
-Make sure Kong is running and portal is on:
+Make sure Kong is running and portal is on.
 
-Now from root folder of the templates repo you can run:
+Now from the root folder of the templates repo, you can run:
 
-```portal [-h,--help] [--config PATH] [-v,--verbose] <command>```
+```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
 
 Where `<command>` is one of:
 
 * `config`   Output or change configuration of the portal on the given
-* `workspace`, locally.
+`workspace`, locally.
 * `deploy`   Deploy changes made locally under the given workspace upstream.
 * `disable`  Enable the portal on the given workspace.
 * `enable`   Enable the portal on the given workspace.
 * `fetch`    Fetches content and themes from the given workspace.
-* `serve`    Run the portal of a given workspace locally.
 * `wipe`     Deletes all content and themes from upstream workspace
 
-Add `--watch` to make changes reactive
+Where <workspace> indicates the directory/workspace pairing you would like to operate on.
+
+#### Deploy
 
 
 [clipanion]: https://github.com/arcanis/clipanion

--- a/app/enterprise/2.1.x/developer-portal/helpers/cli.md
+++ b/app/enterprise/2.1.x/developer-portal/helpers/cli.md
@@ -51,7 +51,23 @@ Where `<command>` is one of:
 
 Where <workspace> indicates the directory/workspace pairing you would like to operate on.
 
-#### Deploy
+#### For `deploy`
+- Add `-W` or `--watch` to make changes reactive.
+- Add `-P` or `--preserve` to avoid deleting files upstream that you do not have locally.
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the '/specs' directory.
+
+#### For `fetch`
+- Add `-K` or `--keep-encode` to keep binary assets as base64-encoded strings locally.
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the '/specs' directory.
+
+#### For `wipe`
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
+- Add `-I` or `--ignore-specs` to ignore the '/specs' directory.
+
+#### For `enable` and `disable`
+- Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
 
 
 [clipanion]: https://github.com/arcanis/clipanion

--- a/app/enterprise/2.1.x/developer-portal/helpers/cli.md
+++ b/app/enterprise/2.1.x/developer-portal/helpers/cli.md
@@ -30,12 +30,12 @@ For Kong Enterprise `<= 0.36`, or for `legacy mode` on Kong Enterprise `>= 1.3` 
 The easiest way to start is by cloning the [portal-templates repo][templates]
 master branch locally.
 
-Then edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token`
+Next, edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token`
 to match your setup.
 
 Make sure Kong is running and portal is on.
 
-Now from the root folder of the templates repo, you can run:
+Now, from the root folder of the templates repo, you can run:
 
 ```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
 
@@ -55,16 +55,16 @@ Where <workspace> indicates the directory/workspace pairing you would like to op
 - Add `-W` or `--watch` to make changes reactive.
 - Add `-P` or `--preserve` to avoid deleting files upstream that you do not have locally.
 - Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
-- Add `-I` or `--ignore-specs` to ignore the '/specs' directory.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
 
 #### For `fetch`
 - Add `-K` or `--keep-encode` to keep binary assets as base64-encoded strings locally.
 - Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
-- Add `-I` or `--ignore-specs` to ignore the '/specs' directory.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
 
 #### For `wipe`
 - Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.
-- Add `-I` or `--ignore-specs` to ignore the '/specs' directory.
+- Add `-I` or `--ignore-specs` to ignore the `/specs` directory.
 
 #### For `enable` and `disable`
 - Add `-D` or `--disable-ssl-verification` to disable SSL verification and use self-signed certs.


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1244

Used information from readme https://github.com/Kong/kong-portal-cli per @HenriPro. Verfied it matches cli output v 3.1.0 per slack convo: https://kongstrong.slack.com/archives/CDSTDSG9J/p1597418866006800?thread_ts=1597415934.002200&cid=CDSTDSG9J.

Updated 2.1.x to readme with parameter descriptions.
1.3 and 1.5 only deleted serve command.

Direct review links:
https://deploy-preview-2228--kongdocs.netlify.app/enterprise/2.1.x/developer-portal/helpers/cli/#usage
https://deploy-preview-2228--kongdocs.netlify.app/enterprise/1.5.x/developer-portal/helpers/cli/#usage
https://deploy-preview-2228--kongdocs.netlify.app/enterprise/1.3-x/developer-portal/helpers/cli/#usage
