### PR TITLE
docs(1.5.x) update brain-immunity toc to add topics

### DIFF
--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -412,16 +412,25 @@
 
 - title: Kong Brain & Kong Immunity
   icon: /assets/images/icons/documentation/icn-brain-color.svg
-  url: /brain-immunity/install-configure
   items:
+    - text: Overview
+      url: /brain-immunity/overview
     - text: Installation and Configuration
       url: /brain-immunity/install-configure
-    - text: Alerts
-      url: /brain-immunity/alerts
+    - text: Kong Brain
+      items:
+        - text: Service Map
+          url: /brain-immunity/service-map
+    - text: Kong Immunity
+      items:
+        - text: Alerts
+          url: /brain-immunity/alerts
+        - text: Model Training
+          url: /brain-immunity/model-training
+        - text: Slack Integration
+          url: /brain-immunity/slack-integration
     - text: Auto-Generated API Documentation
       url: /brain-immunity/auto-generated-specs
-    - text: Service Map
-      url: /brain-immunity/service-map
     - text: Troubleshooting
       url: /brain-immunity/troubleshooting
     - text: Changelog


### PR DESCRIPTION
- updating 1.5.x release
- adding overview
- splitting out immunity model training and slack integration

