### PR TITLE
Datadog plugin v3 remove unsupported ee versions

### DIFF
--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -42,8 +42,6 @@ kong_version_compatibility:
         - 0.6.x
     enterprise_edition:
       compatible:
-        - 1.5.x
-        - 1.3-x
         - 0.36-x
         - 0.35-x
         - 0.34-x

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -42,6 +42,7 @@ kong_version_compatibility:
         - 0.6.x
     enterprise_edition:
       compatible:
+        - 2.1.x
         - 0.36-x
         - 0.35-x
         - 0.34-x


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1046

3.0 plugin version not supported until 2.1.x release (tomorrow). I had hoped somehow it would be backported to 1.3.x and 1.5.x but not going to happen.

Update: release slipped. Merge when GA release goes live.

Direct review link:

https://deploy-preview-2237--kongdocs.netlify.app/hub/kong-inc/datadog/