### PR TITLE
docs(plugins) Plugin examples overhaul project, part 1

### DIFF
--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -34,6 +34,7 @@ params:
     - name: account_email
       required: yes
       default:
+      value_in_examples: example@example.com
       description: |
         The account identifier, can be reused in different plugin instance.
     - name: api_uri
@@ -105,7 +106,7 @@ params:
           },
         }
     ```
-  
+
     To configure storage type other than `kong`, please refer to [lua-resty-acme](https://github.com/fffonion/lua-resty-acme#storage-adapters).
 
 ---

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -82,7 +82,7 @@ params:
     - name: host
       required: semi
       default:
-      value_in_examples: AWS_HOST
+      value_in_examples:
       description: |
         The host where the Lambda function is located. This value can point to a
         local Lambda server, allowing for easier debugging. Either `host` or

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -46,7 +46,7 @@ params:
     - name: functionname
       required: true
       default:
-      value_in_exaples: AZURE_FUNCTIONNAME
+      value_in_examples: AZURE_FUNCTIONNAME
       description: Name of the Azure function to invoke.
     - name: appname
       required: true

--- a/app/_hub/kong-inc/canary/index.md
+++ b/app/_hub/kong-inc/canary/index.md
@@ -48,7 +48,7 @@ params:
     - name: percentage
       required:
       default:
-      value_in_examples:
+      value_in_examples: 50
       description: |
         Fixed % of traffic to be routed to new target, if given overrides `start` and `duration`
     - name: steps
@@ -60,7 +60,7 @@ params:
     - name: upstream_host
       required:
       default:
-      value_in_examples:
+      value_in_examples: example.com
       description: |
         The target hostname where traffic will be routed. (Required if `upstream_uri/port` is not set.)
     - name: upstream_fallback
@@ -72,7 +72,7 @@ params:
     - name: upstream_port
       required:
       default:
-      value_in_examples:
+      value_in_examples: 80
       description: |
         The target port where traffic will be routed. (Required if `upstream_uri/host` is not set.)
     - name: upstream_uri

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -25,11 +25,13 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
+  yaml_examples: false
+  k8s_examples: false
   protocols: ["http", "https"]
   config:
     - name: functions
       required: true
-      value_in_examples: "[]"
+      value_in_examples: [ "@example/my_function.lua" ]
       description: Array of functions used to transform any Kong proxy exit response.
     - name: handle_unknown
       default: "`false`"

--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -36,15 +36,15 @@ params:
   consumer_id: true
   config:
     - name: proxy_host
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: example.com
       description: |
         The hostname or IP address of the forward proxy to which to connect
     - name: proxy_port
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: 80
       description: |
         The TCP port of the forward proxy to which to connect
     - name: proxy_scheme

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -46,15 +46,15 @@ params:
       description: |
         A scoring factor to multiply (or divide) the cost.
     - name: limit
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: [ "5" ]
       description: |
         One or more requests-per-window limits to apply.
     - name: window_size
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: [ "30" ]
       description: |
         One or more window sizes to apply a limit to (defined in seconds).
     - name: identifier
@@ -74,9 +74,9 @@ params:
       description: |
         The shared dictionary where counters will be stored until the next sync cycle.
     - name: sync_rate
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: -1
       description: |
         How often to sync counter data to the central data store. A value of 0
         results in synchronous behavior; a value of -1 ignores sync behavior

--- a/app/_hub/kong-inc/kafka-upstream/index.md
+++ b/app/_hub/kong-inc/kafka-upstream/index.md
@@ -25,14 +25,14 @@ params:
   config:
     - name: bootstrap_servers
       required: true
-      value_in_examples: BOOTSTRAP_SERVERS
+      value_in_examples: <BOOTSTRAP_SERVERS>
       urlencode_in_examples: true
       default:
       description: |
         List of bootstrap brokers in a `{host: host, port: port}` format.
     - name: topic
       required: true
-      value_in_examples: TOPIC
+      value_in_examples: <TOPIC>
       urlencode_in_examples: true
       default:
       description: |
@@ -40,13 +40,13 @@ params:
     - name: timeout
       required: false
       default: "`10000`"
-      value_in_examples: TIMEOUT
+      value_in_examples: 10000
       description: |
          Socket timeout in milliseconds.
     - name: keepalive
       required: false
       default: "`60000`"
-      value_in_examples: KEEPALIVE
+      value_in_examples: 60000
       description: |
          Keepalive timeout in milliseconds.
     - name: forward_method
@@ -72,31 +72,31 @@ params:
     - name: producer_request_acks
       required: false
       default: "`1`"
-      value_in_examples: PRODUCER_REQUEST_ACKS
+      value_in_examples: -1
       description: |
          The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values are 0 for no acknowledgments, 1 for only the leader, and -1 for the full ISR
     - name: producer_request_timeout
       required: false
       default: "`2000`"
-      value_in_examples: PRODUCER_REQUEST_TIMEOUT
+      value_in_examples: 2000
       description: |
          Time to wait for a Produce response in milliseconds
     - name: producer_request_limits_messages_per_request
       required: false
       default: "`200`"
-      value_in_examples: PRODUCER_REQUEST_LIMITS_MESSAGES_PER_REQUEST
+      value_in_examples: 200
       description: |
          Maximum number of messages to include into a single Produce request
     - name: producer_request_limits_bytes_per_request
       required: false
       default: "`1048576`"
-      value_in_examples: PRODUCER_REQUEST_LIMITS_BYTES_PER_REQUEST
+      value_in_examples: 1048576
       description: |
          Maximum size of a Produce request in bytes
     - name: producer_request_retries_max_attempts
       required: false
       default: "`10`"
-      value_in_examples: PRODUCER_REQUEST_RETRIES_MAX_ATTEMPTS
+      value_in_examples: 10
       description: |
          Maximum number of retry attempts per single Produce request
     - name: producer_request_retries_backoff_timeout
@@ -132,10 +132,10 @@ $ curl -X POST http://kong:8001/routes/my-route/plugins \
     --data "config.topic=kong-upstream" \
     --data "config.timeout=10000" \
     --data "config.keepalive=60000" \
-    --data "config.forward_method=false",
-    --data "config.forward_uri=false",
-    --data "config.forward_headers=false",
-    --data "config.forward_body=true",
+    --data "config.forward_method=false" \
+    --data "config.forward_uri=false" \
+    --data "config.forward_headers=false" \
+    --data "config.forward_body=true" \
     --data "config.producer_request_acks=1" \
     --data "config.producer_request_timeout=2000" \
     --data "config.producer_request_limits_messages_per_request=200" \

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -32,9 +32,9 @@ params:
   consumer_id: false
   config:
     - name: ldap_host
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: ldap.example.com
       description: |
         Host on which the LDAP server is running
     - name: ldap_port
@@ -63,9 +63,9 @@ params:
         Set it to `true` to use `ldaps`, a secure protocol (that can be configured
         to TLS) to connect to the LDAP server.
     - name: base_dn
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: dc=example,dc=com
       description: |
         Base DN as the starting point for the search; e.g., "dc=example,dc=com"
     - name: verify_ldap_host
@@ -75,9 +75,9 @@ params:
       description: |
         Set it to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.
     - name: attribute
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: cn
       description: |
         Attribute to be used to search the user; e.g., "cn"
     - name: cache_ttl

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -38,7 +38,7 @@ params:
         Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array) then auto-matching is disabled.
     - name: ca_certificates
       required: true
-      value_in_examples: fdac360e-7b19-4ade-a553-6dd22937c82f
+      value_in_examples: [ "fdac360e-7b19-4ade-a553-6dd22937c82f" ]
       description: |
         List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`).
     - name: skip_consumer_lookup

--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -42,15 +42,15 @@ params:
   consumer_id: true
   config:
     - name: introspection_url
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: https://example-url.com
       description: |
         The full URL to the third-party introspection endpoint
     - name: authorization_value
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: Basic MG9hNWlpbjpPcGVuU2VzYW1l
       description: |
         The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`).
     - name: token_type_hint

--- a/app/_hub/kong-inc/oauth2/0.1-x.md
+++ b/app/_hub/kong-inc/oauth2/0.1-x.md
@@ -59,8 +59,8 @@ params:
   service_id: true
   route_id: false
   consumer_id: false
-  yaml_compatible: false
-  k8s_compatible: false
+  yaml_examples: false
+  k8s_examples: false
   config:
     - name: scopes
       required: true

--- a/app/_hub/kong-inc/oauth2/0.1-x.md
+++ b/app/_hub/kong-inc/oauth2/0.1-x.md
@@ -59,6 +59,8 @@ params:
   service_id: true
   route_id: false
   consumer_id: false
+  yaml_compatible: false
+  k8s_compatible: false
   config:
     - name: scopes
       required: true

--- a/app/_hub/kong-inc/oauth2/1.0-x.md
+++ b/app/_hub/kong-inc/oauth2/1.0-x.md
@@ -70,6 +70,8 @@ params:
   route_id: false
   consumer_id: false
   protocols: ["http", "https"]
+  yaml_compatible: false
+  k8s_compatible: false
   dbless_compatible: no
   dbless_explanation: |
     For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with DB-less.

--- a/app/_hub/kong-inc/oauth2/1.0-x.md
+++ b/app/_hub/kong-inc/oauth2/1.0-x.md
@@ -70,8 +70,8 @@ params:
   route_id: false
   consumer_id: false
   protocols: ["http", "https"]
-  yaml_compatible: false
-  k8s_compatible: false
+  yaml_examples: false
+  k8s_examples: false
   dbless_compatible: no
   dbless_explanation: |
     For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with DB-less.

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -71,8 +71,8 @@ params:
   route_id: false
   consumer_id: false
   protocols: ["http", "https", "grpc", "grpcs"]
-  yaml_compatible: false
-  k8s_compatible: false
+  yaml_examples: false
+  k8s_examples: false
   dbless_compatible: no
   dbless_explanation: |
     For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with DB-less.

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -71,6 +71,8 @@ params:
   route_id: false
   consumer_id: false
   protocols: ["http", "https", "grpc", "grpcs"]
+  yaml_compatible: false
+  k8s_compatible: false
   dbless_compatible: no
   dbless_explanation: |
     For its regular work, the plugin needs to both generate and delete tokens, and commit those changes to the database, which is not compatible with DB-less.
@@ -166,7 +168,7 @@ params:
         all the clients. `lax` mode enforces PKCE for public clients, but it does
         not enforce it for confidential clients. `none` mode does not enforce PKCE
         on any client. In any case, if client asks for PKCE on authorization
-        endpoint, the PKCE is also enforced on token endpoint. 
+        endpoint, the PKCE is also enforced on token endpoint.
 
   extra: |
     <div class="alert alert-warning">

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -34,15 +34,15 @@ params:
   consumer_id: true
   config:
     - name: limit
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: [ "5" ]
       description: |
         One or more requests-per-window limits to apply.
     - name: window_size
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: [ "30" ]
       description: |
         One or more window sizes to apply a limit to (defined in seconds).
     - name: identifier
@@ -62,9 +62,9 @@ params:
       description: |
         The shared dictionary where counters will be stored until the next sync cycle.
     - name: sync_rate
-      required:
+      required: true
       default:
-      value_in_examples:
+      value_in_examples: -1
       description: |
         How often to sync counter data to the central data store. A value of 0
          results in synchronous behavior; a value of -1 ignores sync behavior
@@ -152,7 +152,7 @@ params:
         This sets the time window to either `sliding` or `fixed`.
   extra: |
     **Notes:**  
-    
+
      * Redis configuration values are ignored if the `cluster` strategy is used.
 
      * PostgreSQL 9.5+ is required when using the `cluster` strategy with `postgres` as the backing Kong cluster data store. This requirement varies from the PostgreSQL 9.4+ requirement as described in the <a href="/install/source">Kong Community Edition documentation</a>.

--- a/app/_hub/kong-inc/request-validator/index.md
+++ b/app/_hub/kong-inc/request-validator/index.md
@@ -30,7 +30,7 @@ params:
   config:
     - name: body_schema
       required: true
-      value_in_examples: '[{\"name\":{\"type\": \"string\", \"required\": true}}]'
+      value_in_examples: '''[{"name":{"type": "string", "required": true}}]'''
       description: Array of schema fields.
 
     - name: allowed_content_types
@@ -54,7 +54,7 @@ params:
       value_in_examples:
       description: Array of parameter validator specifications.
        For details and examples, see [Parameter Schema Definition](#parameter-schema-definition).
-        
+
 
     - name: verbose_response
       required: false

--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -32,11 +32,11 @@ params:
   config:
     - name: remove.headers
       required: false
-      value_in_examples: "x-toremove, x-another-one:application/json, x-list-of-values:v1,v2,v3 Set-Cookie:/JSESSIONID=.*/, x-another-regex://status/$/, x-one-more-regex:/^/begin//"
+      value_in_examples: ["x-toremove", "x-another-one:application/json", "x-list-of-values:v1,v2,v3", "Set-Cookie:/JSESSIONID=.*/", "x-another-regex://status/$/", "x-one-more-regex:/^/begin//"]
       description: List of header_name[:header_value]. If only header_name is given, unset the header field with the given header_name. If header_name:header_value is given, remove a specific header_value. If header_value starts and ends with a '/' (slash character), then it is considered to be a regular expression. Note that as per https://httpwg.org/specs/rfc7230.html#field.order multiple header values with the same header name are allowed if the entire field value for that header field is defined as a comma-separated list or the header field is a Set-Cookie header field.
     - name: remove.json
       required: false
-      value_in_examples: "json-key-toremove, another-json-key"
+      value_in_examples: ["json-key-toremove", "another-json-key"]
       description: List of property names. Remove the property from the JSON body if it is present.
     - name: remove.if_status
       required: false
@@ -58,18 +58,18 @@ params:
       description: List of response status codes or status code ranges to which the transformation will apply. Empty means all response codes
     - name: add.headers
       required: false
-      value_in_examples: "x-new-header:value,x-another-header:something"
+      value_in_examples: ["x-new-header:value","x-another-header:something"]
       description: List of headername:value pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
     - name: add.json
       required: false
-      value_in_examples: "new-json-key:some_value, another-json-key:some_value"
+      value_in_examples: ["new-json-key:some_value", "another-json-key:some_value"]
       description: List of property:value pairs. If and only if the property is not present, add a new property with the given value to the JSON body. Ignored if the property is already present.
     - name: add.if_status
       required: false
       description: List of response status codes or status code ranges to which the transformation will apply. Empty means all response codes
     - name: append.headers
       required: false
-      value_in_examples: "x-existing-header:some_value, x-another-header:some_value"
+      value_in_examples: ["x-existing-header:some_value", "x-another-header:some_value"]
       description: List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
     - name: append.json
       required: false

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -57,11 +57,11 @@ params:
   config:
     - name: remove.headers
       required: false
-      value_in_examples: "x-toremove, x-another-one"
+      value_in_examples: ["x-toremove", "x-another-one"]
       description: List of header names. Unset the header(s) with the given name.
     - name: remove.json
       required: false
-      value_in_examples: "json-key-toremove, another-json-key"
+      value_in_examples: ["json-key-toremove", "another-json-key"]
       description: List of property names. Remove the property from the JSON body if it is present.
     - name: rename.headers
       required: false
@@ -74,15 +74,15 @@ params:
       description: List of property:value pairs. If and only if the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
     - name: add.headers
       required: false
-      value_in_examples: "x-new-header:value,x-another-header:something"
+      value_in_examples: ["x-new-header:value","x-another-header:something"]
       description: List of headername:value pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
     - name: add.json
       required: false
-      value_in_examples: "new-json-key:some_value, another-json-key:some_value"
+      value_in_examples: ["new-json-key:some_value", "another-json-key:some_value"]
       description: List of property:value pairs. If and only if the property is not present, add a new property with the given value to the JSON body. Ignored if the property is already present.
     - name: append.headers
       required: false
-      value_in_examples: "x-existing-header:some_value, x-another-header:some_value"
+      value_in_examples: ["x-existing-header:some_value", "x-another-header:some_value"]
       description: List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
     - name: append.json
       required: false

--- a/app/_hub/kong-inc/statsd-advanced/index.md
+++ b/app/_hub/kong-inc/statsd-advanced/index.md
@@ -65,7 +65,7 @@ params:
     - name: allow_status_codes
       required:
       default: "All responses are passed to log metrics"
-      value_in_examples: 200-205,400-499
+      value_in_examples: ["200-205","400-499"]
       description: List of status code ranges which are allowed to be logged in metrics  
   extra: |
     By default the Plugin sends a packet for each metric it observes. `udp_packet_size` configures the greatest datagram size the Plugin can combine. It should be less than 65507 according to UDP protocol. Please consider the MTU of the network when setting this parameter.

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -32,9 +32,10 @@ params:
       default: "`access_token`"
       description: |
         Describes an array of comma separated parameter names where the plugin will look for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
-    - name: vault
+    - name: vault.id
       required: true
       default:
+      value_in_examples: "<UUID>"
       description: |
         A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.
     - name: secret_token_name

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -291,7 +291,7 @@ plugins:
     {% if page.params.consumer_id %}
       <tr><td><code>consumer.id</code></td><td>The ID of the Consumer the plugin targets.</td></tr>
     {% endif %}
-      <tr><td><code>enabled</code><br><br><strong>default field: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
+      <tr><td><code>enabled</code><br><br><strong>default value: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
     {% if page.params.api_id %}
     <tr><td><code>api_id</code></td><td>The ID of the API the plugin targets. <br><br><strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
     {% endif %}
@@ -301,7 +301,7 @@ plugins:
           {% if field.required == true %}<br><em>required</em>{% endif %}
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default field: </strong>{{ field.default | markdownify }}{% endif %}
+          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default | markdownify }}{% endif %}
         </td>
         <td>{{ field.description | markdownify }}</td>
       </tr>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -14,10 +14,10 @@ breadcrumbs:
   if field.value_in_examples != nil %}{%
   if field.value_in_examples.first %}{%
   for value in field.value_in_examples %} \
-    --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ value }}"{%
+    --data{% if field.urlencode_in_examples %}-urlencode{% endif %} {% if field.value_in_examples contains "'" %}'config.{{ field.name }}={{ value | replace: "'", "" }}'{% else %}"config.{{ field.name }}={{ value }}"{% endif %}{%
   endfor %}{%
   else %} \
-    --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ field.value_in_examples }}"{%
+    --data{% if field.urlencode_in_examples %}-urlencode{% endif %} {% if field.value_in_examples contains "'" %}'config.{{ field.name }}={{ field.value_in_examples | replace: "'", "" }}'{% else %}"config.{{ field.name }}={{ field.value_in_examples }}"{% endif %}{%
   endif %}{%
   elsif field.required == true %} \
     --data{% if field.urlencode_in_examples %}-urlencode{% endif %} "config.{{ field.name }}={{ field.default | markdownify | strip_html | strip }}"{%
@@ -28,11 +28,24 @@ breadcrumbs:
   %}config: {%
   for field in page.params.config %}{%
   if field.value_in_examples != nil %}{%
-    if field.value_in_examples.first %}
+    if field.value_in_examples.first %}{%
+        if field.name contains "." %}{%
+          assign names = field.name | split: "." %}
+    {{ names[0] }}:{%
+      for name in names offset:1 %}
+      {{ name }}:{% endfor %}{%
+      for value in field.value_in_examples %}
+      - {{ value }}{%
+      endfor %}{% else %}
     {{ field.name }}:{%
     for value in field.value_in_examples %}
     - {{ value }}{%
-    endfor %}{%
+    endfor %}{% endif %}{%
+    elsif field.name contains "." %}{%
+          assign names = field.name | split: "." %}
+    {{ names[0] }}:{%
+      for name in names offset:1 %}
+      {{ name }}:{% endfor %} {{ field.value_in_examples }}{%
     else %}
     {{ field.name }}: {{ field.value_in_examples }}{%
     endif %}{%
@@ -41,14 +54,17 @@ breadcrumbs:
   endif %}{% endfor
 %}{% endcapture %}
 
-{% if page.params.service_id %}
-{% capture plugin_config_for_service_with_db %}
+<!-- Service config example -->
 
-Configure this plugin on a [Service](/latest/admin-api/#service-object) by
+{% if page.params.service_id %}
+
+{% capture plugin_config_for_service_admin_api %}
+
+For example, configure this plugin on a [Service](/latest/admin-api/#service-object) by
 making the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/services/{service}/plugins \
+$ curl -X POST http://<admin-hostname>:8001/services/<service>/plugins \
     --data "name={{page.params.name}}" {{ config_required_fields }}
 ```
 {% endcapture %}
@@ -56,47 +72,58 @@ $ curl -X POST http://kong:8001/services/{service}/plugins \
 {% capture plugin_config_for_service %}
 ### Enabling the plugin on a Service
 
-{% if page.enterprise or page.params.dbless_compatible == false or page.params.dbless_compatible == nil %}
+{% if page.params.yaml_examples == false and page.params.k8s_examples == false %}
 
-{{ plugin_config_for_service_with_db }}
+{{ plugin_config_for_service_admin_api }}
 
-{% elsif page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
+{% else %}
 
 {% navtabs %}
-{% navtab With a database %}
+{% navtab Kong Admin API %}
 
-{{ plugin_config_for_service_with_db }}
+{{ plugin_config_for_service_admin_api }}
 
 {% endnavtab %}
-{% navtab Without a database %}
+{% unless page.params.yaml_examples == false %}
+{% navtab Declarative (YAML) %}
 
-Configure this plugin on a [Service](/latest/admin-api/#service-object) by
+For example, configure this plugin on a [Service](/latest/admin-api/#service-object) by
 adding this section to your declarative configuration file:
 
 ``` yaml
 plugins:
 - name: {{page.params.name}}
-  service: {service}
-  {{ config_required_fields_yaml }}
+  service: <service>
+  {% if config_required_fields_yaml == 'config: ' %}config:
+    <optional_parameter>: <value>{% else %}{{ config_required_fields_yaml }}{% endif %}
 ```
 {% endnavtab %}
+{% endunless %}
 {% endnavtabs %}
-
 {% endif %}
 
-`{service}` is the `id` or `name` of the Service that this plugin configuration will target.
+`<service>` is the `id` or `name` of the Service that this plugin
+  configuration will target.
+
+{% if page.params.api_id %}
+  > **Note:** The legacy API entity has been **deprecated** in favor of Services
+  since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">
+  CE 0.13.0</a> and
+  <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.
+{% endif %}
 
 {% endcapture %}
 {% endif %}
 
+<!-- Route config example -->
+
 {% if page.params.route_id %}
 
-{% capture plugin_config_for_route_with_db %}
-
-Configure this plugin on a [Route](/latest/admin-api/#Route-object) with:
+{% capture plugin_config_for_route_admin_api %}
+For example, configure this plugin on a [Route](/latest/admin-api/#Route-object) with:
 
 ```bash
-$ curl -X POST http://kong:8001/routes/{route}/plugins \
+$ curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
     --data "name={{page.params.name}}" {{ config_required_fields }}
 ```
 {% endcapture %}
@@ -104,112 +131,148 @@ $ curl -X POST http://kong:8001/routes/{route}/plugins \
 {% capture plugin_config_for_route %}
 ### Enabling the plugin on a Route
 
-{% if page.enterprise or page.params.dbless_compatible == false or page.params.dbless_compatible == nil %}
+{% if page.params.yaml_examples == false and page.params.k8s_examples == false %}
 
-{{ plugin_config_for_route_with_db }}
+{{ plugin_config_for_route_admin_api }}
 
-{% elsif page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
-
+{% else %}
 {% navtabs %}
-{% navtab With a database %}
+{% navtab Kong Admin API %}
 
-{{ plugin_config_for_route_with_db }}
+{{ plugin_config_for_route_admin_api }}
 
 {% endnavtab %}
-{% navtab Without a database %}
+{% unless page.params.yaml_examples == false %}
+{% navtab Declarative (YAML) %}
 
-Configure this plugin on a [Route](/latest/admin-api/#route-object) by
+For example, configure this plugin on a [Route](/latest/admin-api/#route-object) by
 adding this section to your declarative configuration file:
 
-``` yaml
+```yaml
 plugins:
 - name: {{page.params.name}}
-  route: {route}
-  {{ config_required_fields_yaml }}
+  route: <route>
+  {% if config_required_fields_yaml == 'config: ' %}config:
+    <optional_parameter>: <value>{% else %}{{ config_required_fields_yaml }}{% endif %}
 ```
 {% endnavtab %}
+{% endunless %}
 {% endnavtabs %}
 {% endif %}
 
-`{route}` is the `id` or `name` of the Route that this plugin configuration will target.
+`<route>` is the `id` or `name` of the Route that this plugin configuration
+  will target.
 
 {% endcapture %}
 {% endif %}
 
-{% if page.params.consumer_id %}
-{% capture plugin_config_for_consumer_with_db %}
+<!-- Consumer config example -->
 
-Configure this plugin on a [Consumer](/latest/admin-api/#Consumer-object) with:
+{% if page.params.consumer_id %}
+
+{% capture plugin_config_for_consumer_admin_api %}
+
+For example, configure this plugin on a [Consumer](/latest/admin-api/#Consumer-object) with:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/plugins \
+$ curl -X POST http://<admin-hostname>:8001/consumers/<consumer>/plugins \
     --data "name={{page.params.name}}" {{ config_required_fields }}
 ```
+
 {% endcapture %}
 
 {% capture plugin_config_for_consumer %}
 ### Enabling the plugin on a Consumer
 
-{% if page.enterprise or page.params.dbless_compatible == false or page.params.dbless_compatible == nil %}
+{% if page.params.yaml_examples == false and page.params.k8s_examples == false %}
 
-{{ plugin_config_for_consumer_with_db }}
+{{ plugin_config_for_consumer_admin_api }}
 
-{% elsif page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
+{% else %}
+
 {% navtabs %}
+{% navtab Kong Admin API %}
 
-{% navtab With a database %}
-
-{{ plugin_config_for_consumer_with_db }}
+{{ plugin_config_for_consumer_admin_api }}
 
 {% endnavtab %}
-{% navtab Without a database %}
+{% unless page.params.yaml_examples == false %}
+{% navtab Declarative (YAML) %}
 
-Configure this plugin on a [Consumer](/latest/admin-api/#consumer-object) by
+For example, configure this plugin on a [Consumer](/latest/admin-api/#consumer-object) by
 adding this section to your declarative configuration file:
 
 ``` yaml
 plugins:
 - name: {{page.params.name}}
-  consumer: {consumer}
-  {{ config_required_fields_yaml }}
+  consumer: <consumer>
+  {% if config_required_fields_yaml == 'config: ' %}config:
+    <optional_parameter>: <value>{% else %}{{ config_required_fields_yaml }}{% endif %}
 ```
 {% endnavtab %}
+{% endunless %}
 {% endnavtabs %}
 {% endif %}
 
-`{consumer}` is the `id` or `username` of the Consumer that this plugin configuration will target.
+`<consumer>` is the `id` or `username` of the Consumer that this plugin
+  configuration will target.
 
-{% if page.params.service_id or page.params_route_id or page.params.api_id %}
-You can combine `consumer.id` and {%
-  if page.params.service_id %}`service.id`{%
-  elsif page.params.route_id %}`route.id`{%
-  elsif page.params.api_id %}`api_id`{%
+{% if page.params.service_id and page.params.route_id %}
+  You can combine `consumer.id`, `service.id`, or `route.id`
+{% elsif page.params.service_id %} and `service.id`
+{% elsif page.params.route_id %} and `route.id`{%
   endif %} in the same request, to further narrow the scope of the plugin.
-{% endif %}
 
 {% endcapture %}
 {% endif %}
 
-{% if page.params.api_id %}
-{% capture plugin_config_for_api %}
-### Enabling the plugin on an API
+<!-- Global config example -->
 
-If you are using an older version of Kong with the legacy [API
-entity](/0.13.x/admin-api/#api-object) (**deprecated** in favor of Services
-since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">
-CE 0.13.0</a> and
-<a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.), you
-can configure this plugin on top of such an API by making the following request:
+{% capture plugin_global_config_admin_api %}
+
+For example, configure this plugin globally with:
 
 ```bash
-$ curl -X POST http://kong:8001/apis/{api}/plugins \
+$ curl -X POST http://<admin-hostname>:8001/plugins/ \
     --data "name={{page.params.name}}" {{ config_required_fields }}
 ```
-
-* `api`: either id or name of the API that this plugin configuration will
-  target.
 {% endcapture %}
+
+{% capture plugin_global_config %}
+### Enabling the plugin globally
+
+A plugin which is not associated to any Service, Route, or Consumer is
+considered _global_, and will be run on every request. Read the
+[Plugin Reference](/latest/admin-api/#add-plugin) and the [Plugin Precedence](/latest/admin-api/#precedence)
+sections for more information.
+
+{% if page.params.yaml_examples == false and page.params.k8s_examples == false %}
+
+{{ plugin_global_config_admin_api }}
+
+{% else %}
+{% navtabs %}
+{% navtab Kong Admin API %}
+
+{{ plugin_global_config_admin_api }}
+
+{% endnavtab %}
+{% unless page.params.yaml_examples == false %}
+{% navtab Declarative (YAML) %}
+For example, configure this plugin using the <code>plugins:</code> entry in the declarative
+configuration file:
+
+``` yaml
+plugins:
+- name: {{page.params.name}}
+  {% if config_required_fields_yaml == 'config: ' %}config:
+    <optional_parameter>: <value>{% else %}{{ config_required_fields_yaml }}{% endif %}
+```
+{% endnavtab %}
+{% endunless %}
+{% endnavtabs %}
 {% endif %}
+{% endcapture %}
 
 {% capture params_table %}
 <table>
@@ -228,16 +291,17 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
     {% if page.params.consumer_id %}
       <tr><td><code>consumer.id</code></td><td>The ID of the Consumer the plugin targets.</td></tr>
     {% endif %}
-      <tr><td><code>enabled</code><br><br><strong>default value: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
+      <tr><td><code>enabled</code><br><br><strong>default field: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
     {% if page.params.api_id %}
     <tr><td><code>api_id</code></td><td>The ID of the API the plugin targets. <br><br><strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
     {% endif %}
     {% for field in page.params.config %}
       <tr>
         <td><code>config.{{ field.name }}</code>
+          {% if field.required == true %}<br><em>required</em>{% endif %}
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default | markdownify }}{% endif %}
+          {% if field.default != nil %}<br><br><strong>default field: </strong>{{ field.default | markdownify }}{% endif %}
         </td>
         <td>{{ field.description | markdownify }}</td>
       </tr>
@@ -360,8 +424,16 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
         <hr>
       {% endif %}
 
-      {% if page.type == "plugin" %}
-        <h2 id="configuration">Configuration</h2>
+      {% unless extn_publisher == "kong-inc" %}{{ content }}{% endunless %}
+
+      {% if page.type == "plugin" and page.params %}
+        <h2 id="configuration">Configuration Reference</h2>
+        {% if page.params.yaml_examples != false %}
+        <p>You can configure this plugin using the
+        {% if page.enterprise %}<a href="/enterprise/latest/admin-api/#plugin-object">Kong Admin API</a>{% else %}<a href="/latest/admin-api/#plugin-object">Kong Admin API</a>{% endif %}
+        or through <a href="/deck">declarative configuration</a>, which involves directly editing
+        the Kong configuration file.<p/>
+        {% endif %}
         {% if page.params.protocols %}
           <p>This plugin is compatible with requests with the following protocols:</p>
           <ul>
@@ -378,38 +450,29 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
         {% elsif page.params.dbless_compatible != nil %}
           <p>This plugin is <strong>not compatible</strong> with DB-less mode.</p>
         {% endif %}
+        {% if page.params.dbless_compatible == "partially" or page.params.dbless_compatible == true %}
+          <p>In DB-less mode, Kong does not have an Admin API. If using this
+            mode, configure the plugin using declarative configuration.<p>
+        {% endif %}
 
         {% if page.params.dbless_explanation %}
           {{ page.params.dbless_explanation | markdownify }}
         {% endif %}
 
-        {% if page.params.service_id %}
-          {{ plugin_config_for_service | markdownify }}
-        {% endif %}
-        {% if page.params.route_id %}
-          {{ plugin_config_for_route | markdownify }}
-        {% endif %}
-        {% if page.params.consumer_id %}
-          {{ plugin_config_for_consumer | markdownify }}
-        {% endif %}
-        {% if page.params.api_id %}
-          {{ plugin_config_for_api | markdownify }}
-        {% endif %}
-
-        <h3 id="global-plugins">Global plugins</h3>
-        <p>A plugin which is not associated to any Service, Route, or Consumer (or API, if you are using an older
-        version of Kong) is considered "global", and will be run on every request.
-        Read the <a href="/latest/admin-api/#add-plugin">Plugin Reference</a> and the
-        <a href="/latest/admin-api/#precedence">Plugin Precedence</a> sections for more information.
-        </p>
-        {% if page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}
-        <ul>
-          <li><strong>Using a database</strong>, all plugins can be configured using the <code>http://kong:8001/plugins/</code> endpoint.</li>
-          <li><strong>Without a database</strong>, all plugins can be configured via the <code>plugins:</code> entry on the declarative configuration file.</li>
-        </ul>
-        {% else %}
-        <p>Plugins can be configured using the <code>http://kong:8001/plugins/</code> endpoint.
-        </p>
+        {% if page.params.examples != false %}
+          {% if page.params.service_id %}
+            {{ plugin_config_for_service | markdownify }}
+          {% endif %}
+          {% if page.params.route_id %}
+            {{ plugin_config_for_route | markdownify }}
+          {% endif %}
+          {% if page.params.consumer_id %}
+            {{ plugin_config_for_consumer | markdownify }}
+          {% endif %}
+          {% if page.params.api_id %}
+            {{ plugin_config_for_api | markdownify }}
+          {% endif %}
+          {{ plugin_global_config | markdownify }}
         {% endif %}
 
         <h3 id="parameters">Parameters</h3>
@@ -422,7 +485,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 
       {{ page.params.extra | markdownify }}
 
-      {{ content }}
+      {% if extn_publisher == "kong-inc" %}{{ content }}{% endif %}
 
       {% if page.terms_of_service %}
         <h3 id="terms-of-service">Terms of Service</h3>
@@ -470,6 +533,17 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
             </ul>
           </td>
         </tr>
+        {% unless page.enterprise or page.params.dbless_compatible == nil %}
+        <tr>
+          <td>DB-less compatible?</td>
+          <td>
+            <a href="/hub/plugins/compatibility">{% if page.params.dbless_compatible == "yes" or page.params.dbless_compatible == true %}Yes{% endif %}{%
+               if page.params.dbless_compatible == "no" or page.params.dbless_compatible == false %}No{% endif %}{%
+               if page.params.dbless_compatible == "partially" %}Partially{% endif %}
+               {% if page.params.dbless_compatible == "yes" or page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}({{site.ce_product_name}} only){% endif %}</a>
+          </td>
+        </tr>
+        {% endunless %}
         {% if page.support_url %}
           {% assign support_dom = page.support_url | split: "/" %}
           {% assign support_dom = support_dom[2] | remove: "www." | remove: "support." | remove: "help." | remove: "docs." %}

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -538,9 +538,9 @@ plugins:
           <td>DB-less compatible?</td>
           <td>
             <a href="/hub/plugins/compatibility">{% if page.params.dbless_compatible == "yes" or page.params.dbless_compatible == true %}Yes{% endif %}{%
-               if page.params.dbless_compatible == "no" or page.params.dbless_compatible == false %}No{% endif %}{%
-               if page.params.dbless_compatible == "partially" %}Partially{% endif %}
-               {% if page.params.dbless_compatible == "yes" or page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}({{site.ce_product_name}} only){% endif %}</a>
+              if page.params.dbless_compatible == "no" or page.params.dbless_compatible == false %}No{% endif %}{%
+              if page.params.dbless_compatible == "partially" %}Partially{% endif %}
+              {% if page.params.dbless_compatible == "yes" or page.params.dbless_compatible == true or page.params.dbless_compatible == "partially" %}({{site.ce_product_name}} only){% endif %}</a>
           </td>
         </tr>
         {% endunless %}


### PR DESCRIPTION
### Summary
This PR introduces declarative YAML examples for all plugins. 

To make these examples work required the following:
1. Adjustments to the plugin template in /app/_layouts/extensions.html to parse declarative yaml examples.
2. Adjustments to the plugin template to position DB-less as a mode of deployment and not as equal to declarative config.
DB-less compatibility now sits in the right-hand table along with other plugin info, and links to the plugin compatibility table.
3. Fixes of the plugin values for accuracy and to fit templates.
4. Removal of API entity examples.
5. For third party plugins only: as these plugins need to be installed from an external source before using, the install info is now moved above the examples and general config.

### Testing and remaining work
All Kong Inc plugin examples have been tested; most plugins examples should now work, other than the following exceptions:
* Response Rate Limiting: unique syntax that isn't used in other plugins, this needs a non-templated example
* Kafka upstream and Kafka Log: template syntax still needs adjustment for mapping values
* Exit transformer: Needs a yaml example; cURL and YAML seem to require very different values here
* OAuth2: No declarative examples, as this plugin is ostensibly not compatible?
* OpenID Connect: Config section deactivated, as this plugin doc is complex and written in a different format from other plugins.

Third-party plugins have been spot-tested and most work. Some still have missing values, and that will require further testing in a future edit.

### Plugin doc metadata
For doc writers: changes to the template introduce the following metadata, which you can set in your plugin doc going forward:
* `yaml_examples` - default is true. Set to false to disable declarative yaml examples.
* `k8s_examples` - default is true. Set to false to disable autogenerated kubernetes examples (these examples don't exist yet, but this param adds the foundation for them. Currently needed to circumvent the tabs format in the OAuth plugin.)
* `examples` - default is true. Set to false to disable all autogenerated examples (cURL, Declarative YAML, and later K8S YAML)

### Previews
* [Sample Kong Inc Enterprise plugin with YAML example](https://deploy-preview-2238--kongdocs.netlify.app/hub/kong-inc/application-registration/)
* [Sample Kong Inc Community plugin with YAML example](https://deploy-preview-2238--kongdocs.netlify.app/hub/kong-inc/ldap-auth/)
See "DB-less compatible?" entry in the table on the right-hand nav. If the entry is "Yes" or "Partially", it will also say "Kong Gateway only" (ie, Community).
* [Sample plugin with schema value in example](https://deploy-preview-2238--kongdocs.netlify.app/hub/kong-inc/request-validator/)
* [Sample plugin with many nested arrays](https://deploy-preview-2238--kongdocs.netlify.app/hub/kong-inc/request-transformer/)
This one might need more tweaking - currently each top-level param (eg remove) has multiple sections. However, decK parses and reformats it just fine, so is this okay to leave as is? At the moment, not sure how to write the code for combining sections.
* [Sample third-party plugin with the install and config reference sections switched](https://deploy-preview-2238--kongdocs.netlify.app/hub/inspur/apig-response-transform/)