### PR TITLE
docs(landing pages) Disable image expand on resources icons

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -152,15 +152,15 @@ id: documentation
             <div class="knowledge-base-links">
               <a class="knowledge-base-link" href="https://support.konghq.com/" target="_blank">
                 <div class="knowledge-base-link-title">Support</div>
-                <img src="/assets/images/icons/documentation/icn-support.svg" />
+                <img class="no-image-expand" src="/assets/images/icons/documentation/icn-support.svg" />
               </a>
               <a class="knowledge-base-link" href="https://discuss.konghq.com/" target="_blank">
                 <div class="knowledge-base-link-title">Community</div>
-                <img src="/assets/images/icons/documentation/icn-kongnation-md.svg" />
+                <img class="no-image-expand" src="/assets/images/icons/documentation/icn-kongnation-md.svg" />
               </a>
               <a class="knowledge-base-link" href="https://learn.konghq.com/account/login/" target="_blank">
                 <div class="knowledge-base-link-title">Kong University</div>
-                <img src="/assets/images/icons/documentation/icn-learning.svg" />
+                <img class="no-image-expand" src="/assets/images/icons/documentation/icn-learning.svg" />
               </a>
             </div>
           </div>


### PR DESCRIPTION
Adding the `no-image-expand` class to icons at the bottom of landing pages (https://docs.konghq.com/, https://docs.konghq.com/enterprise, and https://docs.konghq.com/deck), in the resource section.