### PR TITLE
docs(hybrid): Add required KONG_CLUSTER_TELEMETRY_ENDPOINT

### DIFF
--- a/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
@@ -185,6 +185,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     role = data_plane
     database = off
     cluster_control_plane = control-plane.<admin-hostname>.com:8005
+    cluster_telemetry_endpoint = control-plane.<admin-hostname>.com:8006
     cluster_cert = /<path-to-file>/cluster.crt
     cluster_cert_key = /<path-to-file>/cluster.key
     lua_ssl_trusted_certificate = /<path-to-file>/cluster.crt


### PR DESCRIPTION
In hybrid mode, the data planes need to have `KONG_CLUSTER_TELEMETRY_ENDPOINT` specified and pointing to the control plane. Otherwise, `127.0.0.1:8006` is assumed which will fail and cause constant errors to be printed to the log.

/cc @fffonion 