### PR TITLE
docs(hybrid) Fix cluster_cert property name

### DIFF
--- a/app/2.1.x/hybrid-mode.md
+++ b/app/2.1.x/hybrid-mode.md
@@ -111,7 +111,7 @@ and redundancy as long as they points to the same backend database.
 Starting in Kong 2.1, the Hybrid cluster can use certificates signed by a central certificate authority (CA).
 This mode can be activated by setting `cluster_mtls` to `"pki"` in `kong.conf`. The default value is `"shared"`.
 
-In PKI mode, the Control Plane and Data Plane don't need to use the same `cluster_key` and `cluster_cert_key`.
+In PKI mode, the Control Plane and Data Plane don't need to use the same `cluster_cert` and `cluster_cert_key`.
 Instead, Kong validates both sides by checking if they are from the same CA. This eliminates the risk of
 transporting private keys around.
 


### PR DESCRIPTION
Unless `cluster_key` is an undocumented property, this is a typo and should be `cluster_cert`.