### PR TITLE
fix typo in deprecated Route by Header plugin

### DIFF
--- a/app/_hub/kong-inc/route-by-header/index.md
+++ b/app/_hub/kong-inc/route-by-header/index.md
@@ -46,7 +46,7 @@ params:
 | `condition` |  List of headers name and value pairs |
 | `upstream_name` |  Target hostname where traffic will be routed in case of condition match |
 
-Note: if more than one pair of header name and value is provided, the plugin looks for all of these
+Note: If more than one pair of header name and value is provided, the plugin looks for all of these
 in the request - that is, requests must contain all of the specified headers with the specified
 values for a match to occur.
 
@@ -61,7 +61,7 @@ The first such match dictates the upstream to which the request is forwarded to.
 ## Example
 
 Let's run through an example scenario to demonstrate the plugin. Let's say we have
-a Kong service `searviceA`, which routes all the requests to upstream `default.domain.com`.
+a Kong service `serviceA`, which routes all the requests to upstream `default.domain.com`.
 
 Add an upstream object and a target:
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1266

Pointed out by Aaron Miller. Note that this plugin is deprecated but will exist on the hub for older versions for some time until its removal.

Direct review link:

https://deploy-preview-2257--kongdocs.netlify.app/hub/kong-inc/route-by-header/#example