### PR TITLE
docs(hybrid-mode) use "database" instead of "storage" when enabling

### DIFF
--- a/app/2.1.x/hybrid-mode.md
+++ b/app/2.1.x/hybrid-mode.md
@@ -306,8 +306,8 @@ have already specified a different `lua_ssl_trusted_certificate`, then adding th
 of `cluster.crt` into that file will achieve the same result.
 
 **Note:** In this release of the Hybrid Mode, the Data Plane receives updates from the Control
-Plane via a format that is similar to the Declarative Config, therefore the `storage`
-property has to be set to `memory` for Kong to start up properly.
+Plane via a format that is similar to the Declarative Config, therefore the `database`
+property has to be set to `off` for Kong to start up properly.
 
 ```
 KONG_ROLE=data_plane KONG_CLUSTER_CONTROL_PLANE=control-plane.example.com:8005 KONG_CLUSTER_CERT=cluster.crt KONG_CLUSTER_CERT_KEY=cluster.key KONG_LUA_SSL_TRUSTED_CERTIFICATE=cluster.crt KONG_DATABASE=off kong start


### PR DESCRIPTION
DB-less mode
