### PR TITLE
docs (release-notes) update version used in title

### DIFF
--- a/app/enterprise/2.1.x/release-notes.md
+++ b/app/enterprise/2.1.x/release-notes.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Enterprise 2.1.3.0 Release Notes
+title: Kong Enterprise 2.1.x Release Notes
 ---
 
 These release notes provide a high-level overview of Kong Enterprise release version 2.1.3.0, which includes version 2.1.0.0 (beta)
@@ -54,27 +54,6 @@ For more information, see the [Vitals Overview](/enterprise/{{page.kong_version}
 For the {{site.ee_product_name}}, Kong for Kubernetes Enterprise (K4K8s) now uses the `kong-enterprise-edition` image, which works as a drop-in replacement for the `kong-enterprise-k8s` image used in earlier versions.
 
 For more information, including instructions for switching images, see [Kong for Kubernetes Deployment Options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options/).
-
-## What's New in the Docs
-
-In addition to the features listed above, updates to Kong's user documentation and Docs site include:
-* [decK documentation](https://docs.konghq.com/deck/) has moved to docs.konghq.com.
-* Improved [Vitals section](/enterprise/{{page.kong_version}}/vitals/overview/), including new [Overview](/enterprise/{{page.kong_version}}/vitals/overview/), [Reports](/enterprise/{{page.kong_version}}/vitals/vitals-reports/), and [Metrics](/enterprise/{{page.kong_version}}/vitals/vitals-metrics/) topics.
-* New and Updated Plugins topics:
-  * Declarative configuration (YAML) information added to Plugins examples. 
-  * [Plugin Overview](/hub/plugins/overview/) introduces the most basic things you need to know to get started with plugins: what they are, why you might use them, terminology, and information on creating your own plugins and plugin documentation.
-  * [Plugin Compatibility Matrix](/hub/plugins/compatibility/) compares the various Kong Gateway deployment modes.
-  * [gRPC Gateway](/hub/kong-inc/grpc-gateway/) Plugin documentation is improved. 
-* New Deployment topics:
-  * [Kong Deployment Options](/enterprise/{{page.kong_version}}/deployment/deployment-options/)
-  * [DNS Considerations](/enterprise/{{page.kong_version}}/deployment/dns-considerations/)
-  * [Kong Security Update Process](/enterprise/{{page.kong_version}}/kong-security-update-process/)
-* Improved Kubernetes topics:
-  * [Kubernetes Deployment Options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options/) breaks down the differences between the two available Kong Enterprise images and helps you choose a deployment.
-  * [Installing Kong Enterprise on Kubernetes](/enterprise/{{page.kong_version}}/kong-for-kubernetes/install-on-kubernetes/) walks you through installation of the `kong-enterprise-edition` image on Kubernetes with all Enterprise plugins and add-ons.
-* [Installation topics](/enterprise/{{page.kong_version}}/deployment/installation/overview/) reorganized.
-* New [Version Support](/enterprise/{{page.kong_version}}/support-policy/) information and matrix.
-* New Doc site improvements, including: table of contents rework; collapsible sub-sections; mobile layout fixes; images expand on click; ability to copy code snippets; ability to stay on same topic when navigating between versions; right-hand navigation "On this page" redesign with collapse and reopen feature; scroll to the top button; and resizable table columns.
 
 ## Known Issues and Workarounds
 


### PR DESCRIPTION
-- updated version used in release notes from 2.1.3.0 to 2.1.x
-- removed "What's New in the Docs", as creating own page. 

