### PR TITLE
Application Registration Documentation Enhancements Part 1

### DIFF
--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -92,8 +92,10 @@ the Issuer URL is essential for the
 ## Next steps
 
 * If using the Kong-managed authorization strategy
-(`kong-oauth2`), configure the OAuth2 plugin. You can use the Kong Manager GUI
-or cURL commands as documented on the [Plugin Hub](/hub/kong-inc/oauth2).
+(`kong-oauth2`, configure the OAuth2 plugin.
+ You can use the Kong Manager GUI or cURL commands as documented on the
+ [Plugin Hub](/hub/kong-inc/oauth2). This plugin cannot be used in hybrid mode.
 * if using the third-party authorization strategy
 (`external-oauth2`), configure the OIDC plugin. You can use the GUI or cURL
-commands as documented on the plugin hub.
+commands as documented on the [Plugin Hub](/hub/kong-inc/openid-connect). This
+plugin must be used in hybrid mode.

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -85,17 +85,19 @@ Default: `false`
 
 Displays the Issuer URL in the Service Details. **Note:** Exposing
 the Issuer URL is essential for the
-[Authorization Code Flow](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow) workflow configured for third-party identity providers.
+[Authorization Code Flow](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow)
+workflow configured for third-party identity providers.
 
 ![Issuer URL](/assets/images/docs/dev-portal/dev-portal-issuer-url.png)
 
 ## Next steps
 
 * If using the Kong-managed authorization strategy
-(`kong-oauth2`, configure the OAuth2 plugin.
+(`kong-oauth2`), configure the OAuth2 plugin.
  You can use the Kong Manager GUI or cURL commands as documented on the
- [Plugin Hub](/hub/kong-inc/oauth2). This plugin cannot be used in hybrid mode.
+ [Plugin Hub](/hub/kong-inc/oauth2). The OAuth2 plugin cannot be used in hybrid mode.
 * If using the third-party authorization strategy
-(`external-oauth2`), configure the OIDC plugin. You can use the GUI or cURL
-commands as documented on the [Plugin Hub](/hub/kong-inc/openid-connect). This
-plugin must be used in hybrid mode.
+(`external-oauth2`), configure the OIDC plugin. You can use the Kong Manager GUI
+or cURL commands as documented on the [Plugin Hub](/hub/kong-inc/openid-connect).
+When your deployment is hybrid mode, the OIDC plugin must be configured to handle
+authentication for the Portal Application Registration plugin.

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -95,7 +95,7 @@ the Issuer URL is essential for the
 (`kong-oauth2`, configure the OAuth2 plugin.
  You can use the Kong Manager GUI or cURL commands as documented on the
  [Plugin Hub](/hub/kong-inc/oauth2). This plugin cannot be used in hybrid mode.
-* if using the third-party authorization strategy
+* If using the third-party authorization strategy
 (`external-oauth2`), configure the OIDC plugin. You can use the GUI or cURL
 commands as documented on the [Plugin Hub](/hub/kong-inc/openid-connect). This
 plugin must be used in hybrid mode.

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -58,7 +58,8 @@ Available options:
             # Developer Portal application registration
             # auth provider and strategy. Must be set to configure the
             # application_registration plugin.
-            # Currently accepts kong-oauth2 (default) or external-oauth2.
+            # Currently accepts kong-oauth2 (default, cannot be used with hybrid
+            #  mode) or external-oauth2 (must be used with hybrid mode).
    ```
 
 2. [Restart](https://docs.konghq.com/2.1.x/cli/#kong-restart) your Kong Enterprise

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -23,7 +23,7 @@ OAuth2 plugins for use with the Application Registration plugin:
 - When Kong is the system of record, the Application Registration plugin works
   in conjunction with the Kong OAuth2 plugin.
 
-  **Note:** The Kong OAuth2 plugin does not support
+  **Important:** The Kong OAuth2 plugin does not support
   [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/).
   If your organization uses hybrid mode, you must use an external identity
   provider and configure the Kong OIDC plugin.

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -44,15 +44,16 @@ authorization strategy.
 Available options:
 
 * `kong-oauth2`: Default. Kong is the system of record. The Application
-  Registration plugin is used in conjunction with the Kong OAuth2 plugin. This
-  option cannot be used with hybrid mode deployments. The `kong-oauth2` option
-  can be used with classic (traditional) deployments.
-* `external-oauth2`: An external IdP is the system of record. The 
+  Registration plugin is used in conjunction with the Kong OAuth2 plugin.
+  The `kong-oauth2` option can only be used with classic (traditional) deployments.
+  Because the OAuth2 plugin requires a database for every Kong instance, the
+  `kong-oauth2` option cannot be used with hybrid mode deployments.
+* `external-oauth2`: An external IdP is the system of record. The
   Portal Application Registration plugin is used in conjunction with the Kong
-  OIDC plugin. The `external-oauth2` option must be used with
+  OIDC plugin. The `external-oauth2` option can be used with any deployment type.
+  The `external-oauth2` option must be used with
   [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/)
-  deployments instead of `kong-oauth2`. The `external-oauth2` option can also be used
-  with classic (traditional) deployments.
+  deployments because hybrid mode does not support `kong-oauth2`.
 
 1. Open `kong.conf.default` and set the `portal_app_auth` option to your chosen
    strategy. The example configuration below switches from the default

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -23,10 +23,11 @@ OAuth2 plugins for use with the Application Registration plugin:
 - When Kong is the system of record, the Application Registration plugin works
   in conjunction with the Kong OAuth2 plugin.
 
-  **Important:** The Kong OAuth2 plugin does not support
-  [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/).
-  If your organization uses hybrid mode, you must use an external identity
-  provider and configure the Kong OIDC plugin.
+  <div class="alert alert-warning">
+    <strong>Important:</strong> The Kong OAuth2 plugin does not support
+    hybrid mode. If your organization uses hybrid mode, you must use an external identity
+    provider and configure the Kong OIDC plugin.
+  </div>
 
 - When an external OAuth2 is the system of record, the Application Registration
   plugin works in conjunction with the Kong OIDC plugin.
@@ -47,7 +48,8 @@ Available options:
   option cannot be used with hybrid mode deployments.
 * `external-oauth2`: An external IdP is the system of record. The Developer
   Portal Application Registration plugin is used in conjunction with the Kong
-  OIDC plugin. This option must be used with hybrid mode deployments.
+  OIDC plugin. This option must be used with
+  [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/) deployments.
 
 1. Open `kong.conf.default` and set the `portal_app_auth` option to your chosen
    strategy. The example configuration below switches from the default

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -45,7 +45,8 @@ Available options:
 
 * `kong-oauth2`: Default. Kong is the system of record. The Application
   Registration plugin is used in conjunction with the Kong OAuth2 plugin. This
-  option cannot be used with hybrid mode deployments.
+  option cannot be used with hybrid mode deployments. The `kong-oauth2` option
+  can be used with classic (traditional) deployments.
 * `external-oauth2`: An external IdP is the system of record. The Developer
   Portal Application Registration plugin is used in conjunction with the Kong
   OIDC plugin. The `external-oauth2` option must be used with

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -48,8 +48,10 @@ Available options:
   option cannot be used with hybrid mode deployments.
 * `external-oauth2`: An external IdP is the system of record. The Developer
   Portal Application Registration plugin is used in conjunction with the Kong
-  OIDC plugin. This option must be used with
-  [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/) deployments.
+  OIDC plugin. The `external-oauth2` option must be used with
+  [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/)
+  deployments instead of `kong-oauth2`. The `external-oauth2` option can also be used
+  with classic (traditional) deployments.
 
 1. Open `kong.conf.default` and set the `portal_app_auth` option to your chosen
    strategy. The example configuration below switches from the default

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -56,10 +56,9 @@ Available options:
    ```
    portal_app_auth = external-oauth2
             # Developer Portal application registration
-            # auth provider and strategy. Must be set to configure the
-            # application_registration plugin.
-            # Currently accepts kong-oauth2 (default, cannot be used with hybrid
-            #  mode) or external-oauth2 (must be used with hybrid mode).
+            # auth provider and strategy. Must be set to configure
+            # authentication in conjunction with the application_registration plugin.
+            # Currently accepts kong-oauth2 or external-oauth2.
    ```
 
 2. [Restart](https://docs.konghq.com/2.1.x/cli/#kong-restart) your Kong Enterprise
@@ -67,7 +66,7 @@ Available options:
 
 ### Next steps
 
-1. If you plan to use external OAuth, review the
+1. If you plan to use external OAuth2, review the
 [recommended workflows](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#supported-oauth-flows).
 Configure the identity provider for your application, configure your
 <<<<<<< HEAD

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -15,16 +15,21 @@ providers. Developers have the flexibility to choose from either
 Kong or a third-party identity provider (IdP) as the system of record for
 application credentials. With third-party (external) OAuth2 support, developers
 can centralize application credential management with the
-[supported identity provider](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#idps) of their
-choice.
+[supported identity provider](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#idps)
+of their choice.
 
 OAuth2 plugins for use with the Application Registration plugin:
 
 - When Kong is the system of record, the Application Registration plugin works
-in conjunction with the Kong OAuth2 plugin.
+  in conjunction with the Kong OAuth2 plugin.
+
+  **Note:** The Kong OAuth2 plugin does not support
+  [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/).
+  If your organization uses hybrid mode, you must use an external identity
+  provider and configure the Kong OIDC plugin.
 
 - When an external OAuth2 is the system of record, the Application Registration
-plugin works in conjunction with the Kong OIDC plugin.
+  plugin works in conjunction with the Kong OIDC plugin.
 
 The third-party authorization strategy (`external-oauth2`) applies to all
 applications across all Workspaces (Dev Portals) in a Kong cluster.
@@ -37,10 +42,16 @@ authorization strategy.
 
 Available options:
 
-* `kong-oauth2`: Default. Kong is the system of record. The Application Registration plugin is used in conjunction with the Kong OAuth2 plugin.
-* `external-oauth2`: An external IdP is the system of record. The Developer Portal Application Registration plugin is used in conjunction with the Kong OIDC plugin.
+* `kong-oauth2`: Default. Kong is the system of record. The Application
+  Registration plugin is used in conjunction with the Kong OAuth2 plugin. This
+  option cannot be used with hybrid mode deployments.
+* `external-oauth2`: An external IdP is the system of record. The Developer
+  Portal Application Registration plugin is used in conjunction with the Kong
+  OIDC plugin. This option must be used with hybrid mode deployments.
 
-1. Open `kong.conf.default` and set the `portal_app_auth` option to your chosen strategy. The example configuration below switches from the default (`kong-oauth2`) to an external IdP (`external-oauth2`).
+1. Open `kong.conf.default` and set the `portal_app_auth` option to your chosen
+   strategy. The example configuration below switches from the default
+   (`kong-oauth2`) to an external IdP (`external-oauth2`).
 
    ```
    portal_app_auth = external-oauth2
@@ -50,14 +61,20 @@ Available options:
             # Currently accepts kong-oauth2 (default) or external-oauth2.
    ```
 
-2. Restart your Kong Enterprise instance.
+2. [Restart](https://docs.konghq.com/2.1.x/cli/#kong-restart) your Kong Enterprise
+   instance.
 
 ### Next steps
 
 1. If you plan to use external OAuth, review the
 [recommended workflows](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#supported-oauth-flows).
 Configure the identity provider for your application, configure your
+<<<<<<< HEAD
 application in Kong, and associate them with each other. See the [Okta](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config), or the [Azure](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config) setup examples.
+=======
+application in Kong, and associate them with each other. See the
+[Okta example](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
+>>>>>>> cf9bcc93f6... hybrid mode limitations; links; edits; char wrap
 2. Enable the [Application Registration plugin](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
 3. Depending on your configured authentication strategy, configure the Kong
 [OAuth2](/hub/kong-inc/oauth2) or

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -47,7 +47,7 @@ Available options:
   Registration plugin is used in conjunction with the Kong OAuth2 plugin. This
   option cannot be used with hybrid mode deployments. The `kong-oauth2` option
   can be used with classic (traditional) deployments.
-* `external-oauth2`: An external IdP is the system of record. The Developer
+* `external-oauth2`: An external IdP is the system of record. The 
   Portal Application Registration plugin is used in conjunction with the Kong
   OIDC plugin. The `external-oauth2` option must be used with
   [hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/)

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/index.md
@@ -74,12 +74,9 @@ Available options:
 1. If you plan to use external OAuth2, review the
 [recommended workflows](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#supported-oauth-flows).
 Configure the identity provider for your application, configure your
-<<<<<<< HEAD
-application in Kong, and associate them with each other. See the [Okta](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config), or the [Azure](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config) setup examples.
-=======
 application in Kong, and associate them with each other. See the
-[Okta example](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
->>>>>>> cf9bcc93f6... hybrid mode limitations; links; edits; char wrap
+[Okta](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config),
+or the [Azure](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config) setup examples.
 2. Enable the [Application Registration plugin](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
 3. Depending on your configured authentication strategy, configure the Kong
 [OAuth2](/hub/kong-inc/oauth2) or

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
@@ -67,7 +67,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
    ```
 
-8. Configure a Portal Application Registration plugin on the Service as well. See [Application Registration](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#config-app-reg-plugin).
+8. Configure a Portal Application Registration plugin on the Service as well. See
+[Application Registration](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#config-app-reg-plugin).
 
 ## Register an application in Okta
 

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
@@ -1,5 +1,5 @@
 ---
-title: Set up Okta and Kong for use with external OAuth
+title: Set Up External Portal Application Authentication with Okta and OIDC
 ---
 
 ## Overview

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
@@ -103,7 +103,7 @@ Okta application with the corresponding application in Kong's Developer Portal.
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Each developer should have their own application in both Okta and Kong.  
-  Each Okta application has its own `client_id` that maps to its respective developer in Kong.
+  Each Okta application has its own `client_id` that maps to its respective application in Kong.
   Essentially, this maps identity provider applications to portal applications.
 </div>
 

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
@@ -51,8 +51,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
    2. In the `Config.Consumer Claim` field, enter `<application_id>`.
 
    **Tip:** Because Okta's discovery document does not include all supported
-   auth types by default, it is recommended to disable the
-   `config.verify_parameters` option.
+   auth types by default, ensure the
+   `config.verify_parameters` option is disabled.
 
    ![Clear Config Verify Parameters for OIDC with Okta](/assets/images/docs/dev-portal/oidc-clear-verify-params-app-reg.png)
 

--- a/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/enterprise/2.1.x/developer-portal/administration/application-registration/okta-config.md
@@ -39,7 +39,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
    ![Okta Claim](/assets/images/docs/dev-portal/okta-add-claim.png)
 
-    Now that you have created a custom claim, you can associate the `client_id` with a Service via the Application Registration plugin. Start by creating a Service in Kong Manager.
+    Now that you have created a custom claim, you can associate the `client_id`
+    with a Service via the Application Registration plugin. Start by creating a Service in Kong Manager.
 
 7. Create a Service and a Route and instantiate an OIDC plugin on that Service.
    You can allow most options to use their defaults.
@@ -48,7 +49,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
       ![OIDC with Okta Issuer URL](/assets/images/docs/dev-portal/oidc-issuer-url.png)
 
-   2. In the `Config.Consumer Claim` field, enter `<application_id>`.
+   2. In the `Config.Consumer Claim` field, enter your `<application_id>`.
 
    **Tip:** Because Okta's discovery document does not include all supported
    auth types by default, ensure the
@@ -99,6 +100,13 @@ your Okta application will vary:
 
 Now that the application has been configured in Okta, you need to associate the
 Okta application with the corresponding application in Kong's Developer Portal.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> Each developer should have their own application in both Okta and Kong.  
+  Each Okta application has its own `client_id` that maps to its respective developer in Kong.
+  Essentially, this maps identity provider applications to portal applications.
+</div>
+
 This example assumes Client Credentials is the chosen OAuth flow.
 
 1. In the Kong Dev Portal, create an account if you haven't already.

--- a/app/enterprise/2.1.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.1.x/plugins/oidc-okta.md
@@ -5,15 +5,26 @@ title: OpenID Connect with Okta
 
 This guide covers an example OpenID Connect plugin configuration to authenticate browser clients using an Okta identity provider.
 
+For information about configuring OIDC using Okta as an Identity provider
+in conjunction with the Application Registration plugin, see
+[Set Up External Portal Application Authentication with Okta and OIDC](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
+
 ## Prerequisites
 
-Because OpenID Connect deals with user credentials, all transactions should take place over HTTPS. Although user passwords for third party identity providers are only submitted to those providers and not Kong, authentication tokens grant access to a subset of user account data and protected APIs, and should be secured. As such, you should make Kong's proxy available via a fully-qualified domain name and [add a certificate][add-certificate] for it.
+Because OpenID Connect deals with user credentials, all transactions should take place over HTTPS.
+Although user passwords for third party identity providers are only submitted to
+those providers and not Kong, authentication tokens grant access to a subset of
+user account data and protected APIs, and should be secured. As such, you should
+make Kong's proxy available via a fully-qualified domain name and [add a certificate][add-certificate] for it.
 
 ## Kong Configuration
 
-If you have not yet [added a **Route** and a **Service**][add-service], go ahead and do so. Again, note that you should be able to secure this route with HTTPS, so use a hostname you have a certificate for. Add a location handled by your route as an authorized redirect URI in Okta (under the **Authentication** section of your app registration).
+If you have not yet [added a **Route** and a **Service**][add-service], go ahead
+and do so. Again, note that you should be able to secure this route with HTTPS,
+so use a hostname you have a certificate for. Add a location handled by your route
+as an authorized redirect URI in Okta (under the **Authentication** section of your app registration).
 
-## Okta IDP Configuration
+## Okta IdP Configuration
 
 ### Sample Okta Configuration Steps
 
@@ -25,7 +36,7 @@ If you have not yet [added a **Route** and a **Service**][add-service], go ahead
 
     <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
-3. Fill out the Application's Settings
+3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
@@ -47,7 +58,7 @@ If you have not yet [added a **Route** and a **Service**][add-service], go ahead
 
 ## Plugin Configuration
 
-Add a plugin with the configuration below to your route using an HTTP client or [Kong Manager][enable-plugin].
+Add a plugin with the configuration below to your Route using an HTTP client or [Kong Manager][enable-plugin].
 
 ```bash
 $ curl -i -X POST https://admin.kong.example/routes/ROUTE_ID/plugins --data name="openid-connect" \
@@ -60,25 +71,40 @@ $ curl -i -X POST https://admin.kong.example/routes/ROUTE_ID/plugins --data name
   --data config.scopes="profile"
 ```
 
-Several pieces of configuration above must use values specific to your environment:
+Some of the configurations above must use values specific to your environment:
 
 * The `issuer` URL can be found from your Authorization Server settings.
-* `redirect_uri` should be the URI you specified earlier when configuring your app. You can view and edit this from the **General** page for your application.
-* For `client_id` and `client_secret` replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` with the client ID and secret shown in your Okta application's **General** page.
+* The `redirect_uri` should be the URI you specified earlier when configuring your app.
+You can view and edit this from the **General** page for your application.
+* For `client_id` and `client_secret`, replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET`
+with the client ID and secret shown in your Okta application's **General** page.
 
-Visiting a URL matched by that route in a browser will now redirect to Okta's authentication site and return you to the redirect URI after authenticating.
+Visiting a URL matched by that route in a browser will now redirect to Okta's authentication
+site and return you to the redirect URI after authenticating.
 
-Additional plugin parameter to consider:
+Additional plugin parameters to consider:
 
-* The `auth_methods` parameter defines a lists of all the authentication methods that you want the plugin to accept. By default value is a list of all the supported methods. It is advisable to define this parameter with only the methods you wish to allow.
+* The `auth_methods` parameter defines a lists of all the authentication methods
+that you want the plugin to accept. By default, its value is a list of all the supported methods.
+It is advisable to define this parameter with only the methods you want to allow.
 
 ### Access Restrictions
 
-The configuration above allows users to authenticate and access the Route even though no consumer was created for them: any user with a valid account in the directory will have access to the Route. The OIDC plugin allows this as the simplest authentication option, but you may wish to restrict access further. There are several options for this:
+The configuration above allows users to authenticate and access the Route even though
+no Consumer was created for them: any user with a valid account in the directory
+will have access to the Route. The OIDC plugin allows this as the simplest authentication option,
+but you may wish to restrict access further. There are several options for this:
+
+- Domain Restrictions
+- Consumer Mapping
+- Pseudo-Consumer Mapping
 
 #### Consumer Mapping
 
-If you need to interact with other Kong plugins using consumer information, you can add configuration that maps account data received from the identity provider to a Kong consumer. For this example, the user's Okta's AD account GUID is mapped to a consumer by setting it as the `custom_id` on their consumer, e.g.
+If you need to interact with other Kong plugins using consumer information, you
+can add configuration that maps account data received from the identity provider to a Kong consumer.
+For this example, the user's Okta's AD account GUID is mapped to a Consumer by setting it
+as the `custom_id` on their consumer:
 
 ```bash
 $ curl -i -X POST http://admin.kong.example/consumers/ \
@@ -90,13 +116,19 @@ $ curl -i -X PATCH http://admin.kong.example/plugins/OIDC_PLUGIN_ID \
   --data config.consumer_claim="sub"
 ```
 
-Now, if a user logs into an Okta account with the GUID `e5634b31-d67f-4661-a6fb-b6cb77849bcf`, Kong will apply configuration associated with the consumer `Yoda` to their requests.
+Now, if a user logs into an Okta account with the GUID `e5634b31-d67f-4661-a6fb-b6cb77849bcf`, Kong will apply configuration associated with the Consumer `Yoda` to their requests.
 
-This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer. You can alternately set `consumer_optional` to `true` to allow similar logins without mapping an anonymous consumer.
+This also requires that clients login using an account mapped to some Consumer, which might
+not be desirable (e.g., you apply OpenID Connect to a service, but only use plugins
+requiring a Consumer on some Routes). To deal with this, you can set the `anonymous` parameter
+in your OIDC plugin configuration to the ID of a generic Consumer, which will
+then be used for all authenticated users that cannot be mapped to some other Consumer.
+You can alternately set `consumer_optional` to `true` to allow similar logins
+without mapping an anonymous Consumer.
 
 #### Pseudo-consumers
 
-For plugins that typically require consumers, the OIDC plugin can provide a consumer ID based on the value of a claim without mapping to an actual consumer. Setting `credential_claim` to a claim [in your plugin configuration][credential-claim] will extract the value of that claim and use it where Kong would normally use a consumer ID. Note that this may not work with all consumer-related functionality.
+For plugins that typically require consumers, the OIDC plugin can provide a consumer ID based on the value of a claim without mapping to an actual Consumer. Setting `credential_claim` to a claim [in your plugin configuration][credential-claim] will extract the value of that claim and use it where Kong would normally use a consumer ID. Note that this may not work with all consumer-related functionality.
 
 Similarly, setting `authenticated_groups_claim` will extract that claim's value and use it as a group for the ACL plugin.
 

--- a/app/enterprise/2.1.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.1.x/plugins/oidc-okta.md
@@ -82,7 +82,7 @@ with the client ID and secret shown in your Okta application's **General** page.
 Visiting a URL matched by that route in a browser will now redirect to Okta's authentication
 site and return you to the redirect URI after authenticating.
 
-Additional plugin parameters to consider:
+Additional plugin parameter to consider:
 
 * The `auth_methods` parameter defines a lists of all the authentication methods
 that you want the plugin to accept. By default, its value is a list of all the supported methods.

--- a/app/enterprise/2.1.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.1.x/plugins/oidc-okta.md
@@ -95,7 +95,6 @@ no Consumer was created for them: any user with a valid account in the directory
 will have access to the Route. The OIDC plugin allows this as the simplest authentication option,
 but you may wish to restrict access further. There are several options for this:
 
-- Domain Restrictions
 - Consumer Mapping
 - Pseudo-Consumer Mapping
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1281 See Fel's comments linked in the ticket

Need to provide standalone config instructions for auth plugins (configured in conjunction with app reg plugin).

Part 1 PR make clear OAuth2 plugin does not support hybrid mode. Part 2 will provide OAuth2-specific instructions.

Direct review links:

https://deploy-preview-2276--kongdocs.netlify.app/enterprise/2.1.x/developer-portal/administration/application-registration/

Also need to make clear OAuth2 plugin does not support hybrid mode. See highlighted updates:

![image](https://user-images.githubusercontent.com/3756245/93807887-e16e4d00-fc10-11ea-865a-454db92a9bb9.png)

![image](https://user-images.githubusercontent.com/3756245/93813756-30b87b80-fc19-11ea-9b15-2d537d723bfc.png)

^ Outdated above but better now after Lena's feedback
![image](https://user-images.githubusercontent.com/3756245/94825350-af58aa00-03cb-11eb-8219-55a64797eb66.png)


Added more links in next steps area of app reg plugin (Kong Manager, not hub) docs:

https://deploy-preview-2276--kongdocs.netlify.app/enterprise/2.1.x/developer-portal/administration/application-registration/enable-application-registration/#next-steps

Per Fel's slack comments linked in ticket:

![image](https://user-images.githubusercontent.com/3756245/94474527-64ece880-0193-11eb-84d9-fa5a87ef0a74.png)

Part 2 PR will provide specific steps for OAuth2 wrt app reg. Will provide both Kong Manager and cURL examples.