### PR TITLE
docs(getting started guide) Declarative config examples and instructions

### DIFF
--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -155,6 +155,7 @@ The route is created and you are automatically redirected back to the `example_s
     - name: mocking
       paths:
       - /mock
+      strip_path: true
     ```
 
     Your file should now look like this:
@@ -170,6 +171,7 @@ The route is created and you are automatically redirected back to the `example_s
       - name: mocking
         paths:
         - /mock
+        strip_path: true
     ```
 
 2. Sync the configuration:
@@ -218,7 +220,7 @@ is now using:
         - http
         - https
         regex_priority: 0
-        strip_path: false
+        strip_path: true
         https_redirect_status_code: 426
     ```
 
@@ -227,7 +229,7 @@ is now using:
 
     The rest of this guide continues using the simplified version of the
     configuration file without performing a `deck dump` for every step, to keep
-    it easy to follow. 
+    it easy to follow.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -4,7 +4,7 @@ title: Expose your Services with Kong Gateway
 
 In this topic, you’ll learn how to expose your Services using Routes.
 
-If you are following the Getting Started workflow, make sure you have completed [Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration) before moving on.
+If you are following the Getting Started workflow, make sure you have completed [Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare) before moving on.
 
 If you are not following the Getting Started workflow, make sure you have Kong Gateway installed and started.
 
@@ -74,7 +74,7 @@ The service is created, and the page automatically redirects back to the `exampl
 {% navtab Using decK %}
 
 1. Paste the following into the `kong.yaml` file you exported in
-[Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare):
+[Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration):
 
     ``` yaml
     services:

--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -73,10 +73,13 @@ The service is created, and the page automatically redirects back to the `exampl
 {% endnavtab %}
 {% navtab Using decK %}
 
-1. Paste the following into the `kong.yaml` file you exported in
-[Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration):
+1. In the `kong.yaml` file you exported in
+[Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration),
+define a Service with the name `example_service` and the URL
+`http://mockbin.org`:
 
     ``` yaml
+    _format_version: "1.1"
     services:
     - host: mockbin.org
       name: example_service
@@ -178,9 +181,18 @@ The route is created and you are automatically redirected back to the `example_s
 3. (Optional) You can update your local file with the configuration that Kong
 is now using:
 
+    <div class="alert alert-warning">
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
+    overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
+    </div>
+
     ``` bash
     $ deck dump
     ```
+
+    Alternatively, you will also see this configuration in the diff that decK
+    shows when you're syncing a change to the configuration.
 
     You'll notice that both the Service and Route now have parameters that you
     did not explicitly set. These are default parameters that every Service and
@@ -212,6 +224,10 @@ is now using:
 
     You can do this after any `deck sync` to see {{site.base_gateway}}'s most
     recent configuration.
+
+    The rest of this guide continues using the simplified version of the
+    configuration file without performing a `deck dump` for every step, to keep
+    it easy to follow. 
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -4,7 +4,7 @@ title: Expose your Services with Kong Gateway
 
 In this topic, you’ll learn how to expose your Services using Routes.
 
-If you are following the Getting Started workflow, make sure you have completed [Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare) before moving on.
+If you are following the Getting Started workflow, make sure you have completed [Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration) before moving on.
 
 If you are not following the Getting Started workflow, make sure you have Kong Gateway installed and started.
 
@@ -71,6 +71,35 @@ Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s conf
 
 The service is created, and the page automatically redirects back to the `example_service` overview page.
 {% endnavtab %}
+{% navtab Using decK %}
+
+1. Paste the following into the `kong.yaml` file you exported in
+[Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare):
+
+    ``` yaml
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+    ```
+2. Save the file. From your terminal, sync the configuration to update Kong:
+
+    ``` bash
+    $ deck sync
+    ```
+
+    The message should show that you’re creating a service:
+
+    ```
+    creating service example_service
+    Summary:
+    Created: 1
+    Updated: 0
+    Deleted: 0
+    ```
+
+{% endnavtab %}
 {% endnavtabs %}
 
 ## Add a Route
@@ -113,6 +142,78 @@ A 201 message indicates the route was created successfully.
 The route is created and you are automatically redirected back to the `example_service` overview page. The new Route appears under the Routes section.
 
 {% endnavtab %}
+{% navtab Using decK %}
+
+1. Paste the following into the `kong.yaml` file, under the entry for
+`example_service`:
+
+    ``` yaml
+    routes:
+    - name: mocking
+      paths:
+      - /mock
+    ```
+
+    Your file should now look like this:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+    ```
+
+2. Sync the configuration:
+
+    ``` bash
+    $ deck sync
+    ```
+
+3. (Optional) You can update your local file with the configuration that Kong
+is now using:
+
+    ``` bash
+    $ deck dump
+    ```
+
+    You'll notice that both the Service and Route now have parameters that you
+    did not explicitly set. These are default parameters that every Service and
+    Route are created with:
+
+    ``` yaml
+    services:
+    - connect_timeout: 60000
+      host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      read_timeout: 60000
+      retries: 5
+      write_timeout: 60000
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+        path_handling: v0
+        preserve_host: false
+        protocols:
+        - http
+        - https
+        regex_priority: 0
+        strip_path: false
+        https_redirect_status_code: 426
+    ```
+
+    You can do this after any `deck sync` to see {{site.base_gateway}}'s most
+    recent configuration.
+
+{% endnavtab %}
 {% endnavtabs %}
 
 ## Verify the Route is forwarding requests to the Service
@@ -133,7 +234,7 @@ $ http :8000/mock
 ```
 
 {% endnavtab %}
-{% navtab Using Kong Manager %}
+{% navtab Using a Web Browser %}
 
 By default, Kong handles proxy requests on port `:8000`.
 

--- a/app/getting-started-guide/2.1.x/improve-performance.md
+++ b/app/getting-started-guide/2.1.x/improve-performance.md
@@ -61,6 +61,28 @@ $ http -f :8001/plugins name=proxy-cache config.strategy=memory config.content_t
 
 8. Click **Create**.
 {% endnavtab %}
+{% navtab Using decK %}
+
+1. In the `plugins` section of your `kong.yaml` file, add the `proxy-cache`
+plugin with a timeout of 30 seconds for Content-Type
+`application/json; charset=utf-8`.
+
+    ``` yaml
+    - name: proxy-cache
+    config:
+      content_type:
+      - "application/json; charset=utf-8"
+      cache_ttl: 30
+      strategy: memory
+    ```
+
+2. Sync the configuration:
+
+    ```bash
+    $ deck sync
+    ```
+
+{% endnavtab %}
 {% endnavtabs %}
 
 

--- a/app/getting-started-guide/2.1.x/improve-performance.md
+++ b/app/getting-started-guide/2.1.x/improve-performance.md
@@ -90,6 +90,7 @@ plugin with a timeout of 30 seconds for Content-Type
       - name: mocking
         paths:
         - /mock
+        strip_path: true
     plugins:
     - name: rate-limiting
       config:

--- a/app/getting-started-guide/2.1.x/improve-performance.md
+++ b/app/getting-started-guide/2.1.x/improve-performance.md
@@ -68,12 +68,39 @@ plugin with a timeout of 30 seconds for Content-Type
 `application/json; charset=utf-8`.
 
     ``` yaml
+    plugins:
     - name: proxy-cache
-    config:
-      content_type:
-      - "application/json; charset=utf-8"
-      cache_ttl: 30
-      strategy: memory
+      config:
+        content_type:
+        - "application/json; charset=utf-8"
+        cache_ttl: 30
+        strategy: memory
+    ```
+
+    Your file should now look like this:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 5
+        policy: local
+    - name: proxy-cache
+      config:
+        content_type:
+        - "application/json; charset=utf-8"
+        cache_ttl: 30
+        strategy: memory
     ```
 
 2. Sync the configuration:

--- a/app/getting-started-guide/2.1.x/load-balancing.md
+++ b/app/getting-started-guide/2.1.x/load-balancing.md
@@ -122,6 +122,7 @@ Upstream:
       - name: mocking
         paths:
         - /mock
+        strip_path: true
         plugins:
         - name: key-auth
           enabled: false

--- a/app/getting-started-guide/2.1.x/load-balancing.md
+++ b/app/getting-started-guide/2.1.x/load-balancing.md
@@ -83,6 +83,38 @@ In this section, you will create an Upstream named `upstream` and add two target
 11. Find your `example_service` and click **Edit**.
 12. Change the **Host** field to `upstream`, then click **Update**.
 {% endnavtab %}
+
+{% navtab Using decK %}
+1. In your `kong.yaml` file, create an Upstream with two targets, each with port
+80: `mockbin.org:80` and `httpbin.org:80`.
+
+    ``` yaml
+    upstreams:
+    - name: upstream
+      targets:
+        - target: httpbin.org:80
+          weight: 100
+        - target: mockbin.org:80
+          weight: 100
+    ```
+
+2. Update the service you created previously, pointing the `host` to this
+Upstream:
+
+    ``` yaml
+    services:
+      host: upstream
+      name: example_service
+      port: 80
+      protocol: http
+    ```
+
+3. Sync the configuration:
+
+    ``` bash
+    $ deck sync
+    ```
+{% endnavtab %}
 {% endnavtabs %}
 
 You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that Upstream.

--- a/app/getting-started-guide/2.1.x/load-balancing.md
+++ b/app/getting-started-guide/2.1.x/load-balancing.md
@@ -109,6 +109,47 @@ Upstream:
       protocol: http
     ```
 
+    After these updates, your file should now look like this:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: upstream
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+        plugins:
+        - name: key-auth
+          enabled: false
+    consumers:
+    - custom_id: consumer
+      username: consumer
+      keyauth_credentials:
+      - key: apikey
+    upstreams:
+    - name: upstream
+      targets:
+        - target: httpbin.org:80
+          weight: 100
+        - target: mockbin.org:80
+          weight: 100
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 5
+        policy: local
+    - name: proxy-cache
+      config:
+        content_type:
+        - "application/json; charset=utf-8"
+        cache_ttl: 30
+        strategy: memory
+    ```
+
 3. Sync the configuration:
 
     ``` bash

--- a/app/getting-started-guide/2.1.x/manage-teams.md
+++ b/app/getting-started-guide/2.1.x/manage-teams.md
@@ -19,6 +19,9 @@ Many organizations have strict security requirements. For example, organizations
 
 In this example, you’ll start by creating a simple workspace called `SecureWorkspace`. Then, you’ll create an administrator for that workspace, with rights to administer only the objects in the SecureWorkspace and nothing else.
 
+>**Note:** The steps in this topic cannot be performed using declarative
+configuration.
+
 ## Securing your Kong Enterprise Installation
 
 At a high level, securing {{site.ee_product_name}} administration is a two-step process:
@@ -321,6 +324,38 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 {% endnavtabs %}
 
 That's it! You are now controlling access to {{site.ee_product_name}} administration with RBAC.
+
+## Reference: Using decK with RBAC and Workspaces
+
+### RBAC
+
+Once RBAC is enabled, you will have to pass the `kong-admin-token` in a header
+any time you use decK:
+
+``` bash
+$ deck sync --headers "kong-admin-token:mytoken"   
+```
+> **Note:** You should not use an RBAC token with Super Admin
+privileges for decK. Always scope down to the exact permissions you need to
+give decK.
+
+### Workspaces
+
+When you have multiple workspaces, decK creates a file for each one. Export
+them as follows:
+
+``` bash
+$ deck dump --all-workspaces
+```
+
+Or, to export the configuration for only one workspace:
+
+``` bash
+$ deck dump --workspace SecureWorkspace
+```
+
+You can use these flags with any decK commands to update and export your
+configuration.
 
 ## Summary and next steps
 

--- a/app/getting-started-guide/2.1.x/overview.md
+++ b/app/getting-started-guide/2.1.x/overview.md
@@ -76,10 +76,18 @@ Note the following before you start using this guide:
     * To find the URL, check the `admin_listen` property in the `/etc/kong/kong.conf` file.
 
 ### Using this guide
-* As a {{site.ee_product_name}} or Free Trial user, functionalities can be managed programmatically using a REST-based Admin API, or using the Kong Manager GUI. As a {{site.base_gateway}} user, you need to follow the Admin API steps since Manager is an Enterprise feature. In this guide, you can choose your preferred method, if options are available — you don’t have to follow both.
-* If you're running Kong in Hybrid mode, all tasks contained in this guide take place on the Control Plane.
-* This guide provides Kong Admin API examples in both HTTPie and cURL. If you want to use HTTPie, install it from [here](https://httpie.org/).
-* Any references to “{{site.base_gateway}}” refer to features or concepts common to both {{site.ce_product_name}} and {{site.ee_gateway_name}}.
+* Throughout this guide, you will have the option to configure Kong in a few
+different ways. Choose your preferred method, if options are available —
+you don’t have to walk through all of them:
+  * Programmatically manage Kong using its REST-based Admin API
+  * Use the Kong Manager GUI *(Enterprise or Free Trial users only)*
+  * Use decK for declarative configuration
+* If you're running Kong in Hybrid mode, all tasks contained in this guide take
+place on the Control Plane.
+* This guide provides Kong Admin API examples in both HTTPie and cURL. If you
+want to use HTTPie, install it from [here](https://httpie.org/).
+* Any references to “{{site.base_gateway}}” refer to features or concepts
+common to both {{site.ce_product_name}} and {{site.ee_gateway_name}}.
 
 ### Next Steps
 

--- a/app/getting-started-guide/2.1.x/overview.md
+++ b/app/getting-started-guide/2.1.x/overview.md
@@ -81,7 +81,7 @@ different ways. Choose your preferred method, if options are available —
 you don’t have to walk through all of them:
   * Programmatically manage Kong using its REST-based Admin API
   * Use the Kong Manager GUI *(Enterprise or Free Trial users only)*
-  * Use decK for declarative configuration
+  * Use decK for declarative configuration (YAML)
 * If you're running Kong in Hybrid mode, all tasks contained in this guide take
 place on the Control Plane.
 * This guide provides Kong Admin API examples in both HTTPie and cURL. If you

--- a/app/getting-started-guide/2.1.x/prepare.md
+++ b/app/getting-started-guide/2.1.x/prepare.md
@@ -9,6 +9,7 @@ Before getting started with using {{site.base_gateway}}, verify that it was inst
 Before you start this section, make sure that:
 * {{site.base_gateway}} is installed and running.
 * Kong Manager (if applicable) and Kong Admin API ports are listening on the appropriate port/IP/DNS settings.
+* If using declarative configuration to configure Kong, [decK](/deck/installation) is installed.
 
 In this guide, an instance of {{site.base_gateway}} is referenced via `<admin-hostname>`. Make sure to replace `<admin-hostname>` with the hostname of your control plane instance.
 
@@ -44,12 +45,12 @@ Ensure that you can send requests to the Kong Admin API using either cURL or HTT
 View the current configuration by issuing the following command in a terminal window:
 
 *Using cURL:*
-```
+```bash
 $ curl -i -X GET http://<admin-hostname>:8001
 ```
 
 *or using HTTPie:*
-```
+```bash
 $ http <admin-hostname>:8001
 ```
 The current configuration returns.
@@ -61,6 +62,51 @@ As a {{site.ee_product_name}} user, you can use Kong Manager for environment adm
 Open a web browser and navigate to `http://<admin-hostname>:8002`.
 
 If {{site.ee_product_name}} was installed correctly, it automatically logs you in and presents the Kong Manager Overview page.
+{% endnavtab %}
+
+{% navtab Using decK %}
+
+1. Check that decK is connected to Kong:
+
+    ``` bash
+    $ deck ping
+    ```
+
+    You should see a success message with the version of Kong that you're
+    connected to:
+    ```
+    Successfully connected to Kong!
+    Kong version:  2.1.0
+    ```
+
+2. Ensure that you can pull configuration from Kong by issuing the following
+command in a terminal window:
+
+    ``` bash
+    $ deck dump
+    ```
+
+    This command creates a `kong.yaml` file with Kong's entire current
+    configuration, in the directory where decK is installed.
+
+    You can also use this command at any time (for example, after a `deck sync`)
+    to see the {{site.base_gateway}}'s most recent configuration.
+
+    <div class="alert alert-warning">
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
+    overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
+    </div>
+
+3. Open the file in your preferred code editor. Since you haven't configured
+anything yet, the file should only contain the decK version:
+
+    ``` yaml
+    _format_version: "1.1"
+    ```
+
+    You will use this file to configure Kong.
+
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -105,4 +151,4 @@ The output shows all of the connected Data Plane instances:
 
 ## Summary and next steps
 
-In this section, you learned about the two methods of administering {{site.base_gateway}} and how to access its configuration. Next, go on to learn about [exposing your services with {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/expose-services).
+In this section, you learned about the methods of administering {{site.base_gateway}} and how to access its configuration. Next, go on to learn about [exposing your services with {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/expose-services).

--- a/app/getting-started-guide/2.1.x/protect-services.md
+++ b/app/getting-started-guide/2.1.x/protect-services.md
@@ -55,7 +55,7 @@ $ http -f post :8001/plugins name=rate-limiting config.minute=5 config.policy=lo
 
     If you switched it to **Scoped**, the rate limiting would apply the plugin to only one Service, Route, or Consumer.
 
-    **Note**: By default, the plugin is automatically enabled when the form is submitted. You can also toggle the **This plugin is Enabled** button at the top of the form to configure the plugin without enabling it. For this example, keep the plugin enabled.
+    > **Note**: By default, the plugin is automatically enabled when the form is submitted. You can also toggle the **This plugin is Enabled** button at the top of the form to configure the plugin without enabling it. For this example, keep the plugin enabled.
 
 6. Scroll down and complete only the following fields with the following parameters.
     1. config.limit: `5`
@@ -65,6 +65,41 @@ $ http -f post :8001/plugins name=rate-limiting config.minute=5 config.policy=lo
     Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
 
 7. Click **Create**.
+{% endnavtab %}
+{% navtab Using decK %}
+
+<div class="alert alert-ee">
+<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have Kong Enterprise or free trial access, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced instead.
+</div>
+
+1. Add a new `plugins` section to the bottom of your `kong.yaml` file. Enable
+`rate-limiting` with a limit of five (5) requests per minute, stored locally
+and in-memory, on the node:
+
+    ``` yaml
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 5
+        policy: local
+    ```
+
+    This plugin will be applied globally, which means the rate limiting
+    applies to all requests, including every Service and Route in the Workspace.
+
+    If you pasted the plugin section under an existing Service, Route, or
+    Consumer, the rate limiting would only apply to that specific
+    entity.
+
+    >**Note**: By default, `enabled` is set to `true` for the plugin. You can
+    disable the plugin at any time by setting `enabled: false`.
+
+2. Sync the configuration:
+
+    ``` bash
+    $ deck sync
+    ```
+
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -106,7 +141,9 @@ After the 6th request, you should receive a 429 "API rate limit exceeded" error:
 ## Summary and next steps
 
 In this section:
-* If using Kong Community Gateway, you enabled the Rate Limiting plugin, setting the rate limit to 5 times per minute.
-* If using Kong Enterprise Gateway, you enabled the Rate Limiting Advanced plugin, setting the rate limit to 5 times for every 30 seconds.
+* If using the Kong Admin API or decK, you enabled the Rate Limiting plugin,
+setting the rate limit to 5 times per minute.
+* If using Kong Manager, you enabled the Rate Limiting Advanced plugin,
+setting the rate limit to 5 times for every 30 seconds.
 
 Next, head on to learn about [proxy caching](/getting-started-guide/{{page.kong_version}}/improve-performance).

--- a/app/getting-started-guide/2.1.x/protect-services.md
+++ b/app/getting-started-guide/2.1.x/protect-services.md
@@ -97,6 +97,7 @@ and in-memory, on the node:
       - name: mocking
         paths:
         - /mock
+        strip_path: true
     plugins:
     - name: rate-limiting
       config:

--- a/app/getting-started-guide/2.1.x/protect-services.md
+++ b/app/getting-started-guide/2.1.x/protect-services.md
@@ -84,6 +84,26 @@ and in-memory, on the node:
         policy: local
     ```
 
+    Your file should now look like this:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 5
+        policy: local
+    ```
+
     This plugin will be applied globally, which means the rate limiting
     applies to all requests, including every Service and Route in the Workspace.
 

--- a/app/getting-started-guide/2.1.x/secure-services.md
+++ b/app/getting-started-guide/2.1.x/secure-services.md
@@ -92,6 +92,41 @@ Now, if you try to access the route without providing an API key, the request wi
 
 Before Kong proxies requests for this route, it needs an API key. For this example, since you installed the Key Authentication plugin, you need to create a consumer with an associated key first.
 {% endnavtab %}
+{% navtab Using decK %}
+1. Under the `mocking` route in the `routes` section of the `kong.yaml` file,
+add a plugin section and enable the `key-auth` plugin:
+
+    ``` yaml
+    plugins:
+    - name: key-auth
+    ```
+
+    The `routes` section should now look something like this:
+    ``` yaml
+    routes:
+    - name: mocking
+      paths:
+      - /mock
+      strip_path: true
+      plugins:
+      - name: key-auth
+    ```
+
+2. Sync the configuration:
+
+    ``` bash
+    $ deck sync
+    ```
+
+Now, if you try to access the route at `http://<admin-hostname>:8000/mock`
+without providing an API key, the request will fail, and you’ll see the message
+`"No API key found in request".`
+
+Before Kong proxies requests for this route, it needs an API key. For this
+example, since you installed the Key Authentication plugin, you need to create
+a consumer with an associated key first.
+
+{% endnavtab %}
 {% endnavtabs %}
 
 
@@ -153,6 +188,26 @@ Before Kong proxies requests for this route, it needs an API key. For this examp
 
   The new Key Authentication ID displays on the **Consumers** page under the **Credentials** tab.
 {% endnavtab %}
+{% navtab Using decK %}
+1. Add a `consumers` section to your `kong.yaml` file and create a new consumer:
+
+    ``` yaml
+    consumers:
+    - custom_id: consumer
+      username: consumer
+      keyauth_credentials:
+      - key: apikey
+    ```
+
+2. Sync the configuration:
+
+    ``` bash
+    $ deck sync
+    ```
+
+You now have a consumer with an API key provisioned to access the route.
+
+{% endnavtab %}
 {% endnavtabs %}
 
 
@@ -176,7 +231,7 @@ $ http :8000/mock/request apikey:apikey
 You should get an `HTTP/1.1 200 OK` message in response.
 
 {% endnavtab %}
-{% navtab Using Kong Manager %}
+{% navtab Using a Web Browser %}
 
 To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
 ```
@@ -224,6 +279,23 @@ If you are following this getting started guide topic by topic, you will need to
 {% navtab Using Kong Manager %}
 1. Go to the Plugins page and click on **View** for the key-auth row.
 2. Use the toggle at the top of the page to switch the plugin from **Enabled** to **Disabled**.
+{% endnavtab %}
+{% navtab Using decK %}
+
+1. Disable the `key-auth` plugin in the `kong.yaml` file:
+
+    ``` yaml
+    plugins:
+    - name: key-auth
+      enabled: false
+    ```
+
+2. Sync the configuration:
+
+    ``` bash
+    $ deck sync
+    ```
+
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/getting-started-guide/2.1.x/secure-services.md
+++ b/app/getting-started-guide/2.1.x/secure-services.md
@@ -114,6 +114,7 @@ add a plugin section and enable the `key-auth` plugin:
       - name: mocking
         paths:
         - /mock
+        strip_path: true
         plugins:
         - name: key-auth
     plugins:
@@ -229,6 +230,7 @@ a consumer with an associated key first.
       - name: mocking
         paths:
         - /mock
+        strip_path: true
         plugins:
         - name: key-auth
     consumers:

--- a/app/getting-started-guide/2.1.x/secure-services.md
+++ b/app/getting-started-guide/2.1.x/secure-services.md
@@ -101,15 +101,32 @@ add a plugin section and enable the `key-auth` plugin:
     - name: key-auth
     ```
 
-    The `routes` section should now look something like this:
+    Your file should now look like this:
+
     ``` yaml
-    routes:
-    - name: mocking
-      paths:
-      - /mock
-      strip_path: true
-      plugins:
-      - name: key-auth
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+        plugins:
+        - name: key-auth
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 5
+        policy: local
+    - name: proxy-cache
+      config:
+        content_type:
+        - "application/json; charset=utf-8"
+        cache_ttl: 30
+        strategy: memory
     ```
 
 2. Sync the configuration:
@@ -199,6 +216,39 @@ a consumer with an associated key first.
       - key: apikey
     ```
 
+    Your file should now look like this:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: mocking
+        paths:
+        - /mock
+        plugins:
+        - name: key-auth
+    consumers:
+    - custom_id: consumer
+      username: consumer
+      keyauth_credentials:
+      - key: apikey
+    plugins:
+    - name: rate-limiting
+      config:
+        minute: 5
+        policy: local
+    - name: proxy-cache
+      config:
+        content_type:
+        - "application/json; charset=utf-8"
+        cache_ttl: 30
+        strategy: memory
+    ```
+
 2. Sync the configuration:
 
     ``` bash
@@ -282,7 +332,8 @@ If you are following this getting started guide topic by topic, you will need to
 {% endnavtab %}
 {% navtab Using decK %}
 
-1. Disable the `key-auth` plugin in the `kong.yaml` file:
+1. Disable the key-auth plugin in the `kong.yaml` file by setting
+`enabled` to `false`:
 
     ``` yaml
     plugins:


### PR DESCRIPTION
Updating the getting started guide to include declarative config examples. 

Previews:

[Overview](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/overview/#using-this-guide): updated the Using this Guide section to include decK

New decK tabs:
* [Prepare to Administer Kong](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/prepare/#verify-the-kong-gateway-configuration)
* Expose your Services: 
  * [Add a Service](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/expose-services/#add-a-service)
  * [Add a Route](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/expose-services/#add-a-service) 
Note: also added a sample of a `deck dump` command to the Route section as part of the topic rollup, to show that Kong also implicitly adds some default values.
* [Rate Limiting](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/protect-services/#set-up-rate-limiting)
* [Proxy Caching](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/improve-performance/#set-up-the-proxy-caching-plugin)
* Protect Services:
  * [Enable Key Auth](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/secure-services/#set-up-the-key-authentication-plugin)
  * [Create a consumer](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/secure-services/#set-up-consumers-and-credentials)
  * [Disable Key Auth](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/secure-services/#optional-disable-the-plugin)
* [Load Balancing](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/load-balancing/#configure-upstream-services)

[Manage Admin Teams](https://deploy-preview-2279--kongdocs.netlify.app/getting-started-guide/2.1.x/manage-teams/#reference-using-deck-with-rbac-and-workspaces): added reference section on how to use decK after having enabled RBAC, and for workspaces

