### PR TITLE
docs(2.1.x) moving version info from B&I

### DIFF
--- a/app/enterprise/2.1.x/brain-immunity/auto-generated-specs.md
+++ b/app/enterprise/2.1.x/brain-immunity/auto-generated-specs.md
@@ -33,6 +33,6 @@ In the specification, the fields `title`, `version`, and `description` are fille
 
 Use the parameter `openapi_version` to specify which version of the OpenAPI specification to use - possible values are `2` (default) and `3`.
 
-```
+```bash
 http://<COLLECTOR_HOST>:<COLLECTOR_PORT>/swagger?openapi_version=<2|3>&host=<request_host>&route_id=<route_id>&service_id=<service_id>&workspace_name=<workspace_name>&title=<title>&version=<version>&description=<description>
 ```

--- a/app/enterprise/2.1.x/brain-immunity/install-configure.md
+++ b/app/enterprise/2.1.x/brain-immunity/install-configure.md
@@ -6,14 +6,15 @@ Kong Brain (Brain) and Kong Immunity (Immunity) are installed on Kong Enterprise
 
 ## Version Compatibility
 Kong Brain and Kong Immunity follow a different versioning scheme from Kong Enterprise. See the following table for version compatibility. Note the following:
-* The Brain and Immunity version reflects the `kong-brain-immunity-base` available in Bintray.
-* For Kong Enterprise 2.1.x and 1.5.x, use Brain and Immunity `kong-brain-immunity-base` 3.0.0 version. Do not use Brain and Immunity `kong-brain-immunity-base` 2.x.x version as it is end-of-life. 
+* The Brain and Immunity version reflects the `kong-brain-immunity-base` package available in Bintray.
+* For Kong Enterprise 2.1.x and 1.5.x, use Brain and Immunity `kong-brain-immunity-base` 3.0.0 package version. 
+* Do not use Brain and Immunity `kong-brain-immunity-base` 2.x.x package version, as it is end-of-life. 
 
-| Brain and Immunity Version     | Kong Enterprise Version |
-|:-------------------------------|:------------------------|
-| 3.0.0                          | 2.1.x, 1.5.x            |
-| 2.x.x is EOL. Use 3.0.0 instead| 1.5.x                   |
-| 1.x.x                          | 1.3.x                   |
+| Brain and Immunity Version      | Kong Enterprise Version |
+|:--------------------------------|:------------------------|
+| 3.0.0                           | 2.1.x, 1.5.x            |
+| 2.x.x is EOL. Use 3.0.0 instead | 1.5.x                   |
+| 1.x.x                           | 1.3.x                   |
 
 ## Install Brain and Immunity on Kubernetes
 Set up the Collector App via Helm. Use the public helm chart for setting up the Collector App and all its dependencies on Kubernetes. Instructions for setup can be found on the public repo at: [https://github.com/Kong/kong-collector-helm/blob/master/README.md](https://github.com/Kong/kong-collector-helm/blob/master/README.md).

--- a/app/enterprise/2.1.x/brain-immunity/install-configure.md
+++ b/app/enterprise/2.1.x/brain-immunity/install-configure.md
@@ -1,7 +1,7 @@
 ---
 title: Kong Brain and Kong Immunity Installation and Configuration
 ---
-
+## Introduction
 Kong Brain (Brain) and Kong Immunity (Immunity) are installed on Kong Enterprise, either on Kubernetes or Docker, as defined below. The Collector App and Collector Plugin enable Brain and Immunity to communicate with Kong Enterprise. 
 
 ## Version Compatibility

--- a/app/enterprise/2.1.x/brain-immunity/install-configure.md
+++ b/app/enterprise/2.1.x/brain-immunity/install-configure.md
@@ -4,6 +4,17 @@ title: Kong Brain and Kong Immunity Installation and Configuration
 
 Kong Brain (Brain) and Kong Immunity (Immunity) are installed on Kong Enterprise, either on Kubernetes or Docker, as defined below. The Collector App and Collector Plugin enable Brain and Immunity to communicate with Kong Enterprise. 
 
+## Version Compatibility
+Kong Brain and Kong Immunity follow a different versioning scheme from Kong Enterprise. See the following table for version compatibility. Note the following:
+* The Brain and Immunity version reflects the `kong-brain-immunity-base` available in Bintray.
+* For Kong Enterprise 2.1.x and 1.5.x, use Brain and Immunity `kong-brain-immunity-base` 3.0.0 version. Do not use Brain and Immunity `kong-brain-immunity-base` 2.x.x version as it is end-of-life. 
+
+| Brain and Immunity Version     | Kong Enterprise Version |
+|:-------------------------------|:------------------------|
+| 3.0.0                          | 2.1.x, 1.5.x            |
+| 2.x.x is EOL. Use 3.0.0 instead| 1.5.x                   |
+| 1.x.x                          | 1.3.x                   |
+
 ## Install Brain and Immunity on Kubernetes
 Set up the Collector App via Helm. Use the public helm chart for setting up the Collector App and all its dependencies on Kubernetes. Instructions for setup can be found on the public repo at: [https://github.com/Kong/kong-collector-helm/blob/master/README.md](https://github.com/Kong/kong-collector-helm/blob/master/README.md).
 

--- a/app/enterprise/2.1.x/brain-immunity/install-configure.md
+++ b/app/enterprise/2.1.x/brain-immunity/install-configure.md
@@ -8,7 +8,7 @@ Kong Brain (Brain) and Kong Immunity (Immunity) are installed on Kong Enterprise
 Kong Brain and Kong Immunity follow a different versioning scheme from Kong Enterprise. See the following table for version compatibility. Note the following:
 * The Brain and Immunity version reflects the `kong-brain-immunity-base` package available in Bintray.
 * For Kong Enterprise 2.1.x and 1.5.x, use Brain and Immunity `kong-brain-immunity-base` 3.0.0 package version. 
-* Do not use Brain and Immunity `kong-brain-immunity-base` 2.x.x package version, as it is end-of-life. 
+* Do not use Brain and Immunity `kong-brain-immunity-base` 2.x.x package version, as it is end-of-life (EOL). 
 
 | Brain and Immunity Version      | Kong Enterprise Version |
 |:--------------------------------|:------------------------|

--- a/app/enterprise/2.1.x/brain-immunity/overview.md
+++ b/app/enterprise/2.1.x/brain-immunity/overview.md
@@ -10,15 +10,6 @@ title: Kong Brain and Kong Immunity Overview
 
 Brain and Immunity are installed on Kong Enterprise, either on Kubernetes or Docker. The Collector App and Collector Plugin enable Brain and Immunity to communicate with Kong Enterprise. The diagram above illustrate how the components work together.
 
-## Version Compatibility
-Kong Brain and Kong Immunity follow a different versioning scheme from Kong Enterprise. See the following table for version compatibility.
-
-| Brain and Immunity Version | Kong Enterprise Version |
-|:---------------------------|:------------------------|
-| 3.0.0                      | 2.1.x, 1.5.x            |
-| 2.x.x                      | 1.5.x                   |
-| 1.x.x                      | 1.3.x                   |
-
 
 ## About Kong Brain
 Brain automates tasks, increases visibility, and ensures consistency across complex architectures. Other features include:


### PR DESCRIPTION
-- moving the version compatibility table for Brain and Immunity to the installation and config topic.



