### PR TITLE
docs(mesh) Formatting and image name fixes for installation

### DIFF
--- a/app/mesh/1.0.x/gettingstarted.md
+++ b/app/mesh/1.0.x/gettingstarted.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started With Kong Mesh
+title: Getting Started with Kong Mesh
 no_search: true
 ---
 

--- a/app/mesh/1.0.x/gettingstarted.md
+++ b/app/mesh/1.0.x/gettingstarted.md
@@ -5,21 +5,31 @@ no_search: true
 
 ## Getting Started
 
-{{site.mesh_product_name}} - built on top of CNCF's Kuma and Envoy - tries to be as close as possible to the usage of Kuma itself, while providing drop-in binary replacements for both the control plane and data plane executables.
+{{site.mesh_product_name}} &mdash; built on top of CNCF's Kuma and Envoy &mdash;
+ tries to be as close as possible to the usage of Kuma itself, while providing
+ drop-in binary replacements for both the control plane and data plane
+ executables.
 
-As such - while the {{site.mesh_product_name}} binaries can be downloaded from the [official installation page](/mesh/{{page.kong_version}}/install) - we can follow [Kuma's official documentation](https://kuma.io/docs) after downloading {{site.mesh_product_name}} to start using the product.
+You can download the {{site.mesh_product_name}} binaries from the
+[official installation page](/mesh/{{page.kong_version}}/install), then follow
+[Kuma's official documentation](https://kuma.io/docs) to start using the product.
 
-For {{site.mesh_product_name}}'s enterprise features instead, we can take a look at the [enterprise documentation](/mesh/{{page.kong_version}}/features).
+For {{site.mesh_product_name}}'s enterprise features, take a look at the
+[enterprise documentation](/mesh/{{page.kong_version}}/features).
 
 <div class="alert alert-ee blue">
-   Kuma, a donated CNCF project, was originally created by Kong which is currently maintaining both the project and the documentation.
+   Kuma, a donated CNCF project, was originally created by Kong, which is
+   currently maintaining both the project and the documentation.
 </div>
 
 ## 1. Installing {{site.mesh_product_name}}
 
-The first step to start using {{site.mesh_product_name}} is to download the product from the [official installation page](/mesh/{{page.kong_version}}/install).
+Download and install {{site.mesh_product_name}} from the
+[official installation page](/mesh/{{page.kong_version}}/install).
 
-To make sure that {{site.mesh_product_name}} has been downloaded properly, we can check the versions of the executables and make sure that they start with the `{{site.mesh_product_name}}` prefix:
+To confirm that {{site.mesh_product_name}} has been installed properly, you
+can check the versions of the executables and make sure that they start with
+the `{{site.mesh_product_name}}` prefix:
 
 ```sh
 $ kumactl version
@@ -34,16 +44,20 @@ Kong Mesh [VERSION NUMBER]
 
 ## 2. Getting Started
 
-Once downloaded, follow the getting started guide to get up and running:
+Once installed, follow the getting started guide to get
+{{site.mesh_product_name}} up and running:
 
 * [Getting started with Kubernetes](https://kuma.io/docs/latest/quickstart/kubernetes/)
 * [Getting started with Universal](https://kuma.io/docs/latest/quickstart/universal/)
 
-## 3. Reading the documentation
+## 3. Reading the Documentation
 
-Finally, we can learn more about the product by reading the official Kuma documentation, and the enterprise features documentation that are exclusive to {{site.mesh_product_name}}:
+You can learn more about the product by reading the official Kuma documentation,
+and the documentation for the enterprise features that are exclusive to
+{{site.mesh_product_name}}:
 
 * [Official Kuma documentation](https://kuma.io/docs/)
 * [Enterprise features documentation](/mesh/{{page.kong_version}}/features)
 
-Of course, if you are a {{site.mesh_product_name}} customer you can also open a support ticket with any question or feedback you may have.
+If you are a {{site.mesh_product_name}} customer, you can also open a support
+ticket with any question or feedback you may have.

--- a/app/mesh/1.0.x/install.md
+++ b/app/mesh/1.0.x/install.md
@@ -9,7 +9,7 @@ no_search: true
 seamless experience, {{site.mesh_product_name}} follows the same installation
 and configuration procedures as Kuma, but uses its own binaries.
 
-On this page you will find access to the official {{site.mesh_product_name}}
+On this page, you will find access to the official {{site.mesh_product_name}}
 distributions that provide a drop-in replacement to Kuma's native binaries.
 
 <b>The latest {{site.mesh_product_name}} is {{page.kong_latest.version}}:</b>
@@ -25,7 +25,7 @@ distributions that provide a drop-in replacement to Kuma's native binaries.
 * [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
 * [macOS](/mesh/{{page.kong_version}}/installation/macos)
 
-## Verify installation
+## Verify Installation
 
 To confirm that you have installed the right version of
 {{site.mesh_product_name}}, you can always run the following commands and

--- a/app/mesh/1.0.x/install.md
+++ b/app/mesh/1.0.x/install.md
@@ -5,9 +5,12 @@ no_search: true
 
 ## Install {{site.mesh_product_name}}
 
-{{site.mesh_product_name}} is built on top of Kuma and Envoy and in order to create a seamless experience it follows the same exact installation and configuration procedures as Kuma, but with its own binaries instead.
+{{site.mesh_product_name}} is built on top of Kuma and Envoy. To create a
+seamless experience, {{site.mesh_product_name}} follows the same installation
+and configuration procedures as Kuma, but uses its own binaries.
 
-On this page you will find access to the official {{site.mesh_product_name}} distributions that provide a drop-in replacemement to Kuma's native binaries.
+On this page you will find access to the official {{site.mesh_product_name}}
+distributions that provide a drop-in replacement to Kuma's native binaries.
 
 <b>The latest {{site.mesh_product_name}} is {{page.kong_latest.version}}:</b>
 
@@ -24,7 +27,10 @@ On this page you will find access to the official {{site.mesh_product_name}} dis
 
 ## Verify installation
 
-To make sure that we have installed the right version of {{site.mesh_product_name}}, you can always run the following commands and make sure that the version output is being prefixed with `{{site.mesh_product_name}}`:
+To confirm that you have installed the right version of
+{{site.mesh_product_name}}, you can always run the following commands and
+make sure that the version output starts with the `{{site.mesh_product_name}}`
+prefix:
 
 ```sh
 $ kumactl version

--- a/app/mesh/1.0.x/installation/amazonlinux.md
+++ b/app/mesh/1.0.x/installation/amazonlinux.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With Amazon Linux
+title: Kong Mesh with Amazon Linux
 no_search: true
 ---
 

--- a/app/mesh/1.0.x/installation/amazonlinux.md
+++ b/app/mesh/1.0.x/installation/amazonlinux.md
@@ -6,33 +6,50 @@ no_search: true
 ## Amazon Linux
 
 <div class="alert alert-ee blue">
-If you wish to use Kuma on Amazon EKS please follow the <a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes instructions</a> instead.
+If you want to use Kuma on Amazon EKS, follow the
+<a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes instructions</a>
+instead.
 </div>
 
-To install and run {{site.mesh_product_name}} on Amazon Linux (**x86_64**) execute the following steps:
+To install and run {{site.mesh_product_name}} on Amazon Linux (**x86_64**),
+execute the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
 
 ### 1. Download {{site.mesh_product_name}}
 
-Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system and
+download the latest version of {{site.mesh_product_name}}:
 
 ```sh
 $ yum install -y tar gzip
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 
-or you can [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz) the distribution manually.
+{% endnavtab %}
+{% navtab Manually %}
 
-Then extract the archive with:
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+the distribution manually.
+
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/amazonlinux/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/amazonlinux/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/centos.md
+++ b/app/mesh/1.0.x/installation/centos.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With CentOS
+title: Kong Mesh with CentOS
 no_search: true
 ---
 

--- a/app/mesh/1.0.x/installation/centos.md
+++ b/app/mesh/1.0.x/installation/centos.md
@@ -5,29 +5,43 @@ no_search: true
 
 ## CentOS
 
-To install and run {{site.mesh_product_name}} on CentOS (**x86_64**) execute the following steps:
+To install and run {{site.mesh_product_name}} on CentOS (**x86_64**), execute
+the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
 
 ### 1. Download {{site.mesh_product_name}}
 
-Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 
-or you can [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz) the distribution manually.
+{% endnavtab %}
+{% navtab Manually %}
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+the distribution manually.
 
-Then extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/centos/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/centos/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/debian.md
+++ b/app/mesh/1.0.x/installation/debian.md
@@ -5,29 +5,41 @@ no_search: true
 
 ## Debian
 
-To install and run {{site.mesh_product_name}} on Debian (**amd64**) execute the following steps:
+To install and run {{site.mesh_product_name}} on Debian (**amd64**),
+execute the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
 
 ### 1. Download {{site.mesh_product_name}}
 
-Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+{% navtabs %}
+{% navtab Script %}
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
+{% endnavtab %}
+{% navtab Manually %}
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+the distribution manually.
 
-or you can [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz) the distribution manually.
-
-Then extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/debian/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/debian/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/debian.md
+++ b/app/mesh/1.0.x/installation/debian.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With Debian
+title: Kong Mesh with Debian
 no_search: true
 ---
 

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -5,28 +5,40 @@ no_search: true
 
 ## Docker
 
-To install and run {{site.mesh_product_name}} on Docker execute the following steps:
+To install and run {{site.mesh_product_name}} on Docker, execute the following
+steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
 
 <div class="alert alert-ee blue">
-The official Docker images are used by default in the <a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes</a> distributions.  
+The official Docker images are used by default in the
+<a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes</a>
+distributions.  
 </div>
 
 ### 1. Download {{site.mesh_product_name}}
 
-{{site.mesh_product_name}} provides the following Docker images for all of its executables:
+{{site.mesh_product_name}} provides the following Docker images for all of its
+executables:
 
 * **kuma-cp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}`
-* **kuma-dp**: at `kong-docker-kuma-docker.bintray.io/kuma-dp:{{page.kong_latest.version}}`
-* **kumactl**: at `kong-docker-kuma-docker.bintray.io/kumactl:{{page.kong_latest.version}}`
-* **kuma-prometheus-sd**: at `kong-docker-kuma-docker.bintray.io/kuma-prometheus-sd:{{page.kong_latest.version}}`
+* **kuma-dp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-dp:{{page.kong_latest.version}}`
+* **kumactl**: at `kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}}`
+* **kuma-prometheus-sd**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-prometheus-sd:{{page.kong_latest.version}}`
 
-You can freely `docker pull` these images to start using Kuma, as we will demonstrate in the following steps.
+`docker pull` each image that you need. For example:
+
+```sh
+$ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}
+```
 
 ### 2. Follow Kuma instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After pulling the {{site.mesh_product_name}} images, the remaining installation
+instructions for Kuma are fully compatible with {{site.mesh_product_name}},
+except you will be using the {{site.mesh_product_name}} Docker images instead
+of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/docker/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/docker/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With Docker
+title: Kong Mesh with Docker
 no_search: true
 ---
 
@@ -33,7 +33,7 @@ executables:
 $ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}
 ```
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
 After pulling the {{site.mesh_product_name}} images, the remaining installation
 instructions for Kuma are fully compatible with {{site.mesh_product_name}},

--- a/app/mesh/1.0.x/installation/helm.md
+++ b/app/mesh/1.0.x/installation/helm.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With Helm
+title: Kong Mesh with Helm
 no_search: true
 ---
 

--- a/app/mesh/1.0.x/installation/helm.md
+++ b/app/mesh/1.0.x/installation/helm.md
@@ -5,4 +5,4 @@ no_search: true
 
 ## Helm
 
-Helm charts are not currently available for Kong Mesh.
+Helm charts are not currently available for {{site.mesh_product_name}}.

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With Kubernetes
+title: Kong Mesh with Kubernetes
 no_search: true
 ---
 

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -5,23 +5,23 @@ no_search: true
 
 ## Kubernetes
 
-To install and run {{site.mesh_product_name}} on Kubernetes execute the following steps:
+To install and run {{site.mesh_product_name}} on Kubernetes, execute the
+following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
 
-<div class="alert alert-ee blue">
-{{site.mesh_product_name}} also provides <a href="/mesh/{{page.kong_version}}/installation/helm">Helm charts</a> that we can use instead of this distribution.
-</div>
-
 ### 1. Download {{site.mesh_product_name}}
 
-To run {{site.mesh_product_name}} on Kubernetes, you need to download a compatible version of {{site.mesh_product_name}} for the machine from which you will be executing the commands.
+To run {{site.mesh_product_name}} on Kubernetes, you need to download a
+compatible version of {{site.mesh_product_name}} for the machine from which you
+will be executing the commands.
 
 {% navtabs %}
 {% navtab Script %}
 
-You can run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+You can run the following script to automatically detect the operating system
+and download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
@@ -30,7 +30,9 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
+You can also download the distribution manually. Download a distribution for
+the **client host** from where you will be executing the commands to access
+Kubernetes:
 
 * [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
 * [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
@@ -38,7 +40,7 @@ You can also download the distribution manually. Download a distribution for the
 * [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
 
-and extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
@@ -47,8 +49,13 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/kubernetes/#_2-run-kuma).
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/kubernetes/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/macos.md
+++ b/app/mesh/1.0.x/installation/macos.md
@@ -5,19 +5,22 @@ no_search: true
 
 ## macOS
 
-To install and run {{site.mesh_product_name}} on macOS execute the following steps:
+To install and run {{site.mesh_product_name}} on macOS, execute the following
+steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
 
 ### 1. Download {{site.mesh_product_name}}
 
-To run {{site.mesh_product_name}} on macOS you can choose among different installation methods:
+To run {{site.mesh_product_name}} on macOS, you can choose from the following
+installation methods:
 
 {% navtabs %}
 {% navtab Script %}
 
-Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
@@ -26,26 +29,24 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also download the distribution manually:
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+the distribution manually.
 
-* [Download {{site.mesh_product_name}}](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
-
-Then extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 
 {% endnavtab %}
-{% navtab Homebrew (kumactl only) %}
-
-Homebrew is currently not support with Kong Mesh.
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ### 2. Follow Kuma instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/macos/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/macos/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/macos.md
+++ b/app/mesh/1.0.x/installation/macos.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Mesh With macOS
+title: Kong Mesh with macOS
 no_search: true
 ---
 
@@ -41,7 +41,7 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
 After downloading the {{site.mesh_product_name}} binaries, the remaining
 installation instructions for Kuma are fully compatible with

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -12,12 +12,15 @@ To install and run {{site.mesh_product_name}} on OpenShift execute the following
 
 ### 1. Download {{site.mesh_product_name}}
 
-To run {{site.mesh_product_name}} on OpenShift, you need to download a compatible version of {{site.mesh_product_name}} for the machine from which you will be executing the commands.
+To run {{site.mesh_product_name}} on OpenShift, you need to download a
+compatible version of {{site.mesh_product_name}} for the machine from which
+you will be executing the commands.
 
 {% navtabs %}
 {% navtab Script %}
 
-You can run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+You can run the following script to automatically detect the operating system
+and download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
@@ -26,7 +29,9 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
+You can also download the distribution manually. Download a distribution for
+the **client host** from where you will be executing the commands to access
+Kubernetes:
 
 * [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
 * [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
@@ -34,7 +39,7 @@ You can also download the distribution manually. Download a distribution for the
 * [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
 
-and extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
@@ -45,6 +50,10 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 
 ### 2. Follow Kuma instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/openshift/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/openshift/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -1,11 +1,12 @@
 ---
-title: Kong Mesh With OpenShift
+title: Kong Mesh with OpenShift
 no_search: true
 ---
 
 ## OpenShift
 
-To install and run {{site.mesh_product_name}} on OpenShift execute the following steps:
+To install and run {{site.mesh_product_name}} on OpenShift, execute the
+following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
@@ -48,7 +49,7 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
 After downloading the {{site.mesh_product_name}} binaries, the remaining
 installation instructions for Kuma are fully compatible with

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -1,11 +1,12 @@
 ---
-title: Kong Mesh With RedHat
+title: Kong Mesh with RedHat
 no_search: true
 ---
 
 ## Redhat
 
-To install and run {{site.mesh_product_name}} on RedHat (**x86_64**) execute the following steps:
+To install and run {{site.mesh_product_name}} on RedHat (**x86_64**), execute
+the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
@@ -33,7 +34,7 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
 After downloading the {{site.mesh_product_name}} binaries, the remaining
 installation instructions for Kuma are fully compatible with

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -12,22 +12,33 @@ To install and run {{site.mesh_product_name}} on RedHat (**x86_64**) execute the
 
 ### 1. Download {{site.mesh_product_name}}
 
-Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system
+and download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
+{% endnavtab %}
+{% navtab Manually %}
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz) the distribution manually.
 
-or you can [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz) the distribution manually.
-
-Then extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ### 2. Follow Kuma instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/redhat/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/redhat/#_2-run-kuma).

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -1,11 +1,12 @@
 ---
-title: Kong Mesh With Ubuntu
+title: Kong Mesh with Ubuntu
 no_search: true
 ---
 
 ## Ubuntu
 
-To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**) execute the following steps:
+To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**), execute
+the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#_1-download-kong-mesh)
 * [2. Follow Kuma instructions](#_2-follow-kuma-instructions)
@@ -15,7 +16,8 @@ To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**) execute the 
 {% navtabs %}
 {% navtab Script %}
 
-Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
@@ -34,7 +36,7 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Follow Kuma instructions
+### 2. Follow Kuma Instructions
 
 After downloading the {{site.mesh_product_name}} binaries, the remaining
 installation instructions for Kuma are fully compatible with

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -12,22 +12,34 @@ To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**) execute the 
 
 ### 1. Download {{site.mesh_product_name}}
 
+{% navtabs %}
+{% navtab Script %}
+
 Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
 
 ```sh
 $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
+{% endnavtab %}
+{% navtab Manually %}
 
-or you can [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz) the distribution manually.
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+ the distribution manually.
 
-Then extract the archive with:
+Then, extract the archive with:
 
 ```sh
 $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ### 2. Follow Kuma instructions
 
-Afer downloading the {{site.mesh_product_name}} binaries, the installation instructions are compatible with Kuma, except they will be running the {{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+After downloading the {{site.mesh_product_name}} binaries, the remaining
+installation instructions for Kuma are fully compatible with
+{{site.mesh_product_name}}, except you will be running the
+{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
 
-To continue the installation follow the second installation step on [the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/ubuntu/#_2-run-kuma).
+To continue the installation, start from the second installation step in
+[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/ubuntu/#_2-run-kuma).


### PR DESCRIPTION
* Adjusting formatting, language, grammar
* For Docker install: fixing Docker image name to point to Kong Mesh instead of Kuma (tested pulling them, they should be correct now)
* Adding tabs to installation pages that were missing them to match other installation pages
* Removing link to Helm and Helm chart tab, as Helm install doesn't exist yet. Will re-add when that changes.

Previews:
- [Getting Started](https://deploy-preview-2290--kongdocs.netlify.app/mesh/1.0.x/gettingstarted/) - included this topic because it's mainly about installation
- [Install](https://deploy-preview-2290--kongdocs.netlify.app/mesh/1.0.x/install/) - see all installation topics under this section
