### PR TITLE
docs(plugins) Change third-party plugins filter label on Hub page

### DIFF
--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -54,7 +54,7 @@ body_id: page-hub
             </li>
             <li class="nav-item">
               <a class="nav-link" data-filter="pub-not-konghq">
-                Community Published
+                Third-Party
               </a>
             </li>
           </ul>


### PR DESCRIPTION
Changing filter label from "Community Published" to "Third-Party". The current label confuses people, who assume that it's referring to Kong Community/Kong Gateway.

Aligns with term in docs.konghq.com/hub/plugins/overview/#terminology.

Preview: https://deploy-preview-2299--kongdocs.netlify.app/hub/