### PR TITLE
docs(ee-hybrid) Clarify CP/DP connection behavior

### DIFF
--- a/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
@@ -333,8 +333,8 @@ is disabled.
 <div class="alert alert-warning">
 <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
 <b>Important:</b> Data Plane nodes receive updates from the Control Plane via a format
-similar to declarative config, therefore `database` has to be set to `off`
-for Kong to start up properly.
+similar to declarative config, therefore <code>database</code> has to be set to
+<code>off</code> for Kong to start up properly.
 </div>
 
 {% navtabs %}

--- a/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
@@ -13,7 +13,7 @@ We will bring up any subsequent Data Plane (DP) instances in this topic.
 > Note: For a Hybrid mode deployment on Kubernetes, see [Hybrid mode](https://github.com/Kong/charts/blob/main/charts/kong/README.md#hybrid-mode)
 in the `kong/charts` repository.
 
-## Step 1: Generate a certificate/key pair
+## Step 1: Generate a Certificate/Key Pair
 In Hybrid mode, a mutual TLS handshake (mTLS) is used for authentication so the
 actual private key is never transferred on the network, and communication
 between CP and DP nodes is secure.
@@ -218,7 +218,7 @@ Kong doesn't validate the CommonName (CN) in the DP certificate; it can take an 
 {% endnavtab %}
 {% endnavtabs %}
 
-## Step 2: Set up the Control Plane
+## Step 2: Set Up the Control Plane
 Next, give the Control Plane node the `control_plane` role, and set
 certificate/key parameters to point at the location of your certificates and
 keys.
@@ -321,7 +321,7 @@ backend database.
 
 >**Note:** Control Plane nodes cannot be used for proxying.
 
-## Step 3: Install and start Data Planes
+## Step 3: Install and Start Data Planes
 Now that the Control Plane is running, you can attach Data Plane nodes to it to
 start serving traffic.
 
@@ -333,8 +333,8 @@ is disabled.
 <div class="alert alert-warning">
 <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
 <b>Important:</b> Data Plane nodes receive updates from the Control Plane via a format
-similar to declarative config, therefore the storage property has to be
-set to <code>memory</code> for Kong to start up properly.
+similar to declarative config, therefore `database` has to be set to `off`
+for Kong to start up properly.
 </div>
 
 {% navtabs %}
@@ -486,7 +486,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
 {% endnavtab %}
 {% endnavtabs %}
 
-## Step 4: Verify that nodes are connected
+## Step 4: Verify that Nodes are Connected
 
 Use the Control Plane’s Cluster Status API to monitor your Data Planes. It provides:
 * The name of the node
@@ -526,7 +526,7 @@ The output shows all of the connected Data Plane instances:
 }
 ```
 
-## Configuration reference
+## Configuration Reference
 
 Use the following configuration properties to configure {{site.ee_product_name}}
 in Hybrid mode.
@@ -550,7 +550,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 `cluster_server_name` <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
 `cluster_telemetry_server_name` |  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
-## Next steps
+## Next Steps
 
 Now, you can start managing the cluster using the Control Plane. Once
 all instances are set up, use the Admin API on the Control Plane as usual, and

--- a/app/enterprise/2.1.x/deployment/hybrid-mode.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode.md
@@ -19,6 +19,13 @@ and receive the latest configuration.
 
 ![Hybrid mode topology](/assets/images/docs/ee/deployment/deployment-hybrid-2.png)
 
+When you create a new Data Plane node, it establishes a connection to the
+Control Plane. The Control Plane listens on port 8005 for connections and
+tracks any incoming data from its Data Planes.
+
+Once connected, every Admin API or Kong Manager action on the Control Plane
+triggers an update to the Data Planes in the cluster.
+
 ## Benefits
 
 Hybrid mode deployments have the following benefits:
@@ -40,12 +47,12 @@ won’t be able to affect other nodes in the Kong cluster.
 * **Ease of management:** Admins only need to interact with the CP nodes to
 control and monitor the status of the entire Kong cluster.
 
-## Platform compatibility
+## Platform Compatibility
 
 You can run {{site.ee_product_name}} in Hybrid mode on any platform where
 {{site.ee_product_name}} is [supported](/enterprise/{{page.kong_version}}/deployment/installation/overview).
 
-### Kubernetes support and additional documentation
+### Kubernetes Support and Additional Documentation
 [Kong Enterprise on Kubernetes](/enterprise/{{page.kong_version}}/kong-for-kubernetes/install-on-kubernetes)
 fully supports Hybrid mode deployments, with or without the Kong Ingress Controller.
 
@@ -55,14 +62,14 @@ in the `kong/charts` repository.
 
 ## Limitations
 
-### Configuration inflexibility
+### Configuration Inflexibility
 When a configuration change is made at the Control Plane level via the Admin
-API, it triggers a cluster-wide update of all Data Plane configurations. This
-means that the same configuration is synced from the CP to all DPs. For
-different DPs to have different configurations, they will need their own CP
-instances.
+API, it immediately triggers a cluster-wide update of all Data Plane
+configurations. This means that the same configuration is synced from the CP to
+all DPs, and the update cannot be scheduled or batched. For different DPs to
+have different configurations, they will need their own CP instances.
 
-### Plugin incompatibility
+### Plugin Incompatibility
 When plugins are running on a Data Plane in hybrid mode, there is no Admin API
 exposed directly from that DP. Since the Admin API is only exposed from the
 Control Plane, all plugin configuration has to occur from the CP. Due to this
@@ -80,7 +87,12 @@ compatible with Hybrid mode. For its regular workflow, the plugin needs to both
 generate and delete tokens, and commit those changes to the database, which is
 not possible with CP/DP separation.
 
-### Custom plugins
+### Custom Plugins
 Custom plugins (either your own plugins or third-party plugins that are not
 shipped with Kong) need to be installed on both the Control Plane and the Data
 Plane in Hybrid mode.
+
+### Load Balancing
+Currently, there is no automated load balancing for connections between the
+Control Plane and the Data Plane. You can load balance manually by using
+multiple Control Planes and redirecting the traffic using a TCP proxy.


### PR DESCRIPTION
Updating docs based on 2.1 internal enablement session (see https://konghq.atlassian.net/browse/DOCS-1238) and change made in https://github.com/Kong/docs.konghq.com/pull/2266. 
* Clarify how often config gets synced between CP and DP and whether that's customizable 
* Clarify what happens when you add a new data plane
* Add limitation on load balancing between CP and DP
* Change `storage` property to `database`

Previews:
https://deploy-preview-2302--kongdocs.netlify.app/enterprise/2.1.x/deployment/hybrid-mode-setup/
https://deploy-preview-2302--kongdocs.netlify.app/enterprise/2.1.x/deployment/hybrid-mode/