### PR TITLE
docs(getting started guide) Example formatting and decK tab titles

### DIFF
--- a/app/getting-started-guide/2.1.x/dev-portal.md
+++ b/app/getting-started-guide/2.1.x/dev-portal.md
@@ -17,12 +17,12 @@ Make sure the Dev Portal is on. You should have enabled it for Kong Gateway duri
 {% navtab Using the Admin API %}
 
 *Using cURL:*
-```
+```sh
 $ curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
---data "config.portal=true"
+--data config.portal=true
 ```
 *Or using HTTPie:*
-```
+```sh
 $ http PATCH :8001/workspaces/SecureWorkspace config.portal=true
 ```
 

--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -34,13 +34,13 @@ Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s conf
 1. Define a Service with the name `example_service` and the URL `http://mockbin.org`.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -i -X POST http://<admin-hostname>:8001/services \
     --data name=example_service \
     --data url='http://mockbin.org'
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http POST :8001/services name=example_service url='http://mockbin.org'
     ```
     If the service is created successfully, you'll get a 201 success message.
@@ -48,11 +48,11 @@ Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s conf
 2. Verify the service’s endpoint.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -i http://<admin-hostname>:8001/services/example_service
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8001/services/example_service
     ```
 
@@ -71,7 +71,7 @@ Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s conf
 
 The service is created, and the page automatically redirects back to the `example_service` overview page.
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 
 1. In the `kong.yaml` file you exported in
 [Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare/#verify-the-kong-gateway-configuration),
@@ -115,14 +115,14 @@ For the Service to be accessible through the Kong Gateway, you need to add a Rou
 Define a Route (`/mock`) for the Service (`example_service`) with a specific path that clients need to request. Note at least one of the hosts, paths, or methods must be set for the route to be matched to the service.
 
 *Using cURL*:
-  ```
+  ```sh
   $ curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
-  --data 'name=mocking'
+  --data name=mocking
   ```
 
 *Or using HTTPie*:
-  ```
+  ```sh
   $ http :8001/services/example_service/routes paths:='["/mock"]' name=mocking
   ```
 
@@ -145,7 +145,7 @@ A 201 message indicates the route was created successfully.
 The route is created and you are automatically redirected back to the `example_service` overview page. The new Route appears under the Routes section.
 
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 
 1. Paste the following into the `kong.yaml` file, under the entry for
 `example_service`:
@@ -242,12 +242,12 @@ is now using:
 Using the Admin API, issue the following:
 
 *Using cURL*:
-```
+```sh
 $ curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
 
 *Or using HTTPie*:
-```
+```sh
 $ http :8000/mock/request
 ```
 

--- a/app/getting-started-guide/2.1.x/improve-performance.md
+++ b/app/getting-started-guide/2.1.x/improve-performance.md
@@ -24,7 +24,7 @@ Use proxy caching so that Upstream services are not bogged down with repeated re
 Call the Admin API on port `8001` and configure plugins to enable in-memory caching globally, with a timeout of 30 seconds for Content-Type `application/json`.
 
 *Using cURL*:
-```
+```sh
 $ curl -i -X POST http://<admin-hostname>:8001/plugins \
 --data name=proxy-cache \
 --data config.content_type="application/json; charset=utf-8" \
@@ -33,7 +33,7 @@ $ curl -i -X POST http://<admin-hostname>:8001/plugins \
 ```
 
 *Or using HTTPie*:
-```
+```sh
 $ http -f :8001/plugins name=proxy-cache config.strategy=memory config.content_type="application/json; charset=utf-8"
 ```
 
@@ -61,7 +61,7 @@ $ http -f :8001/plugins name=proxy-cache config.strategy=memory config.content_t
 
 8. Click **Create**.
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 
 1. In the `plugins` section of your `kong.yaml` file, add the `proxy-cache`
 plugin with a timeout of 30 seconds for Content-Type
@@ -121,12 +121,12 @@ Let’s check that proxy caching works.
 1. Access the */mock* route using the Admin API and note the response headers.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -i -X GET http://<admin-hostname>:8000/mock/request
     ```
 
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8000/mock/request
     ```
 
@@ -162,11 +162,11 @@ Let’s check that proxy caching works.
 3. To test more rapidly, the cache can be deleted by calling the Admin API:
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http delete :8001/proxy-cache
     ```
 

--- a/app/getting-started-guide/2.1.x/load-balancing.md
+++ b/app/getting-started-guide/2.1.x/load-balancing.md
@@ -30,39 +30,39 @@ In this section, you will create an Upstream named `upstream` and add two target
 1. Call the Admin API on port `8001` and create an Upstream named `upstream`.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -X POST http://<admin-hostname>:8001/upstreams \
     --data name=upstream
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http POST :8001/upstreams name=upstream
     ```
 
 2. Update the service you created previously to point to this upstream.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -X PATCH http://<admin-hostname>:8001/services/example_service \
     --data host='upstream'
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http PATCH :8001/services/example_service host='upstream'
     ```
 
 3. Add two targets to the upstream, each with port 80: `mockbin.org:80` and `httpbin.org:80`.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -X POST http://<admin-hostname>:8001/upstreams/upstream/targets \
-    --data target=’mockbin.org:80’
+    --data target='mockbin.org:80'
 
     $ curl -X POST http://<admin-hostname>:8001/upstreams/upstream/targets \
-    --data target=’httpbin.org:80’
+    --data target='httpbin.org:80'
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http POST :8001/upstreams/upstream/targets target=mockbin.org:80
     $ http POST :8001/upstreams/upstream/targets target=httpbin.org:80
     ```
@@ -84,7 +84,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 12. Change the **Host** field to `upstream`, then click **Update**.
 {% endnavtab %}
 
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 1. In your `kong.yaml` file, create an Upstream with two targets, each with port
 80: `mockbin.org:80` and `httpbin.org:80`.
 
@@ -163,7 +163,7 @@ You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and 
 
 ## Validate the Upstream Services
 
-1. With the upstream configured, validate that it’s working by visiting the route `http://<admin-hostname>:8000/mock` using a web browser or CLI.
+1. With the Upstream configured, validate that it’s working by visiting the route `http://<admin-hostname>:8000/mock` using a web browser or CLI.
 2. Continue hitting the endpoint and the site should change from `httpbin` to `mockbin`.
 
 ## Summary and next steps

--- a/app/getting-started-guide/2.1.x/manage-teams.md
+++ b/app/getting-started-guide/2.1.x/manage-teams.md
@@ -40,18 +40,18 @@ To enable RBAC, you will need the initial KONG_PASSWORD that was used when you f
 {% navtabs %}
 {% navtab UNIX-based system or Windows %}
 1. Modify configuration settings below in your `kong.conf` file. Navigate to the file at `/etc/kong/kong.conf`:
-    ```
+    ```sh
     $ cd /etc/kong/
     ```
 2. Copy the `kong.conf.default` file so you know you have a working copy to fall back to.
 
-    ```
+    ```sh
     $ cp kong.conf.default kong.conf
     ```
 
 3. Now, edit the following settings in `kong.conf`:
 
-    ```
+    ```sh
     $ echo >> “enforce_rbac = on” >> /etc/kong/kong.conf
     $ echo >> “admin_gui_auth = basic-auth” >> /etc/kong.conf
     $ echo >> “admin_gui_session_conf = {"secret":"secret","storage":"kong","cookie_secure":false}”
@@ -63,7 +63,7 @@ To enable RBAC, you will need the initial KONG_PASSWORD that was used when you f
 
 4. Restart {{site.ee_product_name}} and point to the new config file:
 
-    ```
+    ```sh
     $ kong restart -c /etc/kong/kong.conf
     ```
 {% endnavtab %}
@@ -73,7 +73,7 @@ If you have a Docker installation, run the following command to set the needed e
 
 **Note:** make sure to replace `<kong-container-id>` with the ID of your container.
 
-```
+```sh
 $ echo "KONG_ENFORCE_RBAC=on KONG_ADMIN_GUI_AUTH=basic-auth KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' kong reload exit" | docker exec -i <kong-container-id>
 ```
 
@@ -140,12 +140,12 @@ Outside of this guide, you will likely want to modify these settings differently
 Create a new Workspace called SecureWorkspace, substituting the `kong_admin` account’s password in place of `<super-user-token>`.
 
 *Using cURL:*
-```
+```sh
 $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/workspaces \
 --data 'name=SecureWorkspace'
 ```
 *Or using HTTPie:*
-```
+```sh
 $ http :8001/workspaces name=SecureWorkspace Kong-Admin-Token:<super-user-token>
 ```
 
@@ -224,51 +224,51 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 1. Create a new user named `secureworkspaceadmin` with the RBAC token `secureadmintoken`.
 
     *Using cURL:*
-    ```
+    ```sh
     $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
     --data 'name=secureworkspaceadmin' \
     --data 'user_token=secureadmintoken'
     ```
     *Or using HTTPie:*
-    ```
+    ```sh
     $ http :8001/SecureWorkspace/rbac/users name=secureworkspaceadmin user_token=secureadmintoken Kong-Admin-Token:<super-user-token>
     ```
 
 2. Create a blank role in the workspace and name it `admin`.
 
     *Using cURL:*
-    ```
+    ```sh
     $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
     --data 'name=admin' \
     ```
     *Or using HTTPie:*
-    ```
+    ```sh
     http :8001/SecureWorkspace/rbac/roles/ name=admin Kong-Admin-Token:<super-user-token>
     ```
 
 3. Give the `admin` role permissions to do everything on all endpoints in the workspace.
 
     *Using cURL:*
-    ```
+    ```sh
     $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
     --data 'endpoint=*'
     --data 'workspace=SecureWorkspace' \
     --data 'actions=*'
     ```
     *Or using HTTPie:*
-    ```
+    ```sh
     http :8001/secureworkspace/rbac/roles/admin/endpoints/ endpoint='*' workspace=SecureWorkspace actions='*' Kong-Admin-Token:<super-user-token>
     ```
 
 4. Grant the `admin` role to `secureworkspaceadmin`.
 
     *Using cURL:*
-    ```
+    ```sh
     $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
     --data 'role=admin'
     ```
     *Or using HTTPie:*
-    ```
+    ```sh
     http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ roles=admin Kong-Admin-Token:<super-user-token>
     ```
 
@@ -292,12 +292,12 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 1. Try to access the `default` workspace using `secureworkspaceadmin`'s user token.
 
     *Using cURL:*
-    ```
+    ```sh
     $ curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
     ```
     *Or using HTTPie:*
 
-    ```
+    ```sh
     http :8001/default/rbac/users Kong-Admin-Token:secureadmintoken
     ```
 
@@ -310,12 +310,12 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 2. Then, try to access the same endpoint, but this time in the `SecureWorkspace`.
 
     *Using cURL:*
-    ```
+    ```sh
     $ curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
     ```
     *Or using HTTPie:*
 
-    ```
+    ```sh
     http :8001/default/rbac/users Kong-Admin-Token:secureadmintoken
     ```
     This time, you should get a `200 OK` success message and a list of users.

--- a/app/getting-started-guide/2.1.x/prepare.md
+++ b/app/getting-started-guide/2.1.x/prepare.md
@@ -64,7 +64,7 @@ Open a web browser and navigate to `http://<admin-hostname>:8002`.
 If {{site.ee_product_name}} was installed correctly, it automatically logs you in and presents the Kong Manager Overview page.
 {% endnavtab %}
 
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 
 1. Check that decK is connected to Kong:
 
@@ -120,7 +120,7 @@ the Cluster Status CLI.
 Run the following on a Control Plane:
 {% navtabs %}
 {% navtab Using cURL %}
-```
+```sh
 $ curl -i -X GET http://<admin-hostname>:8001/clustering/status
 ```
 {% endnavtab %}
@@ -132,7 +132,7 @@ $ http :8001/clustering/status
 {% endnavtabs %}
 The output shows all of the connected Data Plane instances:
 
-```bash
+```sh
 {
     "a08f5bf2-43b8-4f1c-bdf5-0a0ffb421c21": {
         "config_hash": "64d661f505f7e1de5b4c5e5faa1797dd",

--- a/app/getting-started-guide/2.1.x/protect-services.md
+++ b/app/getting-started-guide/2.1.x/protect-services.md
@@ -29,14 +29,14 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.
 
 *Using cURL*:
-```
+```bash
 $ curl -i -X POST http://<admin-hostname>:8001/plugins \
---data "name=rate-limiting" \
---data "config.minute=5" \
---data "config.policy=local"
+--data name=rate-limiting \
+--data config.minute=5 \
+--data config.policy=local
 ```
 *Or using HTTPie*:
-```
+```bash
 $ http -f post :8001/plugins name=rate-limiting config.minute=5 config.policy=local
 ```
 {% endnavtab %}
@@ -66,7 +66,7 @@ $ http -f post :8001/plugins name=rate-limiting config.minute=5 config.policy=lo
 
 7. Click **Create**.
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have Kong Enterprise or free trial access, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced instead.
@@ -133,11 +133,11 @@ and in-memory, on the node:
 To validate rate limiting, access the API six (6) times from the CLI to confirm the requests are rate limited.
 
 *Using cURL*:
-```
+```bash
 $ curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
 *Or using HTTPie*:
-```
+```bash
 $ http :8000/mock/request
 ```
 

--- a/app/getting-started-guide/2.1.x/protect-services.md
+++ b/app/getting-started-guide/2.1.x/protect-services.md
@@ -29,14 +29,14 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.
 
 *Using cURL*:
-```bash
+```sh
 $ curl -i -X POST http://<admin-hostname>:8001/plugins \
 --data name=rate-limiting \
 --data config.minute=5 \
 --data config.policy=local
 ```
 *Or using HTTPie*:
-```bash
+```sh
 $ http -f post :8001/plugins name=rate-limiting config.minute=5 config.policy=local
 ```
 {% endnavtab %}
@@ -133,11 +133,11 @@ and in-memory, on the node:
 To validate rate limiting, access the API six (6) times from the CLI to confirm the requests are rate limited.
 
 *Using cURL*:
-```bash
+```sh
 $ curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
 *Or using HTTPie*:
-```bash
+```sh
 $ http :8000/mock/request
 ```
 

--- a/app/getting-started-guide/2.1.x/secure-services.md
+++ b/app/getting-started-guide/2.1.x/secure-services.md
@@ -38,30 +38,30 @@ For more information, see [What is API Gateway Authentication?](https://konghq.c
 
     *Using cURL*:
 
-    ```
+    ```sh
     $ curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
     --data name=key-auth
     ```
     *Or using HTTPie*:
 
-    ```
+    ```sh
     $ http :8001/routes/mocking/plugins name=key-auth
     ```
 
 2. Try to access the service again:
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -i http://<admin-hostname>:8000/mock
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8000/mock
     ```
 
     Since you added key authentication, you should be unable to access it:
 
-    ```
+    ```sh
     HTTP/1.1 401 Unauthorized
     ...
     {
@@ -92,7 +92,7 @@ Now, if you try to access the route without providing an API key, the request wi
 
 Before Kong proxies requests for this route, it needs an API key. For this example, since you installed the Key Authentication plugin, you need to create a consumer with an associated key first.
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 1. Under the `mocking` route in the `routes` section of the `kong.yaml` file,
 add a plugin section and enable the `key-auth` plugin:
 
@@ -155,29 +155,32 @@ a consumer with an associated key first.
 1. To create a consumer, call the Admin API and the consumer’s endpoint. The following creates a new consumer called **consumer**.
 
     *Using cURL*:
-    ```
-    $ curl -i -X POST -d "username=consumer&custom_id=consumer" http://<admin-hostname>:8001/consumers/
+    ```sh
+    $ curl -i -X POST http://<admin-hostname>:8001/consumers/ \
+     --data username=consumer \
+     --data custom_id=consumer
     ```
 
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8001/consumers username=consumer custom_id=consumer
     ```
 
 2. Once provisioned, call the Admin API to provision a key for the consumer created above. For this example, set the key to `apikey`. If no key is entered, Kong automatically generates the key.
 
     *Using cURL*:
-    ```
-    $ curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth -d 'key=apikey'
+    ```sh
+    $ curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
+    --data key=apikey
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8001/consumers/consumer/key-auth key=apikey
     ```
 
     Result:
 
-    ```
+    ```sh
     HTTP/1.1 201 Created
     ...
     {
@@ -206,7 +209,7 @@ a consumer with an associated key first.
 
   The new Key Authentication ID displays on the **Consumers** page under the **Credentials** tab.
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 1. Add a `consumers` section to your `kong.yaml` file and create a new consumer:
 
     ``` yaml
@@ -270,13 +273,13 @@ You now have a consumer with an API key provisioned to access the route.
 To validate the Key Authentication plugin, access the *mocking* route again, using the header `apikey` with a key value of `apikey`.
 
 *Using cURL*:
-```
+```sh
 $ curl -i http://<admin-hostname>:8000/mock/request -H 'apikey:apikey'
 ```
 
 *Or using HTTPie*:
 
-```
+```sh
 $ http :8000/mock/request apikey:apikey
 ```
 
@@ -302,28 +305,28 @@ If you are following this getting started guide topic by topic, you will need to
 1. Find the plugin ID and copy it.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8001/routes/mocking/plugins
     ```
 
     Output:
-     ```
+     ```sh
      "id": "2512e48d9-7by0-674c-84b7-00606792f96b"
      ```
 
 2. Disable the plugin.
 
     *Using cURL*:
-    ```
+    ```sh
     $ curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
-    --data "enabled=false"
+    --data enabled=false
     ```
     *Or using HTTPie*:
-    ```
+    ```sh
     $ http :8001/routes/mocking/plugins/{<plugin-id>} enabled=false
     ```
 {% endnavtab %}
@@ -332,7 +335,7 @@ If you are following this getting started guide topic by topic, you will need to
 1. Go to the Plugins page and click on **View** for the key-auth row.
 2. Use the toggle at the top of the page to switch the plugin from **Enabled** to **Disabled**.
 {% endnavtab %}
-{% navtab Using decK %}
+{% navtab Using decK (YAML) %}
 
 1. Disable the key-auth plugin in the `kong.yaml` file by setting
 `enabled` to `false`:


### PR DESCRIPTION
* Change tab labels from "Using decK" to "Using decK (YAML)" for a bit more clarity (per Reza)
* add `sh` to cURL and HTTPie examples for syntax highlighting
* adjust cURL example syntax to be more consistent between topics (tested to make sure it works)
* fix: ` to ' in example

