### PR TITLE
acme plugin fix endpoint

### DIFF
--- a/app/_hub/kong-inc/acme/0.2.2.md
+++ b/app/_hub/kong-inc/acme/0.2.2.md
@@ -122,7 +122,7 @@ is mapped to a Route in Kong. You can check this by sending
 If not, add a Route and a dummy Service to catch this route.
 ```bash
 # add a dummy service if needed
-$ curl http://localhost:8001/service \
+$ curl http://localhost:8001/services \
         -d name=acme-dummy \
         -d url=http://127.0.0.1:65535
 

--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -161,7 +161,7 @@ You can also [use the Admin API](#create-certificates) to verify the setup.
 If not, add a Route and a dummy Service to catch this route.
 ```bash
 # add a dummy service if needed
-$ curl http://localhost:8001/service \
+$ curl http://localhost:8001/services \
         -d name=acme-dummy \
         -d url=http://127.0.0.1:65535
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1267 logged from Shane's PR https://konghq.atlassian.net/browse/DOCS-1162

Direct review link:

https://deploy-preview-2311--kongdocs.netlify.app/hub/kong-inc/acme/#enable-the-plugin

services replaced service, needs to be plural.

This area is not in the generated template section.
