### PR TITLE
fix consumer and route links in plugin template

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -201,7 +201,7 @@ plugins:
 {% if page.params.route_id %}
 
 {% capture plugin_config_for_route_admin_api %}
-For example, configure this plugin on a [Route](/latest/admin-api/#Route-object) with:
+For example, configure this plugin on a [Route](/latest/admin-api/#route-object) with:
 
 ```bash
 $ curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
@@ -299,7 +299,7 @@ plugins:
 
 {% capture plugin_config_for_consumer_admin_api %}
 
-For example, configure this plugin on a [Consumer](/latest/admin-api/#Consumer-object) with:
+For example, configure this plugin on a [Consumer](/latest/admin-api/#consumer-object) with:
 
 ```bash
 $ curl -X POST http://<admin-hostname>:8001/consumers/<consumer>/plugins \


### PR DESCRIPTION
 From Shane's ticket https://konghq.atlassian.net/browse/DOCS-1162, this fixes subtickets:

https://konghq.atlassian.net/browse/DOCS-1272
https://konghq.atlassian.net/browse/DOCS-1274
https://konghq.atlassian.net/browse/DOCS-1275
(dupe tickets, turns out due to template links-Lena would've spotted it right away--thanks for the links to the template areas, Lena)

Sample direct links to test:

Click on Consumer link:
https://deploy-preview-2312--kongdocs.netlify.app/hub/kong-inc/proxy-cache/#enabling-the-plugin-on-a-consumer

Click on Route link:
https://deploy-preview-2312--kongdocs.netlify.app/hub/kong-inc/canary/#enabling-the-plugin-on-a-route
