### PR TITLE
Docs/cors limits proxy link latest

### DIFF
--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -5,7 +5,8 @@ version: 1.0.0
 
 desc: Allow developers to make requests from the browser
 description: |
-  Easily add __Cross-origin resource sharing *(CORS)*__ to a Service, a Route by enabling this plugin.
+  Easily add __Cross-origin resource sharing *(CORS)*__ to a Service and a Route
+  by enabling this plugin.
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled
@@ -68,19 +69,19 @@ params:
       default:
       value_in_examples: ["http://mockbin.com"]
       description: |
-        List of allowed domains for the `Access-Control-Allow-Origin` header. If you wish to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes. **NOTE**: Prior to Kong 0.10.x, this parameter was `config.origin` (note the change in trailing `s`), and only accepted a single value, or the `*` special value.
+        List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes. **NOTE**: Prior to Kong 0.10.x, this parameter was `config.origin` (note the change in trailing `s`), and only accepted a single value, or the `*` special value.
     - name: methods
       required: false
       default: "`GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS, TRACE, CONNECT`"
       value_in_examples: [ "GET", "POST" ]
       description:
-        Value for the `Access-Control-Allow-Methods` header
+        Value for the `Access-Control-Allow-Methods` header.
     - name: headers
       required: false
       default: "Value of the `Access-Control-Request-Headers` request header"
       value_in_examples: [ "Accept", "Accept-Version", "Content-Length", "Content-MD5", "Content-Type", "Date", "X-Auth-Token" ]
       description: |
-        Value for the `Access-Control-Allow-Headers` header
+        Value for the `Access-Control-Allow-Headers` header.
     - name: exposed_headers
       required: false
       default:
@@ -98,11 +99,11 @@ params:
       default:
       value_in_examples: 3600
       description: |
-        Indicated how long the results of the preflight request can be cached, in `seconds`.
+        Indicates how long the results of the preflight request can be cached, in `seconds`.
     - name: preflight_continue
       required: false
       default: "`false`"
-      description: A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the upstream service.
+      description: A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service.
 
 ---
 
@@ -116,12 +117,9 @@ If the client is a browser, there is a known issue with this plugin caused by a
 limitation of the CORS specification that doesn't allow to specify a custom
 `Host` header in a preflight `OPTIONS` request.
 
-Because of this limitation, this plugin will only work for Routes that have been
-configured with a `paths` setting, and it will not work for Routes that
+Because of this limitation, this plugin only works for Routes that have been
+configured with a `paths` setting. The CORS plugin does not work for Routes that
 are being resolved using a custom DNS (the `hosts` property).
 
-To learn how to configure `paths` for a Route, please read the [Proxy
-Reference][proxy-reference].
-
-[configuration]: /latest/configuration
-[proxy-reference]: /0.12.x/proxy#request-uri
+To learn how to configure `paths` for a Route, read the [Proxy
+Reference](/latest/proxy).

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -464,7 +464,7 @@ plugins:
     <tr><th>Form Parameter</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>name</code></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code></td></tr>
+    <tr><td><code>name</code></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code>.</td></tr>
 
     {% if page.params.service_id %}
       <tr><td><code>service.id</code></td><td>The ID of the Service the plugin targets.</td></tr>


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1270 CORS link update per Shane's ticket https://konghq.atlassian.net/browse/DOCS-1162. 

`The CORS Limitations at https://docs.konghq.com/hub/kong-inc/cors/#cors-limitations links to version 0.12.x of the "Proxy Reference" and should be updated or just removed entirely.`

Kept it and updated from hard-coded link syntax to latest.

Direct review link:
https://deploy-preview-2315--kongdocs.netlify.app/hub/kong-inc/cors/#cors-limitations very last sentence