### PR TITLE
docs(build) Set build action time limit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
     - name: Clean environment and files


### PR DESCRIPTION
We've had a few cases in the recent past where a build fails due to errors, then retries until it reaches the max default time limit of 6 hours. Setting a 30 minute build time limit to avoid this.
