### PR TITLE
docs(ee/guides) fix declarative typo

### DIFF
--- a/app/1.1.x/db-less-and-declarative-config.md
+++ b/app/1.1.x/db-less-and-declarative-config.md
@@ -34,7 +34,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is *declarative*, as opposed to an *imperative* style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the

--- a/app/1.2.x/db-less-and-declarative-config.md
+++ b/app/1.2.x/db-less-and-declarative-config.md
@@ -33,7 +33,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is _declarative_, as opposed to an _imperative_ style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the

--- a/app/1.3.x/db-less-and-declarative-config.md
+++ b/app/1.3.x/db-less-and-declarative-config.md
@@ -34,7 +34,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is *declarative*, as opposed to an *imperative* style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the

--- a/app/1.4.x/db-less-and-declarative-config.md
+++ b/app/1.4.x/db-less-and-declarative-config.md
@@ -34,7 +34,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is *declarative*, as opposed to an *imperative* style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the

--- a/app/1.5.x/db-less-and-declarative-config.md
+++ b/app/1.5.x/db-less-and-declarative-config.md
@@ -34,7 +34,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is *declarative*, as opposed to an *imperative* style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the

--- a/app/2.0.x/db-less-and-declarative-config.md
+++ b/app/2.0.x/db-less-and-declarative-config.md
@@ -34,7 +34,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is *declarative*, as opposed to an *imperative* style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the

--- a/app/2.1.x/db-less-and-declarative-config.md
+++ b/app/2.1.x/db-less-and-declarative-config.md
@@ -34,7 +34,7 @@ may skip this section.</i>
 The key idea in declarative configuration is, as its name shows, the notion
 that it is *declarative*, as opposed to an *imperative* style of
 configuration. "Imperative" means that a configuration is given as a series of
-orders: "do this, then to that". "Declative" means that the configuration is
+orders: "do this, then to that". "Declarative" means that the configuration is
 given all at once: "I declare this to be the state of the world".
 
 The Kong Admin API is an example of an imperative configuration tool: the


### PR DESCRIPTION
* fix typo in DB-less and Declarative Configuration guide
* docs versions: 1.1, 1.2, 1.3, 1.4, 1.5, 2.0, 2.1

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

