### PR TITLE
docs(styles) Unifying alert styles across docs

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1134,39 +1134,40 @@ Generic Styling for Desktop
 }
 
 .alert {
-  border: 1px solid @gray;
-  border-radius: 4px;
+  border: none;
+  border-left: 3px solid @gray;
+  border-radius: 0;
   font-size: 18px;
   padding: 8px 13px;
 }
 
 .alert-info {
   color: #757575;
-  border-color: #e0e0e0;
+  border-left: 3px solid #e0e0e0;
   background-color: #f9f9f9;
 
   &.blue {
     color: #004a80;
-    border: none;
+    border-left: 3px solid #004b80;
     background-color: #edf7ff;
   }
 }
 
 .alert-success {
   color: #3dcc3d;
-  border-color: #c0eac0;
+  border-left: 3px solid #c0eac0;
   background-color: #f4fff4;
 }
 
 .alert-warning {
   color: #808060;
-  border-color: #e0e0c9;
+  border-left: 3px solid #e0e0c9;
   background-color: #fffff7;
 }
 
 .alert-danger {
   color: #cc3d3d;
-  border-color: #eac0c0;
+  border-left: 3px solid #eac0c0;
   background-color: #fff4f4;
 }
 

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -70,7 +70,7 @@
 
     &.blue {
       color: #004A80;
-      border: none;
+      border-left: 3px solid #004b80;
       background-color: #EDF7FF;
     }
   }


### PR DESCRIPTION
Our docs have varying designs for alerts based on who wrote the CSS when, and for what product. Aligning the styles to match the left-border style in Kongponents: https://kongponents.netlify.app/components/alert.html#left-border.

Examples of different styles currently existing in the docs: 

![Screen Shot 2020-09-21 at 9 58 03 AM](https://user-images.githubusercontent.com/54370747/93797730-78c3a800-fbf1-11ea-82dd-5a1bd7dd00bb.png)

![Screen Shot 2020-09-21 at 9 59 05 AM](https://user-images.githubusercontent.com/54370747/93797739-7a8d6b80-fbf1-11ea-9427-ee92578fb8e2.png)

Previews of unified styles:
https://deploy-preview-2325--kongdocs.netlify.app/hub/peter-evans/paseto
https://deploy-preview-2325--kongdocs.netlify.app/2.1.x/getting-started/configuring-a-grpc-service/
