### PR TITLE
Terraform integration module 

### DIFF
--- a/app/_hub/kong-inc/kong-terraform-aws/index.md
+++ b/app/_hub/kong-inc/kong-terraform-aws/index.md
@@ -28,19 +28,7 @@ kong_version_compatibility:
         - 1.0.x
         - 0.14.x
         - 0.13.x
-#      incompatible:
-#        - 0.13.x
-#        - 0.12.x
-#        - 0.11.x
-#        - 0.10.x
-#        - 0.9.x
-#        - 0.8.x
-#        - 0.7.x
-#        - 0.6.x
-#        - 0.5.x
-#        - 0.4.x
-#        - 0.3.x
-#        - 0.2.x
+
     enterprise_edition:
       compatible:
         - 2.1.x
@@ -51,11 +39,7 @@ kong_version_compatibility:
         - 0.34-x
         - 0.33-x
         - 0.32-x
-#      incompatible:
-#        - 0.32-x
-#        - 0.31-x
-#        - 0.30-x
-#        - 0.29-x
+
 
 ###############################################################################
 # END YAML DATA
@@ -71,4 +55,5 @@ kong_version_compatibility:
 
 ### Documentation
 
-Details, prerequisites, and usage examples are provided at https://github.com/kong/kong-terraform-aws
+Details, prerequisites, and usage examples are provided on GitHub at
+[https://github.com/kong/kong-terraform-aws](https://github.com/kong/kong-terraform-aws).


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1280 make link to GitHub readme work. Part 1 of ticket to make the link to GitHub work. Part 2 pull readme docs into plugin hub. Subticket of Shane's plugins ticket https://konghq.atlassian.net/browse/DOCS-1162.

Direct review link:

https://deploy-preview-2327--kongdocs.netlify.app/hub/kong-inc/kong-terraform-aws/#documentation
