### PR TITLE
Add curl example for quotas Response Rate Limiting plugin 

### DIFF
--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -13,7 +13,7 @@ description: |
   days, months, or years.
 
   If the underlying Service/Route (or deprecated API entity) has no authentication
-  layer, the **Client IP** address will be used, otherwise the Consumer will be
+  layer, the **Client IP** address will be used; otherwise, the Consumer will be
   used if an authentication plugin has been configured.
 
   <div class="alert alert-warning">

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -6,7 +6,7 @@ version: 1.0.0
 desc: Rate-limiting based on a custom response header value
 description: |
   This plugin allows you to limit the number of requests a developer can make
-  based on a custom response header returned by the Upstream service. You can
+  based on a custom response header returned by the upstream service. You can
   arbitrarily set as many rate-limiting objects (or quotas) as you want and
   instruct Kong to increase or decrease them by any number of units. Each custom
   rate-limiting object can limit the inbound requests per seconds, minutes, hours,
@@ -193,9 +193,9 @@ returns an `HTTP/1.1 429` (Too Many Requests) status code and an empty response 
 ### Upstream Headers
 
 The plugin appends the usage headers for each limit before proxying it to the
-Upstream service, so that you can properly refuse to process the request if there
+upstream service, so that you can properly refuse to process the request if there
 are no more limits remaining. The headers are in the form of
-`X-RateLimit-Remaining-{limit_name}`, like:
+`X-RateLimit-Remaining-{limit_name}`, for example:
 
 ```
 X-RateLimit-Remaining-Videos: 3

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -78,8 +78,8 @@ params:
   config:
     - name: limits.{limit_name}
       required: true
-      description: This is a list of custom objects that you can set, with arbitrary
-      names set in the `{limit_name`} placeholder, like `config.limits.sms.minute=20` if your object is called "SMS".
+      value_in_examples: <SMS>
+      description: This is a list of custom objects that you can set, with arbitrary names set in the `{limit_name`} placeholder, like `config.limits.sms.minute=20` if your object is called "SMS".
     - name: limits.{limit_name}.second
       required: semi
       description: The amount of HTTP requests the developer can make per second. At least one limit must exist.

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -155,8 +155,8 @@ Header-Name: Limit=Value [,Limit=Value]
 Because `X-Kong-Limit` is the default header name (you can optionally change it),
 the request looks like:
 
-```
-X-Kong-Limit: limitname1=2, limitname2=4
+```bash
+$ curl -v -H 'X-Kong-Limit: limitname1=2, limitname2=4'
 ```
 
 The above example increments the limit `limitname1` by 2 units, and `limitname2` by 4 units.

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -5,9 +5,16 @@ version: 1.0.0
 
 desc: Rate-limiting based on a custom response header value
 description: |
-  This plugin allows you to limit the number of requests a developer can make based on a custom response header returned by the upstream service. You can arbitrary set as many rate-limiting objects (or quotas) as you want and instruct Kong to increase or decrease them by any number of units. Each custom rate-limiting object can limit the inbound requests per seconds, minutes, hours, days, months or years.
+  This plugin allows you to limit the number of requests a developer can make
+  based on a custom response header returned by the Upstream service. You can
+  arbitrarily set as many rate-limiting objects (or quotas) as you want and
+  instruct Kong to increase or decrease them by any number of units. Each custom
+  rate-limiting object can limit the inbound requests per seconds, minutes, hours,
+  days, months, or years.
 
-  If the underlying Service/Route (or deprecated API entity) has no authentication layer, the **Client IP** address will be used, otherwise the Consumer will be used if an authentication plugin has been configured.
+  If the underlying Service/Route (or deprecated API entity) has no authentication
+  layer, the **Client IP** address will be used, otherwise the Consumer will be
+  used if an authentication plugin has been configured.
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled
@@ -71,7 +78,8 @@ params:
   config:
     - name: limits.{limit_name}
       required: true
-      description: This is a list of custom objects that you can set, with arbitrary names set in the `{limit_name`} placeholder, like `config.limits.sms.minute=20` if your object is called "SMS".
+      description: This is a list of custom objects that you can set, with arbitrary
+      names set in the `{limit_name`} placeholder, like `config.limits.sms.minute=20` if your object is called "SMS".
     - name: limits.{limit_name}.second
       required: semi
       description: The amount of HTTP requests the developer can make per second. At least one limit must exist.
@@ -110,7 +118,7 @@ params:
     - name: fault_tolerant
       required: false
       default: "`true`"
-      description: A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true` requests will be proxied anyways effectively disabling the rate-limiting function until the datastore is working again. If `false` then the clients will see `500` errors.
+      description: A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors.
     - name: hide_client_headers
       required: false
       default: "`false`"
@@ -144,28 +152,33 @@ After adding the plugin, you can increment the configured limits by adding the f
 Header-Name: Limit=Value [,Limit=Value]
 ```
 
-Since `X-Kong-Limit` is the default header name (you can optionally change it), it will look like:
+Because `X-Kong-Limit` is the default header name (you can optionally change it),
+the request looks like:
 
 ```
 X-Kong-Limit: limitname1=2, limitname2=4
 ```
 
-That will increment the limit `limitname1` by 2 units, and `limitname2` by 4 units.
+The above example increments the limit `limitname1` by 2 units, and `limitname2` by 4 units.
 
-You can optionally increment more than one limit by comma separating the entries. The header will be removed before returning the response to the original client.
+You can optionally increment more than one limit with comma-separated entries.
+The header is removed before returning the response to the original client.
 
 ----
 
 ## Headers sent to the client
 
-When this plugin is enabled, Kong will send some additional headers back to the client telling how many units are available and how many are allowed. For example if you created a limit/quota called "Videos" with a per-minute limit:
+When the plugin is enabled, Kong sends some additional headers back to the
+client telling how many units are available and how many are allowed.
+
+For example, if you created a limit/quota called "Videos" with a per-minute limit:
 
 ```
 X-RateLimit-Limit-Videos-Minute: 10
 X-RateLimit-Remaining-Videos-Minute: 9
 ```
 
-or it will return a combination of more time limits, if more than one is being set:
+If more than one limit value is being set, it returns a combination of more time limits:
 
 ```
 X-RateLimit-Limit-Videos-Second: 5
@@ -174,11 +187,15 @@ X-RateLimit-Limit-Videos-Minute: 10
 X-RateLimit-Remaining-Videos-Minute: 10
 ```
 
-If any of the limits configured is being reached, the plugin will return a `HTTP/1.1 429` status code and an empty body.
+If any of the limits configured is being reached, the plugin
+returns an `HTTP/1.1 429` (Too Many Requests) status code and an empty response body.
 
 ### Upstream Headers
 
-The plugin will append the usage headers for each limit before proxying it to the upstream service, so that you can properly refuse to process the request if there are no more limits remaining. The headers are in the form of `X-RateLimit-Remaining-{limit_name}`, like:
+The plugin appends the usage headers for each limit before proxying it to the
+Upstream service, so that you can properly refuse to process the request if there
+are no more limits remaining. The headers are in the form of
+`X-RateLimit-Remaining-{limit_name}`, like:
 
 ```
 X-RateLimit-Remaining-Videos: 3


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1277 from Shane's parent ticket https://konghq.atlassian.net/browse/DOCS-1162

Description: It'd be nice to add a curl example at https://docs.konghq.com/hub/kong-inc/response-ratelimiting/#configuring-quotas

Direct review link:
https://deploy-preview-2328--kongdocs.netlify.app/hub/kong-inc/response-ratelimiting/#configuring-quotas

Requested syntax verification from reviewers. Links not jumping to proper location, so screenshot:

![image](https://user-images.githubusercontent.com/3756245/94064860-e1588380-fdaf-11ea-8996-7879fbe9874b.png)

