### PR TITLE
docs(ToC) Fix RBAC and Admins sections in Kong Manager

### DIFF
--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -348,7 +348,7 @@
         - text: Add a Workspace
           url: /kong-manager/administration/workspaces/add-workspace
         - text: RBAC
-        - items:
+          items:
           - text: RBAC in Kong Manager
             url: /kong-manager/administration/rbac
           - text: Create a New Role
@@ -358,7 +358,7 @@
           - text: Add a Role and Permissions
             url: /kong-manager/administration/rbac/add-role
         - text: Admins
-        - items:
+          items:
           - text: Invite an Admin
             url: /kong-manager/administration/admins/invite
           - text: Add an Admin


### PR DESCRIPTION
Extra dashes in `- items` entries were breaking the ToC structure.

Relates to: https://konghq.atlassian.net/browse/DOCS-1320