### PR TITLE
docs(style) Adjust headers to less imposing size

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -123,19 +123,19 @@
     // titles proportions overridden from base.less
 
     h2 {
-      margin-top: 3rem;
+      margin-top: 3.2rem;
       margin-bottom: 1rem;
-      font-size: 3.5rem;
-      font-weight: 400;
+      font-size: 3.2rem;
+      font-weight: 500;
     }
 
     h3 {
-      font-size: 2.5rem;
-      font-weight: 300;
+      font-size: 2.4rem;
+      font-weight: 400;
     }
 
     h4 {
-      font-size: 2.2rem;
+      font-size: 2rem;
       font-weight: 300;
     }
 


### PR DESCRIPTION
The H2 headers are especially intense in the docs. This is only a slight adjustment, to make sure the Admin API docs don't get  confusing, however, it should help the rest of the doc site - EE installation topics in particular.