### PR TITLE
docs(style) Adjust padding for navtabs

### DIFF
--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -1,4 +1,6 @@
 .navtabs {
+  margin-top: 1.5rem;
+
   .navtab-titles {
     display: flex;
     align-items: center;
@@ -36,6 +38,6 @@
   }
 
   .navtab-contents {
-    padding: 24px 0;
+    padding: 1.5rem 0 0 0;
   }
 }


### PR DESCRIPTION
Remove awkward whitespace after navtab sections.

For comparison, see tab whitespace in the following install topic:

Old: https://docs.konghq.com/enterprise/2.1.x/kong-for-kubernetes/install/
New: https://deploy-preview-2331--kongdocs.netlify.app/enterprise/2.1.x/kong-for-kubernetes/install/