### PR TITLE
Exit Transformer cURL examples in demo section; remove obsolete handle_admin field; update for errs by mimetype

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -85,7 +85,7 @@ Kong -> f(status, body, headers) -> ... -> exit(status, body, headers)
   instantiate them if they do not exist.
 </div>
 
-If you maniupulate body and headers, see the
+If you manipulate body and headers, see the
 [Modify the body and headers regardless if provided](#mod-body-head) example below.
 
 ### Example Functions
@@ -177,7 +177,7 @@ end
    ```
 
    {% endnavtab %}
-   {% navtab Using httpie %}
+   {% navtab Using HTTPie %}
 
    ```bash
    $ http :8001/services name=example.com host=mockbin.org
@@ -198,7 +198,7 @@ curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
 ```
 
    {% endnavtab %}
-   {% navtab Using httpie %}
+   {% navtab Using HTTPie %}
 
 ```bash
 $ http -f :8001/services/example.com/routes hosts=example.com
@@ -244,7 +244,7 @@ Configure the `exit-transformer` plugin with `transform.lua`.
     --data "config.functions=@transform.lua"
    ```
    {% endnavtab %}
-   {% navtab Using httpie %}
+   {% navtab Using HTTPie %}
 
    ```bash
    $ http -f :8001/services/example.com/plugins \
@@ -269,7 +269,7 @@ response in [step 6](#testy-exit):
    ```
 
    {% endnavtab %}
-   {% navtab Using httpie %}
+   {% navtab Using HTTPie %}
 
    ```bash
    $ http :8001/services/example.com/plugins name=key-auth
@@ -292,7 +292,7 @@ $ curl --header 'Host: example.com' 'localhost:8000'
 ```
 
 {% endnavtab %}
-{% navtab Using httpie %}
+{% navtab Using HTTPie %}
 
 ```bash
 $ http :8000 Host:example.com

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -231,7 +231,7 @@ following example adds a header, appends "arr!" to any message, and adds
     end
 ```
 
-### Step 4: Configure Plugin with its Transform
+### Step 4: Configure the Plugin with its Transform
 
 Configure the `exit-transformer` plugin with `transform.lua`.
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -6,8 +6,8 @@ version: 1.5.x
 desc: Customize Kong exit responses sent downstream
 description: |
   Transform and customize Kong response exit messages using Lua functions.
-  The capabilities range from changing messages, status codes, and headers, to completely transforming
-  the structure of Kong responses.
+  The capabilities range from changing messages, status codes, and headers
+  to completely transforming the structure of Kong responses.
 
 type: plugin
 enterprise: true
@@ -52,22 +52,22 @@ params:
 ## Transforming 404 and 400 responses
 
 By default, the exit transformer is only applied to requests that match its
-criteria (its route, service, or consumer matching configuration) or
-globally within a workspace. However, requests that result in 400 or 404
+criteria (its Route, Service, or Consumer matching configuration) or
+globally within a Workspace. However, requests that result in 400 or 404
 responses neither match any criteria nor fall within any specific workspace,
 and standard plugin criteria will never match them. Users can designate exit
 transformer configurations that _do_ handle these responses by enabling the
 `handle_unknown` (404) and `handle_unexpected` (400) settings. These should
 only be enabled on a single plugin configuration.
 
-`handle_admin` allows the exit transformer to apply to Admin API responses.
-Users should only modify headers only applying functions to Admin API
+The `handle_admin` parameter allows the exit transformer to apply to Admin API responses.
+Users should only modify headers that only apply functions to Admin API
 responses, as modifying the body or status will interfere with Kong Manager's
 ability to communicate with the Admin API.
 
 ## Function syntax
 
-The exit transformer expects a configuration function to be Lua code that returns
+The Exit Transformer plugin expects a configuration function to be Lua code that returns
 a function accepting three arguments: status, body, and headers.
 
 Any Kong exit call exposed on the proxy side gets reduced through these
@@ -81,15 +81,16 @@ Kong -> f(status, body, headers) -> ... -> exit(status, body, headers)
   <strong>Warning</strong>
   <code>kong.response.exit()</code> requires a <code>status</code> argument only.
   <code>body</code> and <code>headers</code> may be <code>nil</code>.
-  If you manipulate them, first check that they exist and instantiate them
-  if they do not. The "Modify the body and headers, even if none were provided"
-  example below shows how to do this.
+  If you manipulate the body and headers, first check that they exist and
+  instantiate them if they do not exist.
 </div>
 
+If you maniupulate body and headers, see the
+[Modify the body and headers regardless if provided](#mod-body-head) example below.
 
-### Examples
+### Example Functions
 
-* Identity function: does not transform the exit responses
+#### Identity function that does not transform the exit responses
 
 ```lua
 return function(status, body, headers)
@@ -97,7 +98,7 @@ return function(status, body, headers)
 end
 ```
 
-* Always return a 200 status code, bundling the status within the message
+#### Function that always returns a 200 status code with status bundled within the message
 
 ```lua
 return function(status, body, headers)
@@ -112,7 +113,7 @@ return function(status, body, headers)
 end
 ```
 
-* Customize particular Kong messages
+#### Customize particular Kong messages
 
 ```lua
 local responses = {
@@ -142,7 +143,7 @@ return function(status, body, headers)
 end
 ```
 
-* Modify the body and headers, even if none were provided
+#### Modify the body and headers regardless if provided {#mod-body-head}
 
 ```lua
 return function(status, body, headers)
@@ -164,18 +165,55 @@ end
 
 ## Demonstration
 
-1. Create a Service and a Route in Kong:
+### Step 1: Create a Service in Kong
 
-    ```bash
-    $ http :8001/services name=example.com host=mockbin.org
-    $ http -f :8001/services/example.com/routes hosts=example.com
-    ```
+   {% navtabs %}
+   {% navtab Using cURL %}
 
-2. Create a file named `transform.lua` with the transformation code. The
-   following example adds a header, appends "arr!" to any message, and adds
-   an `error` and `status` field on the response.
+   ```bash
+   curl -i -X POST http://<admin-hostname>:8001/services \
+    --data name=example.com \
+    --data url='http://mockbin.org'
+   ```
 
-    ```lua
+   {% endnavtab %}
+   {% navtab Using httpie %}
+
+   ```bash
+   $ http :8001/services name=example.com host=mockbin.org
+   ```
+
+   {% endnavtab %}
+   {% endnavtabs %}
+
+### Step 2: Create a Route in Kong
+
+   {% navtabs %}
+   {% navtab Using cURL %}
+
+```bash
+curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
+  --data 'paths[]=/mock' reviewers need conversion help here \
+  --data name=mocking
+```
+
+   {% endnavtab %}
+   {% navtab Using httpie %}
+
+```bash
+$ http -f :8001/services/example.com/routes hosts=example.com
+```
+
+   {% endnavtab %}
+   {% endnavtabs %}
+
+### Step 3: Create a Transform
+
+Create a file named `transform.lua` with the transformation code. The
+following example adds a header, appends "arr!" to any message, and adds
+`error` and `status` fields on the response body.
+
+```lua
     -- transform.lua
     return function(status, body, headers)
       if not body or not body.message then
@@ -191,26 +229,81 @@ end
 
       return status, body, headers
     end
-    ```
+```
 
-3. Configure the `exit-transformer` plugin with `transform.lua`
+### Step 4: Configure Plugin with its Transform
 
-    ```bash
-    $ http -f :8001/services/example.com/plugins \
-        name=exit-transformer \
-        config.functions=@transform.lua
-    ```
+Configure the `exit-transformer` plugin with `transform.lua`.
 
-4. (example) Add key-auth plugin to force generation of an exit response
+   {% navtabs %}
+   {% navtab Using cURL %}
 
-    ```bash
-    $ http :8001/services/example.com/plugins name=key-auth
-    ```
+   ```bash
+   $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+    --data "name=exit-transformer"  \
+    --data "config.functions=@transform.lua"
+   ```
+   {% endnavtab %}
+   {% navtab Using httpie %}
 
-5. Attempt a request to the Service to get the custom error
+   ```bash
+   $ http -f :8001/services/example.com/plugins \
+   name=exit-transformer \
+   config.functions=@transform.lua
+   ```
 
-    ```bash
-    $ http :8000 Host:example.com
+   {% endnavtab %}
+   {% endnavtabs %}
+
+### Step 5: Configure the Key-Auth Plugin to Test the Exit Transform
+
+Add the `key-auth` plugin to test a forced generation of an exit transform
+response in [step 6](#testy-exit):
+
+   {% navtabs %}
+   {% navtab Using cURL %}
+
+   ```bash
+   $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+    --data "name=key-auth"
+   ```
+
+   {% endnavtab %}
+   {% navtab Using httpie %}
+
+   ```bash
+   $ http :8001/services/example.com/plugins name=key-auth
+   ```
+
+   {% endnavtab %}
+   {% endnavtabs %}
+
+### Step 6: Test a Forced Generation of an Exit Response {#testy-exit}
+
+Attempt a request to the Service to get the custom error. Because the
+request did not provide credentials (API key), a 401 response is returned
+in the message body.
+
+{% navtabs %}
+{% navtab Using cURL %}
+
+```bash
+$ curl --header 'Host: example.com' 'localhost:8000'
+```
+
+{% endnavtab %}
+{% navtab Using httpie %}
+
+```bash
+$ http :8000 Host:example.com
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Response:
+
+```bash
     HTTP/1.1 200 OK
     ...
     X-Some-Header: some value
@@ -220,11 +313,11 @@ end
         "status": 401,
         "kong_message": "No API key found in request, arr!"
     }
-    ```
+```
 
-6. Note the plugin can also be applied globally
+Note the plugin can also be applied globally:
 
-   ```bash
+  ```bash
     $ http :8001/plugins \
         name=exit-transformer \
         config.handle_unknown=true \
@@ -238,6 +331,6 @@ end
     {
         "error": true,
         "status": 404,
-        "kong_message": "no Route matched with those values, arr!"
+        "kong_message": "No Route matched with those values, arr!"
     }
-    ```
+  ```

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -41,7 +41,7 @@ params:
     - name: handle_unexpected
       default: "`false`"
       required: false
-      description: Allow transform to apply to unexpected request (400) responses. Should not be enabled on more than one plugin configuration.
+      description: Allow transform to apply to unexpected request (400) responses. 
 
 ---
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -37,11 +37,12 @@ params:
     - name: handle_unknown
       default: "`false`"
       required: false
-      description: Allow transform to apply to unmatched route (404) responses. Should not be enabled on more than one plugin configuration.
+      description: Allow transform to apply to unmatched route (404) responses.
+      Should not be enabled on more than one plugin configuration.
     - name: handle_unexpected
       default: "`false`"
       required: false
-      description: Allow transform to apply to unexpected request (400) responses. 
+      description: Allow transform to apply to unexpected request (400) responses.
 
 ---
 
@@ -53,8 +54,7 @@ globally within a Workspace. However, requests that result in 400 or 404
 responses neither match any criteria nor fall within any specific workspace,
 and standard plugin criteria will never match them. Users can designate exit
 transformer configurations that _do_ handle these responses by enabling the
-`handle_unknown` (404) and `handle_unexpected` (400) settings. These should
-only be enabled on a single plugin configuration.
+`handle_unknown` (404) and `handle_unexpected` (400) settings.
 
 ## Function syntax
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -42,10 +42,6 @@ params:
       default: "`false`"
       required: false
       description: Allow transform to apply to unexpected request (400) responses. Should not be enabled on more than one plugin configuration.
-    - name: handle_admin
-      default: "`false`"
-      required: false
-      description: Allow transform to apply to Admin API responses. Should not be enabled on more than one plugin configuration.
 
 ---
 
@@ -59,11 +55,6 @@ and standard plugin criteria will never match them. Users can designate exit
 transformer configurations that _do_ handle these responses by enabling the
 `handle_unknown` (404) and `handle_unexpected` (400) settings. These should
 only be enabled on a single plugin configuration.
-
-The `handle_admin` parameter allows the exit transformer to apply to Admin API responses.
-Users should only modify headers that only apply functions to Admin API
-responses, as modifying the body or status will interfere with Kong Manager's
-ability to communicate with the Admin API.
 
 ## Function syntax
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -274,7 +274,7 @@ following example adds a header, appends "arr!" to any message, and adds
         message = body.message .. ", arr!",
       }
 
-      return status, body, headers
+      return status, new_body, headers
     end
 ```
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -37,8 +37,8 @@ params:
     - name: handle_unknown
       default: "`false`"
       required: false
-      description: Allow transform to apply to unmatched route (404) responses.
-      Should not be enabled on more than one plugin configuration.
+      description: Allow transform to apply to unmatched Service, Route, or Workspace
+      (404) responses. This flag only applies to one configuration entry.
     - name: handle_unexpected
       default: "`false`"
       required: false
@@ -46,15 +46,67 @@ params:
 
 ---
 
-## Transforming 404 and 400 responses
+## Transforming 4xx and 5xx Responses
 
-By default, the exit transformer is only applied to requests that match its
-criteria (its Route, Service, or Consumer matching configuration) or
-globally within a Workspace. However, requests that result in 400 or 404
-responses neither match any criteria nor fall within any specific workspace,
-and standard plugin criteria will never match them. Users can designate exit
-transformer configurations that _do_ handle these responses by enabling the
-`handle_unknown` (404) and `handle_unexpected` (400) settings.
+By default, the Exit Transformer is only applied to requests that match its
+criteria (its Route or Service matching configuration) or globally within a Workspace.
+
+### Handling Unmatched 400 and 404 Responses
+
+Requests that result in 400 or 404 responses neither match any criteria nor fall
+within any specific Workspace, and standard plugin criteria will never match those
+responses. You can designate Exit Transformer configurations that _do_ handle these
+responses by enabling the `handle_unexpected` (400) and `handle_unknown` (404) settings.
+The `handle_unknown` parameter should only be enabled on a single plugin configuration.
+
+#### HTTP Response Status Codes
+
+**4xx** codes are client error responses:
+
+- [400 Bad request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400)
+- [401 Unauthorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401)
+- [402 Payment required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402)
+- [403 Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403)
+- [404 Not found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404)
+- [405 Method not allowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405)
+- [406 Not acceptable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406)
+- [407 Proxy authentication required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407)
+- [408 Request timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408)
+- [409 Conflict](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409)
+- [410 Gone](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410)
+- [411 Length required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/411)
+- [412 Precondition failed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412)
+- [413 Payload too large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413)
+- [414 URI too long](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414)
+- [415 Unsupported media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415)
+- [416 Range not satisfiable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/416)
+- [417 Expectation failed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/417)
+- [418 I'm a teapot](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418)
+- [421 Misdirected request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/421)
+- [422 Unprocessable entity](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422)
+- [423 Locked](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/423)
+- [424 Failed dependency](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/424)
+- [425 Too early](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425)
+- [426 Upgrade required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/426)
+- [428 Precondition required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/428)
+- [429 Too many requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429)
+- [431 Request header fields too large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431)
+- [451 Unavailable for legal reasons](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/451)
+- [494 Request header or cookie too large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/494)
+
+**5xx** codes are server error responses:
+
+- [500 An unexpected error occurred](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)
+- [501 Not implemented](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501)
+- [502 An invalid response was received from the upstream server](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502)
+- [503 The upstream server is currently unavailable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503)
+- [504 The upstream server is timing out](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
+- [505 HTTP version not supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/505)
+- [506 Variant also negotiates](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/506)
+- [507 Insufficient storage](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/507)
+- [508 Loop detected](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/508)
+- [510 Not extended](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/510)
+- [511 Network authentication required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/511)
 
 ## Function syntax
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -37,8 +37,7 @@ params:
     - name: handle_unknown
       default: "`false`"
       required: false
-      description: Allow transform to apply to unmatched Service, Route, or Workspace
-      (404) responses. This flag only applies to one configuration entry.
+      description: Allow transform to apply to unmatched Service, Route, or Workspace (404) responses.
     - name: handle_unexpected
       default: "`false`"
       required: false
@@ -358,7 +357,24 @@ Response:
     }
 ```
 
+### Apply the Plugin Globally to Handle Unknown Responses
+
 Note the plugin can also be applied globally:
+
+{% navtabs %}
+{% navtab Using cURL %}
+
+```bash
+curl -X POST http://<admin-hostname>:8001/plugins/ \
+    --data "name=exit-transformer"  \
+    --data "config.handle_unknown=true" \
+    --data "config.functions=@transform.lua"
+...
+curl --header 'Host: non-existent.com' 'localhost:8000'
+```
+
+{% endnavtab %}
+{% navtab Using HTTPie %}
 
   ```bash
     $ http :8001/plugins \
@@ -367,6 +383,13 @@ Note the plugin can also be applied globally:
         config.functions=@transform.lua
 
     $ http :8000 Host:non-existent.com
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Response:
+
+```bash  
     HTTP/1.1 200 OK
     ...
     X-Some-Header: some value

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -221,7 +221,7 @@ end
    {% navtab Using cURL %}
 
    ```bash
-   curl -i -X POST http://<admin-hostname>:8001/services \
+   $ curl -i -X POST http://<admin-hostname>:8001/services \
     --data name=example.com \
     --data url='http://mockbin.org'
    ```
@@ -242,7 +242,7 @@ end
    {% navtab Using cURL %}
 
 ```bash
-curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
+$ curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
   --data 'hosts[]=example.com'
 ```
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -58,7 +58,7 @@ responses. You can designate Exit Transformer configurations that _do_ handle th
 responses by enabling the `handle_unexpected` (400) and `handle_unknown` (404) settings.
 The `handle_unknown` parameter should only be enabled on a single plugin configuration.
 
-#### HTTP Response Status Codes
+### HTTP Response Status Codes
 
 **4xx** codes are client error responses:
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -55,10 +55,13 @@ criteria (its Route or Service matching configuration) or globally within a Work
 Requests that result in 400 or 404 responses neither match any criteria nor fall
 within any specific Workspace, and standard plugin criteria will never match those
 responses. You can designate Exit Transformer configurations that _do_ handle these
-responses by enabling the `handle_unexpected` (400) and `handle_unknown` (404) settings.
-The `handle_unknown` parameter should only be enabled on a single plugin configuration.
-The `handle_unexpected` parameter can be enabled on as many plugin configurations
-as you want. It's not a prerequisite for `handle_unexpected` to also have `handle_unknown` set,
+responses by enabling the `handle_unexpected` (400) and `handle_unknown` (404) settings:
+
+- The `handle_unknown` parameter should only be enabled on a single plugin configuration.
+- The `handle_unexpected` parameter can be enabled on as many plugin configurations
+as you want.
+
+It's not a prerequisite for `handle_unexpected` to also have `handle_unknown` set,
 if an unexpected error happened within some known Service or Route context. If a
 configuration has both `handle_unknown` and `handle_unexpected` enabled, then an
 unexpected error on an _unknown_ Service or Route will pass through the Exit Transformer plugin.

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -63,7 +63,7 @@ if an unexpected error happened within some known Service or Route context. If a
 configuration has both `handle_unknown` and `handle_unexpected` enabled, then an
 unexpected error on an _unknown_ Service or Route will pass through the Exit Transformer plugin.
 
-### HTTP Response Status Codes
+### HTTP Response Status Codes {#http-msgs}
 
 **4xx** codes are client error responses:
 
@@ -413,6 +413,77 @@ Response:
 
 This example shows a use case where you want custom JSON and HTML responses
 based on an [Accept header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
+
+Create a file named `custom-errors-by-mimetype.lua` file with the transformation
+code shown below. See the full list of HTTP response codes [above](#http-msgs).
+Include the status codes you want to customize. Any status code not listed in the
+`custom-errors-by-mimetype.lua` file will use the default
+response `The upstream server responded with <status code>`.
+
+```lua
+local template = require "resty.template"
+local split = require "kong.tools.utils".split
+
+local HTTP_MESSAGES = {
+    s400 = "Bad request",
+    s401 = "Unauthorized",
+    -- ...
+    -- See HTTP Response Status Codes section above for the full list
+    s511 = "Network authentication required",
+    default = "The upstream server responded with %d"
+}
+
+local function get_message(status)
+  return HTTP_MESSAGES["s" .. status] or HTTP_MESSAGES.default.format(status)
+end
+
+local html = template.compile([[
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Some Title</title>
+  </head>
+  <body>
+    <h1>HTTP {{ status }}</h1>
+    <p>{{ error }}</p>
+    <img src="https://thumbs.gfycat.com/RegularJointEwe-size_restricted.gif"/>
+  </body>
+</html>
+]])
+
+-- Customize responses based on content type
+local formats = {
+  ["application/json"] = function(status, message, headers)
+    return status, { status = status, error = message }, headers
+  end,
+  ["text/html"] = function(status, message, headers)
+    return status, html { status = status, error = message }, headers
+  end,
+}
+
+return function(status, body, headers)
+  if status < 400 then
+    return status, body, headers
+  end
+
+  local accept = kong.request.get_header("accept")
+  -- Gets just first accept value. Can be improved to be compliant quality
+  -- etc parser. Look into kong.pdk.response get_response_type
+  if type(accept) == "table" then
+    accept = accept[1]
+  end
+  accept = split(accept, ",")[1]
+
+  if not formats[accept] then
+    return status, body, headers
+  end
+
+  return formats[accept](status, get_message(status), headers)
+end
+```
+
+Configure the `exit-transformer` plugin with `custom-errors-by-mimetype.lua`.
 
 {% navtabs %}
 {% navtab Using cURL %}

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -243,8 +243,7 @@ end
 
 ```bash
 curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
-  --data 'paths[]=/mock' \
-  --data name=mocking
+  --data 'hosts[]=example.com'
 ```
 
    {% endnavtab %}

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -287,8 +287,8 @@ Configure the `exit-transformer` plugin with `transform.lua`.
 
    ```bash
    $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
-    --data "name=exit-transformer"  \
-    --data "config.functions=@transform.lua"
+    -F "name=exit-transformer"  \
+    -F "config.functions=@transform.lua"
    ```
    {% endnavtab %}
    {% navtab Using HTTPie %}
@@ -373,9 +373,9 @@ Note the plugin can also be applied globally:
 
 ```bash
 curl -X POST http://<admin-hostname>:8001/plugins/ \
-    --data "name=exit-transformer"  \
-    --data "config.handle_unknown=true" \
-    --data "config.functions=@transform.lua"
+    -F "name=exit-transformer"  \
+    -F "config.handle_unknown=true" \
+    -F "config.functions=@transform.lua"
 ...
 curl --header 'Host: non-existent.com' 'localhost:8000'
 ```
@@ -419,10 +419,10 @@ based on an [Accept header](https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 
 ```bash
 $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
- --data "name=exit-transformer"  \
- --data "config.handle_unknown=true" \
- --data "config.handle_unexpected=true" \
- --data "config.functions=@examples/custom-errors-by-mimetype.lua"
+ -F "name=exit-transformer"  \
+ -F "config.handle_unknown=true" \
+ -F "config.handle_unexpected=true" \
+ -F "config.functions=@examples/custom-errors-by-mimetype.lua"
 ```
 
 {% endnavtab %}

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -222,8 +222,8 @@ end
 
    ```bash
    $ curl -i -X POST http://<admin-hostname>:8001/services \
-    --data name=example.com \
-    --data url='http://mockbin.org'
+     --data name=example.com \
+     --data url='http://mockbin.org'
    ```
 
    {% endnavtab %}
@@ -289,16 +289,16 @@ Configure the `exit-transformer` plugin with `transform.lua`.
 
    ```bash
    $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
-    -F "name=exit-transformer"  \
-    -F "config.functions=@transform.lua"
+     -F "name=exit-transformer"  \
+     -F "config.functions=@transform.lua"
    ```
    {% endnavtab %}
    {% navtab Using HTTPie %}
 
    ```bash
    $ http -f :8001/services/example.com/plugins \
-   name=exit-transformer \
-   config.functions=@transform.lua
+     name=exit-transformer \
+     config.functions=@transform.lua
    ```
 
    {% endnavtab %}
@@ -314,7 +314,7 @@ response in [step 6](#testy-exit):
 
    ```bash
    $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
-    --data "name=key-auth"
+     --data "name=key-auth"
    ```
 
    {% endnavtab %}
@@ -375,9 +375,9 @@ The plugin can also be applied globally:
 
 ```bash
 $ curl -X POST http://<admin-hostname>:8001/plugins/ \
-    -F "name=exit-transformer"  \
-    -F "config.handle_unknown=true" \
-    -F "config.functions=@transform.lua"
+  -F "name=exit-transformer"  \
+  -F "config.handle_unknown=true" \
+  -F "config.functions=@transform.lua"
 ...
 $ curl --header 'Host: non-existent.com' 'localhost:8000'
 ```
@@ -387,9 +387,9 @@ $ curl --header 'Host: non-existent.com' 'localhost:8000'
 
 ```bash
 $ http :8001/plugins \
-    name=exit-transformer \
-    config.handle_unknown=true \
-    config.functions=@transform.lua
+  name=exit-transformer \
+  config.handle_unknown=true \
+  config.functions=@transform.lua
 
 $ http :8000 Host:non-existent.com
 ```
@@ -492,10 +492,10 @@ Configure the `exit-transformer` plugin with `custom-errors-by-mimetype.lua`.
 
 ```bash
 $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
- -F "name=exit-transformer"  \
- -F "config.handle_unknown=true" \
- -F "config.handle_unexpected=true" \
- -F "config.functions=@examples/custom-errors-by-mimetype.lua"
+  -F "name=exit-transformer"  \
+  -F "config.handle_unknown=true" \
+  -F "config.handle_unexpected=true" \
+  -F "config.functions=@examples/custom-errors-by-mimetype.lua"
 ```
 
 {% endnavtab %}

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -357,6 +357,8 @@ Response:
     }
 ```
 
+## More Examples
+
 ### Apply the Plugin Globally to Handle Unknown Responses
 
 Note the plugin can also be applied globally:
@@ -376,14 +378,15 @@ curl --header 'Host: non-existent.com' 'localhost:8000'
 {% endnavtab %}
 {% navtab Using HTTPie %}
 
-  ```bash
-    $ http :8001/plugins \
-        name=exit-transformer \
-        config.handle_unknown=true \
-        config.functions=@transform.lua
+```bash
+$ http :8001/plugins \
+    name=exit-transformer \
+    config.handle_unknown=true \
+    config.functions=@transform.lua
 
     $ http :8000 Host:non-existent.com
 ```
+
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -400,3 +403,32 @@ Response:
         "kong_message": "No Route matched with those values, arr!"
     }
   ```
+
+### Custom Errors by Mimetype
+
+This example shows a use case where you want custom JSON and HTML responses
+based on an [Accept header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
+
+{% navtabs %}
+{% navtab Using cURL %}
+
+```bash
+$ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+ --data "name=exit-transformer"  \
+ --data "config.handle_unknown=true" \
+ --data "config.handle_unexpected=true" \
+ --data "config.functions=@examples/custom-errors-by-mimetype.lua"
+```
+
+{% endnavtab %}
+{% navtab Using HTTPie %}
+
+```bash
+$ http -f :8001/plugins name=exit-transformer \
+  config.handle_unknown=true \
+  config.handle_unexpected=true \
+  config.functions=@examples/custom-errors-by-mimetype.lua
+```
+
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -107,7 +107,7 @@ The `handle_unknown` parameter should only be enabled on a single plugin configu
 - [510 Not extended](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/510)
 - [511 Network authentication required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/511)
 
-## Function syntax
+## Function Syntax
 
 The Exit Transformer plugin expects a configuration function to be Lua code that returns
 a function accepting three arguments: status, body, and headers.
@@ -130,7 +130,7 @@ Kong -> f(status, body, headers) -> ... -> exit(status, body, headers)
 If you manipulate body and headers, see the
 [Modify the body and headers regardless if provided](#mod-body-head) example below.
 
-### Example Functions
+### Example Lua Functions
 
 #### Identity function that does not transform the exit responses
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -6,7 +6,7 @@ version: 1.5.x
 desc: Customize Kong exit responses sent downstream
 description: |
   Transform and customize Kong response exit messages using Lua functions.
-  The capabilities range from changing messages, status codes, and headers
+  The capabilities range from changing messages, status codes, and headers,
   to completely transforming the structure of Kong responses.
 
 type: plugin
@@ -366,18 +366,18 @@ Response:
 
 ### Apply the Plugin Globally to Handle Unknown Responses
 
-Note the plugin can also be applied globally:
+The plugin can also be applied globally:
 
 {% navtabs %}
 {% navtab Using cURL %}
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/plugins/ \
+$ curl -X POST http://<admin-hostname>:8001/plugins/ \
     -F "name=exit-transformer"  \
     -F "config.handle_unknown=true" \
     -F "config.functions=@transform.lua"
 ...
-curl --header 'Host: non-existent.com' 'localhost:8000'
+$ curl --header 'Host: non-existent.com' 'localhost:8000'
 ```
 
 {% endnavtab %}
@@ -389,7 +389,7 @@ $ http :8001/plugins \
     config.handle_unknown=true \
     config.functions=@transform.lua
 
-    $ http :8000 Host:non-existent.com
+$ http :8000 Host:non-existent.com
 ```
 
 {% endnavtab %}
@@ -414,7 +414,7 @@ Response:
 This example shows a use case where you want custom JSON and HTML responses
 based on an [Accept header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
 
-Create a file named `custom-errors-by-mimetype.lua` file with the transformation
+Create a file named `custom-errors-by-mimetype.lua` with the transformation
 code shown below. See the full list of HTTP response codes [above](#http-msgs).
 Include the status codes you want to customize. Any status code not listed in the
 `custom-errors-by-mimetype.lua` file will use the default

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -240,7 +240,7 @@ end
 
 ```bash
 curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
-  --data 'paths[]=/mock' reviewers need conversion help here \
+  --data 'paths[]=/mock' \
   --data name=mocking
 ```
 

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -57,6 +57,11 @@ within any specific Workspace, and standard plugin criteria will never match tho
 responses. You can designate Exit Transformer configurations that _do_ handle these
 responses by enabling the `handle_unexpected` (400) and `handle_unknown` (404) settings.
 The `handle_unknown` parameter should only be enabled on a single plugin configuration.
+The `handle_unexpected` parameter can be enabled on as many plugin configurations
+as you want. It's not a prerequisite for `handle_unexpected` to also have `handle_unknown` set,
+if an unexpected error happened within some known Service or Route context. If a
+configuration has both `handle_unknown` and `handle_unexpected` enabled, then an
+unexpected error on an _unknown_ Service or Route will pass through the Exit Transformer plugin.
 
 ### HTTP Response Status Codes
 
@@ -404,7 +409,7 @@ Response:
     }
   ```
 
-### Custom Errors by Mimetype
+### Custom Errors by MIME Type
 
 This example shows a use case where you want custom JSON and HTML responses
 based on an [Accept header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -418,8 +418,8 @@ This example shows a use case where you want custom JSON and HTML responses
 based on an [Accept header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
 
 Create a file named `custom-errors-by-mimetype.lua` with the transformation
-code shown below. See the full list of HTTP response codes [above](#http-msgs).
-Include the status codes you want to customize. Any status code not listed in the
+code shown below. Include the status codes you want to customize. See the full list
+of HTTP response codes [above](#http-msgs). Any status code not listed in the
 `custom-errors-by-mimetype.lua` file will use the default
 response `The upstream server responded with <status code>`.
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1279 subticket in Shane's epic https://konghq.atlassian.net/browse/DOCS-1162 add curl examples in demo section, currently only httpie

Other tickets in this PR:
https://konghq.atlassian.net/browse/DOCS-1323 update docs for MIMEtype example

https://konghq.atlassian.net/browse/DOCS-1322 per https://konghq.atlassian.net/browse/FTI-1743
- remove config.handle_admin was removed 1.5.3. 

Before: 
![image](https://user-images.githubusercontent.com/3756245/94606565-456fc180-0260-11eb-838d-a5142e3ded99.png)

(Current plugin version indicates 1.5.x. Actual internal plugin version is 0.2.3. Plugin versions policy TBD.)
![image](https://user-images.githubusercontent.com/3756245/94310504-5a3a1580-ff3f-11ea-8cba-7c297825e386.png)

- clarify 4xx and 5xx response codes. Legacy content implies only 404 and 400 responses are transformed. List responses as requested by Karl K. 

https://deploy-preview-2332--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#transforming-4xx-and-5xx-responses
https://deploy-preview-2332--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#handling-unmatched-400-and-404-responses
https://deploy-preview-2332--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#http-response-status-codes

After: 
![image](https://user-images.githubusercontent.com/3756245/94729388-31db5e00-0327-11eb-82f4-e6714214fce0.png)


Direct review link (main entry point):

https://deploy-preview-2332--kongdocs.netlify.app/hub/kong-inc/exit-transformer/

Demo section added cURL examples; please review closely:

https://deploy-preview-2332--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#demonstration

Added MIME type example:

https://deploy-preview-2332--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#custom-errors-by-mimetype