### PR TITLE
docs(styles) Fixing numbering issue with nested unordered lists 

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -621,7 +621,7 @@
 .content {
   padding: 50px 0;
   .font-source-sans();
-  font-size: 16px;
+  font-size: 17px;
   line-height: 1.5;
 
   .big {
@@ -713,7 +713,6 @@
 
       &:before {
         color: @font-color;
-        font-size: 13px;
         width: 36px;
         height: 36px;
         line-height: 36px;
@@ -1085,7 +1084,6 @@ Generic Styling for Desktop
 .instructions-steps {
   list-style: none;
   padding-left: 26px;
-  counter-reset: step;
 
   .instructions-step-item {
     position: relative;
@@ -1099,8 +1097,6 @@ Generic Styling for Desktop
     }
 
     &:before {
-      counter-increment: step;
-      content: counter(step);
       box-sizing: border-box;
       width: 36px;
       height: 36px;

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -90,12 +90,20 @@
   .content {
     ol {
       padding-left: 2rem;
+      counter-reset: base;
+    }
+
+    ol > li::before {
+      counter-increment: base;
+      content: counter(base);
+      font-size: 13px;
     }
 
     ul {
       // avoid nested lists and lists elements to have smaller and smaller
       // font sizes
       font-size: inherit;
+      margin-left: 0.5rem;
 
       li {
         // avoid ridiculously big spaces between lists elements


### PR DESCRIPTION
Currently, the docs site has a problem with nested lists, in that unordered lists are implicitly counted as part of the step count. For example:

```
1. Example
2. List
  * Here's a point
  * And another one
5. List count doesn't continue at 3, but instead assumes the bullet points were part of it.
```

With this fix, it should all work as intended:
```
1. Example
2. List
  * Point
  * Point
3. Proper numbering continues
```

Also fixing font size to match across lists, whether the `<li>` has a `<p>` tag or not. Previous behaviour with two different font sizes:
https://docs.konghq.com/getting-started-guide/2.1.x/manage-teams/
![Screen Shot 2020-09-28 at 12 40 13 PM](https://user-images.githubusercontent.com/54370747/94478226-d6269e80-0187-11eb-9fa0-d9c4e1dbd809.png)
