### PR TITLE
docs(styles) Adjust link contrast

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -729,9 +729,11 @@
 
   a {
     text-decoration: none;
+    color: @blue;
 
     &:hover {
       text-decoration: underline;
+      opacity: 0.7;
     }
   }
 

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -519,6 +519,10 @@
 
   li {
     line-height: 26px;
+
+    a {
+      color: #85898c;
+    }
   }
 
   li ul {
@@ -530,15 +534,28 @@
   }
 
   li a.active {
-    color: @blue;
+    color: @gray-darker;
+    font-weight: 600;
+    opacity: 1;
   }
 
   a {
     font-size: 14px;
+    color: @blue;
+
+    &:hover {
+      opacity: 0.5;
+    }
   }
 
   .fa {
     color: #acb7bf;
+  }
+
+  table {
+    a {
+      color: @blue;
+    }
   }
 }
 


### PR DESCRIPTION
Adjusting links for visibility/accessibility.
* Changed links in body text to lighter blue to match existing headers on landing pages
* Adjusted plugin hub page nav for cleaner look with blue for off-page links, grey for on-page links (same colors/weights as nav on main docs)

Old:
![Screen Shot 2020-09-28 at 1 58 32 PM](https://user-images.githubusercontent.com/54370747/94485743-3e2eb200-0193-11eb-82b9-a56aa998f3db.png)

New:
![Screen Shot 2020-09-28 at 1 57 59 PM](https://user-images.githubusercontent.com/54370747/94485683-2820f180-0193-11eb-8d54-ade8b66ffcf0.png)

