### PR TITLE
Add class annotations to K8S plugin examples

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -248,6 +248,7 @@ kind: Ingress
 metadata:
   name: <route>
   annotations:
+    kubernetes.io/ingress.class: kong
     plugins.konghq.com: <{{page.params.name}}-example>
 spec:
   rules:
@@ -355,6 +356,7 @@ metadata:
   name: <consumer>
   annotations:
     plugins.konghq.com: <{{page.params.name}}-example>
+    kubernetes.io/ingress.class: kong
   ```
 
 <div class="alert alert-ee blue">
@@ -432,6 +434,8 @@ apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
 metadata:
   name: <global-{{page.params.name}}>
+  annotations:
+    kubernetes.io/ingress.class: kong
   labels:
     global: \"true\"
 {% if config_required_fields_k8s == 'config: ' %}config:


### PR DESCRIPTION
Add `kubernetes.io/ingress.class: kong` annotations to Ingress, KongConsumer, and global KongClusterPlugin examples. [As of controller 0.10.0](https://github.com/Kong/kubernetes-ingress-controller/blob/master/CHANGELOG.md#0100---20200915), this annotation is required by default on these resources, and our examples should include them as such. Adding this annotation
does not create issues for older versions--they were simply more permissive about when they permitted resources that lacked them by default, but still work fine when the annotation is present.

Minor note is that this annotation should have a different value when using [a non-standard class](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/concepts/ingress-classes.md#when-to-use-a-custom-class), e.g. `kubernetes.io/ingress.class: mycustomclass`. Using `kubernetes.io/ingress.class: kong` with a custom class will in fact _exclude_ those resources when using some other class. However, as users must intentionally set a custom class and adapt examples elsewhere to their environment, we can reasonably expect them to be aware that they need to change the value if they use one.

Submitted as a result of https://github.com/Kong/kubernetes-ingress-controller/issues/884