### PR TITLE
Response Transformer Advanced plugin correction

### DIFF
--- a/app/_hub/kong-inc/response-transformer-advanced/1.3-x.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/1.3-x.md
@@ -40,9 +40,6 @@ params:
     - name: remove.if_status
       required: false
       description: List of response status codes or status code ranges to which the transformation will apply. Empty means all response codes.
-    - name: rename.headers
-      required: false
-      description: List of headername:value pairs. Renames header with headername to new name.
     - name: replace.headers
       required: false
       description: List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1351 ticket moved from FTI-1531

This PR removes the rename header field from version 1.3-x since it wasn't available in that version.

Schema link: https://github.com/Kong/kong-plugin-response-transformer-advanced/blob/master/kong/plugins/response-transformer-advanced/schema.lua

Ticket summary:

> Problem Statement:
> 
> The documentation lists version 1.3-x as the latest version of the plugin but that is actually incorrect because 0.3.3 seems to have been released with Kong 1.5.0.0:
> 
> https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule#KongEnterprise-Changelog,Features&ReleaseSchedule-KongEnterprise1.5.0.0
> 
> The latest version introduced the header rename feature which incorrectly is documented to be available in the 1.3-x version
> 
> Business Impact:
> 
> Customer tried unsuccessfully to use the header rename feature in 1.3.0.1, and thought there was something wrong with their setup


Direct review link:

https://deploy-preview-2363--kongdocs.netlify.app/hub/kong-inc/response-transformer-advanced/#parameters
