### PR TITLE
Kong Mesh installation docs

### DIFF
--- a/app/_includes/md/mesh/1.0.x/install-universal-quickstart.md
+++ b/app/_includes/md/mesh/1.0.x/install-universal-quickstart.md
@@ -1,0 +1,10 @@
+<!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the [quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).

--- a/app/_includes/md/mesh/1.0.x/install-universal-run.md
+++ b/app/_includes/md/mesh/1.0.x/install-universal-run.md
@@ -1,0 +1,43 @@
+<!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
+## 2. Run {{site.mesh_product_name}}
+Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
+
+Navigate to the `bin` folder:
+
+```sh
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the <code>kuma-cp</code>
+executable &mdash; you need to have a valid {{site.mesh_product_name}} license
+in place.
+</div>
+
+Then, run the control plane with:
+
+```sh
+$ KUMA_LICENSE_PATH=/path/to/file/license.json kuma-cp run
+```
+
+Where `/path/to/file/license.json` is the path to a valid
+{{site.mesh_product_name}} license file on the file system.
+
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with a memory
+<a href="https://kuma.io/docs/latest/documentation/backends/">backend</a>, but you can use a persistent storage like PostgreSQL by updating the
+<code>conf/kuma-cp.conf</code> file.
+</div>

--- a/app/_includes/md/mesh/1.0.x/install-universal-verify.md
+++ b/app/_includes/md/mesh/1.0.x/install-universal-verify.md
@@ -1,0 +1,61 @@
+<!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} has been installed, you can access the
+control plane via either the GUI, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681/gui` to see
+the GUI.
+
+{% endnavtab %}
+{% navtab HTTP API (Read & Write) %}
+
+{{site.mesh_product_name}} ships with a **read and write** HTTP API that you can
+use to perform operations on {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681` to see
+the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read & Write) %}
+
+You can use the `kumactl` CLI to perform **read and write** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. For example:
+
+```sh
+$ kumactl get meshes
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "type: Mesh
+  name: default
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kumactl apply -f -
+```
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```sh
+$ kumactl config control-planes add \
+--name=XYZ \
+--address=http://{address-to-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.

--- a/app/_includes/md/mesh/1.0.x/install-universal-verify.md
+++ b/app/_includes/md/mesh/1.0.x/install-universal-verify.md
@@ -2,7 +2,7 @@
 ## 3. Verify the Installation
 
 Now that {{site.mesh_product_name}} has been installed, you can access the
-control plane via either the GUI, the HTTP API, or the CLI:
+control plane using either the GUI, the HTTP API, or the CLI:
 
 {% navtabs %}
 {% navtab GUI (Read-Only) %}

--- a/app/mesh/1.0.x/installation/amazonlinux.md
+++ b/app/mesh/1.0.x/installation/amazonlinux.md
@@ -13,8 +13,8 @@ To install and run {{site.mesh_product_name}} on Amazon Linux (**x86_64**),
 execute the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
 

--- a/app/mesh/1.0.x/installation/amazonlinux.md
+++ b/app/mesh/1.0.x/installation/amazonlinux.md
@@ -3,8 +3,6 @@ title: Kong Mesh with Amazon Linux
 no_search: true
 ---
 
-## Amazon Linux
-
 <div class="alert alert-ee blue">
 If you want to use Kuma on Amazon EKS, follow the
 <a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes instructions</a>
@@ -18,7 +16,12 @@ execute the following steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 {% navtabs %}
 {% navtab Script %}
@@ -45,24 +48,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+{% include /md/mesh/1.0.x/install-universal-run.md %}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` executable - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
 
-This can be done by running the control plane with:
-
-```sh
-$ KUMA_LICENSE_PATH=license.json kuma-cp run
-```
-
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
-
-### 3. Follow Kuma Instructions
-
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
-
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/amazonlinux/#_2-run-kuma) keeping in mind that we need to run the control plane with the appropriate license file as described on this page.
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.0.x/installation/centos.md
+++ b/app/mesh/1.0.x/installation/centos.md
@@ -7,8 +7,8 @@ To install and run {{site.mesh_product_name}} on CentOS (**x86_64**), execute
 the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/app/mesh/1.0.x/installation/centos.md
+++ b/app/mesh/1.0.x/installation/centos.md
@@ -3,8 +3,6 @@ title: Kong Mesh with CentOS
 no_search: true
 ---
 
-## CentOS
-
 To install and run {{site.mesh_product_name}} on CentOS (**x86_64**), execute
 the following steps:
 
@@ -12,7 +10,13 @@ the following steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 {% navtabs %}
 {% navtab Script %}
@@ -37,24 +41,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+{% include /md/mesh/1.0.x/install-universal-run.md %}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` executable - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
 
-This can be done by running the control plane with:
-
-```sh
-$ KUMA_LICENSE_PATH=license.json kuma-cp run
-```
-
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
-
-### 3. Follow Kuma Instructions
-
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
-
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/centos/#_2-run-kuma) keeping in mind that we need to run the control plane with the appropriate license file as described on this page.
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.0.x/installation/debian.md
+++ b/app/mesh/1.0.x/installation/debian.md
@@ -3,8 +3,6 @@ title: Kong Mesh with Debian
 no_search: true
 ---
 
-## Debian
-
 To install and run {{site.mesh_product_name}} on Debian (**amd64**),
 execute the following steps:
 
@@ -12,7 +10,13 @@ execute the following steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 {% navtabs %}
 {% navtab Script %}
@@ -35,24 +39,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+{% include /md/mesh/1.0.x/install-universal-run.md %}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` executable - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
 
-This can be done by running the control plane with:
-
-```sh
-$ KUMA_LICENSE_PATH=license.json kuma-cp run
-```
-
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
-
-### 3. Follow Kuma Instructions
-
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
-
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/debian/#_2-run-kuma) keeping in mind that we need to run the control plane with the appropriate license file as described on this page.
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.0.x/installation/debian.md
+++ b/app/mesh/1.0.x/installation/debian.md
@@ -7,8 +7,8 @@ To install and run {{site.mesh_product_name}} on Debian (**amd64**),
 execute the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -7,8 +7,8 @@ To install and run {{site.mesh_product_name}} on Docker, execute the following
 steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
@@ -38,7 +38,7 @@ executables:
 $ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}
 ```
 
-## Run {{site.mesh_product_name}}
+## 2. Run {{site.mesh_product_name}}
 
 <div class="alert alert-ee blue">
 <strong>Note:</strong> Before running the {{site.mesh_product_name}}

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -3,8 +3,6 @@ title: Kong Mesh with Docker
 no_search: true
 ---
 
-## Docker
-
 To install and run {{site.mesh_product_name}} on Docker, execute the following
 steps:
 
@@ -12,13 +10,19 @@ steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
 <div class="alert alert-ee blue">
 The official Docker images are used by default in the
 <a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes</a>
 distributions.  
 </div>
 
-### 1. Download {{site.mesh_product_name}}
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 {{site.mesh_product_name}} provides the following Docker images for all of its
 executables:
@@ -34,28 +38,122 @@ executables:
 $ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}
 ```
 
-### 2. Configure The License
+## Run {{site.mesh_product_name}}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` container - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the
+<code>kuma-cp</code> container &mdash; you need to have a valid
+{{site.mesh_product_name}} license in place.
+</div>
 
-This can be done by running the control plane with:
+Run the control plane with:
 
 ```sh
 $ docker run \
-    -p 5681:5681 \
-    -v /path/to/license.json:/license.json \
-    -e "KUMA_LICENSE_PATH=/license.json" \
-    kong-docker-kuma-docker.bintray.io/kuma-cp:0.7.1 run
+  -p 5681:5681 \
+  -v /path/to/license.json:/license.json \
+  -e "KUMA_LICENSE_PATH=/license.json" \
+  kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}} run
 ```
 
-Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}} license file on the host that will be mounted as `/license.json` into the container.
+Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+license file on the host that will be mounted as `/license.json` into the
+container.
 
-### 3. Follow Kuma Instructions
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
 
-After pulling the {{site.mesh_product_name}} images, the remaining installation
-instructions for Kuma are fully compatible with {{site.mesh_product_name}},
-except you will be using the {{site.mesh_product_name}} Docker images instead
-of the vanilla Kuma ones.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with
+a memory <a href="https://kuma.io/docs/latest/documentation/backends/">backend</a>,
+but you can use a persistent storage like PostgreSQL by updating the
+<code>conf/kuma-cp.conf</code> file.
+</div>
 
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/docker/#_2-run-kuma).
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) is running, you can access the
+control plane using either the GUI, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681/gui` to see
+the GUI.
+
+{% endnavtab %}
+{% navtab HTTP API (Read & Write) %}
+
+{{site.mesh_product_name}} ships with a **read and write** HTTP API that you can
+use to perform operations on {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681` to see
+the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read & Write) %}
+
+You can use the `kumactl` CLI to perform **read and write** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. For example:
+
+```sh
+$ docker run \
+  --net="host" \
+  kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}} kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "type: Mesh
+  name: default
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | docker run -i --net="host" \
+    kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}} kumactl apply -f -
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> We are running <code>kumactl</code> from the Docker
+container on the same network as the host, but most likely you want to download
+a compatible version of {{site.mesh_product_name}} for the machine where you
+will be executing the commands.
+</div>
+
+See the individual installation pages for your OS to download and extract
+`kumactl` to your machine:
+* [CentOS](/mesh/{{page.kong_version}}/installation/centos)
+* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Debian](/mesh/{{page.kong_version}}/installation/debian)
+* [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
+* [macOS](/mesh/{{page.kong_version}}/installation/macos)
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).
+If you are entirely using Docker, you may also be interested in checking out the
+[Kubernetes quickstart](https://kuma.io/docs/latest/quickstart/kubernetes/) as well.

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -12,7 +12,13 @@ following steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 To run {{site.mesh_product_name}} on Kubernetes, you need to download a
 compatible version of {{site.mesh_product_name}} for the machine from which you
@@ -50,24 +56,152 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+## 2. Run {{site.mesh_product_name}}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` container - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the
+<code>kuma-cp</code> container &mdash; you need to have a valid
+{{site.mesh_product_name}} license in place.
+</div>
 
-This can be done by installing the control plane with:
+Navigate to the `bin` folder:
 
 ```sh
-$ kumactl install control-plane --license-path=license.json | kubectl apply -f -
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
 ```
 
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
+Then, run the control plane with:
 
-### 3. Follow Kuma Instructions
+```sh
+$ kumactl install control-plane --license-path=/path/to/license.json | kubectl apply -f -
+```
 
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+license file on the file system.
 
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/kubernetes/#_2-run-kuma) keeping in mind that we need to install the control plane with the appropriate license file as described on this page.
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> It may take a while for Kubernetes to start the
+{{site.mesh_product_name}} resources. You can check the status by executing:
+<pre class="highlight">
+<code>$ kubectl get pod -n kuma-system</code></pre>
+</div>
+
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
+created `kuma-system` namespace, you can access the control plane using either
+the GUI, `kubectl`, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
+
+{% endnavtab %}
+{% navtab kubectl (Read & Write) %}
+You can use {{site.mesh_product_name}} with `kubectl` to perform
+**read and write** operations on {{site.mesh_product_name}} resources. For
+example:
+
+```sh
+$ kubectl get meshes
+
+NAME          AGE
+default       1m
+```
+
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "apiVersion: kuma.io/v1alpha1
+  kind: Mesh
+  metadata:
+    name: default
+  spec:
+    mtls:
+      enabledBackend: ca-1
+      backends:
+      - name: ca-1
+        type: builtin" | kubectl apply -f -
+```
+
+{% endnavtab %}
+{% navtab HTTP API (Read-Only) %}
+
+{{site.mesh_product_name}} ships with a **read-only** HTTP API that you use
+to retrieve {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read-Only) %}
+
+You can use the `kumactl` CLI to perform **read-only** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
+service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Then run `kumactl`. For example:
+
+```sh
+$ kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```
+$ kumactl config control-planes add --name=XYZ --address=http://{address-to-kong-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -3,14 +3,12 @@ title: Kong Mesh with Kubernetes
 no_search: true
 ---
 
-## Kubernetes
-
 To install and run {{site.mesh_product_name}} on Kubernetes, execute the
 following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/app/mesh/1.0.x/installation/macos.md
+++ b/app/mesh/1.0.x/installation/macos.md
@@ -7,8 +7,8 @@ To install and run {{site.mesh_product_name}} on macOS, execute the following
 steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/app/mesh/1.0.x/installation/macos.md
+++ b/app/mesh/1.0.x/installation/macos.md
@@ -3,8 +3,6 @@ title: Kong Mesh with macOS
 no_search: true
 ---
 
-## macOS
-
 To install and run {{site.mesh_product_name}} on macOS, execute the following
 steps:
 
@@ -12,7 +10,13 @@ steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 To run {{site.mesh_product_name}} on macOS, you can choose from the following
 installation methods:
@@ -42,24 +46,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+{% include /md/mesh/1.0.x/install-universal-run.md %}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` executable - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
 
-This can be done by running the control plane with:
-
-```sh
-$ KUMA_LICENSE_PATH=license.json kuma-cp run
-```
-
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
-
-### 3. Follow Kuma Instructions
-
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
-
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/macos/#_2-run-kuma) keeping in mind that we need to run the control plane with the appropriate license file as described on this page.
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -3,14 +3,12 @@ title: Kong Mesh with OpenShift
 no_search: true
 ---
 
-## OpenShift
-
 To install and run {{site.mesh_product_name}} on OpenShift, execute the
 following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
@@ -18,7 +16,7 @@ and continue your {{site.mesh_product_name}} journey.
 ## Prerequisites
 You have a license for {{site.mesh_product_name}}.
 
-### 1. Download {{site.mesh_product_name}}
+## 1. Download {{site.mesh_product_name}}
 
 To run {{site.mesh_product_name}} on OpenShift, you need to download a
 compatible version of {{site.mesh_product_name}} for the machine from which

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -12,6 +12,12 @@ following steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
 ### 1. Download {{site.mesh_product_name}}
 
 To run {{site.mesh_product_name}} on OpenShift, you need to download a
@@ -50,26 +56,51 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` container - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+## 2. Run {{site.mesh_product_name}}
 
-This can be done by installing the control plane with:
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the
+<code>kuma-cp</code> container &mdash; you need to have a valid
+{{site.mesh_product_name}} license in place.
+</div>
+
+Navigate to the `bin` folder:
+
+```sh
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
+```
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+Then, run the control plane on OpenShift with:
 
 {% navtabs %}
 {% navtab OpenShift 4.x %}
 
 ```sh
-kumactl install control-plane --cni-enabled --license-path=license.json | oc apply -f -
+kumactl install control-plane --cni-enabled --license-path=/path/to/license.json | oc apply -f -
 ```
 
-Starting from version 4.1 OpenShift utilizes `nftables` instead of `iptables`. So using init container for redirecting traffic to the proxy is no longer works. Instead, we use `kuma-cni` which could be installed with `--cni-enabled` flag.
+Starting from version 4.1, OpenShift uses `nftables` instead of `iptables`. So,
+using init container for redirecting traffic to the proxy no longer works.
+Instead, we use `kuma-cni`, which can be installed with the `--cni-enabled` flag.
 
 {% endnavtab %}
 {% navtab OpenShift 3.11 %}
 
-By default `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` are disabled on OpenShift 3.11.
-In order to make it work add the following `pluginConfig` into `/etc/origin/master/master-config.yaml` on the master node:
+By default, `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` are
+disabled on OpenShift 3.11.
+
+To make them work, add the following `pluginConfig` into
+`/etc/origin/master/master-config.yaml` on the master node:
 
 ```yaml
 admissionConfig:
@@ -86,23 +117,142 @@ admissionConfig:
         kind: WebhookAdmission
 ```
 
-After updating `master-config.yaml` restart the cluster and install `control-plane`:
+After updating `master-config.yaml`, restart the cluster and install
+`control-plane`:
 
 ```sh
-$ ./kumactl install control-plane --license-path=license.json | oc apply -f -
+$ ./kumactl install control-plane --license-path=/path/to/license.json | oc apply -f -
 ```
 
 {% endnavtab %}
 {% endnavtabs %}
 
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
+Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+license file on the file system.
 
-### 3. Follow Kuma Instructions
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
 
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> It may take a while for OpenShift to start the
+{{site.mesh_product_name}} resources. You can check the status by executing:
+<pre class="highlight">
+<code>$ oc get pod -n kuma-system</code></pre>
+</div>
 
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/openshift/#_2-run-kuma) keeping in mind that we need to install the control plane with the appropriate license file as described on this page.
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
+created `kuma-system` namespace, you can access the control plane using either
+the GUI, `oc`, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681` and defaults to `:5681/gui`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
+
+{% endnavtab %}
+{% navtab oc (Read & Write) %}
+You can use {{site.mesh_product_name}} with `oc` to perform
+**read and write** operations on {{site.mesh_product_name}} resources. For
+example:
+
+```sh
+$ oc get meshes
+
+NAME          AGE
+default       1m
+```
+
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "apiVersion: kuma.io/v1alpha1
+  kind: Mesh
+  metadata:
+    name: default
+  spec:
+    mtls:
+      enabledBackend: ca-1
+      backends:
+      - name: ca-1
+        type: builtin" | oc apply -f -
+```
+
+{% endnavtab %}
+{% navtab HTTP API (Read-Only) %}
+
+{{site.mesh_product_name}} ships with a **read-only** HTTP API that you use
+to retrieve {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read-Only) %}
+
+You can use the `kumactl` CLI to perform **read-only** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
+service with:
+
+```sh
+$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Then run `kumactl`. For example:
+
+```sh
+$ kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```
+$ kumactl config control-planes add --name=XYZ --address=http://{address-to-kong-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+Kuma explicitly specifies a UID for <code>kuma-dp</code> to avoid capturing
+traffic from <code>kuma-dp</code> itself. For that reason, special privilege has
+to be granted to the application namespace:
+<pre class=highlight>
+<code>$ oc adm policy add-scc-to-user anyuid -z APPLICATION_SERVICE_ACCOUNT -n APPLICATION_NAMESPACE</code></pre>
+</div>
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -3,8 +3,6 @@ title: Kong Mesh with RedHat
 no_search: true
 ---
 
-## Redhat
-
 To install and run {{site.mesh_product_name}} on RedHat (**x86_64**), execute
 the following steps:
 
@@ -12,7 +10,12 @@ the following steps:
 * [2. Configure the license](#2-configure-the-license)
 * [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 {% navtabs %}
 {% navtab Script %}
@@ -35,24 +38,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+{% include /md/mesh/1.0.x/install-universal-run.md %}
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` executable - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
 
-This can be done by running the control plane with:
-
-```sh
-$ KUMA_LICENSE_PATH=license.json kuma-cp run
-```
-
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
-
-### 3. Follow Kuma Instructions
-
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
-
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/redhat/#_2-run-kuma) keeping in mind that we need to run the control plane with the appropriate license file as described on this page.
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -7,8 +7,8 @@ To install and run {{site.mesh_product_name}} on RedHat (**x86_64**), execute
 the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
 

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -3,16 +3,20 @@ title: Kong Mesh with Ubuntu
 no_search: true
 ---
 
-## Ubuntu
-
 To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**), execute
 the following steps:
 
-* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Configure the license](#2-configure-the-license)
-* [3. Follow Kuma instructions](#3-follow-kuma-instructions)
 
-### 1. Download {{site.mesh_product_name}}
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run Kong Mesh](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
 
 {% navtabs %}
 {% navtab Script %}
@@ -37,24 +41,116 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-### 2. Configure The License
+## 2. Run {{site.mesh_product_name}}
+Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
 
-Before running the {{site.mesh_product_name}} control plane process - which is served by the `kuma-cp` executable - we need to make sure that we have a valid {{site.mesh_product_name}} license in place.
-
-This can be done by running the control plane with:
+Navigate to the `bin` folder:
 
 ```sh
-$ KUMA_LICENSE_PATH=license.json kuma-cp run
+$ cd kuma-0.7.1/bin
 ```
 
-Where `license.json` is the path to a valid {{site.mesh_product_name}} license file on the file system.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the <code>kuma-cp</code>
+executable &mdash; you need to have a valid {{site.mesh_product_name}} license
+in place.
+</div>
 
-### 3. Follow Kuma Instructions
+Run the control plane with:
 
-After downloading the {{site.mesh_product_name}} binaries, the remaining
-installation instructions for Kuma are fully compatible with
-{{site.mesh_product_name}}, except you will be running the
-{{site.mesh_product_name}} binaries instead of the vanilla Kuma ones.
+```sh
+$ KUMA_LICENSE_PATH=/path/to/file/license.json kuma-cp run
+```
 
-To continue the installation, start from the second installation step in
-[the official Kuma installation guide](https://kuma.io/docs/0.7.1/installation/ubuntu/#_2-run-kuma) keeping in mind that we need to run the control plane with the appropriate license file as described on this page.
+Where `/path/to/file/license.json` is the path to a valid
+{{site.mesh_product_name}} license file on the file system.
+
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with a memory
+backend, but you can use a persistent storage like PostgreSQL by updating the
+<code>conf/kuma-cp.conf</code> file.
+</div>
+
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} has been installed, you can access the
+control plane via either the GUI, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a read-only GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681/gui` to see
+the GUI.
+
+{% endnavtab %}
+{% navtab HTTP API (Read & Write) %}
+
+{{site.mesh_product_name}} ships with a read and write HTTP API that you can
+use to perform operations on {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681` to see
+the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read & Write) %}
+
+You can use the `kumactl` CLI to perform read and write operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. For example:
+
+```sh
+$ kumactl get meshes
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+echo "type: Mesh
+name: default
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin" | kumactl apply -f -
+```
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```sh
+$ kumactl config control-planes add \
+--name=XYZ \
+--address=http://{address-to-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a Mesh
+entity with the name `default`.
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}} on Ubuntu.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the [quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -7,7 +7,7 @@ To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**), execute
 the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-* [2. Run Kong Mesh](#2-run-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
 * [3. Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -6,7 +6,6 @@ no_search: true
 To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**), execute
 the following steps:
 
-
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
 * [2. Run Kong Mesh](#2-run-kong-mesh)
 * [3. Verify the Installation](#3-verify-the-installation)
@@ -41,116 +40,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-## 2. Run {{site.mesh_product_name}}
-Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
+{% include /md/mesh/1.0.x/install-universal-run.md %}
 
-Navigate to the `bin` folder:
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
 
-```sh
-$ cd kuma-0.7.1/bin
-```
-
-<div class="alert alert-ee blue">
-<strong>Note:</strong> Before running the {{site.mesh_product_name}}
-control plane process in the next step &mdash; which is served by the <code>kuma-cp</code>
-executable &mdash; you need to have a valid {{site.mesh_product_name}} license
-in place.
-</div>
-
-Run the control plane with:
-
-```sh
-$ KUMA_LICENSE_PATH=/path/to/file/license.json kuma-cp run
-```
-
-Where `/path/to/file/license.json` is the path to a valid
-{{site.mesh_product_name}} license file on the file system.
-
-This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
-like _multi-zone_.
-
-We suggest adding the `kumactl` executable to your `PATH` so that it's always
-available in every working directory. Alternatively, you can also create a link
-in `/usr/local/bin/` by executing:
-
-```sh
-$ ln -s ./kumactl /usr/local/bin/kumactl
-```
-
-<div class="alert alert-ee blue">
-<strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with a memory
-backend, but you can use a persistent storage like PostgreSQL by updating the
-<code>conf/kuma-cp.conf</code> file.
-</div>
-
-## 3. Verify the Installation
-
-Now that {{site.mesh_product_name}} has been installed, you can access the
-control plane via either the GUI, the HTTP API, or the CLI:
-
-{% navtabs %}
-{% navtab GUI (Read-Only) %}
-{{site.mesh_product_name}} ships with a read-only GUI that you can use to
-retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
-the API port `5681`.
-
-To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681/gui` to see
-the GUI.
-
-{% endnavtab %}
-{% navtab HTTP API (Read & Write) %}
-
-{{site.mesh_product_name}} ships with a read and write HTTP API that you can
-use to perform operations on {{site.mesh_product_name}} resources. By default,
-the HTTP API listens on port `5681`.
-
-To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681` to see
-the HTTP API.
-
-{% endnavtab %}
-{% navtab kumactl (Read & Write) %}
-
-You can use the `kumactl` CLI to perform read and write operations on
-{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
-the {{site.mesh_product_name}} HTTP API. For example:
-
-```sh
-$ kumactl get meshes
-NAME          mTLS      METRICS      LOGGING   TRACING
-default       off       off          off       off
-```
-Or, you can enable mTLS on the `default` Mesh with:
-
-```sh
-echo "type: Mesh
-name: default
-mtls:
-  enabledBackend: ca-1
-  backends:
-  - name: ca-1
-    type: builtin" | kumactl apply -f -
-```
-You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
-
-```sh
-$ kumactl config control-planes add \
---name=XYZ \
---address=http://{address-to-mesh}:5681
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-You will notice that {{site.mesh_product_name}} automatically creates a Mesh
-entity with the name `default`.
-
-## 4. Quickstart
-
-Congratulations! You have successfully installed {{site.mesh_product_name}} on Ubuntu.
-
-After installation, the Kuma quickstart documentation is fully compatible with
-{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
-binaries instead of the vanilla Kuma ones.
-
-To start using {{site.mesh_product_name}}, see the [quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}


### PR DESCRIPTION
Issue tracked in https://konghq.atlassian.net/browse/DOCS-1304.

Previous state of the install docs: we gave users some vague instructions, expecting them to cross-reference the Kuma docs. For a better (less confusing) user experience, this PR brings all the installation instructions over from the Kuma doc site and adjusts them for Kong Mesh. 

For reference, see each topic in Kuma docs, eg https://kuma.io/docs/0.7.2/installation/kubernetes/.

**Preview:** all topics under https://deploy-preview-2368--kongdocs.netlify.app/mesh/1.0.x/install/ except Helm.

### Universal install instructions
Ubuntu, CentOS, MacOS, Debian, Amazon Linux, and Redhat installation instructions are exactly the same after downloading the binaries. Therefore, they're documented through `include` sections. 

### Kubernetes, OpenShift, and Docker
These installation topics have some differences between each other, enough that using shared instructions doesn't work. 

### Comments/Notes
Writing these topics brought up some formatting issues in the docs. In subsequent PRs, I'll be adjusting the styling for codeblocks within notes:

<img width="979" alt="Screen Shot 2020-10-09 at 11 30 57 AM" src="https://user-images.githubusercontent.com/54370747/95619142-fde8f280-0a22-11eb-8498-59490489f32f.png">

and for tabs:
<img width="981" alt="Screen Shot 2020-10-09 at 11 31 18 AM" src="https://user-images.githubusercontent.com/54370747/95619186-0f31ff00-0a23-11eb-9497-0b9fc819f467.png">

Final styling tbd.