### PR TITLE
docs(ee/yum-install) remove epel-release install instruction

### DIFF
--- a/app/enterprise/1.5.x/deployment/installation/centos.md
+++ b/app/enterprise/1.5.x/deployment/installation/centos.md
@@ -68,7 +68,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 
   ```
   kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
-  ```  
+  ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
@@ -118,16 +118,10 @@ You should now have two files in your home directory on the target CentOS system
 {% navtabs %}
 {% navtab Using a downloaded RPM package %}
 
-1. Install EPEL (Extra Packages for Enterprise Linux), if not already installed:
+1. Execute a command similar to the following, using the appropriate RPM file name you downloaded:
 
     ```bash
-    $ sudo yum install epel-release
-    ```
-
-2. Execute a command similar to the following, using the appropriate RPM file name you downloaded:
-
-    ```bash
-    $ sudo yum install kong-enterprise-edition-1.5.el7.noarch.rpm
+    $ sudo yum install /path/to/package.rpm --nogpgcheck
     ```
 {% endnavtab %}
 {% navtab Using Yum repo %}
@@ -143,7 +137,7 @@ You should now have two files in your home directory on the target CentOS system
     ```bash
     $ sudo yum update -y
     $ sudo yum install kong-enterprise-edition
-    ```    
+    ```
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/1.5.x/deployment/installation/rhel.md
+++ b/app/enterprise/1.5.x/deployment/installation/rhel.md
@@ -67,7 +67,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 
     ```
     kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm: digests signatures OK
-    ```  
+    ```
 
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
@@ -119,17 +119,10 @@ You should now have two files in your home directory on the target RHEL system:
 {% navtabs %}
 {% navtab Using downloaded RPM package %}
 
-1. Install EPEL (Extra Packages for Enterprise Linux), if not already installed:
+1. Execute a command similar to the following, using the appropriate RPM file name you downloaded:
 
     ```bash
-    $ sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y
-    $ sudo yum install epel-release -y
-    ```
-    
-2. Execute a command similar to the following, using the appropriate RPM file name you downloaded:
-
-    ```bash
-    $ sudo yum install kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm -y
+    $ sudo yum install /path/to/package.rpm --nogpgcheck
     ```
 *Note: If you're using RHEL 7.0, change the version of the RPM file above from 8 to 7.*
 
@@ -147,7 +140,7 @@ You should now have two files in your home directory on the target RHEL system:
     ```bash
     $ sudo yum update -y
     $ sudo yum install kong-enterprise-edition -y
-    ```    
+    ```
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/enterprise/1.5.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/1.5.x/deployment/installation/ubuntu.md
@@ -62,17 +62,16 @@ You should now have two files in your home directory on the target system:
 
 ## Step 2. Install Kong Enterprise
 
-1. Update APT and install dependencies
+1. Update APT
 
     ```bash
     $ sudo apt-get update
-    $ sudo apt-get install openssl libpcre3 procps perl
     ```
 
 2. Install Kong Enterprise
 
     ```bash
-    $ sudo dpkg -i kong-enterprise-edition-<VERSION_NUMBER>.deb
+    $ sudo apt-get install /absolute/path/to/package.deb
     ```
   
     > Note: Your version may be different based on when you obtained the package


### PR DESCRIPTION
Backporting the EE 2.1 yum docs changes to EE 1.5: https://github.com/Kong/docs.konghq.com/pull/2321

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

