### PR TITLE
docs(plugins) Update plugin annotations in k8s examples

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -145,7 +145,7 @@ metadata:
   labels:
     app: <service>
   annotations:
-    plugins.konghq.com: <{{page.params.name}}-example>
+    konghq.com/plugins: <{{page.params.name}}-example>
 spec:
   ports:
   - port: 80
@@ -249,7 +249,7 @@ metadata:
   name: <route>
   annotations:
     kubernetes.io/ingress.class: kong
-    plugins.konghq.com: <{{page.params.name}}-example>
+    konghq.com/plugins: <{{page.params.name}}-example>
 spec:
   rules:
   - host: examplehostname.com
@@ -355,7 +355,7 @@ kind: KongConsumer
 metadata:
   name: <consumer>
   annotations:
-    plugins.konghq.com: <{{page.params.name}}-example>
+    konghq.com/plugins: <{{page.params.name}}-example>
     kubernetes.io/ingress.class: kong
   ```
 


### PR DESCRIPTION
Based on https://konghq.atlassian.net/browse/DOCS-1358.

The `plugins.konghq.com` annotation has been replaced with `konghq.com/plugins`, back in 0.8. 
No doc versioning needed, this annotation should've been used originally.


For reference, see https://github.com/Kong/kubernetes-ingress-controller/pull/873/files#diff-ab7186fbfc65b74973321a0a1d7f0e7c3080bffcf3fa4d3a91eb1555b072d3e0
