### PR TITLE
docs(styles) Link contrast again

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -519,6 +519,10 @@
 
   li {
     line-height: 26px;
+
+    a {
+      color: #85898c;
+    }
   }
 
   li ul {
@@ -530,15 +534,28 @@
   }
 
   li a.active {
-    color: @blue;
+    color: @gray-darker;
+    font-weight: 600;
+    opacity: 1;
   }
 
   a {
     font-size: 14px;
+    color: @blue;
+
+    &:hover {
+    opacity: 0.5;
+    }
   }
 
   .fa {
     color: #acb7bf;
+  }
+
+  table {
+    a {
+      color: @blue;
+    }
   }
 }
 
@@ -729,9 +746,11 @@
 
   a {
     text-decoration: none;
+    color: @blue;
 
     &:hover {
       text-decoration: underline;
+      opacity: 0.7;
     }
   }
 


### PR DESCRIPTION
Link contrast changes were overwritten in a recent update: 
https://github.com/Kong/docs.konghq.com/commit/9f71410c351b90d1bde95ab781513cf09aae170e#diff-b76a2d61b8dc0d44c6a369273267d460fdcc320fe792861a1d3dea28ccc7d1c2

Redoing the updates.
