### PR TITLE
docs(ee-license) Clarify and update license and Bintray doc

### DIFF
--- a/app/_includes/md/1.5.x/bintray-and-license.md
+++ b/app/_includes/md/1.5.x/bintray-and-license.md
@@ -1,0 +1,12 @@
+<!-- License and bintray access info step; used in all Enterprise installation topics-->
+* A valid Bintray account with access to the Kong repository. You receive access
+when you begin a **paid Kong Enterprise subscription**.
+  * You will need your **username**, account **password**, account **API Key**,
+    and Kong Enterprise **license file**. For example:
+    * **Bintray username**: `john-company@kong`
+    * **Bintray password**: `12345678`
+    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
+  * To find the API Key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
+  * To find the Kong Enterprise license JSON file, log into your Bintray
+  account and go to `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`.
+ For more details, see [Accessing Your License](/enterprise/latest/deployment/access-license).

--- a/app/_includes/md/2.1.x/bintray-and-license.md
+++ b/app/_includes/md/2.1.x/bintray-and-license.md
@@ -9,4 +9,4 @@ when you begin a **paid Kong Enterprise subscription**.
   * To find the API Key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
   * To find the Kong Enterprise license JSON file, log into your Bintray
   account and go to `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`.
- For more detail, see [Accessing Your License](/enterprise/latest/deployment/access-license).
+ For more details, see [Accessing Your License](/enterprise/latest/deployment/access-license).

--- a/app/_includes/md/2.1.x/bintray-and-license.md
+++ b/app/_includes/md/2.1.x/bintray-and-license.md
@@ -1,0 +1,12 @@
+<!-- License and bintray access info step; used in all Enterprise installation topics-->
+* A valid Bintray account with access to the Kong repository. You receive access
+when you begin a **paid Kong Enterprise subscription**.
+  * You will need your **username**, account **password**, account **API Key**,
+    and Kong Enterprise **license file**. For example:
+    * **Bintray username**: `john-company@kong`
+    * **Bintray password**: `12345678`
+    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
+  * To find the API Key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
+  * To find the Kong Enterprise license JSON file, log into your Bintray
+  account and go to `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`.
+ For more detail, see [Accessing Your License](/enterprise/latest/deployment/access-license).

--- a/app/enterprise/1.5.x/deployment/access-license.md
+++ b/app/enterprise/1.5.x/deployment/access-license.md
@@ -4,32 +4,48 @@ title: Access Your Kong Enterprise License
 
 Kong Enterprise requires a license file. This guide walks you through how to access your license file.
 
-**Note:** The following guide only pertains to paid versions of Kong Enterprise. For free trial information, check the email received after signing up.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> The following guide only pertains to paid versions of
+Kong Enterprise. For free trial information, see our list of ways to
+<a href="/enterprise/{{page.kong_version}}/introduction/#try-kong-enterprise">
+try Kong Enterprise</a>, or see your free trial sign-up email.
+</div>
 
-Log into [https://bintray.com/login?forwardedFrom=%2Fkong%2F](https://bintray.com/login?forwardedFrom=%2Fkong%2F)
+## Prerequisites
+
+Before you can access your license, you need to sign up for a Kong Enterprise
+subscription. With this subscription, you will receive access to the Kong
+Bintray repository, which contains the necessary license files.
+
+If you have purchased a subscription but haven't received a license file,
+contact your sales representative.
+
+## Accessing your license file through a browser
+
+1. Log into [https://bintray.com/](https://bintray.com/login?forwardedFrom=%2Fkong%2F).
 If you are unaware of your login credentials, reach out to your CSE and they'll
 be able to assist you.
 
-You will notice that along with Kong Enterprise, there is a new
+2. Notice that along with Kong Enterprise, there is a new
 repository that has the same name as your company. Click on that repo.
 
-In the repo, click on the file called **license**.
+3. In the repo, click on the file called **license**.
 
-![bintray-license](/assets/images/docs/ee/access-bintray-license.png)
+    ![bintray-license](/assets/images/docs/ee/access-bintray-license.png)
 
-Click into the **Files** section
+4. Click into the **Files** section
 
-![bintray-license-files](/assets/images/docs/ee/access-bintray-license-files.png)
+    ![bintray-license-files](/assets/images/docs/ee/access-bintray-license-files.png)
 
-Click any file you would like to download.
+5. Click any file you want to download.
 
 ## Programmatically accessing your license file
 
 For programmatic access you'll need 3 pieces of information:
 
- - username (was provided by email by your CSE)
- - repository name (the Bintray repository, visible in the GUI, usually named after your company name)
- - the Bintray API key for the account (see below)
+ - Username (provided through email by your CSE)
+ - Repository name (the Bintray repository, visible in the GUI, usually named after your company name)
+ - The Bintray API key for the account (see below)
 
 To get the API key follow these steps:
 

--- a/app/enterprise/1.5.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/1.5.x/deployment/installation/amazon-linux-2.md
@@ -17,37 +17,32 @@ steps to configure PostgreSQL. For assistance in setting up Cassandra, please co
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported Amazon Linux 2 system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported Amazon Linux 2 system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on Amazon Linux 2. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM File %}
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws](https://bintray.com/kong/kong-enterprise-edition-aws).
-2. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
-3. Select the latest Kong version from the list.
-4. From the Kong version detail page, select the **Files** tab and click the distribution folder.
-5. Save the RPM file available. For example, `kong-enterprise-edition-1.5.0.1.aws.rpm`.
-6. Copy the RPM file to your home directory on the Amazon Linux 2 system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws](https://bintray.com/kong/kong-enterprise-edition-aws).
+3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
+4. Select the latest Kong version from the list.
+5. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
+6. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.aws.rpm`.
+7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You can use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-1.5.0.1.aws.rpm <amazon user>@<server>:~
     ```
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
-7. Download Kong's official public key to ensure the integrity of the RPM package:
+
+### (Optional) Verify the Package Integrity
+
+1. Download Kong's official public key to ensure the integrity of the RPM package:
 
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
@@ -55,7 +50,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     $ sudo rpm -K kong-enterprise-edition-1.5.0.1.aws.rpm
     ```
 
-8. Verify you get an OK check. You should have output similar to this:
+2. Verify you get an OK check. Output should be similar to this:
 
     ```
     kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: sha1 md5 OK
@@ -63,16 +58,21 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
 
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows::
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
+
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-aws
     ```
 
-    Replace `USERNAME` with your Bintray account user name.
-    Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting the API Key menu item.
+    * Replace `USERNAME` with your Bintray account username.
+    * Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
 
     The result should look something like this:
 
@@ -80,7 +80,8 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-aws
     ```
 
-3. Securely copy the changed repo file to your home directory on the Amazon Linux 2 system. You may use a command such as:
+4. Securely copy the changed repo file to your home directory on the Amazon
+Linux 2 system. For example:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-aws.repo <amazon user>@<server>:~
@@ -97,7 +98,8 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`
     ```
 
-2. Securely copy the license file to your home directory on the Amazon Linux system. You may use a command like:
+2. Securely copy the license file to your home directory on the Amazon Linux
+system. For example:
 
     ```bash
     $ scp license.json <amazon username>@<server>:~
@@ -134,7 +136,7 @@ $ sudo yum install kong-enterprise-edition-1.5.0.1.aws.rpm
     ```bash
     $ sudo yum update -y
     $ sudo yum install kong-enterprise-edition -y
-    ```    
+    ```
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/enterprise/1.5.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/1.5.x/deployment/installation/amazon-linux.md
@@ -17,37 +17,32 @@ steps to configure PostgreSQL. For assistance in setting up Cassandra, please co
 
 To complete this installation guide you will need:
 
-
-* A valid *Bintray* account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-* A supported Amazon Linux 1 system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported Amazon Linux 1 system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on Amazon Linux 1. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM file %}
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws/aws](https://bintray.com/kong/kong-enterprise-edition-aws/aws).
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws/aws](https://bintray.com/kong/kong-enterprise-edition-aws/aws).
+
     Kong Enterprise versions are listed in reverse chronological order.
+
 3. Select the latest Kong version from the list.
-4. From the Kong version detail page, select the **Files** tab and click the distribution folder.
-5. Save the RPM file available. For example, `kong-enterprise-edition-1.5.0.1.aws.rpm`.
+4. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
+5. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
-  ```bash
-  $ scp kong-enterprise-edition-1.5.0.1.aws.rpm <amazon user>@<server>:~
-  ```
+    ```bash
+    $ scp kong-enterprise-edition-1.5.0.1.aws.rpm <amazon user>@<server>:~
+    ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
+### (Optional) Verify the Package Integrity
 
 1. Download Kong's official public key to ensure the integrity of the RPM package:
 
@@ -57,7 +52,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     $ sudo rpm -K kong-enterprise-edition-1.5.0.1.aws.rpm
     ```
 
-2. Verify you get an OK check. You should have an output similar to this:
+2. Verify you get an OK check. Output should be similar to this:
 
       ```
       kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: sha1 md5 OK
@@ -65,15 +60,21 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
+
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
       ```
       baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-aws
       ```
 
-      - Replace `USERNAME` with your Bintray account user name.
-      - Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting the API Key menu item.
+      - Replace `USERNAME` with your Bintray account username.
+      - Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
 
       The result should look something like this:
 
@@ -81,7 +82,8 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
       baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-aws
       ```
 
-3. Securely copy the changed repo file to your home directory on the Amazon Linux 1 system. You may use a command like:
+4. Securely copy the changed repo file to your home directory on the Amazon
+Linux 1 system. For example:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-aws.repo <amazon user>@<server>:~
@@ -93,7 +95,8 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 
 1. Download your license file from your account files in Bintray: `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`
 
-2. Securely copy the license file to your home directory on the Amazon Linux system. You may use a command like:
+2. Securely copy the license file to your home directory on the Amazon Linux
+system. For example:
 
     ```bash
     $ scp license.json <amazon username>@<server>:~
@@ -145,7 +148,7 @@ $ sudo cp license.json /etc/kong/license.json
 
 1. Install PostgreSQL.
 
-    Follow the instructions available at [https://www.postgresql.org/download/linux/redhat/](https://www.postgresql.org/download/linux/redhat/) to install a supported version of PostgreSQL. Kong supports version 9.5 and higher. As an example, you can run a command set similar to:
+    Follow the instructions avaialble at [https://www.postgresql.org/download/linux/redhat/](https://www.postgresql.org/download/linux/redhat/) to install a supported version of PostgreSQL. Kong supports version 9.5 and higher. As an example, you can run a command set similar to:
 
     ```bash
     $ sudo yum install postgresql96 postgresql96-server

--- a/app/enterprise/1.5.x/deployment/installation/centos.md
+++ b/app/enterprise/1.5.x/deployment/installation/centos.md
@@ -18,37 +18,30 @@ steps to configure PostgreSQL. For assistance in setting up Cassandra, please co
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported CentOS system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported CentOS system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on CentOS. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM file %}
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/centos](https://bintray.com/kong/kong-enterprise-edition-rpm/centos).
-2. Select the latest Kong version from the list.
-3. From the Kong version detail page, select the **Files** tab.
-4. Select the CentOS version appropriate for your environment. e.g. `centos` -> `7`.
-5. Save the RPM file available: e.g. `kong-enterprise-edition-1.5.0.1.el7.noarch.rpm`
-6. Copy the RPM file to your home directory on the CentOS system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/centos](https://bintray.com/kong/kong-enterprise-edition-rpm/centos).
+3. Select the latest Kong version from the list.
+4. From the Kong version detail page, select the **Files** tab.
+5. Select the CentOS version appropriate for your environment, such as `centos` -> `7`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.el7.noarch.rpm`
+7. Copy the RPM file to your home directory on the CentOS system. For example:
 
     ```bash
     $ scp kong-enterprise-edition-1.5.0.1.el7.noarch.rpm <centos user>@<server>:~
     ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
+### (Optional) Verify the Package Integrity
 
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
@@ -64,24 +57,30 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     $ rpm -K kong-enterprise-edition-1.5.el7.noarch.rpm
     ```
 
-3. Verify you get an OK check. You should have an output similar to this:
+3. Verify you get an OK check. Output should be similar to this:
 
-  ```
-  kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
-  ```
+    ```
+    kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
+    ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm).
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm)
+
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-rpm/centos/RELEASEVER
     ```
 
-    Replace `USERNAME` with your Bintray account user name.
-    Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at https://bintray.com/profile/edit and selecting the API Key menu item.
-    Replace `RELEASEVER` with the major CentOS version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
+    * Replace `USERNAME` with your Bintray account username.
+    * Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
+    * Replace `RELEASEVER` with the major CentOS version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
 
     The result should look something like this:
 

--- a/app/enterprise/1.5.x/deployment/installation/docker.md
+++ b/app/enterprise/1.5.x/deployment/installation/docker.md
@@ -18,16 +18,8 @@ steps to configure PostgreSQL.
 
 To complete this installation you will need:
 
-* A valid *Bintray* account. You will need your *username*, account *password* and account *API Key*.
-  - Example:
-    * Bintray Access key = `john-company`
-    * Bintray username = `john-company@kong`
-    * Bintray password = `12345678`
-    * Bintray API key = `12234e314356291a2b11058591bba195830`
-  - The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
 * A Docker-enabled system with proper Docker access.
-* A valid **Kong Enterprise License** JSON file.
-  - The license file can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
 
 ## Step 1. Add the Kong Docker Repository and Pull the Kong Enterprise Docker Image
 

--- a/app/enterprise/1.5.x/deployment/installation/rhel.md
+++ b/app/enterprise/1.5.x/deployment/installation/rhel.md
@@ -17,45 +17,38 @@ steps to configure PostgreSQL. For assistance in setting up Cassandra, please co
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported RHEL system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported RHEL system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on RHEL. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM file %}
 
-1. Go to [https://bintray.com/kong/kong-enterprise-edition-rpm/rhel](https://bintray.com/kong/kong-enterprise-edition-rpm/rhel).
-2. Select the latest Kong version from the list.
-3. From the Kong version detail page, select the **Files** tab.
-4. Select the RHEL version appropriate for your environment. e.g. `RHEL` -> `8`.
-5. Save the RPM file available: e.g. `kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm`
-6. Copy the RPM file to your home directory on the RHEL system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/rhel](https://bintray.com/kong/kong-enterprise-edition-rpm/rhel).
+3. Select the latest Kong version from the list.
+4. From the Kong version detail page, select the **Files** tab.
+5. Select the RHEL version appropriate for your environment, such as `RHEL` -> `8`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm`
+7. Copy the RPM file to your home directory on the RHEL system. For example:
 
     ```bash
     $ scp kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm <rhel user>@<server>:~
     ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
+### (Optional) Verify the Package Integrity
 
-7. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
+1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
     ```bash
     $ rpm -qpi kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm | grep Signature
     ```
 
-8. Download Kong's official public key to ensure the integrity of the RPM package:
+2. Download Kong's official public key to ensure the integrity of the RPM package:
 
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
@@ -63,7 +56,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     $ rpm -K kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm
     ```
 
-9. Verify you get an OK check. You should have an output similar to this:
+3. Verify you get an OK check. Output should be similar to this:
 
     ```
     kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm: digests signatures OK
@@ -72,24 +65,29 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm).
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
 
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm).
+
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-rpm/rhel/RELEASEVER
     ```
 
-    Replace `USERNAME` with your Bintray account user name.
-    Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at https://bintray.com/profile/edit and selecting the API Key menu item.
-    Replace `RELEASEVER` with the major RHEL version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
+    * Replace `USERNAME` with your Bintray account username.
+    * Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
+    * Replace `RELEASEVER` with the major RHEL version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
 
     The result should look something like this:
     ```
     baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-rpm/rhel/8
     ```
 
-3. Securely copy the changed repo file to your home directory on the RHEL system:
+4. Securely copy the changed repo file to your home directory on the RHEL system:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-rpm.repo <rhel user>@<server>:~

--- a/app/enterprise/1.5.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/1.5.x/deployment/installation/ubuntu.md
@@ -17,36 +17,32 @@ steps to configure PostgreSQL. For assistance in setting up Cassandra, please co
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported Ubuntu system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
-
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported Ubuntu system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 ### Download the Debian package
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu). 
-2. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
-3. From the Kong version detail page, select the **Files** tab.
-4. Click the .deb file matching your target Ubuntu OS version. e.g. `kong-enterprise-edition-1.5.0.0.bionic.all.deb` for the Ubuntu Bionic Beaver release.
-5. Copy the .deb file to your home directory on the Ubuntu system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
+3. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
+4. From the Kong version detail page, select the **Files** tab.
+5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-1.5.0.0.bionic.all.deb` for the Ubuntu Bionic Beaver release.
+6. Copy the `.deb` file to your home directory on the Ubuntu system. For example:
 
     ```bash
     $ scp kong-enterprise-edition-1.5.0.0.bionic.all.deb <ubuntu_user>@<server>:~
     ```
 
 ### Download your Kong Enterprise License
-   
-1. Download your license file from your account files in Bintray: `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`
+
+1. Download your license file from your [account files in Bintray](#prerequisites):
+
+    ```
+    https://bintray.com/kong/<YOUR_REPO_NAME>/license#files
+    ```
 
 2. Securely copy the license file to your home directory on the Ubuntu system:
 
@@ -57,7 +53,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 ### Result
 
 You should now have two files in your home directory on the target system:
-- The Kong .deb package file
+- The Kong `.deb` package file
 - The license file `license.json`
 
 ## Step 2. Install Kong Enterprise
@@ -73,7 +69,7 @@ You should now have two files in your home directory on the target system:
     ```bash
     $ sudo apt-get install /absolute/path/to/package.deb
     ```
-  
+
     > Note: Your version may be different based on when you obtained the package
 
 3. Copy the license file to the `/etc/kong` directory
@@ -86,9 +82,16 @@ You should now have two files in your home directory on the target system:
 
 ## Step 3. Set up PostgreSQL
 
-PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu "snapshots" a specific version of PostgreSQL that is then supported throughout the lifetime of that Ubuntu version. Other versions of PostgreSQL are available through the PostgreSQL apt repository. Kong supports version 9.5 and higher. Ensure the distribution of PostgreSQL for your version of Ubuntu is a supported version. More information about PostgreSQL on Ubuntu can be found here: [https://www.postgresql.org/download/linux/ubuntu/](https://www.postgresql.org/download/linux/ubuntu/). 
+PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu
+snapshots a specific version of PostgreSQL that is then supported throughout the
+lifetime of that Ubuntu version. Other versions of PostgreSQL are available
+through the PostgreSQL apt repository.
 
-1. Install PostgreSQL. This command may not work on all version of Ubuntu.
+Kong supports versions 9.5 and higher. Ensure the distribution of PostgreSQL
+for your version of Ubuntu is a supported version for Kong. For more
+information about PostgreSQL on Ubuntu, see [https://www.postgresql.org/download/linux/ubuntu/](https://www.postgresql.org/download/linux/ubuntu/).
+
+1. Install PostgreSQL. This command may not work on all versions of Ubuntu.
 
     ```bash
     $ sudo apt-get install postgresql postgresql-contrib
@@ -108,7 +111,7 @@ PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu "snap
     ```
 
     > ⚠️ **Note**: Make sure the username and password for the Kong Database are
-    > kept safe. This example uses a simple username and password for illustration purposes only. Note the database name, username and password for later. 
+    > kept safe. This example uses a simple username and password for illustrative purposes only. Note the database name, username and password for later.
 
 4. Exit from PostgreSQL and return to your terminal account.
 
@@ -125,7 +128,7 @@ PostgreSQL is available in all Ubuntu versions by default. However, Ubuntu "snap
     $ sudo cp /etc/kong/kong.conf.default /etc/kong/kong.conf
     ```
 
-2. Uncomment and update the PostgreSQL database properties in `/etc/kong/kong.conf` using your preferred text editor. Replace `pg_user`, `pg_password`, and `pg_database` with the values: 
+2. Uncomment and update the PostgreSQL database properties in `/etc/kong/kong.conf` using your preferred text editor. Replace `pg_user`, `pg_password`, and `pg_database` with the values:
 
     ```
     pg_user = kong
@@ -166,9 +169,9 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
     ```
     admin_gui_url = http://<DNSorIP>:8002
     ```
-  
+
     This setting needs to resolve to a network path that will reach the host.
-  
+
 2. It is necessary to update the administration API setting to listen on the needed network interfaces on the host. A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
     ```
@@ -225,6 +228,6 @@ your setup, reach out to your Kong Support contact or go to the
 
 ## Next Steps
 
-Check out Kong Enterprise's series of 
+Check out Kong Enterprise's series of
 [Getting Started](/enterprise/latest/getting-started) guides to get the most
 out of Kong Enterprise.

--- a/app/enterprise/1.5.x/introduction.md
+++ b/app/enterprise/1.5.x/introduction.md
@@ -57,10 +57,16 @@ Kong Vitals provides useful metrics about the health and performance of your Kon
 
 Kong Studio enables spec-first development for all REST and GraphQL services. With Kong Studio, organizations can accelerate design and test workflows using automated testing, direct Git sync, and inspection of all response types. Teams of all sizes can use Kong Studio to increase development velocity, reduce deployment risk, and increase collaboration. For more information, see [_Kong Studio_](https://docs.konghq.com/studio/).
 
-
 ## Try Kong Enterprise
 
-Here are a couple of ways to try Kong Enterprise:
+Here are a few ways to try Kong Enterprise:
 
-* Get a demonstration at [_Request Demo_](https://konghq.com/request-demo/?itm_source=website&itm_medium=nav/)
-* Get a free trial at [_Kong Free Trial_](https://konghq.com/products/kong-enterprise/free-trial?itm_source=website&itm_medium=nav)
+* Sign up for the Kong Enterprise self-serve, cloud-based, 15 day
+[free trial](https://konghq.com/get-started/#free-trial/).
+* Try out Kong for Kubernetes Enterprise using a live tutorial at
+[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
+* If you are interested in evaluating Kong Enterprise locally, the Kong sales
+team manages evaluation licenses as part of a formal sales process. The best
+way to get started with the sales process is to
+[request a demo](https://konghq.com/get-started/#request-demo) and indicate
+your interest.

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -17,12 +17,8 @@ Before starting installation, be sure you have the following:
 
 - **Kubernetes cluster with load balancer**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
-- A valid Kong Enterprise License:
-  * If you have a license, continue to [Set Up Kong Enterprise License](#step-2-set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
-  * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
-  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-- Kong Enterprise Docker registry access on Bintray.
 - Helm installed.
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
 
 ## Step 1. Provision a namespace
 
@@ -210,17 +206,17 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i> 
-    <strong>Important:</strong> 
-    If you are running Postgres as a sub-chart and having problems with connecting to 
-    the database, delete Postgres' persistent volumes in your Kubernetes cluster, then 
-    retry the Helm install. 
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Important:</strong>
+    If you are running Postgres as a sub-chart and having problems with connecting to
+    the database, delete Postgres' persistent volumes in your Kubernetes cluster, then
+    retry the Helm install.
     </div>
-    
+
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i> 
-    <strong>Important:</strong> 
-    If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>. 
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Important:</strong>
+    If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>.
     </div>
 
 
@@ -254,10 +250,10 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     ```
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i> 
-    <strong>Important:</strong> The command above requires the Kong Admin API. If you 
-    have not set <code>admin.enabled</code> to <code>true</code> in your 
-    <code>values.yaml</code>, then this command will not work. 
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Important:</strong> The command above requires the Kong Admin API. If you
+    have not set <code>admin.enabled</code> to <code>true</code> in your
+    <code>values.yaml</code>, then this command will not work.
     </div>
 
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -39,13 +39,9 @@ $ oc new-project kong
 {% endnavtabs %}
 
 ## Step 2. Set Up Kong Enterprise license
-Running Kong Enterprise on Kubernetes requires a valid license.
+Running Kong Enterprise on Kubernetes requires a valid license. See [prerequisites](#prerequisites) for more information.
 
-As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
-
-> Note:
-* There is no `.json` extension in the `--from-file` parameter.
-* `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
+Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -59,6 +55,12 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong><br>
+<ul>
+  <li>There is no <code>.json</code> extension in the <code>--from-file</code> parameter.</li>
+  <li><code>-n kong</code> specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.</li></ul></div>
 
 ## Step 3. Set up Helm
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -40,12 +40,9 @@ $ oc new-project kong
 {% endnavtabs %}
 
 ## Step 2. Set Up Kong Enterprise License
-Running Kong for Kubernetes Enterprise requires a valid license.
+Running Kong for Kubernetes Enterprise requires a valid license. See [prerequisites](#prerequisites) for more information.
 
-As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
-
-> Note: There is no `.json` extension in the `--from-file` parameter.
-> `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
+Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -59,6 +56,12 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong><br>
+<ul>
+  <li>There is no <code>.json</code> extension in the <code>--from-file</code> parameter.</li>
+  <li><code>-n kong</code> specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.</li></ul></div>
 
 ## Step 3. Configure Kong Enterprise Docker registry access
 

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -14,13 +14,12 @@ You can install Kong for Kubernetes Enterprise using YAML with kubectl, or with 
 ## Prerequisites
 Before starting installation, be sure you have the following:
 
+## Prerequisites
+Before starting installation, be sure you have the following:
+
 - **Kubernetes cluster**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
-- A valid Kong Enterprise License
-  * If you have a license, continue to [Set Up Kong Enterprise License](#step-2-set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
-  * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
-  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-- Kong Enterprise Docker registry access on Bintray.
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
 
 ## Step 1. Provision a Namespace
 

--- a/app/enterprise/2.1.x/deployment/access-license.md
+++ b/app/enterprise/2.1.x/deployment/access-license.md
@@ -26,7 +26,7 @@ contact your sales representative.
 If you are unaware of your login credentials, reach out to your CSE and they'll
 be able to assist you.
 
-2. You will notice that along with Kong Enterprise, there is a new
+2. Notice that along with Kong Enterprise, there is a new
 repository that has the same name as your company. Click on that repo.
 
 3. In the repo, click on the file called **license**.
@@ -37,13 +37,13 @@ repository that has the same name as your company. Click on that repo.
 
     ![bintray-license-files](/assets/images/docs/ee/access-bintray-license-files.png)
 
-5. Click any file you would like to download.
+5. Click any file you want to download.
 
 ## Programmatically accessing your license file
 
 For programmatic access you'll need 3 pieces of information:
 
- - Username (was provided by email by your CSE)
+ - Username (provided through email by your CSE)
  - Repository name (the Bintray repository, visible in the GUI, usually named after your company name)
  - The Bintray API key for the account (see below)
 

--- a/app/enterprise/2.1.x/deployment/access-license.md
+++ b/app/enterprise/2.1.x/deployment/access-license.md
@@ -4,32 +4,48 @@ title: Access Your Kong Enterprise License
 
 Kong Enterprise requires a license file. This guide walks you through how to access your license file.
 
-**Note:** The following guide only pertains to paid versions of Kong Enterprise. For free trial information, check the email received after signing up.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> The following guide only pertains to paid versions of
+Kong Enterprise. For free trial information, see our list of ways to
+<a href="/enterprise/{{page.kong_version}}/introduction/#try-kong-enterprise">
+try Kong Enterprise</a>, or see your free trial sign-up email.
+</div>
 
-Log into [https://bintray.com/login?forwardedFrom=%2Fkong%2F](https://bintray.com/login?forwardedFrom=%2Fkong%2F)
+## Prerequisites
+
+Before you can access your license, you need to sign up for a Kong Enterprise
+subscription. With this subscription, you will receive access to the Kong
+Bintray repository, which contains the necessary license files.
+
+If you have purchased a subscription but haven't received a license file,
+contact your sales representative.
+
+## Accessing your license file through a browser
+
+1. Log into [https://bintray.com/](https://bintray.com/login?forwardedFrom=%2Fkong%2F).
 If you are unaware of your login credentials, reach out to your CSE and they'll
 be able to assist you.
 
-You will notice that along with Kong Enterprise, there is a new
+2. You will notice that along with Kong Enterprise, there is a new
 repository that has the same name as your company. Click on that repo.
 
-In the repo, click on the file called **license**.
+3. In the repo, click on the file called **license**.
 
-![bintray-license](/assets/images/docs/ee/access-bintray-license.png)
+    ![bintray-license](/assets/images/docs/ee/access-bintray-license.png)
 
-Click into the **Files** section
+4. Click into the **Files** section
 
-![bintray-license-files](/assets/images/docs/ee/access-bintray-license-files.png)
+    ![bintray-license-files](/assets/images/docs/ee/access-bintray-license-files.png)
 
-Click any file you would like to download.
+5. Click any file you would like to download.
 
 ## Programmatically accessing your license file
 
 For programmatic access you'll need 3 pieces of information:
 
- - username (was provided by email by your CSE)
- - repository name (the Bintray repository, visible in the GUI, usually named after your company name)
- - the Bintray API key for the account (see below)
+ - Username (was provided by email by your CSE)
+ - Repository name (the Bintray repository, visible in the GUI, usually named after your company name)
+ - The Bintray API key for the account (see below)
 
 To get the API key follow these steps:
 

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
@@ -40,15 +40,15 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws](https://bintray.com/kong/kong-enterprise-edition-aws).
 3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
 4. Select the latest Kong version from the list.
-5. From the Kong version detail page, select the **Files** tab and click the distribution folder.
-6. Save the RPM file available. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
-7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You may use a command like:
+5. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
+6. Save the available RPM file. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You can use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
     ```
 
-### (Optional) Verify the Integrity of the Package
+### (Optional) Verify the Package Integrity
 
 1. Download Kong's official public key to ensure the integrity of the RPM package:
 
@@ -58,7 +58,7 @@ for information on how to get access.
     $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
     ```
 
-2. Verify you get an OK check. You should have output similar to this:
+2. Verify you get an OK check. Output should be similar to this:
 
     ```
     kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
@@ -73,7 +73,7 @@ for information on how to get access.
 
     [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
 
-3. Edit the repo file using your preferred editor and alter the baseurl line as follows::
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-aws
@@ -88,7 +88,8 @@ for information on how to get access.
     baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-aws
     ```
 
-4. Securely copy the changed repo file to your home directory on the Amazon Linux 2 system. You may use a command such as:
+4. Securely copy the changed repo file to your home directory on the Amazon
+Linux 2 system. For example:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-aws.repo <amazon user>@<server>:~
@@ -105,7 +106,8 @@ for information on how to get access.
     https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`
     ```
 
-2. Securely copy the license file to your home directory on the Amazon Linux system. You may use a command like:
+2. Securely copy the license file to your home directory on the Amazon Linux
+system. For example:
 
     ```bash
     $ scp license.json <amazon username>@<server>:~

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
@@ -41,7 +41,7 @@ for information on how to get access.
 3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
 4. Select the latest Kong version from the list.
 5. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-6. Save the available RPM file. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
 7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You can use a command like:
 
     ```bash

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
@@ -30,8 +30,6 @@ To complete this installation you will need:
 
 There are two options to install Kong Enterprise on Amazon Linux 2. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM File %}
 

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
@@ -23,15 +23,8 @@ If you want to run {{site.ee_product_name}} in Hybrid mode, the instructions in 
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported Amazon Linux 2 system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported Amazon Linux 2 system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
@@ -42,19 +35,22 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% navtabs %}
 {% navtab Download RPM File %}
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws](https://bintray.com/kong/kong-enterprise-edition-aws).
-2. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
-3. Select the latest Kong version from the list.
-4. From the Kong version detail page, select the **Files** tab and click the distribution folder.
-5. Save the RPM file available. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
-6. Copy the RPM file to your home directory on the Amazon Linux 2 system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws](https://bintray.com/kong/kong-enterprise-edition-aws).
+3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
+4. Select the latest Kong version from the list.
+5. From the Kong version detail page, select the **Files** tab and click the distribution folder.
+6. Save the RPM file available. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You may use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
     ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
-7. Download Kong's official public key to ensure the integrity of the RPM package:
+### (Optional) Verify the Integrity of the Package
+
+1. Download Kong's official public key to ensure the integrity of the RPM package:
 
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
@@ -62,7 +58,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
     ```
 
-8. Verify you get an OK check. You should have output similar to this:
+2. Verify you get an OK check. You should have output similar to this:
 
     ```
     kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
@@ -70,16 +66,21 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
 
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows::
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
+
+3. Edit the repo file using your preferred editor and alter the baseurl line as follows::
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-aws
     ```
 
-    Replace `USERNAME` with your Bintray account user name.
-    Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting the API Key menu item.
+    * Replace `USERNAME` with your Bintray account username.
+    * Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
 
     The result should look something like this:
 
@@ -87,7 +88,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-aws
     ```
 
-3. Securely copy the changed repo file to your home directory on the Amazon Linux 2 system. You may use a command such as:
+4. Securely copy the changed repo file to your home directory on the Amazon Linux 2 system. You may use a command such as:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-aws.repo <amazon user>@<server>:~

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
@@ -41,7 +41,7 @@ for information on how to get access.
 
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-5. Save the available RPM file. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+5. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
     ```bash

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
@@ -23,37 +23,32 @@ If you want to run {{site.ee_product_name}} in Hybrid mode, the instructions in 
 
 To complete this installation guide you will need:
 
-
-* A valid *Bintray* account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-* A supported Amazon Linux 1 system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported Amazon Linux 1 system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on Amazon Linux 1. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM file %}
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws/aws](https://bintray.com/kong/kong-enterprise-edition-aws/aws).
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-aws/aws](https://bintray.com/kong/kong-enterprise-edition-aws/aws).
+
     Kong Enterprise versions are listed in reverse chronological order.
+
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab and click the distribution folder.
 5. Save the RPM file available. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
-  ```bash
-  $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
-  ```
+    ```bash
+    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
+    ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
+### (Optional) Verify the Integrity of the Package
 
 1. Download Kong's official public key to ensure the integrity of the RPM package:
 
@@ -71,15 +66,21 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
+
+3. Edit the repo file using your preferred editor and alter the baseurl line as follows:
 
       ```
       baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-aws
       ```
 
-      - Replace `USERNAME` with your Bintray account user name.
-      - Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting the API Key menu item.
+      - Replace `USERNAME` with your Bintray account username.
+      - Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
 
       The result should look something like this:
 
@@ -87,7 +88,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
       baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-aws
       ```
 
-3. Securely copy the changed repo file to your home directory on the Amazon Linux 1 system. You may use a command like:
+4. Securely copy the changed repo file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-aws.repo <amazon user>@<server>:~

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
@@ -40,15 +40,15 @@ for information on how to get access.
     Kong Enterprise versions are listed in reverse chronological order.
 
 3. Select the latest Kong version from the list.
-4. From the Kong version detail page, select the **Files** tab and click the distribution folder.
-5. Save the RPM file available. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+4. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
+5. Save the available RPM file. For example, `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
     ```
 
-### (Optional) Verify the Integrity of the Package
+### (Optional) Verify the Package Integrity
 
 1. Download Kong's official public key to ensure the integrity of the RPM package:
 
@@ -58,7 +58,7 @@ for information on how to get access.
     $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
     ```
 
-2. Verify you get an OK check. You should have an output similar to this:
+2. Verify you get an OK check. Output should be similar to this:
 
       ```
       kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
@@ -73,7 +73,7 @@ for information on how to get access.
 
     [https://bintray.com/kong/kong-enterprise-edition-aws/rpm](https://bintray.com/kong/kong-enterprise-edition-aws/rpm).
 
-3. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
       ```
       baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-aws
@@ -88,7 +88,8 @@ for information on how to get access.
       baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-aws
       ```
 
-4. Securely copy the changed repo file to your home directory on the Amazon Linux 1 system. You may use a command like:
+4. Securely copy the changed repo file to your home directory on the Amazon
+Linux 1 system. For example:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-aws.repo <amazon user>@<server>:~
@@ -100,7 +101,8 @@ for information on how to get access.
 
 1. Download your license file from your account files in Bintray: `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`
 
-2. Securely copy the license file to your home directory on the Amazon Linux system. You may use a command like:
+2. Securely copy the license file to your home directory on the Amazon Linux
+system. For example:
 
     ```bash
     $ scp license.json <amazon username>@<server>:~

--- a/app/enterprise/2.1.x/deployment/installation/centos.md
+++ b/app/enterprise/2.1.x/deployment/installation/centos.md
@@ -24,37 +24,30 @@ If you want to run {{site.ee_product_name}} in Hybrid mode, the instructions in 
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported CentOS system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported CentOS system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on CentOS. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM file %}
 
-1. Go to: https://bintray.com/kong/kong-enterprise-edition-rpm/centos.
-2. Select the latest Kong version from the list.
-3. From the Kong version detail page, select the **Files** tab.
-4. Select the CentOS version appropriate for your environment. e.g. `centos` -> `7`.
-5. Save the RPM file available: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
-6. Copy the RPM file to your home directory on the CentOS system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/centos](https://bintray.com/kong/kong-enterprise-edition-rpm/centos).
+3. Select the latest Kong version from the list.
+4. From the Kong version detail page, select the **Files** tab.
+5. Select the CentOS version appropriate for your environment. e.g. `centos` -> `7`.
+6. Save the RPM file available: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
+7. Copy the RPM file to your home directory on the CentOS system. You may use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm <centos user>@<server>:~
     ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
+### (Optional) Verify the Integrity of the Package
 
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
@@ -72,22 +65,28 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 
 3. Verify you get an OK check. You should have an output similar to this:
 
-  ```
-  kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
-  ```
+    ```
+    kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
+    ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: https://bintray.com/kong/kong-enterprise-edition-rpm/rpm.
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm)
+
+3. Edit the repo file using your preferred editor and alter the baseurl line as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-rpm/centos/RELEASEVER
     ```
 
-    Replace `USERNAME` with your Bintray account user name.
-    Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at https://bintray.com/profile/edit and selecting the API Key menu item.
-    Replace `RELEASEVER` with the major CentOS version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
+    * Replace `USERNAME` with your Bintray account username.
+    * Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
+    * Replace `RELEASEVER` with the major CentOS version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
 
     The result should look something like this:
 
@@ -160,7 +159,7 @@ $ sudo cp license.json /etc/kong/license.json
 
 1. Install PostgreSQL.
 
-    Follow the instructions avaialble at https://www.postgresql.org/download/linux/redhat/ to install a supported version of PostgreSQL. Kong supports version 9.5 and higher. As an example, you can run a command set similar to:
+    Follow the instructions available at [https://www.postgresql.org/download/linux/redhat/](https://www.postgresql.org/download/linux/redhat/) to install a supported version of PostgreSQL. Kong supports version 9.5 and higher. As an example, you can run a command set similar to:
 
     ```bash
     $ sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm

--- a/app/enterprise/2.1.x/deployment/installation/centos.md
+++ b/app/enterprise/2.1.x/deployment/installation/centos.md
@@ -39,15 +39,15 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/centos](https://bintray.com/kong/kong-enterprise-edition-rpm/centos).
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
-5. Select the CentOS version appropriate for your environment. e.g. `centos` -> `7`.
-6. Save the RPM file available: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
-7. Copy the RPM file to your home directory on the CentOS system. You may use a command like:
+5. Select the CentOS version appropriate for your environment, such as `centos` -> `7`.
+6. Save the available RPM file: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
+7. Copy the RPM file to your home directory on the CentOS system. For example:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm <centos user>@<server>:~
     ```
 
-### (Optional) Verify the Integrity of the Package
+### (Optional) Verify the Package Integrity
 
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
@@ -63,7 +63,7 @@ for information on how to get access.
     $ rpm -K kong-enterprise-edition-1.3.el7.noarch.rpm
     ```
 
-3. Verify you get an OK check. You should have an output similar to this:
+3. Verify you get an OK check. Output should be similar to this:
 
     ```
     kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
@@ -78,7 +78,7 @@ for information on how to get access.
 
     [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm)
 
-3. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-rpm/centos/RELEASEVER

--- a/app/enterprise/2.1.x/deployment/installation/centos.md
+++ b/app/enterprise/2.1.x/deployment/installation/centos.md
@@ -40,7 +40,7 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the CentOS version appropriate for your environment, such as `centos` -> `7`.
-6. Save the available RPM file: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
 7. Copy the RPM file to your home directory on the CentOS system. For example:
 
     ```bash

--- a/app/enterprise/2.1.x/deployment/installation/docker.md
+++ b/app/enterprise/2.1.x/deployment/installation/docker.md
@@ -23,16 +23,8 @@ If you want to run {{site.ee_product_name}} in Hybrid mode, the instructions in 
 
 To complete this installation you will need:
 
-* A valid *Bintray* account. You will need your *username*, account *password* and account *API Key*.
-  - Example:
-    * Bintray Access key = `john-company`
-    * Bintray username = `john-company@kong`
-    * Bintray password = `12345678`
-    * Bintray API key = `12234e314356291a2b11058591bba195830`
-  - The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
 * A Docker-enabled system with proper Docker access.
-* A valid **Kong Enterprise License** JSON file.
-  - The license file can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
 
 ## Step 1. Add the Kong Docker Repository and Pull the Kong Enterprise Docker Image {#pull-image}
 

--- a/app/enterprise/2.1.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.1.x/deployment/installation/rhel.md
@@ -39,14 +39,14 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the RHEL version appropriate for your environment. e.g. `RHEL` -> `8`.
-6. Save the RPM file available: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
-7. Copy the RPM file to your home directory on the RHEL system. You may use a command like:
+6. Save the available RPM file: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
+7. Copy the RPM file to your home directory on the RHEL system. For example:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm <rhel user>@<server>:~
     ```
 
-### (Optional) Verify the Integrity of the Package
+### (Optional) Verify the Package Integrity
 
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
@@ -62,7 +62,7 @@ for information on how to get access.
     $ rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm
     ```
 
-3. Verify you get an OK check. You should have an output similar to this:
+3. Verify you get an OK check. Output should be similar to this:
 
     ```
     kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm: digests signatures OK
@@ -78,7 +78,7 @@ for information on how to get access.
 
     [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm).
 
-3. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+3. Edit the repo file using your preferred editor and alter the `baseurl` line with your information as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-rpm/rhel/RELEASEVER

--- a/app/enterprise/2.1.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.1.x/deployment/installation/rhel.md
@@ -38,8 +38,8 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/rhel](https://bintray.com/kong/kong-enterprise-edition-rpm/rhel).
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
-5. Select the RHEL version appropriate for your environment. e.g. `RHEL` -> `8`.
-6. Save the available RPM file: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
+5. Select the RHEL version appropriate for your environment, such as `RHEL` -> `8`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
 7. Copy the RPM file to your home directory on the RHEL system. For example:
 
     ```bash

--- a/app/enterprise/2.1.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.1.x/deployment/installation/rhel.md
@@ -23,45 +23,38 @@ If you want to run {{site.ee_product_name}} in Hybrid mode, the instructions in 
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported RHEL system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported RHEL system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
 There are two options to install Kong Enterprise on RHEL. Both require a login to Bintray.
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 {% navtabs %}
 {% navtab Download RPM file %}
 
-1. Go to: https://bintray.com/kong/kong-enterprise-edition-rpm/rhel.
-2. Select the latest Kong version from the list.
-3. From the Kong version detail page, select the **Files** tab.
-4. Select the RHEL version appropriate for your environment. e.g. `RHEL` -> `8`.
-5. Save the RPM file available: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
-6. Copy the RPM file to your home directory on the RHEL system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-rpm/rhel](https://bintray.com/kong/kong-enterprise-edition-rpm/rhel).
+3. Select the latest Kong version from the list.
+4. From the Kong version detail page, select the **Files** tab.
+5. Select the RHEL version appropriate for your environment. e.g. `RHEL` -> `8`.
+6. Save the RPM file available: e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
+7. Copy the RPM file to your home directory on the RHEL system. You may use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm <rhel user>@<server>:~
     ```
 
-*Optional:* The following steps are for verifying the integrity of the package. They are not necessary to move on to [installation](#option-1-if-installing-using-a-downloaded-rpm-package).
+### (Optional) Verify the Integrity of the Package
 
-7. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
+1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
     ```bash
     $ rpm -qpi kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm | grep Signature
     ```
 
-8. Download Kong's official public key to ensure the integrity of the RPM package:
+2. Download Kong's official public key to ensure the integrity of the RPM package:
 
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
@@ -69,7 +62,7 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
     $ rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm
     ```
 
-9. Verify you get an OK check. You should have an output similar to this:
+3. Verify you get an OK check. You should have an output similar to this:
 
     ```
     kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm: digests signatures OK
@@ -78,24 +71,29 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
 
-1. Click this URL to download the Kong Enterprise RPM repo file: https://bintray.com/kong/kong-enterprise-edition-rpm/rpm.
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
 
-2. Edit the repo file using your preferred editor and alter the baseurl line as follows:
+2. Download the Kong Enterprise RPM repo file from:
+
+    [https://bintray.com/kong/kong-enterprise-edition-rpm/rpm](https://bintray.com/kong/kong-enterprise-edition-rpm/rpm).
+
+3. Edit the repo file using your preferred editor and alter the baseurl line as follows:
 
     ```
     baseurl=https://USERNAME:API_KEY@kong.bintray.com/kong-enterprise-edition-rpm/rhel/RELEASEVER
     ```
 
-    Replace `USERNAME` with your Bintray account user name.
-    Replace `API_KEY` with your Bintray API key. You can find your key on your Bintray profile page at https://bintray.com/profile/edit and selecting the API Key menu item.
-    Replace `RELEASEVER` with the major RHEL version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
+    * Replace `USERNAME` with your Bintray account username.
+    * Replace `API_KEY` with your Bintray API key. To find the key, go to [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and select **API Key**.
+    * Replace `RELEASEVER` with the major RHEL version number on your target system. For example, for version 7.7.1908, the appropriate `RELEASEVER` replacement is 7.
 
     The result should look something like this:
     ```
     baseurl=https://john-company:12234e314356291a2b11058591bba195830@kong.bintray.com/kong-enterprise-edition-rpm/rhel/8
     ```
 
-3. Securely copy the changed repo file to your home directory on the RHEL system:
+4. Securely copy the changed repo file to your home directory on the RHEL system:
 
     ```bash
     $ scp bintray--kong-kong-enterprise-edition-rpm.repo <rhel user>@<server>:~
@@ -162,7 +160,7 @@ $ sudo cp license.json /etc/kong/license.json
 
 1. Install PostgreSQL.
 
-    Follow the instructions avaialble at https://www.postgresql.org/download/linux/redhat/ to install a supported version of PostgreSQL. Kong supports version 9.5 and higher. As an example, you can run a command set similar to:
+    Follow the instructions available at [https://www.postgresql.org/download/linux/redhat/](https://www.postgresql.org/download/linux/redhat/) to install a supported version of PostgreSQL. Kong supports version 9.5 and higher. As an example, you can run a command set similar to:
 
     ```bash
     $ sudo dnf install postgresql-server

--- a/app/enterprise/2.1.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.1.x/deployment/installation/ubuntu.md
@@ -35,8 +35,8 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
 3. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
 4. From the Kong version detail page, select the **Files** tab.
-5. Click the .deb file matching your target Ubuntu OS version. e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
-6. Copy the .deb file to your home directory on the Ubuntu system. You may use a command like:
+5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
+6. Copy the `.deb` file to your home directory on the Ubuntu system. For example:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb <ubuntu_user>@<server>:~
@@ -59,7 +59,7 @@ for information on how to get access.
 ### Result
 
 You should now have two files in your home directory on the target system:
-- The Kong .deb package file
+- The Kong `.deb` package file
 - The license file `license.json`
 
 ## Step 2. Install Kong Enterprise

--- a/app/enterprise/2.1.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.1.x/deployment/installation/ubuntu.md
@@ -23,28 +23,20 @@ If you want to run {{site.ee_product_name}} in Hybrid mode, the instructions in 
 
 To complete this installation you will need:
 
-* A valid Bintray account. You will need your **username**, account **password** and account **API Key**.
-  * Example:
-    * **Bintray Access key**: `john-company`
-    * **Bintray username**: `john-company@kong`
-    * **Bintray password**: `12345678`
-    * **Bintray API key**: `12234e314356291a2b11058591bba195830`
-  * The API Key can be obtained by visiting [https://bintray.com/profile/edit](https://bintray.com/profile/edit) and selecting **API Key**
-* A supported Ubuntu system with root equivalent access.
-* A valid Kong Enterprise license JSON file, this can be found in your Bintray account. See [Accessing Your License](/enterprise/latest/deployment/access-license)
-
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
+* A supported Ubuntu system with root-equivalent access.
 
 ## Step 1. Prepare to Install Kong Enterprise and Download the License File
 
-Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will assign credentials to you.
-
 ### Download the Debian package
 
-1. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
-2. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
-3. From the Kong version detail page, select the **Files** tab.
-4. Click the .deb file matching your target Ubuntu OS version. e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
-5. Copy the .deb file to your home directory on the Ubuntu system. You may use a command like:
+1. Log in to [Bintray](http://bintray.com) using your Kong credentials. See [prerequisites](#prerequisites)
+for information on how to get access.
+2. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
+3. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
+4. From the Kong version detail page, select the **Files** tab.
+5. Click the .deb file matching your target Ubuntu OS version. e.g. `kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
+6. Copy the .deb file to your home directory on the Ubuntu system. You may use a command like:
 
     ```bash
     $ scp kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb <ubuntu_user>@<server>:~
@@ -52,7 +44,11 @@ Log in to [Bintray](http://bintray.com). Your Kong Sales or Support contact will
 
 ### Download your Kong Enterprise License
 
-1. Download your license file from your account files in Bintray: `https://bintray.com/kong/<YOUR_REPO_NAME>/license#files`
+1. Download your license file from your [account files in Bintray](#prerequisites):
+
+    ```
+    https://bintray.com/kong/<YOUR_REPO_NAME>/license#files
+    ```
 
 2. Securely copy the license file to your home directory on the Ubuntu system:
 

--- a/app/enterprise/2.1.x/introduction.md
+++ b/app/enterprise/2.1.x/introduction.md
@@ -60,7 +60,14 @@ Kong Studio enables spec-first development for all REST and GraphQL services. Wi
 
 ## Try Kong Enterprise
 
-Here are a couple of ways to try Kong Enterprise:
+Here are a few ways to try Kong Enterprise:
 
-* Get a demonstration at [_Request Demo_](https://konghq.com/request-demo/?itm_source=website&itm_medium=nav/)
-* Get a free trial at [_Kong Free Trial_](https://konghq.com/products/kong-enterprise/free-trial?itm_source=website&itm_medium=nav)
+* Sign up for the Kong Enterprise self-serve, cloud-based, 15 day
+[free trial](https://konghq.com/get-started/#free-trial/).
+* Try out Kong for Kubernetes Enterprise using a live tutorial at
+[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
+* If you are interested in evaluating Kong Enterprise locally, the Kong sales
+team manages evaluation licenses as part of a formal sales process. The best
+way to get started with the sales process is to
+[request a demo](https://konghq.com/get-started/#request-demo) and indicate
+your interest.

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -6,7 +6,11 @@ title: Installing Kong Enterprise on Kubernetes
 
 Kong Enterprise on Kubernetes is recommended for deployments that require features not supported by Kong for Kubernetes Enterprise. It supports all Kong Enterprise plugins and features, but can't run in DB-less mode.
 
-> Note: See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for a feature breakdown and image comparison.
+<div class="alert alert-ee blue">
+<strong>Note:</strong>
+See <a href="/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options">Kong for Kubernetes deployment options</a>
+for a feature breakdown and image comparison.
+</div>
 
 You can use kubectl or OpenShift oc to configure Kong Enterprise on Kubernetes, then deploy it using Helm.
 
@@ -23,12 +27,8 @@ Before starting installation, be sure you have the following:
 
 - **Kubernetes cluster with load balancer**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
-- A valid Kong Enterprise License:
-  * If you have a license, continue to [Set Up Kong Enterprise License](#step-2-set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
-  * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
-  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-- Kong Enterprise Docker registry access on Bintray.
 - Helm installed.
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
 
 ## Step 1. Provision a namespace
 
@@ -49,13 +49,9 @@ $ oc new-project kong
 {% endnavtabs %}
 
 ## Step 2. Set Up Kong Enterprise license
-Running Kong Enterprise on Kubernetes requires a valid license.
+Running Kong Enterprise on Kubernetes requires a valid license. See [prerequisites](#prerequisites) for more information.
 
-As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
-
-> Note:
-* There is no `.json` extension in the `--from-file` parameter.
-* `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
+Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -69,6 +65,12 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong><br>
+<ul>
+  <li>There is no <code>.json</code> extension in the <code>--from-file</code> parameter.</li>
+  <li><code>-n kong</code> specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.</li></ul></div>
 
 ## Step 3. Set up Helm
 
@@ -112,16 +114,17 @@ $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
 ```
 kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
 ```
-⚠️**Important:** Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
 {% endnavtab %}
 {% navtab OpenShift oc %}
 (Optional) Create a password for the super admin:
 ```
 oc create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
 ```
-⚠️**Important:** Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
 {% endnavtab %}
 {% endnavtabs %}
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong>Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.</div>
 
 ## Step 6. Prepare the sessions plugin for Kong Manager and Dev Portal
 In the following steps, replace `<your-password>` with a secure password.
@@ -205,7 +208,9 @@ In the following steps, replace `<your-password>` with a secure password.
 
 ## Step 8. Deploy Kong Enterprise on Kubernetes
 The steps in this section show you how to install Kong Enterprise on Kubernetes using Helm.
->Note: the following instructions assume that you're running Helm 3.
+<div class="alert alert-ee blue">
+<strong>Note:</strong> The following instructions assume that you're running Helm 3.
+</div>
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -216,17 +221,17 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i> 
-    <strong>Important:</strong> 
-    If you are running Postgres as a sub-chart and having problems with connecting to 
-    the database, delete Postgres' persistent volumes in your Kubernetes cluster, then 
-    retry the Helm install. 
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Important:</strong>
+    If you are running Postgres as a sub-chart and having problems with connecting to
+    the database, delete Postgres' persistent volumes in your Kubernetes cluster, then
+    retry the Helm install.
     </div>
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i> 
-    <strong>Important:</strong> 
-    If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>. 
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Important:</strong>
+    If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>.
     </div>
 
 2. Check pod status:
@@ -258,16 +263,17 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i> 
-    <strong>Important:</strong> The command above requires the Kong Admin API. If you 
-    have not set <code>admin.enabled</code> to <code>true</code> in your 
-    <code>values.yaml</code>, then this command will not work. 
+    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+    <strong>Important:</strong> The command above requires the Kong Admin API. If you
+    have not set <code>admin.enabled</code> to <code>true</code> in your
+    <code>values.yaml</code>, then this command will not work.
     </div>
-    
+
 2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
 
-    > **Note:** Do not use IPs with RBAC. If you want to use RBAC, you need to set
-    up a DNS hostname first, instead of directly specifying an IP.
+    <div class="alert alert-ee blue">
+    <strong>Note:</strong> Do not use IPs with RBAC. If you want to use RBAC, you need to set
+    up a DNS hostname first, instead of directly specifying an IP.</div>
 
     ```
     admin_api_uri: <your-DNSorIP>
@@ -304,8 +310,10 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
 
-    > **Note:** Do not use IPs with RBAC. If you want to use RBAC, you need to set
+    <div class="alert alert-ee blue">
+    <strong>Note:</strong> Do not use IPs with RBAC. If you want to use RBAC, you need to set
     up a DNS hostname first, instead of directly specifying an IP.
+    </div>
 
     ```
     admin_api_uri: <your-DNSorIP>

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install.md
@@ -6,7 +6,11 @@ skip_read_time: true
 ## Introduction
 Kong for Kubernetes Enterprise provides most Kong Enterprise plugins and runs without a database, but does not include other Kong Enterprise features (Kong Manager, Dev Portal, Vitals, etc).
 
->Note: See [Kong for Kubernetes deployment options](/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options) for a feature breakdown and image comparison.
+<div class="alert alert-ee blue">
+<strong>Note:</strong>
+See <a href="/enterprise/{{page.kong_version}}/kong-for-kubernetes/deployment-options">Kong for Kubernetes deployment options</a>
+for a feature breakdown and image comparison.
+</div>
 
 You can install Kong for Kubernetes Enterprise using YAML with kubectl, with OpenShift oc, or [with Helm](https://github.com/Kong/charts/tree/main/charts/kong).
 
@@ -23,11 +27,7 @@ Before starting installation, be sure you have the following:
 
 - **Kubernetes cluster**: Kong is compatible with all distributions of Kubernetes. You can use a [Minikube](https://kubernetes.io/docs/setup/minikube/), [GKE](https://cloud.google.com/kubernetes-engine/), or [OpenShift](https://www.openshift.com/products/container-platform) cluster.
 - **kubectl or oc access**: You should have `kubectl` or `oc` (if working with OpenShift) installed and configured to communicate to your Kubernetes cluster.
-- A valid Kong Enterprise License
-  * If you have a license, continue to [Set Up Kong Enterprise License](#step-2-set-up-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
-  * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
-  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-- Kong Enterprise Docker registry access on Bintray.
+{% include /md/{{page.kong_version}}/bintray-and-license.md %}
 
 ## Step 1. Provision a Namespace
 
@@ -48,12 +48,9 @@ $ oc new-project kong
 {% endnavtabs %}
 
 ## Step 2. Set Up Kong Enterprise License
-Running Kong for Kubernetes Enterprise requires a valid license.
+Running Kong for Kubernetes Enterprise requires a valid license. See [prerequisites](#prerequisites) for more information.
 
-As part of the sign-up process for Kong Enterprise, you should have received a license file. If you do not have one, contact your Kong sales representative. Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
-
-> Note: There is no `.json` extension in the `--from-file` parameter.
-> `-n kong` specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.
+Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
 {% navtabs %}
 {% navtab kubectl %}
@@ -67,6 +64,12 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong><br>
+<ul>
+  <li>There is no <code>.json</code> extension in the <code>--from-file</code> parameter.</li>
+  <li><code>-n kong</code> specifies the namespace in which you are deploying Kong for Kubernetes Enterprise. If you are deploying in a different namespace, change this value.</li></ul></div>
 
 ## Step 3. Configure Kong Enterprise Docker registry access
 
@@ -137,8 +140,12 @@ kong-proxy   LoadBalancer   10.63.254.78   35.233.198.16   80:32697/TCP,443:3236
 {% endnavtab %}
 {% endnavtabs %}
 
-> Note: Depending on the Kubernetes distribution you are using, you may or may not see an external IP address assigned to the service. See your provider's guide on obtaining an IP address for a Kubernetes Service of type LoadBalancer.
-
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Depending on the Kubernetes distribution you are using,
+you may or may not see an external IP address assigned to the service. See your
+provider's guide on obtaining an IP address for a Kubernetes Service of type
+LoadBalancer.
+</div>
 
 Set up an environment variable to hold the IP address:
 

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install.md
@@ -142,7 +142,7 @@ kong-proxy   LoadBalancer   10.63.254.78   35.233.198.16   80:32697/TCP,443:3236
 
 <div class="alert alert-ee blue">
 <strong>Note:</strong> Depending on the Kubernetes distribution you are using,
-you may or may not see an external IP address assigned to the service. See your
+you might see an external IP address assigned to the service. Refer to your
 provider's guide on obtaining an IP address for a Kubernetes Service of type
 LoadBalancer.
 </div>


### PR DESCRIPTION
Based on https://konghq.atlassian.net/browse/DOCS-1252.

Trying to settle some of the confusion about where to find your license. The main culprit was the mention of Bintray and licenses with no context in the installation steps (people tend to ignore the prereqs). 

* Turned license prereq into an include file that's now reused for every installation doc.
* Updated "Accessing your License" with a prereq section and a link to trial/demo info.
* Updated trial section of the Introduction to Kong Enterprise topic.
* Some cleanup to installation docs - typos, formatting of the license and Bintray sections, turning URLs into actual links, turning notes into note-formatted content. 

Will backport into 1.5.x (and maybe into 1.3.x) once phrasing is reviewed and finalized.

Preview:
* [Introduction > Try Kong Enterprise](https://deploy-preview-2376--kongdocs.netlify.app/enterprise/2.1.x/introduction/)
* [Access your License](https://deploy-preview-2376--kongdocs.netlify.app/enterprise/2.1.x/deployment/access-license/) - see note and prereqs at top of page.
* Installation > [Ubuntu](https://deploy-preview-2376--kongdocs.netlify.app/enterprise/2.1.x/deployment/installation/ubuntu/) - see prereqs. Same changes in CentOS topic.
* Installation > [Amazon Linux 2](https://deploy-preview-2376--kongdocs.netlify.app/enterprise/2.1.x/deployment/installation/amazon-linux-2/) - see prereqs and links back to prereqs in step 1. Same changes in Amazon Linux 1 and Red Hat
* Installation > [Kubernetes](https://deploy-preview-2376--kongdocs.netlify.app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes/) - See prereqs and step 2. Same changes in other kubernetes topic.
