### PR TITLE
changing the name of the K8s secret

### DIFF
--- a/app/enterprise/2.1.x/kong-for-kubernetes/install.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install.md
@@ -75,7 +75,7 @@ Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterp
 {% navtabs %}
 {% navtab kubectl %}
 ```
-$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
+$ kubectl create secret -n kong docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
@@ -83,7 +83,7 @@ $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```
-$ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
+$ oc create secret -n kong docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>


### PR DESCRIPTION
changing the name of the K8s secret creation command to match what's located here: https://bit.ly/k4k8s-enterprise. Note the following on the k4k8s-enterprise YAML file: 

      imagePullSecrets:
      - name: kong-enterprise-k8s-docker

I looked at the version 1.5.x of the doc and it had it right. So I dug a bit deeper and found this to be the cause: 
https://github.com/Kong/docs.konghq.com/pull/2191

which *used to* reference: https://bit.ly/k4k8s-enterprise-beta. In this "beta", the imagePullSecrets was set to: 

      imagePullSecrets:
      - name: kong-enterprise-edition-docker

so it worked. However, we're using the non-beta version which has the other name.

The question becomes which one do we want to use? Whichever we use, we should make sure that the instructions can be copied and pasted. As of now, it doesn't work due to the mismatch we have in the secret names.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

