### PR TITLE
port LDAP advanced plugin hub improvements to community plugin

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -120,7 +120,7 @@ params:
       default: "`ldap`"
       value_in_examples: ldap
       description: |
-        An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic" then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
+        An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
     - name: consumer_optional
       required: false
       default: "`false`"

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -5,8 +5,8 @@ version: 2.2.0
 
 desc: Integrate Kong with an LDAP server
 description: |
-  Add LDAP Bind Authentication to a Route with username and password protection.
-  The plugin checks for valid credentials in the `Proxy-Authorization` and `Authorization` header
+  Add LDAP Bind Authentication to a Route with username and password protection. The plugin
+  checks for valid credentials in the `Proxy-Authorization` and `Authorization` header
   (in that order).
 
   <div class="alert alert-warning">
@@ -63,8 +63,7 @@ params:
       required: false
       default: "`false`"
       value_in_examples: true
-      description: An optional boolean value telling the plugin to hide the credential
-      to the upstream server. It will be removed by Kong before proxying the request.
+      description: An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.
     - name: ldap_host
       required: true
       default:

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -3,9 +3,11 @@ name: LDAP Authentication
 publisher: Kong Inc.
 version: 2.2.0
 
-desc: Integrate Kong with a LDAP server
+desc: Integrate Kong with an LDAP server
 description: |
-  Add LDAP Bind Authentication to a Route with username and password protection. The plugin will check for valid credentials in the `Proxy-Authorization` and `Authorization` header (in this order).
+  Add LDAP Bind Authentication to a Route with username and password protection.
+  The plugin checks for valid credentials in the `Proxy-Authorization` and `Authorization` header
+  (in that order).
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled
@@ -61,7 +63,8 @@ params:
       required: false
       default: "`false`"
       value_in_examples: true
-      description: An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.
+      description: An optional boolean value telling the plugin to hide the credential
+      to the upstream server. It will be removed by Kong before proxying the request.
     - name: ldap_host
       required: true
       default:
@@ -69,7 +72,7 @@ params:
       description: Host on which the LDAP server is running.
     - name: ldap_port
       required: true
-      default:
+      default: 389
       value_in_examples: 389
       description: TCP port where the LDAP server is listening.
     - name: start_tls
@@ -81,12 +84,12 @@ params:
       required: true
       default: "`false`"
       description: |
-        Set it to `true` to connect using the LDAPS protocol (LDAP over TLS)
+        Set it to `true` to connect using the LDAPS protocol (LDAP over TLS).
     - name: base_dn
       required: true
       default:
       value_in_examples: dc=example,dc=com
-      description: Base DN as the starting point for the search.
+      description: Base DN as the starting point for the search; e.g., "dc=example,dc=com".
     - name: verify_ldap_host
       required: true
       default: "`false`"
@@ -96,7 +99,7 @@ params:
       required: true
       default:
       value_in_examples: cn
-      description: Attribute to be used to search the user.
+      description: Attribute to be used to search the user; e.g., "cn".
     - name: cache_ttl
       required: true
       default: "`60`"
@@ -108,36 +111,50 @@ params:
     - name: keepalive
       required: false
       default: "`60000`"
-      description: An optional value in milliseconds that defines for how long an idle connection to LDAP server will live before being closed.
+      description: An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.
     - name: anonymous
       required: false
       default:
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
     - name: header_type
       required: false
       default: "`ldap`"
       value_in_examples: ldap
       description: |
-        An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic" then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
+        An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
   extra:
     <div class="alert alert-warning">
-        <strong>Note:</strong> The <code>config.header_type</code> option was introduced in Kong 0.12.0. Previous versions of this plugin behave as if <code>ldap</code> was set for this value.
+        <strong>Note:</strong> The <code>config.header_type</code> option was
+        introduced in Kong 0.12.0. Previous versions of this plugin behave as if
+        <code>ldap</code> was set for this value.
     </div>
 
 ---
 
 ## Usage
 
-In order to authenticate the user, client must set credentials in `Proxy-Authorization` or `Authorization` header in following format
+To authenticate a user, the client must set credentials in either the
+`Proxy-Authorization` or `Authorization` header in the following format:
 
     credentials := [ldap | LDAP] base64(username:password)
 
-The plugin will validate the user against the LDAP server and cache the credential for future requests for the duration specified in `config.cache_ttl`.
+The Authorization header would look something like:
+
+    Authorization:  ldap dGxibGVzc2luZzpLMG5nU3RyMG5n
+
+The plugin validates the user against the LDAP server and caches the
+credentials for future requests for the duration specified in
+`config.cache_ttl`.
+
+You can set the header type `ldap` to any string (such as `basic`) using
+`config.header_type`.
 
 ### Upstream Headers
 
-When a client has been authenticated, the plugin will append some headers to the request before proxying it to the upstream service, so that you can identify the consumer in your code:
+When a client has been authenticated, the plugin appends some headers to the
+request before proxying it to the upstream service so that you can identify
+the consumer in your code:
 
 * `X-Anonymous-Consumer`, will be set to `true` when authentication failed, and the 'anonymous' consumer was set instead.
 * `X-Consumer-ID`, the ID of the 'anonymous' consumer on Kong (only if authentication failed and 'anonymous' was set)

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -6,7 +6,7 @@ version: 2.2.0
 desc: Integrate Kong with an LDAP server
 description: |
   Add LDAP Bind Authentication to a Route with username and password protection. The plugin
-  checks for valid credentials in the `Proxy-Authorization` and `Authorization` header
+  checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
   <div class="alert alert-warning">

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -73,17 +73,23 @@ params:
       required: true
       default: 389
       value_in_examples: 389
-      description: TCP port where the LDAP server is listening.
+      description: TCP port where the LDAP server is listening.  389 is the default
+        port for non-SSL LDAP and AD. 686 is the port required for SSL LDAP and AD. If `ldaps` is
+        configured, you must use port 686.
     - name: start_tls
       required: true
       default: "`false`"
       description: |
-        Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection.
+        Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap`
+        connection. If the `start_tls` setting is enabled, ensure the `ldaps`
+        setting is disabled.
     - name: ldaps
       required: true
       default: "`false`"
       description: |
-        Set it to `true` to connect using the LDAPS protocol (LDAP over TLS).
+        Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is
+        configured, you must use port 686. If the `ldap` setting is enabled, ensure the
+        `start_tls` setting is disabled.
     - name: base_dn
       required: true
       default:
@@ -93,7 +99,7 @@ params:
       required: true
       default: "`false`"
       description: |
-        Set it to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.
+        Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.
     - name: attribute
       required: true
       default:
@@ -115,7 +121,7 @@ params:
       required: false
       default:
       description: |
-        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
     - name: header_type
       required: false
       default: "`ldap`"


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1353

Per https://konghq.atlassian.net/browse/DOCS-1269 as part of Shane's epic ticket https://konghq.atlassian.net/browse/DOCS-1162

This content was already approved by Darren and Lena in the advanced ldap plugin.

Parity as much as possible between community and enterprise docs.

Direct review link:

https://deploy-preview-2380--kongdocs.netlify.app/hub/kong-inc/ldap-auth/