### PR TITLE
docs(styles) Code syntax highlighting

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -142,7 +142,7 @@ code {
   padding: 4px;
   color: @gray-darker;
   font-size: 14px;
-  background-color: #f0f0f0;
+  background-color: #f5f5f5;
   border-radius: 3px;
   border: 0 none;
   margin: 0;

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -140,9 +140,9 @@ strong {
 
 code {
   padding: 4px;
-  color: @red;
+  color: @gray-darker;
   font-size: 14px;
-  background-color: #fff2f2;
+  background-color: #f0f0f0;
   border-radius: 3px;
   border: 0 none;
   margin: 0;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1176,6 +1176,12 @@ Generic Styling for Desktop
   border-radius: 0;
   font-size: 18px;
   padding: 8px 13px;
+
+  pre, code {
+    background-color: #fff;
+    border: none;
+}
+
 }
 
 .alert-info {

--- a/app/_assets/stylesheets/syntax.less
+++ b/app/_assets/stylesheets/syntax.less
@@ -1,64 +1,64 @@
-//.highlight { background-color: #ffffcc }
-.c { color: #999988; font-style: italic } /* Comment */
-.err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.k { color: #000000; font-weight: bold } /* Keyword */
-.o { color: #000000; font-weight: bold } /* Operator */
-.cm { color: #999988; font-style: italic } /* Comment.Multiline */
-.cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
-.c1 { color: #999988; font-style: italic } /* Comment.Single */
-.cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-.gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.ge { color: #000000; font-style: italic } /* Generic.Emph */
-.gr { color: #aa0000 } /* Generic.Error */
-.gh { color: #999999 } /* Generic.Heading */
-.gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+//.highlight { background-color: @blue-600fcc }
+.c { color: #949494; font-style: italic } /* Comment */
+.err { color: @red-700; background-color: @red-100 } /* Error */
+.k { color: @blue-400; font-weight: bold } /* Keyword */
+.o { color: @blue-600; font-weight: bold } /* Operator */
+.cm { color: #949494; font-style: italic } /* Comment.Multiline */
+.cp { color: @grey-400; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.c1 { color: #949494; font-style: italic } /* Comment.Single */
+.cs { color: @grey-400; font-weight: bold; font-style: italic } /* Comment.Special */
+.gd { color: @red-700; background-color: @red-200 } /* Generic.Deleted */
+.ge { color: @red-600; font-style: italic } /* Generic.Emph */
+.gr { color: @red-700 } /* Generic.Error */
+.gh { color: @grey-400 } /* Generic.Heading */
+.gi { color: @red-500; background-color: @red-100 } /* Generic.Inserted */
 .go { color: #888888 } /* Generic.Output */
-.gp { color: #555555 } /* Generic.Prompt */
+.gp { color: @steal-700 } /* Generic.Prompt */
 .gs { font-weight: bold } /* Generic.Strong */
 .gu { color: #aaaaaa } /* Generic.Subheading */
-.gt { color: #aa0000 } /* Generic.Traceback */
-.kc { color: #000000; font-weight: bold } /* Keyword.Constant */
-.kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
-.kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
-.kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
-.kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
-.kt { color: #445588; font-weight: bold } /* Keyword.Type */
-.m { color: #009999 } /* Literal.Number */
-.s { color: #d01040 } /* Literal.String */
-.na { color: #008080 } /* Name.Attribute */
-.nb { color: #0086B3 } /* Name.Builtin */
-.nc { color: #445588; font-weight: bold } /* Name.Class */
-.no { color: #008080 } /* Name.Constant */
-.nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
-.ni { color: #800080 } /* Name.Entity */
-.ne { color: #990000; font-weight: bold } /* Name.Exception */
-.nf { color: #990000; font-weight: bold } /* Name.Function */
-.nl { color: #990000; font-weight: bold } /* Name.Label */
-.nn { color: #555555 } /* Name.Namespace */
-.nt { color: #000080 } /* Name.Tag */
-.nv { color: #008080 } /* Name.Variable */
-.ow { color: #000000; font-weight: bold } /* Operator.Word */
+.gt { color: @red-700 } /* Generic.Traceback */
+.kc { color: @blue-700; font-weight: bold } /* Keyword.Constant */
+.kd { color: @blue-700; font-weight: bold } /* Keyword.Declaration */
+.kn { color: @blue-700; font-weight: bold } /* Keyword.Namespace */
+.kp { color: @blue-700; font-weight: bold } /* Keyword.Pseudo */
+.kr { color: @blue-700; font-weight: bold } /* Keyword.Reserved */
+.kt { color: @steal-600; font-weight: bold } /* Keyword.Type */
+.m { color: @blue-400 } /* Literal.Number */
+.s { color: @blue-600 } /* Literal.String */
+.na { color: @green-500 } /* Name.Attribute */
+.nb { color: #8a7ca3 } /* Name.Builtin */
+.nc { color: @steal-600; font-weight: bold } /* Name.Class */
+.no { color: @steal-400 } /* Name.Constant */
+.nd { color: @steal-500; font-weight: bold } /* Name.Decorator */
+.ni { color: #9266cc } /* Name.Entity */
+.ne { color: #391d6b; font-weight: bold } /* Name.Exception */
+.nf { color: #391d6b; font-weight: bold } /* Name.Function */
+.nl { color: #391d6b; font-weight: bold } /* Name.Label */
+.nn { color: @steal-700 } /* Name.Namespace */
+.nt { color: #9266cc } /* Name.Tag */
+.nv { color: @green-500 } /* Name.Variable */
+.ow { color: @blue-700; font-weight: bold } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #009999 } /* Literal.Number.Float */
-.mh { color: #009999 } /* Literal.Number.Hex */
-.mi { color: #009999 } /* Literal.Number.Integer */
-.mo { color: #009999 } /* Literal.Number.Oct */
-.sb { color: #d01040 } /* Literal.String.Backtick */
-.sc { color: #d01040 } /* Literal.String.Char */
-.sd { color: #d01040 } /* Literal.String.Doc */
-.s2 { color: @red } /* Literal.String.Double */
-.se { color: #d01040 } /* Literal.String.Escape */
-.sh { color: #d01040 } /* Literal.String.Heredoc */
-.si { color: #d01040 } /* Literal.String.Interpol */
-.sx { color: #d01040 } /* Literal.String.Other */
-.sr { color: #009926 } /* Literal.String.Regex */
-.s1 { color: #d01040 } /* Literal.String.Single */
-.ss { color: #990073 } /* Literal.String.Symbol */
-.bp { color: #999999 } /* Name.Builtin.Pseudo */
-.vc { color: #008080 } /* Name.Variable.Class */
-.vg { color: #008080 } /* Name.Variable.Global */
-.vi { color: #008080 } /* Name.Variable.Instance */
-.il { color: #009999 } /* Literal.Number.Integer.Long */
+.mf { color: #651fbf } /* Literal.Number.Float */
+.mh { color: #651fbf } /* Literal.Number.Hex */
+.mi { color: #651fbf } /* Literal.Number.Integer */
+.mo { color: #651fbf } /* Literal.Number.Oct */
+.sb { color: @blue-600 } /* Literal.String.Backtick */
+.sc { color: @blue-600 } /* Literal.String.Char */
+.sd { color: @blue-600 } /* Literal.String.Doc */
+.s2 { color: @blue-400 } /* Literal.String.Double */
+.se { color: @blue-600 } /* Literal.String.Escape */
+.sh { color: @blue-600 } /* Literal.String.Heredoc */
+.si { color: @blue-600 } /* Literal.String.Interpol */
+.sx { color: @blue-600 } /* Literal.String.Other */
+.sr { color: @blue-400 } /* Literal.String.Regex */
+.s1 { color: @blue-600 } /* Literal.String.Single */
+.ss { color: #9266cc } /* Literal.String.Symbol */
+.bp { color: @grey-400 } /* Name.Builtin.Pseudo */
+.vc { color: @green-500 } /* Name.Variable.Class */
+.vg { color: @green-500 } /* Name.Variable.Global */
+.vi { color: @green-500 } /* Name.Variable.Instance */
+.il { color: #651fbf } /* Literal.Number.Integer.Long */
 
 /* Disable selecting $ prompt, e.g. shell curl call docs */
 .gp {

--- a/app/_assets/stylesheets/syntax.less
+++ b/app/_assets/stylesheets/syntax.less
@@ -1,64 +1,64 @@
-//.highlight { background-color: @blue-600fcc }
-.c { color: #949494; font-style: italic } /* Comment */
-.err { color: @red-700; background-color: @red-100 } /* Error */
-.k { color: @blue-400; font-weight: bold } /* Keyword */
-.o { color: @blue-600; font-weight: bold } /* Operator */
-.cm { color: #949494; font-style: italic } /* Comment.Multiline */
-.cp { color: @grey-400; font-weight: bold; font-style: italic } /* Comment.Preproc */
-.c1 { color: #949494; font-style: italic } /* Comment.Single */
-.cs { color: @grey-400; font-weight: bold; font-style: italic } /* Comment.Special */
-.gd { color: @red-700; background-color: @red-200 } /* Generic.Deleted */
-.ge { color: @red-600; font-style: italic } /* Generic.Emph */
-.gr { color: @red-700 } /* Generic.Error */
-.gh { color: @grey-400 } /* Generic.Heading */
-.gi { color: @red-500; background-color: @red-100 } /* Generic.Inserted */
+//.highlight { background-color: #ffffcc }
+.c { color: #999988; font-style: italic } /* Comment */
+.err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.k { color: #000000; font-weight: bold } /* Keyword */
+.o { color: #000000; font-weight: bold } /* Operator */
+.cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.c1 { color: #999988; font-style: italic } /* Comment.Single */
+.cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
+.gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.ge { color: #000000; font-style: italic } /* Generic.Emph */
+.gr { color: #aa0000 } /* Generic.Error */
+.gh { color: #999999 } /* Generic.Heading */
+.gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
 .go { color: #888888 } /* Generic.Output */
-.gp { color: @steal-700 } /* Generic.Prompt */
+.gp { color: #555555 } /* Generic.Prompt */
 .gs { font-weight: bold } /* Generic.Strong */
 .gu { color: #aaaaaa } /* Generic.Subheading */
-.gt { color: @red-700 } /* Generic.Traceback */
-.kc { color: @blue-700; font-weight: bold } /* Keyword.Constant */
-.kd { color: @blue-700; font-weight: bold } /* Keyword.Declaration */
-.kn { color: @blue-700; font-weight: bold } /* Keyword.Namespace */
-.kp { color: @blue-700; font-weight: bold } /* Keyword.Pseudo */
-.kr { color: @blue-700; font-weight: bold } /* Keyword.Reserved */
-.kt { color: @steal-600; font-weight: bold } /* Keyword.Type */
-.m { color: @blue-400 } /* Literal.Number */
-.s { color: @blue-600 } /* Literal.String */
-.na { color: @green-500 } /* Name.Attribute */
-.nb { color: #8a7ca3 } /* Name.Builtin */
-.nc { color: @steal-600; font-weight: bold } /* Name.Class */
-.no { color: @steal-400 } /* Name.Constant */
-.nd { color: @steal-500; font-weight: bold } /* Name.Decorator */
-.ni { color: #9266cc } /* Name.Entity */
-.ne { color: #391d6b; font-weight: bold } /* Name.Exception */
-.nf { color: #391d6b; font-weight: bold } /* Name.Function */
-.nl { color: #391d6b; font-weight: bold } /* Name.Label */
-.nn { color: @steal-700 } /* Name.Namespace */
-.nt { color: #9266cc } /* Name.Tag */
-.nv { color: @green-500 } /* Name.Variable */
-.ow { color: @blue-700; font-weight: bold } /* Operator.Word */
+.gt { color: #aa0000 } /* Generic.Traceback */
+.kc { color: #000000; font-weight: bold } /* Keyword.Constant */
+.kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
+.kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
+.kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
+.kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
+.kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.m { color: #009999 } /* Literal.Number */
+.s { color: #d01040 } /* Literal.String */
+.na { color: #008080 } /* Name.Attribute */
+.nb { color: #0086B3 } /* Name.Builtin */
+.nc { color: #445588; font-weight: bold } /* Name.Class */
+.no { color: #008080 } /* Name.Constant */
+.nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
+.ni { color: #800080 } /* Name.Entity */
+.ne { color: #990000; font-weight: bold } /* Name.Exception */
+.nf { color: #990000; font-weight: bold } /* Name.Function */
+.nl { color: #990000; font-weight: bold } /* Name.Label */
+.nn { color: #555555 } /* Name.Namespace */
+.nt { color: #000080 } /* Name.Tag */
+.nv { color: #008080 } /* Name.Variable */
+.ow { color: #000000; font-weight: bold } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #651fbf } /* Literal.Number.Float */
-.mh { color: #651fbf } /* Literal.Number.Hex */
-.mi { color: #651fbf } /* Literal.Number.Integer */
-.mo { color: #651fbf } /* Literal.Number.Oct */
-.sb { color: @blue-600 } /* Literal.String.Backtick */
-.sc { color: @blue-600 } /* Literal.String.Char */
-.sd { color: @blue-600 } /* Literal.String.Doc */
-.s2 { color: @blue-400 } /* Literal.String.Double */
-.se { color: @blue-600 } /* Literal.String.Escape */
-.sh { color: @blue-600 } /* Literal.String.Heredoc */
-.si { color: @blue-600 } /* Literal.String.Interpol */
-.sx { color: @blue-600 } /* Literal.String.Other */
-.sr { color: @blue-400 } /* Literal.String.Regex */
-.s1 { color: @blue-600 } /* Literal.String.Single */
-.ss { color: #9266cc } /* Literal.String.Symbol */
-.bp { color: @grey-400 } /* Name.Builtin.Pseudo */
-.vc { color: @green-500 } /* Name.Variable.Class */
-.vg { color: @green-500 } /* Name.Variable.Global */
-.vi { color: @green-500 } /* Name.Variable.Instance */
-.il { color: #651fbf } /* Literal.Number.Integer.Long */
+.mf { color: #009999 } /* Literal.Number.Float */
+.mh { color: #009999 } /* Literal.Number.Hex */
+.mi { color: #009999 } /* Literal.Number.Integer */
+.mo { color: #009999 } /* Literal.Number.Oct */
+.sb { color: #d01040 } /* Literal.String.Backtick */
+.sc { color: #d01040 } /* Literal.String.Char */
+.sd { color: #d01040 } /* Literal.String.Doc */
+.s2 { color: @red } /* Literal.String.Double */
+.se { color: #d01040 } /* Literal.String.Escape */
+.sh { color: #d01040 } /* Literal.String.Heredoc */
+.si { color: #d01040 } /* Literal.String.Interpol */
+.sx { color: #d01040 } /* Literal.String.Other */
+.sr { color: #009926 } /* Literal.String.Regex */
+.s1 { color: #d01040 } /* Literal.String.Single */
+.ss { color: #990073 } /* Literal.String.Symbol */
+.bp { color: #999999 } /* Name.Builtin.Pseudo */
+.vc { color: #008080 } /* Name.Variable.Class */
+.vg { color: #008080 } /* Name.Variable.Global */
+.vi { color: #008080 } /* Name.Variable.Instance */
+.il { color: #009999 } /* Literal.Number.Integer.Long */
 
 /* Disable selecting $ prompt, e.g. shell curl call docs */
 .gp {

--- a/app/_assets/stylesheets/variables.less
+++ b/app/_assets/stylesheets/variables.less
@@ -113,3 +113,48 @@
 @grid-width-md: 768px;
 @grid-width-lg: 992px;
 @grid-width-xl: 1095px;
+
+
+// Kongponents colors
+// -------------------------
+
+@blue-100: #f0f5ff;
+@blue-200: #d9e7ff;
+@blue-300: #a6c6ff;
+@blue-400: #5996ff;
+@blue-500: #1456cb;
+@blue-600: #083c99;
+@blue-700: #0a2b66;
+
+@steal-100: #f0f4fa;
+@steal-200: #dae3f2;
+@steal-300: #a3b6d9;
+@steal-400: #7d91b3;
+@steal-500: #5c7299;
+@steal-600: #395380;
+@steal-700: #273c61;
+
+@red-100: #fff7f9;
+@red-200: #ffe6ea;
+@red-300: #ffb3bf;
+@red-400: #f26d83;
+@red-500: #e6173a;
+@red-600: #bf1330;
+@red-700: #99001a;
+
+@green-100: #f1fff7;
+@green-200: #ccffe1;
+@green-300: #82d9a6;
+@green-400: #19a654;
+@green-500: #008036;
+
+@yellow-100: #fff9e6;
+@yellow-200: #ffedb9;
+@yellow-300: #ffdc73;
+@yellow-400: #f2a230;
+@yellow-500: #8c5200;
+
+@grey-100: #fafafa;
+@grey-200: #ebebeb;
+@grey-300: #e0e0e0;
+@grey-400: #d6d6d6;

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -6,10 +6,6 @@ timezone: America/San_Francisco
 markdown: kramdown
 incremental: true
 
-kramdown:
-  syntax_highlighter_opts:
-    disable : true
-
 keep_files:
   - assets
 


### PR DESCRIPTION
Two main goals here: update our variables with colours from [Kongponents](https://kongponents.netlify.app/style-guide/colors.html), and make the syntax highlighting less red.

* Change inline text highlighting from red to grey
* Add Kong colour variables
* Using the Kong colour variables as much as possible, redo syntax highlighting theme for codeblocks
* Change codeblock background to white for contrast in alert blocks
* Enable syntax highlighter for jekyll-dev

Previews - anywhere with codeblocks or inline code, e.g.:
https://deploy-preview-2381--kongdocs.netlify.app/hub/kong-inc/application-registration/
https://deploy-preview-2381--kongdocs.netlify.app/enterprise/2.1.x/admin-api/
https://deploy-preview-2381--kongdocs.netlify.app/getting-started-guide/2.1.x/prepare/ - see codeblocks inside blue panel