### PR TITLE
Update sessions.md in docs for kong-ee 2.1.x

### DIFF
--- a/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host): `"cookie_samesite": "off"`
+* If using different sub domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains) below. 
 
 ## Example Configurations
 

--- a/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different sub domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains) below. 
+* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains). 
 
 ## Example Configurations
 


### PR DESCRIPTION
docs(ee/dev-portal) clarify sessions instructions

* The docs mention tell you to use cookie_samesite when using different domains. 
* Rather you should be using cookie_domain using the instruction in the domain section further below. And only subdomains are supported, do not believe completely different domain would work. 
* Slack conversation outlining this configuration: https://kongstrong.slack.com/archives/CAW1MAFLZ/p1585170652026600
