### PR TITLE
IP Restriction plugin fixes for whitelist/blacklist allow/deny versions

### DIFF
--- a/app/_data/extensions/kong-inc/ip-restriction/versions.yml
+++ b/app/_data/extensions/kong-inc/ip-restriction/versions.yml
@@ -1,2 +1,3 @@
+- release: 2.0.x
 - release: 1.0-x
 - release: 0.1-x

--- a/app/_hub/kong-inc/ip-restriction/1.0-x.md
+++ b/app/_hub/kong-inc/ip-restriction/1.0-x.md
@@ -1,11 +1,11 @@
 ---
 name: IP Restriction
 publisher: Kong Inc.
-version: 0.1-x
+version: 1.0-x
 
 desc: Whitelist or blacklist IPs that can make API requests
 description: |
-  Restrict access to a Service or a Route (or the deprecated API entity) by either whitelisting or blacklisting IP addresses. Single IPs, multiple IPs or ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) like `10.10.10.0/24` can be used.
+  Restrict access to a Service or a Route (or the deprecated API entity) by either whitelisting or blacklisting IP addresses. Single IPs, multiple IPs or ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) like `10.10.10.0/24` can be used. The plugin supports IPv4 and IPv6 addresses.
 
 type: plugin
 categories:
@@ -14,6 +14,12 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 1.5.x
+        - 1.4.x
+        - 1.3.x
+        - 1.2.x
+        - 1.1.x
+        - 1.0.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -27,6 +33,10 @@ kong_version_compatibility:
         - 0.4.x
     enterprise_edition:
       compatible:
+        - 1.5.x
+        - 1.3-x
+        - 0.36-x
+        - 0.35-x
         - 0.34-x
         - 0.33-x
         - 0.32-x
@@ -34,15 +44,16 @@ kong_version_compatibility:
 
 params:
   name: ip-restriction
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true
+  protocols: ["http", "https"]
+  dbless_compatible: yes
   config:
     - name: whitelist
       required: semi
       default:
-      value_in_examples: 54.13.21.1, 143.1.0.0/24
+      value_in_examples: [ "54.13.21.1", "143.1.0.0/24" ]
       description: |
         Comma-separated list of IPs or CIDR ranges to whitelist. One of `config.whitelist` or `config.blacklist` must be specified.
     - name: blacklist

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -1,7 +1,7 @@
 ---
 name: IP Restriction
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0-x
 
 desc: Allow or deny IPs that can make requests to your Services
 description: |

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -1,7 +1,7 @@
 ---
 name: IP Restriction
 publisher: Kong Inc.
-version: 2.0-x
+version: 2.0.x
 
 desc: Allow or deny IPs that can make requests to your Services
 description: |


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1356

Direct review links:

- New index file for 2.0.x allow/deny https://deploy-preview-2385--kongdocs.netlify.app/hub/kong-inc/ip-restriction/
- Reconstructed version for 1.0.x that uses whitelist/blacklist instead of allow/deny https://deploy-preview-2385--kongdocs.netlify.app/hub/kong-inc/ip-restriction/1.0-x.html
- first version of the plugin  https://deploy-preview-2385--kongdocs.netlify.app/hub/kong-inc/ip-restriction/0.1-x.html