### PR TITLE
docs(style) List adjustments part 2

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -91,6 +91,12 @@
     ol {
       padding-left: 2rem;
       counter-reset: base;
+
+      li {
+        p {
+          font-size: inherit;
+        }
+      }
     }
 
     ol > li::before {
@@ -104,10 +110,16 @@
       // font sizes
       font-size: inherit;
       margin-left: 0.5rem;
+      list-style: none;
 
       li {
         // avoid ridiculously big spaces between lists elements
         margin-bottom: 0.2rem;
+        list-style-type: disc;
+
+        p {
+          font-size: inherit;
+        }
       }
 
       ul {

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -53,6 +53,23 @@
     h2, h4, p .highlight {
       margin: 0 0 2.5rem 0;
     }
+
+    ol, ul {
+      li {
+        p {
+          font-size: inherit;
+        }
+      }
+    }
+
+    ul {
+      margin-left: 0.5rem;
+
+      li {
+        list-style-type: disc;
+      }
+    }
+
     table {
       p {
         font-size: 14px;


### PR DESCRIPTION
* Change list style to bullets instead of circles
* Set paragraph font size to inherit from the list element above it to avoid awkward font size changes between lines

Previously, I had changed the list font size to match the rest of the content; this was overwritten in another PR. This solution ends up being a better one, as it doesn't set an explicit size, and instead nested paragraph elements pick up the font sizes they're supposed to have.

**Preview:** any page with a list. 
Here's a sample doc with both ordered and unordered lists:
https://deploy-preview-2387--kongdocs.netlify.app/getting-started-guide/2.1.x/manage-teams/

Plugin doc samples:
https://deploy-preview-2387--kongdocs.netlify.app/hub/yesinteractive/kong-jwt2header/
