### PR TITLE
docs(styles) Fix scroll-to-top button overlap with feedback widget

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1599,8 +1599,8 @@ Generic Styling for Desktop
 
 #scroll-to-top-button {
   position: fixed;
-  bottom: 12px;
-  right: 16px;
+  bottom: 45px;
+  right: 100px;
   z-index: 10;
   cursor: pointer;
   background: #e3e3e3;
@@ -1624,7 +1624,7 @@ Generic Styling for Desktop
     transform: translateY(0);
   }
 
-  @media (max-width: 600px) {
+  @media (max-width: 800px) {
     right: 50%;
   }
 }


### PR DESCRIPTION
At some point, this started happening:

![Screen Shot 2020-10-16 at 2 58 59 PM](https://user-images.githubusercontent.com/54370747/96312301-2a22e700-0fc0-11eb-997a-8e6610ac718c.png)

* Fixing it so that they're at least side-by-side.
* Adjusting media screen size to match the size set for the feedback widget, so they shift at the same screen size.