### PR TITLE
fix(k8s) Improvements to enterprise K8s installation page

### DIFF
--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -153,13 +153,14 @@ In the following steps, replace `<your-password>` with a secure password.
 {% endnavtabs %}
 ## Step 7. Prepare Kong's configuration file
 
-1. Create a `values.yaml` file based on the sample in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file sets all the necessary parameters for your Kong environment.
+1. Create a `values.yaml` file for Helm based on the template in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file contains all the necessary parameters for your Kong deployment. As an example, [this values file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml) enables most Kong Enterprise features.
 
 2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
 
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
+    |`enterprise.portal.enabled` | (Optional) Set to `true` to enable the Kong Developer Portal. Find out more about it [here](https://docs.konghq.com/enterprise/latest/developer-portal/). |
     |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password; see [above](#step-5-seed-the-super-admin-password). |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |
@@ -172,8 +173,8 @@ In the following steps, replace `<your-password>` with a secure password.
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
     |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
-    |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
+    |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`postgresql.enabled` | Set to `true` to deploy a Postgres database along with Kong. |
     |`postgresql.postgresqlUsername` | Set Postgres user (e.g. `kong`). |
     |`postgresql.postgresqlPassword` | Set Postgres user's password. |

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -147,7 +147,7 @@ In the following steps, replace `<your-password>` with a secure password.
     ```
 3. Create secret:
     ```
-    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf=<manager-config-filename> --from-file=portal_session_conf=<portal-config-filename>
+    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
     ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -46,12 +46,12 @@ Save the license file temporarily to disk with filename `license` (no file exten
 {% navtabs %}
 {% navtab kubectl %}
 ```
-$ kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+$ kubectl create secret generic kong-enterprise-license -n kong --from-file=./license
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```
-$ oc create secret generic kong-enterprise-license --from-file=./license -n kong
+$ oc create secret generic kong-enterprise-license -n kong --from-file=./license
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -80,7 +80,7 @@ Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterp
 {% navtab kubectl %}
 Set up the credentials:
 ```
-$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
+$ kubectl create secret docker-registry kong-enterprise-edition-docker -n kong \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
@@ -89,7 +89,7 @@ $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
 {% navtab OpenShift oc %}
 Set up the credentials:
 ```
-$ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
+$ oc create secret docker-registry kong-enterprise-edition-docker -n kong \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \      
     --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
@@ -102,7 +102,7 @@ $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
 {% navtab kubectl %}
 (Optional) Create a password for the super admin:
 ```
-kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
+kubectl create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
 ```
 ⚠️**Important:** Though not required, this is recommended if you want to use RBAC, as it cannot be done after initial setup.
 {% endnavtab %}
@@ -160,13 +160,24 @@ In the following steps, replace `<your-password>` with a secure password.
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
+    |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password, see above. |
     |`env.database` | `"postgres"` or `"cassandra"` |
+    |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |
+    |`env.pg_port` | (If using Postgres) Set to port of the Postgres server (only if `postgresql.enabled` is `false`). |
+    |`env.pg_user` | (If using Postgres) Set to Postgres user (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlUsername`. |
+    |`env.pg_password` | (If using Postgres) Set to Postgres user's password. When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlPassword`. |
+    |`env.pg_database` | (If using Postgres) Set to Postgres database name (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlDatabase`. |
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
-    |`image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.2-alpine"`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.6-alpine"`. |
+    |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
+    |`postgresql.enabled` | Set to `true` to deploy a Postgres database along with Kong. |
+    |`postgresql.postgresqlUsername` | Set Postgres user (e.g. `kong`). |
+    |`postgresql.postgresqlPassword` | Set Postgres user's password. |
+    |`postgresql.postgresqlDatabase` | Set Postgres database name (e.g. `kong`). |
 
 3. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
 
@@ -203,7 +214,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab kubectl %}
 1. Run:
     ```
-    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm install my-kong kong/kong -n kong --values ./values.yaml
     ```
     This may take some time.
 
@@ -231,7 +242,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab OpenShift oc %}
 1. Run:
     ```
-    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm install my-kong kong/kong -n kong --values ./values.yaml
     ```
     This may take some time.
 
@@ -248,7 +259,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab kubectl %}
 1. Run:
     ```
-    $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    $ kubectl get svc my-kong-kong-admin -n kong --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
 
     <div class="alert alert-warning">
@@ -275,7 +286,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 4. Update Kong to use the changed `values.yaml`:
     ```
-    $ helm upgrade my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm upgrade my-kong kong/kong -n kong --values ./values.yaml
     ```
 
 6. After the upgrade is complete, run:
@@ -294,7 +305,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab OpenShift oc %}
 1. Run:
     ```
-    $ oc get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    $ oc get svc my-kong-kong-admin -n kong --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
 
 2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
@@ -313,7 +324,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 4. Update Kong to use the changed `values.yaml`:
     ```
-    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm upgrade my-kong kong/kong -n kong --values ./values.yaml
     ```
 
 6. After the upgrade is complete, run:

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -160,17 +160,17 @@ In the following steps, replace `<your-password>` with a secure password.
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
-    |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password, see above. |
+    |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password; see [above](#step-5-seed-the-super-admin-password). |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |
     |`env.pg_port` | (If using Postgres) Set to port of the Postgres server (only if `postgresql.enabled` is `false`). |
-    |`env.pg_user` | (If using Postgres) Set to Postgres user (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlUsername`. |
-    |`env.pg_password` | (If using Postgres) Set to Postgres user's password. When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlPassword`. |
-    |`env.pg_database` | (If using Postgres) Set to Postgres database name (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlDatabase`. |
+    |`env.pg_user` | (If using Postgres) Set to the Postgres user (default `kong`). When `postgresql.enabled` is `true`, this has to match `postgresql.postgresqlUsername`. |
+    |`env.pg_password` | (If using Postgres) Set to the Postgres user's password. When `postgresql.enabled` is `true`, this has to match `postgresql.postgresqlPassword`. |
+    |`env.pg_database` | (If using Postgres) Set to the Postgres database name (default `kong`). When `postgresql.enabled` is `true`, this has to match `postgresql.postgresqlDatabase`. |
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
-    |`image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.6-alpine"`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -131,7 +131,7 @@ In the following steps, replace `<your-password>` with a secure password.
     ```
 3. Create secret:
     ```
-    kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf=<manager-config-filename> --from-file=portal_session_conf=<portal-config-filename>
+    kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
     ```
 
 {% endnavtab %}

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -153,14 +153,18 @@ In the following steps, replace `<your-password>` with a secure password.
 {% endnavtabs %}
 ## Step 7. Prepare Kong's configuration file
 
-1. Create a `values.yaml` file for Helm based on the template in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file contains all the necessary parameters for your Kong deployment. As an example, [this values file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml) enables most Kong Enterprise features.
+1. Create a `values.yaml` file for Helm based on the template in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file contains all the possible parameters for your Kong deployment. 
+
+    You can also base your configuration on a sample Kong Enterprise `values.yaml` 
+    file. For example, [this values file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml) 
+    enables most Kong Enterprise features.
 
 2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
 
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
-    |`enterprise.portal.enabled` | (Optional) Set to `true` to enable the Kong Developer Portal. Find out more about it [here](https://docs.konghq.com/enterprise/latest/developer-portal/). |
+    |`enterprise.portal.enabled` | (Optional) Set to `true` to enable the [Kong Developer Portal](/enterprise/{{page.kong_version}}/developer-portal/). |
     |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password; see [above](#step-5-seed-the-super-admin-password). |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -164,13 +164,14 @@ In the following steps, replace `<your-password>` with a secure password.
 {% endnavtabs %}
 ## Step 7. Prepare Kong's configuration file
 
-1. Create a `values.yaml` file based on the sample in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file sets all the necessary parameters for your Kong environment.
+1. Create a `values.yaml` file for Helm based on the template in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file contains all the necessary parameters for your Kong deployment. As an example, [this values file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml) enables most Kong Enterprise features.
 
 2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
 
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
+    |`enterprise.portal.enabled` | (Optional) Set to `true` to enable the Kong Developer Portal. Find out more about it [here](https://docs.konghq.com/enterprise/latest/developer-portal/). |
     |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password; see [above](#step-5-seed-the-super-admin-password). |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |
@@ -183,8 +184,8 @@ In the following steps, replace `<your-password>` with a secure password.
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
     |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
-    |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
+    |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`postgresql.enabled` | Set to `true` to deploy a Postgres database along with Kong. |
     |`postgresql.postgresqlUsername` | Set Postgres user (e.g. `kong`). |
     |`postgresql.postgresqlPassword` | Set Postgres user's password. |

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -158,7 +158,7 @@ In the following steps, replace `<your-password>` with a secure password.
     ```
 3. Create secret:
     ```
-    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf=<manager-config-filename> --from-file=portal_session_conf=<portal-config-filename>
+    $ oc create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
     ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -171,17 +171,17 @@ In the following steps, replace `<your-password>` with a secure password.
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
-    |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password, see above. |
+    |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password; see [above](#step-5-seed-the-super-admin-password). |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |
     |`env.pg_port` | (If using Postgres) Set to port of the Postgres server (only if `postgresql.enabled` is `false`). |
-    |`env.pg_user` | (If using Postgres) Set to Postgres user (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlUsername`. |
-    |`env.pg_password` | (If using Postgres) Set to Postgres user's password. When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlPassword`. |
-    |`env.pg_database` | (If using Postgres) Set to Postgres database name (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlDatabase`. |
+    |`env.pg_user` | (If using Postgres) Set to the Postgres user (default `kong`). When `postgresql.enabled` is `true`, this has to match `postgresql.postgresqlUsername`. |
+    |`env.pg_password` | (If using Postgres) Set to the Postgres user's password. When `postgresql.enabled` is `true`, this has to match `postgresql.postgresqlPassword`. |
+    |`env.pg_database` | (If using Postgres) Set to the Postgres database name (default `kong`). When `postgresql.enabled` is `true`, this has to match `postgresql.postgresqlDatabase`. |
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
-    |`image.tag` | The Docker image tag you want to pull down, e.g. `"2.1.4.0-alpine"`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -164,14 +164,18 @@ In the following steps, replace `<your-password>` with a secure password.
 {% endnavtabs %}
 ## Step 7. Prepare Kong's configuration file
 
-1. Create a `values.yaml` file for Helm based on the template in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file contains all the necessary parameters for your Kong deployment. As an example, [this values file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml) enables most Kong Enterprise features.
+1. Create a `values.yaml` file for Helm based on the template in the [Kong charts repository](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml). This file contains all the possible parameters for your Kong deployment. 
+
+    You can also base your configuration on a sample Kong Enterprise `values.yaml` 
+    file. For example, [this values file](https://github.com/Kong/charts/blob/main/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml) 
+    enables most Kong Enterprise features.
 
 2. Minimally, for setting up Kong Enterprise on Kubernetes, you will need to set the following parameters:
 
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
-    |`enterprise.portal.enabled` | (Optional) Set to `true` to enable the Kong Developer Portal. Find out more about it [here](https://docs.konghq.com/enterprise/latest/developer-portal/). |
+    |`enterprise.portal.enabled` | (Optional) Set to `true` to enable the [Kong Developer Portal](/enterprise/{{page.kong_version}}/developer-portal/). |
     |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password; see [above](#step-5-seed-the-super-admin-password). |
     |`env.database` | `"postgres"` or `"cassandra"` |
     |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -142,7 +142,7 @@ In the following steps, replace `<your-password>` with a secure password.
     ```
 3. Create secret:
     ```
-    kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf=<manager-config-filename> --from-file=portal_session_conf=<portal-config-filename>
+    kubectl create secret generic kong-session-config -n kong --from-file=admin_gui_session_conf --from-file=portal_session_conf
     ```
 
 {% endnavtab %}

--- a/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -56,12 +56,12 @@ Save the license file temporarily to disk with filename `license` (no file exten
 {% navtabs %}
 {% navtab kubectl %}
 ```
-$ kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+$ kubectl create secret generic kong-enterprise-license -n kong --from-file=./license
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```
-$ oc create secret generic kong-enterprise-license --from-file=./license -n kong
+$ oc create secret generic kong-enterprise-license -n kong --from-file=./license
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -90,7 +90,7 @@ Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterp
 {% navtab kubectl %}
 Set up the credentials:
 ```
-$ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
+$ kubectl create secret docker-registry kong-enterprise-edition-docker -n kong \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
@@ -99,7 +99,7 @@ $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
 {% navtab OpenShift oc %}
 Set up the credentials:
 ```
-$ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
+$ oc create secret docker-registry kong-enterprise-edition-docker -n kong \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \      
     --docker-username=<your-bintray-username> \
     --docker-password=<your-bintray-api-key>
@@ -112,7 +112,7 @@ $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
 {% navtab kubectl %}
 (Optional) Create a password for the super admin:
 ```
-kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=<your-password>
+kubectl create secret generic kong-enterprise-superuser-password -n kong --from-literal=password=<your-password>
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
@@ -171,13 +171,24 @@ In the following steps, replace `<your-password>` with a secure password.
     |Parameter      | Value                         |
     |---------------|-------------------------------|
     |`enterprise.enabled` | `true` |
+    |`enterprise.rbac.enabled` | (Optional) Set to `true` to enable RBAC. Requires seeding the super admin password, see above. |
     |`env.database` | `"postgres"` or `"cassandra"` |
+    |`env.pg_host` | (If using Postgres) Set to host of the Postgres server (only if `postgresql.enabled` is `false`). |
+    |`env.pg_port` | (If using Postgres) Set to port of the Postgres server (only if `postgresql.enabled` is `false`). |
+    |`env.pg_user` | (If using Postgres) Set to Postgres user (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlUsername`. |
+    |`env.pg_password` | (If using Postgres) Set to Postgres user's password. When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlPassword`. |
+    |`env.pg_database` | (If using Postgres) Set to Postgres database name (default `kong`). When `postgresql.enabled` is `true` this has to match `postgresql.postgresqlDatabase`. |
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
-    |`image.tag` | The Docker image tag you want to pull down, e.g. `"1.5.0.3-alpine"`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"2.1.4.0-alpine"`. |
+    |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
+    |`postgresql.enabled` | Set to `true` to deploy a Postgres database along with Kong. |
+    |`postgresql.postgresqlUsername` | Set Postgres user (e.g. `kong`). |
+    |`postgresql.postgresqlPassword` | Set Postgres user's password. |
+    |`postgresql.postgresqlDatabase` | Set Postgres database name (e.g. `kong`). |
 
 3. In the `Kong Enterprise` section, enable Kong Manager (`manager`) and Kong Dev Portal (`portal`).
 
@@ -216,7 +227,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab kubectl %}
 1. Run:
     ```
-    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm install my-kong kong/kong -n kong --values ./values.yaml
     ```
     This may take some time.
 
@@ -243,7 +254,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab OpenShift oc %}
 1. Run:
     ```
-    $ helm install  my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm install my-kong kong/kong -n kong --values ./values.yaml
     ```
     This may take some time.
 
@@ -286,7 +297,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 4. Update Kong to use the changed `values.yaml`:
     ```
-    $ helm upgrade my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm upgrade my-kong kong/kong -n kong --values ./values.yaml
     ```
 
 6. After the upgrade is complete, run:
@@ -305,7 +316,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 {% navtab OpenShift oc %}
 1. Run:
     ```
-    $ oc get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    $ oc get svc my-kong-kong-admin -n kong --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
 
 2. Copy the IP address from the output, then edit the `values.yaml` file to add the following line under `env` section:
@@ -326,7 +337,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
 
 4. Update Kong to use the changed `values.yaml`:
     ```
-    $ helm upgrade  my-kong kong/kong --namespace kong --values ~/values.yaml
+    $ helm upgrade my-kong kong/kong -n kong --values ./values.yaml
     ```
 
 6. After the upgrade is complete, run:


### PR DESCRIPTION
Fixes the command to create the session config secret. `admin_gui_session_conf` and `portal_session_conf` are actually files that have been created in the instructions just before.

