### PR TITLE
fix(file-log) Soften performance warning

### DIFF
--- a/app/_hub/kong-inc/file-log/0.1-x.md
+++ b/app/_hub/kong-inc/file-log/0.1-x.md
@@ -3,14 +3,14 @@ name: File Log
 publisher: Kong Inc.
 version: 0.1-x
 
-desc: Append request and response data to a log file on disk
+desc: Append request and response data to a log file
 description: |
-  Append request and response data to a log file on disk.
+  Append request and response data to a log file (as JSON). You can also specify
+  streams, e.g. `/dev/stdout` and `/dev/stderr` - this is especially useful
+  when running Kong in Kubernetes.
 
-  It is not recommended to use this plugin in production, it would be better to
-  use another logging plugin, for example `syslog`, in those cases. Due to system
-  limitations this plugin uses blocking file i/o, which will hurt performance,
-  and hence is an anti-pattern for Kong installations.
+  This plugin uses blocking I/O - this could affect performance when writing
+  to physical files on slow - e.g. spinning - disks.
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled

--- a/app/_hub/kong-inc/file-log/0.1-x.md
+++ b/app/_hub/kong-inc/file-log/0.1-x.md
@@ -5,12 +5,12 @@ version: 0.1-x
 
 desc: Append request and response data to a log file
 description: |
-  Append request and response data to a log file (as JSON). You can also specify
-  streams, e.g. `/dev/stdout` and `/dev/stderr` - this is especially useful
+  Append request and response data in JSON format to a log file. You can also specify
+  streams (for example, `/dev/stdout` and `/dev/stderr`), which is especially useful
   when running Kong in Kubernetes.
 
-  This plugin uses blocking I/O - this could affect performance when writing
-  to physical files on slow - e.g. spinning - disks.
+  This plugin uses blocking I/O, which could affect performance when writing
+  to physical files on slow (spinning) disks.
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -6,7 +6,7 @@ version: 1.0.0
 desc: Append request and response data to a log file
 description: |
   Append request and response data in JSON format to a log file. You can also specify
-streams (for example, `/dev/stdout` and `/dev/stderr`), which is especially useful
+  streams (for example, `/dev/stdout` and `/dev/stderr`), which is especially useful
   when running Kong in Kubernetes.
 
   This plugin uses blocking I/O, which could affect performance when writing

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -5,12 +5,12 @@ version: 1.0.0
 
 desc: Append request and response data to a log file
 description: |
-  Append request and response data to a log file (as JSON). You can also specify
-  streams, e.g. `/dev/stdout` and `/dev/stderr` - this is especially useful
+  Append request and response data in JSON format to a log file. You can also specify
+streams (for example, `/dev/stdout` and `/dev/stderr`), which is especially useful
   when running Kong in Kubernetes.
 
-  This plugin uses blocking I/O - this could affect performance when writing
-  to physical files on slow - e.g. spinning - disks.
+  This plugin uses blocking I/O, which could affect performance when writing
+  to physical files on slow (spinning) disks.
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -3,14 +3,14 @@ name: File Log
 publisher: Kong Inc.
 version: 1.0.0
 
-desc: Append request and response data to a log file on disk
+desc: Append request and response data to a log file
 description: |
-  Append request and response data to a log file on disk.
+  Append request and response data to a log file (as JSON). You can also specify
+  streams, e.g. `/dev/stdout` and `/dev/stderr` - this is especially useful
+  when running Kong in Kubernetes.
 
-  It is not recommended to use this plugin in production, it would be better to
-  use another logging plugin, for example `syslog`, in those cases. Due to system
-  limitations this plugin uses blocking file i/o, which will hurt performance,
-  and hence is an anti-pattern for Kong installations.
+  This plugin uses blocking I/O - this could affect performance when writing
+  to physical files on slow - e.g. spinning - disks.
 
   <div class="alert alert-warning">
     <strong>Note:</strong> The functionality of this plugin as bundled


### PR DESCRIPTION
Speaking to a number of people and hearing from users the consensus seems to be that the current warning against the file-log plugin is too strong. In most deployment scenarios it does not affect performance.

Additionally, it only applies when writing to actual files on a slow (e.g. spinning) disk. Many times, logs might be written to virtual files, e.g. stdout/stderr - especially in Kubernetes. In those cases, blocking I/O is not a concern.

So I think it is appropriate to soften - but not remove - the warning and add a note about streams.