### PR TITLE
docs(changelog) Kong Brain deprecated in 2.1.4.0

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -26,9 +26,9 @@ skip_read_time: true
 * Fixed application registration issue rendered unusable with certain plugin configurations.
 * Fixed sidebar links with "."
 
-### Deprecated
+### Deprecated Features
 
-* Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+* Kong Brain is deprecated and not available for use in Kong Enterprise.
 
 ## 2.1.3.1
 **Release Date** 2020/08/31

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -10,23 +10,25 @@ skip_read_time: true
 
 ### Fixes
 
-#### Kong Manager
-
-* Added path to service on display page.
-
-### Fixes
-
 #### Kong Gateway
 
 * Fixed upsert for RBAC users using Admin API.
 * Allow PostgreSQL keepalive time to be configurable.
 
-#### Developer Portal
+#### Kong Manager
+
+* Added path to service on display page.
+
+#### Kong Developer Portal
 
 * Fixed app ``Save`` button to display as ``Save`` instead of ``Edit``.
 * Added `plugin.service` check in `app_reg` helper.
 * Fixed application registration issue rendered unusable with certain plugin configurations.
 * Fixed sidebar links with "."
+
+### Deprecated
+
+* Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
 
 ## 2.1.3.1
 **Release Date** 2020/08/31


### PR DESCRIPTION
* Update changelog that Kong Brain is deprecated and not available in Kong Enterprise 2.1.4.0 and later.

See preview: https://deploy-preview-2395--kongdocs.netlify.app/enterprise/changelog/#deprecated-features