### PR TITLE
docs(release notes) added "Deprecated" section

### DIFF
--- a/app/enterprise/2.1.x/release-notes.md
+++ b/app/enterprise/2.1.x/release-notes.md
@@ -71,9 +71,8 @@ For more information, including instructions for switching images, see [Kong for
   * The Correlation ID (`correlation-id`) plugin has a higher priority than in CE. This is an incompatible change with CE in case `correlation-id` is configured against a Consumer.
 
   * The ability to share an entity between Workspaces is no longer supported. The new method requires a copy of the entity to be created in the other Workspaces.
-
-## Deprecated
-Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+  
+  * Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
 
 ## Changelog
 For a complete list of features, fixes, and changes, see the Kong Enterprise [Changelog](/enterprise/changelog/) for versions 2.1.x and 2.1.0.0 (beta).

--- a/app/enterprise/2.1.x/release-notes.md
+++ b/app/enterprise/2.1.x/release-notes.md
@@ -74,7 +74,7 @@ For more information, including instructions for switching images, see [Kong for
   
 ## Deprecated Features
 
-Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
 
 ## Changelog
 

--- a/app/enterprise/2.1.x/release-notes.md
+++ b/app/enterprise/2.1.x/release-notes.md
@@ -64,7 +64,7 @@ For more information, including instructions for switching images, see [Kong for
 
 ### Breaking Changes
 
-  * When performing upgrade and migration to 2.1.x, custom entities and plugins have breaking changes. See [https://docs.konghq.com/enterprise/2.1.x/deployment/upgrades/custom-changes/](https://docs.konghq.com/enterprise/2.1.x/deployment/upgrades/custom-changes/).
+* When performing upgrade and migration to 2.1.x, custom entities and plugins have breaking changes. See [https://docs.konghq.com/enterprise/2.1.x/deployment/upgrades/custom-changes/](https://docs.konghq.com/enterprise/2.1.x/deployment/upgrades/custom-changes/).
 
   * `run_on` is removed from plugins, as it has not been used for a long time but compatibility was kept in 1.x. Any plugin with `run_on` will now break because the schema no longer contains that entry. If testing custom plugins against this beta release, update the plugin's schema.lua file and remove the `run_on` field.
 
@@ -72,7 +72,10 @@ For more information, including instructions for switching images, see [Kong for
 
   * The ability to share an entity between Workspaces is no longer supported. The new method requires a copy of the entity to be created in the other Workspaces.
   
-  * Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+## Deprecated Features
+
+Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
 
 ## Changelog
+
 For a complete list of features, fixes, and changes, see the Kong Enterprise [Changelog](/enterprise/changelog/) for versions 2.1.x and 2.1.0.0 (beta).

--- a/app/enterprise/2.1.x/release-notes.md
+++ b/app/enterprise/2.1.x/release-notes.md
@@ -62,8 +62,7 @@ For more information, including instructions for switching images, see [Kong for
 
 * Setting your Kong password (`Kong_Password`) using a value containing four ticks (for example, `KONG_PASSWORD="a''a'a'a'a"`) causes a Postgres syntax error on bootstrap. To work around this issue, do not use special characters in your password.
 
-
-### Breaking changes
+### Breaking Changes
 
   * When performing upgrade and migration to 2.1.x, custom entities and plugins have breaking changes. See [https://docs.konghq.com/enterprise/2.1.x/deployment/upgrades/custom-changes/](https://docs.konghq.com/enterprise/2.1.x/deployment/upgrades/custom-changes/).
 
@@ -73,6 +72,8 @@ For more information, including instructions for switching images, see [Kong for
 
   * The ability to share an entity between Workspaces is no longer supported. The new method requires a copy of the entity to be created in the other Workspaces.
 
+## Deprecated
+Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
 
 ## Changelog
-For a complete list of features, fixes, and changes, see the Kong Enterprise [Changelog](/enterprise/changelog/) for versions 2.1.3.0 and 2.1.0.0 (beta).
+For a complete list of features, fixes, and changes, see the Kong Enterprise [Changelog](/enterprise/changelog/) for versions 2.1.x and 2.1.0.0 (beta).


### PR DESCRIPTION
-- added Deprecated section to indicate "Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later."
-- in Changelog section, changed 2.1.3.0 to 2.1.x to keep consistent with other references of this version.

See https://deploy-preview-2397--kongdocs.netlify.app/enterprise/2.1.x/release-notes/#deprecated-features
