### PR TITLE
docs(brain) added important brain deprecated

### DIFF
--- a/app/enterprise/2.1.x/brain-immunity/auto-generated-specs.md
+++ b/app/enterprise/2.1.x/brain-immunity/auto-generated-specs.md
@@ -2,6 +2,11 @@
 title: Auto-Generated Specs
 ---
 
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
+</div>
+
 ## Introduction
 Writing API documentation and keeping them up to date is often the easiest, most important task that either doesn't happen or doesn't happen enough. Having great API specifications is especially difficult for organizations with legacy APIs that were never documented to begin with.
 

--- a/app/enterprise/2.1.x/brain-immunity/changelog.md
+++ b/app/enterprise/2.1.x/brain-immunity/changelog.md
@@ -3,6 +3,11 @@ title: Kong Brain and Kong Immunity Changelog
 toc: false
 ---
 
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
+</div>
+
 The Kong Brain and Kong Immunity changelog can be found under the Kong Collector documentation at   [https://github.com/Kong/kong-collector/releases](https://github.com/Kong/kong-collector/releases). 
 
 See this changelog for the latest release information for Kong Brain, Kong Immunity, and Kong Collector. 

--- a/app/enterprise/2.1.x/brain-immunity/install-configure.md
+++ b/app/enterprise/2.1.x/brain-immunity/install-configure.md
@@ -1,6 +1,12 @@
 ---
 title: Kong Brain and Kong Immunity Installation and Configuration
 ---
+
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong> Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+</div>
+
 ## Introduction
 Kong Brain (Brain) and Kong Immunity (Immunity) are installed on Kong Enterprise, either on Kubernetes or Docker, as defined below. The Collector App and Collector Plugin enable Brain and Immunity to communicate with Kong Enterprise. 
 

--- a/app/enterprise/2.1.x/brain-immunity/install-configure.md
+++ b/app/enterprise/2.1.x/brain-immunity/install-configure.md
@@ -4,7 +4,7 @@ title: Kong Brain and Kong Immunity Installation and Configuration
 
 <div class="alert alert-warning">
 <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-<strong>Important:</strong> Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+<strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
 </div>
 
 ## Introduction

--- a/app/enterprise/2.1.x/brain-immunity/overview.md
+++ b/app/enterprise/2.1.x/brain-immunity/overview.md
@@ -2,6 +2,11 @@
 title: Kong Brain and Kong Immunity Overview
 ---
 
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong> Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+</div>
+
 ## Overview
 
 **Kong Brain** (Brain) and **Kong Immunity** (Immunity) help automate the entire API and service development life cycle. By automating processes for configuration, traffic analysis and the creation of documentation, Brain and Immunity help organizations improve efficiency, governance, reliability and security.  Brain automates API and service documentation and Immunity uses advanced machine learning to analyze traffic patterns to diagnose and improve security.

--- a/app/enterprise/2.1.x/brain-immunity/overview.md
+++ b/app/enterprise/2.1.x/brain-immunity/overview.md
@@ -4,7 +4,7 @@ title: Kong Brain and Kong Immunity Overview
 
 <div class="alert alert-warning">
 <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-<strong>Important:</strong> Kong Brain is deprecated and not available in Kong Enterprise version 2.1.4.0 and later.
+<strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
 </div>
 
 ## Overview

--- a/app/enterprise/2.1.x/brain-immunity/service-map.md
+++ b/app/enterprise/2.1.x/brain-immunity/service-map.md
@@ -2,6 +2,11 @@
 title: Using Kong's Service Map
 ---
 
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
+</div>
+
 ### Introduction
 
 Get a high-level view of your architecture with Kong Enterprise’s real-time visual Service Map. Analyze inter-service dependencies across teams and platforms to improve governance and minimize risk.

--- a/app/enterprise/2.1.x/brain-immunity/troubleshooting.md
+++ b/app/enterprise/2.1.x/brain-immunity/troubleshooting.md
@@ -2,6 +2,11 @@
 title: Troubleshooting Common Issues
 ---
 
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+<strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.
+</div>
+
 This troubleshooting topic contains common issues you might experience when using Kong Brain and Kong Immunity, and troubleshooting tips for how to resolve these issues. Information is also provided about how to contact Kong to report an issue, and how to submit suggestions to help improve functionality. 
 
 ## Common Issues and Troubleshooting Tips


### PR DESCRIPTION
* added Important note that Kong Brain is deprecated and not available in Kong Enterprise 2.1.4.0.

See:
https://deploy-preview-2399--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/overview/
https://deploy-preview-2399--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/install-configure/
https://deploy-preview-2399--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/service-map/
https://deploy-preview-2399--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/auto-generated-specs/
https://deploy-preview-2399--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/troubleshooting/
https://deploy-preview-2399--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/changelog/
