### PR TITLE
Forward proxy plugin missing https_verify field description

### DIFF
--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -41,20 +41,27 @@ params:
       default:
       value_in_examples: example.com
       description: |
-        The hostname or IP address of the forward proxy to which to connect
+        The hostname or IP address of the forward proxy to which to connect.
     - name: proxy_port
       required: true
       default:
       value_in_examples: 80
       description: |
-        The TCP port of the forward proxy to which to connect
+        The TCP port of the forward proxy to which to connect.
     - name: proxy_scheme
-      required:
+      required: true
       default: http
-      value_in_examples:
+      value_in_examples: http
       description: |
-        The proxy scheme to use when connecting. Currently only `http` is supported
-
+        The proxy scheme to use when connecting. Currently only `http` is supported.
+    - name: proxy_scheme
+      required: true
+      default: false
+      value_in_examples: false
+      description: |
+        Whether the server certificate will be verified according to the CA certificates
+        specified in
+        [lua_ssl_trusted_certificate](https://www.nginx.com/resources/wiki/modules/lua/#lua-ssl-trusted-certificate).
 ---
 
 ### Notes

--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -54,7 +54,7 @@ params:
       value_in_examples: http
       description: |
         The proxy scheme to use when connecting. Currently only `http` is supported.
-    - name: proxy_scheme
+    - name: https_verify
       required: true
       default: false
       value_in_examples: false


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-869

Direct review link:

https://deploy-preview-2401--kongdocs.netlify.app/hub/kong-inc/forward-proxy/#parameters

Question for reviewers (@gszr or @RobSerafini): I'm not sure which doc versions this field should be in? It looks like it was added 2 years ago per blame. Also, is port 80 appropriate for the existing port example?

