### PR TITLE
Proxy Cache plugins: add extra warning about exact content type matches

### DIFF
--- a/app/_hub/kong-inc/proxy-cache-advanced/index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/index.md
@@ -154,9 +154,13 @@ params:
         Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream.
   extra: |
 
-    **Warning:** The `content_type` requires an exact match. For example, if your Upstream expects
-    `application/json; charset=utf-8` and the `config.content_type` value is only `application/json`
+    <div class="alert alert-ee red">
+    <strong>Warning:</strong> The <code>content_type</code> parameter requires
+    an exact match. For example, if your Upstream expects
+    <code>application/json; charset=utf-8</code> and the
+    <code>config.content_type</code> value is only <code>application/json</code>
     (a partial match), then the proxy cache is bypassed.
+    </div>
 
 
 ---

--- a/app/_hub/kong-inc/proxy-cache-advanced/index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/index.md
@@ -49,7 +49,7 @@ params:
       default: text/plain, application/json
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned.
+        Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned.
     - name: vary_headers
       required: false
       default:
@@ -152,6 +152,12 @@ params:
       value_in_examples:
       description: |
         Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream.
+  extra: |
+
+    **Warning:** The `content_type` requires an exact match. For example, if your Upstream expects
+    `application/json; charset=utf-8` and the `config.content_type` value is only `application/json`
+    (a partial match), then the proxy cache is bypassed.
+
 
 ---
 ### Strategies

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -99,9 +99,13 @@ params:
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
   extra: |
 
-    **Warning:** The `content_type` requires an exact match. For example, if your Upstream expects
-    `application/json; charset=utf-8` and the `config.content_type` value is only `application/json`
+    <div class="alert alert-ee red">
+    <strong>Warning:</strong> The <code>content_type</code> parameter requires
+    an exact match. For example, if your Upstream expects
+    <code>application/json; charset=utf-8</code> and the
+    <code>config.content_type</code> value is only <code>application/json</code>
     (a partial match), then the proxy cache is bypassed.
+    </div>
 
 ---
 ### Strategies

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -54,7 +54,7 @@ params:
       default: '`["text/plain", "application/json"]`'
       value_in_examples:
       description: |
-        Upstream response content types considered cacheable. The plugin performs an exact match against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status will be returned.
+        Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned.
     - name: vary_headers
       required: false
       default:
@@ -97,6 +97,11 @@ params:
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
+  extra: |
+
+    **Warning:** The `content_type` requires an exact match. For example, if your Upstream expects
+    `application/json; charset=utf-8` and the `config.content_type` value is only `application/json`
+    (a partial match), then the proxy cache is bypassed.
 
 ---
 ### Strategies


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-335

Added extra warning underneath params table. 

Direct review links (see the warning underneath the parameters table):
- https://deploy-preview-2402--kongdocs.netlify.app/hub/kong-inc/proxy-cache/#parameters
- https://deploy-preview-2402--kongdocs.netlify.app/hub/kong-inc/proxy-cache-advanced/#parameters
