### PR TITLE
docs(version support) change 2.1.3.x to 2.1.x

### DIFF
--- a/app/enterprise/2.1.x/support-policy.md
+++ b/app/enterprise/2.1.x/support-policy.md
@@ -21,7 +21,7 @@ Bug fixes and patches will be issued against the latest version of Kong Enterpri
 
 | Version  | Released Date | End of Support |
 |:---------|:-------------:|---------------:|
-|  2.1.3.x |  2020-08-25   |   2021-08-24   |
+|  2.1.x   |  2020-08-25   |   2021-08-24   |
 |  1.5.0.x |  2020-04-10   |   2021-04-09   |    
 |  1.3.0.x |  2019-11-05   |   2020-11-04   |
 |   0.36   |  2019-08-05   |   2020-08-04   |


### PR DESCRIPTION
-- changing supported version 2.1.3.x to 2.1.x in table, as we now have 2.1.4.0 released
-- in 2.2, this page will most likely be updated by Shane with current Support policies



