### PR TITLE
fix(styles) Bring cookie banner to top

### DIFF
--- a/app/_assets/stylesheets/cookie-policy.less
+++ b/app/_assets/stylesheets/cookie-policy.less
@@ -6,7 +6,7 @@
   border-radius: 3px;
   box-shadow: 0 15px 35px rgba(50,50,93,.1), 0 5px 15px rgba(0,0,0,.07);
   background: #fff;
-  z-index: 10;
+  z-index: 15;
 
   p {
     color: rgba(0,0,0,.7);

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -147,11 +147,13 @@ id: documentation
       </div>
     </div>
   </div>
+  {% if page.is_homepage != true %}
   <div id="scroll-to-top-button">
     <i class="fas fa-chevron-up"></i>
   </div>
-  {% if page.is_homepage != true and page.feedback != false %}
-  {% include feedback-widget.html %}
+    {% if page.feedback != false %}
+    {% include feedback-widget.html %}
+    {% endif %}
   {% endif %}
 </div>
 <style>


### PR DESCRIPTION
* Fix issue of cookie banner appearing underneath other elements:

<img width="428" alt="Screen Shot 2020-10-22 at 10 29 55 AM" src="https://user-images.githubusercontent.com/54370747/96908522-9f276e00-1451-11eb-945b-041821aee264.png">

* Remove scroll-to-top button from landing pages, positioning is off without the feedback widget there.

Preview:
* Scroll down any landing page, only the cookie banner should be there: https://deploy-preview-2406--kongdocs.netlify.app
* Without dismissing the cookie banner, also scroll down on any page one level down, eg https://deploy-preview-2406--kongdocs.netlify.app/2.1.x/admin-api/. Cookie banner should appear overtop other icons.