### PR TITLE
docs(styles) Adjust table styling for better contrast with code

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -828,12 +828,15 @@ Generic Styling for Desktop
   table {
     display: block;
     max-width: 100%;
-    border-collapse: collapse;
     font-size: 14px;
     overflow-x: auto;
+    border: none;
+    border-collapse: collapse;
+    margin-top: 1.5em;
 
     code {
       white-space: normal;
+      font-size: 13px;
     }
   }
 
@@ -841,20 +844,21 @@ Generic Styling for Desktop
     font-size: 14px;
   }
 
-  /* Zebra striping */
-
-  tr:nth-of-type(odd) {
-    background: @gray-light;
+  tr, th, td {
+    border: none;
   }
 
   th {
-    font-weight: bold;
+    font-weight: 600;
+    color: @black-80;
+    background-color: @grey-100;
   }
 
   td,
   th {
-    padding: 6px;
-    border: 1px solid #ccc;
+    padding: 8px 16px 8px;
+    border-bottom: 1px solid @grey-300;
+    border-top: 1px solid @grey-300;
   }
 
   @media only screen and (max-width: 1099px) {
@@ -876,13 +880,14 @@ Generic Styling for Desktop
       }
 
       tr {
-        border: 1px solid #ccc;
+        border-top: 1px solid @grey-300;
+        border-bottom: 1px solid @grey-300;
       }
 
       td {
         /* Behave  like a "row" */
         border: none;
-        border-bottom: 1px solid #eee;
+        border-bottom: 1px solid @grey-300;
         position: relative;
       }
 
@@ -892,6 +897,7 @@ Generic Styling for Desktop
 
         content: attr(data-label);
         font-size: 14px;
+        font-weight: 600;
       }
     }
   }

--- a/app/_hub/plugins/compatibility/index.md
+++ b/app/_hub/plugins/compatibility/index.md
@@ -30,8 +30,8 @@ nodes, so only control plane nodes require a database
 <br/><i class="fa fa-times" style="opacity:50%;color:red"></i> Not supported
 </div>
 
-| Plugin  | Kong or Third-Party |  Classic  |  DB-less |  Hybrid mode | Notes {:width=40%:} |
-|:--------|:--------------------|:---------:|:--------:|:------------:|:--------------------|
+| Plugin  | Owner |  Classic  |  DB-less |  Hybrid mode | Notes {:width=40%:} |
+|:--------|:------|:---------:|:--------:|:------------:|:--------------------|
 | [ACL](/hub/kong-inc/acl/)                                                          | Kong                | <i class="fa fa-check"></i> |            <i class="fa fa-minus-square"></i>             |                <i class="fa fa-check"></i>                | Authentication plugins can only be used if the set of credentials is static and specified as part of the declarative configuration. Admin API endpoints to dynamically create, update, or delete credentials are not available in DB-less mode. |
 | [ACME (Let's Encrypt)](/hub/kong-inc/acme/)                                        | Kong                | <i class="fa fa-check"></i> |                <i class="fa fa-check"></i>                |                <i class="fa fa-check"></i>                |   |
 | [Apache OpenWhisk](/hub/kong-inc/openwhisk/)                                       | Kong                | <i class="fa fa-check"></i> |                <i class="fa fa-check"></i>                |                <i class="fa fa-check"></i>                |   |
@@ -118,8 +118,8 @@ and [{{site.ee_product_name}} for Kubernetes Deployment Options](/enterprise/lat
 <br/> <i class="fa fa-times" style="opacity:50%;color:red"></i> Not supported
 </div>
 
-| Plugin  | Kong or Third-Party | Classic  | DB-less Kong Enterprise on Kubernetes |   Hybrid Mode   | Notes {:width=30%:} |
-|:--------|:--------------------|:--------------------------------------:|:-----------:|:--------------:|:--------------------|
+| Plugin  | Owner | Classic  | DB-less Kong Enterprise on K8S |   Hybrid Mode   | Notes {:width=30%:} |
+|:--------|:------|:--------:|:-------------------------------------:|:---------------:|:--------------------|
 | [ACL](/hub/kong-inc/acl/)                                                          | Kong                |      <i class="fa fa-check"></i>       |                <i class="fa fa-check"></i>                |                <i class="fa fa-check"></i>                |   |
 | [Apache OpenWhisk](/hub/kong-inc/openwhisk/)                                       | Kong                |      <i class="fa fa-check"></i>       |                <i class="fa fa-check"></i>                |                <i class="fa fa-check"></i>                |   |
 | [Approov API Threat Protection](/hub/critical-blue/approov/)                       | Third-party         |      <i class="fa fa-check"></i>       |                <i class="fa fa-check"></i>                |                <i class="fa fa-check"></i>                |   |


### PR DESCRIPTION
Issue: code blends into table rows, now that it's no longer bright red. (https://konghq.atlassian.net/browse/DOCS-1370)

<img width="732" alt="Screen Shot 2020-10-22 at 10 47 11 AM" src="https://user-images.githubusercontent.com/54370747/96910199-f595ac00-1453-11eb-9c0e-81de32609d8d.png">

* Remove zebra striping from tables and simplify.
* Adjust headers of plugin compat table


Previews:
* Table without code: https://deploy-preview-2407--kongdocs.netlify.app/getting-started-guide/2.1.x/overview/
* Table with code: https://deploy-preview-2407--kongdocs.netlify.app/hub/kong-inc/basic-auth/
* Table inside a step: https://deploy-preview-2407--kongdocs.netlify.app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes/#step-7-prepare-kongs-configuration-file