### PR TITLE
Release: Kong Mesh 1.0.4

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -362,5 +362,5 @@
   edition: "deck"
 -
   release: "1.0.x"
-  version: "1.0.3"
+  version: "1.0.4"
   edition: "mesh"


### PR DESCRIPTION
Updating version for installations.

Preview: https://deploy-preview-2412--kongdocs.netlify.app/mesh/latest_version/ - should just see the new version number and nothing else.