### PR TITLE
docs(*) missing docs for 2.2 release

### DIFF
--- a/app/2.2.x/hybrid-mode.md
+++ b/app/2.2.x/hybrid-mode.md
@@ -38,13 +38,13 @@ Parameter | Description
 `cluster_mtls` *Optional* | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. Defaults to `"shared"`. See below sections for differences in mTLS modes.
 
 The following properties are used differently between "shared" and "PKI" modes:
- 
+
 Parameter | Description | Shared Mode | PKI Mode
 --- | --- | --- | ---
 `cluster_cert` and `cluster_cert_key` *Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 `cluster_ca_cert` *Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 `cluster_server_name` *Required in PKI mode* | The SNI Server Name presented by the DP node mTLS handshake. | *Ignored* | In PKI mode the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside certificate presented by CP matches the `cluster_server_name` value.
- 
+
 ## Topology
 
 ![Example Hybrid Mode Topology](/assets/images/docs/hybrid-mode.png "Example Hybrid Mode Topology")
@@ -333,21 +333,29 @@ Control Plane's new Cluster Status API:
 
 ```
 # on Control Plane node
-http :8001/clustering/status
+http :8001/clustering/data_planes
+
 
 {
-    "a08f5bf2-43b8-4f1c-bdf5-0a0ffb421c21": {
-        "config_hash": "64d661f505f7e1de5b4c5e5faa1797dd",
-        "hostname": "data-plane-2",
-        "ip": "192.168.10.3",
-        "last_seen": 1571197860
-    },
-    "e1fd4970-6d24-4dfb-b2a7-5a832a5de6e1": {
-        "config_hash": "64d661f505f7e1de5b4c5e5faa1797dd",
-        "hostname": "data-plane-1",
-        "ip": "192.168.10.4",
-        "last_seen": 1571197866
-    }
+    "data": [
+        {
+            "config_hash": "a9a166c59873245db8f1a747ba9a80a7",
+            "hostname": "data-plane-2",
+            "id": "ed58ac85-dba6-4946-999d-e8b5071607d4",
+            "ip": "192.168.10.3",
+            "last_seen": 1580623199,
+            "status": "connected"
+        },
+        {
+            "config_hash": "a9a166c59873245db8f1a747ba9a80a7",
+            "hostname": "data-plane-1",
+            "id": "ed58ac85-dba6-4946-999d-e8b5071607d4",
+            "ip": "192.168.10.4",
+            "last_seen": 1580623200,
+            "status": "connected"
+        }
+    ],
+    "next": null
 }
 ```
 

--- a/app/_data/extensions/kong-inc/correlation-id/versions.yml
+++ b/app/_data/extensions/kong-inc/correlation-id/versions.yml
@@ -1,2 +1,3 @@
-- release: 1.0-x
-- release: 0.1-x
+- release: 2.0.x
+- release: 1.0.x
+- release: 0.1.x

--- a/app/_data/extensions/kong-inc/grpc-web/versions.yml
+++ b/app/_data/extensions/kong-inc/grpc-web/versions.yml
@@ -1,1 +1,2 @@
-- release: 0.1.1
+- release: 2.2.x
+- release: 0.1.x

--- a/app/_data/extensions/kong-inc/grpc-web/versions.yml
+++ b/app/_data/extensions/kong-inc/grpc-web/versions.yml
@@ -1,2 +1,2 @@
-- release: 2.2.x
+- release: 0.2.x
 - release: 0.1.x

--- a/app/_hub/kong-inc/correlation-id/0.1.x.md
+++ b/app/_hub/kong-inc/correlation-id/0.1.x.md
@@ -62,7 +62,7 @@ When enabled, this plugin will add a new header to all of the requests processed
 
 This header is always added to calls to your upstream services, and optionally echoed back to your clients according to the `config.echo_downstream` setting.
 
-If a header bearing the same name is already present in the client request, it is honored and this plugin will **not** temper with it.
+If a header bearing the same name is already present in the client request, it is honored and this plugin will **not** tamper with it.
 
 ## Generators
 

--- a/app/_hub/kong-inc/correlation-id/1.0.0.md
+++ b/app/_hub/kong-inc/correlation-id/1.0.0.md
@@ -1,7 +1,7 @@
 ---
 name: Correlation ID
 publisher: Kong Inc.
-version: 1.0.0
+version: 1.0.x
 
 desc: Correlate requests and responses using a unique ID
 description: |

--- a/app/_hub/kong-inc/correlation-id/1.0.0.md
+++ b/app/_hub/kong-inc/correlation-id/1.0.0.md
@@ -1,7 +1,7 @@
 ---
 name: Correlation ID
 publisher: Kong Inc.
-version: 2.0.2
+version: 1.0.0
 
 desc: Correlate requests and responses using a unique ID
 description: |
@@ -14,7 +14,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.2.x
         - 2.1.x
         - 2.0.x
         - 1.5.x

--- a/app/_hub/kong-inc/correlation-id/1.0.x.md
+++ b/app/_hub/kong-inc/correlation-id/1.0.x.md
@@ -76,7 +76,7 @@ When enabled, this plugin will add a new header to all of the requests processed
 
 This header is always added to calls to your upstream services, and optionally echoed back to your clients according to the `config.echo_downstream` setting.
 
-If a header bearing the same name is already present in the client request, it is honored and this plugin will **not** temper with it.
+If a header bearing the same name is already present in the client request, it is honored and this plugin will **not** tamper with it.
 
 ## Generators
 

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -1,7 +1,7 @@
 ---
 name: Correlation ID
 publisher: Kong Inc.
-version: 2.0.2
+version: 2.0.x
 
 desc: Correlate requests and responses using a unique ID
 description: |

--- a/app/_hub/kong-inc/grpc-web/0.1.x.md
+++ b/app/_hub/kong-inc/grpc-web/0.1.x.md
@@ -1,6 +1,7 @@
 ---
 name: gRPC-Web
 publisher: Kong Inc.
+version: 0.1.x
 
 categories:
   - transformations

--- a/app/_hub/kong-inc/grpc-web/0.1.x.md
+++ b/app/_hub/kong-inc/grpc-web/0.1.x.md
@@ -19,7 +19,6 @@ license_type: MIT
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 2.2.x
       - 2.1.x
       - 2.0.x
       - 1.5.x
@@ -43,15 +42,8 @@ params:
       value_in_examples: path/to/hello.proto
       description: |
         If present, describes the gRPC types and methods.
-        Required to support payload transcoding. When absent, the
+        Required to support payload transcoding.  When absent, the
         web client must use application/grpw-web+proto content.
-    - name: pass_stripped_path
-      required: false
-      default:
-      value_in_examples:
-      description:
-        If set to `true` causes the plugin to pass the stripped request path to
-        the upstream gRPC service (see the `strip_path` Route attribute).
 
 ---
 

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -19,6 +19,7 @@ license_type: MIT
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.2.x
       - 2.1.x
       - 2.0.x
       - 1.5.x
@@ -44,6 +45,13 @@ params:
         If present, describes the gRPC types and methods.
         Required to support payload transcoding.  When absent, the
         web client must use application/grpw-web+proto content.
+    - name: pass_stripped_path
+      required: false
+      default:
+      value_in_examples:
+      description:
+        If set to `true` causes the plugin to pass the stripped request path to
+        the upstream gRPC service (see the `strip_path` Route attribute).
 
 ---
 

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -1,6 +1,7 @@
 ---
 name: gRPC-Web
 publisher: Kong Inc.
+version: 2.2.x
 
 categories:
   - transformations

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -1,7 +1,7 @@
 ---
 name: gRPC-Web
 publisher: Kong Inc.
-version: 2.2.x
+version: 0.2.x
 
 categories:
   - transformations

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -93,10 +93,13 @@ params:
       required: false
       default: '`consumer`'
       description: |
-        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`. If the `consumer`, the `credential`, or the `service` cannot be determined, the system will always fallback to `ip`. If value `header` is chosen, the `header_name` configuration has to be provided.
+        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`. If the `consumer`, the `credential`, or the `service` cannot be determined, the system will always fallback to `ip`. If value `header` is chosen, the `header_name` configuration has to be provided. If value `path` is choses, the `path` configuration has to be provided.
     - name: header_name
       required: semi
       description: Header name to be used if `limit_by` is set to `header`.
+    - name: path
+      required: semi
+      description: Path to be used if `limit_by` is set to `path`.
     - name: policy
       required: false
       value_in_examples: "local"

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -3,7 +3,7 @@ name: Rate Limiting
 publisher: Kong Inc.
 redirect_from:
   - /enterprise/0.35-x/rate-limiting/
-version: 2.2.0
+version: 2.2.x
 
 desc: Rate-limit how many HTTP requests can be made in a period of time
 description: |
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.2.x
       - 2.1.x
       - 2.0.x
       - 1.4.x
@@ -93,7 +94,7 @@ params:
       required: false
       default: '`consumer`'
       description: |
-        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`. If the `consumer`, the `credential`, or the `service` cannot be determined, the system will always fallback to `ip`. If value `header` is chosen, the `header_name` configuration has to be provided. If value `path` is choses, the `path` configuration has to be provided.
+        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`. If the `consumer`, the `credential`, or the `service` cannot be determined, the system will always fallback to `ip`. If value `header` is chosen, the `header_name` configuration must be provided. If value `path` is choses, the `path` configuration must be provided.
     - name: header_name
       required: semi
       description: Header name to be used if `limit_by` is set to `header`.


### PR DESCRIPTION
- Updated hybrid-mode docs with new data_planes path
- Update correlation-id plugin version
- Added grpc-web new config param
- Added new possible value to limit_by config param