### PR TITLE
Correct version compatibility for gRPC plugins

### DIFF
--- a/app/_data/extensions/kong-inc/grpc-gateway/versions.yml
+++ b/app/_data/extensions/kong-inc/grpc-gateway/versions.yml
@@ -1,1 +1,1 @@
-- release: 0.1.0
+- release: 0.1.x

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -1,6 +1,7 @@
 ---
 name: gRPC-gateway
 publisher: Kong Inc.
+version: 0.1.x
 
 categories:
   - transformations
@@ -19,6 +20,7 @@ license_type: MIT
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.2.x
       - 2.1.x
   enterprise_edition:
     compatible:

--- a/app/_hub/kong-inc/grpc-web/0.1.x.md
+++ b/app/_hub/kong-inc/grpc-web/0.1.x.md
@@ -21,14 +21,11 @@ kong_version_compatibility:
   community_edition:
     compatible:
       - 2.1.x
-      - 2.0.x
-      - 1.5.x
-      - 1.4.x
+
   enterprise_edition:
     compatible:
       - 2.1.x
-      - 1.5.x
-      - 1.3.x
+
 
 params:
   name: grpc-web

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -22,14 +22,11 @@ kong_version_compatibility:
     compatible:
       - 2.2.x
       - 2.1.x
-      - 2.0.x
-      - 1.5.x
-      - 1.4.x
+
   enterprise_edition:
     compatible:
       - 2.1.x
-      - 1.5.x
-      - 1.3.x
+
 
 params:
   name: grpc-web


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1392 per slack convo, plugins not released until version 2.1 both KE/CE
https://konghq.atlassian.net/browse/DOCS-1376 menu should be 0.1.x

Direct review links:
https://deploy-preview-2424--kongdocs.netlify.app/hub/kong-inc/grpc-gateway/

https://deploy-preview-2424--kongdocs.netlify.app/hub/kong-inc/grpc-web/
https://deploy-preview-2424--kongdocs.netlify.app/hub/kong-inc/grpc-web/0.1.x.html