### PR TITLE
docs(getting-started) Rework instructions for free trials

### DIFF
--- a/app/getting-started-guide/2.1.x/dev-portal.md
+++ b/app/getting-started-guide/2.1.x/dev-portal.md
@@ -16,6 +16,13 @@ Make sure the Dev Portal is on. You should have enabled it for Kong Gateway duri
 {% navtabs %}
 {% navtab Using the Admin API %}
 
+<div class="alert alert-ee">
+<strong><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for {{site.ee_product_name}} free trial users:</strong>
+<br/>
+If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial, make sure you have set up an RBAC user for the Admin API:
+<a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
+</div>
+
 *Using cURL:*
 ```sh
 $ curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \

--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -4,32 +4,57 @@ title: Expose your Services with Kong Gateway
 
 In this topic, you’ll learn how to expose your Services using Routes.
 
-If you are following the Getting Started workflow, make sure you have completed [Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare) before moving on.
+If you are following the Getting Started workflow, make sure you have completed
+[Prepare to Administer Kong Gateway](/getting-started-guide/{{page.kong_version}}/prepare)
+before moving on.
 
-If you are not following the Getting Started workflow, make sure you have Kong Gateway installed and started.
+If you are not following the Getting Started workflow, make sure you have Kong
+Gateway installed and started.
 
 ## What are Services and Routes?
 
-**Service** and **Route** objects let you expose your services to clients with Kong Gateway. When configuring access to your API, you’ll start by specifying a Service. In Kong Gateway, a Service is an entity representing an external upstream API or microservice &mdash; for example, a data transformation microservice, a billing API, and so on.
+**Service** and **Route** objects let you expose your services to clients with
+Kong Gateway. When configuring access to your API, you’ll start by specifying a
+Service. In Kong Gateway, a Service is an entity representing an external
+upstream API or microservice &mdash; for example, a data transformation
+microservice, a billing API, and so on.
 
-The main attribute of a Service is its **URL**, where the service listens for requests. You can specify the URL with a single string, or by specifying its protocol, host, port, and path individually.
+The main attribute of a Service is its **URL**, where the service listens for
+requests. You can specify the URL with a single string, or by specifying its
+protocol, host, port, and path individually.
 
-Before you can start making requests against the Service, you will need to add a Route to it. Routes determine how (and if) requests are sent to their Services after they reach Kong Gateway. A single Service can have many Routes.
+Before you can start making requests against the Service, you will need to add
+a Route to it. Routes determine how (and if) requests are sent to their Services
+after they reach Kong Gateway. A single Service can have many Routes.
 
-After configuring the Service and the Route, you’ll be able to start making requests through Kong Gateway.
+After configuring the Service and the Route, you’ll be able to start making
+requests through Kong Gateway.
 
-This diagram illustrates the flow of requests and responses being routed through the Service to the backend API.
+This diagram illustrates the flow of requests and responses being routed through
+the Service to the backend API.
 
 ![Services and routes](/assets/images/docs/getting-started-guide/route-and-service.png)
 
 ## Add a Service
 
-For the purpose of this example, you’ll create a Service pointing to the Mockbin API. Mockbin is an “echo” type public website that returns requests back to the requester as responses. This visualization will be helpful for learning how Kong Gateway proxies API requests.
+For the purpose of this example, you’ll create a Service pointing to the Mockbin
+API. Mockbin is an “echo” type public website that returns requests back to the
+requester as responses. This visualization will be helpful for learning how Kong
+Gateway proxies API requests.
 
-Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s configuration, including adding Services and Routes, is done through requests to the Admin API.
+Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s
+configuration, including adding Services and Routes, is done through requests to
+the Admin API.
 
 {% navtabs %}
 {% navtab Using the Admin API %}
+
+<div class="alert alert-ee">
+<strong><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for {{site.ee_product_name}} free trial users:</strong>
+<br/>
+If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial, make sure you have set up an RBAC user for the Admin API:
+<a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
+</div>
 
 1. Define a Service with the name `example_service` and the URL `http://mockbin.org`.
 
@@ -59,17 +84,21 @@ Kong Gateway exposes the RESTful Admin API on port `:8001`. The gateway’s conf
 {% endnavtab %}
 {% navtab Using Kong Manager %}
 
-1. On the Workspaces tab in Kong Manager, scroll to the Workspace section and click the **default** workspace.
+1. On the Workspaces tab in Kong Manager, scroll to the Workspace section and
+click the **default** workspace.
 
-    This example uses the default workspace, but you can also create a new workspace, or use an existing workspace.
+    This example uses the default workspace, but you can also create a new
+    workspace, or use an existing workspace.
 
 2. Scroll down to **Services** and click **Add a Service**.
 
-3. In the **Create Service** dialog, enter the name `example_service` and the URL `http://mockbin.org`.
+3. In the **Create Service** dialog, enter the name `example_service` and the
+URL `http://mockbin.org`.
 
 4. Click **Create**.
 
-The service is created, and the page automatically redirects back to the `example_service` overview page.
+The service is created, and the page automatically redirects back to the
+`example_service` overview page.
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
 
@@ -107,12 +136,15 @@ define a Service with the name `example_service` and the URL
 
 ## Add a Route
 
-For the Service to be accessible through the Kong Gateway, you need to add a Route to it.
+For the Service to be accessible through the Kong Gateway, you need to add a
+Route to it.
 
 {% navtabs %}
 {% navtab Using the Admin API %}
 
-Define a Route (`/mock`) for the Service (`example_service`) with a specific path that clients need to request. Note at least one of the hosts, paths, or methods must be set for the route to be matched to the service.
+Define a Route (`/mock`) for the Service (`example_service`) with a specific
+path that clients need to request. Note at least one of the hosts, paths, or
+methods must be set for the route to be matched to the service.
 
 *Using cURL*:
   ```sh
@@ -130,19 +162,26 @@ A 201 message indicates the route was created successfully.
 
 {% endnavtab %}
 {% navtab Using Kong Manager %}
-1. From the `example_service` overview page, scroll down to the Routes section and click **New Route**.  
+1. From the `example_service` overview page, scroll down to the Routes section
+and click **New Route**.  
 
-    The Create Route dialog displays with the Service field auto-populated with the Service name and ID number. This field is required.
+    The Create Route dialog displays with the Service field auto-populated with
+    the Service name and ID number. This field is required.
 
-    **Note:** If the Service field is not automatically populated, click **Services** in the left navigation pane. Find your Service, click the clipboard icon next to the id field, then go back to the Create Route page and paste it into the Service field.
+    **Note:** If the Service field is not automatically populated, click
+    **Services** in the left navigation pane. Find your Service, click the
+    clipboard icon next to the id field, then go back to the Create Route
+    page and paste it into the Service field.
 
-2. Enter a name for the Route, and at least one of the following fields: Host, Methods, or Paths. For this example, use the following:
+2. Enter a name for the Route, and at least one of the following fields: Host,
+Methods, or Paths. For this example, use the following:
       1. For **Name**, enter `mocking`.
       2. For **Path(s)**, click **Add Path** and enter `/mock`.
 
 3. Click **Create**.
 
-The route is created and you are automatically redirected back to the `example_service` overview page. The new Route appears under the Routes section.
+The route is created and you are automatically redirected back to the
+`example_service` overview page. The new Route appears under the Routes section.
 
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
@@ -266,7 +305,10 @@ From a web browser, enter `http://<admin-hostname>:8000/mock`.
 In this section, you:
 * Added a Service named `example_service` with a URL of `http://mockbin.org`.
 * Added a Route named `/mock`.
-* This means if an HTTP request is sent to the Kong Gateway node on port `8000` (the proxy port) and it matches route `/mock`, then that request is sent to `http://mockbin.org`.
-* Abstracted a backend/upstream service and put a route of your choice on the front end, which you can now give to clients to make requests.
+* This means if an HTTP request is sent to the Kong Gateway node on port `8000`
+(the proxy port) and it matches route `/mock`, then that request is sent to
+`http://mockbin.org`.
+* Abstracted a backend/upstream service and put a route of your choice on the
+front end, which you can now give to clients to make requests.
 
 Next, go on to learn about [enforcing rate limiting](/getting-started-guide/{{page.kong_version}}/protect-services).

--- a/app/getting-started-guide/2.1.x/improve-performance.md
+++ b/app/getting-started-guide/2.1.x/improve-performance.md
@@ -21,6 +21,13 @@ Use proxy caching so that Upstream services are not bogged down with repeated re
 {% navtabs %}
 {% navtab Using the Admin API %}
 
+<div class="alert alert-ee">
+<strong><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for {{site.ee_product_name}} free trial users:</strong>
+<br/>
+If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial, make sure you have set up an RBAC user for the Admin API:
+<a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
+</div>
+
 Call the Admin API on port `8001` and configure plugins to enable in-memory caching globally, with a timeout of 30 seconds for Content-Type `application/json`.
 
 *Using cURL*:

--- a/app/getting-started-guide/2.1.x/load-balancing.md
+++ b/app/getting-started-guide/2.1.x/load-balancing.md
@@ -27,6 +27,13 @@ In this section, you will create an Upstream named `upstream` and add two target
 {% navtabs %}
 {% navtab Using the Admin API %}
 
+<div class="alert alert-ee">
+<strong><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for {{site.ee_product_name}} free trial users:</strong>
+<br/>
+If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial, make sure you have set up an RBAC user for the Admin API:
+<a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
+</div>
+
 1. Call the Admin API on port `8001` and create an Upstream named `upstream`.
 
     *Using cURL*:

--- a/app/getting-started-guide/2.1.x/overview.md
+++ b/app/getting-started-guide/2.1.x/overview.md
@@ -74,6 +74,9 @@ Note the following before you start using this guide:
 * You can use this guide to get started in production environments, but this guide does not provide all of the necessary configurations and security settings that you would need for a production environment.
 * The examples in this guide all use `<admin-hostname>` to refer to a {{site.base_gateway}} instance's Admin API URL. Make sure to replace the variable with the actual URL of your {{site.base_gateway}} installation.
     * To find the URL, check the `admin_listen` property in the `/etc/kong/kong.conf` file.
+    * {{site.ee_product_name}} free trials: Check your welcome email for the
+    proxy and administration endpoints, which replace `<admin-hostname>:8000` and
+    `<admin-hostname>:8001` respectively.
 
 ### Using this guide
 * Throughout this guide, you will have the option to configure Kong in a few
@@ -88,6 +91,13 @@ place on the Control Plane.
 want to use HTTPie, install it from [here](https://httpie.org/).
 * Any references to “{{site.base_gateway}}” refer to features or concepts
 common to both {{site.ce_product_name}} and {{site.ee_gateway_name}}.
+* **Cloud-based Enterprise free trial users**: Since the {{site.ee_product_name}}
+ free trial is a Kong-hosted cloud trial, you'll need to refer to the generated
+ admin and proxy endpoints instead of defining your own, and you don't need to
+ use the port number in the URL. Head to
+ [Prepare to Administer {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/prepare)
+ to learn more about the endpoints and to set up an RBAC token for Admin API
+ access.  
 
 ### Next Steps
 

--- a/app/getting-started-guide/2.1.x/overview.md
+++ b/app/getting-started-guide/2.1.x/overview.md
@@ -94,7 +94,7 @@ common to both {{site.ce_product_name}} and {{site.ee_gateway_name}}.
 * **Cloud-based Enterprise free trial users**: Since the {{site.ee_product_name}}
  free trial is a Kong-hosted cloud trial, you'll need to refer to the generated
  admin and proxy endpoints instead of defining your own, and you don't need to
- use the port number in the URL. Head to
+ use the port number in the URL. See
  [Prepare to Administer {{site.base_gateway}}](/getting-started-guide/{{page.kong_version}}/prepare)
  to learn more about the endpoints and to set up an RBAC token for Admin API
  access.  

--- a/app/getting-started-guide/2.1.x/prepare.md
+++ b/app/getting-started-guide/2.1.x/prepare.md
@@ -13,29 +13,99 @@ Before you start this section, make sure that:
 
 In this guide, an instance of {{site.base_gateway}} is referenced via `<admin-hostname>`. Make sure to replace `<admin-hostname>` with the hostname of your control plane instance.
 
+## (Free Trials Only) Expose the Admin API {#free-trials-setup}
+
 <div class="alert alert-ee">
-<h5><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for {{site.ee_product_name}} free trial users</h5>
-If you are trying out {{site.ee_product_name}} using a hosted free trial, you can go through this guide to experience some of this enhanced functionality. However, you need to enable access to the Admin API first.
-  <ol>
-    <li>Open the Kong Manager using the link provided in your free trial welcome email.</li>
-    <li>Open <strong>Teams</strong> > <strong>RBAC Users</strong>, then click <strong>Add New User</strong>.</li>
-    <li>Set up an RBAC user with an appropriate role (e.g. admin) and an RBAC token. Make sure to leave the <strong>Enabled</strong> box checked.</li>
-    <li>Test by building a request to the Admin API.
-<p></p>
-<span style="font-size:14px"><em>Using cURL:</em></span>
-<pre class="highlight">
-<code>$ curl -H “Kong-Admin-Token:&lt;your-RBAC-token&gt;” \
-&lt;admin-endpoint-from-email&gt;/services</code></pre>
-<span style="font-size:14px"><em>Or using HTTPie:</em></span>
-<pre class="highlight">
-<code>$ http &lt;admin-endpoint-from-email&gt;/services \
-Kong-Admin-Token:&lt;your-RBAC-token&gt; </code></pre>
-You should get a 200 response code and your list of services will be empty.
-<br/>
-<br/>You can now use the Admin API instructions in this guide. Remember to switch any mentions of <code>http://&lt;admin-hostname&gt;:8001</code> or <code>&lt;admin-hostname&gt;:8001</code> with your Admin API endpoint (no port number required).
-</li>
-</ol>
+  <img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg"
+  alt="Enterprise" />
+  This section is only applicable to {{site.ee_product_name}} hosted free trials.
+  Skip to <a href="#verify-the-kong-gateway-configuration">Verify the Kong Gateway Configuration</a>
+  if you aren't a free trial user.
 </div>
+
+If you are trying out {{site.ee_product_name}} using a hosted free trial, you
+can go through this guide to experience some of this enhanced functionality.
+However, if you want to test out configuring {{site.ee_product_name}}
+programmatically, you need to enable access to the Admin API first.
+
+### Hosted Free Trial Endpoints
+
+In the Free Trials welcome email, you should have received a list of endpoints.
+You will need to reference the following endpoints and substitute them in
+instructions throughout this guide.
+
+{% navtabs %}
+{% navtab Kong Administration endpoint %}
+Use this endpoint for configuring Kong Gateway using the Kong Admin API. The
+endpoint looks something like this:
+
+`https://admin-kong1a2b3c.kong-cloud.com`
+
+In this guide, substitute this endpoint any time you're asked to access the
+admin host with **port 8001**. For example, given the following request
+and placeholders:
+
+```sh
+$ curl -i -X GET http://<admin-hostname>:8001/services/
+```
+
+Replace `http://<admin-hostname>:8001` with your administration endpoint:
+
+```sh
+$ curl -i -X GET https://admin-kong1a2b3c.kong-cloud.com/mock/request
+```
+{% endnavtab %}
+{% navtab Kong Proxy endpoint %}
+
+Use this URL to access your Services. The URL looks something like this:
+
+`http://kong1a2b3c.kong-cloud.com`
+
+In this guide, substitute this URL any time you're asked to access the admin
+host with **port 8000**. For example, given the following request and
+placeholders:
+
+```sh
+$ curl -i -X GET http://<admin-hostname>:8000/mock/request
+```
+
+Replace `http://<admin-hostname>:8000` with your proxy URL:
+
+```sh
+$ curl -i -X GET http://kong1a2b3c.kong-cloud.com/mock/request
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+### Create a User with an RBAC Token
+
+1. Open the Kong Manager using the link provided in your free trial welcome
+email.
+2. Open **Teams** > **RBAC Users**, then click **Add New User**.
+3. Set up an RBAC user with an appropriate role (e.g. admin) and an RBAC token.
+Make sure to leave the **Enabled** box checked.
+4. Test by building a request to the Admin API:
+
+    *Using cURL:*
+    ```sh
+    $ curl <admin-endpoint-from-email>/services \
+      -H “Kong-Admin-Token:<your-RBAC-token>”
+    ```
+
+    *Or using HTTPie:*
+    ```sh
+    $ http <admin-endpoint-from-email>/services \
+      Kong-Admin-Token:<your-RBAC-token>
+    ```
+
+    You should get a `200` response code and your list of services will be empty.
+
+You can now use the Admin API instructions in this guide.
+
+Remember to switch any mentions of `http://<admin-hostname>:8001` or
+`<admin-hostname>:8001` with your Admin API endpoint (no port number required).
+
 
 ## Verify the Kong Gateway configuration
 {% navtabs %}

--- a/app/getting-started-guide/2.1.x/prepare.md
+++ b/app/getting-started-guide/2.1.x/prepare.md
@@ -25,6 +25,7 @@ In this guide, an instance of {{site.base_gateway}} is referenced via `<admin-ho
 
 If you are trying out {{site.ee_product_name}} using a hosted free trial, you
 can go through this guide to experience some of this enhanced functionality.
+We recommend that you get started using the Kong Manager user interface.
 However, if you want to test out configuring {{site.ee_product_name}}
 programmatically, you need to enable access to the Admin API first.
 

--- a/app/getting-started-guide/2.1.x/protect-services.md
+++ b/app/getting-started-guide/2.1.x/protect-services.md
@@ -24,6 +24,11 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have Kong Enterprise or free trial access, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced instead.
+<br/><br/>
+<strong>{{site.ee_product_name}} free trial users:</strong>
+<br/>
+If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial, make sure you have set up an RBAC user for the Admin API:
+<a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
 </div>
 
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.

--- a/app/getting-started-guide/2.1.x/secure-services.md
+++ b/app/getting-started-guide/2.1.x/secure-services.md
@@ -34,6 +34,13 @@ For more information, see [What is API Gateway Authentication?](https://konghq.c
 {% navtabs %}
 {% navtab Using the Admin API %}
 
+<div class="alert alert-ee">
+<strong><img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />Note for {{site.ee_product_name}} free trial users:</strong>
+<br/>
+If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial, make sure you have set up an RBAC user for the Admin API:
+<a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
+</div>
+
 1. Call the Admin API on port `8001` and configure plugins to enable key authentication. For this example, apply the plugin to the */mock* route you created.
 
     *Using cURL*:


### PR DESCRIPTION
Based on issue https://konghq.atlassian.net/browse/DOCS-1388.

### Issue

The getting started guide does not sufficiently explain how to follow Admin API instructions and use provided endpoints for free trial users. This is a big problem, as users are constantly getting lost and having to go back and forth with support for the same questions, over and over.

### Changes
I tried out a couple of suggestions to restructure and clear up this content, including moving the instructions for setting up for free trials into [Expose your Services](https://docs.konghq.com/getting-started-guide/2.1.x/expose-services/). It ended up obscuring the content and not really fitting into the theme of the topic, so I left it in [Prepare to Administer Kong Gateway](https://docs.konghq.com/getting-started-guide/2.1.x/prepare/), but expanded the blue block into a full section. @connorckong hope this makes sense!

Details:
* Added callouts to Free Trials in the overview topic
* Removed giant blue panel from Prepare to Administer and reworked into two sections: 
  * Hosted Free Trial Endpoints: explained the two main endpoints they need for the getting started guide, provided examples
  * Create a User with an RBAC Token
* Added a blue callout to each topic where the Admin API is used, telling free trial users to set up their RBAC token first, as people could easily skip through content.

### Preview

[Overview](https://deploy-preview-2425--kongdocs.netlify.app/getting-started-guide/2.1.x/overview/#using-this-guide) - note in Using this Guide section
[Prepare to Administer](https://deploy-preview-2425--kongdocs.netlify.app/getting-started-guide/2.1.x/prepare) - the bulk of the content is here
The rest of the topics just have a note in them, eg: [Improve Performance](https://deploy-preview-2425--kongdocs.netlify.app/getting-started-guide/2.1.x/improve-performance/#set-up-the-proxy-caching-plugin)

**Note:** Most of the changes in Expose your Services are just linebreaks, feel free to ignore. Was originally going to work mostly in this topic.
