### PR TITLE
docs(plugins) Introduce datatype field for plugin template

### DIFF
--- a/app/_hub/_init/my-extension/index.md
+++ b/app/_hub/_init/my-extension/index.md
@@ -144,6 +144,7 @@ params: # Metadata about your plugin
         # options are 'yes', 'no', or 'semi'
         # 'semi' means dependent on other settings
       default: # any type - the default value (non-required settings only)
+      datatype: # specify the type of the value: e.g., string, array, boolean, etc.
       value_in_examples:
         # If the field is to appear in examples, this is the value to use.
         # A required field with no value_in_examples entry will resort to

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -70,6 +70,7 @@ params:
     - name: hide_credentials
       required: false
       value_in_examples: true
+      datatype: boolean
       default: "`false`"
       description: |
         An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it.
@@ -77,6 +78,7 @@ params:
     - name: anonymous
       required: false
       default:
+      datatype: string
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
   extra: |

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -468,20 +468,46 @@ plugins:
     <tr><th>Form Parameter</th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>name</code></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code>.</td></tr>
+    <tr>
+      <td><code>name</code>
+        <br><br><strong>Type: </strong>string</td>
+      <td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code>.</td>
+    </tr>
 
     {% if page.params.service_id %}
-      <tr><td><code>service.id</code></td><td>The ID of the Service the plugin targets.</td></tr>
+      <tr>
+        <td><code>service.id</code>
+          <br><br><strong>Type: </strong>string</td>
+        <td>The ID of the Service the plugin targets.</td>
+      </tr>
     {% endif %}
     {% if page.params.route_id %}
-      <tr><td><code>route.id</code></td><td>The ID of the Route the plugin targets.</td></tr>
+      <tr>
+        <td><code>route.id</code>
+          <br><br><strong>Type: </strong>string</td>
+        <td>The ID of the Route the plugin targets.</td>
+      </tr>
     {% endif %}
     {% if page.params.consumer_id %}
-      <tr><td><code>consumer.id</code></td><td>The ID of the Consumer the plugin targets.</td></tr>
+      <tr>
+        <td><code>consumer.id</code>
+          <br><br><strong>Type: </strong>string</td>
+        <td>The ID of the Consumer the plugin targets.</td>
+      </tr>
     {% endif %}
-      <tr><td><code>enabled</code><br><br><strong>default value: </strong><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
+      <tr>
+        <td><code>enabled</code>
+          <br><br><strong>Type: </strong>boolean
+          <br><br><strong>Default value: </strong><code>true</code></td>
+        <td>Whether this plugin will be applied.</td>
+      </tr>
     {% if page.params.api_id %}
-    <tr><td><code>api_id</code></td><td>The ID of the API the plugin targets. <br><br><strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td></tr>
+    <tr>
+      <td><code>api_id</code>
+        <br><br><strong>Type: </strong>string</td>
+      <td>The ID of the API the plugin targets.
+        <br><br><strong>Note:</strong> The <a href="/0.13.x/admin-api/#api-object">API Entity</a> is deprecated in favor of Services since <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md#0130---20180322">CE 0.13.0</a> and <a href="https://docs.konghq.com/enterprise/changelog/#0-32">EE 0.32</a>.</td>
+      </tr>
     {% endif %}
     {% for field in page.params.config %}
       <tr>
@@ -489,9 +515,11 @@ plugins:
           {% if field.required == true %}<br><em>required</em>{% endif %}
           {% if field.required == false %}<br><em>optional</em>{% endif %}
           {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.default != nil %}<br><br><strong>default value: </strong>{{ field.default | markdownify }}{% endif %}
+          {% if field.datatype != nil %}<br><br><strong>Type: </strong>{{ field.datatype | markdownify | strip_html }}{% endif %}
+          {% if field.default != nil %}<br><br><strong>Default value: </strong>{{ field.default | markdownify | strip_html }}{% endif %}
         </td>
-        <td>{{ field.description | markdownify }}</td>
+        <td>
+          <br>{{ field.description | markdownify }}</td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
### Issue
Plugin docs don't list config parameter datatypes, which is a standard piece of information in config reference documentation.

### Changes
* Adding "datatype" field to plugin template and doc layout, so that if a datatype is specified for a parameter, it'll appear below the config parameter name.
* Testing this out with the Basic Auth plugin

### Preview
[Basic Auth](https://deploy-preview-2428--kongdocs.netlify.app/hub/kong-inc/basic-auth/) plugin - see parameter table

### Notes 
* Based the `name` and `id` datatypes on our PDK doc: 
https://docs.konghq.com/2.2.x/plugin-development/plugin-configuration/#schemalua-specifications
* There's a lot of work to do to actually add the datatype field to the doc for each plugin; ideally, it should be automated.
* Will also update autogenerated example parser once this is applied to more plugins to get more accurate syntax
* Tested out adding a column for the datatype instead of including it in the same cell as the param name, and it looked pretty good. Unfortunately, because most of the plugins don't have this value set, we'd end up with a lot of empty cells until this was all automated or filled out manually.

Test:
![Screen Shot 2020-10-29 at 2 27 36 PM](https://user-images.githubusercontent.com/54370747/97637661-4ed38180-19f8-11eb-92f3-039e6de2149a.png)

Reality for most plugins:
![Screen Shot 2020-10-29 at 2 27 54 PM](https://user-images.githubusercontent.com/54370747/97637682-53983580-19f8-11eb-82d3-6188f8e592b2.png)

