### PR TITLE
update sitemap priority levels

### DIFF
--- a/app/sitemap.xml
+++ b/app/sitemap.xml
@@ -9,7 +9,7 @@ sitemap: false
     <loc>{{ site.links.web }}{{ page.url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema}}</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>{% if page.kong_version == site.data.kong_latest.release %}2.0{% else %}1.0{%endif%}</priority>
+    <priority>{% if page.kong_version == site.data.kong_latest.release %}1.0{% else %}0.5{%endif%}</priority>
   </url>
 {% endif %}{% endfor %}
 </urlset>


### PR DESCRIPTION
* sitemap priority levels updated from 2.0/1.0 (for latest vs previous version pages) to 1.0/0.5 (as priority should be set at a maximum of 1.0)- this should help balance SEO results to prioritize most recent versions

