### PR TITLE
fix(docs-nav) Stop links to docs from opening in new window/tab

### DIFF
--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -475,7 +475,6 @@
                     class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12486 navbar-item"
                   >
                     <a
-                      target="_blank"
                       href="https://docs.konghq.com/?itm_source=website&itm_medium=nav"
                       class="nav-link"
                       ><img
@@ -488,7 +487,6 @@
                     class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12487 navbar-item"
                   >
                     <a
-                      target="_blank"
                       href="https://docs.konghq.com/enterprise/?itm_source=website&itm_medium=nav"
                       class="nav-link"
                       ><img
@@ -501,7 +499,6 @@
                     class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12489 navbar-item"
                   >
                     <a
-                      target="_blank"
                       href="https://docs.konghq.com/mesh/?itm_source=website&itm_medium=nav"
                       class="nav-link"
                       ><img
@@ -514,7 +511,6 @@
                     class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12488 navbar-item"
                   >
                     <a
-                      target="_blank"
                       href="https://docs.konghq.com/studio/?itm_source=website&itm_medium=nav"
                       class="nav-link"
                       ><img
@@ -527,7 +523,6 @@
                     class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12489 navbar-item"
                   >
                     <a
-                      target="_blank"
                       href="https://docs.konghq.com/hub/?itm_source=website&itm_medium=nav"
                       class="nav-link"
                       ><img


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1133

There's no reason that docs should open in a new window or tab - might make sense on the main konghq.com site, but for the docs subdomain, it's logical to keep the user in the same tab as they navigate through the docs.

