### PR TITLE
fix(getting-started) Add missing argument for enabling RBAC with Docker

### DIFF
--- a/app/getting-started-guide/2.1.x/manage-teams.md
+++ b/app/getting-started-guide/2.1.x/manage-teams.md
@@ -74,7 +74,10 @@ If you have a Docker installation, run the following command to set the needed e
 **Note:** make sure to replace `<kong-container-id>` with the ID of your container.
 
 ```sh
-$ echo "KONG_ENFORCE_RBAC=on KONG_ADMIN_GUI_AUTH=basic-auth KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' kong reload exit" | docker exec -i <kong-container-id>
+$ echo "KONG_ENFORCE_RBAC=on \
+  KONG_ADMIN_GUI_AUTH=basic-auth \
+  KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' \
+  kong reload exit" | docker exec -i <kong-container-id> /bin/sh
 ```
 
 This will turn on RBAC, tell {{site.ee_product_name}} to use basic authentication (username/password), and tell the Sessions Plugin how to create a session cookie.


### PR DESCRIPTION
If you run the command as-is, you get the following error:

```
"docker exec" requires at least 2 arguments.
```

Fixing it, and formatting the codeblock for readability.

Preview:
https://deploy-preview-2441--kongdocs.netlify.app/getting-started-guide/2.1.x/manage-teams/#turn-on-rbac