### PR TITLE
Docs(styles) Add support for tabbed codeblocks and make copy icon transparent

### DIFF
--- a/app/_assets/stylesheets/copy-code-snippet.less
+++ b/app/_assets/stylesheets/copy-code-snippet.less
@@ -7,14 +7,12 @@
     top: 4px;
     right: 4px;
     cursor: pointer;
-    color: rgba(black, 0.3);
+    color: rgba(black, 0.4);
     transition: color 0.3s;
-    background: white;
-    border-radius: 2px;
-    border: 1px solid #ebebeb;
+    z-index: 10;
 
     &:hover {
-      color: rgba(black, 0.5);
+      color: rgba(black, 0.8);
     }
   }
 }

--- a/app/_assets/stylesheets/copy-code-snippet.less
+++ b/app/_assets/stylesheets/copy-code-snippet.less
@@ -3,7 +3,7 @@
 
   .copy-action {
     position: absolute;
-    padding: 4px;
+    padding: 3px;
     top: 4px;
     right: 4px;
     cursor: pointer;

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -13,17 +13,25 @@
       pre {
         border: none;
         margin-bottom: 0;
+
+        code {
+          padding: 0;
+        }
       }
 
       .navtab-titles {
         background-color: @grey-200;
-        color: rgba(black, 0.9);
+        color: rgba(black, 0.6);
         opacity: 1;
 
         .navtab-title {
           font-size: 14px;
           z-index: 10;
           padding: 6px 16px;
+
+          &:not(.active):hover {
+            color: rgba(black, 1);
+          }
         }
       }
 

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -1,5 +1,45 @@
 .navtabs {
   margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+
+    &.codeblock {
+      background-color: @grey-100;
+      border-bottom: 1px solid @grey-200;
+      border-left: 1px solid @grey-200;
+      border-right: 1px solid @grey-200;
+      border-radius: 3px;
+      line-height: 24px;
+
+      pre {
+        border: none;
+        margin-bottom: 0;
+      }
+
+      .navtab-titles {
+        background-color: @grey-200;
+        color: rgba(black, 0.9);
+        opacity: 1;
+
+        .navtab-title {
+          font-size: 14px;
+          z-index: 10;
+          padding: 6px 16px;
+        }
+      }
+
+      .navtab-contents {
+        padding: 0;
+        margin-top: -20px;
+        margin-bottom: 0;
+        border: none;
+
+        .copy-code-snippet {
+          .copy-action {
+            margin-top: -35px;
+          }
+        }
+      }
+    }
 
   .navtab-titles {
     display: flex;
@@ -13,6 +53,11 @@
       font-size: 16px;
       font-weight: 600;
       opacity: 0.7;
+
+      &:hover {
+        color: rgba(black, 0.4);
+        transition: color 0.2s;
+      }
 
       &::after {
         position: absolute;
@@ -29,6 +74,7 @@
       &.active {
         opacity: 1;
         color: @blue;
+        cursor: text;
 
         &::after {
           opacity: 1;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -778,8 +778,8 @@
   }
 
   pre {
-    background-color: @gray-light;
-    border: 1px solid @gray;
+    background-color: @grey-100;
+    border: 1px solid @grey-200;
     color: #000;
     line-height: 24px;
     margin: 1.3em 0;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -809,7 +809,7 @@
     }
 
     code {
-      padding: 0;
+      padding: 8px 0;
       color: #000;
       background: transparent;
     }

--- a/app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes.md
@@ -45,7 +45,7 @@ Before starting installation, be sure you have the following:
 To create the secrets for license and Docker registry access,
 first provision the `kong` namespace:
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab kubectl %}
 ```bash
 $ kubectl create namespace kong
@@ -63,14 +63,14 @@ Running Kong for Kubernetes Enterprise requires a valid license. See [prerequisi
 
 Save the license file temporarily to disk with filename `license` (no file extension) and execute the following:
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab kubectl %}
-```
+```sh
 $ kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
-```
+```sh
 $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 ```
 {% endnavtab %}
@@ -86,9 +86,9 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 
 Set up Docker credentials to allow Kubernetes nodes to pull down the Kong Enterprise Docker image, which is hosted in a private repository. You receive credentials for the Kong Enterprise Docker image when you sign up for Kong Enterprise.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab kubectl %}
-```
+```sh
 $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username> \
@@ -96,7 +96,7 @@ $ kubectl create secret -n kong docker-registry kong-enterprise-edition-docker \
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
-```
+```sh
 $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
     --docker-username=<your-bintray-username> \
@@ -108,48 +108,61 @@ $ oc create secret -n kong docker-registry kong-enterprise-edition-docker \
 ## Step 4. Deploy Kong for Kubernetes Enterprise
 The steps in this section show you how to install Kong for Kubernetes Enterprise using YAML.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab kubectl %}
-```
+```sh
 $ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
 ```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+```sh
+$ oc create -f https://bit.ly/k4k8s-enterprise-install
+```
+{% endnavtab %}
+{% endnavtabs %}
+
 The initial setup might take a few minutes.
 
-```
+{% navtabs codeblock %}
+{% navtab kubectl %}
+```sh
 $ kubectl get pods -n kong
+
 NAME                            READY   STATUS    RESTARTS   AGE
 ingress-kong-6ffcf8c447-5qv6z   2/2     Running   1          44m
 ```
+{% endnavtab %}
+{% navtab OpenShift oc %}
+```sh
+$ oc get pods -n kong
+
+NAME                            READY   STATUS    RESTARTS   AGE
+ingress-kong-6ffcf8c447-5qv6z   2/2     Running   1          44m
+```
+{% endnavtab %}
+{% endnavtabs %}
 
 You can also see the **kong-proxy service**:
 
-```
+{% navtabs codeblock %}
+{% navtab kubectl %}
+```sh
 $ kubectl get service kong-proxy -n kong
+
 NAME         TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
 kong-proxy   LoadBalancer   10.63.254.78   35.233.198.16   80:32697/TCP,443:32365/TCP   22h
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
-```
-$ oc create -f https://bit.ly/k4k8s-enterprise-install
-```
-The initial setup might take a few minutes.
-
-```
-$ oc get pods -n kong
-NAME                            READY   STATUS    RESTARTS   AGE
-ingress-kong-6ffcf8c447-5qv6z   2/2     Running   1          44m
-```
-
-You can also see the **kong-proxy service**:
-
-```
+```sh
 $ oc get service kong-proxy -n kong
+
 NAME         TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
 kong-proxy   LoadBalancer   10.63.254.78   35.233.198.16   80:32697/TCP,443:32365/TCP   22h
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
 
 <div class="alert alert-ee blue">
 <strong>Note:</strong> Depending on the Kubernetes distribution you are using,
@@ -160,7 +173,7 @@ LoadBalancer.
 
 Set up an environment variable to hold the IP address:
 
-```
+```sh
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
 ```
 


### PR DESCRIPTION
### Changes
- Add support for tabbed codeblocks
- make copy icon transparent so it doesn't obscure code in longer lines

### Usage
Same as current navtabs, except you can only include codeblocks in them. Use `navtabs` with the `codeblock` class, eg:
![Screen Shot 2020-11-06 at 4 41 58 PM](https://user-images.githubusercontent.com/54370747/98426764-01d25980-204f-11eb-9eff-79aaad52489d.png)

Output:
![Screen Shot 2020-11-06 at 4 34 46 PM](https://user-images.githubusercontent.com/54370747/98426773-0bf45800-204f-11eb-98f2-34e6f56012a1.png)

### Outstanding issues/questions
I'm not sure what to do with the copy-code icon when there's no header. Should I force a header on every codeblock? There's probably a more elegant solution than that...

Current behaviour:
![Screen Shot 2020-11-06 at 4 43 54 PM](https://user-images.githubusercontent.com/54370747/98426831-5f66a600-204f-11eb-92c9-a5f60f6d202a.png)

@adamjkuhn I think this PR definitely needs your expertise - I doubt my attempts are the most efficient or clean.

### Preview
Test topic: https://deploy-preview-2442--kongdocs.netlify.app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes/