### PR TITLE
Update AWS Lambda CE/EE 2.2 

### DIFF
--- a/app/_data/extensions/kong-inc/aws-lambda/versions.yml
+++ b/app/_data/extensions/kong-inc/aws-lambda/versions.yml
@@ -1,3 +1,4 @@
+- release: 3.5.x
 - release: 3.4.x
 - release: 3.0.x
 - release: 1.0-x

--- a/app/_hub/kong-inc/aws-lambda/3.4.x.md
+++ b/app/_hub/kong-inc/aws-lambda/3.4.x.md
@@ -1,7 +1,7 @@
 ---
 name: AWS Lambda
 publisher: Kong Inc.
-version: 3.5.x
+version: 3.4.x
 
 desc: Invoke and manage AWS Lambda functions from Kong
 description: |
@@ -24,7 +24,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.2.x
         - 2.1.x
         - 2.0.x
         - 1.5.x
@@ -40,7 +39,6 @@ kong_version_compatibility:
         - 0.10.x
     enterprise_edition:
       compatible:
-        - 2.2.x      
         - 2.1.x
         - 1.5.x
         - 1.3-x
@@ -153,7 +151,7 @@ params:
       required: false
       default: "`false`"
       description: |
-        An optional value that defines whether the response format to receive from the Lambda to [this format](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format).
+        An optional value that defines whether the response format to receive from the Lambda to [this format](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format). Note that the parameter `isBase64Encoded` is not implemented.
     - name: awsgateway_compatible
       required: false
       default: "`false`"


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1412

This was in the 2.2 CE changelog https://github.com/Kong/kong/pull/6379 so some updates have been missed. 

This PR removes the statement that isBased64Encoded flag is not supported/implemented, and bumps the version to match 3.5.x. This plugin consistently is versioned by its internal handler version.

Since CE is already released, and EE beta released, and this is a minor change, I just made the PR off of master rather than the private repo.

```
aws-lambda 3.5.0 22-Sep-2020
feat: adding support for 'isBase64Encoded' flag in Lambda function responses

fix: respect skip_large_bodies config setting even when not using
AWS API Gateway compatibility
```

Direct review links:
https://deploy-preview-2443--kongdocs.netlify.app/hub/kong-inc/aws-lambda/
https://deploy-preview-2443--kongdocs.netlify.app/hub/kong-inc/aws-lambda/3.4.x.html
