### PR TITLE
fix(toc) Nest quickstart topics into quickstart guide section

### DIFF
--- a/app/_data/docs_nav_2.1.x.yml
+++ b/app/_data/docs_nav_2.1.x.yml
@@ -23,20 +23,20 @@
     - text: Quickstart Guide
       url: /getting-started/introduction
       items:
-    - text: Five-minute quickstart
-      url: /getting-started/quickstart
+        - text: Five-minute quickstart
+          url: /getting-started/quickstart
 
-    - text: Configuring a Service
-      url: /getting-started/configuring-a-service
+        - text: Configuring a Service
+          url: /getting-started/configuring-a-service
 
-    - text: Configuring a gRPC Service
-      url: /getting-started/configuring-a-grpc-service
+        - text: Configuring a gRPC Service
+          url: /getting-started/configuring-a-grpc-service
 
-    - text: Enabling Plugins
-      url: /getting-started/enabling-plugins
+        - text: Enabling Plugins
+          url: /getting-started/enabling-plugins
 
-    - text: Adding Consumers
-      url: /getting-started/adding-consumers
+        - text: Adding Consumers
+          url: /getting-started/adding-consumers
 
     - text: Configuration reference
       url: /configuration

--- a/app/_data/docs_nav_2.2.x.yml
+++ b/app/_data/docs_nav_2.2.x.yml
@@ -23,20 +23,20 @@
     - text: Quickstart Guide
       url: /getting-started/introduction
       items:
-    - text: Five-minute quickstart
-      url: /getting-started/quickstart
+        - text: Five-minute quickstart
+          url: /getting-started/quickstart
 
-    - text: Configuring a Service
-      url: /getting-started/configuring-a-service
+        - text: Configuring a Service
+          url: /getting-started/configuring-a-service
 
-    - text: Configuring a gRPC Service
-      url: /getting-started/configuring-a-grpc-service
+        - text: Configuring a gRPC Service
+          url: /getting-started/configuring-a-grpc-service
 
-    - text: Enabling Plugins
-      url: /getting-started/enabling-plugins
+        - text: Enabling Plugins
+          url: /getting-started/enabling-plugins
 
-    - text: Adding Consumers
-      url: /getting-started/adding-consumers
+        - text: Adding Consumers
+          url: /getting-started/adding-consumers
 
     - text: Configuration reference
       url: /configuration

--- a/autodoc-nav/docs_nav_2.1.x.yml.head.in
+++ b/autodoc-nav/docs_nav_2.1.x.yml.head.in
@@ -22,20 +22,20 @@
     - text: Quickstart Guide
       url: /getting-started/introduction
       items:
-    - text: Five-minute quickstart
-      url: /getting-started/quickstart
+        - text: Five-minute quickstart
+          url: /getting-started/quickstart
 
-    - text: Configuring a Service
-      url: /getting-started/configuring-a-service
+        - text: Configuring a Service
+          url: /getting-started/configuring-a-service
 
-    - text: Configuring a gRPC Service
-      url: /getting-started/configuring-a-grpc-service
+        - text: Configuring a gRPC Service
+          url: /getting-started/configuring-a-grpc-service
 
-    - text: Enabling Plugins
-      url: /getting-started/enabling-plugins
+        - text: Enabling Plugins
+          url: /getting-started/enabling-plugins
 
-    - text: Adding Consumers
-      url: /getting-started/adding-consumers
+        - text: Adding Consumers
+          url: /getting-started/adding-consumers
 
     - text: Configuration reference
       url: /configuration


### PR DESCRIPTION
This error was introduced in 2.1.x; before that, the nav was correctly indented (see [2.0.x](https://docs.konghq.com/2.0.x/getting-started/introduction/) vs [2.1.x](https://docs.konghq.com/2.1.x/getting-started/introduction/)). 

I'm guessing that we missed something on the autodoc side when updating the nav originally, but I couldn't figure out how the
`.yml.head.in` file gets generated - and, I noticed that the file is also missing for 2.2? @kikito, what's the role of this file, and is there somewhere else that we need to update anytime nav changes are made (not including Admin API and PDK)?

Preview: 
Look at the CE table of contents under Guides & References. Quickstart should have five nested topics:
https://deploy-preview-2444--kongdocs.netlify.app/2.2.x/getting-started/introduction/
https://deploy-preview-2444--kongdocs.netlify.app/2.1.x/getting-started/introduction/ 
