### PR TITLE
Schema error OAuth2 Introspection plugin Consumer entity not supported

### DIFF
--- a/app/_hub/kong-inc/oauth2-introspection/0.31-x.md
+++ b/app/_hub/kong-inc/oauth2-introspection/0.31-x.md
@@ -29,7 +29,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required:

--- a/app/_hub/kong-inc/oauth2-introspection/0.32-x.md
+++ b/app/_hub/kong-inc/oauth2-introspection/0.32-x.md
@@ -29,7 +29,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required:

--- a/app/_hub/kong-inc/oauth2-introspection/0.33-x.md
+++ b/app/_hub/kong-inc/oauth2-introspection/0.33-x.md
@@ -29,7 +29,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required:

--- a/app/_hub/kong-inc/oauth2-introspection/0.34-x.md
+++ b/app/_hub/kong-inc/oauth2-introspection/0.34-x.md
@@ -29,7 +29,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required:

--- a/app/_hub/kong-inc/oauth2-introspection/0.35-x.md
+++ b/app/_hub/kong-inc/oauth2-introspection/0.35-x.md
@@ -30,7 +30,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required:

--- a/app/_hub/kong-inc/oauth2-introspection/0.36-x.md
+++ b/app/_hub/kong-inc/oauth2-introspection/0.36-x.md
@@ -31,7 +31,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required:
@@ -101,8 +100,8 @@ params:
       default: false
       value_in_examples:
       description: |
-        A boolean indicating whether to forward information about the current 
-        downstream request to the introspect endpoint. If true, headers 
+        A boolean indicating whether to forward information about the current
+        downstream request to the introspect endpoint. If true, headers
         `X-Request-Path` and `X-Request-Http-Method` will be inserted in the
         introspect request
     - name: custom_introspection_headers

--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -40,7 +40,6 @@ params:
   api_id: true
   service_id: true
   route_id: true
-  consumer_id: true
   config:
     - name: introspection_url
       required: true


### PR DESCRIPTION
See https://konghq.atlassian.net/browse/DOCS-1418 and https://konghq.atlassian.net/browse/FTI-2072

You cannot set this on Consumer entity, so removed autogen examples from template.

Direct review link:

https://deploy-preview-2448--kongdocs.netlify.app/hub/kong-inc/oauth2-introspection/ 

Note autogenerated Consumer examples are removed from all versions of the plugin