### PR TITLE
Specified that kong host names are case-sensitive.

### DIFF
--- a/app/0.10.x/admin-api.md
+++ b/app/0.10.x/admin-api.md
@@ -320,8 +320,9 @@ of `hosts`, `uris`, and `methods`. Kong will proxy all requests to the API to th
 ```
 HTTP 201 Created
 ```
-
+ 
 ```json
+When matching a request against an api's hosts field, the match is case sensitive
 {
     "created_at": 1488830759000,
     "hosts": [

--- a/app/0.10.x/admin-api.md
+++ b/app/0.10.x/admin-api.md
@@ -322,7 +322,7 @@ HTTP 201 Created
 ```
  
 ```json
-When matching a request against an api's hosts field, the match is case sensitive
+When matching a request against an api's hosts field, the match is cases-ensitive
 {
     "created_at": 1488830759000,
     "hosts": [

--- a/app/0.10.x/admin-api.md
+++ b/app/0.10.x/admin-api.md
@@ -322,7 +322,8 @@ HTTP 201 Created
 ```
  
 ```json
-When matching a request against an api's hosts field, the match is cases-ensitive
+When matching a request against an api's hosts field, the match is case-sensitive.
+
 {
     "created_at": 1488830759000,
     "hosts": [

--- a/app/0.10.x/getting-started/adding-your-api.md
+++ b/app/0.10.x/getting-started/adding-your-api.md
@@ -24,7 +24,8 @@ configuration of your Kong instance or cluster.
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin])
     to Kong:
-
+    When matching a request against an api's hosts field, the match is case sensitive
+    
     ```bash
     $ curl -i -X POST \
       --url http://localhost:8001/apis/ \

--- a/app/0.10.x/getting-started/adding-your-api.md
+++ b/app/0.10.x/getting-started/adding-your-api.md
@@ -24,7 +24,7 @@ configuration of your Kong instance or cluster.
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin])
     to Kong:
-    When matching a request against an api's hosts field, the match is case sensitive
+    When matching a request against an api's hosts field, the match is case-sensitive.
     
     ```bash
     $ curl -i -X POST \


### PR DESCRIPTION
## Description

Specified that kong host names are case-sensitive.

## Related Issues

addresses #586