### PR TITLE
docs(install) Add instructions for switching to kong user on CE

### DIFF
--- a/app/2.2.x/kong-user.md
+++ b/app/2.2.x/kong-user.md
@@ -25,7 +25,7 @@ configuration property.
 
 ## Prerequisites
 
-{{site.ee_product_name}} is installed on one of the following Linux distributions:
+{{site.ce_product_name}} is installed on one of the following Linux distributions:
 * [Amazon Linux](/install/aws-linux)
 * [CentOS](/install/centos)
 * [Debian](/install/debian)

--- a/app/2.2.x/kong-user.md
+++ b/app/2.2.x/kong-user.md
@@ -1,0 +1,45 @@
+---
+title: Running Kong as a Non-Root User
+---
+
+After installing {{site.ce_product_name}} on a GNU/Linux system, you can
+configure Kong to run as the built-in `kong` user and group instead of `root`.
+This makes the Nginx master and worker processes run as the `kong` user and
+group, overriding any settings in the
+[`nginx_user`](/{{page.kong_version}}/configuration/#nginx_user)
+configuration property.
+
+<div class="alert alert-warning">
+<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  <b>Warning</b>
+  <br>The Nginx master process needs to run as <code>root</code> for
+  Nginx to execute certain actions (for example, to listen on the privileged
+  port 80).
+  <br>
+  <br>Although running Kong as the <code>kong</code> user
+  and group does provide more security, we advise that a system and network
+  administration evaluation be performed before making this decision. Otherwise,
+  Kong nodes might become unavailable due to insufficient permissions to execute
+  privileged system calls in the operating system.
+</div>
+
+## Prerequisites
+
+{{site.ee_product_name}} is installed on one of the following Linux distributions:
+* [Amazon Linux](/install/aws-linux)
+* [CentOS](/install/centos)
+* [Debian](/install/debian)
+* [RedHat](/install/redhat)
+* [Ubuntu](/install/ubuntu)
+
+## Run Kong Gateway as a non-root user
+
+1. Switch to the `kong` user and group:
+    ```sh
+    $ su kong
+    ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```

--- a/app/_data/docs_nav_2.2.x.yml
+++ b/app/_data/docs_nav_2.2.x.yml
@@ -80,8 +80,11 @@
     - text: Securing the Admin API
       url: /secure-admin-api
 
-    - text : Control Kong Community Gateway through systemd
+    - text: Control Kong Community Gateway through systemd
       url: /systemd
+
+    - text: Running Kong as a Non-Root User
+      url: /kong-user
 
     - text: Upgrade Guide
       url: /upgrading

--- a/app/_includes/md/2.2.x/ee-kong-user.md
+++ b/app/_includes/md/2.2.x/ee-kong-user.md
@@ -2,10 +2,10 @@
 Amazon Linux 2, CentOS, Ubuntu, and RHEL -->
 
 <div class="alert alert-ee blue">
-<b>Note:</b> When you start Kong, by default, the Nginx master process will run
-as <code>root</code>, and the worker processes will run as <code>nobody</code>.
-If this is not the desired behavior, you can switch to the built-in
+<b>Note:</b> When you start Kong, the Nginx master process runs
+as <code>root</code>, and the worker processes run as <code>nobody</code> by
+default. If this is not the desired behavior, you can switch to the built-in
 <code>kong</code> user and group before starting Kong in the following steps.
-See <a href="/enterprise/{{page.kong_version}}/deployment/kong-user">Running Kong as a Non-Root User</a>
-for more information.
+For more information, see
+<a href="/enterprise/{{page.kong_version}}/deployment/kong-user">Running Kong as a Non-Root User</a>.
 </div>

--- a/app/_includes/md/ce-kong-user.md
+++ b/app/_includes/md/ce-kong-user.md
@@ -1,9 +1,8 @@
 <!-- Shared between all Community Linux installation topics: Amazon Linux,
  CentOS, Debian, RedHat, and Ubuntu -->
 
-    **Note:** When you start Kong, by default, the Nginx master process will run
-    as `root` and the worker processes will run as `nobody`.
+    **Note:** When you start Kong, the Nginx master process runs
+    as `root` and the worker processes as `nobody` by default.
     If this is not the desired behavior, you can switch to the built-in
-    `kong` user and group before starting Kong.
-    See [Running Kong as a Non-Root User](/latest/kong-user)
-    for more information.
+    `kong` user and group before starting Kong. For more information, see
+    [Running Kong as a Non-Root User](/latest/kong-user).

--- a/app/_includes/md/ce-kong-user.md
+++ b/app/_includes/md/ce-kong-user.md
@@ -1,5 +1,5 @@
-<!-- Shared between all Enterprise Linux installation topics: Amazon Linux,
-Amazon Linux 2, CentOS, Ubuntu, and RHEL -->
+<!-- Shared between all Community Linux installation topics: Amazon Linux,
+ CentOS, Debian, RedHat, and Ubuntu -->
 
     **Note:** When you start Kong, by default, the Nginx master process will run
     as `root` and the worker processes will run as `nobody`.

--- a/app/_includes/md/ce-kong-user.md
+++ b/app/_includes/md/ce-kong-user.md
@@ -1,0 +1,9 @@
+<!-- Shared between all Enterprise Linux installation topics: Amazon Linux,
+Amazon Linux 2, CentOS, Ubuntu, and RHEL -->
+
+    **Note:** When you start Kong, by default, the Nginx master process will run
+    as `root` and the worker processes will run as `nobody`.
+    If this is not the desired behavior, you can switch to the built-in
+    `kong` user and group before starting Kong.
+    See [Running Kong as a Non-Root User](/latest/kong-user)
+    for more information.

--- a/app/install/aws-linux.md
+++ b/app/install/aws-linux.md
@@ -110,6 +110,8 @@ baseurl=https://kong.bintray.com/kong-rpm/amazonlinux/amazonlinux
 
 3. **Start Kong**
 
+    {% include /md/ce-kong-user.md %}
+    
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```

--- a/app/install/centos.md
+++ b/app/install/centos.md
@@ -113,6 +113,8 @@ baseurl=https://kong.bintray.com/kong-rpm/centos/7
 
 3. **Start Kong**
 
+    {% include /md/ce-kong-user.md %}
+
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```

--- a/app/install/debian.md
+++ b/app/install/debian.md
@@ -103,6 +103,8 @@ section on the page below, setting  *distribution* to the appropriate value
 
 3. **Start Kong**
 
+    {% include /md/ce-kong-user.md %}
+
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```

--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -113,6 +113,8 @@ baseurl=https://kong.bintray.com/kong-rpm/rhel/7
 
 3. **Start Kong**
 
+    {% include /md/ce-kong-user.md %}
+
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -102,6 +102,8 @@ section on the page below, setting  *distribution* to the appropriate value ( ls
 
 3. **Start Kong**
 
+    {% include /md/ce-kong-user.md %}
+
     ```bash
     $ kong start [-c /path/to/kong.conf]
     ```


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1385

Creating an unversioned include file for the note, and adding a CE topic for switching to the `kong` user and group.

Added the note to step 3 in the following docs:
https://deploy-preview-2462--kongdocs.netlify.app/install/ubuntu/
https://deploy-preview-2462--kongdocs.netlify.app/install/redhat/
https://deploy-preview-2462--kongdocs.netlify.app/install/centos/
https://deploy-preview-2462--kongdocs.netlify.app/install/aws-linux/
https://deploy-preview-2462--kongdocs.netlify.app/install/debian/

And the instructions themselves:
https://deploy-preview-2462--kongdocs.netlify.app/2.2.x/kong-user/
