### PR TITLE
fix(kic-search) KIC Algolia config

### DIFF
--- a/algolia/config-kic.json
+++ b/algolia/config-kic.json
@@ -2,13 +2,7 @@
   "index_name": "prod_KIC",
   "start_urls": [
     {
-      "url": "https://docs.konghq.com/kubernetes-ingress-controller/(?P<version>.*?)/",
-      "variables": {
-        "version": {
-          "url": "https://docs.konghq.com/kubernetes-ingress-controller/",
-          "js": "var versions = $('ul[aria-labelledby=version-dropdown] a, button#version-dropdown').map(function(i, e) { return $(e).data().versionId }).toArray(); return JSON.stringify(versions);"
-        }
-      }
+      "url": "https://docs.konghq.com/kubernetes-ingress-controller/"
     }
   ],
   "sitemap_urls": [

--- a/algolia/config-kic.json
+++ b/algolia/config-kic.json
@@ -15,18 +15,22 @@
     "https://docs.konghq.com/sitemap.xml"
   ],
   "stop_urls": [
-
-  ],
+    "https://docs.konghq.com/enterprise/",
+    "https://docs.konghq.com/studio/",
+    "https://docs.konghq.com/deck/",
+    "https://docs.konghq.com/install/",
+    "https://docs.konghq.com/mesh/",
+    "https://docs.konghq.com/konnect/",
+    "https://docs.konghq.com/free-trial/",
+    "https://docs.konghq.com/getting-started-guide/",
+    "https://docs.konghq.com/plugins/",
+    "https://docs.konghq.com/[0-9]"
+    ],
   "selectors": {
-    "lvl0": {
-      "selector": ".docs-navigation > a.active",
-      "global": true,
-      "default_value": "Kong"
-    },
-    "lvl1": "h1",
-    "lvl2": ".content h2",
-    "lvl3": ".content h3",
-    "lvl4": ".content h4",
+    "lvl0": "h1",
+    "lvl1": ".content h2",
+    "lvl2": ".content h3",
+    "lvl3": ".content h4",
     "text": ".content p, .content li"
   },
   "selectors_exclude": [

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -219,8 +219,7 @@ id: documentation
     indexName: 'prod_KIC',
     inputSelector: '#getkong-algolia-search-input',
     algoliaOptions: {
-      hitsPerPage: 5,
-      'facetFilters': ["version: {{page.kong_version}}"]
+      hitsPerPage: 5
     },
     // Override selected event to allow for local environment navigation
     handleSelected: function (input, event, suggestion) {


### PR DESCRIPTION
Temporary configuration to make search work for this release. 

For the future: not sure that giving KIC its own search bar makes sense; should probably integrate the index into both CE and EE.

Preview: go to any KIC doc page (https://deploy-preview-2469--kongdocs.netlify.app/kubernetes-ingress-controller/1.0.x/introduction/) and test out the search bar. Should only give you results for KIC topics.