### PR TITLE
fix(nav-style) Fix border displacement on top site nav

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -13,11 +13,15 @@
       color: @blue;
       border-bottom: 2px solid @blue;
       margin-bottom: -2px;
+      cursor: text;
     }
 
-    &:hover {
-      border-bottom: 2px solid @black-40;
-      margin-bottom: -2px;
+    &:not(.active) {
+      &:hover {
+        border-bottom: 2px solid @black-40;
+        margin-bottom: -2px;
+        transition: border 0.3s;
+      }
     }
 
     &:first-child {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -8,7 +8,6 @@
     padding: 0 10px 16px;
     font-size: 16px;
     color: @black-70;
-    margin-bottom: 2px;
 
     &.active {
       color: @blue;
@@ -18,10 +17,12 @@
     }
 
     &:not(.active) {
-      &:hover {
+      &:hover, &:focus {
         border-bottom: 2px solid @black-40;
         margin-bottom: -2px;
-        transition: border 0.3s;
+        transition: all 0.1s;
+        -moz-transition: all 0.1s;
+        -webkit-transition: all 0.1s; 
       }
     }
 

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -8,6 +8,7 @@
     padding: 0 10px 16px;
     font-size: 16px;
     color: @black-70;
+    margin-bottom: 2px;
 
     &.active {
       color: @blue;

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -12,10 +12,12 @@
     &.active {
       color: @blue;
       border-bottom: 2px solid @blue;
+      margin-bottom: -2px;
     }
 
     &:hover {
       border-bottom: 2px solid @black-40;
+      margin-bottom: -2px;
     }
 
     &:first-child {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -22,7 +22,7 @@
         margin-bottom: -2px;
         transition: all 0.1s;
         -moz-transition: all 0.1s;
-        -webkit-transition: all 0.1s; 
+        -webkit-transition: all 0.1s;
       }
     }
 


### PR DESCRIPTION
Issue: when no tab is highlighted at the top of the site (for KIC, decK, and eventually Getting Started), hovering over any tab makes the nav jump down a couple of pixels (see https://docs.konghq.com/kubernetes-ingress-controller/1.0.x/introduction/).

Fix: adjust margins to account for border.

Preview: compare [current problem](https://docs.konghq.com/kubernetes-ingress-controller/1.0.x/introduction/) with [proposed solution](https://deploy-preview-2471--kongdocs.netlify.app/kubernetes-ingress-controller/1.0.x/introduction/). Hover over top nav tabs (Kong Gateway, Kong Enterprise, etc) to test.