### PR TITLE
docs(changelog-ee) updates for OIDC/JWT security issue

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -40,6 +40,7 @@ features, fixes, known issues, and workarounds. The changelog for 2.2.0.0 versio
 #### **OpenID Connect Library**
   - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
 
 #### **Plugins**
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
@@ -304,6 +305,11 @@ open-source **Kong Gateway 2.2.0.0**:
 
 #### Kong Developer Portal
 - Fixed Application Save button label, changing from Edit to Save.
+
+#### **OpenID Connect Library**
+  - Changed to disable HS-signature verification by default.
+  - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
 
 #### Plugins
 - Mutual TLS Authentication (`mtls-auth`)
@@ -639,13 +645,10 @@ Kong Enterprise 2.1.3.0 version includes 2.1.0.0 (beta) features, fixes, known i
  
 ### Fixes
 
-#### **Plugins**
-- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  - HS-signature verification is now disabled by default.
+#### **OpenID Connect Library**
+  - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Updated `lua-resty-session` dependency to 3.7. 
-- [JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
-  - HS-signature verification is now disabled by default.
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
 
 
 ## 1.5.0.7
@@ -942,18 +945,14 @@ Kong Enterprise 2.1.3.0 version includes 2.1.0.0 (beta) features, fixes, known i
   
 
 ## 1.3.0.3
-**Release Date:** 2020/04/15
+**Release Date:** 2020/11/19
 
 ### Fixes
 
-#### **Plugins**
-- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  - HS-signature verification is now disabled by default.
+#### **OpenID Connect Library**
+  - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Updated `lua-resty-session` dependency to 3.7. 
-- [JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
-  - HS-signature verification is now disabled by default.
-
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
 
 ## 1.3.0.2
 **Release Date:** 2020/02/20
@@ -1489,6 +1488,16 @@ repository will allow you to do both easily.
 
 - Fixes: centos and alpine images did not work on some OpenShift setups with relaxed anyuid SCC settings.
 
+
+## 0.36-7
+**Release Date** 2020/11/20
+ 
+### Fixes
+
+#### **OpenID Connect Library**
+  - Changed to disable HS-signature verification by default.
+  - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
 
 ## 0.36-6
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -40,7 +40,7 @@ features, fixes, known issues, and workarounds. The changelog for 2.2.0.0 versio
 #### **OpenID Connect Library**
   - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. Login to the [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin) details.
 
 #### **Plugins**
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
@@ -309,7 +309,7 @@ open-source **Kong Gateway 2.2.0.0**:
 #### **OpenID Connect Library**
   - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. Login to the [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin) details.
 
 #### Plugins
 - Mutual TLS Authentication (`mtls-auth`)
@@ -648,7 +648,7 @@ Kong Enterprise 2.1.3.0 version includes 2.1.0.0 (beta) features, fixes, known i
 #### **OpenID Connect Library**
   - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. Login to the [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin) details.
 
 
 ## 1.5.0.7
@@ -952,7 +952,7 @@ Kong Enterprise 2.1.3.0 version includes 2.1.0.0 (beta) features, fixes, known i
 #### **OpenID Connect Library**
   - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. Login to the [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin) details.
 
 ## 1.3.0.2
 **Release Date:** 2020/02/20
@@ -1497,7 +1497,7 @@ repository will allow you to do both easily.
 #### **OpenID Connect Library**
   - Changed to disable HS-signature verification by default.
   - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
-  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).
+  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. Login to the [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin) details.
 
 ## 0.36-6
 


### PR DESCRIPTION
For 2.2.0.0 and 2.1.4.2 the following is listed for OIDC/JWT vulnerability issue:
#### **OpenID Connect Library**
  - Changed to disable HS-signature verification by default.
  - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).

#### **Plugins**
- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
  - HS-signature verification is now disabled by default.
  - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
  - Updated `lua-resty-session` dependency to 3.7.
- [JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
  - HS-signature verification is now disabled by default.

For new versions 1.5.0.8, 1.3.0.3, and 0.36-7, only the OpenID Connect Library changes are in the fix:
#### **OpenID Connect Library**
  - Changed to disable HS-signature verification by default.
  - Changed to use `client_secret` as a fallback secret for HS-signature verification only when it is a string and has more than one character in it.
  - Fixes vulnerability in the OpenID Connect and JWT Signer Plugins. See [Kong Enterprise Support Portal](https://support.konghq.com/support/s/) for [OIDC advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-OIDC-Plugin) and [JWT advisory](https://support.konghq.com/support/s/article/Kong-Security-Advisory-JWT-Signer-Plugin).


See the following previews. Note the OIDC Library is a separate section from Plugins, so it is in bold. 

 https://deploy-preview-2473--kongdocs.netlify.app/enterprise/changelog/#openid-connect-library

https://deploy-preview-2473--kongdocs.netlify.app/enterprise/changelog/#openid-connect-library-1

https://deploy-preview-2473--kongdocs.netlify.app/enterprise/changelog/#openid-connect-library-2

https://deploy-preview-2473--kongdocs.netlify.app/enterprise/changelog/#openid-connect-library-3

https://deploy-preview-2473--kongdocs.netlify.app/enterprise/changelog/#openid-connect-library-4


