### PR TITLE
docs(k8s) add ingress version documentation

### DIFF
--- a/app/_data/docs_nav_2.1.x.yml
+++ b/app/_data/docs_nav_2.1.x.yml
@@ -452,6 +452,8 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
+        - text: Ingress Versions
+          url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:
         - text: Overview

--- a/app/_data/docs_nav_2.1.x.yml
+++ b/app/_data/docs_nav_2.1.x.yml
@@ -452,7 +452,7 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
-        - text: Ingress Versions
+        - text: Ingress Resource API Versions
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:

--- a/app/_data/docs_nav_2.2.x.yml
+++ b/app/_data/docs_nav_2.2.x.yml
@@ -455,6 +455,8 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
+        - text: Ingress Versions
+          url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:
         - text: Overview

--- a/app/_data/docs_nav_2.2.x.yml
+++ b/app/_data/docs_nav_2.2.x.yml
@@ -455,7 +455,7 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
-        - text: Ingress Versions
+        - text: Ingress Resource API Versions
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -311,6 +311,8 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
+        - text: Ingress Versions
+          url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:
         - text: Overview

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -311,7 +311,7 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
-        - text: Ingress Versions
+        - text: Ingress Resource API Versions
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -306,7 +306,7 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
-        - text: Ingress Versions
+        - text: Ingress Resource API Versions
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -306,6 +306,8 @@
           url: /../../kubernetes-ingress-controller/latest/concepts/ingress-classes
         - text: Security
           url: /../../kubernetes-ingress-controller/latest/concepts/security
+        - text: Ingress Versions
+          url: /../../kubernetes-ingress-controller/latest/concepts/ingress-versions
     - text: Deployment
       items:
         - text: Overview

--- a/app/_data/docs_nav_kic_1.0.x.yml
+++ b/app/_data/docs_nav_kic_1.0.x.yml
@@ -306,7 +306,7 @@
           url: /concepts/ingress-classes
         - text: Security
           url: /concepts/security
-        - text: Ingress Versions
+        - text: Ingress Resource API Versions
           url: /concepts/ingress-versions
     - text: Deployment
       items:

--- a/app/_data/docs_nav_kic_1.0.x.yml
+++ b/app/_data/docs_nav_kic_1.0.x.yml
@@ -306,6 +306,8 @@
           url: /concepts/ingress-classes
         - text: Security
           url: /concepts/security
+        - text: Ingress Versions
+          url: /concepts/ingress-versions
     - text: Deployment
       items:
         - text: Overview

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -4,7 +4,7 @@ title: Ingress v1 and v1beta1 Differences
 
 ## Introduction
 
-Kubernetes 1.18 introduced a new `networking.k8s.io/v1` API for the [Ingress resource][kubernetes-ingress-doc].
+Kubernetes 1.19 introduced a new `networking.k8s.io/v1` API for the [Ingress resource][kubernetes-ingress-doc].
 It standardizes common practices and clarifies implementation requirements that
 were previously up to individual controller vendors. This document covers those
 changes as they relate to {{site.kic_product_name}} and provides sample
@@ -141,12 +141,13 @@ and `bar.example.com` with either v1 or v1beta1 Ingresses.
 Ingress v1 introduces support for backends other than Kubernetes Services through
 [resource backends][resource-backends].
 
-Kong has support for Routes without a Service in some cases, such as Routes
-that use the [AWS Lambda plugin][lambda-plugin]. However, it does not yet offer
-Kubernetes resources for them. As such, you should instead create a placeholder
-Kubernetes Service for them, using an [ExternalName Service][external-name]
-with an RFC 2606 invalid hostname (for example,`kong.invalid`). You can use these
-placeholder services with either v1 or v1beta1 Ingresses.
+Kong does not support any dedicated resource backend configurations, though it
+does have support for Routes without Services in some cases (for example, when
+using the [AWS Lambda plugin][lambda-plugin]). For these routes, you should
+create a placeholder Kubernetes Service for them, using an [ExternalName
+Service][external-name] with an RFC 2606 invalid hostname, e.g.
+`kong.invalid`. You can use these placeholder services with either v1 or
+v1beta1 Ingresses.
 
 [kubernetes-ingress-doc]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [ingress-class]: /kubernertes-ingress-controller/{{page.kong_version}}/concepts/ingress-classes

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -1,0 +1,164 @@
+---
+title: Ingress v1 and v1beta1 differences
+---
+
+## Introduction
+
+Kubernetes 1.18 introduced a new v1 API for the [Ingress resource][kubernetes-ingress-doc].
+It standardizes common practices and clarifies implementation requirements that
+were previously up to individual controller vendors. This document covers those
+changes as they relate to Kong Ingress Controller and provides example
+equivalent v1beta1 and v1 resources for comparison.
+
+## Paths
+
+Both Ingress v1beta1 and v1 HTTP rules require a path, which represents a [URI
+path][uri-rfc-paths]. Although v1beta1 had specified that paths were [POSIX
+regular expressions][posix-regex] and enforced this, but in practice most
+controllers used other other implementations that did not match the
+specification. v1 seeks to reduce confusion by introducing several i[path
+types][path-types] and lifting restrictions on regular expression grammars used
+by controllers.
+
+### v1beta1
+
+The controller passes paths directly to Kong and relies on its [path handling
+logic][kong-path]. The Kong proxy treats paths as a prefix unless they include
+characters [not allowed in RFC 3986 paths][uri-rfc-paths], in which case the
+proxy assumes they are a regular expression, and does not treat slashes as
+special characters. For example, the prefix `/foo` can match any of the
+following:
+
+```
+/foo
+/foo/
+/foobar
+/foo/bar
+```
+
+### v1
+
+Although v1 Ingresses provide path types with more clearly-defined logic, the
+controller must still create Kong routes and work within the Kong proxy's
+routing logic. As such, the controller translates Ingress rule paths to create
+Kong routes that match the specification:
+
+#### Exact
+
+To handle exact matches, the controller creates a Kong route with a regular
+expression that matches the rule path only, e.g. an exact rule for `/foo` in an
+Ingress translates to a Kong route with a `/foo$` regular expression path.
+
+#### Prefix
+
+To handle prefix matches, the controller creates a Kong route with two path
+criteria, e.g. `/foo` will create a route with a `/foo$` regular expression and
+`/foo/` plain path.
+
+#### ImplementationSpecific
+
+The controller leaves ImplementationSpecific path rules entirely up to the Kong
+router. It creates a route with the exact same path string as the Ingress rule.
+
+## Ingress class
+
+[Ingress class][ingress-class] indicates which resources an ingress controller
+should process. It provides a means to separate out configuration intended for
+other controllers or other instances of the Kong Ingress Controller.
+
+In v1beta1, ingress class was handled informally using
+`kubernetes.io/ingress.class` [annotations][deprecated-annotation]. v1
+introduces a new [IngressClass resource][ingress-class-api] which provides
+richer information about the controller. v1 Ingresses are bound to a class via
+their `ingressClassName` field.
+
+For example, consider this v1beta1 Ingress:
+
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: example-ingress
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /test
+        backend:
+          serviceName: echo
+          servicePort: 80
+```
+
+Its ingress class annotation is set to `kong`, and ingress controllers set to
+process `kong` class Ingresses will process it.
+
+In v1, the equivalent configuration declares a `kong` IngressClass resource
+whose `metadata.name` field indicates the class name. The `ingressClassName`
+value of the Ingress object must match the value of the `name` field in the
+IngressClass metadata:
+
+```
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: kong
+spec:
+  controller: konghq.com/kong
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80
+```
+
+## Hostnames
+
+Ingress v1 formally codifies support for [wildcard hostnames][wildcard-hostnames].
+v1beta1 Ingresses did not reject wildcard hostnames, however, and Kong had
+[existing support for them][kong-wildcard-hostnames].
+
+As such, while the v1beta1 specification did not officially support wildcard
+hostnames, you can use wildcard hostnames with either version. Setting a
+hostname like `*.example.com` will match requests for both `foo.example.com`
+and `bar.example.com` with either v1 or v1beta1 Ingresses.
+
+## Backend types
+
+Ingress v1 introduces support for backends other than Kubernetes Services, via
+[resource backends][resource-backends].
+
+Kong has support for routes without a service in some cases, such as routes
+that use the [AWS Lambda plugin][lambda-plugin]. However, it does not yet offer
+Kubernetes resources for them. As such, you should instead create a placeholder
+Kubernetes Service for them, using an [ExternalName Service][external-name]
+with an RFC 2606 invalid hostname, e.g. `kong.invalid`. You can use these
+placeholder services with either v1 or v1beta1 Ingresses.
+
+[kubernetes-ingress-doc]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[ingress-class]: ./ingress-classes.md
+[uri-rfc-paths]: https://tools.ietf.org/html/rfc3986#section-3.3
+[posix-regex]: https://www.boost.org/doc/libs/1_38_0/libs/regex/doc/html/boost_regex/syntax/basic_extended.html
+[path-types]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+[kong-paths]: /latest/proxy/#request-path
+[wildcard-hostnames]: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards
+[kong-wildcard-hostnames]: /latest/proxy/#using-wildcard-hostnames
+[resource-backends]: https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
+[lambda-plugin]: /hub/kong-inc/aws-lambda/
+[external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
+[deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -158,7 +158,7 @@ Service][external-name] with an RFC 2606 invalid hostname, e.g.
 v1beta1 Ingresses.
 
 [kubernetes-ingress-doc]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[ingress-class]: /kubernertes-ingress-controller/{{page.kong_version}}/concepts/ingress-classes
+[ingress-class]: /kubernetes-ingress-controller/{{page.kong_version}}/concepts/ingress-classes
 [uri-rfc-paths]: https://tools.ietf.org/html/rfc3986#section-3.3
 [posix-regex]: https://www.boost.org/doc/libs/1_38_0/libs/regex/doc/html/boost_regex/syntax/basic_extended.html
 [path-types]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -60,6 +60,14 @@ criteria. For example, `/foo` will create a route with a `/foo$` regular express
 The controller leaves `ImplementationSpecific` path rules entirely up to the Kong
 router. It creates a route with the exact same path string as the Ingress rule.
 
+<div class="alert alert-warning">
+  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  Both <code>Prefix</code> and <code>Exact</code> paths modify the paths you
+  provide, and those modifications may interfere with user-provided regular
+  expressions. If you are using your own regular expressions in paths, use
+  <code>ImplementationSpecific</code> to avoid unexpected behavior.
+</div>
+
 ## Ingress class
 
 [Ingress class][ingress-class] indicates which resources an ingress controller

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -4,11 +4,11 @@ title: Ingress v1 and v1beta1 differences
 
 ## Introduction
 
-Kubernetes 1.18 introduced a new v1 API for the [Ingress resource][kubernetes-ingress-doc].
+Kubernetes 1.18 introduced a new `networking.k8s.io/v1` API for the [Ingress resource][kubernetes-ingress-doc].
 It standardizes common practices and clarifies implementation requirements that
 were previously up to individual controller vendors. This document covers those
 changes as they relate to Kong Ingress Controller and provides example
-equivalent v1beta1 and v1 resources for comparison.
+equivalent `networking.k8s.io/v1beta1` and `networking.k8s.io/v1` resources for comparison.
 
 ## Paths
 
@@ -20,7 +20,7 @@ specification. v1 seeks to reduce confusion by introducing several i[path
 types][path-types] and lifting restrictions on regular expression grammars used
 by controllers.
 
-### v1beta1
+### `networking.k8s.io/v1beta1`
 
 The controller passes paths directly to Kong and relies on its [path handling
 logic][kong-path]. The Kong proxy treats paths as a prefix unless they include
@@ -36,7 +36,7 @@ following:
 /foo/bar
 ```
 
-### v1
+### `networking.k8s.io/v1`
 
 Although v1 Ingresses provide path types with more clearly-defined logic, the
 controller must still create Kong routes and work within the Kong proxy's
@@ -45,13 +45,13 @@ Kong routes that match the specification:
 
 #### Exact
 
-To handle exact matches, the controller creates a Kong route with a regular
+If `pathType` is `Exact`, the controller creates a Kong route with a regular
 expression that matches the rule path only, e.g. an exact rule for `/foo` in an
 Ingress translates to a Kong route with a `/foo$` regular expression path.
 
 #### Prefix
 
-To handle prefix matches, the controller creates a Kong route with two path
+If `pathType` is `Prefix`, the controller creates a Kong route with two path
 criteria, e.g. `/foo` will create a route with a `/foo$` regular expression and
 `/foo/` plain path.
 
@@ -75,7 +75,7 @@ their `ingressClassName` field.
 For example, consider this v1beta1 Ingress:
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -106,7 +106,6 @@ kind: IngressClass
 metadata:
   name: kong
 spec:
-  controller: konghq.com/kong
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Add a concept document that covers the differences between v1beta1 and v1 versions of the Ingress resource.

Converted from https://github.com/Kong/kubernetes-ingress-controller/pull/950/

Open question regarding matching between `metadata.name` in IngressClass resources and `ingressClassName` in Ingress resources remains open, but I believe it's correct as written based on what info I can find. I can't test that in our GKE cluster, as GKE 1.18 still rejects v1 Ingresses and 1.19 isn't yet available. Not sure why this is, as [their release notes suggest otherwise](https://cloud.google.com/kubernetes-engine/docs/release-notes#known-20200908), but I can't find other documentation related to it. IMO better to go ahead and publish this with what we know, as we can always correct it if needed later.

