### PR TITLE
fix docs for developer-portal collections

### DIFF
--- a/app/enterprise/1.3-x/developer-portal/working-with-templates.md
+++ b/app/enterprise/1.3-x/developer-portal/working-with-templates.md
@@ -246,10 +246,10 @@ Each configuration item is made up of a few parts:
       - `:name`: Replaces namespace with the filename of a piece of content.
       - `:collection`: Replaces namespace with name of current collection.
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
-- ###### `route`
-    - **required**: true
-      - **type**: `boolean`
-      - **description**: The `layout` attribute determines what HTML layout the collections use to render.  The path root is assessed from within the current themes `layouts` directory.
+- ###### `layout`
+  - **required**: true
+  - **type**: `string`
+  - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
 ##### `content/_posts/post1.md`
 

--- a/app/enterprise/1.5.x/developer-portal/working-with-templates.md
+++ b/app/enterprise/1.5.x/developer-portal/working-with-templates.md
@@ -246,10 +246,10 @@ Each configuration item is made up of a few parts:
       - `:name`: Replaces namespace with the filename of a piece of content.
       - `:collection`: Replaces namespace with name of current collection.
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
-- ###### `route`
-    - **required**: true
-      - **type**: `boolean`
-      - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
+- ###### `layout`
+  - **required**: true
+  - **type**: `string`
+  - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
 ##### `content/_posts/post1.md`
 

--- a/app/enterprise/2.1.x/developer-portal/working-with-templates.md
+++ b/app/enterprise/2.1.x/developer-portal/working-with-templates.md
@@ -246,10 +246,10 @@ Each configuration item is made up of a few parts:
       - `:name`: Replaces namespace with the filename of a piece of content.
       - `:collection`: Replaces namespace with name of current collection.
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
-- ###### `route`
-    - **required**: true
-      - **type**: `boolean`
-      - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
+- ###### `layout`
+  - **required**: true
+  - **type**: `string`
+  - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
 ##### `content/_posts/post1.md`
 

--- a/app/enterprise/2.2.x/developer-portal/working-with-templates.md
+++ b/app/enterprise/2.2.x/developer-portal/working-with-templates.md
@@ -246,10 +246,10 @@ Each configuration item is made up of a few parts:
       - `:name`: Replaces namespace with the filename of a piece of content.
       - `:collection`: Replaces namespace with name of current collection.
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
-- ###### `route`
-    - **required**: true
-      - **type**: `boolean`
-      - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
+- ###### `layout`
+  - **required**: true
+  - **type**: `string`
+  - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
 ##### `content/_posts/post1.md`
 


### PR DESCRIPTION
I was trying to change route for rendered spec file using `x-headmatter` and stumbled upon collections having issues.
I've fixed only the obvious mistakes.
I don't know if it a required attribute or if other (route, output) attributes are correct.
