### PR TITLE
Release: Kong Mesh 1.1.x

### DIFF
--- a/app/_data/docs_nav_mesh_1.1.x.yml
+++ b/app/_data/docs_nav_mesh_1.1.x.yml
@@ -1,0 +1,43 @@
+- title: Introduction
+  icon: /assets/images/icons/documentation/icn-flag.svg
+  items:
+    - text: Overview
+      url: /overview
+
+- title: Getting Started
+  icon: /assets/images/icons/documentation/icn-quickstart-color.svg
+  items:
+    - text: Getting Started
+      url: /gettingstarted
+
+- title: Install
+  icon: /assets/images/icons/documentation/icn-deployment-color.svg
+  items:
+    - text: Overview
+      url: /install
+    - text: Kubernetes
+      url: /installation/kubernetes
+    - text: Helm
+      url: /installation/helm
+    - text: OpenShift
+      url: /installation/openshift
+    - text: Docker
+      url: /installation/docker
+    - text: CentOS
+      url: /installation/centos
+    - text: RedHat
+      url: /installation/redhat
+    - text: Amazon Linux
+      url: /installation/amazonlinux
+    - text: Debian
+      url: /installation/debian
+    - text: Ubuntu
+      url: /installation/ubuntu
+    - text: macOS
+      url: /installation/macos
+
+- title: Enterprise Features
+  icon: /assets/images/icons/documentation/icn-brain-color.svg
+  items:
+    - text: HashiCorp Vault CA
+      url: /features/vault

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -395,6 +395,10 @@
   version: "1.0.4"
   edition: "mesh"
 -
+  release: "1.1.x"
+  version: "1.1.0"
+  edition: "mesh"
+-
   release: "1.0.x"
   version: "1.0.0"
   edition: "kubernetes-ingress-controller"

--- a/app/_includes/md/mesh/1.0.x/install-universal-run.md
+++ b/app/_includes/md/mesh/1.0.x/install-universal-run.md
@@ -1,11 +1,11 @@
 <!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
 ## 2. Run {{site.mesh_product_name}}
-Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
+Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_versions[0].version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
 
 Navigate to the `bin` folder:
 
 ```sh
-$ cd kong-mesh-{{page.kong_latest.version}}/bin
+$ cd kong-mesh-{{page.kong_versions[0].version}}/bin
 ```
 
 <div class="alert alert-ee blue">

--- a/app/_includes/md/mesh/1.1.x/install-universal-quickstart.md
+++ b/app/_includes/md/mesh/1.1.x/install-universal-quickstart.md
@@ -1,0 +1,10 @@
+<!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the [quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).

--- a/app/_includes/md/mesh/1.1.x/install-universal-run.md
+++ b/app/_includes/md/mesh/1.1.x/install-universal-run.md
@@ -1,0 +1,43 @@
+<!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
+## 2. Run {{site.mesh_product_name}}
+Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
+
+Navigate to the `bin` folder:
+
+```sh
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the <code>kuma-cp</code>
+executable &mdash; you need to have a valid {{site.mesh_product_name}} license
+in place.
+</div>
+
+Then, run the control plane with:
+
+```sh
+$ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
+```
+
+Where `/path/to/file/license.json` is the path to a valid
+{{site.mesh_product_name}} license file on the file system.
+
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with a memory
+<a href="https://kuma.io/docs/latest/documentation/backends/">backend</a>, but you can use a persistent storage like PostgreSQL by updating the
+<code>conf/kuma-cp.conf</code> file.
+</div>

--- a/app/_includes/md/mesh/1.1.x/install-universal-verify.md
+++ b/app/_includes/md/mesh/1.1.x/install-universal-verify.md
@@ -1,0 +1,61 @@
+<!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} has been installed, you can access the
+control plane using either the GUI, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681/gui` to see
+the GUI.
+
+{% endnavtab %}
+{% navtab HTTP API (Read & Write) %}
+
+{{site.mesh_product_name}} ships with a **read and write** HTTP API that you can
+use to perform operations on {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681` to see
+the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read & Write) %}
+
+You can use the `kumactl` CLI to perform **read and write** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. For example:
+
+```sh
+$ kumactl get meshes
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "type: Mesh
+  name: default
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kumactl apply -f -
+```
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```sh
+$ kumactl config control-planes add \
+--name=XYZ \
+--address=http://{address-to-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -28,7 +28,7 @@ id: documentation
                 {% assign version_page_url = page.url | replace: page.kong_version, ver.release %}
                 {% capture version_page_exists %}{% page_exists {{version_page_url}} %}{% endcapture %}<li {% if page.kong_version==ver.release %} class="active" {% endif %}>
                 <li {% if page.kong_version==ver.release %} class="active" {% endif %}>
-                  <a href="{% if version_page_exists == 'true' %}{{version_page_url}}{% else %}/{% if page.edition == 'enterprise' %}enterprise/{% endif %}{{ver.release}}{% endif %}"
+                  <a href="{% if version_page_exists == 'true' %}{{version_page_url}}{% else %}/{% if page.edition == 'enterprise' %}enterprise/{% endif %}{% if page.edition == 'mesh' %}mesh/{% endif %}{{ver.release}}{% endif %}"
                     {% if ver.release==page.kong_version %} class="active" {% endif %}
                     data-version-id="{{ver.release}}"
                   >
@@ -98,9 +98,9 @@ id: documentation
           {% endif %}
           {% if page.kong_version != page.kong_latest.release and page.no_version != true %}
           <div class="alert alert-warning">
-            <strong>Careful!</strong> You are browsing documentation for an outdated version of Kong {% if page.edition == 'community' %}{{site.ce_product_name}}{% endif %}{% if page.edition == 'enterprise' %}Enterprise{% endif %}. Go <a
-                  href="{% if page.edition == 'enterprise' %}/enterprise{% endif %}/latest">here</a>
-            to browse the documentation for the latest version.
+            <strong>Careful!</strong> You are browsing documentation for an outdated version{% if page.edition == 'community' %} of {{site.ce_product_name}}{% endif %}{% if page.edition == 'enterprise' %} of {{site.ee_product_name}}{% endif %}{% if page.edition == 'mesh' %} of {{site.mesh_product_name}}{% endif %}. Go <a
+                  href="{% if page.edition == 'enterprise' %}/enterprise{% endif %}{% if page.edition == 'mesh' %}/mesh{% endif %}/latest">here</a>
+            to see the documentation for the latest version.
           </div>
           {% elsif page.is_homepage != true and page.beta == true %}
           <div class="alert alert-ee red condensed margin-bigger">

--- a/app/mesh/1.0.x/install.md
+++ b/app/mesh/1.0.x/install.md
@@ -11,7 +11,8 @@ and configuration procedures as Kuma, but uses its own binaries.
 On this page, you will find access to the official {{site.mesh_product_name}}
 distributions that provide a drop-in replacement to Kuma's native binaries.
 
-<b>The latest {{site.mesh_product_name}} is {{page.kong_latest.version}}:</b>
+**The latest {{page.kong_version}} version of {{site.mesh_product_name}} is
+{{page.kong_versions[0].version}}:**
 
 * [Kubernetes](/mesh/{{page.kong_version}}/installation/kubernetes)
 * [Helm](/mesh/{{page.kong_version}}/installation/helm)

--- a/app/mesh/1.0.x/installation/amazonlinux.md
+++ b/app/mesh/1.0.x/installation/amazonlinux.md
@@ -36,13 +36,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/centos.md
+++ b/app/mesh/1.0.x/installation/centos.md
@@ -29,13 +29,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/debian.md
+++ b/app/mesh/1.0.x/installation/debian.md
@@ -27,13 +27,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -26,15 +26,15 @@ You have a license for {{site.mesh_product_name}}.
 {{site.mesh_product_name}} provides the following Docker images for all of its
 executables:
 
-* **kuma-cp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}`
-* **kuma-dp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-dp:{{page.kong_latest.version}}`
-* **kumactl**: at `kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}}`
-* **kuma-prometheus-sd**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-prometheus-sd:{{page.kong_latest.version}}`
+* **kuma-cp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_versions[0].version}}`
+* **kuma-dp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-dp:{{page.kong_versions[0].version}}`
+* **kumactl**: at `kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_versions[0].version}}`
+* **kuma-prometheus-sd**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-prometheus-sd:{{page.kong_versions[0].version}}`
 
 `docker pull` each image that you need. For example:
 
 ```sh
-$ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}
+$ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_versions[0].version}}
 ```
 
 ## 2. Run {{site.mesh_product_name}}
@@ -53,7 +53,7 @@ $ docker run \
   -p 5681:5681 \
   -v /path/to/license.json:/license.json \
   -e "KUMA_LICENSE_PATH=/license.json" \
-  kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}} run
+  kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_versions[0].version}} run
 ```
 
 Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
@@ -105,7 +105,7 @@ the {{site.mesh_product_name}} HTTP API. For example:
 ```sh
 $ docker run \
   --net="host" \
-  kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}} kumactl get meshes
+  kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_versions[0].version}} kumactl get meshes
 
 NAME          mTLS      METRICS      LOGGING   TRACING
 default       off       off          off       off
@@ -120,7 +120,7 @@ $ echo "type: Mesh
     backends:
     - name: ca-1
       type: builtin" | docker run -i --net="host" \
-    kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}} kumactl apply -f -
+    kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_versions[0].version}} kumactl apply -f -
 ```
 
 <div class="alert alert-ee blue">

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -38,16 +38,16 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
-* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
-* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
-* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
+* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
+* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
+* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
+* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 
 {% endnavtab %}
@@ -65,7 +65,7 @@ control plane process in the next step &mdash; which is served by the
 Navigate to the `bin` folder:
 
 ```sh
-$ cd kong-mesh-{{page.kong_latest.version}}/bin
+$ cd kong-mesh-{{page.kong_versions[0].version}}/bin
 ```
 
 Then, run the control plane with:

--- a/app/mesh/1.0.x/installation/macos.md
+++ b/app/mesh/1.0.x/installation/macos.md
@@ -33,13 +33,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 
 {% endnavtab %}

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -38,16 +38,16 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
-* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
-* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
-* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
+* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
+* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
+* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
+* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 
 {% endnavtab %}
@@ -66,7 +66,7 @@ control plane process in the next step &mdash; which is served by the
 Navigate to the `bin` folder:
 
 ```sh
-$ cd kong-mesh-{{page.kong_latest.version}}/bin
+$ cd kong-mesh-{{page.kong_versions[0].version}}/bin
 ```
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -27,12 +27,12 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -28,13 +28,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.1.x/features/vault.md
+++ b/app/mesh/1.1.x/features/vault.md
@@ -1,0 +1,133 @@
+---
+title: Kong Mesh - Vault Policy
+redirect_from: "/mesh/1.0.x/features/"
+---
+
+## Vault CA Backend
+
+The default [mTLS policy in Kuma](https://kuma.io/docs/latest/policies/mutual-tls/)
+supports the following backends:
+
+* `builtin`: {{site.mesh_product_name}} automatically generates the Certificate
+Authority (CA) root certificate and key that will be used to generate the data
+plane certificates.
+* `provided`: the CA root certificate and key can be provided by the user.
+
+This feature adds one more mTLS backend mode:
+
+* `vault`: {{site.mesh_product_name}} will generate data plane certificates
+using a CA root certificate and key stored in a third-party HashiCorp Vault
+server.
+
+## Using Vault Mode
+
+Unlike the `builtin` and `provided` backends, when using the `vault` mTLS mode,
+{{site.mesh_product_name}} communicates with a third-party HashiCorp Vault PKI,
+which generates the data plane proxy certificates automatically.
+
+The `vault` mTLS backend expects a `kuma-pki-${MESH_NAME}` PKI already
+configured in Vault. For example, the PKI path for a mesh named `default` would
+be `kuma-pki-default`.
+
+To use this feature, you also need to point {{site.mesh_product_name}} to the
+Vault server and provide the appropriate credentials. {{site.mesh_product_name}}
+will use these parameters to authenticate the control plane and generate the
+data plane certificates.
+
+Once running, this backend is responsible for communicating with Vault and for
+using Vault's PKI to automatically issue and rotate data plane certificates for
+each proxy.
+
+## Enabling Vault Authentication
+
+The communication to Vault happens directly from `kuma-cp`. To connect to
+Vault, you must provide the following values in the configuration for `kuma-cp`:
+
+* A `clientKey`.
+* A `clientCert`.
+* A `secret` token.
+
+These values can be inline (for testing purposes only), a path to a file on the
+same host as `kuma-cp`, or contained in a `secret`. See the official Kuma
+documentation to learn more about [Kuma Secrets](https://kuma.io/docs/latest/documentation/secrets/)
+and how to create one.
+
+Here's an example of a configuration using a `vault`-backed CA:
+
+{% navtabs %}
+{% navtab Kubernetes %}
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: vault-1
+    backends:
+      - name: vault-1
+        type: vault
+        dpCert:
+          rotation:
+            expiration: 1d # must be lower than max_ttl in Vault role
+        conf:
+          fromCp:
+            address: https://vault.8200
+            agentAddress: "" # optional
+            namespace: "" # optional
+            tls:
+              caCert:
+                secret: sec-1
+              skipVerify: false # if set to true, caCert is optional. Set to true only for development
+              serverName: "" # verify sever name
+            auth: # only one auth options is allowed so it's either "token" or "tls"
+              token:
+                secret: token-1  # can be file, secret or inline
+              tls:
+                clientKey:
+                  secret: sec-2  # can be file, secret or inline
+                clientCert:
+                  file: /tmp/cert.pem # can be file, secret or inline
+```
+
+Apply the configuration with `kubectl apply -f [..]`.
+
+{% endnavtab %}
+{% navtab Universal %}
+
+```yaml
+type: Mesh
+name: default
+mtls:
+  enabledBackend: vault-1
+  backends:
+  - name: vault-1
+    type: vault
+    dpCert:
+      rotation:
+        expiration: 24h # must be lower than max_ttl in Vault role
+    conf:
+      fromCp:
+        address: https://vault.8200
+        agentAddress: "" # optional
+        namespace: "" # optional
+        tls:
+          caCert:
+            secret: sec-1
+          skipVerify: false # if set to true, caCert is optional. Set to true only for development
+          serverName: "" # verify sever name
+        auth: # only one auth options is allowed so it's either "token" or "tls"
+          token:
+            secret: token-1  # can be file, secret or inline
+          tls:
+            clientKey:
+              secret: sec-2  # can be file, secret or inline
+            clientCert:
+              file: /tmp/cert.pem # can be file, secret or inline
+```
+
+Apply the configuration with `kumactl apply -f [..]`, or using the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/mesh/1.1.x/features/vault.md
+++ b/app/mesh/1.1.x/features/vault.md
@@ -1,6 +1,6 @@
 ---
 title: Kong Mesh - Vault Policy
-redirect_from: "/mesh/1.0.x/features/"
+redirect_from: "/mesh/1.1.x/features/"
 ---
 
 ## Vault CA Backend

--- a/app/mesh/1.1.x/gettingstarted.md
+++ b/app/mesh/1.1.x/gettingstarted.md
@@ -1,0 +1,62 @@
+---
+title: Getting Started with Kong Mesh
+---
+
+## Getting Started
+
+{{site.mesh_product_name}} &mdash; built on top of CNCF's Kuma and Envoy &mdash;
+ tries to be as close as possible to the usage of Kuma itself, while providing
+ drop-in binary replacements for both the control plane and data plane
+ executables.
+
+You can download the {{site.mesh_product_name}} binaries from the
+[official installation page](/mesh/{{page.kong_version}}/install), then follow
+[Kuma's official documentation](https://kuma.io/docs) to start using the product.
+
+For {{site.mesh_product_name}}'s enterprise features, take a look at the
+[enterprise documentation](/mesh/{{page.kong_version}}/features).
+
+<div class="alert alert-ee blue">
+   Kuma, a donated CNCF project, was originally created by Kong, which is
+   currently maintaining both the project and the documentation.
+</div>
+
+## 1. Installing {{site.mesh_product_name}}
+
+Download and install {{site.mesh_product_name}} from the
+[official installation page](/mesh/{{page.kong_version}}/install).
+
+To confirm that {{site.mesh_product_name}} has been installed properly, you
+can check the versions of the executables and make sure that they start with
+the `{{site.mesh_product_name}}` prefix:
+
+```sh
+$ kumactl version
+Kong Mesh [VERSION NUMBER]
+
+$ kuma-cp version
+Kong Mesh [VERSION NUMBER]
+
+$ kuma-dp version
+Kong Mesh [VERSION NUMBER]
+```
+
+## 2. Getting Started
+
+Once installed, follow the getting started guide to get
+{{site.mesh_product_name}} up and running:
+
+* [Getting started with Kubernetes](https://kuma.io/docs/latest/quickstart/kubernetes/)
+* [Getting started with Universal](https://kuma.io/docs/latest/quickstart/universal/)
+
+## 3. Reading the Documentation
+
+You can learn more about the product by reading the official Kuma documentation,
+and the documentation for the enterprise features that are exclusive to
+{{site.mesh_product_name}}:
+
+* [Official Kuma documentation](https://kuma.io/docs/)
+* [Enterprise features documentation](/mesh/{{page.kong_version}}/features)
+
+If you are a {{site.mesh_product_name}} customer, you can also open a support
+ticket with any question or feedback you may have.

--- a/app/mesh/1.1.x/index.md
+++ b/app/mesh/1.1.x/index.md
@@ -1,0 +1,31 @@
+---
+title: Documentation for Kong Mesh
+is_homepage: true
+---
+<div class="docs-grid">
+
+  <div class="docs-grid-block">
+    <h3><a href="/mesh/{{page.kong_version}}/overview">Introduction to {{site.mesh_product_name}}</a></h3>
+    <p>Learn about {{site.mesh_product_name}}, the enterprise service mesh built on top of CNCF's Kuma and Envoy.</p>
+    <a href="/mesh/{{page.kong_version}}/overview">Learn about {{site.mesh_product_name}} &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><a href="/mesh/{{page.kong_version}}/gettingstarted">Getting Started</a></h3>
+    <p>Get started with {{site.mesh_product_name}} in a few minutes, and start creating an enterprise service mesh.</p>
+    <a href="/mesh/{{page.kong_version}}/gettingstarted">Get Started with {{site.mesh_product_name}} &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><a href="/mesh/{{page.kong_version}}/install">Install {{site.mesh_product_name}}</a></h3>
+    <p>Download and install {{site.mesh_product_name}} by using the official distributions.</p>
+    <a href="/mesh/{{page.kong_version}}/install">Download {{site.mesh_product_name}} &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><a href="/mesh/{{page.kong_version}}/features">Enterprise Features</a></h3>
+    <p>Explore the enterprise features available in {{site.mesh_product_name}}, on top of CNCF's Kuma and Envoy.</p>
+    <a href="/mesh/{{page.kong_version}}/features">Explore enterprise features &rarr;</a>
+  </div>
+
+</div>

--- a/app/mesh/1.1.x/install.md
+++ b/app/mesh/1.1.x/install.md
@@ -1,0 +1,44 @@
+---
+title: Install Kong Mesh
+---
+
+## Install {{site.mesh_product_name}}
+
+{{site.mesh_product_name}} is built on top of Kuma and Envoy. To create a
+seamless experience, {{site.mesh_product_name}} follows the same installation
+and configuration procedures as Kuma, but uses its own binaries.
+
+On this page, you will find access to the official {{site.mesh_product_name}}
+distributions that provide a drop-in replacement to Kuma's native binaries.
+
+**The latest {{site.mesh_product_name}} version is 
+{{page.kong_latest.version}}:**
+
+* [Kubernetes](/mesh/{{page.kong_version}}/installation/kubernetes)
+* [Helm](/mesh/{{page.kong_version}}/installation/helm)
+* [OpenShift](/mesh/{{page.kong_version}}/installation/openshift)
+* [Docker](/mesh/{{page.kong_version}}/installation/docker)
+* [CentOS](/mesh/{{page.kong_version}}/installation/centos)
+* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Amazon Linux](/mesh/{{page.kong_version}}/installation/amazonlinux)
+* [Debian](/mesh/{{page.kong_version}}/installation/debian)
+* [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
+* [macOS](/mesh/{{page.kong_version}}/installation/macos)
+
+## Verify Installation
+
+To confirm that you have installed the right version of
+{{site.mesh_product_name}}, you can always run the following commands and
+make sure that the version output starts with the `{{site.mesh_product_name}}`
+prefix:
+
+```sh
+$ kumactl version
+Kong Mesh [VERSION NUMBER]
+
+$ kuma-cp version
+Kong Mesh [VERSION NUMBER]
+
+$ kuma-dp version
+Kong Mesh [VERSION NUMBER]
+```

--- a/app/mesh/1.1.x/installation/amazonlinux.md
+++ b/app/mesh/1.1.x/installation/amazonlinux.md
@@ -47,8 +47,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/mesh/1.0.x/install-universal-run.md %}
+{% include /md/mesh/1.1.x/install-universal-run.md %}
 
-{% include /md/mesh/1.0.x/install-universal-verify.md %}
+{% include /md/mesh/1.1.x/install-universal-verify.md %}
 
-{% include /md/mesh/1.0.x/install-universal-quickstart.md %}
+{% include /md/mesh/1.1.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/amazonlinux.md
+++ b/app/mesh/1.1.x/installation/amazonlinux.md
@@ -1,0 +1,54 @@
+---
+title: Kong Mesh with Amazon Linux
+---
+
+<div class="alert alert-ee blue">
+If you want to use Kuma on Amazon EKS, follow the
+<a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes instructions</a>
+instead.
+</div>
+
+To install and run {{site.mesh_product_name}} on Amazon Linux (**x86_64**),
+execute the following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system and
+download the latest version of {{site.mesh_product_name}}:
+
+```sh
+$ yum install -y tar gzip
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+
+{% endnavtab %}
+{% navtab Manually %}
+
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+the distribution manually.
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% include /md/mesh/1.0.x/install-universal-run.md %}
+
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
+
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/centos.md
+++ b/app/mesh/1.1.x/installation/centos.md
@@ -1,0 +1,47 @@
+---
+title: Kong Mesh with CentOS
+---
+
+To install and run {{site.mesh_product_name}} on CentOS (**x86_64**), execute
+the following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+
+{% endnavtab %}
+{% navtab Manually %}
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+the distribution manually.
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% include /md/mesh/1.0.x/install-universal-run.md %}
+
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
+
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/centos.md
+++ b/app/mesh/1.1.x/installation/centos.md
@@ -40,8 +40,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/mesh/1.0.x/install-universal-run.md %}
+{% include /md/mesh/1.1.x/install-universal-run.md %}
 
-{% include /md/mesh/1.0.x/install-universal-verify.md %}
+{% include /md/mesh/1.1.x/install-universal-verify.md %}
 
-{% include /md/mesh/1.0.x/install-universal-quickstart.md %}
+{% include /md/mesh/1.1.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/debian.md
+++ b/app/mesh/1.1.x/installation/debian.md
@@ -1,0 +1,45 @@
+---
+title: Kong Mesh with Debian
+---
+
+To install and run {{site.mesh_product_name}} on Debian (**amd64**),
+execute the following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+{% navtabs %}
+{% navtab Script %}
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+{% endnavtab %}
+{% navtab Manually %}
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+the distribution manually.
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% include /md/mesh/1.0.x/install-universal-run.md %}
+
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
+
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/debian.md
+++ b/app/mesh/1.1.x/installation/debian.md
@@ -38,8 +38,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/mesh/1.0.x/install-universal-run.md %}
+{% include /md/mesh/1.1.x/install-universal-run.md %}
 
-{% include /md/mesh/1.0.x/install-universal-verify.md %}
+{% include /md/mesh/1.1.x/install-universal-verify.md %}
 
-{% include /md/mesh/1.0.x/install-universal-quickstart.md %}
+{% include /md/mesh/1.1.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/docker.md
+++ b/app/mesh/1.1.x/installation/docker.md
@@ -1,0 +1,158 @@
+---
+title: Kong Mesh with Docker
+---
+
+To install and run {{site.mesh_product_name}} on Docker, execute the following
+steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+<div class="alert alert-ee blue">
+The official Docker images are used by default in the
+<a href="/mesh/{{page.kong_version}}/installation/kubernetes">Kubernetes</a>
+distributions.  
+</div>
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+{{site.mesh_product_name}} provides the following Docker images for all of its
+executables:
+
+* **kuma-cp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}`
+* **kuma-dp**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-dp:{{page.kong_latest.version}}`
+* **kumactl**: at `kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}}`
+* **kuma-prometheus-sd**: at `kong-docker-kong-mesh-docker.bintray.io/kuma-prometheus-sd:{{page.kong_latest.version}}`
+
+`docker pull` each image that you need. For example:
+
+```sh
+$ docker pull kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}}
+```
+
+## 2. Run {{site.mesh_product_name}}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the
+<code>kuma-cp</code> container &mdash; you need to have a valid
+{{site.mesh_product_name}} license in place.
+</div>
+
+Run the control plane with:
+
+```sh
+$ docker run \
+  -p 5681:5681 \
+  -v /path/to/license.json:/license.json \
+  -e "KUMA_LICENSE_PATH=/license.json" \
+  kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}} run
+```
+
+Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+license file on the host that will be mounted as `/license.json` into the
+container.
+
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with
+a memory <a href="https://kuma.io/docs/latest/documentation/backends/">backend</a>,
+but you can use a persistent storage like PostgreSQL by updating the
+<code>conf/kuma-cp.conf</code> file.
+</div>
+
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) is running, you can access the
+control plane using either the GUI, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681/gui` to see
+the GUI.
+
+{% endnavtab %}
+{% navtab HTTP API (Read & Write) %}
+
+{{site.mesh_product_name}} ships with a **read and write** HTTP API that you can
+use to perform operations on {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, navigate to `127.0.0.1:5681` to see
+the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read & Write) %}
+
+You can use the `kumactl` CLI to perform **read and write** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. For example:
+
+```sh
+$ docker run \
+  --net="host" \
+  kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}} kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "type: Mesh
+  name: default
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | docker run -i --net="host" \
+    kong-docker-kong-mesh-docker.bintray.io/kumactl:{{page.kong_latest.version}} kumactl apply -f -
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> We are running <code>kumactl</code> from the Docker
+container on the same network as the host, but most likely you want to download
+a compatible version of {{site.mesh_product_name}} for the machine where you
+will be executing the commands.
+</div>
+
+See the individual installation pages for your OS to download and extract
+`kumactl` to your machine:
+* [CentOS](/mesh/{{page.kong_version}}/installation/centos)
+* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Debian](/mesh/{{page.kong_version}}/installation/debian)
+* [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
+* [macOS](/mesh/{{page.kong_version}}/installation/macos)
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).
+If you are entirely using Docker, you may also be interested in checking out the
+[Kubernetes quickstart](https://kuma.io/docs/latest/quickstart/kubernetes/) as well.

--- a/app/mesh/1.1.x/installation/docker.md
+++ b/app/mesh/1.1.x/installation/docker.md
@@ -52,7 +52,7 @@ Run the control plane with:
 $ docker run \
   -p 5681:5681 \
   -v /path/to/license.json:/license.json \
-  -e "KUMA_LICENSE_PATH=/license.json" \
+  -e "KMESH_LICENSE_PATH=/license.json" \
   kong-docker-kong-mesh-docker.bintray.io/kuma-cp:{{page.kong_latest.version}} run
 ```
 

--- a/app/mesh/1.1.x/installation/helm.md
+++ b/app/mesh/1.1.x/installation/helm.md
@@ -1,0 +1,171 @@
+---
+title: Kong Mesh with Helm
+---
+
+To install and run {{site.mesh_product_name}} on Kubernetes using Helm, execute
+the following steps:
+
+* [1. Add the {{site.mesh_product_name}} Helm Repository](#1-add-the-kong-mesh-helm-repository)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Add the {{site.mesh_product_name}} Helm Repository
+
+To start using {{site.mesh_product_name}} with Helm charts, first add the
+{{site.mesh_product_name}} charts repository to your local Helm deployment:
+
+```sh
+$ helm repo add kong-mesh https://kong.github.io/kong-mesh-charts
+```
+
+Once the repo is added, any following updates can be fetched with
+`helm repo update`.
+
+## 2. Run {{site.mesh_product_name}}
+
+Install and run {{site.mesh_product_name}} using the following commands.
+You can use any Kubernetes namespace to install Kuma, but as a default, we
+suggest `kong-mesh-system`.
+
+1. Create the `kong-mesh-system` namespace:
+
+    ```sh
+    $ kubectl create namespace kong-mesh-system
+    ```
+
+2. Upload the license secret to the cluster:
+
+    ```sh
+    $ kubectl create secret generic kong-mesh-license -n kong-mesh-system --from-file=/path/to/license.json
+    ```
+
+    Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+    license file on the file system.
+
+    <div class="alert alert-ee blue">
+    <strong>Note:</strong>The name of the file should be <code>license.json</code>, unless otherwise specified in <code>values.yaml</code>.
+    </div>
+
+3. Deploy the {{site.mesh_product_name}} Helm chart:
+
+    ```sh
+    $ helm repo update
+    $ helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh
+    ```
+
+    This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    like _multi-zone_.
+
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
+created `kong-mesh-system` namespace, you can access the control plane using either
+the GUI, `kubectl`, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
+
+{% endnavtab %}
+{% navtab kubectl (Read & Write) %}
+You can use {{site.mesh_product_name}} with `kubectl` to perform
+**read and write** operations on {{site.mesh_product_name}} resources. For
+example:
+
+```sh
+$ kubectl get meshes
+
+NAME          AGE
+default       1m
+```
+
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "apiVersion: kuma.io/v1alpha1
+  kind: Mesh
+  metadata:
+    name: default
+  spec:
+    mtls:
+      enabledBackend: ca-1
+      backends:
+      - name: ca-1
+        type: builtin" | kubectl apply -f -
+```
+
+{% endnavtab %}
+{% navtab HTTP API (Read-Only) %}
+
+{{site.mesh_product_name}} ships with a **read-only** HTTP API that you use
+to retrieve {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read-Only) %}
+
+You can use the `kumactl` CLI to perform **read-only** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
+service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Then run `kumactl`. For example:
+
+```sh
+$ kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```
+$ kumactl config control-planes add --name=XYZ --address=http://{address-to-kong-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}} on
+Kubernetes.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).

--- a/app/mesh/1.1.x/installation/kubernetes.md
+++ b/app/mesh/1.1.x/installation/kubernetes.md
@@ -1,0 +1,204 @@
+---
+title: Kong Mesh with Kubernetes
+---
+
+To install and run {{site.mesh_product_name}} on Kubernetes, execute the
+following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+To run {{site.mesh_product_name}} on Kubernetes, you need to download a
+compatible version of {{site.mesh_product_name}} for the machine from which you
+will be executing the commands.
+
+{% navtabs %}
+{% navtab Script %}
+
+You can run the following script to automatically detect the operating system
+and download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+
+{% endnavtab %}
+{% navtab Manually %}
+
+You can also download the distribution manually. Download a distribution for
+the **client host** from where you will be executing the commands to access
+Kubernetes:
+
+* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+## 2. Run {{site.mesh_product_name}}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the
+<code>kuma-cp</code> container &mdash; you need to have a valid
+{{site.mesh_product_name}} license in place.
+</div>
+
+Navigate to the `bin` folder:
+
+```sh
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
+```
+
+Then, run the control plane with:
+
+```sh
+$ kumactl install control-plane --license-path=/path/to/license.json | kubectl apply -f -
+```
+
+Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+license file on the file system.
+
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> It may take a while for Kubernetes to start the
+{{site.mesh_product_name}} resources. You can check the status by executing:
+<pre class="highlight">
+<code>$ kubectl get pod -n kuma-system</code></pre>
+</div>
+
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
+created `kuma-system` namespace, you can access the control plane using either
+the GUI, `kubectl`, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
+
+{% endnavtab %}
+{% navtab kubectl (Read & Write) %}
+You can use {{site.mesh_product_name}} with `kubectl` to perform
+**read and write** operations on {{site.mesh_product_name}} resources. For
+example:
+
+```sh
+$ kubectl get meshes
+
+NAME          AGE
+default       1m
+```
+
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "apiVersion: kuma.io/v1alpha1
+  kind: Mesh
+  metadata:
+    name: default
+  spec:
+    mtls:
+      enabledBackend: ca-1
+      backends:
+      - name: ca-1
+        type: builtin" | kubectl apply -f -
+```
+
+{% endnavtab %}
+{% navtab HTTP API (Read-Only) %}
+
+{{site.mesh_product_name}} ships with a **read-only** HTTP API that you use
+to retrieve {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read-Only) %}
+
+You can use the `kumactl` CLI to perform **read-only** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
+service with:
+
+```sh
+$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Then run `kumactl`. For example:
+
+```sh
+$ kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```
+$ kumactl config control-planes add --name=XYZ --address=http://{address-to-kong-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+After installation, the Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).

--- a/app/mesh/1.1.x/installation/macos.md
+++ b/app/mesh/1.1.x/installation/macos.md
@@ -45,8 +45,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/mesh/1.0.x/install-universal-run.md %}
+{% include /md/mesh/1.1.x/install-universal-run.md %}
 
-{% include /md/mesh/1.0.x/install-universal-verify.md %}
+{% include /md/mesh/1.1.x/install-universal-verify.md %}
 
-{% include /md/mesh/1.0.x/install-universal-quickstart.md %}
+{% include /md/mesh/1.1.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/macos.md
+++ b/app/mesh/1.1.x/installation/macos.md
@@ -1,0 +1,52 @@
+---
+title: Kong Mesh with macOS
+---
+
+To install and run {{site.mesh_product_name}} on macOS, execute the following
+steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+To run {{site.mesh_product_name}} on macOS, you can choose from the following
+installation methods:
+
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+
+{% endnavtab %}
+{% navtab Manually %}
+
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+the distribution manually.
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+{% include /md/mesh/1.0.x/install-universal-run.md %}
+
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
+
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/openshift.md
+++ b/app/mesh/1.1.x/installation/openshift.md
@@ -1,0 +1,276 @@
+---
+title: Kong Mesh with OpenShift
+---
+
+To install and run {{site.mesh_product_name}} on OpenShift, execute the
+following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
+and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+To run {{site.mesh_product_name}} on OpenShift, you need to download a
+compatible version of {{site.mesh_product_name}} for the machine from which
+you will be executing the commands.
+
+{% navtabs %}
+{% navtab Script %}
+
+You can run the following script to automatically detect the operating system
+and download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+
+{% endnavtab %}
+{% navtab Manually %}
+
+You can also download the distribution manually. Download a distribution for
+the **client host** from where you will be executing the commands to access
+Kubernetes:
+
+* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+
+## 2. Run {{site.mesh_product_name}}
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the {{site.mesh_product_name}}
+control plane process in the next step &mdash; which is served by the
+<code>kuma-cp</code> container &mdash; you need to have a valid
+{{site.mesh_product_name}} license in place.
+</div>
+
+Navigate to the `bin` folder:
+
+```sh
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
+```
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always
+available in every working directory. Alternatively, you can also create a link
+in `/usr/local/bin/` by executing:
+
+```sh
+$ ln -s ./kumactl /usr/local/bin/kumactl
+```
+
+Then, run the control plane on OpenShift with:
+
+{% navtabs %}
+{% navtab OpenShift 4.x %}
+
+```sh
+kumactl install control-plane --cni-enabled --license-path=/path/to/license.json | oc apply -f -
+```
+
+Starting from version 4.1, OpenShift uses `nftables` instead of `iptables`. So,
+using init container for redirecting traffic to the proxy no longer works.
+Instead, we use `kuma-cni`, which can be installed with the `--cni-enabled` flag.
+
+{% endnavtab %}
+{% navtab OpenShift 3.11 %}
+
+By default, `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` are
+disabled on OpenShift 3.11.
+
+To make them work, add the following `pluginConfig` into
+`/etc/origin/master/master-config.yaml` on the master node:
+
+```yaml
+admissionConfig:
+  pluginConfig:
+    MutatingAdmissionWebhook:
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1alpha1
+        kubeConfigFile: /dev/null
+        kind: WebhookAdmission
+    ValidatingAdmissionWebhook:
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1alpha1
+        kubeConfigFile: /dev/null
+        kind: WebhookAdmission
+```
+
+After updating `master-config.yaml`, restart the cluster and install
+`control-plane`:
+
+```sh
+$ ./kumactl install control-plane --license-path=/path/to/license.json | oc apply -f -
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
+license file on the file system.
+
+This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+like _multi-zone_.
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> It may take a while for OpenShift to start the
+{{site.mesh_product_name}} resources. You can check the status by executing:
+<pre class="highlight">
+<code>$ oc get pod -n kuma-system</code></pre>
+</div>
+
+## 3. Verify the Installation
+
+Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
+created `kuma-system` namespace, you can access the control plane using either
+the GUI, `oc`, the HTTP API, or the CLI:
+
+{% navtabs %}
+{% navtab GUI (Read-Only) %}
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to
+retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on
+the API port `5681` and defaults to `:5681/gui`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
+
+{% endnavtab %}
+{% navtab oc (Read & Write) %}
+You can use {{site.mesh_product_name}} with `oc` to perform
+**read and write** operations on {{site.mesh_product_name}} resources. For
+example:
+
+```sh
+$ oc get meshes
+
+NAME          AGE
+default       1m
+```
+
+Or, you can enable mTLS on the `default` Mesh with:
+
+```sh
+$ echo "apiVersion: kuma.io/v1alpha1
+  kind: Mesh
+  metadata:
+    name: default
+  spec:
+    mtls:
+      enabledBackend: ca-1
+      backends:
+      - name: ca-1
+        type: builtin" | oc apply -f -
+```
+
+{% endnavtab %}
+{% navtab HTTP API (Read-Only) %}
+
+{{site.mesh_product_name}} ships with a **read-only** HTTP API that you use
+to retrieve {{site.mesh_product_name}} resources. By default,
+the HTTP API listens on port `5681`.
+
+To access {{site.mesh_product_name}}, port-forward the API service with:
+
+```sh
+$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
+
+{% endnavtab %}
+{% navtab kumactl (Read-Only) %}
+
+You can use the `kumactl` CLI to perform **read-only** operations on
+{{site.mesh_product_name}} resources. The `kumactl` binary is a client to
+the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
+service with:
+
+```sh
+$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+```
+
+Then run `kumactl`. For example:
+
+```sh
+$ kumactl get meshes
+
+NAME          mTLS      METRICS      LOGGING   TRACING
+default       off       off          off       off
+```
+
+You can configure `kumactl` to point to any remote `kuma-cp` instance by running:
+
+```
+$ kumactl config control-planes add --name=XYZ --address=http://{address-to-kong-mesh}:5681
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+You will notice that {{site.mesh_product_name}} automatically creates a `Mesh`
+entity with the name `default`.
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> {{site.mesh_product_name}} explicitly specifies a UID
+for <code>kuma-dp</code> sidecar to avoid capturing traffic from
+<code>kuma-dp</code> itself. For that reason, a <code>nonroot</code>
+<a href="https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html">Security Context Constraint</a>
+has to be granted to the application namespace:
+
+<pre>
+<code>$ oc adm policy add-scc-to-group nonroot system:serviceaccounts:&lt;app-namespace&gt;</code></pre>
+
+If the namespace is not configured properly, you will see the following error
+on the <code>Deployment</code> or <code>DeploymentConfig</code>:
+
+<pre>
+<code>'pods "kuma-demo-backend-v0-cd6b68b54-" is forbidden: unable to validate against any security context constraint:
+[spec.containers[1].securityContext.securityContext.runAsUser: Invalid value: 5678: must be in the ranges: [1000540000, 1000549999]]'</code></pre>
+
+</div>
+
+## 4. Quickstart
+
+Congratulations! You have successfully installed {{site.mesh_product_name}}.
+
+<div class="alert alert-ee blue">
+<strong>Note:</strong> Before running the Kuma Demo in the Quickstart guide,
+run the following command:
+
+<pre>
+<code>$ oc adm policy add-scc-to-group anyuid system:serviceaccounts:kuma-demo</code></pre>
+
+One of the components in the demo requires root access, therefore it uses the
+<code>anyuid</code> instead of the <code>nonroot</code> permission.
+</div>
+
+After installation and the above command, the Kuma quickstart documentation
+is fully compatible with {{site.mesh_product_name}}, except that you are
+running {{site.mesh_product_name}} containers instead of the vanilla Kuma ones.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).

--- a/app/mesh/1.1.x/installation/redhat.md
+++ b/app/mesh/1.1.x/installation/redhat.md
@@ -1,0 +1,44 @@
+---
+title: Kong Mesh with RedHat
+---
+
+To install and run {{site.mesh_product_name}} on RedHat (**x86_64**), execute
+the following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system
+and download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+{% endnavtab %}
+{% navtab Manually %}
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz) the distribution manually.
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% include /md/mesh/1.0.x/install-universal-run.md %}
+
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
+
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/redhat.md
+++ b/app/mesh/1.1.x/installation/redhat.md
@@ -37,8 +37,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/mesh/1.0.x/install-universal-run.md %}
+{% include /md/mesh/1.1.x/install-universal-run.md %}
 
-{% include /md/mesh/1.0.x/install-universal-verify.md %}
+{% include /md/mesh/1.1.x/install-universal-verify.md %}
 
-{% include /md/mesh/1.0.x/install-universal-quickstart.md %}
+{% include /md/mesh/1.1.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/ubuntu.md
+++ b/app/mesh/1.1.x/installation/ubuntu.md
@@ -1,0 +1,46 @@
+---
+title: Kong Mesh with Ubuntu
+---
+
+To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**), execute
+the following steps:
+
+* [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)
+* [2. Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+* [3. Verify the Installation](#3-verify-the-installation)
+
+Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
+
+## Prerequisites
+You have a license for {{site.mesh_product_name}}.
+
+## 1. Download {{site.mesh_product_name}}
+
+{% navtabs %}
+{% navtab Script %}
+
+Run the following script to automatically detect the operating system and
+download {{site.mesh_product_name}}:
+
+```sh
+$ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+{% endnavtab %}
+{% navtab Manually %}
+
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+ the distribution manually.
+
+Then, extract the archive with:
+
+```sh
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% include /md/mesh/1.0.x/install-universal-run.md %}
+
+{% include /md/mesh/1.0.x/install-universal-verify.md %}
+
+{% include /md/mesh/1.0.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/installation/ubuntu.md
+++ b/app/mesh/1.1.x/installation/ubuntu.md
@@ -39,8 +39,8 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/mesh/1.0.x/install-universal-run.md %}
+{% include /md/mesh/1.1.x/install-universal-run.md %}
 
-{% include /md/mesh/1.0.x/install-universal-verify.md %}
+{% include /md/mesh/1.1.x/install-universal-verify.md %}
 
-{% include /md/mesh/1.0.x/install-universal-quickstart.md %}
+{% include /md/mesh/1.1.x/install-universal-quickstart.md %}

--- a/app/mesh/1.1.x/overview.md
+++ b/app/mesh/1.1.x/overview.md
@@ -1,0 +1,141 @@
+---
+title: Kong Mesh Overview
+no_search: true
+---
+
+## Introduction
+
+<div class="alert alert-ee blue">
+   <b>Demo</b>: To see {{site.mesh_product_name}} in action, you can
+   <a href="https://konghq.com/request-demo-kong-mesh/">request a demo</a> and
+   we will get in touch with you.
+</div>
+
+Welcome to the official documentation for {{site.mesh_product_name}}!
+
+{{site.mesh_product_name}} is an enterprise-grade service mesh that runs on
+both Kubernetes and VMs on any cloud. Built on top of CNCF's
+[Kuma](https://kuma.io) and Envoy and focused on simplicity,
+{{site.mesh_product_name}} enables the microservices transformation with:
+* Out-of-the-box service connectivity and discovery
+* Zero-trust security
+* Traffic reliability
+* Global observability across all traffic, including cross-cluster deployments
+
+{{site.mesh_product_name}} extends Kuma and Envoy with enterprise features and
+support, while providing native integration with
+[{{site.ee_product_name}}](https://konghq.com/products/kong-enterprise) for a
+full-stack connectivity platform for all of your services and APIs, across
+every cloud and environment.
+
+<div class="alert alert-ee blue">
+   Kuma itself was originally created by Kong and donated to CNCF to
+   provide the first neutral Envoy-based service mesh to the industry. Kong
+   still maintains and develops Kuma, which is the foundation for
+   {{site.mesh_product_name}}.
+</div>
+<br>
+<center>
+  <img src="/assets/images/docs/mesh/kong-mesh-diagram@2x.png" width="500px"/>
+  <br>
+  <i>{{site.mesh_product_name}} extends CNCF's Kuma and Envoy to provide an
+  enterprise-grade service mesh with unique features in the service mesh
+  landscape, while still relying on a neutral foundation.</i>
+</center>
+<br>
+{{site.mesh_product_name}} provides a unique combination of strengths and
+features in the service mesh ecosystem, specifically designed for the enterprise
+architect, including:
+
+* **Universal** support for both Kubernetes and VM-based services.
+* **Single and Multi Zone** deployments to support multi-cloud and multi-cluster
+ environments with global/remote control plane modes, automatic Ingress
+ connectivity, and service discovery.
+* **Multi-Mesh** to create as many service meshes as we need, using one cluster
+ with low operational costs.
+* **Easy to install and use** and turnkey, by abstracting away all the
+complexity of running a service mesh with easy-to-use policies for managing
+services and traffic.
+* **Full-Stack Connectivity** by natively integrating with Kong and
+{{site.ee_product_name}} for end-to-end connectivity that goes from the API
+gateway to the service mesh.
+* **Powered by Kuma and Envoy** to provide a modern and reliable CNCF
+open source foundation for an enterprise service mesh.
+
+When used in combination with {{site.ee_product_name}}, {{site.mesh_product_name}}
+provides a full stack connectivity platform for all of our L4-L7 connectivity,
+for both edge and internal API traffic.
+
+<center>
+  <img src="/assets/images/docs/mesh/gw_mesh.png" width="600px"/>
+  <br>
+  <i>Two different applications - "Banking" and "Trading" - run in their
+  own meshes "A" and "B" across different datacenters. In this example,
+  Kong Gateway is being used both for edge communication, and for internal
+  communication between meshes.</i>
+</center>
+
+## Why {{site.mesh_product_name}}? {#why-kong-mesh}
+
+Organizations are transitioning to distributed software architectures to
+support and accelerate innovation, gain digital revenue, and reduce costs.
+A successful transition to microservices requires many pieces to fall into
+place: that services are connected reliably with minimal latency,
+that they are protected with end-to-end security, that they are discoverable
+and fully observable. However, this presents challenges due to the need to
+write custom code for security and identity, a lack of granular telemetry,
+and insufficient traffic management capabilities, especially as the number of
+services grows.
+
+Leading organizations are looking to service meshes to address these challenges
+in a scalable and standardized way. With a service mesh, you can:
+
+* **Ensure service connectivity, discovery, and traffic reliability**: Apply
+out-of-box traffic management to intelligently route traffic across any
+platform and any cloud to meet expectations and SLAs.
+* **Achieve Zero-Trust Security**: Restrict access by default, encrypt all
+traffic, and only complete transactions when identity is verified.
+* **Gain Global Traffic Observability**: Gain a detailed understanding of your
+service behavior to increase application reliability and the efficiency of
+your teams.
+
+{{site.mesh_product_name}} is the universal service mesh for enterprise
+organizations focused on simplicity and scalability with Kuma and Envoy.
+Kong’s service mesh is unique in that it allows you to:
+
+* **Start, secure, and scale with ease**:
+  * Deploy a turnkey service mesh with a single command.
+  * Group services by attributes to efficiently apply policies.
+  * Manage multiple service meshes as tenants of a single control plane to
+  provide scale and reduce operational costs.
+* **Run anywhere**:
+  * Deploy the service mesh across any environment, including multi-cluster,
+  multi-cloud, and multi-platform.
+  * Manage service meshes natively in Kubernetes using CRDs, or start with a
+  service mesh in a VM environment and migrate to Kubernetes at your own pace.
+* **Connect services end-to-end**:
+  * Integrate into the {{site.ee_product_name}} platform for full stack connectivity,
+  including Ingress and Egress traffic for your service mesh.
+  * Expose mesh services for internal or external consumption and manage the
+  full lifecycle of APIs.
+
+Thanks to the underlying Kuma runtime, with {{site.mesh_product_name}}, you
+can easily support multiple clusters, clouds, and architectures using the
+multi-zone capability that ships out of the box. This &mdash; combined with
+multi-mesh support &mdash; lets you create a service mesh powered by an Envoy proxy
+for the entire organization in just a few steps. You can do this for both
+simple and distributed deployments, including multi-cloud, multi-cluster, and
+hybrid Kubernetes/VMs:
+
+<center>
+  <img src="/assets/images/docs/mesh/multi-zone.jpg" width="600px"/>
+  <br>
+  <i>{{site.mesh_product_name}} can support multiple zones (like a Kubernetes
+    cluster, VPC, datacenter, etc.) together in the same distributed deployment.
+     Then, you can create multiple isolated virtual meshes with the same
+     control plane in order to support every team and application in the
+     organization.</i>
+</center>
+<br>
+[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+standalone and multi-zone deployment modes in the Kuma documentation.


### PR DESCRIPTION
No docs ticket (should have tickets for minor releases in the future, as well as a schedule). 

Kong Mesh 1.1.0 was released Nov 27th: https://konghq.com/blog/kong-mesh-1-1-ga-released/

This PR creates a new doc version for 1.1.0 and fixes a couple of issues with the layout to make the release display properly.

### Changes
- Create new version for 1.1.x and all metadata 
- Update version variables (more on this TBA)
- Fix layout to pull the correct URLs for the version dropdown
- Fix "outdated version" banner for old versions, as it was picking up the wrong product name.
- Change `KUMA_LICENSE_PATH` variable to `KMESH_LICENSE_PATH` for 1.1.x

### Previews
* [Mesh landing page](https://deploy-preview-2481--kongdocs.netlify.app/mesh/) (new version in dropdown, 1.1.x) - check that dropdown links to the correct versions and product
* [1.1.x Installation topics](https://deploy-preview-2481--kongdocs.netlify.app/mesh/1.1.x/install) - topics point to 1.1.0 and if the installation refers to the `LICENSE_PATH` variable, it's now `KMESH_LICENSE_PATH`. For example:
  * [Docker install](https://deploy-preview-2481--kongdocs.netlify.app/mesh/1.1.x/installation/docker/#2-run-kong-mesh)
  * [CentOS install](https://deploy-preview-2481--kongdocs.netlify.app/mesh/1.1.x/installation/centos/#2-run-kong-mesh)
* [1.0.x installation overview page](https://deploy-preview-2481--kongdocs.netlify.app/mesh/1.0.x/install/) refers to the correct minor and patch versions; yellow banner at the top of the page refers to Kong Mesh and links to the latest version of Kong Mesh.