### PR TITLE
Initial Draft on improving Kong with Kubernetes documentation

### DIFF
--- a/app/enterprise/2.2.x/deployment/install-kong-in-kubernetes.md
+++ b/app/enterprise/2.2.x/deployment/install-kong-in-kubernetes.md
@@ -1,0 +1,34 @@
+---
+title: Kong Enterprise in Kubernetes
+---
+
+# Install Options
+
+Kong provides two main Enterprise packages that you can deploy with Kubernetes. These packages are normally deployed in one of three ways, each with its pros and cons which are outlined below:
+
+1. **[Kong for Kubernetes Enterprise (K4K8s)](/enterprise/{{page.kong_version}}/deployment/installation/kong-for-kubernetes/)**: The Kong Ingress Controller (KIC) with
+Enterprise plugins. \
+_**Pros:** No DB required. Majority Kong Enterprise plugins are compatible_\
+_**Cons:** Kong Manager, Vitals (analytics), Developer Portal, RBAC, Immunity, Workspaces are **disabled**._\
+\
+If you're interested in deploying this option, please click [here](/enterprise/{{page.kong_version}}/deployment/installation/kong-for-kubernetes/) for additional information and instructions.
+
+2. **[Kong Enterprise on Kubernetes (w/KIC)](/enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes/)**: The whole Kong Enterprise platform
+deployed on Kubernetes, **including**  Kong's Ingress Controller (documentation <a href="https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/concepts/design.md">here</a>).\
+_**Pros:** Full platform is included: Kong Manager, Vitals (analytics), Developer Portal, RBAC, Immunity, Workspaces, etc. By installing Kong's Ingress Controller (KIC), you can configure the gateway the same way you configure K8s, using kubectl with declarative configuration files._\
+_**Cons:** Requires a database. Need to deploy an ingress controller._\
+\
+If you're interested in deploying this option, please click [here](/enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes/) for additional information and instructions.
+
+3. **[Kong Enterprise on Kubernetes (without KIC)](/enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes-without-kic/)**: The whole Kong Enterprise platform
+deployed on Kubernetes, **without** the Kong Ingress Controller.\
+_**Pros:** Full platform is included (Kong Manager, Vitals (analytics), Developer Portal, RBAC, Immunity, Workspaces, etc._\
+_**Cons:** Requires a database. By **not** installing Kong's Ingress Controller (KIC),  you may need create Kubernetes services and DNS entries to properly expose the applications that live in your K8s cluster. _\
+\
+If you're interested in deploying this option, please click [here](/enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes-without-kic/) for additional information and instructions.
+
+
+## See Also
+
+For more information about the architecture of Kong's Ingress Controller (KIC), see
+[Kong Ingress Controller Design](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/concepts/design.md).

--- a/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes-without-kic.md
+++ b/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes-without-kic.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Kong Enterprise on Kubernetes (w/KIC)
+title: Installing Kong Enterprise on Kubernetes (without KIC)
 ---
 
 ## Introduction
@@ -193,7 +193,7 @@ In the following steps, replace `<your-password>` with a secure password.
     |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
-    |`ingressController.enabled` | Set to `true` as we want to use the Kong Ingress Controller. |
+    |`ingressController.enabled` | Set to `false` as we do not want to use the Kong Ingress Controller. |
     |`postgresql.enabled` | Set to `true` to deploy a Postgres database along with Kong. |
     |`postgresql.postgresqlUsername` | Set Postgres user (e.g. `kong`). |
     |`postgresql.postgresqlPassword` | Set Postgres user's password. |

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -20,20 +20,14 @@ disable_image_expand: true
     <div class="install-description">Install Kong Enterprise on Docker</div>
   </a>
 
-  <a href="/enterprise/{{page.kong_version}}/deployment/installation/kong-for-kubernetes" class="docs-grid-install-block">
+  <a href="/enterprise/{{page.kong_version}}/deployment/install-kong-in-kubernetes" class="docs-grid-install-block">
     <img class="install-icon" src="/assets/images/icons/documentation/k8s-and-openshift.png" alt="kubernetes" />
-    <div class="install-text">K4K8s Enterprise
-    <br/>(Kong Ingress Controller)</div>
+    <div class="install-text">Kubernetes
+    <br/></div>
     <div class="install-description">(kubectl or OpenShift oc)
-    <br/><br/>Install the Kong Ingress Controller with the Kong Gateway (Enterprise), without any Enterprise add-ons</div>
+    <br/><br/>Install Kong with Kubernetes, vanilla or OpenShift</div>
   </a>
 
-  <a href="/enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes" class="docs-grid-install-block">
-    <img class="install-icon" src="/assets/images/icons/documentation/k8s-and-openshift.png" alt="kubernetes" />
-    <div class="install-text">Full Kong Enterprise on Kubernetes</div>
-    <div class="install-description">(kubectl or OpenShift oc)
-    <br/><br/>Install Kong Enterprise on Kubernetes with Enterprise plugins and add-ons, optionally with the Kong Ingress Controller</div>
-  </a>
 
 </div>
 

--- a/app/enterprise/2.2.x/deployment/kubernetes-deployment-options.md
+++ b/app/enterprise/2.2.x/deployment/kubernetes-deployment-options.md
@@ -10,7 +10,8 @@ As of 2.1.x, Kong for Kubernetes with Kong Enterprise
 (the [kong-enterprise-edition][enterprise-bintray] proxy image) supports DB-less
 operation and is recommended for all deployments.
 * [DB-less installation with the Kong Ingress Controller][k4k8s-enterprise-install]
-* [Database-backed installation with or without the Kong Ingress Controller][k4k8s-with-enterprise-install]
+* [Database-backed installation with the Kong Ingress Controller][k4k8s-with-enterprise-with-kic-install]
+* [Database-backed installation without the Kong Ingress Controller][k4k8s-with-enterprise-without-kic-install]
 
 > The Bintray repository requires a login. If you see a 404, log in through the
 [Kong repository home page](https://bintray.com/kong) first.
@@ -161,7 +162,8 @@ migrating in the opposite direction.
 [route-validation]: /enterprise/{{page.kong_version}}/property-reference/#route_validation_strategy
 [supported-plugins]: https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/plugin-compatibility.md
 [k4k8s-enterprise-install]: /enterprise/{{page.kong_version}}/deployment/installation/kong-for-kubernetes
-[k4k8s-with-enterprise-install]: /enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes
+[k4k8s-with-enterprise-with-kic-install]: /enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes
+[k4k8s-with-enterprise-without-kic-install]: /enterprise/{{page.kong_version}}/deployment/installation/kong-on-kubernetes-without-kic/
 [vitals-prometheus]: /enterprise/{{page.kong_version}}/vitals/vitals-prometheus-strategy/
 [vitals-influxdb]: /enterprise/{{page.kong_version}}/vitals/vitals-influx-strategy/
 [support]: https://support.konghq.com/


### PR DESCRIPTION
@felderi / @nedward - Here you will find a PR on the initial stab at helping with our Kong with Kubernetes documentation. Currently, this PR does the following: 
- On the "General" Install page, merges the two K8s options that the user had into one. 
- This Kubernetes option takes the user to a page where you will see the three options on how to deploy Kong in K8s: DB-less, DB-full with KIC and DB-full without KIC. Each of the options have its pros and cons.
- The links for all of these options send the user to detailed instructions on how to get their selected option up and running
- The K4K8s (aka, DB-less) option is complete

Now, there are a couple of things that still need to be done: 
- The DB-full with KIC option is still only using helm. There are no commands for kubectl
- The DB-full without KIC option is, as of now, simply a copy of the KIC option. Hence, it needs to be rewritten to address the complexities that come up when deploying without a KIC and potential solutions. Additionally, similar to above, we need to add the kubectl commands.


<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

