### PR TITLE
fix(banner) Fix docs site banner in safari

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -414,12 +414,23 @@
     bottom: 0;
     max-width: 100%;
     background-size: cover;
-    background-image: linear-gradient(to bottom, #ffffff, 40%, transparent),
+    background-image: linear-gradient(
+        to bottom,
+        #ffffff,
+        40%,
+        transparent
+      ),
       url("/assets/images/docs/banner-bkg.png");
     background-image: -moz-linear-gradient(
         bottom,
         rgba(255, 255, 255, 0) 40%,
         #ffffff
+      ),
+      url("/assets/images/docs/banner-bkg.png");
+    background-image: -webkit-linear-gradient(
+        top,
+        rgba(255,255,255,1) 0%,
+        rgba(255,255,255,0) 100%
       ),
       url("/assets/images/docs/banner-bkg.png");
     transform: translateX(-50%);


### PR DESCRIPTION
Fixing the gradient issue:
<img width="1263" alt="Screen Shot 2020-12-03 at 10 07 24 AM" src="https://user-images.githubusercontent.com/54370747/101069867-6fd74700-354f-11eb-9c47-d214adae6294.png">

To preview fix, open preview link in Safari.
