### PR TITLE
docs(ee-install) Update AWS AMI links for 2.2

### DIFF
--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -53,7 +53,7 @@
         - text: Marketplaces
           items:
             - text: AWS (AMI)
-              url: https://aws.amazon.com/marketplace/pp/B084L6PQPY?ref_=srh_res_product_title
+              url: https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title
               absolute_url: true
             - text: AWS (EKS)
               url: https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -71,7 +71,7 @@ disable_image_expand: true
 {% navtab Marketplaces %}
 <div class="docs-grid-install">
 
-  <a href="https://aws.amazon.com/marketplace/pp/B084L6PQPY?ref_=srh_res_product_title" class="docs-grid-install-block no-description">
+  <a href="https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
     <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>


### PR DESCRIPTION
Based on https://konghq.atlassian.net/wiki/spaces/CP/pages/1299481287/Marketplace+Integrations.

Note: Azure has also been updated to a Kong Enterprise 2.2 image, but that link doesn't change. 

Preview: https://deploy-preview-2488--kongdocs.netlify.app/enterprise/2.2.x/deployment/installation/overview/ > Marketplaces tab