### PR TITLE
fix(kic) update outdated KongIngress annotations

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/using-kongingress-resource.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/using-kongingress-resource.md
@@ -196,7 +196,7 @@ kongingress.configuration.konghq.com/demo-customization created
 Now, let's associate this KongIngress resource to the echo service.
 
 ```bash
-$ kubectl patch service echo -p '{"metadata":{"annotations":{"configuration.konghq.com":"demo-customization"}}}'
+$ kubectl patch service echo -p '{"metadata":{"annotations":{"konghq.com/override":"demo-customization"}}}'
 service/echo patched
 ```
 

--- a/app/kubernetes-ingress-controller/1.0.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.0.x/references/custom-resources.md
@@ -229,7 +229,7 @@ Once a `KongIngress` resource is created, it needs to be associated with
 an Ingress or Service resource using the following annotation:
 
 ```yaml
-configuration.konghq.com: kong-ingress-resource-name
+konghq.com/override: kong-ingress-resource-name
 ```
 
 Specifically,


### PR DESCRIPTION
Several locations in the docs still used the outdated `configuration.konghq.com` annotation for applying KongIngress resources. Support for that was removed in 1.0.0; it was replaced with the `konghq.com/override` annotation.

Thought those were all fixed before the migration from the old repo docs, but it looks like a few got missed :woman_shrugging: 