### PR TITLE
docs(ee-license) Add note to use your own license for Docker installs

### DIFF
--- a/app/enterprise/1.3-x/deployment/installation/docker.md
+++ b/app/enterprise/1.3-x/deployment/installation/docker.md
@@ -75,11 +75,21 @@ $ docker run -d --name kong-ee-database \
 
 ## Step 4. Export the License Key to a Variable
 
+Run the following command, substituting your own license key (see
+[Prerequisites](#prerequisites)).
+
+The license data must contain straight quotes to be considered valid JSON
+(`'` and `"`, not `’` or `“`).
+
+<div class="alert alert-ee blue">
+<b>Note:</b>
+The following license is only an example. You must use the following format,
+but provide your own content.
+</div>
+
 ```bash
 $ export KONG_LICENSE_DATA='{"license":{"signature":"LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tClZlcnNpb246IEdudVBHIHYyCgpvd0did012TXdDSFdzMTVuUWw3dHhLK01wOTJTR0tLWVc3UU16WTBTVTVNc2toSVREWk1OTFEzVExJek1MY3dTCjA0ek1UVk1OREEwc2pRM04wOHpNalZKVHpOTE1EWk9TVTFLTXpRMVRVNHpTRXMzTjA0d056VXdUTytKWUdNUTQKR05oWW1VQ21NWEJ4Q3NDc3lMQmorTVBmOFhyWmZkNkNqVnJidmkyLzZ6THhzcitBclZtcFZWdnN1K1NiKzFhbgozcjNCeUxCZzdZOVdFL2FYQXJ0NG5lcmVpa2tZS1ozMlNlbGQvMm5iYkRzcmdlWFQzek1BQUE9PQo9b1VnSgotLS0tLUVORCBQR1AgTUVTU0FHRS0tLS0tCg=","payload":{"customer":"Test Company Inc","license_creation_date":"2017-11-08","product_subscription":"Kong Enterprise","admin_seats":"5","support_plan":"None","license_expiration_date":"2017-11-10","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU"},"version":1}}'
 ```
-
-**Note:** the license data must contain only straight quotes to be considered valid JSON. (`'` and `"`, not `’` or `“`)
 
 ## Step 5. Prepare the Kong Database
 
@@ -141,7 +151,7 @@ Verify that Kong Manager is running by accessing it using the URL specified in `
 
 ## Step 8. Enable the Developer Portal
 
-Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of your Docker host: 
+Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of your Docker host:
 
   ```bash
   $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default --data "config.portal=true"

--- a/app/enterprise/1.5.x/deployment/installation/docker.md
+++ b/app/enterprise/1.5.x/deployment/installation/docker.md
@@ -68,11 +68,21 @@ $ docker run -d --name kong-ee-database \
 
 ## Step 4. Export the License Key to a Variable
 
+Run the following command, substituting your own license key (see
+[Prerequisites](#prerequisites)).
+
+The license data must contain straight quotes to be considered valid JSON
+(`'` and `"`, not `’` or `“`).
+
+<div class="alert alert-ee blue">
+<b>Note:</b>
+The following license is only an example. You must use the following format,
+but provide your own content.
+</div>
+
 ```bash
 $ export KONG_LICENSE_DATA='{"license":{"signature":"LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tClZlcnNpb246IEdudVBHIHYyCgpvd0did012TXdDSFdzMTVuUWw3dHhLK01wOTJTR0tLWVc3UU16WTBTVTVNc2toSVREWk1OTFEzVExJek1MY3dTCjA0ek1UVk1OREEwc2pRM04wOHpNalZKVHpOTE1EWk9TVTFLTXpRMVRVNHpTRXMzTjA0d056VXdUTytKWUdNUTQKR05oWW1VQ21NWEJ4Q3NDc3lMQmorTVBmOFhyWmZkNkNqVnJidmkyLzZ6THhzcitBclZtcFZWdnN1K1NiKzFhbgozcjNCeUxCZzdZOVdFL2FYQXJ0NG5lcmVpa2tZS1ozMlNlbGQvMm5iYkRzcmdlWFQzek1BQUE9PQo9b1VnSgotLS0tLUVORCBQR1AgTUVTU0FHRS0tLS0tCg=","payload":{"customer":"Test Company Inc","license_creation_date":"2017-11-08","product_subscription":"Kong Enterprise","admin_seats":"5","support_plan":"None","license_expiration_date":"2017-11-10","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU"},"version":1}}'
 ```
-
-**Note:** the license data must contain only straight quotes to be considered valid JSON. (`'` and `"`, not `’` or `“`)
 
 ## Step 5. Prepare the Kong Database
 
@@ -134,7 +144,7 @@ Verify that Kong Manager is running by accessing it using the URL specified in `
 
 ## Step 8. Enable the Developer Portal
 
-Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of your Docker host: 
+Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of your Docker host:
 
   ```bash
   $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default --data "config.portal=true"

--- a/app/enterprise/2.1.x/deployment/installation/docker.md
+++ b/app/enterprise/2.1.x/deployment/installation/docker.md
@@ -73,11 +73,21 @@ $ docker run -d --name kong-ee-database \
 
 ## Step 4. Export the License Key to a Variable {#license-key}
 
+Run the following command, substituting your own license key (see
+[Prerequisites](#prerequisites)).
+
+The license data must contain straight quotes to be considered valid JSON
+(`'` and `"`, not `’` or `“`).
+
+<div class="alert alert-ee blue">
+<b>Note:</b>
+The following license is only an example. You must use the following format,
+but provide your own content.
+</div>
+
 ```bash
 $ export KONG_LICENSE_DATA='{"license":{"signature":"LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tClZlcnNpb246IEdudVBHIHYyCgpvd0did012TXdDSFdzMTVuUWw3dHhLK01wOTJTR0tLWVc3UU16WTBTVTVNc2toSVREWk1OTFEzVExJek1MY3dTCjA0ek1UVk1OREEwc2pRM04wOHpNalZKVHpOTE1EWk9TVTFLTXpRMVRVNHpTRXMzTjA0d056VXdUTytKWUdNUTQKR05oWW1VQ21NWEJ4Q3NDc3lMQmorTVBmOFhyWmZkNkNqVnJidmkyLzZ6THhzcitBclZtcFZWdnN1K1NiKzFhbgozcjNCeUxCZzdZOVdFL2FYQXJ0NG5lcmVpa2tZS1ozMlNlbGQvMm5iYkRzcmdlWFQzek1BQUE9PQo9b1VnSgotLS0tLUVORCBQR1AgTUVTU0FHRS0tLS0tCg=","payload":{"customer":"Test Company Inc","license_creation_date":"2017-11-08","product_subscription":"Kong Enterprise","admin_seats":"5","support_plan":"None","license_expiration_date":"2017-11-10","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU"},"version":1}}'
 ```
-
-**Note:** the license data must contain only straight quotes to be considered valid JSON. (`'` and `"`, not `’` or `“`)
 
 ## Step 5. Prepare the Kong Database
 

--- a/app/enterprise/2.2.x/deployment/installation/docker.md
+++ b/app/enterprise/2.2.x/deployment/installation/docker.md
@@ -73,11 +73,21 @@ $ docker run -d --name kong-ee-database \
 
 ## Step 4. Export the License Key to a Variable {#license-key}
 
+Run the following command, substituting your own license key (see
+[Prerequisites](#prerequisites)).
+
+The license data must contain straight quotes to be considered valid JSON
+(`'` and `"`, not `’` or `“`).
+
+<div class="alert alert-ee blue">
+<b>Note:</b>
+The following license is only an example. You must use the following format,
+but provide your own content.
+</div>
+
 ```bash
 $ export KONG_LICENSE_DATA='{"license":{"signature":"LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tClZlcnNpb246IEdudVBHIHYyCgpvd0did012TXdDSFdzMTVuUWw3dHhLK01wOTJTR0tLWVc3UU16WTBTVTVNc2toSVREWk1OTFEzVExJek1MY3dTCjA0ek1UVk1OREEwc2pRM04wOHpNalZKVHpOTE1EWk9TVTFLTXpRMVRVNHpTRXMzTjA0d056VXdUTytKWUdNUTQKR05oWW1VQ21NWEJ4Q3NDc3lMQmorTVBmOFhyWmZkNkNqVnJidmkyLzZ6THhzcitBclZtcFZWdnN1K1NiKzFhbgozcjNCeUxCZzdZOVdFL2FYQXJ0NG5lcmVpa2tZS1ozMlNlbGQvMm5iYkRzcmdlWFQzek1BQUE9PQo9b1VnSgotLS0tLUVORCBQR1AgTUVTU0FHRS0tLS0tCg=","payload":{"customer":"Test Company Inc","license_creation_date":"2017-11-08","product_subscription":"Kong Enterprise","admin_seats":"5","support_plan":"None","license_expiration_date":"2017-11-10","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU"},"version":1}}'
 ```
-
-**Note:** the license data must contain only straight quotes to be considered valid JSON. (`'` and `"`, not `’` or `“`)
 
 ## Step 5. Prepare the Kong Database
 


### PR DESCRIPTION
Based on docs ticket: https://konghq.atlassian.net/browse/DOCS-1435

Changed only Docker installation pages, as none of the other install topics include a license sample. 