### PR TITLE
fix(decK+KIC) Remove Harry's email from docs

### DIFF
--- a/app/deck/overview.md
+++ b/app/deck/overview.md
@@ -97,11 +97,9 @@ decK's state file can contain sensitive data such as private keys of
 certificates, credentials, etc. It is left up to the user to manage
 and store the state file in a secure fashion.
 
-If you believe that you have found a security vulnerability in decK, please
+If you believe that you have found a security vulnerability in decK,
 submit a detailed report, along with reproducible steps
-to Harry Bagdi (email address is first name last name At gmail Dot com).
-I will try to respond in a timely manner and will really appreciate it you
-report the issue privately first.
+to [security@konghq.com](mailto:security@konghq.com).
 
 ## Getting help
 

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/gke.md
@@ -62,7 +62,7 @@ roleRef:
 subjects:
 - kind: User
   name: <the current user using kubectl> # usually the Google account
-                                         # eg: harry@konghq.com
+                                         # e.g.: example@testorg.com
   namespace: kube-system" | kubectl apply -f -
 
 ```


### PR DESCRIPTION
Based on slack convo, and also common sense: shouldn't have any personal emails in the docs. 

Preview: 
https://deploy-preview-2495--kongdocs.netlify.app/deck/overview/#security
https://deploy-preview-2495--kongdocs.netlify.app/kubernetes-ingress-controller/1.0.x/deployment/gke/#update-user-permissions