### PR TITLE
Bracket issues Exit Transformer example (need SME review before DOCS review)

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -207,7 +207,7 @@ return function(status, body, headers)
   if not headers then
     headers = { ["X-Message"] = "This adds X-Message to an empty set of headers" }
   else
-    headers = { ["X-Message"] = "This adds X-Message to an existing set of headers" }
+    headers["X-Message"] = "This adds X-Message to an existing set of headers"
   end
 
   return status, body, headers

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -205,9 +205,9 @@ return function(status, body, headers)
   end
 
   if not headers then
-    headers = { X-Message = "This adds X-Message to an empty set of headers" }
+    headers = { [X-Message] = "This adds X-Message to an empty set of headers" }
   else
-    headers["X-Message"] = "This adds X-Message to an existing set of headers" }
+    headers = { [X-Message] = "This adds X-Message to an existing set of headers" }
   end
 
   return status, body, headers

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -205,9 +205,9 @@ return function(status, body, headers)
   end
 
   if not headers then
-    headers = { [X-Message] = "This adds X-Message to an empty set of headers" }
+    headers = { ["X-Message"] = "This adds X-Message to an empty set of headers" }
   else
-    headers = { [X-Message] = "This adds X-Message to an existing set of headers" }
+    headers = { ["X-Message"] = "This adds X-Message to an existing set of headers" }
   end
 
   return status, body, headers


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1456

Per Lluis:

It does need brackets and "

the logic goes as:

foo = { some = "this is ok" }
foo = { ["some-thing"] = "this is ok too" }
foo = { some-thing = "this is not ok and does not work" }

headers = { some = "thing", ["some-other"] = "thingie" }
...
print(headers.some)
print(headers["some"])
print(headers["some-other"])
...
headers.foo = "bar"
headers["bar"] = "baz"
headers["foo-bar-baz"] = "fuzz"
...

See: 

https://github.com/Kong/docs.konghq.com/blame/70847c2447fe467b99830a7d343c3672d2274d0b/app/_hub/kong-inc/exit-transformer/index.md#L273