### PR TITLE
fix(k8s) correct port-forward example

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/configuring-custom-entities.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/configuring-custom-entities.md
@@ -154,7 +154,7 @@ on Kong's Admin API.
 You can forward traffic from your local machine to the Kong Pod to access it:
 
 ```bash
-$ kubectl port-forward kong/kong-pod-name 8444:8444
+$ kubectl port-forward -n kong KONG-POD-NAME 8444:8444
 ```
 
 and in a separate terminal:


### PR DESCRIPTION
This example was not correct. For `port-forward` commands, the `class/instance` syntax allows you to switch from forwarding to a 

>  Use resource type/name such as deployment/mydeployment to select a pod. Resource type defaults to 'pod' if omitted.

Converted to `-n`, which is correct for the namespace.