### PR TITLE
docs(codeblocks) Disabled selecting the $ marker in codeblocks

### DIFF
--- a/app/_assets/stylesheets/syntax.less
+++ b/app/_assets/stylesheets/syntax.less
@@ -61,7 +61,7 @@
 .il { color: #009999 } /* Literal.Number.Integer.Long */
 
 /* Disable selecting $ prompt, e.g. shell curl call docs */
-.gp {
+.gp, .nv {
   -webkit-user-select: none;
   -khtml-user-drag: none;
   -khtml-user-select: none;


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-852

**Note:** will only work on codeblocks with a language specified (eg ```bash)

**Preview:** https://deploy-preview-2502--kongdocs.netlify.app/enterprise/2.2.x/deployment/installation/docker/ - try selecting the code directly by highlighting the text in the codeblock (not using the copy-code icon).