### PR TITLE
docs(ee-immunity) Add icon for immunity and replace brain icon in nav

### DIFF
--- a/app/_assets/images/icons/documentation/icn-immunity-color.svg
+++ b/app/_assets/images/icons/documentation/icn-immunity-color.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="31px" height="33px" viewBox="0 0 31 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icn-immunity-color</title>
+    <g id="Page-1" stroke="none" stroke-width="1.5" fill="none" fill-rule="evenodd">
+        <g id="icn-immunity-color" transform="translate(1.000000, 1.000000)" stroke="#0070BF">
+            <ellipse id="Oval-2" cx="14.4015305" cy="14.5176262" rx="4.1797555" ry="14.2155629"></ellipse>
+            <ellipse id="Oval-2" transform="translate(14.401530, 14.517627) rotate(125.000000) translate(-14.401530, -14.517627) " cx="14.4015304" cy="14.5176265" rx="4.1797555" ry="14.2155629"></ellipse>
+            <ellipse id="Oval-2" transform="translate(14.401530, 14.517626) scale(-1, 1) rotate(-55.000000) translate(-14.401530, -14.517626) " cx="14.4015304" cy="14.5176261" rx="4.1797555" ry="14.2155629"></ellipse>
+            <circle id="Oval-3" fill="#0070BF" fill-rule="nonzero" cx="26.8387097" cy="5.67741935" r="2.06451613"></circle>
+            <circle id="Oval-3" fill="#0070BF" fill-rule="nonzero" cx="14.4516129" cy="29.4193548" r="2.06451613"></circle>
+            <circle id="Oval-3" fill="#0070BF" fill-rule="nonzero" cx="2.06451613" cy="5.67741935" r="2.06451613"></circle>
+        </g>
+    </g>
+</svg>

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -600,7 +600,7 @@
       url: /vitals/vitals-prometheus-strategy
 
 - title: Kong Immunity
-  icon: /assets/images/icons/documentation/icn-brain-color.svg
+  icon: /assets/images/icons/documentation/icn-immunity-color.svg
   items:
     - text: Overview
       url: /immunity/overview


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1339

Preview: see Immunity section in the 2.2.x nav: https://deploy-preview-2503--kongdocs.netlify.app/enterprise/
Brain was still available in earlier versions of 2.1.3.x, so none of the navs before 2.2.x need to change.