### PR TITLE
docs(datadog) corrects metrics field name in docs (FTI-2131)

### DIFF
--- a/app/_hub/kong-inc/datadog/0.1-x.md
+++ b/app/_hub/kong-inc/datadog/0.1-x.md
@@ -94,7 +94,7 @@ Field           | description                                           | allowe
 `name`          | Datadog metric's name                                 | [Metrics](#metrics)
 `stat_type`     | determines what sort of event the metric represents   | `gauge`, `timer`, `counter`, `histogram`, `meter` and `set`
 `sample_rate`<br>*conditional*   | sampling rate                        | `number`
-`customer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
+`consumer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
 `tags`<br>*optional*| List of tags                                      | `key[:value]`
 
 ### Metric requirements
@@ -103,7 +103,7 @@ Field           | description                                           | allowe
 2.  metric with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
 3.  `unique_users` metric only works with `stat_type` as `set`.
 4.  `status_count`, `status_count_per_user` and `request_per_user` work only with `stat_type`  as `counter`.
-5.  `status_count_per_user`, `request_per_user` and `unique_users` must have `customer_identifier` defined.
+5.  `status_count_per_user`, `request_per_user` and `unique_users` must have `consumer_identifier` defined.
 
 
 ## Kong Process Errors

--- a/app/_hub/kong-inc/datadog/1.0-x.md
+++ b/app/_hub/kong-inc/datadog/1.0-x.md
@@ -105,7 +105,7 @@ Field           | description                                           | allowe
 `name`          | Datadog metric's name                                 | [Metrics](#metrics)
 `stat_type`     | determines what sort of event the metric represents   | `gauge`, `timer`, `counter`, `histogram`, `meter` and `set`
 `sample_rate`<br>*conditional*   | sampling rate                        | `number`
-`customer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
+`consumer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
 `tags`<br>*optional*| List of tags                                      | `key[:value]`
 
 ### Metric requirements
@@ -114,7 +114,7 @@ Field           | description                                           | allowe
 2.  metric with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
 3.  `unique_users` metric only works with `stat_type` as `set`.
 4.  `status_count`, `status_count_per_user` and `request_per_user` work only with `stat_type`  as `counter`.
-5.  `status_count_per_user`, `request_per_user` and `unique_users` must have `customer_identifier` defined.
+5.  `status_count_per_user`, `request_per_user` and `unique_users` must have `consumer_identifier` defined.
 
 
 ## Kong Process Errors

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -105,7 +105,7 @@ Field           | description                                           | allowe
 `name`          | Datadog metric's name                                 | [Metrics](#metrics)
 `stat_type`     | determines what sort of event the metric represents   | `gauge`, `timer`, `counter`, `histogram`, `meter` and `set`
 `sample_rate`<br>*conditional*   | sampling rate                        | `number`
-`customer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
+`consumer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
 `tags`<br>*optional*| List of tags                                      | `key[:value]`
 
 ### Metric requirements


### PR DESCRIPTION
The optional Metrics field is incorrectly documented as
`customer_identifier`. It should in fact be `consumer_identifier` [1].

[1] https://github.com/Kong/kong/blob/72821447ede25a86709ee6d7af29424f9a841725/kong/plugins/datadog/schema.lua#L90

Signed-off-by: Jeremy J. Miller <jeremy.miller@konghq.com>


