### PR TITLE
docs(kong-user) fix install notes to switch users

### DIFF
--- a/app/_includes/md/2.2.x/ee-kong-user.md
+++ b/app/_includes/md/2.2.x/ee-kong-user.md
@@ -3,9 +3,9 @@ Amazon Linux 2, CentOS, Ubuntu, and RHEL -->
 
 <div class="alert alert-ee blue">
 <b>Note:</b> When you start Kong, the Nginx master process runs
-as <code>root</code>, and the worker processes run as <code>nobody</code> by
+as <code>root</code>, and the worker processes run as <code>kong</code> by
 default. If this is not the desired behavior, you can switch to the built-in
-<code>kong</code> user and group before starting Kong in the following steps.
+<code>kong</code> user or to a custom non-root user before starting Kong.
 For more information, see
 <a href="/enterprise/{{page.kong_version}}/deployment/kong-user">Running Kong as a Non-Root User</a>.
 </div>

--- a/app/_includes/md/2.2.x/ee-kong-user.md
+++ b/app/_includes/md/2.2.x/ee-kong-user.md
@@ -4,7 +4,7 @@ Amazon Linux 2, CentOS, Ubuntu, and RHEL -->
 <div class="alert alert-ee blue">
 <b>Note:</b> When you start Kong, the Nginx master process runs
 as <code>root</code>, and the worker processes run as <code>kong</code> by
-default. If this is not the desired behavior, you can switch to the built-in
+default. If this is not the desired behavior, you can switch the Nginx master process to run on the built-in
 <code>kong</code> user or to a custom non-root user before starting Kong.
 For more information, see
 <a href="/enterprise/{{page.kong_version}}/deployment/kong-user">Running Kong as a Non-Root User</a>.

--- a/app/_includes/md/ce-kong-user.md
+++ b/app/_includes/md/ce-kong-user.md
@@ -3,6 +3,6 @@
 
     **Note:** When you start Kong, the Nginx master process runs
     as `root` and the worker processes as `kong` by default.
-    If this is not the desired behavior, you can switch to the built-in
+    If this is not the desired behavior, you can switch the Nginx master process to run on the built-in
     `kong` user or to a custom non-root user before starting Kong. For more
     information, see [Running Kong as a Non-Root User](/latest/kong-user).

--- a/app/_includes/md/ce-kong-user.md
+++ b/app/_includes/md/ce-kong-user.md
@@ -2,7 +2,7 @@
  CentOS, Debian, RedHat, and Ubuntu -->
 
     **Note:** When you start Kong, the Nginx master process runs
-    as `root` and the worker processes as `nobody` by default.
+    as `root` and the worker processes as `kong` by default.
     If this is not the desired behavior, you can switch to the built-in
-    `kong` user and group before starting Kong. For more information, see
-    [Running Kong as a Non-Root User](/latest/kong-user).
+    `kong` user or to a custom non-root user before starting Kong. For more
+    information, see [Running Kong as a Non-Root User](/latest/kong-user).


### PR DESCRIPTION
Now that https://github.com/Kong/kong/pull/6421 is merged, this part of the docs need to be updated.