### PR TITLE
Fix syntax for hybrid mode status endpoint

### DIFF
--- a/app/2.2.x/hybrid-mode.md
+++ b/app/2.2.x/hybrid-mode.md
@@ -333,7 +333,7 @@ Control Plane's new Cluster Status API:
 
 ```
 # on Control Plane node
-http :8001/clustering/data_planes
+http :8001/clustering/data-planes
 
 
 {

--- a/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
@@ -503,12 +503,12 @@ following on a Control Plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-$ curl -i -X GET http://<admin-hostname>:8001/clustering/data_planes
+$ curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}
 ```bash
-$ http :8001/clustering/data_planes
+$ http :8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.2.x/release-notes.md
+++ b/app/enterprise/2.2.x/release-notes.md
@@ -104,7 +104,7 @@ receiving large and frequent updates.
 
 Along with this improvement comes an upgrade to the Control Plane Cluster API,
 which replaces the `/clustering/status` endpoint with the
-`/clustering/data_planes` endpoint. This new endpoint provides information about
+`/clustering/data-planes` endpoint. This new endpoint provides information about
 all Data Planes in the cluster, regardless of the Control Plane node to which
 they are connected.
 

--- a/app/getting-started-guide/2.2.x/prepare.md
+++ b/app/getting-started-guide/2.2.x/prepare.md
@@ -192,12 +192,12 @@ Run the following on a Control Plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-$ curl -i -X GET http://<admin-hostname>:8001/clustering/data_planes
+$ curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}
 ```bash
-$ http :8001/clustering/data_planes
+$ http :8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
Based on issue brought up on slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1607928995184600

Documentation lists the hybrid mode status endpoint as `/clustering/data_planes/` but the real endpoint (from testing) is `/clustering/data-planes/`.


