### PR TITLE
docs(gsg) Add tabs for cURL and HTTPie example pairs and fix examples

### DIFF
--- a/app/getting-started-guide/2.2.x/dev-portal.md
+++ b/app/getting-started-guide/2.2.x/dev-portal.md
@@ -23,15 +23,22 @@ If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial
 <a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
 </div>
 
-*Using cURL:*
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
 $ curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
---data config.portal=true
+  --data config.portal=true
 ```
-*Or using HTTPie:*
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
-$ http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace config.portal=true
+$ http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+  config.portal=true
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 {% endnavtab %}
 {% navtab Using Kong Manager %}

--- a/app/getting-started-guide/2.2.x/expose-services.md
+++ b/app/getting-started-guide/2.2.x/expose-services.md
@@ -56,30 +56,46 @@ If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial
 <a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
 </div>
 
-1. Define a Service with the name `example_service` and the URL `http://mockbin.org`.
+Define a Service with the name `example_service` and the URL `http://mockbin.org`:
 
-    *Using cURL*:
-    ```sh
-    $ curl -i -X POST http://<admin-hostname>:8001/services \
-    --data name=example_service \
-    --data url='http://mockbin.org'
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http POST :8001/services name=example_service url='http://mockbin.org'
-    ```
-    If the service is created successfully, you'll get a 201 success message.
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X POST http://<admin-hostname>:8001/services \
+  --data name=example_service \
+  --data url='http://mockbin.org'
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http POST :8001/services \
+  name=example_service \
+  url='http://mockbin.org'
+```
+<!-- end codeblock tabs -->
 
-2. Verify the service’s endpoint.
+{% endnavtab %}
+{% endnavtabs %}
 
-    *Using cURL*:
-    ```sh
-    $ curl -i http://<admin-hostname>:8001/services/example_service
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http :8001/services/example_service
-    ```
+If the service is created successfully, you'll get a 201 success message.
+
+Verify the service’s endpoint:
+
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i http://<admin-hostname>:8001/services/example_service
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/services/example_service
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 {% endnavtab %}
 {% navtab Using Kong Manager %}
@@ -146,17 +162,24 @@ Define a Route (`/mock`) for the Service (`example_service`) with a specific
 path that clients need to request. Note at least one of the hosts, paths, or
 methods must be set for the route to be matched to the service.
 
-*Using cURL*:
-  ```sh
-  $ curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
-  ```
-
-*Or using HTTPie*:
-  ```sh
-  $ http :8001/services/example_service/routes paths:='["/mock"]' name=mocking
-  ```
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/services/example_service/routes \
+  paths:='["/mock"]' \
+  name=mocking
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 A 201 message indicates the route was created successfully.
 
@@ -280,15 +303,20 @@ is now using:
 
 Using the Admin API, issue the following:
 
-*Using cURL*:
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
 $ curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
-
-*Or using HTTPie*:
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
 $ http :8000/mock/request
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 {% endnavtab %}
 {% navtab Using a Web Browser %}

--- a/app/getting-started-guide/2.2.x/improve-performance.md
+++ b/app/getting-started-guide/2.2.x/improve-performance.md
@@ -28,21 +28,32 @@ If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial
 <a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
 </div>
 
-Call the Admin API on port `8001` and configure plugins to enable in-memory caching globally, with a timeout of 30 seconds for Content-Type `application/json`.
+Call the Admin API on port `8001` and configure plugins to enable in-memory
+caching globally, with a timeout of 30 seconds for Content-Type
+`application/json`:
 
-*Using cURL*:
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
 $ curl -i -X POST http://<admin-hostname>:8001/plugins \
---data name=proxy-cache \
---data config.content_type="application/json; charset=utf-8" \
---data config.cache_ttl=30 \
---data config.strategy=memory
+  --data name=proxy-cache \
+  --data config.content_type="application/json; charset=utf-8" \
+  --data config.cache_ttl=30 \
+  --data config.strategy=memory
 ```
-
-*Or using HTTPie*:
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
-$ http -f :8001/plugins name=proxy-cache config.strategy=memory config.content_type="application/json; charset=utf-8"
+$ http -f :8001/plugins \
+  name=proxy-cache \
+  config.strategy=memory \
+  config.cache_ttl=30 \
+  config.content_type="application/json; charset=utf-8"
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 {% endnavtab %}
 {% navtab Using Kong Manager %}
@@ -125,57 +136,67 @@ plugin with a timeout of 30 seconds for Content-Type
 
 Let’s check that proxy caching works.
 
-1. Access the */mock* route using the Admin API and note the response headers.
+Access the */mock* route using the Admin API and note the response headers:
 
-    *Using cURL*:
-    ```sh
-    $ curl -i -X GET http://<admin-hostname>:8000/mock/request
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X GET http://<admin-hostname>:8000/mock/request
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8000/mock/request
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-    *Or using HTTPie*:
-    ```sh
-    $ http :8000/mock/request
-    ```
+In particular, pay close attention to the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`:
+```
+HTTP/1.1 200 OK
+...
+X-Cache-Key: d2ca5751210dbb6fefda397ac6d103b1
+X-Cache-Status: Miss
+X-Content-Type-Options: nosniff
+...
+X-Kong-Proxy-Latency: 25
+X-Kong-Upstream-Latency: 37
+```
 
-    In particular, pay close attention to the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`:
-    ```
-    HTTP/1.1 200 OK
-    ...
-    X-Cache-Key: d2ca5751210dbb6fefda397ac6d103b1
-    X-Cache-Status: Miss
-    X-Content-Type-Options: nosniff
-    ...
-    X-Kong-Proxy-Latency: 25
-    X-Kong-Upstream-Latency: 37
+Next, access the */mock* route one more time.
 
-    ```
+This time, notice the differences in the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`. Cache status is a `hit`, which means Kong Gateway is responding to the request directly from cache instead of proxying the request to the Upstream service.
 
-2. Access the */mock* route one more time.
+Further, notice the minimal latency in the response, which allows Kong Gateway to deliver the best performance:
 
-    This time, notice the differences in the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`. Cache status is a `hit`, which means Kong Gateway is responding to the request directly from cache instead of proxying the request to the Upstream service.
+```
+HTTP/1.1 200 OK
+...
+X-Cache-Key: d2ca5751210dbb6fefda397ac6d103b1
+X-Cache-Status: Hit
+...
+X-Kong-Proxy-Latency: 0
+X-Kong-Upstream-Latency: 1
+```
 
-    Further, notice the minimal latency in the response, which allows Kong Gateway to deliver the best performance:
+To test more rapidly, the cache can be deleted by calling the Admin API:
 
-    ```
-    HTTP/1.1 200 OK
-    ...
-    X-Cache-Key: d2ca5751210dbb6fefda397ac6d103b1
-    X-Cache-Status: Hit
-    ...
-    X-Kong-Proxy-Latency: 0
-    X-Kong-Upstream-Latency: 1
-    ```
-
-3. To test more rapidly, the cache can be deleted by calling the Admin API:
-
-    *Using cURL*:
-    ```sh
-    $ curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http delete :8001/proxy-cache
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http delete :8001/proxy-cache
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 ## Summary and Next Steps
 

--- a/app/getting-started-guide/2.2.x/load-balancing.md
+++ b/app/getting-started-guide/2.2.x/load-balancing.md
@@ -34,45 +34,69 @@ If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial
 <a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
 </div>
 
-1. Call the Admin API on port `8001` and create an Upstream named `upstream`.
+Call the Admin API on port `8001` and create an Upstream named `upstream`:
 
-    *Using cURL*:
-    ```sh
-    $ curl -X POST http://<admin-hostname>:8001/upstreams \
-    --data name=upstream
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http POST :8001/upstreams name=upstream
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/upstreams \
+  --data name=upstream
+```
+{% endnavtab %}
+{% navtab HTTPie %}    
+```sh
+$ http POST :8001/upstreams \
+  name=upstream
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-2. Update the service you created previously to point to this upstream.
+Update the service you created previously to point to this upstream:
 
-    *Using cURL*:
-    ```sh
-    $ curl -X PATCH http://<admin-hostname>:8001/services/example_service \
-    --data host='upstream'
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http PATCH :8001/services/example_service host='upstream'
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X PATCH http://<admin-hostname>:8001/services/example_service \
+  --data host='upstream'
+```
+{% endnavtab %}
+{% navtab HTTPie %}    
+```sh
+$ http PATCH :8001/services/example_service \
+  host='upstream'
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-3. Add two targets to the upstream, each with port 80: `mockbin.org:80` and `httpbin.org:80`.
+Add two targets to the upstream, each with port 80: `mockbin.org:80` and
+`httpbin.org:80`:
 
-    *Using cURL*:
-    ```sh
-    $ curl -X POST http://<admin-hostname>:8001/upstreams/upstream/targets \
-    --data target='mockbin.org:80'
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/upstreams/upstream/targets \
+  --data target='mockbin.org:80'
 
-    $ curl -X POST http://<admin-hostname>:8001/upstreams/upstream/targets \
-    --data target='httpbin.org:80'
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http POST :8001/upstreams/upstream/targets target=mockbin.org:80
-    $ http POST :8001/upstreams/upstream/targets target=httpbin.org:80
-    ```
+$ curl -X POST http://<admin-hostname>:8001/upstreams/upstream/targets \
+  --data target='httpbin.org:80'
+```
+{% endnavtab %}
+{% navtab HTTPie %}    
+```sh
+$ http POST :8001/upstreams/upstream/targets \
+  target=mockbin.org:80
+$ http POST :8001/upstreams/upstream/targets \
+  target=httpbin.org:80
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
 {% endnavtab %}
 
 {% navtab Using Kong Manager %}

--- a/app/getting-started-guide/2.2.x/manage-teams.md
+++ b/app/getting-started-guide/2.2.x/manage-teams.md
@@ -140,17 +140,27 @@ Outside of this guide, you will likely want to modify these settings differently
 {% endnavtab %}
 {% navtab Using the Admin API %}
 
-Create a new Workspace called SecureWorkspace, substituting the `kong_admin` account’s password in place of `<super-user-token>`.
+Create a new Workspace called SecureWorkspace, substituting the `kong_admin`
+account’s password in place of `<super-user-token>`:
 
-*Using cURL:*
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
-$ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/workspaces \
---data 'name=SecureWorkspace'
+$ curl -X POST http://<admin-hostname>:8001/workspaces \
+  -H Kong-Admin-Token:<super-user-token> \
+  --data 'name=SecureWorkspace'
 ```
-*Or using HTTPie:*
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
-$ http :8001/workspaces name=SecureWorkspace Kong-Admin-Token:<super-user-token>
+$ http :8001/workspaces \
+  name=SecureWorkspace \
+  Kong-Admin-Token:<super-user-token>
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 **Note:** Each Workspace name should be unique, regardless of letter case. For example, naming one Workspace “Payments” and another one “payments” will create two different workspaces that appear identical.
 
@@ -224,56 +234,97 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 <strong>Note:</strong> The following method refers to the <em>/users</em> endpoint and creates an Admin API user that won't be visible (or manageable) through Kong Manager. If you want to later administer the admin through Kong Manager, create it under the <a href="/enterprise/latest/admin-api/admins/reference/"><em>/admins</em> endpoint</a> instead.
 </div>
 
-1. Create a new user named `secureworkspaceadmin` with the RBAC token `secureadmintoken`.
+Create a new user named `secureworkspaceadmin` with the RBAC token
+`secureadmintoken`:
 
-    *Using cURL:*
-    ```sh
-    $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
-    --data 'name=secureworkspaceadmin' \
-    --data 'user_token=secureadmintoken'
-    ```
-    *Or using HTTPie:*
-    ```sh
-    $ http :8001/SecureWorkspace/rbac/users name=secureworkspaceadmin user_token=secureadmintoken Kong-Admin-Token:<super-user-token>
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
+  -H Kong-Admin-Token:<super-user-token> \
+  --data 'name=secureworkspaceadmin' \
+  --data 'user_token=secureadmintoken'
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/SecureWorkspace/rbac/users \
+  name=secureworkspaceadmin \
+  user_token=secureadmintoken \
+  Kong-Admin-Token:<super-user-token>
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-2. Create a blank role in the workspace and name it `admin`.
+Create a blank role in the workspace and name it `admin`:
 
-    *Using cURL:*
-    ```sh
-    $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
-    --data 'name=admin' \
-    ```
-    *Or using HTTPie:*
-    ```sh
-    http :8001/SecureWorkspace/rbac/roles/ name=admin Kong-Admin-Token:<super-user-token>
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
+  -H Kong-Admin-Token:<super-user-token> \
+  --data 'name=admin' \
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/SecureWorkspace/rbac/roles/ \
+  name=admin \
+  Kong-Admin-Token:<super-user-token>
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-3. Give the `admin` role permissions to do everything on all endpoints in the workspace.
+Give the `admin` role permissions to do everything on all endpoints in the
+workspace:
 
-    *Using cURL:*
-    ```sh
-    $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
-    --data 'endpoint=*'
-    --data 'workspace=SecureWorkspace' \
-    --data 'actions=*'
-    ```
-    *Or using HTTPie:*
-    ```sh
-    http :8001/secureworkspace/rbac/roles/admin/endpoints/ endpoint='*' workspace=SecureWorkspace actions='*' Kong-Admin-Token:<super-user-token>
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
+  -H Kong-Admin-Token:<super-user-token> \
+  --data 'endpoint=*'
+  --data 'workspace=SecureWorkspace' \
+  --data 'actions=*'
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/secureworkspace/rbac/roles/admin/endpoints/ \
+  endpoint='*' \
+  workspace=SecureWorkspace \
+  actions='*' \
+  Kong-Admin-Token:<super-user-token>
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-4. Grant the `admin` role to `secureworkspaceadmin`.
+Grant the `admin` role to `secureworkspaceadmin`:
 
-    *Using cURL:*
-    ```sh
-    $ curl -H Kong-Admin-Token:<super-user-token> -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
-    --data 'role=admin'
-    ```
-    *Or using HTTPie:*
-    ```sh
-    http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ roles=admin Kong-Admin-Token:<super-user-token>
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
+  -H Kong-Admin-Token:<super-user-token> \
+  --data 'role=admin'
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
+  roles=admin \
+  Kong-Admin-Token:<super-user-token>
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -292,36 +343,53 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 
 {% endnavtab %}
 {% navtab Using the Admin API %}
-1. Try to access the `default` workspace using `secureworkspaceadmin`'s user token.
 
-    *Using cURL:*
-    ```sh
-    $ curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
-    ```
-    *Or using HTTPie:*
+Try to access the `default` workspace using `secureworkspaceadmin`'s user token:
 
-    ```sh
-    http :8001/default/rbac/users Kong-Admin-Token:secureadmintoken
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X GET http://<admin-hostname>:8001/default/rbac/users \
+  -H Kong-Admin-Token:secureadmintoken
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/default/rbac/users \
+  Kong-Admin-Token:secureadmintoken
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-    You should get a `403 Forbidden` error message:
-    ```
-    {
-        “message”: “secureworkspaceadmin, you do not have permissions to read this resource”
-    }
-    ```
-2. Then, try to access the same endpoint, but this time in the `SecureWorkspace`.
+You should get a `403 Forbidden` error message:
+```
+{
+    “message”: “secureworkspaceadmin, you do not have permissions to read this resource”
+}
+```
 
-    *Using cURL:*
-    ```sh
-    $ curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
-    ```
-    *Or using HTTPie:*
+Then, try to access the same endpoint, but this time in the `SecureWorkspace`:
 
-    ```sh
-    http :8001/default/rbac/users Kong-Admin-Token:secureadmintoken
-    ```
-    This time, you should get a `200 OK` success message and a list of users.
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
+  -H Kong-Admin-Token:secureadmintoken
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/default/rbac/users \
+  Kong-Admin-Token:secureadmintoken
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
+This time, you should get a `200 OK` success message and a list of users.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/getting-started-guide/2.2.x/prepare.md
+++ b/app/getting-started-guide/2.2.x/prepare.md
@@ -79,29 +79,36 @@ $ curl -i -X GET http://kong1a2b3c.kong-cloud.com/mock/request
 {% endnavtab %}
 {% endnavtabs %}
 
-### Create a User with an RBAC Token
+### Create a user with an RBAC token
 
 1. Open the Kong Manager using the link provided in your free trial welcome
 email.
 2. Open **Teams** > **RBAC Users**, then click **Add New User**.
 3. Set up an RBAC user with an appropriate role (e.g. admin) and an RBAC token.
 Make sure to leave the **Enabled** box checked.
-4. Test by building a request to the Admin API:
 
-    *Using cURL:*
-    ```sh
-    $ curl <admin-endpoint-from-email>/services \
-      -H “Kong-Admin-Token:<your-RBAC-token>”
-    ```
+### Verify the RBAC user
 
-    *Or using HTTPie:*
-    ```sh
-    $ http <admin-endpoint-from-email>/services \
-      Kong-Admin-Token:<your-RBAC-token>
-    ```
+Test by building a request to the Admin API:
 
-    You should get a `200` response code and your list of services will be empty.
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl <admin-endpoint-from-email>/services \
+  -H “Kong-Admin-Token:<your-RBAC-token>”
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http <admin-endpoint-from-email>/services \
+  Kong-Admin-Token:<your-RBAC-token>
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- codeblock tabs -->
 
+You should get a `200` response code and your list of services will be empty.
 You can now use the Admin API instructions in this guide.
 
 Remember to switch any mentions of `http://<admin-hostname>:8001` or
@@ -115,15 +122,21 @@ Ensure that you can send requests to the Kong Admin API using either cURL or HTT
 
 View the current configuration by issuing the following command in a terminal window:
 
-*Using cURL:*
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```bash
 $ curl -i -X GET http://<admin-hostname>:8001
 ```
-
-*or using HTTPie:*
+{% endnavtab %}
+{% navtab HTTPie %}
 ```bash
 $ http <admin-hostname>:8001
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
 The current configuration returns.
 {% endnavtab %}
 
@@ -189,18 +202,22 @@ configurations are being pushed from the Control Plane to your Data Planes using
 the Cluster Status CLI.
 
 Run the following on a Control Plane:
-{% navtabs %}
-{% navtab Using cURL %}
+
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```bash
 $ curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
 {% endnavtab %}
-{% navtab Using HTTPie %}
+{% navtab HTTPie %}
 ```bash
 $ http :8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% endnavtabs %}
+<!-- end codeblock tabs -->
+
 The output shows all of the connected Data Plane instances in the cluster:
 
 ```json

--- a/app/getting-started-guide/2.2.x/protect-services.md
+++ b/app/getting-started-guide/2.2.x/protect-services.md
@@ -33,17 +33,27 @@ If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial
 
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.
 
-*Using cURL*:
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
 $ curl -i -X POST http://<admin-hostname>:8001/plugins \
---data name=rate-limiting \
---data config.minute=5 \
---data config.policy=local
+  --data name=rate-limiting \
+  --data config.minute=5 \
+  --data config.policy=local
 ```
-*Or using HTTPie*:
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
-$ http -f post :8001/plugins name=rate-limiting config.minute=5 config.policy=local
+$ http -f post :8001/plugins \
+  name=rate-limiting \
+  config.minute=5 \
+  config.policy=local
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
 {% endnavtab %}
 
 {% navtab Using Kong Manager %}
@@ -135,16 +145,23 @@ and in-memory, on the node:
 {% navtabs %}
 {% navtab Using the Admin API %}
 
-To validate rate limiting, access the API six (6) times from the CLI to confirm the requests are rate limited.
+To validate rate limiting, access the API six (6) times from the CLI to confirm
+the requests are rate limited:
 
-*Using cURL*:
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
 $ curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
-*Or using HTTPie*:
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
 $ http :8000/mock/request
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 After the 6th request, you should receive a 429 "API rate limit exceeded" error:
 ```

--- a/app/getting-started-guide/2.2.x/secure-services.md
+++ b/app/getting-started-guide/2.2.x/secure-services.md
@@ -41,42 +41,57 @@ If you are trying out {{site.ee_product_name}} using a hosted (cloud) free trial
 <a href="/getting-started-guide/{{page.kong_version}}/prepare/#free-trials-setup">Prepare to Administer {{site.base_gateway}}</a>.
 </div>
 
-1. Call the Admin API on port `8001` and configure plugins to enable key authentication. For this example, apply the plugin to the */mock* route you created.
+Call the Admin API on port `8001` and configure plugins to enable key
+authentication. For this example, apply the plugin to the */mock* route you
+created:
 
-    *Using cURL*:
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
+  --data name=key-auth
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/routes/mocking/plugins \
+  name=key-auth
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-    ```sh
-    $ curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
-    --data name=key-auth
-    ```
-    *Or using HTTPie*:
+Try to access the service again:
 
-    ```sh
-    $ http :8001/routes/mocking/plugins name=key-auth
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i http://<admin-hostname>:8000/mock
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8000/mock
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-2. Try to access the service again:
+Since you added key authentication, you should be unable to access it:
 
-    *Using cURL*:
-    ```sh
-    $ curl -i http://<admin-hostname>:8000/mock
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http :8000/mock
-    ```
+```sh
+HTTP/1.1 401 Unauthorized
+...
+{
+    "message": "No API key found in request"
+}
+```
 
-    Since you added key authentication, you should be unable to access it:
-
-    ```sh
-    HTTP/1.1 401 Unauthorized
-    ...
-    {
-        "message": "No API key found in request"
-    }
-    ```
-
-Before Kong proxies requests for this route, it needs an API key. For this example, since you installed the Key Authentication plugin, you need to create a consumer with an associated key first.
+Before Kong proxies requests for this route, it needs an API key. For this
+example, since you installed the Key Authentication plugin, you need to create
+a consumer with an associated key first.
 
 {% endnavtab %}
 
@@ -159,48 +174,66 @@ a consumer with an associated key first.
 {% navtabs %}
 {% navtab Using the Admin API %}
 
-1. To create a consumer, call the Admin API and the consumer’s endpoint. The following creates a new consumer called **consumer**.
+To create a consumer, call the Admin API and the consumer’s endpoint.
+The following creates a new consumer called **consumer**:
 
-    *Using cURL*:
-    ```sh
-    $ curl -i -X POST http://<admin-hostname>:8001/consumers/ \
-     --data username=consumer \
-     --data custom_id=consumer
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X POST http://<admin-hostname>:8001/consumers/ \
+  --data username=consumer \
+  --data custom_id=consumer
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/consumers \
+  username=consumer \
+  custom_id=consumer
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-    *Or using HTTPie*:
-    ```sh
-    $ http :8001/consumers username=consumer custom_id=consumer
-    ```
+Once provisioned, call the Admin API to provision a key for the consumer
+created above. For this example, set the key to `apikey`.
 
-2. Once provisioned, call the Admin API to provision a key for the consumer created above. For this example, set the key to `apikey`. If no key is entered, Kong automatically generates the key.
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
+  --data key=apikey
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/consumers/consumer/key-auth \
+  key=apikey
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-    *Using cURL*:
-    ```sh
-    $ curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
-    --data key=apikey
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http :8001/consumers/consumer/key-auth key=apikey
-    ```
+If no key is entered, Kong automatically generates the key.
 
-    Result:
+Result:
 
-    ```sh
-    HTTP/1.1 201 Created
-    ...
-    {
-        "consumer": {
-            "id": "2c43c08b-ba6d-444a-8687-3394bb215350"
-        },
-        "created_at": 1568255693,
-        "id": "86d283dd-27ee-473c-9a1d-a567c6a76d8e",
-        "key": "apikey"
-    }
-    ```
+```sh
+HTTP/1.1 201 Created
+...
+{
+    "consumer": {
+        "id": "2c43c08b-ba6d-444a-8687-3394bb215350"
+    },
+    "created_at": 1568255693,
+    "id": "86d283dd-27ee-473c-9a1d-a567c6a76d8e",
+    "key": "apikey"
+}
+```
 
-    You now have a consumer with an API key provisioned to access the route.
+You now have a consumer with an API key provisioned to access the route.
 
 {% endnavtab %}
 {% navtab Using Kong Manager %}
@@ -277,18 +310,24 @@ You now have a consumer with an API key provisioned to access the route.
 
 {% navtabs %}
 {% navtab Using the Admin API %}
-To validate the Key Authentication plugin, access the *mocking* route again, using the header `apikey` with a key value of `apikey`.
+To validate the Key Authentication plugin, access the *mocking* route again,
+using the header `apikey` with a key value of `apikey`:
 
-*Using cURL*:
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
 ```sh
-$ curl -i http://<admin-hostname>:8000/mock/request -H 'apikey:apikey'
+$ curl -i http://<admin-hostname>:8000/mock/request \
+  -H 'apikey:apikey'
 ```
-
-*Or using HTTPie*:
-
+{% endnavtab %}
+{% navtab HTTPie %}
 ```sh
 $ http :8000/mock/request apikey:apikey
 ```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
 You should get an `HTTP/1.1 200 OK` message in response.
 
@@ -309,33 +348,47 @@ If you are following this getting started guide topic by topic, you will need to
 {% navtabs %}
 {% navtab Using the Admin API %}
 
-1. Find the plugin ID and copy it.
+Find the plugin ID and copy it:
 
-    *Using cURL*:
-    ```sh
-    $ curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http :8001/routes/mocking/plugins
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/routes/mocking/plugins
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
 
-    Output:
-     ```sh
-     "id": "2512e48d9-7by0-674c-84b7-00606792f96b"
-     ```
+Output:
+```sh
+"id": "2512e48d9-7by0-674c-84b7-00606792f96b"
+```
 
-2. Disable the plugin.
+Disable the plugin:
 
-    *Using cURL*:
-    ```sh
-    $ curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
-    --data enabled=false
-    ```
-    *Or using HTTPie*:
-    ```sh
-    $ http :8001/routes/mocking/plugins/{<plugin-id>} enabled=false
-    ```
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
+  --data enabled=false
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http -f patch :8001/routes/mocking/plugins/{<plugin-id>} \
+  enabled=false
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
 {% endnavtab %}
 
 {% navtab Using Kong Manager %}


### PR DESCRIPTION
Changes:
* Combining cURL and HTTPie examples into tabbed codeblocks
* Fixing some of the examples along the way
* Making formatting of examples consistent

Notes to reviewers: 
* This PR looks bigger than it is. The majority of the work is simply to replace any instances of separate cURL and HTTPie examples with a tabbed view, saving a potentially huge amount of space on the screen (best example of this is the Kong Admin API tab here: https://docs.konghq.com/getting-started-guide/2.2.x/manage-teams/#create-an-admin). 
* I had to remove numbered lists, whenever these codeblocks were part of them. The output breaks when you try to nest a tab into a list. I found the utility/UX improvement of the tabs to be great enough to still go ahead with the change anyway.

Previews:

Tabs for cURL/HTTPie added to:
[Prepare to Administer Kong Gateway](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/prepare/)
[Expose your Services](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/expose-services/)
[Protect your Services](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/protect-services/)
[Improve Performance](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/improve-performance/) - also fixed HTTPie code sample for creating the plugin
[Secure Services](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/secure-services/) - also fixed HTTPie code sample for disabling the plugin
[Load Balancing](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/load-balancing)
[Manage Administrative Teams](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/manage-teams)
[Publish with Dev Portal](https://deploy-preview-2519--kongdocs.netlify.app/getting-started-guide/2.2.x/dev-portal)