### PR TITLE
feat(redirects) Introduce _redirects file as central location for all redirects

### DIFF
--- a/app/_hub/api-fortress/api-fortress-http-log/index.md
+++ b/app/_hub/api-fortress/api-fortress-http-log/index.md
@@ -1,3 +1,0 @@
----
-redirect_to: /hub/
----

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,0 +1,9 @@
+# getting started guide
+/enterprise/latest/getting-started/   /getting-started-guide/latest/overview/
+/enterprise/1.5.x/getting-started/    /getting-started-guide/ce-2.0.x_ke-1.5.x/overview/
+
+# plugins
+/hub/kong-inc/deck/                         /deck/
+/hub/hbagdi/deck/                           /deck/
+/hub/api-fortress/api-fortress-http-log/    /hub/ 
+/hub/api-fortress/api-fortress-http-log/*   /hub/

--- a/app/deck/index.md
+++ b/app/deck/index.md
@@ -2,9 +2,6 @@
 title: Documentation for decK
 is_homepage: true
 no_version: true
-redirect_from:
-  - /hub/kong-inc/deck
-  - /hub/hbagdi/deck
 ---
 <div class="docs-grid">
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -66,6 +66,9 @@ extensions:
     # - name: dev portal extension
     #   slug: dev-mod
 
+include:
+  - _redirects
+
 exclude:
   - node_modules
   - jekyll-cache

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -66,6 +66,9 @@ extensions:
     # - name: dev portal extension
     #   slug: dev-mod
 
+include:
+  - _redirects
+
 # location vars
 icons_dir: assets/images/icons
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
       "node_modules/**",
       "Dockerfile",
       "gulpfile.js",
-      "app/_assets/javascripts/app.js"
+      "app/_assets/javascripts/app.js",
+      "app/_redirects"
     ]
   },
   "echint": {
@@ -40,7 +41,8 @@
       "autodoc-conf-ee/*.lua",
       "vendor/**",
       "node_modules/**",
-      "Docker"
+      "Docker",
+      "app/_redirects"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1241

**Goal and approach:**

Testing out a central redirect config file. Goal is to get rid of all blank files that just hang around for redirect reasons and get cloned with every release. 

File syntax is very simple: each line contains a "from" path and a "to" path. These can be either relative or absolute, though relative paths are preferred. The number of spaces or tabs between the paths does not matter, as long as there is at least one space to distinguish them as separate paths.

**Changes:**

For this PR, I'm just introducing the file and testing removing `redirect_from` and `redirect_to` in one file each, then replacing them with entries in the `_redirects` file. 

There are a few other config options if needed (see https://docs.netlify.com/routing/redirects/redirect-options/); at the moment, all we're starting with is the basic redirect from one URL to another. 

**Previews:**
To test, check that the "from" paths in the redirect file go to the "to" paths. 

For example:
 https://deploy-preview-2521--kongdocs.netlify.app/enterprise/latest/getting-started/ should go to https://deploy-preview-2521--kongdocs.netlify.app/getting-started-guide/latest/overview/

https://deploy-preview-2521--kongdocs.netlify.app/hub/kong-inc/deck/  should go to https://deploy-preview-2521--kongdocs.netlify.app/deck/
