### PR TITLE
Remove the description about Helm v2 due to it's deprecation.

### DIFF
--- a/app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
@@ -42,9 +42,6 @@ Please ensure that you've Tiller working and then execute:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong
-
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/eks.md
@@ -42,9 +42,6 @@ Please ensure that you have Tiller working and then execute:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong
-
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/gke.md
@@ -94,9 +94,6 @@ Please ensure that you've Tiller working and then execute:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong
-
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
@@ -134,11 +134,6 @@ You can use Helm to install Kong via the official Helm chart:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong \
-    --name demo --namespace kong \
-    --values https://l.yolo42.com/k4k8s-enterprise-helm-values
-
 # Helm 3
 $ helm install kong/kong --generate-name
     --namespace kong \

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s.md
@@ -53,8 +53,6 @@ You can use Helm to install Kong via the official Helm chart:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong
 
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/minikube.md
@@ -49,9 +49,6 @@ Please ensure that you've Tiller working and then execute:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-# Helm 2
-$ helm install kong/kong
-
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```


### PR DESCRIPTION
Remove about Helm v2 due to is't deprecation.
After November 13, 2020,No further Helm v2 releases.

[ref. helm-v2-deprecation-timeline](https://helm.sh/blog/helm-v2-deprecation-timeline/)

Related documents:
* app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
* app/kubernetes-ingress-controller/1.1.x/deployment/eks.md
* app/kubernetes-ingress-controller/1.1.x/deployment/gke.md
* app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
* app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s.md
* app/kubernetes-ingress-controller/1.1.x/deployment/minikube.md

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

