### PR TITLE
docs(kic) Fix syntax for TLS certs

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -173,7 +173,8 @@ spec:
     server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - http01:
-        ingress: {}" | kubectl apply -f -
+        ingress:
+          class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -173,7 +173,8 @@ spec:
     server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - http01:
-        ingress: {}" | kubectl apply -f -
+        ingress:
+          class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 


### PR DESCRIPTION
Based on: https://konghq.atlassian.net/browse/DOCS-1484

Feedback came in from a very unhappy user (logged through thumbs up/down widget on docs site) that spent a long time trying to figure out why the example didn't work as documented.

This syntax is the user's suggestion.