### PR TITLE
docs(ee-install) Change version variables to pull correct versions

### DIFF
--- a/app/enterprise/1.5.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/1.5.x/deployment/installation/amazon-linux-2.md
@@ -33,11 +33,11 @@ for information on how to get access.
 3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
 4. Select the latest Kong version from the list.
 5. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-6. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.aws.rpm`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm`.
 7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You can use a command like:
 
     ```bash
-    $ scp kong-enterprise-edition-1.5.0.1.aws.rpm <amazon user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm <amazon user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -47,13 +47,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ sudo rpm --import kong.key
-    $ sudo rpm -K kong-enterprise-edition-1.5.0.1.aws.rpm
+    $ sudo rpm -K kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm
     ```
 
 2. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: sha1 md5 OK
+    kong-enterprise-edition-{{page.kong_versions[7].version}}.el7.noarch.rpm: sha1 md5 OK
     ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
@@ -120,7 +120,7 @@ You should now have two files in your home directory on the target Amazon system
 Execute a command similar to the following, using the appropriate RPM file name you downloaded.
 
 ```bash
-$ sudo yum install kong-enterprise-edition-1.5.0.1.aws.rpm
+$ sudo yum install kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm
 ```
 {% endnavtab %}
 {% navtab Using Yum repo %}

--- a/app/enterprise/1.5.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/1.5.x/deployment/installation/amazon-linux.md
@@ -35,11 +35,11 @@ for information on how to get access.
 
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-5. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.aws.rpm`.
+5. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
     ```bash
-    $ scp kong-enterprise-edition-1.5.0.1.aws.rpm <amazon user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm <amazon user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -49,13 +49,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ sudo rpm --import kong.key
-    $ sudo rpm -K kong-enterprise-edition-1.5.0.1.aws.rpm
+    $ sudo rpm -K kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm
     ```
 
 2. Verify you get an OK check. Output should be similar to this:
 
       ```
-      kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: sha1 md5 OK
+      kong-enterprise-edition-{{page.kong_versions[7].version}}.el7.noarch.rpm: sha1 md5 OK
       ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}
@@ -116,7 +116,7 @@ You should now have two files in your home directory on the target Amazon system
 Execute a command similar to the following, using the appropriate RPM file name you downloaded:
 
 ```bash
-$ sudo yum install kong-enterprise-edition-1.5.0.1.aws.rpm
+$ sudo yum install kong-enterprise-edition-{{page.kong_versions[7].version}}.aws.rpm
 ```
 {% endnavtab %}
 {% navtab Using Yum repo %}

--- a/app/enterprise/1.5.x/deployment/installation/centos.md
+++ b/app/enterprise/1.5.x/deployment/installation/centos.md
@@ -34,11 +34,11 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the CentOS version appropriate for your environment, such as `centos` -> `7`.
-6. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.el7.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[7].version}}.el7.noarch.rpm`
 7. Copy the RPM file to your home directory on the CentOS system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-1.5.0.1.el7.noarch.rpm <centos user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[7].version}}.el7.noarch.rpm <centos user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -60,7 +60,7 @@ for information on how to get access.
 3. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-1.5.0.1.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
+    kong-enterprise-edition-{{page.kong_versions[7].version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
     ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/1.5.x/deployment/installation/rhel.md
+++ b/app/enterprise/1.5.x/deployment/installation/rhel.md
@@ -33,11 +33,11 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the RHEL version appropriate for your environment, such as `RHEL` -> `8`.
-6. Save the available RPM file. For example: `kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[7].version}}.rhel8.noarch.rpm`
 7. Copy the RPM file to your home directory on the RHEL system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm <rhel user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[7].version}}.rhel8.noarch.rpm <rhel user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -45,7 +45,7 @@ for information on how to get access.
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
     ```bash
-    $ rpm -qpi kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm | grep Signature
+    $ rpm -qpi kong-enterprise-edition-{{page.kong_versions[7].version}}.rhel8.noarch.rpm | grep Signature
     ```
 
 2. Download Kong's official public key to ensure the integrity of the RPM package:
@@ -53,13 +53,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ rpm --import kong.key
-    $ rpm -K kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm
+    $ rpm -K kong-enterprise-edition-{{page.kong_versions[7].version}}.rhel8.noarch.rpm
     ```
 
 3. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-1.5.0.1.rhel8.noarch.rpm: digests signatures OK
+    kong-enterprise-edition-{{page.kong_versions[7].version}}.rhel8.noarch.rpm: digests signatures OK
     ```
 
 {% endnavtab %}

--- a/app/enterprise/1.5.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/1.5.x/deployment/installation/ubuntu.md
@@ -29,11 +29,11 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
 3. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
 4. From the Kong version detail page, select the **Files** tab.
-5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-1.5.0.0.bionic.all.deb` for the Ubuntu Bionic Beaver release.
+5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-{{page.kong_versions[7].version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
 6. Copy the `.deb` file to your home directory on the Ubuntu system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-1.5.0.0.bionic.all.deb <ubuntu_user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[7].version}}.bionic.all.deb <ubuntu_user>@<server>:~
     ```
 
 ### Download your Kong Enterprise License

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux-2.md
@@ -39,11 +39,11 @@ for information on how to get access.
 3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
 4. Select the latest Kong version from the list.
 5. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[8].version}}.aws.rpm`.
 7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You can use a command like:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[8].version}}.aws.rpm <amazon user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -53,13 +53,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ sudo rpm --import kong.key
-    $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
+    $ sudo rpm -K kong-enterprise-edition-{{page.kong_versions[8].version}}.aws.rpm
     ```
 
 2. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
+    kong-enterprise-edition-{{page.kong_versions[8].version}}.el7.noarch.rpm: sha1 md5 OK
     ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.1.x/deployment/installation/amazon-linux.md
@@ -41,11 +41,11 @@ for information on how to get access.
 
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-5. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+5. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[8].version}}.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[8].version}}.aws.rpm <amazon user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -55,13 +55,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ sudo rpm --import kong.key
-    $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
+    $ sudo rpm -K kong-enterprise-edition-{{page.kong_versions[8].version}}.aws.rpm
     ```
 
 2. Verify you get an OK check. Output should be similar to this:
 
       ```
-      kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
+      kong-enterprise-edition-{{page.kong_versions[8].version}}.el7.noarch.rpm: sha1 md5 OK
       ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/2.1.x/deployment/installation/centos.md
+++ b/app/enterprise/2.1.x/deployment/installation/centos.md
@@ -40,11 +40,11 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the CentOS version appropriate for your environment, such as `centos` -> `7`.
-6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[8].version}}.el7.noarch.rpm`
 7. Copy the RPM file to your home directory on the CentOS system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm <centos user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[8].version}}.el7.noarch.rpm <centos user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -66,7 +66,7 @@ for information on how to get access.
 3. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
+    kong-enterprise-edition-{{page.kong_versions[8].version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
     ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/2.1.x/deployment/installation/docker.md
+++ b/app/enterprise/2.1.x/deployment/installation/docker.md
@@ -30,7 +30,7 @@ To complete this installation you will need:
 
 ```bash
 $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kong-docker-kong-enterprise-edition-docker.bintray.io
-$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:{{page.kong_latest.version}}-alpine
+$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[8].version}}-alpine
 ```
 
 You should now have your Kong Enterprise image locally.

--- a/app/enterprise/2.1.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.1.x/deployment/installation/kong-on-kubernetes.md
@@ -191,7 +191,7 @@ In the following steps, replace `<your-password>` with a secure password.
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
-    |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_versions[8].version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |

--- a/app/enterprise/2.1.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.1.x/deployment/installation/rhel.md
@@ -39,11 +39,11 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the RHEL version appropriate for your environment, such as `RHEL` -> `8`.
-6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[8].version}}.rhel8.noarch.rpm`
 7. Copy the RPM file to your home directory on the RHEL system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm <rhel user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[8].version}}.rhel8.noarch.rpm <rhel user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -51,7 +51,7 @@ for information on how to get access.
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
     ```bash
-    $ rpm -qpi kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm | grep Signature
+    $ rpm -qpi kong-enterprise-edition-{{page.kong_versions[8].version}}.rhel8.noarch.rpm | grep Signature
     ```
 
 2. Download Kong's official public key to ensure the integrity of the RPM package:
@@ -59,13 +59,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ rpm --import kong.key
-    $ rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm
+    $ rpm -K kong-enterprise-edition-{{page.kong_versions[8].version}}.rhel8.noarch.rpm
     ```
 
 3. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm: digests signatures OK
+    kong-enterprise-edition-{{page.kong_versions[8].version}}.rhel8.noarch.rpm: digests signatures OK
     ```
 
 {% endnavtab %}

--- a/app/enterprise/2.1.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.1.x/deployment/installation/ubuntu.md
@@ -35,11 +35,11 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
 3. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
 4. From the Kong version detail page, select the **Files** tab.
-5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
+5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-{{page.kong_versions[8].version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
 6. Copy the `.deb` file to your home directory on the Ubuntu system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb <ubuntu_user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[8].version}}.bionic.all.deb <ubuntu_user>@<server>:~
     ```
 
 ### Download your Kong Enterprise License

--- a/app/enterprise/2.2.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.2.x/deployment/installation/amazon-linux-2.md
@@ -39,11 +39,11 @@ for information on how to get access.
 3. Select the `aws` folder. Kong Enterprise versions are listed in reverse chronological order.
 4. Select the latest Kong version from the list.
 5. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[9].version}}.aws.rpm`.
 7. Copy the RPM file to your home directory on the Amazon Linux 2 system. You can use a command like:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[9].version}}.aws.rpm <amazon user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -53,13 +53,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ sudo rpm --import kong.key
-    $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
+    $ sudo rpm -K kong-enterprise-edition-{{page.kong_versions[9].version}}.aws.rpm
     ```
 
 2. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
+    kong-enterprise-edition-{{page.kong_versions[9].version}}.el7.noarch.rpm: sha1 md5 OK
     ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/2.2.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.2.x/deployment/installation/amazon-linux.md
@@ -41,11 +41,11 @@ for information on how to get access.
 
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, click the **Files** tab, then click the distribution folder.
-5. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm`.
+5. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[9].version}}.aws.rpm`.
 6. Copy the RPM file to your home directory on the Amazon Linux 1 system. You may use a command like:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm <amazon user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[9].version}}.aws.rpm <amazon user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -55,13 +55,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ sudo rpm --import kong.key
-    $ sudo rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.aws.rpm
+    $ sudo rpm -K kong-enterprise-edition-{{page.kong_versions[9].version}}.aws.rpm
     ```
 
 2. Verify you get an OK check. Output should be similar to this:
 
       ```
-      kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: sha1 md5 OK
+      kong-enterprise-edition-{{page.kong_versions[9].version}}.el7.noarch.rpm: sha1 md5 OK
       ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/2.2.x/deployment/installation/centos.md
+++ b/app/enterprise/2.2.x/deployment/installation/centos.md
@@ -40,11 +40,11 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the CentOS version appropriate for your environment, such as `centos` -> `7`.
-6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[9].version}}.el7.noarch.rpm`
 7. Copy the RPM file to your home directory on the CentOS system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm <centos user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[9].version}}.el7.noarch.rpm <centos user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -66,7 +66,7 @@ for information on how to get access.
 3. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-{{page.kong_latest.version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
+    kong-enterprise-edition-{{page.kong_versions[9].version}}.el7.noarch.rpm: rsa sha1 (md5) pgp md5 OK
     ```
 {% endnavtab %}
 {% navtab Download Kong repo file and add to Yum repo %}

--- a/app/enterprise/2.2.x/deployment/installation/docker.md
+++ b/app/enterprise/2.2.x/deployment/installation/docker.md
@@ -30,7 +30,7 @@ To complete this installation you will need:
 
 ```bash
 $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kong-docker-kong-enterprise-edition-docker.bintray.io
-$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:{{page.kong_latest.version}}-alpine
+$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[9].version}}-alpine
 ```
 
 You should now have your Kong Enterprise image locally.

--- a/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes.md
@@ -190,7 +190,7 @@ In the following steps, replace `<your-password>` with a secure password.
     |`env.password.valueFrom.secretKeyRef.name` | Name of secret that holds the super admin password. In the example above, this is set to `kong-enterprise-superuser-password`. |
     |`env.password.valueFrom.secretKeyRef.key` | The type of secret key used for authentication. If you followed the default settings in the example above, this is `password`. |
     |`image.repository` | The Docker repository. In this case, `kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition`. |
-    |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_latest.version}}-alpine"`. |
+    |`image.tag` | The Docker image tag you want to pull down, e.g. `"{{page.kong_versions[9].version}}-alpine"`. |
     |`image.pullSecrets` | Name of secret that holds the Docker repository credentials. In the example above, this is `kong-enterprise-edition-docker`. |
     |`admin.enabled` | Set to `true` to enable the Admin API, which is required for the Kong Manager. |
     |`ingressController.enabled` | Set to `true` if you want to use the Kong Ingress Controller, or `false` if you don't want to install it. |

--- a/app/enterprise/2.2.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.2.x/deployment/installation/rhel.md
@@ -39,11 +39,11 @@ for information on how to get access.
 3. Select the latest Kong version from the list.
 4. From the Kong version detail page, select the **Files** tab.
 5. Select the RHEL version appropriate for your environment, such as `RHEL` -> `8`.
-6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm`
+6. Save the available RPM file. For example: `kong-enterprise-edition-{{page.kong_versions[9].version}}.rhel8.noarch.rpm`
 7. Copy the RPM file to your home directory on the RHEL system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm <rhel user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[9].version}}.rhel8.noarch.rpm <rhel user>@<server>:~
     ```
 
 ### (Optional) Verify the Package Integrity
@@ -51,7 +51,7 @@ for information on how to get access.
 1. Kong's official Key ID is `2cac36c51d5f3726`. Verify it by querying the RPM package and comparing it to the Key ID:
 
     ```bash
-    $ rpm -qpi kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm | grep Signature
+    $ rpm -qpi kong-enterprise-edition-{{page.kong_versions[9].version}}.rhel8.noarch.rpm | grep Signature
     ```
 
 2. Download Kong's official public key to ensure the integrity of the RPM package:
@@ -59,13 +59,13 @@ for information on how to get access.
     ```bash
     $ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
     $ rpm --import kong.key
-    $ rpm -K kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm
+    $ rpm -K kong-enterprise-edition-{{page.kong_versions[9].version}}.rhel8.noarch.rpm
     ```
 
 3. Verify you get an OK check. Output should be similar to this:
 
     ```
-    kong-enterprise-edition-{{page.kong_latest.version}}.rhel8.noarch.rpm: digests signatures OK
+    kong-enterprise-edition-{{page.kong_versions[9].version}}.rhel8.noarch.rpm: digests signatures OK
     ```
 
 {% endnavtab %}

--- a/app/enterprise/2.2.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.2.x/deployment/installation/ubuntu.md
@@ -35,11 +35,11 @@ for information on how to get access.
 2. Go to: [https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu](https://bintray.com/kong/kong-enterprise-edition-deb/ubuntu).
 3. Select the latest Kong version from the list. Kong Enterprise versions are listed in reverse chronological order.
 4. From the Kong version detail page, select the **Files** tab.
-5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
+5. Click the `.deb` file matching your target Ubuntu OS version. For example, select `kong-enterprise-edition-{{page.kong_versions[9].version}}.bionic.all.deb` for the Ubuntu Bionic Beaver release.
 6. Copy the `.deb` file to your home directory on the Ubuntu system. For example:
 
     ```bash
-    $ scp kong-enterprise-edition-{{page.kong_latest.version}}.bionic.all.deb <ubuntu_user>@<server>:~
+    $ scp kong-enterprise-edition-{{page.kong_versions[9].version}}.bionic.all.deb <ubuntu_user>@<server>:~
     ```
 
 ### Download your Kong Enterprise License


### PR DESCRIPTION
Installation topics were pulling the latest real version of Enterprise. Instead, each version should be pulling its own most recent patch version number. Fixing 2.2.x, 2.1.x, and 1.5.x (versions that are still being actively maintained in patches). 

