### PR TITLE
docs(old versions) Adjust older versions banner

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -101,8 +101,7 @@ id: documentation
           {% endif %}
           {% if page.kong_version != page.kong_latest.release and page.no_version != true %}
           <div class="alert alert-warning">
-            <strong>Careful!</strong> You are browsing documentation for an outdated version.
-            See the
+            You are browsing documentation for an outdated version. See the
             <a href="{% if latest_page_exists == 'true' %}{{latest_page_url}}{% elsif page.edition == 'enterprise'%}/enterprise/{% elsif page.edition == 'mesh'%}/mesh/{% elsif page.edition == 'kubernetes-ingress-controller/'%}/kubernetes-ingress-controller/{% else %}/{% endif %}">
               latest documentation here</a>.
           </div>

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -4,6 +4,9 @@ sitemap: true
 id: documentation
 ---
 
+{% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}
+{% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
+
 <div class="page v2 {{ page.class }}">
   <header class="page-header">
     <div class="page-header-bg"></div>
@@ -98,9 +101,10 @@ id: documentation
           {% endif %}
           {% if page.kong_version != page.kong_latest.release and page.no_version != true %}
           <div class="alert alert-warning">
-            <strong>Careful!</strong> You are browsing documentation for an outdated version{% if page.edition == 'community' %} of {{site.ce_product_name}}{% endif %}{% if page.edition == 'enterprise' %} of {{site.ee_product_name}}{% endif %}{% if page.edition == 'mesh' %} of {{site.mesh_product_name}}{% endif %}. Go <a
-                  href="{% if page.edition == 'enterprise' %}/enterprise{% endif %}{% if page.edition == 'mesh' %}/mesh{% endif %}/latest">here</a>
-            to see the documentation for the latest version.
+            <strong>Careful!</strong> You are browsing documentation for an outdated version.
+            See the
+            <a href="{% if latest_page_exists == 'true' %}{{latest_page_url}}{% elsif page.edition == 'enterprise'%}/enterprise/{% elsif page.edition == 'mesh'%}/mesh/{% elsif page.edition == 'kubernetes-ingress-controller/'%}/kubernetes-ingress-controller/{% else %}/{% endif %}">
+              latest documentation here</a>.
           </div>
           {% elsif page.is_homepage != true and page.beta == true %}
           <div class="alert alert-ee red condensed margin-bigger">

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -109,14 +109,14 @@ id: documentation
           <div class="alert alert-ee red condensed margin-bigger">
             <div class="alert-body">
               <div class="tag red">BETA</div>
-              <p>Warning: This feature is released as <a href="/enterprise/{{page.kong_version}}/introduction/key-concepts/#beta">BETA</a> and should not be deployed in a production environment.
+              Warning: This feature is released as <a href="/enterprise/{{page.kong_version}}/introduction/key-concepts/#beta">BETA</a> and should not be deployed in a production environment.
             </div>
           </div>
           {% elsif page.is_homepage == true and page.edition == 'enterprise' %}
           <div class="alert alert-ee condensed margin-bigger">
             <div class="alert-body">
               <div class="tag green">NEW</div>
-              <p>{{site.ee_product_name}} {{page.kong_version}} released! We added <a href="/enterprise/changelog">new features</a> and updated docs!
+              <p>{{site.ee_product_name}} {{page.kong_version}} released! We added <a href="/enterprise/changelog">new features</a> and updated docs!</p>
             </div>
           </div>
         {% endif %}


### PR DESCRIPTION
Based on docs ticket: https://konghq.atlassian.net/browse/DOCS-1518

**Issue:** Doc "browsing older version" banner links to the the landing page of the latest doc, while it should point to the same topic (if the topic exists).

![Screen Shot 2021-01-07 at 2 44 05 PM](https://user-images.githubusercontent.com/54370747/104062926-329a5080-51b0-11eb-84c6-3eb92bc55790.png)
(eg see https://docs.konghq.com/1.5.x/proxy/)

**Changes:** 
* Instead of pointing to the doc landing page of the latest version, changing the link in the banner to check if a parallel page exists under `/latest/`. If the page exists, the link points to that page; if not, the link points to the doc landing page as before. 
* Rephrased the text to avoid calling out the product name, and shortened it to avoid banner wrapping onto a second line.

**Preview:**
Test by opening an older topic, then clicking on the link in the banner: 

https://deploy-preview-2534--kongdocs.netlify.app/enterprise/0.36-x/deployment/installation/docker/ 
^ This topic redirects to the latest version of the same topic.

https://deploy-preview-2534--kongdocs.netlify.app/enterprise/0.34-x/installation/docker/
^ This one redirects to docs.konghq.com/enterprise because the directory structure changed between 0.34-x and 0.36-x