### PR TITLE
Autodoc tool for updating plugin version information automatically

### DIFF
--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -1,7 +1,7 @@
 ---
 name: ACL
 publisher: Kong Inc.
-version: 1.0.0
+version: 3.0.1
 
 desc: Control which Consumers can access Services
 description: |
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -37,6 +38,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -46,6 +48,7 @@ kong_version_compatibility:
         - 0.8.x
         - 0.7.x
         - 0.6.x
+        - 0.5.x
         - 0.5.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -1,7 +1,7 @@
 ---
 name: ACME
 publisher: Kong Inc.
-version: 0.2.13
+version: 0.2
 
 source_url: https://github.com/Kong/kong-plugin-acme
 
@@ -16,8 +16,10 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
+        - 2.0.x
         - 2.0.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -1,7 +1,7 @@
 ---
 name: AWS Lambda
 publisher: Kong Inc.
-version: 3.5.x
+version: 3.5
 
 desc: Invoke and manage AWS Lambda functions from Kong
 description: |
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -33,10 +34,12 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
         - 0.11.x
+        - 0.10.x
         - 0.10.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -1,7 +1,7 @@
 ---
 name: Azure Functions
 publisher: Kong Inc.
-version: 1.0.0
+version: 1.0
 
 source_url: https://github.com/Kong/kong-plugin-azure-functions
 
@@ -19,6 +19,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -28,6 +29,8 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
+        - 0.14.x
         - 0.14.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -22,7 +22,8 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.2.x      
+        - 2.3.x
+        - 2.2.x
         - 2.1.x
         - 2.0.x
         - 1.5.x
@@ -31,6 +32,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -43,6 +45,7 @@ kong_version_compatibility:
         - 0.5.x
         - 0.4.x
         - 0.3.x
+        - 0.2.x
         - 0.2.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -1,7 +1,7 @@
 ---
 name: Bot Detection
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.0
 
 desc: Detect and block bots or custom clients
 description: |
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -23,11 +24,13 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
         - 0.11.x
         - 0.10.x
+        - 0.9.x
         - 0.9.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -1,7 +1,7 @@
 ---
 name: Correlation ID
 publisher: Kong Inc.
-version: 2.0.x
+version: 2.0.2
 
 desc: Correlate requests and responses using a unique ID
 description: |
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -23,12 +24,14 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
         - 0.11.x
         - 0.10.x
         - 0.9.x
+        - 0.8.x
         - 0.8.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -1,7 +1,7 @@
 ---
 name: CORS
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.0
 
 desc: Allow developers to make requests from the browser
 description: |
@@ -23,15 +23,17 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x      
+        - 1.5.x
         - 1.4.x
         - 1.3.x
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -44,6 +46,7 @@ kong_version_compatibility:
         - 0.5.x
         - 0.4.x
         - 0.3.x
+        - 0.2.x
         - 0.2.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -1,7 +1,7 @@
 ---
 name: Datadog
 publisher: Kong Inc.
-version: 3.0.0
+version: 3.0.1
 
 desc: Visualize metrics on Datadog
 description: |
@@ -23,15 +23,17 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x      
+        - 1.5.x
         - 1.4.x
         - 1.3.x
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -40,6 +42,7 @@ kong_version_compatibility:
         - 0.9.x
         - 0.8.x
         - 0.7.x
+        - 0.6.x
         - 0.6.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -1,7 +1,7 @@
 ---
 name: File Log
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.2
 
 desc: Append request and response data to a log file
 description: |
@@ -28,15 +28,17 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x      
+        - 1.5.x
         - 1.4.x
         - 1.3.x
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -48,6 +50,8 @@ kong_version_compatibility:
         - 0.6.x
         - 0.5.x
         - 0.4.x
+        - 0.3.x
+        - 0.2.x
         - 0.3.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -1,7 +1,7 @@
 ---
 name: gRPC-gateway
 publisher: Kong Inc.
-version: 0.1.x
+version: 0.1
 
 categories:
   - transformations
@@ -18,9 +18,11 @@ source_url: https://github.com/Kong/kong-plugin-grpc-gateway
 license_type: MIT
 
 kong_version_compatibility:
-  community_edition:
-    compatible:
-      - 2.2.x
+    community_edition:
+      compatible:
+        - 2.3.x
+        - 2.2.x
+        - 2.1.x
       - 2.1.x
   enterprise_edition:
     compatible:

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -1,7 +1,7 @@
 ---
 name: gRPC-Web
 publisher: Kong Inc.
-version: 0.2.x
+version: 0.2
 
 categories:
   - transformations
@@ -18,10 +18,11 @@ source_url: https://github.com/Kong/kong-plugin-grpc-web
 license_type: MIT
 
 kong_version_compatibility:
-  community_edition:
-    compatible:
-      - 2.2.x
-      - 2.1.x
+    community_edition:
+      compatible:
+        - 2.3.x
+        - 2.2.x
+        - 2.1.x
 
   enterprise_edition:
     compatible:

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -37,6 +38,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -46,6 +48,7 @@ kong_version_compatibility:
         - 0.8.x
         - 0.7.x
         - 0.6.x
+        - 0.5.x
         - 0.5.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -1,7 +1,7 @@
 ---
 name: HTTP Log
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Send request and response logs to an HTTP server
 description: |
@@ -22,7 +22,8 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-       - 2.2.x
+        - 2.3.x
+        - 2.2.x
         - 2.1.x
         - 2.0.x
         - 1.5.x
@@ -31,6 +32,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -42,6 +44,7 @@ kong_version_compatibility:
         - 0.6.x
         - 0.5.x
         - 0.4.x
+        - 0.3.x
         - 0.3.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -1,7 +1,7 @@
 ---
 name: IP Restriction
 publisher: Kong Inc.
-version: 2.0.x
+version: 2.0.0
 
 desc: Allow or deny IPs that can make requests to your Services
 description: |
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -23,6 +24,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -33,6 +35,7 @@ kong_version_compatibility:
         - 0.7.x
         - 0.6.x
         - 0.5.x
+        - 0.4.x
         - 0.4.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/jwt/index.md
+++ b/app/_hub/kong-inc/jwt/index.md
@@ -34,6 +34,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -43,6 +44,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -52,6 +54,7 @@ kong_version_compatibility:
         - 0.8.x
         - 0.7.x
         - 0.6.x
+        - 0.5.x
         - 0.5.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -1,7 +1,7 @@
 ---
 name: Key Authentication
 publisher: Kong Inc.
-version: 2.2.0
+version: 2.3.0
 
 desc: Add key authentication to your Services
 description: |
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -31,6 +32,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -43,6 +45,7 @@ kong_version_compatibility:
         - 0.5.x
         - 0.4.x
         - 0.3.x
+        - 0.2.x
         - 0.2.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -33,12 +34,14 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
         - 0.11.x
         - 0.10.x
         - 0.9.x
+        - 0.8.x
         - 0.8.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -1,7 +1,7 @@
 ---
 name: Loggly
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Send request and response logs to Loggly
 description: |
@@ -14,15 +14,17 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x      
+        - 1.5.x
         - 1.4.x
         - 1.3.x
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -31,6 +33,7 @@ kong_version_compatibility:
         - 0.9.x
         - 0.8.x
         - 0.7.x
+        - 0.6.x
         - 0.6.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -35,6 +35,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -44,6 +45,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -54,6 +56,7 @@ kong_version_compatibility:
         - 0.7.x
         - 0.6.x
         - 0.5.x
+        - 0.4.x
         - 0.4.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -1,7 +1,7 @@
 ---
 name: Prometheus
 publisher: Kong Inc.
-version: 0.9.0
+version: 1.0
 
 desc: Expose metrics related to Kong and proxied Upstream services in Prometheus exposition format
 description: |
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -23,6 +24,8 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
+        - 0.14.x
         - 0.14.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -2,7 +2,7 @@
 
 name: Proxy Cache
 publisher: Kong Inc.
-version: 1.3-x
+version: 1.3
 
 desc: Cache and serve commonly requested responses in Kong
 description: |
@@ -15,12 +15,14 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x      
+        - 1.5.x
         - 1.4.x
         - 1.3.x
+        - 1.2.x
         - 1.2.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -3,7 +3,7 @@ name: Rate Limiting
 publisher: Kong Inc.
 redirect_from:
   - /enterprise/0.35-x/rate-limiting/
-version: 2.2.x
+version: 2.2.0
 
 desc: Rate-limit how many HTTP requests can be made in a period of time
 description: |
@@ -29,28 +29,32 @@ categories:
   - traffic-control
 
 kong_version_compatibility:
-  community_edition:
-    compatible:
-      - 2.2.x
-      - 2.1.x
-      - 2.0.x
-      - 1.4.x
-      - 1.3.x
-      - 1.2.x
-      - 1.1.x
-      - 1.0.x
-      - 0.14.x
-      - 0.13.x
-      - 0.12.x
-      - 0.11.x
-      - 0.10.x
-      - 0.9.x
-      - 0.8.x
-      - 0.7.x
-      - 0.6.x
-      - 0.5.x
-      - 0.4.x
-      - 0.3.x
+    community_edition:
+      compatible:
+        - 2.3.x
+        - 2.2.x
+        - 2.1.x
+        - 2.0.x
+        - 1.5.x
+        - 1.4.x
+        - 1.3.x
+        - 1.2.x
+        - 1.1.x
+        - 1.0.x
+        - 0.15.x
+        - 0.14.x
+        - 0.13.x
+        - 0.12.x
+        - 0.11.x
+        - 0.10.x
+        - 0.9.x
+        - 0.8.x
+        - 0.7.x
+        - 0.6.x
+        - 0.5.x
+        - 0.4.x
+        - 0.3.x
+        - 0.2.x
       - 0.2.x
   enterprise_edition:
     compatible:

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -1,7 +1,7 @@
 ---
 name: Request Size Limiting
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.0
 
 desc: Block requests with bodies greater than a specified size
 description: |
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -35,6 +36,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -46,6 +48,7 @@ kong_version_compatibility:
         - 0.6.x
         - 0.5.x
         - 0.4.x
+        - 0.3.x
         - 0.3.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -1,7 +1,7 @@
 ---
 name: Request Termination
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Terminates all requests with a specific response
 description: |
@@ -16,7 +16,8 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.2.x      
+        - 2.3.x
+        - 2.2.x
         - 2.1.x
         - 2.0.x
         - 1.5.x
@@ -25,9 +26,12 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
+        - 0.11.x
+        - 0.10.x
         - 0.11.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -1,7 +1,7 @@
 ---
 name: Request Transformer
 publisher: Kong Inc.
-version: 1.2.5
+version: 1.2
 
 desc: Use regular expressions, variables, and templates to transform requests
 description: |
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -31,6 +32,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -42,6 +44,8 @@ kong_version_compatibility:
         - 0.6.x
         - 0.5.x
         - 0.4.x
+        - 0.3.x
+        - 0.2.x
         - 0.3.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -1,7 +1,7 @@
 ---
 name: Response Rate Limiting
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.0
 
 desc: Rate-limiting based on a custom response header value
 description: |
@@ -31,6 +31,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -40,6 +41,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -49,6 +51,7 @@ kong_version_compatibility:
         - 0.8.x
         - 0.7.x
         - 0.6.x
+        - 0.5.x
         - 0.5.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -1,7 +1,7 @@
 ---
 name: Response Transformer
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.0
 
 desc: Modify the upstream response before returning it to the client
 description: |
@@ -18,6 +18,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -27,6 +28,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -36,6 +38,9 @@ kong_version_compatibility:
         - 0.8.x
         - 0.7.x
         - 0.6.x
+        - 0.5.x
+        - 0.4.x
+        - 0.3.x
         - 0.5.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -1,7 +1,7 @@
 ---
 name: Serverless Functions
 publisher: Kong Inc.
-version: 1.0-x
+version: 1.0
 
 source_url: https://github.com/Kong/kong-plugin-serverless-functions
 
@@ -23,7 +23,18 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.2.x    
+        - 2.3.x
+        - 2.2.x
+        - 2.1.x
+        - 2.0.x
+        - 1.5.x
+        - 1.4.x
+        - 1.3.x
+        - 1.2.x
+        - 1.1.x
+        - 1.0.x
+        - 0.15.x
+        - 0.14.x
         - 2.1.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/session/index.md
+++ b/app/_hub/kong-inc/session/index.md
@@ -1,7 +1,7 @@
 ---
 name: Session
 publisher: Kong Inc.
-version: 2.4.4-x
+version: 2.4
 redirect_from:
   - /hub/kong-in/sessions
   - /hub/kong-inc/sessions
@@ -24,14 +24,15 @@ categories:
 source_url: https://github.com/Kong/kong-plugin-session
 
 kong_version_compatibility:
-  community_edition:
-    compatible:
-      - 2.2.x     
-      - 2.1.x
-      - 2.0.x
-      - 1.5.x
-      - 1.4.x
-      - 1.3.x
+    community_edition:
+      compatible:
+        - 2.3.x
+        - 2.2.x
+        - 2.1.x
+        - 2.0.x
+        - 1.5.x
+        - 1.4.x
+        - 1.3.x
       - 1.2.x
   enterprise_edition:
     compatible:

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -1,7 +1,7 @@
 ---
 name: StatsD
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Send request and response logs to StatsD
 description: |
@@ -26,6 +26,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -35,12 +36,14 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
         - 0.11.x
         - 0.10.x
         - 0.9.x
+        - 0.8.x
         - 0.8.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -1,7 +1,7 @@
 ---
 name: Syslog
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Send request and response logs to Syslog
 description: |
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -23,6 +24,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -31,6 +33,7 @@ kong_version_compatibility:
         - 0.9.x
         - 0.8.x
         - 0.7.x
+        - 0.6.x
         - 0.6.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -1,7 +1,7 @@
 ---
 name: TCP Log
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Send request and response logs to a TCP server
 description: |
@@ -22,6 +22,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -31,6 +32,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -43,6 +45,7 @@ kong_version_compatibility:
         - 0.5.x
         - 0.4.x
         - 0.3.x
+        - 0.2.x
         - 0.2.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -1,7 +1,7 @@
 ---
 name: UDP Log
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.1
 
 desc: Send request and response logs to a UDP server
 description: |
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -23,6 +24,7 @@ kong_version_compatibility:
         - 1.2.x
         - 1.1.x
         - 1.0.x
+        - 0.15.x
         - 0.14.x
         - 0.13.x
         - 0.12.x
@@ -35,6 +37,7 @@ kong_version_compatibility:
         - 0.5.x
         - 0.4.x
         - 0.3.x
+        - 0.2.x
         - 0.2.x
     enterprise_edition:
       compatible:

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -3,7 +3,7 @@ name: Zipkin
 publisher: Kong Inc.
 redirect_from:
   - /hub/kong-inc/zipkin/http-log/
-version: 1.2.0
+version: 1.1
 
 source_url: https://github.com/Kong/kong-plugin-zipkin
 
@@ -24,17 +24,20 @@ categories:
   - analytics-monitoring
 
 kong_version_compatibility:
-  community_edition:
-    compatible:
-      - 2.2.x
-      - 2.1.x
-      - 2.0.x
-      - 1.5.x
-      - 1.4.x
-      - 1.3.x
-      - 1.2.x
-      - 1.1.x
-      - 1.0.x
+    community_edition:
+      compatible:
+        - 2.3.x
+        - 2.2.x
+        - 2.1.x
+        - 2.0.x
+        - 1.5.x
+        - 1.4.x
+        - 1.3.x
+        - 1.2.x
+        - 1.1.x
+        - 1.0.x
+        - 0.15.x
+        - 0.14.x
       - 0.14.x
   enterprise_edition:
     compatible:

--- a/autodoc-kong-hub/gen.py
+++ b/autodoc-kong-hub/gen.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from git import Repo
+import re
+import argparse
+
+parser = argparse.ArgumentParser(description='Update Kong plugin version information. ' \
+                                             'This tool updates the latest plugin version ' \
+                                             'and compatible Kong version info in plugin hub docs.')
+parser.add_argument('--latest-version', help='tag of the latest version of Kong release, can not be prereleases such as x.y.zrc1', required=True, metavar='x.y.z')
+parser.add_argument('--kong-repo', help='path to a freshly cloned Kong Git repository', required=True, metavar="PATH")
+parser.add_argument('--kong-doc-repo', help='path to the Kong Doc repository where the change should be applied to', required=True, metavar='PATH')
+
+args = parser.parse_args()
+
+# transforms old plugin names to new ones
+MAP = {
+    "ip_restriction": "ip-restriction",
+    "log_serializers": "log-serializers",
+    "tcplog": "tcp-log",
+    "udplog": "udp-log",
+    "httplog": "http-log",
+    "filelog": "file-log",
+    "request_transformer": "request-transformer",
+    "ratelimiting": "rate-limiting",
+    "basicauth": "basic-auth",
+    "keyauth": "key-auth",
+    "requestsizelimiting": "request-size-limiting",
+    "response_transformer": "response-transformer",
+}
+
+
+result = {}
+latest = {}
+
+
+LATEST = args.latest_version
+repo = Repo(args.kong_repo)
+
+for t in repo.tags:
+    ts = str(t)
+    if re.match(r"\d\.\d+(?:\.\d)*$", ts):
+        if ts == LATEST:
+            target = t.commit.tree
+            for n in target.blobs:
+                if 'rockspec' in n.name:
+                    spec = target / n.name
+                    spec = spec.data_stream.read().decode("utf-8")
+                    for m in re.finditer(r'"kong-plugin-(.+) .+ (.+)",', spec):
+                        latest[m[1]] = m[2]
+
+                    for m in re.finditer(r'"kong-(.+)-plugin .+ (.+)",', spec):
+                        latest[m[1]] = m[2]
+                    break
+
+        target = t.commit.tree / "kong/plugins"
+        for plugin in target.trees:
+            if ts == LATEST:
+                try:
+                    handler = plugin / "handler.lua"
+                except KeyError:
+                  continue
+
+                handler = handler.data_stream.read().decode("utf-8")
+                ver = re.search(r'VERSION = "(\d\.\d\.\d)"', handler)
+                if ver:
+                  latest[plugin.name] = ver[1]
+
+                else:
+                  print(handler)
+
+            l = result.setdefault(MAP.get(plugin.name) or plugin.name, set())
+
+            ts_mask = ts[:-1] + 'x'
+            l.add(ts_mask)
+
+        target = t.commit.tree
+        for n in target.blobs:
+            if 'rockspec' in n.name:
+                spec = target / n.name
+                spec = spec.data_stream.read().decode("utf-8")
+                for m in re.finditer(r'"kong-plugin-(.+) .+ .+",', spec):
+                    l = result.setdefault(MAP.get(m[1]) or m[1], set())
+
+                    ts = ts[:-1] + 'x'
+                    l.add(ts)
+
+                for m in re.finditer(r'"kong-(.+)-plugin .+ .+",', spec):
+                    l = result.setdefault(MAP.get(m[1]) or m[1], set())
+
+                    ts = ts[:-1] + 'x'
+                    l.add(ts)
+                break
+
+result = { k: list(v) for k, v in result.items() }
+
+for v in result.values():
+    v.sort(key=lambda s: list(map(int, s.split('.')[:-1])), reverse=True)
+
+for k, v in result.items():
+    path = "%s/app/_hub/kong-inc/%s/index.md" % (args.kong_doc_repo, k)
+    try:
+        f = open(path, "r")
+        lines = f.readlines()
+        f.close()
+
+        ce_yaml = ["    community_edition:\n", "      compatible:\n"]
+        for ce in v:
+            ce_yaml.append("        - " + ce + "\n")
+
+        start_ce = None
+        for i, l in enumerate(lines):
+            if "community_edition:" in l:
+                start_ce = i
+
+            if start_ce and "enterprise_edition:" in l:
+                end_ce = i - 1
+                lines[start_ce:end_ce] = ce_yaml
+                break
+
+        for i, l in enumerate(lines):
+            if latest.get(k) and l.startswith("version:"):
+                lines[i] = "version: " + latest[k] + '\n'
+
+        f = open(path, "w")
+        content = f.write(''.join(lines))
+        f.close()
+
+    except FileNotFoundError:
+      continue

--- a/autodoc-kong-hub/requirments.txt
+++ b/autodoc-kong-hub/requirments.txt
@@ -1,0 +1,3 @@
+gitdb==4.0.5
+GitPython==3.1.12
+smmap==3.0.4


### PR DESCRIPTION
This PR adds a new script that allows update of plugin version and Kong CE version information automatically.

To run it, you need to have Python 3, then setup the virtualenv:

```
python3 -m venv /path/to/docs.konghq.com/autodoc-kong-hub
source /path/to/docs.konghq.com/autodoc-kong-hub/bin/activate
pip install -r requirments.txt
```

Then you can run the tool like this:

```
python gen.py --latest-version 2.2.1 --kong-repo /path/to/kong/kong/ --kong-doc-repo /path/to/docs.konghq.com/
```

Running `python gen.py -h` will show the usage of the script.

The script is a bit hacky due to the fact that is is probably the only autodoc tool that updates instead of generating a file, so a lot of logic was involved in manipulating the file in place correctly.

There are also a list of plugins at the top of the script that had changed named over the years, the script handles these and considers them the same plugin.

There is a commit of me running the script against the `2.2.1` tag as a preview of what the script does, however we do not necessarily need to merge that commit if it is not needed. We can easily re run the script against 2.3.0 later.

We can easily make a similar script that handles the EE plugins, however let's make sure the behavior is reasonable before putting more work into it.