### PR TITLE
CE 2.3: Update request-size-limiting plugin for new field that requires valid content-length-header

### DIFF
--- a/app/_data/extensions/kong-inc/request-size-limiting/versions.yml
+++ b/app/_data/extensions/kong-inc/request-size-limiting/versions.yml
@@ -1,3 +1,3 @@
 - release: 2.3.x
-- release: 1.0-x
+- release: 1.0.x
 - release: 0.1-x

--- a/app/_data/extensions/kong-inc/request-size-limiting/versions.yml
+++ b/app/_data/extensions/kong-inc/request-size-limiting/versions.yml
@@ -1,3 +1,3 @@
-- release: 2.3.x
+- release: 2.0.x
 - release: 1.0.x
 - release: 0.1-x

--- a/app/_data/extensions/kong-inc/request-size-limiting/versions.yml
+++ b/app/_data/extensions/kong-inc/request-size-limiting/versions.yml
@@ -1,2 +1,3 @@
+- release: 2.3.x
 - release: 1.0-x
 - release: 0.1-x

--- a/app/_hub/kong-inc/request-size-limiting/1.0.x.md
+++ b/app/_hub/kong-inc/request-size-limiting/1.0.x.md
@@ -11,14 +11,6 @@ description: |
 
   Block incoming requests whose body is greater than a specific size in megabytes.
 
-  <div class="alert alert-warning">
-    <strong>Note:</strong> The functionality of this plugin as bundled
-    with versions of Kong prior to 0.9.0
-    differs from what is documented herein. Refer to the
-    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
-    for details.
-  </div>
-
 type: plugin
 categories:
   - traffic-control

--- a/app/_hub/kong-inc/request-size-limiting/1.0.x.md
+++ b/app/_hub/kong-inc/request-size-limiting/1.0.x.md
@@ -68,6 +68,6 @@ params:
     - name: size_unit
       required: true
       default: "`megabytes`"
-      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes`. Note- this configuration is only supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway
+      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes`. Note this configuration is not available in versions prior to Kong Enterprise 1.3 and Kong Gateway 2.0.
 
 ---

--- a/app/_hub/kong-inc/request-size-limiting/1.0.x.md
+++ b/app/_hub/kong-inc/request-size-limiting/1.0.x.md
@@ -1,16 +1,23 @@
 ---
 name: Request Size Limiting
 publisher: Kong Inc.
-version: 2.0.0
+version: 1.0.0
 
 desc: Block requests with bodies greater than a specified size
 description: |
   <div class="alert alert-warning">
-    For security reasons, we suggest enabling this plugin for any Service you add
-    to Kong Gateway to prevent a DOS (Denial of Service) attack.
+    For security reasons we suggest enabling this plugin for any Service you add to Kong to prevent a DOS (Denial of Service) attack.
   </div>
 
   Block incoming requests whose body is greater than a specific size in megabytes.
+
+  <div class="alert alert-warning">
+    <strong>Note:</strong> The functionality of this plugin as bundled
+    with versions of Kong prior to 0.9.0
+    differs from what is documented herein. Refer to the
+    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
+    for details.
+  </div>
 
 type: plugin
 categories:
@@ -19,7 +26,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
@@ -43,7 +49,6 @@ kong_version_compatibility:
         - 0.3.x
     enterprise_edition:
       compatible:
-        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 1.5.x
@@ -66,21 +71,11 @@ params:
     - name: allowed_payload_size
       required: true
       default: "`128`"
-      datatype: integer
       value_in_examples: 128
-      description: Allowed request payload size in megabytes. Default: `128` (128000000 Bytes).
+      description: Allowed request payload size in megabytes, default is `128` (128000000 Bytes)
     - name: size_unit
       required: true
       default: "`megabytes`"
-      datatype: string
-      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). **Note:** This configuration is only
-      supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway (OSS).
-    - name: require_content_length
-      required: false
-      default: false
-      datatype: boolean
-      value_in_examples: false
-      description: Set to `true` to ensure a valid `Content-Length` header exists before reading the request body. Default: `false`.
-
+      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes`. Note- this configuration is only supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway
 
 ---

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -73,7 +73,7 @@ params:
       required: true
       default: "`megabytes`"
       datatype: string
-      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is only supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway (OSS).
+      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is not available in versions prior to Kong Enterprise 1.3 and Kong Gateway (OSS) 2.0.
     - name: require_content_length
       required: false
       default: false

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -68,19 +68,17 @@ params:
       default: "`128`"
       datatype: integer
       value_in_examples: 128
-      description: Allowed request payload size in megabytes. Default: `128` (128000000 Bytes).
+      description: Allowed request payload size in megabytes. Default is `128` megabytes (128000000 bytes).
     - name: size_unit
       required: true
       default: "`megabytes`"
       datatype: string
-      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). **Note:** This configuration is only
-      supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway (OSS).
+      description: Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is only supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway (OSS).
     - name: require_content_length
       required: false
       default: false
       datatype: boolean
       value_in_examples: false
-      description: Set to `true` to ensure a valid `Content-Length` header exists before reading the request body. Default: `false`.
-
+      description: Set to `true` to ensure a valid `Content-Length` header exists before reading the request body.
 
 ---


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1536

See PR for code: https://github.com/Kong/kong/pull/6660/commits/65ab975eda1e374d93679a5b02bc9de8cb6420f4

Update plugin for new require_content_length field for 2.3. Added data types, copy edited, and bumped the version. 

Direct review link: https://deploy-preview-2547--kongdocs.netlify.app/hub/kong-inc/request-size-limiting/


Reviewers: Do we need to mention 411 error for chunked content (transfer encoding)? (I guess not.)
Does the open source now support the size  field (Yes, adjusted per Thij's feedback)? See legacy content: 

> Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). **Note:** This configuration is only
      supported in Kong Enterprise 1.3 and above, and may eventually extend to Kong Gateway (OSS).