### PR TITLE
Update decK version metadata for 1.3.0

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -406,7 +406,7 @@
   version: "2.3"
   edition: "getting-started-guide"
 -
-  version: "1.2.1"
+  version: "1.3.0"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
Catching up, as this version was released 12 days ago: https://github.com/Kong/deck/releases/tag/v1.3.0

This updates version strings in the installation topic.
