### PR TITLE
KIC: Support Kubernetes 1.20 and 1.21

### DIFF
--- a/app/kubernetes-ingress-controller/1.1.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/1.1.x/references/version-compatibility.md
@@ -64,3 +64,5 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kubernetes 1.17           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |


### PR DESCRIPTION
Add Kubernetes 1.20 and 1.21 to the supported version matrix.

cc @Kong/team-k8s @eskibars 