### PR TITLE
Update algolia config for KE

### DIFF
--- a/algolia/config-ee.json
+++ b/algolia/config-ee.json
@@ -19,9 +19,9 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": ".docs-navigation > a.active",
+      "selector": ".search-selector",
       "global": true,
-      "default_value": "Kong"
+      "default_value": "Kong Gateway (Enterprise)"
     },
     "lvl1": "h1",
     "lvl2": ".content h2",

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -270,3 +270,9 @@ nav {
     display: none !important;
   }
 }
+
+.search-selector {
+  visibility: hidden;
+  height: 0;
+  width: 0;
+}

--- a/app/_includes/search-selector.html
+++ b/app/_includes/search-selector.html
@@ -1,0 +1,1 @@
+<div class="search-selector">{% if page.url contains 'docs.konghq.com/hub' %}Plugin Hub{% else %}{{ page.edition }}{% endif %}</div>

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -17,6 +17,7 @@
     data-offset="350"
   >
     {% include nav-v2.html %}
+    {% include search-selector.html %}
 
     {{ content }}
 


### PR DESCRIPTION
With Kong Enterprise getting removed from the tabs for Konnect, there's no top-level selector for Enterprise pages. 

Adding a selector and adjusting EE config file to match. Will be switching all content to this top-level hidden selector in the future.