### PR TITLE
docs(konnect) Removing khcp, replacing with konnect

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -144,5 +144,5 @@
       url: /reference/konnect-api
       items:
         - text: Konnect API Reference
-          url: https://khcp.konghq.com/docs
+          url: https://konnect.konghq.com/docs
           absolute_url: true

--- a/app/konnect/dev-portal/developers/dev-reg.md
+++ b/app/konnect/dev-portal/developers/dev-reg.md
@@ -12,7 +12,7 @@ Access the Dev Portal for any published Service through the URL
 displayed on the **Dev Portal** page. The format looks something like this:
 
 ```
-<org-name>.portal.khcp.konghq.com/portal/published-services
+<org-name>.portal.konnect.konghq.com/portal/published-services
 ```
 
 1. Navigate to the {{site.konnect_short_name}} Dev Portal page.

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -16,7 +16,7 @@ click **Dev Portal**. The **Published Services** page displays the **Portal URL*
 The format looks something like this:
 
 ```
-<org-name>.portal.khcp.konghq.com
+<org-name>.portal.konnect.konghq.com
 ```
 
 Setting up custom Dev Portal URLs is not currently supported through

--- a/app/konnect/reference/konnect-api.md
+++ b/app/konnect/reference/konnect-api.md
@@ -10,8 +10,8 @@ organization and its entities, so care should be taken when setting up
 [user permissions](/konnect/reference/org-management/#role-definitions).
 
 For a list of all endpoints, see:
-* [Konnect API Swagger documentation](https://khcp.konghq.com/docs)
-* [Raw Swagger JSON](https://khcp.konghq.com/docs-json)
+* [Konnect API Swagger documentation](https://konnect.konghq.com/docs)
+* [Raw Swagger JSON](https://konnect.konghq.com/docs-json)
 
 ## Making a Request to the Konnect API
 


### PR DESCRIPTION
Removing straggling instances of `khcp` in URLs that got missed in the launch.

