### PR TITLE
Fix OIDC issuer url syntax

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/using-oidc-plugin.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/using-oidc-plugin.md
@@ -114,8 +114,7 @@ kind: KongPlugin
 metadata:
   name: oidc-auth
 config:
-  issuer:
-  - https://accounts.google.com/.well-known/openid-configuration
+  issuer: https://accounts.google.com/.well-known/openid-configuration
   client_id:
   - <client-id>
   client_secret:

--- a/app/kubernetes-ingress-controller/1.1.x/guides/using-oidc-plugin.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/using-oidc-plugin.md
@@ -114,8 +114,7 @@ kind: KongPlugin
 metadata:
   name: oidc-auth
 config:
-  issuer:
-  - https://accounts.google.com/.well-known/openid-configuration
+  issuer: https://accounts.google.com/.well-known/openid-configuration
   client_id:
   - <client-id>
   client_secret:


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1556

This is already correct in the OIDC plugin docs, for example: https://docs.konghq.com/hub/kong-inc/openid-connect/#configclient_jwk
