### PR TITLE
fix syntax error of kubernetes manifest in example

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-classes.md
@@ -120,6 +120,7 @@ credential Secret, Ingress, and KongPlugin (a Service is implied, but not
 shown):
 
 ```yaml
+apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: dyadya-styopa

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-classes.md
@@ -120,6 +120,7 @@ credential Secret, Ingress, and KongPlugin (a Service is implied, but not
 shown):
 
 ```yaml
+apiVersion: configuration.konghq.com/v1
 kind: KongConsumer
 metadata:
   name: dyadya-styopa


### PR DESCRIPTION
<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

`apiVersion` missed in kubernetes manifest.