### PR TITLE
fix(search) Adjust plugin hub value for algolia

### DIFF
--- a/app/_includes/search-selector.html
+++ b/app/_includes/search-selector.html
@@ -1,9 +1,8 @@
-<div class="search-selector">{% if page.url contains 'docs.konghq.com/hub/'
-  %}Plugin Hub{% elsif
-    page.edition == 'enterprise' %}{{site.ee_product_name}}{% elsif
+<div class="search-selector">{% if page.edition == 'enterprise' %}{{site.ee_product_name}}{% elsif
     page.edition == 'gateway-oss' %}{{site.ce_product_name}}{% elsif
     page.edition == 'getting-started-guide' %}{{site.base_gateway}} Getting Started Guide {% elsif
     page.edition == 'mesh' %}{{site.mesh_product_name}}{% elsif
     page.edition == 'konnect' %}{{site.konnect_product_name}}{% elsif
     page.edition == 'kubernetes-ingress-controller' %}{{site.kic_product_name}}{% elsif
-    page.edition == 'deck' %}decK{% endif %}</div>
+    page.edition == 'deck' %}decK{% elsif
+    page.url contains '/hub/' %}Plugin Hub{% endif %}</div>


### PR DESCRIPTION
Minor adjustments, as currently the "Plugin Hub" label isn't being picked up properly, and the plugins get categorized as "Kong" instead.
