### PR TITLE
Update link for community

### DIFF
--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -19,7 +19,7 @@
           </div>
         </div>
         <a href="https://support.konghq.com/" class="navbar-item">Support</a>
-        <a href="https://discuss.konghq.com/" class="navbar-item">Community</a>
+        <a href="https://konghq.com/community/" class="navbar-item">Community</a>
         <a href="https://learn.konghq.com/account/login/" class="navbar-item">Kong U</a>
         <a href="https://portal.konglabs.io/workshops" class="navbar-item">Demos & Labs</a>
       </div>


### PR DESCRIPTION
Edit link in navbar to point at a community overview page instead of discuss, which is just one piece.

