### PR TITLE
docs(serverless) document sandboxing in serverless functions 2.0

### DIFF
--- a/app/_data/extensions/kong-inc/serverless-functions/versions.yml
+++ b/app/_data/extensions/kong-inc/serverless-functions/versions.yml
@@ -1,2 +1,3 @@
+- release: 2.0-x
 - release: 1.0-x
 - release: 0.1-x

--- a/app/_hub/kong-inc/serverless-functions/1.0-x.md
+++ b/app/_hub/kong-inc/serverless-functions/1.0-x.md
@@ -1,7 +1,7 @@
 ---
 name: Serverless Functions
 publisher: Kong Inc.
-version: 2.0-x
+version: 1.0-x
 
 source_url: https://github.com/Kong/kong-plugin-serverless-functions
 
@@ -23,12 +23,10 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.3.x
         - 2.2.x
         - 2.1.x
     enterprise_edition:
       compatible:
-        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 1.5.x
@@ -268,36 +266,6 @@ without requiring redeploying or restarting Kong.
 
 
 ### Notes
-
-#### Sandboxing
-
-Starting on version 2.0 of the plugin, the provided Lua environment is sandboxed.
-
-The sandboxing consists on several limitations in the way the Lua code can be executed,
-for heightened security.
-
-The following functions are not available since they can be used to abuse the system:
-
-* `string.rep`: can be used to allocate millions of bytes in 1 operation
-* `{set|get}metatable`: can be used to modify the metatables of global objects (strings, numbers)
-* `collectgarbage`: can be abused to kill the performance of other workers
-* `_G`: Is the root node which has access to all functions. It is masked by a temporary table
-* `load{file|string}`: Is deemed unsafe because it can grant access to global env
-* `raw{get|set|equal}`: Potentially unsafe since the sandboxing relies on some metatable manipulation
-* `string.dump`: Can display confidential server info (implementation of functions)
-* `math.randomseed`: Can affect the host sytem, and Kong already seeds the random number generator properly
-* All `os.*` except `os.clock`, `os.difftime` and `os.time`: `os.execute` can alter the host system significantly
-* `io.*`: provides access to the hard drive
-* `dofile|require`: provides access to the hard drive
-
-The exclusion of `require` means that Plugins must only use PDK functions `kong.*`. The `ngx.*` abstraction is
-also available, but it is not guaranteed to be present in future versions of the plugin.
-
-In addition to these restrictions,
-
-* All the provided modules (like `string` or `table`) are read-only and can't be modified.
-* Bytecode execution is disabled.
-
 
 #### Upvalues
 

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -271,29 +271,29 @@ without requiring redeploying or restarting Kong.
 
 #### Sandboxing
 
-Starting on version 2.0 of the plugin, the provided Lua environment is sandboxed.
+Starting with version 2.0 of the plugin, the provided Lua environment is sandboxed.
 
-The sandboxing consists on several limitations in the way the Lua code can be executed,
+The sandboxing consists of several limitations in the way the Lua code can be executed,
 for heightened security.
 
-The following functions are not available since they can be used to abuse the system:
+The following functions are not available because they can be used to abuse the system:
 
-* `string.rep`: can be used to allocate millions of bytes in 1 operation
-* `{set|get}metatable`: can be used to modify the metatables of global objects (strings, numbers)
-* `collectgarbage`: can be abused to kill the performance of other workers
-* `_G`: Is the root node which has access to all functions. It is masked by a temporary table
-* `load{file|string}`: Is deemed unsafe because it can grant access to global env
-* `raw{get|set|equal}`: Potentially unsafe since the sandboxing relies on some metatable manipulation
-* `string.dump`: Can display confidential server info (implementation of functions)
-* `math.randomseed`: Can affect the host sytem, and Kong already seeds the random number generator properly
-* All `os.*` except `os.clock`, `os.difftime` and `os.time`: `os.execute` can alter the host system significantly
-* `io.*`: provides access to the hard drive
-* `dofile|require`: provides access to the hard drive
+* `string.rep`: Can be used to allocate millions of bytes in one operation.
+* `{set|get}metatable`: Can be used to modify the metatables of global objects (strings, numbers).
+* `collectgarbage`: Can be abused to kill the performance of other workers.
+* `_G`: Is the root node which has access to all functions. It is masked by a temporary table.
+* `load{file|string}`: Is deemed unsafe because it can grant access to global environment.
+* `raw{get|set|equal}`: Potentially unsafe because the sandboxing relies on some metatable manipulation.
+* `string.dump`: Can display confidential server information (such as implementation of functions).
+* `math.randomseed`: Can affect the host system. {{site.base_gateway}} already seeds the random number generator properly.
+* All `os.*` (except `os.clock`, `os.difftime`, and `os.time`: `os.execute`) can significantly alter the host system.
+* `io.*`: Provides access to the hard drive.
+* `dofile|require`: Provides access to the hard drive.
 
 The exclusion of `require` means that Plugins must only use PDK functions `kong.*`. The `ngx.*` abstraction is
 also available, but it is not guaranteed to be present in future versions of the plugin.
 
-In addition to these restrictions,
+In addition to the above restrictions:
 
 * All the provided modules (like `string` or `table`) are read-only and can't be modified.
 * Bytecode execution is disabled.


### PR DESCRIPTION
This PR adds a new version of the serverless plugin (which starts in Kong 2.3).

The main difference between serverless plugin 1.0 and 2.0 is the sandboxing feature, for which I am also attaching some docs.
