### PR TITLE
Konnect updates: deployment week 2021-02-08

### DIFF
--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -11,35 +11,11 @@ services.
 
 ### February 10, 2021
 
-**{{site.base_gateway}} 2.3 support**
-: {{site.konnect_short_name}} SaaS now supports {{site.base_gateway}} 2.3
-runtimes. There is no upgrade path for existing runtimes.
-: To use {{site.base_gateway}} 2.3, [reprovision a new runtime](/konnect/runtime-manager/kong-gateway-runtime).
-
-**Advanced runtime configuration**
-: You can now configure custom {{site.base_gateway}} data planes through the
-Runtime Manager and run gateway instances outside of Docker. Use the
-[advanced option](/konnect/runtime-manager/kong-gateway-runtime/) when
-configuring a new runtime to get started.
-
 **Portal authentication**
 : You can now [disable authentication on a Dev Portal](/konnect/dev-portal/administrators/public-portal/),
 which exposes the Dev Portal publicly to anyone with the link. No one needs to register
 for Dev Portal access.
 : New application registrations aren't available through a public-facing portal.
-
-**Logging plugins**
-: The full set of {{site.base_gateway}}'s logging plugins is now available through
-{{site.konnect_short_name}} SaaS. This includes:
-* [File Log](/hub/kong-inc/file-log)
-* [HTTP Log](/hub/kong-inc/http-log)
-* [Kafka Log](/hub/kong-inc/kafka-log)
-* [Loggly](/hub/kong-inc/loggly)
-* [StatsD](/hub/kong-inc/statsd)
-* [StatsD Advanced](/hub/kong-inc/statsd-advanced)
-* [Syslog](/hub/kong-inc/syslog)
-* [TCP Log](/hub/kong-inc/tcp-log)
-* [UDP Log](/hub/kong-inc/udp-log)
 
 ### February 1, 2021
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -24,7 +24,7 @@ configuring a new runtime to get started.
 
 **Portal authentication**
 : You can now [disable authentication on a Dev Portal](/konnect/dev-portal/administrators/public-portal/),
-which exposes the Dev Portal to anyone with the link. No one needs to register
+which exposes the Dev Portal publicly to anyone with the link. No one needs to register
 for Dev Portal access.
 : New application registrations aren't available through a public-facing portal.
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -1,12 +1,45 @@
 ---
 title: Konnect SaaS Updates
 no_version: true
+skip_read_time: true
 ---
 
 The updates contained in this topic apply to {{site.konnect_short_name}}
 SaaS, an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
+
+### February 10, 2021
+
+**{{site.base_gateway}} 2.3 support**
+: {{site.konnect_short_name}} SaaS now supports {{site.base_gateway}} 2.3
+runtimes. There is no upgrade path for existing runtimes.
+: To use {{site.base_gateway}} 2.3, [reprovision a new runtime](/konnect/runtime-manager/kong-gateway-runtime).
+
+**Advanced runtime configuration**
+: You can now configure custom {{site.base_gateway}} data planes through the
+Runtime Manager and run gateway instances outside of Docker. Use the
+[advanced option](/konnect/runtime-manager/kong-gateway-runtime/) when
+configuring a new runtime to get started.
+
+**Portal authentication**
+: You can now [disable authentication on a Dev Portal](/konnect/dev-portal/administrators/public-portal/),
+which exposes the Dev Portal to anyone with the link. No one needs to register
+for Dev Portal access.
+: New application registrations aren't available through a public-facing portal.
+
+**Logging plugins**
+: The full set of {{site.base_gateway}}'s logging plugins is now available through
+{{site.konnect_short_name}} SaaS. This includes:
+* [File Log](/hub/kong-inc/file-log)
+* [HTTP Log](/hub/kong-inc/http-log)
+* [Kafka Log](/hub/kong-inc/kafka-log)
+* [Loggly](/hub/kong-inc/loggly)
+* [StatsD](/hub/kong-inc/statsd)
+* [StatsD Advanced](/hub/kong-inc/statsd-advanced)
+* [Syslog](/hub/kong-inc/syslog)
+* [TCP Log](/hub/kong-inc/tcp-log)
+* [UDP Log](/hub/kong-inc/udp-log)
 
 ### February 1, 2021
 


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1573

Note for reviewers: the broken link is going to `/konnect/dev-portal/administrators/public-portal/`, which is a new topic added in https://github.com/Kong/docs.konghq.com/pull/2574. This PR can still be merged if that is the only broken link.

Preview: https://deploy-preview-2577--kongdocs.netlify.app/konnect/updates/