### PR TITLE
fix(styles) Plugin numbering display issue

### DIFF
--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -59,7 +59,10 @@
       margin: 0 0 2.5rem 0;
     }
 
-    ol, ul {
+    ol {
+        padding-left: 2rem;
+        counter-reset: base;
+
       li {
         p {
           font-size: inherit;
@@ -67,11 +70,21 @@
       }
     }
 
+    ol > li::before {
+      counter-increment: base;
+      content: counter(base);
+      font-size: 13px;
+    }
+
     ul {
       margin-left: 0.5rem;
 
       li {
         list-style-type: disc;
+
+        p {
+          font-size: inherit;
+        }
       }
     }
 


### PR DESCRIPTION
Sometime around the release of Konnect, an errant CSS change broke the display of ordered lists in the plugin hub. 
Exhibit A: https://docs.konghq.com/hub/kong-inc/openid-connect/#important-configuration-parameters

Fixing that, matching the numbering style to the rest of the site.

Preview:
https://deploy-preview-2584--kongdocs.netlify.app/hub/kong-inc/openid-connect/#important-configuration-parameters