### PR TITLE
Update URLs for OSS installation

### DIFF
--- a/app/gateway-oss/2.0.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.0.x/getting-started/adding-consumers.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.0.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.0.x/getting-started/configuring-a-grpc-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.0.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.0.x/getting-started/configuring-a-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.0.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.0.x/getting-started/enabling-plugins.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> - It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.0.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.0.x/getting-started/introduction.md
@@ -4,7 +4,7 @@ skip_read_time: true
 ---
 
 <div class="alert alert-warning">
-  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 Before going further into Kong, make sure you understand its [purpose and philosophy](/about). Once you are confident with the concept of API Gateways, this guide is going to take you through a quick introduction on how to use Kong and perform basic operations such as:

--- a/app/gateway-oss/2.0.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.0.x/getting-started/quickstart.md
@@ -5,7 +5,7 @@ skip_read_time: true
 
 <div class="alert alert-warning">
   <strong>Before you start:</strong> Make sure you've
-  <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 In this section, you'll learn how to manage your Kong instance. First, we'll

--- a/app/gateway-oss/2.0.x/index.md
+++ b/app/gateway-oss/2.0.x/index.md
@@ -5,9 +5,9 @@ is_homepage: true
 
 <div class="docs-grid">
   <div class="docs-grid-block">
-    <h3><a href="https://konghq.com/install/">Installation</a></h3>
+    <h3><a href="https://konghq.com/install/#kong-community">Installation</a></h3>
     <p>You can install Kong Gateway on most Linux distributions and MacOS. We even provide the source so you can compile it yourself.</p>
-    <a href="https://konghq.com/install/">Install Kong Gateway &rarr;</a>
+    <a href="https://konghq.com/install/#kong-community">Install Kong Gateway &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.0.x/systemd.md
+++ b/app/gateway-oss/2.0.x/systemd.md
@@ -11,7 +11,7 @@ Debian and RPM based packages. Note that some of the supported GNU/Linux
 distributions for Kong may not have adopted systemd as their default init
 system (for example, CentOS 6 and RHEL 6). For the following instructions, it
 is assumed that Kong has already been [installed and
-configured](https://konghq.com/install/) on a systemd-supported GNU/Linux
+configured](https://konghq.com/install/#kong-community) on a systemd-supported GNU/Linux
 distribution.
 
 ## Start Kong

--- a/app/gateway-oss/2.1.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.1.x/getting-started/adding-consumers.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.1.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.1.x/getting-started/configuring-a-grpc-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.1.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.1.x/getting-started/configuring-a-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.1.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.1.x/getting-started/enabling-plugins.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> - It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.1.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.1.x/getting-started/introduction.md
@@ -4,7 +4,7 @@ skip_read_time: true
 ---
 
 <div class="alert alert-warning">
-  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 Before going further into Kong, make sure you understand its [purpose and philosophy](/about). Once you are confident with the concept of API Gateways, this guide is going to take you through a quick introduction on how to use Kong and perform basic operations such as:

--- a/app/gateway-oss/2.1.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.1.x/getting-started/quickstart.md
@@ -5,7 +5,7 @@ skip_read_time: true
 
 <div class="alert alert-warning">
   <strong>Before you start:</strong> Make sure you've
-  <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 In this section, you'll learn how to manage your Kong instance. First, we'll

--- a/app/gateway-oss/2.1.x/index.md
+++ b/app/gateway-oss/2.1.x/index.md
@@ -5,9 +5,9 @@ is_homepage: true
 
 <div class="docs-grid">
   <div class="docs-grid-block">
-    <h3><a href="https://konghq.com/install/">Installation</a></h3>
+    <h3><a href="https://konghq.com/install/#kong-community">Installation</a></h3>
     <p>You can install Kong Gateway on most Linux distributions and MacOS. We even provide the source so you can compile it yourself.</p>
-    <a href="https://konghq.com/install/">Install Kong Gateway &rarr;</a>
+    <a href="https://konghq.com/install/#kong-community">Install Kong Gateway &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.1.x/systemd.md
+++ b/app/gateway-oss/2.1.x/systemd.md
@@ -11,7 +11,7 @@ Debian and RPM based packages. Note that some of the supported GNU/Linux
 distributions for Kong may not have adopted systemd as their default init
 system (for example, CentOS 6 and RHEL 6). For the following instructions, it
 is assumed that Kong has already been [installed and
-configured](https://konghq.com/install/) on a systemd-supported GNU/Linux
+configured](https://konghq.com/install/#kong-community) on a systemd-supported GNU/Linux
 distribution.
 
 ## Start Kong

--- a/app/gateway-oss/2.2.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.2.x/getting-started/adding-consumers.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.2.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.2.x/getting-started/configuring-a-grpc-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.2.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.2.x/getting-started/configuring-a-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.2.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.2.x/getting-started/enabling-plugins.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> - It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.2.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.2.x/getting-started/introduction.md
@@ -4,7 +4,7 @@ skip_read_time: true
 ---
 
 <div class="alert alert-warning">
-  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 Before going further into Kong, make sure you understand its [purpose and philosophy](/about). Once you are confident with the concept of API Gateways, this guide is going to take you through a quick introduction on how to use Kong and perform basic operations such as:

--- a/app/gateway-oss/2.2.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.2.x/getting-started/quickstart.md
@@ -5,7 +5,7 @@ skip_read_time: true
 
 <div class="alert alert-warning">
   <strong>Before you start:</strong> Make sure you've
-  <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 In this section, you'll learn how to manage your Kong instance. First, we'll

--- a/app/gateway-oss/2.2.x/index.md
+++ b/app/gateway-oss/2.2.x/index.md
@@ -5,9 +5,9 @@ is_homepage: true
 
 <div class="docs-grid">
   <div class="docs-grid-block">
-    <h3><a href="https://konghq.com/install/">Installation</a></h3>
+    <h3><a href="https://konghq.com/install/#kong-community">Installation</a></h3>
     <p>You can install {{site.ce_product_name}} on most Linux distributions and MacOS. We even provide the source so you can compile it yourself.</p>
-    <a href="https://konghq.com/install/">Install {{site.ce_product_name}} &rarr;</a>
+    <a href="https://konghq.com/install/#kong-community">Install {{site.ce_product_name}} &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.2.x/systemd.md
+++ b/app/gateway-oss/2.2.x/systemd.md
@@ -11,7 +11,7 @@ Debian and RPM based packages. Note that some of the supported GNU/Linux
 distributions for Kong may not have adopted systemd as their default init
 system (for example, CentOS 6 and RHEL 6). For the following instructions, it
 is assumed that Kong has already been [installed and
-configured](https://konghq.com/install/) on a systemd-supported GNU/Linux
+configured](https://konghq.com/install/#kong-community) on a systemd-supported GNU/Linux
 distribution.
 
 ## Start Kong

--- a/app/gateway-oss/2.3.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.3.x/getting-started/adding-consumers.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.3.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.3.x/getting-started/configuring-a-grpc-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.3.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.3.x/getting-started/configuring-a-service.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
   </ol>
 </div>

--- a/app/gateway-oss/2.3.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.3.x/getting-started/enabling-plugins.md
@@ -6,7 +6,7 @@ skip_read_time: true
 <div class="alert alert-warning">
   <strong>Before you start:</strong>
   <ol>
-    <li>Make sure you've <a href="https://konghq.com/install/">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> - It should only take a minute!</li>
     <li>Make sure you've <a href="/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
     <li>Also, make sure you've <a href="/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
   </ol>

--- a/app/gateway-oss/2.3.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.3.x/getting-started/introduction.md
@@ -4,7 +4,7 @@ skip_read_time: true
 ---
 
 <div class="alert alert-warning">
-  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <strong>Before you start:</strong> Make sure you've <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 Before going further into Kong, make sure you understand its [purpose and philosophy](/about). Once you are confident with the concept of API Gateways, this guide is going to take you through a quick introduction on how to use Kong and perform basic operations such as:

--- a/app/gateway-oss/2.3.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.3.x/getting-started/quickstart.md
@@ -5,7 +5,7 @@ skip_read_time: true
 
 <div class="alert alert-warning">
   <strong>Before you start:</strong> Make sure you've
-  <a href="https://konghq.com/install/">installed Kong</a> &mdash; It should only take a minute!
+  <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
 In this section, you'll learn how to manage your Kong instance. First, we'll

--- a/app/gateway-oss/2.3.x/index.md
+++ b/app/gateway-oss/2.3.x/index.md
@@ -5,9 +5,9 @@ is_homepage: true
 
 <div class="docs-grid">
   <div class="docs-grid-block">
-    <h3><a href="https://konghq.com/install/">Installation</a></h3>
+    <h3><a href="https://konghq.com/install/#kong-community">Installation</a></h3>
     <p>You can install {{site.ce_product_name}} on most Linux distributions and MacOS. We even provide the source so you can compile it yourself.</p>
-    <a href="https://konghq.com/install/">Install {{site.ce_product_name}} &rarr;</a>
+    <a href="https://konghq.com/install/#kong-community">Install {{site.ce_product_name}} &rarr;</a>
   </div>
 
   <div class="docs-grid-block">

--- a/app/gateway-oss/2.3.x/systemd.md
+++ b/app/gateway-oss/2.3.x/systemd.md
@@ -11,7 +11,7 @@ Debian and RPM based packages. Note that some of the supported GNU/Linux
 distributions for Kong may not have adopted systemd as their default init
 system (for example, CentOS 6 and RHEL 6). For the following instructions, it
 is assumed that Kong has already been [installed and
-configured](https://konghq.com/install/) on a systemd-supported GNU/Linux
+configured](https://konghq.com/install/#kong-community) on a systemd-supported GNU/Linux
 distribution.
 
 ## Start Kong


### PR DESCRIPTION
The konghq.com/install page now loads the Enterprise install section by default. The majority of the links from docs should still lead to this page as-is, but any OSS-specific links should go to the `kong-community` section.

### Changes
Updated the OSS install links on landing pages and in the OSS quickstart guide for versions 2.0.x and up (most recent major version).

### Preview
https://deploy-preview-2587--kongdocs.netlify.app/gateway-oss/ - click the link to "Installation", it should open the install page and scroll to the OSS section.