### PR TITLE
fix(jekyll) Adding a scope for the enterprise directory

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -91,6 +91,11 @@ defaults:
       layout: 'docs-v2'
 
   - scope:
+      path: 'enterprise'
+    values:
+      layout: 'docs-v2'
+
+  - scope:
       path: 'gateway-oss'
     values:
       layout: 'docs-v2'
@@ -99,11 +104,6 @@ defaults:
       path: 'install'
     values:
       layout: 'install'
-
-  - scope:
-      path: 'docs/ee'
-    values:
-      layout: 'docs'
 
   - scope:
       path: 'getting-started-guide'

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -87,6 +87,11 @@ defaults:
       layout: 'docs-v2'
 
   - scope:
+      path: 'enterprise'
+    values:
+      layout: 'docs-v2'
+
+  - scope:
       path: 'gateway-oss'
     values:
       layout: 'docs-v2'
@@ -95,11 +100,6 @@ defaults:
       path: 'install'
     values:
       layout: 'install'
-
-  - scope:
-      path: 'docs/ee'
-    values:
-      layout: 'docs'
 
   - scope:
       path: 'getting-started-guide'


### PR DESCRIPTION
Something is messing with our analytics data. It might be this, as this was the only metadata change to occur on April 6th last year, the day before analytics went messy.

Changes: setting a scope for the /enterprise path and removing an obsolete docs/ee path.

No preview, just check that nothing's broken.