### PR TITLE
Add 2.3 to list of supported gateway versions

### DIFF
--- a/app/enterprise/2.3.x/support-policy.md
+++ b/app/enterprise/2.3.x/support-policy.md
@@ -46,6 +46,7 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  2.3.x.x |  2020-02-11   |     2022-08-24      |      2023-08-24       |
 |  2.2.x.x |  2020-11-17   |     2022-08-24      |      2023-08-24       |
 |  2.1.x.x |  2020-08-25   |     2022-08-24      |      2023-08-24       |
 |  1.5.x.x |  2020-04-10   |     2021-04-09      |      2022-04-09       |


### PR DESCRIPTION
Note that the support EOL dates don't change. This is on purpose: all 2.x releases have the same support period, starting from the release of the first 2.x version. 

Considered combining all 2.x versions into one table entry, but then we lose release dates.