### PR TITLE
docs(studio) Note for deprecating Kong Studio bundle

### DIFF
--- a/app/enterprise/2.3.x/release-notes.md
+++ b/app/enterprise/2.3.x/release-notes.md
@@ -98,7 +98,7 @@ These two parameters used to be hardcoded and set to 10m.
   serialization in a custom plugin.
 
 ## Deprecated features
-As of Insomnia 2021.1, the Kong Studio plugin bundle is deprecated and will be
+The Kong Studio plugin bundle is deprecated and will be
 replaced with tighter Insomnia integration in a future release.
 
 ## Changelog

--- a/app/enterprise/2.3.x/studio/dec-conf-studio.md
+++ b/app/enterprise/2.3.x/studio/dec-conf-studio.md
@@ -2,6 +2,9 @@
 title: Generating Kong Declarative Config with Kong Studio
 redirect_from: "/studio/1.0.x/dec-conf-studio/"
 ---
+<div class="alert alert-ee warning">
+<b>Note:</b> The Kong Studio plugin bundle is deprecated and will be replaced
+with tighter Insomnia integration in a future release.</div>
 
 Traditionally, Kong Gateway has always required a database, either PostgreSQL or Cassandra, to store entities such as Routes, Services, and Plugins during runtime. The database settings are typically stored in a configuration file called `kong.conf`.
 

--- a/app/enterprise/2.3.x/studio/deploy-to-dev-portal.md
+++ b/app/enterprise/2.3.x/studio/deploy-to-dev-portal.md
@@ -2,6 +2,9 @@
 title: Deploy to the Dev Portal
 redirect_from: "/studio/1.0.x/deploy-to-dev-portal"
 ---
+<div class="alert alert-ee warning">
+<b>Note:</b> The Kong Studio plugin bundle is deprecated and will be replaced
+with tighter Insomnia integration in a future release.</div>
 
 ### Introduction
 

--- a/app/enterprise/2.3.x/studio/download-install.md
+++ b/app/enterprise/2.3.x/studio/download-install.md
@@ -3,6 +3,9 @@ title: Download and Install the Kong Studio Bundle
 toc: false
 redirect_from: "/studio/1.0.x/download-install/"
 ---
+<div class="alert alert-ee warning">
+<b>Note:</b> The Kong Studio plugin bundle is deprecated and will be replaced
+with tighter Insomnia integration in a future release.</div>
 
 In this guide, you will install:
 * Insomnia Designer: the base of the Kong Studio Bundle

--- a/app/enterprise/2.3.x/studio/index.md
+++ b/app/enterprise/2.3.x/studio/index.md
@@ -4,6 +4,11 @@ redirect_from: "/studio/"
 toc: false
 skip_read_time: true
 ---
+
+<div class="alert alert-ee warning">
+<b>Note:</b> The Kong Studio plugin bundle is deprecated and will be replaced
+with tighter Insomnia integration in a future release.</div>
+
 Kong Studio is a bundle for {{site.ee_product_name}} based on Insomnia Designer,
 which enables spec-first development for all REST and GraphQL services.
 

--- a/app/enterprise/2.3.x/studio/using-insomnia-designer.md
+++ b/app/enterprise/2.3.x/studio/using-insomnia-designer.md
@@ -4,6 +4,10 @@ toc: false
 redirect_from: "/studio/1.0.x/using-insomnia-designer/"
 ---
 
+<div class="alert alert-ee warning">
+<b>Note:</b> The Kong Studio plugin bundle is deprecated and will be replaced
+with tighter Insomnia integration in a future release.</div>
+
 ### Introduction
 
 Kong Studio leverages the powerful open source debugging tool [Insomnia](https://insomnia.rest).


### PR DESCRIPTION
Studio plugin bundle is being deprecated. See docs ticket for more detail: https://konghq.atlassian.net/browse/DOCS-1543

Added the note to studio docs for now; will remove docs entirely when the next Insomnia release comes out.

Preview: https://deploy-preview-2600--kongdocs.netlify.app/enterprise/2.3.x/studio/