### PR TITLE
HMAC plugin add datatypes, fix nav tabs

### DIFF
--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -6,9 +6,9 @@ version: 2.2.0
 desc: Add HMAC Authentication to your Services
 description: |
   Add HMAC Signature authentication to a Service or a Route
-  to establish the integrity of incoming requests. The plugin will validate the
+  to establish the integrity of incoming requests. The plugin validates the
   digital signature sent in the `Proxy-Authorization` or `Authorization` header
-  (in this order). This plugin implementation is based off the
+  (in that order). This plugin implementation is based off the
   [draft-cavage-http-signatures](https://tools.ietf.org/html/draft-cavage-http-signatures)
   draft with a slightly different signature scheme.
 
@@ -63,31 +63,37 @@ params:
     - name: hide_credentials
       required: false
       default: "`false`"
+      datatype: boolean
       description: |
-        An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it.
+        An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request (i.e. the `Authorization` header) before proxying it.
     - name: clock_skew
       required: false
       default: "`300`"
+      datatype: number
       description: |
         [Clock Skew](https://tools.ietf.org/html/draft-cavage-http-signatures-00#section-3.4) in seconds to prevent replay attacks.
     - name: anonymous
       required: false
       default:
+      datatype: string
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails. If empty (default), the request fails with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
     - name: validate_request_body
-      required: false
+      required: true
       default: "`false`"
-      description: A boolean value telling the plugin to enable body validation
+      datatype: boolean
+      description: A boolean value telling the plugin to enable body validation.
     - name: enforce_headers
       required: false
       default:
-      description: A list of headers which the client should at least use for HTTP signature creation
+      datatype: array of string elements
+      description: A list of headers that the client should at least use for HTTP signature creation.
     - name: algorithms
       required: false
       default: "`hmac-sha1`,<br>`hmac-sha256`,<br>`hmac-sha384`,<br>`hmac-sha512`"
+      datatype: array of string elements
       description: |
-        A list of HMAC digest algorithms which the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`
+        A list of HMAC digest algorithms that the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`
   extra: |
     Once applied, any user with a valid credential can access the Service/Route.
     To restrict usage to only some of the authenticated users, also add the
@@ -109,14 +115,15 @@ update or remove any request parameter used in HMAC signature before this plugin
 You need to associate a credential to an existing [Consumer][consumer-object] object.
 A Consumer can have many credentials.
 
-{% tabs %}
-{% tab With a Database %}
+{% navtabs %}
+{% navtab With a Database %}
 To create a Consumer, you can execute the following request:
 
 ```bash
 curl -d "username=user123&custom_id=SOME_CUSTOM_ID" http://kong:8001/consumers/
 ```
-{% tab Without a Database %}
+{% endnavtab %}
+{% navtab Without a Database %}
 Your declarative configuration file will need to have one or more Consumers. You can create them
 on the `consumers:` yaml section:
 
@@ -125,7 +132,8 @@ consumers:
 - username: user123
   custom_id: SOME_CUSTOM_ID
 ```
-{% endtabs %}
+{% endnavtab %}
+{% endnavtabs %}
 
 In both cases, the parameters are as described below:
 
@@ -136,8 +144,9 @@ parameter                       | description
 
 ### Create a Credential
 
-{% tabs %}
-{% tab With a database %}
+{% navtabs %}
+{% navtab With a database %}
+
 You can provision new username/password credentials by making the following
 HTTP request:
 
@@ -146,19 +155,22 @@ $ curl -X POST http://kong:8001/consumers/{consumer}/hmac-auth \
     --data "username=bob" \
     --data "secret=secret456"
 ```
+{% endnavtab %}
 
-{% tab Without a database %}
+{% navtab Without a database %}
+
 You can add credentials on your declarative config file on the `hmacauth_credentials` yaml entry:
 
-``` yaml
+```yaml
 hmacauth_credentials:
 - consumer: {consumer}
   username: bob
   secret: secret456
 ```
-{% endtabs %}
+{% endnavtab %}
+{% endnavtabs %}
 
-In both cases the fields/parameters work as follows:
+In both cases, the fields/parameters work as follows:
 
 field/parameter            | description
 ---                        | ---
@@ -396,13 +408,9 @@ more information about the Consumer.
   <strong>Note:</strong>`X-Credential-Username` was deprecated in favor of `X-Credential-Identifier` in Kong 2.1.
 </div>
 
-### Paginate through the HMAC Credentials
+### Paginate through the HMAC credentials
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> This endpoint was introduced in Kong 0.11.2.
-</div>
-
-You can paginate through the hmac-auth Credentials for all Consumers using the
+Paginate through the `hmac-auth` Credentials for all Consumers using the
 following request:
 
 ```bash
@@ -458,10 +466,6 @@ $ curl -X GET http://kong:8001/consumers/{username or id}/hmac-auth
 `username or id`: The username or id of the consumer whose credentials need to be listed
 
 ### Retrieve the Consumer associated with a Credential
-
-<div class="alert alert-warning">
-  <strong>Note:</strong> This endpoint was introduced in Kong 0.11.2.
-</div>
 
 It is possible to retrieve a [Consumer][consumer-object] associated with an
 HMAC Credential using the following request:


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

There are more improvements that could be made, but the main purpose of this PR is to add missing data types. Fixed broken nav tab syntax and removed ancient version notes per Gayle.

Reviewers: Please compare the datatypes added to the doc with the datatypes shown in the schema.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/hmac-auth/schema.lua

Direct review link:

https://deploy-preview-2601--kongdocs.netlify.app/hub/kong-inc/hmac-auth/

