### PR TITLE
[Konnect] Version number for httpie prereq

### DIFF
--- a/app/konnect/getting-started/configure-runtime.md
+++ b/app/konnect/getting-started/configure-runtime.md
@@ -25,7 +25,7 @@ runtime instances.
 * You have a {{site.konnect_product_name}} account. Contact your sales
 representative for access.
 * Tools and permissions:
-  * **All platforms:** [Docker](https://docs.docker.com/get-docker/), [HTTPie](https://httpie.io/), and [jq](https://stedolan.github.io/jq/) installed
+  * **All platforms:** [Docker](https://docs.docker.com/get-docker/), [HTTPie (2.3.0 or later)](https://httpie.io/), and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
   * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/)
 

--- a/app/konnect/runtime-manager/kong-gateway-runtime.md
+++ b/app/konnect/runtime-manager/kong-gateway-runtime.md
@@ -23,7 +23,7 @@ runtime instances.
 * You have a {{site.konnect_product_name}} account. Contact your sales
 representative for access.
 * Tools and permissions:
-  * **All platforms:** [Docker](https://docs.docker.com/get-docker/), [HTTPie](https://httpie.io/), and [jq](https://stedolan.github.io/jq/) installed
+  * **All platforms:** [Docker](https://docs.docker.com/get-docker/), [HTTPie (2.3.0 or later)](https://httpie.io/), and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
   * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/)
 


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1594
Issue raised on slack. Including the minimum required version number for HTTPie to avoid authentication errors.
