### PR TITLE
Exit Transformer datatypes

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -36,14 +36,17 @@ params:
     - name: functions
       required: true
       value_in_examples: [ "@example/my_function.lua" ]
+      datatype: array of string elements
       description: Array of functions used to transform any Kong proxy exit response.
     - name: handle_unknown
       default: "`false`"
       required: false
+      datatype: boolean
       description: Allow transform to apply to unmatched Service, Route, or Workspace (404) responses.
     - name: handle_unexpected
       default: "`false`"
       required: false
+      datatype: boolean
       description: Allow transform to apply to unexpected request (400) responses.
 
 ---


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema link:

https://github.com/Kong/kong-plugin-enterprise-exit-transformer/blob/master/kong/plugins/exit-transformer/schema.lua

Direct review link:

https://deploy-preview-2603--kongdocs.netlify.app/hub/kong-inc/exit-transformer/