### PR TITLE
Response Transformer datatypes

### DIFF
--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -74,7 +74,7 @@ params:
       description: List of property names. Remove the property from the JSON body if it is present.
     - name: rename.headers
       required: false
-      array of string elements
+      datatype: array of string elements
       description: List of `original_header_name:new_header_name` pairs. If the header `original_headername` is already set, rename it to `new_headername`. Ignored if the header is not already set.
     - name: replace.headers
       required: false

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -65,44 +65,56 @@ params:
     - name: remove.headers
       required: false
       value_in_examples: ["x-toremove", "x-another-one"]
+      datatype: array of string elements
       description: List of header names. Unset the header(s) with the given name.
     - name: remove.json
       required: false
       value_in_examples: ["json-key-toremove", "another-json-key"]
+      datatype: array of string elements
       description: List of property names. Remove the property from the JSON body if it is present.
     - name: rename.headers
       required: false
-      description: List of original_header_name:new_header_name pairs. If the header `original_headername` is already set, rename it to `new_headername`. Ignored if the header is not already set.
+      array of string elements
+      description: List of `original_header_name:new_header_name` pairs. If the header `original_headername` is already set, rename it to `new_headername`. Ignored if the header is not already set.
     - name: replace.headers
       required: false
-      description: List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
+      datatype: array of string elements
+      description: List of `headername:value` pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
     - name: replace.json
       required: false
-      description: List of property:value pairs. If and only if the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
+      datatype: array of string elements
+      description: List of `property:value` pairs. If and only if the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
     - name: replace.json_types
       required: false
+      datatype: array of string, boolean, or number elements
       description: List of JSON type names. Specify the types of the JSON values returned when replacing JSON properties.
     - name: add.headers
       required: false
       value_in_examples: ["x-new-header:value","x-another-header:something"]
-      description: List of headername:value pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
+      datatype: array of string elements
+      description: List of `headername:value` pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
     - name: add.json
       required: false
       value_in_examples: ["new-json-key:some_value", "another-json-key:some_value"]
-      description: List of property:value pairs. If and only if the property is not present, add a new property with the given value to the JSON body. Ignored if the property is already present.
+      datatype: array of string elements
+      description: List of `property:value` pairs. If and only if the property is not present, add a new property with the given value to the JSON body. Ignored if the property is already present.
     - name: add.json_types
       required: false
-      value_in_examples: ["new-json-key:string", "another-json-key:number"]
+      value_in_examples: ["new-json-key:string", "another-json-key:boolean", "another-json-key:number"]
+      datatype: array of string, boolean, or number elements
       description: List of JSON type names. Specify the types of the JSON values returned when adding a new JSON property.
     - name: append.headers
       required: false
       value_in_examples: ["x-existing-header:some_value", "x-another-header:some_value"]
-      description: List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
+      datatype: array of string elements
+      description: List of `headername:value` pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
     - name: append.json
       required: false
-      description: List of property:value pairs. If the property is not present in the JSON body, add it with the given value. If it is already present, the two values (old and new) will be aggregated in an array.
+      datatype: array of string elements
+      description: List of `property:value` pairs. If the property is not present in the JSON body, add it with the given value. If it is already present, the two values (old and new) will be aggregated in an array.
     - name: append.json_types
       required: false
+      datatype: array of string, boolean, or number elements
       description: List of JSON type names. Specify the types of the JSON values returned when appending JSON properties.
 
 ---

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -52,11 +52,7 @@ kong_version_compatibility:
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
-        - 0.34-x
-        - 0.33-x
-        - 0.32-x
-        - 0.31-x
+
 
 params:
   name: response-transformer

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -86,8 +86,11 @@ params:
       description: List of `property:value` pairs. If and only if the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
     - name: replace.json_types
       required: false
-      datatype: array of string, boolean, or number elements
-      description: List of JSON type names. Specify the types of the JSON values returned when replacing JSON properties.
+      datatype: array of string elements
+      description: |
+        List of JSON type names. Specify the types of the JSON values returned when
+        replacing JSON properties. Each string
+        element can be one of: boolean, number, or string.
     - name: add.headers
       required: false
       value_in_examples: ["x-new-header:value","x-another-header:something"]
@@ -110,7 +113,7 @@ params:
       description: |
         List of `headername:value` pairs. If the header is not set, set it with the given value. If it is
         already set, a new header with the same name and the new value will be set. Each string
-        can be either one of: boolean, number, or string.
+        element can be one of: boolean, number, or string.
     - name: append.json
       required: false
       datatype: array of string elements

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -105,7 +105,9 @@ params:
       required: false
       value_in_examples: ["new-json-key:string", "another-json-key:boolean", "another-json-key:number"]
       datatype: array of string elements
-      description: List of JSON type names. Specify the types of the JSON values returned when adding a new JSON property.
+      description: |
+        List of JSON type names. Specify the types of the JSON values returned when adding
+        a new JSON property. Each string element can be one of: boolean, number, or string.
     - name: append.headers
       required: false
       value_in_examples: ["x-existing-header:some_value", "x-another-header:some_value"]
@@ -120,8 +122,10 @@ params:
       description: List of `property:value` pairs. If the property is not present in the JSON body, add it with the given value. If it is already present, the two values (old and new) will be aggregated in an array.
     - name: append.json_types
       required: false
-      datatype: array of string, boolean, or number elements
-      description: List of JSON type names. Specify the types of the JSON values returned when appending JSON properties.
+      datatype: array of string elements
+      description: |
+        List of JSON type names. Specify the types of the JSON values returned when appending
+        JSON properties. Each string element can be one of: boolean, number, or string.
 
 ---
 

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -101,13 +101,16 @@ params:
     - name: add.json_types
       required: false
       value_in_examples: ["new-json-key:string", "another-json-key:boolean", "another-json-key:number"]
-      datatype: array of string, boolean, or number elements
+      datatype: array of string elements
       description: List of JSON type names. Specify the types of the JSON values returned when adding a new JSON property.
     - name: append.headers
       required: false
       value_in_examples: ["x-existing-header:some_value", "x-another-header:some_value"]
       datatype: array of string elements
-      description: List of `headername:value` pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
+      description: |
+        List of `headername:value` pairs. If the header is not set, set it with the given value. If it is
+        already set, a new header with the same name and the new value will be set. Each string
+        can be either one of: boolean, number, or string.
     - name: append.json
       required: false
       datatype: array of string elements


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Ported the datatypes from the advanced version of the plugin that Murillo and I worked on.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/response-transformer/schema.lua

Direct review link:

https://deploy-preview-2604--kongdocs.netlify.app/hub/kong-inc/response-transformer/