### PR TITLE
ACL plugin datatypes

### DIFF
--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -74,17 +74,20 @@ params:
       required: semi
       default:
       value_in_examples: [ "group1", "group2" ]
+      datatype: array of string elements
       description: |
         Arbitrary group names that are allowed to consume the Service or Route. One of `config.allow` or `config.deny` must be specified.
     - name: deny
       required: semi
       default:
+      datatype: array of string elements
       description: |
         Arbitrary group names that are not allowed to consume the Service or Route. One of `config.allow` or `config.deny` must be specified.
     - name: hide_groups_header
-      required: false
+      required: true
       default: false
       value_in_examples: true
+      datatype: boolean
       description: |
         Flag that if enabled (`true`), prevents the `X-Consumer-Groups` header to be sent in the request to the Upstream service.
   extra: |

--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -56,11 +56,7 @@ kong_version_compatibility:
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
-        - 0.34-x
-        - 0.33-x
-        - 0.32-x
-        - 0.31-x
+
 
 params:
   name: acl


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/acl/schema.lua

Direct review link:

https://deploy-preview-2606--kongdocs.netlify.app/hub/kong-inc/acl/
