### PR TITLE
docs(admin-api/license) Rework licenses admin api doc

### DIFF
--- a/app/enterprise/2.3.x/admin-api/licenses/examples.md
+++ b/app/enterprise/2.3.x/admin-api/licenses/examples.md
@@ -2,31 +2,37 @@
 title: Licenses Examples
 book: licenses
 ---
+<div class="alert alert-ee">
+<b>Note:</b> The <code>/licenses</code> endpoint does not override standard
+license configuration.
+</div>
 
-## **Note**: License's endpoint will not override standard license configuration
+The `/licenses` endpoint provides a way to configure your {{site.ee_gateway_name}}
+without using environment variables or placing a plaintext file
+in your system directories. In a hybrid mode deployment, the Admin API
+`/licenses` endpoint also configures all data planes in the cluster, simplifying
+the configuration process.
 
-License's endpoint provides a way to configure your {{site.ee_product_name}}
-without the need to create environment variables or placing a plain text file
-in your system directories. The admin-api licenses endpoint also configures the
-dataplane(s) in the cluster when using a hybrid configuration; thus simplifying
-the configuration process of those dataplane nodes.
+## Prerequisites
+Remove all standard license configurations from traditional deployments, control
+planes, and data planes.
 
-The standard license configuration takes precedence over the licenses endpoint
-and **does not** communicate license changes if configured. In order to use
-this feature correctly all standard license configurations in traditional,
-control plane(s), and dataplane(s) must be removed; otherwise the licenses
-endpoint will not trigger the use of licenses added or updated.
+If you deploy a license using environmental variables or a plaintext
+file, this configuration takes precedence over the
+`/licenses` endpoint and **does not** communicate any changes to the Admin API.
+If you try to use the `/licenses` endpoint while having a license configured
+in some other way, the new license will not apply.
 
-## List licenses
+## List all licenses
 
 Submit the following request:
 
 ```bash
-http GET :8001/licenses
+$ http GET :8001/licenses
 ```
 
-### Contains licenses
-
+{% navtabs codeblock %}
+{% navtab Response when license exists %}
 ```json
 {
   "data": [
@@ -40,8 +46,8 @@ http GET :8001/licenses
   "next": null,
 }
 ```
-
-### Does not contain any licenses
+{% endnavtab %}
+{% navtab Response if there is no license %}
 
 ```json
 {
@@ -49,13 +55,15 @@ http GET :8001/licenses
   "next": null
 }
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## List a license
 
-Submit the following providing the id of the license:
+Using the ID of the license, submit the following request:
 
 ```bash
-http GET :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f
+$ http GET :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f
 ```
 
 ```json
@@ -71,10 +79,14 @@ http GET :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f
 
 ### Auto-generated ID
 
+To generate an ID automatically, submit a `POST` request directly to `/licenses`:
+
 ```bash
-http POST :8001/licenses payload="{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}"
+$ http POST :8001/licenses \
+  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
 ```
 
+Response:
 ```json
 {
   "created_at": 1500508800,
@@ -86,10 +98,15 @@ http POST :8001/licenses payload="{\"license\":{\"payload\":{\"admin_seats\":\"1
 
 ### Manually provided ID
 
+To create a license with a custom ID, submit a `PUT` request to
+`/licenses/<uuid>`:
+
 ```bash
-http PUT :8001/licenses/e8201120-4ee3-43ca-9e92-3fed08b1a15d payload="{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}"
+$ http PUT :8001/licenses/e8201120-4ee3-43ca-9e92-3fed08b1a15d \
+  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
 ```
 
+Response:
 ```json
 {
   "created_at": 1500508800,
@@ -99,15 +116,20 @@ http PUT :8001/licenses/e8201120-4ee3-43ca-9e92-3fed08b1a15d payload="{\"license
 }
 ```
 
-**Note**: If provided ID exists the license will not be added, but will perform
-          an update to the license for the given ID.
+**Note**: If the provided ID exists, the request will perform
+          an update to the license for the given ID instead of creating a new
+          `license` entity.
 
 ## Update a license
 
+To update a license, submit a `PATCH` request to an existing license ID:
+
 ```bash
-http PATCH :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f payload="{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-21\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb\",\"version\":\"1\"}}"
+$ http PATCH :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f \
+  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-21\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb\",\"version\":\"1\"}}'
 ```
 
+Response:
 ```json
 {
   "created_at": 1500595200,

--- a/app/enterprise/2.3.x/admin-api/licenses/examples.md
+++ b/app/enterprise/2.3.x/admin-api/licenses/examples.md
@@ -83,7 +83,7 @@ To generate an ID automatically, submit a `POST` request directly to `/licenses`
 
 ```bash
 $ http POST :8001/licenses \
-  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
+  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 
 Response:
@@ -103,7 +103,7 @@ To create a license with a custom ID, submit a `PUT` request to
 
 ```bash
 $ http PUT :8001/licenses/e8201120-4ee3-43ca-9e92-3fed08b1a15d \
-  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
+  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 
 Response:
@@ -126,7 +126,7 @@ To update a license, submit a `PATCH` request to an existing license ID:
 
 ```bash
 $ http PATCH :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f \
-  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-21\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb\",\"version\":\"1\"}}'
+  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-21","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb","version":"1"}}'
 ```
 
 Response:

--- a/app/enterprise/2.3.x/admin-api/licenses/reference.md
+++ b/app/enterprise/2.3.x/admin-api/licenses/reference.md
@@ -99,7 +99,7 @@ HTTP 201 Created
 {{ page.licenses_attribute_id }}
 
 When using `PUT`, if the request payload
-**does not** contain an entity's primary key (`id` for Licenses), the
+**does not** contain an entity's primary key (`id` for licenses), the
 license will be added and assigned the given ID.
 
 If the request payload
@@ -136,11 +136,11 @@ HTTP 200 OK
 {{ page.licenses_attribute_id }}
 
 When using `PATCH`, if the request payload
-**does** contain an entity's primary key (`id` for Licenses), the license will
+**does** contain an entity's primary key (`id` for licenses), the license will
 be replaced with the given payload attribute.
 
 If the request payload **does
-not** contain an entity's primary key (`id` for Licenses), a `404 NOT FOUND`
+not** contain an entity's primary key (`id` for licenses), a `404 NOT FOUND`
 will be returned or if the request payload contains a invalid licence, a `400
 BAD REQUEST` will be returned.
 

--- a/app/enterprise/2.3.x/admin-api/licenses/reference.md
+++ b/app/enterprise/2.3.x/admin-api/licenses/reference.md
@@ -15,7 +15,7 @@ licenses_body: |
 
 ## Introduction
 
-The {{site.ee_base_gateway}} Licenses feature is configurable through the
+The {{site.base_gateway}} Licenses feature is configurable through the
 [Admin API]. This feature lets you configure a license in your
 {{site.base_gateway}} cluster, in both traditional and hybrid mode deployments.
 In hybrid mode deployments, the control plane sends licenses configured

--- a/app/enterprise/2.3.x/admin-api/licenses/reference.md
+++ b/app/enterprise/2.3.x/admin-api/licenses/reference.md
@@ -5,22 +5,22 @@ book: licenses
 licenses_attribute_id: |
     Attributes | Description
     ---:| ---
-    `id` | The **License's** unique ID.
+    `id` | The **license's** unique ID.
 
 licenses_body: |
     Attribute | Description
     ---:| ---
-    `payload` | The **{{site.ee_product_name}} License** in JSON format.
+    `payload` | The **Kong Gateway license** in JSON format.
 ---
 
 ## Introduction
 
-The {{site.ee_product_name}} Licenses feature is configurable through the
-[Admin API]. This feature allows the configuration a license in your
-{{site.ee_product_name}} cluster; traditional and hybrid mode deployments. In
-hybrid mode deployments, licenses configured via the `/licenses` endpoint will
-be sent to all dataplanes in the cluster and the most recent `updated_at`
-license will be used.
+The {{site.ee_base_gateway}} Licenses feature is configurable through the
+[Admin API]. This feature lets you configure a license in your
+{{site.base_gateway}} cluster, in both traditional and hybrid mode deployments.
+In hybrid mode deployments, the control plane sends licenses configured
+through the `/licenses` endpoint to all data planes in the cluster. The data
+planes use the most recent `updated_at` license.
 
 ### List Licenses
 **Endpoint**
@@ -47,7 +47,7 @@ HTTP 200 OK
 }
 ```
 
-If there are no licenses stored by {{site.ee_product_name}} the data array will
+If there are no licenses stored by {{site.base_gateway}}, the data array will
 be empty.
 
 ```json
@@ -59,20 +59,21 @@ be empty.
 
 ### Add License
 
-To create a license using an auto-generation UUID
+To create a license using an auto-generated UUID:
 
 **Endpoint**
 
 <div class="endpoint post">/licenses/</div>
 
-#### Request Body
+**Request Body**
 
 {{ page.licenses_body }}
 
-* The behavior of `POST` endpoint is the following: if the request payload
-contains a valid {{site.ee_product_name}} license, the license will be added.
-If the request payload contains a invalid licence, a `400 BAD REQUEST` will be
-returned.
+When using `POST`, if the request payload **does**
+contain a valid {{site.base_gateway}} license, the license will be added.
+
+If the request payload **does not** contain a valid licence, a `400 BAD REQUEST`
+will be returned.
 
 **Response**
 
@@ -97,15 +98,17 @@ HTTP 201 Created
 
 {{ page.licenses_attribute_id }}
 
-* The behavior of `PUT` endpoint is the following: if the request payload
+When using `PUT`, if the request payload
 **does not** contain an entity's primary key (`id` for Licenses), the
-license will be added and assign the id given. If the request payload
-**does** contain an entity's primary key (`id` for Licenses), the license
-will be replaced with the given payload attribute. If the id is not a valid
-UUID, a `400 BAD REQUEST` will be returned or if the id omitted, a `405 NOT
-ALLOWED` will be returned.
+license will be added and assigned the given ID.
 
-#### Request Body
+If the request payload
+**does** contain an entity's primary key (`id` for Licenses), the license
+will be replaced with the given payload attribute.
+If the ID is not a valid UUID, a `400 BAD REQUEST` will be returned. If the ID
+is omitted, a `405 NOT ALLOWED` will be returned.
+
+**Request Body**
 
 {{ page.licenses_body }}
 
@@ -132,14 +135,16 @@ HTTP 200 OK
 
 {{ page.licenses_attribute_id }}
 
-* The behavior of `PATCH` endpoint is the following: if the request payload
+When using `PATCH`, if the request payload
 **does** contain an entity's primary key (`id` for Licenses), the license will
-be replaced with the given payload attribute. If the request payload **does
+be replaced with the given payload attribute.
+
+If the request payload **does
 not** contain an entity's primary key (`id` for Licenses), a `404 NOT FOUND`
 will be returned or if the request payload contains a invalid licence, a `400
 BAD REQUEST` will be returned.
 
-#### Request Body
+**Request Body**
 
 {{ page.licenses_body }}
 

--- a/app/enterprise/2.3.x/deployment/licenses/deploy-license.md
+++ b/app/enterprise/2.3.x/deployment/licenses/deploy-license.md
@@ -36,13 +36,13 @@ but provide your own content.
 {% navtab cURL %}
 ```bash
 $ curl -i -X POST http://<hostname>:8001/licenses \
-  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
+  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
 $ http POST :8001/licenses \
-  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
+  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.3.x/deployment/licenses/deploy-license.md
+++ b/app/enterprise/2.3.x/deployment/licenses/deploy-license.md
@@ -36,13 +36,13 @@ but provide your own content.
 {% navtab cURL %}
 ```bash
 $ curl -i -X POST http://<hostname>:8001/licenses \
-  payload="{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}"
+  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
 $ http POST :8001/licenses \
-  payload="{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}"
+  payload='{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.3.x/deployment/licensing.md
+++ b/app/enterprise/2.3.x/deployment/licensing.md
@@ -44,6 +44,8 @@ of any `kong` CLI commands. License file environmental variables must be
 exported to the shell in which the Nginx process will run, ahead of the `kong`
 CLI tool.
 
+For more information, see [Deploy Your License](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+
 ## Examining the license data on a Kong Gateway node
 Retrieve license data using the Admin API's `/licenses` endpoint, or through
 the Admin GUI in Kong Manager.


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1593

### Changes
* Changing double quotes (`" "`) around licenses to single quotes (`' '`)
* Link to deploy a license from license overview
* Cleaning up the Admin API reference and examples for clarity, formatting, flow

### Previews
[Licenses Admin API reference](https://deploy-preview-2607--kongdocs.netlify.app/enterprise/2.3.x/admin-api/licenses/reference/)
[Licenses examples](https://deploy-preview-2607--kongdocs.netlify.app/enterprise/2.3.x/admin-api/licenses/examples/)