### PR TITLE
grpc-gateway plugin add datatype

### DIFF
--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -41,6 +41,7 @@ params:
       required: false
       default:
       value_in_examples: path/to/hello.proto
+      datatype: string
       description: |
         Describes the gRPC types and methods.
         [HTTP configuration](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto)


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema link:

https://github.com/Kong/kong-plugin-grpc-gateway/blob/master/kong/plugins/grpc-gateway/schema.lua

Direct review link:

https://deploy-preview-2608--kongdocs.netlify.app/hub/kong-inc/grpc-gateway/