### PR TITLE
Fix Immunity docker URLs

### DIFF
--- a/app/enterprise/2.2.x/immunity/install-configure.md
+++ b/app/enterprise/2.2.x/immunity/install-configure.md
@@ -50,7 +50,7 @@ $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kon
 ```
 2. Pull the Kong Immunity Docker image.
 ```bash
-$ docker pull kong-docker-immunity-base.bintray.io/kong-immunity:3.0.0
+$ docker pull kong-docker-kong-immunity-base.bintray.io/kong-immunity:3.0.0
 ```
 You should now have your Kong Immunity image locally.
 
@@ -174,7 +174,7 @@ configure the Collector Plugin:
     `http://collector:5000`.
     * The default values populating the remaining fields are valid for a
     minimal configuration.
-    
+
 7. Click **Create**. The Collector Plugin is configured.
 
 {% endnavtab %}

--- a/app/enterprise/2.2.x/immunity/install-configure.md
+++ b/app/enterprise/2.2.x/immunity/install-configure.md
@@ -130,7 +130,7 @@ Start the scheduler and worker.
 $ docker run -d --name celery-beat \
   --network=kong-ee-net \
   -e "CELERY_BROKER_URL=redis://redis:6379/0" \
-  kong-bi \
+  kong-immunity \
   celery beat -l info -A collector.scheduler.celery
 ```
 

--- a/app/enterprise/2.2.x/immunity/install-configure.md
+++ b/app/enterprise/2.2.x/immunity/install-configure.md
@@ -13,7 +13,7 @@ Immunity follows a different versioning scheme from Kong Enterprise, as defined 
 
 | Immunity Version                 | Kong Enterprise Version |
 |:---------------------------------|:------------------------|
-| 4.0.0                            | 2.2.x                   |
+| 4.0.0                            | 2.2.x, 2.3.x            |
 | 3.0.0                            | 1.5.x, 2.1.x            |
 
 ## Install Immunity on Kubernetes
@@ -50,7 +50,7 @@ $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kon
 ```
 2. Pull the Kong Immunity Docker image.
 ```bash
-$ docker pull kong-docker-kong-immunity-base.bintray.io/kong-immunity:3.0.0
+$ docker pull kong-docker-kong-immunity-base.bintray.io/kong-immunity:4.0.0
 ```
 You should now have your Kong Immunity image locally.
 

--- a/app/enterprise/2.3.x/immunity/install-configure.md
+++ b/app/enterprise/2.3.x/immunity/install-configure.md
@@ -50,7 +50,7 @@ $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kon
 ```
 2. Pull the Kong Immunity Docker image.
 ```bash
-$ docker pull kong-docker-immunity-base.bintray.io/kong-immunity:3.0.0
+$ docker pull kong-docker-kong-immunity-base.bintray.io/kong-immunity:3.0.0
 ```
 You should now have your Kong Immunity image locally.
 
@@ -174,7 +174,7 @@ configure the Collector Plugin:
     `http://collector:5000`.
     * The default values populating the remaining fields are valid for a
     minimal configuration.
-    
+
 7. Click **Create**. The Collector Plugin is configured.
 
 {% endnavtab %}

--- a/app/enterprise/2.3.x/immunity/install-configure.md
+++ b/app/enterprise/2.3.x/immunity/install-configure.md
@@ -130,7 +130,7 @@ Start the scheduler and worker.
 $ docker run -d --name celery-beat \
   --network=kong-ee-net \
   -e "CELERY_BROKER_URL=redis://redis:6379/0" \
-  kong-bi \
+  kong-immunity \
   celery beat -l info -A collector.scheduler.celery
 ```
 

--- a/app/enterprise/2.3.x/immunity/install-configure.md
+++ b/app/enterprise/2.3.x/immunity/install-configure.md
@@ -13,7 +13,7 @@ Immunity follows a different versioning scheme from Kong Enterprise, as defined 
 
 | Immunity Version                 | Kong Enterprise Version |
 |:---------------------------------|:------------------------|
-| 4.0.0                            | 2.2.x                   |
+| 4.0.0                            | 2.2.x, 2.3.x            |
 | 3.0.0                            | 1.5.x, 2.1.x            |
 
 ## Install Immunity on Kubernetes
@@ -50,7 +50,7 @@ $ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kon
 ```
 2. Pull the Kong Immunity Docker image.
 ```bash
-$ docker pull kong-docker-kong-immunity-base.bintray.io/kong-immunity:3.0.0
+$ docker pull kong-docker-kong-immunity-base.bintray.io/kong-immunity:4.0.0
 ```
 You should now have your Kong Immunity image locally.
 


### PR DESCRIPTION
Docs ticket: https://konghq.atlassian.net/browse/DOCS-1602

Fixing URL for Immunity Docker image in 2.2.x and 2.3.x. Checked with a quick `docker pull` to make sure this one works.
This image didn't exist before 2.2.x, it was Brain&Immunity before that.
