### PR TITLE
IP Restriction plugin add datatypes

### DIFF
--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -56,11 +56,13 @@ params:
       required: semi
       default:
       value_in_examples: [ "54.13.21.1", "143.1.0.0/24" ]
+      datatype: array of string elements
       description: |
         List of IPs or CIDR ranges to allow. One of `config.allow` or `config.deny` must be specified.
     - name: deny
       required: semi
       default:
+      datatype: array of string elements
       description: |
         List of IPs or CIDR ranges to deny. One of `config.allow` or `config.deny` must be specified.
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/ip-restriction/schema.lua

Direct review link:

https://deploy-preview-2612--kongdocs.netlify.app/hub/kong-inc/ip-restriction/
