### PR TITLE
Forward Proxy plugin add datatypes

### DIFF
--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -41,24 +41,28 @@ params:
       required: true
       default:
       value_in_examples: example.com
+      datatype: string
       description: |
         The hostname or IP address of the forward proxy to which to connect.
     - name: proxy_port
       required: true
       default:
       value_in_examples: 80
+      datatype: string
       description: |
         The TCP port of the forward proxy to which to connect.
     - name: proxy_scheme
       required: true
       default: http
       value_in_examples: http
+      datatype: string
       description: |
         The proxy scheme to use when connecting. Currently only `http` is supported.
     - name: https_verify
       required: true
       default: false
       value_in_examples: false
+      datatype: boolean
       description: |
         Whether the server certificate will be verified according to the CA certificates
         specified in


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema links:

https://github.com/Kong/kong-plugin-enterprise-forward-proxy/blob/master/kong/plugins/forward-proxy/schema.lua
https://github.com/Kong/kong/blob/master/kong/db/schema/typedefs.lua (host and port)

Direct review link:

https://deploy-preview-2613--kongdocs.netlify.app/hub/kong-inc/forward-proxy/