### PR TITLE
Request Termination plugin add datatypes

### DIFF
--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -51,17 +51,21 @@ params:
       required: false
       default: "`503`"
       value_in_examples: 403
-      description: The response code to send.
+      datatype: integer
+      description: The response code to send. Must be an integer between 100 and 599.
     - name: message
       required: false
       value_in_examples: "So long and thanks for all the fish!"
+      datatype: string
       description: The message to send, if using the default response generator.
     - name: body
       required: false
-      description: The raw response body to send, this is mutually exclusive with the `config.message` field.
+      datatype: string
+      description: The raw response body to send. This is mutually exclusive with the `config.message` field.
     - name: content_type
       required: false
       default: "`application/json; charset=utf-8`"
+      datatype: string
       description: Content type of the raw response configured with `config.body`.
   extra: |
     Once applied, every request (within the configured plugin scope of a Service,


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/request-termination/schema.lua

Direct review link:

https://deploy-preview-2614--kongdocs.netlify.app/hub/kong-inc/request-termination/