### PR TITLE
Response Rate Limiting plugin add datatypes

### DIFF
--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -71,7 +71,7 @@ params:
     - name: limits.{limit_name}
       required: true
       value_in_examples: <SMS>
-      datatype:
+      datatype: string
       description: This is a list of custom objects that you can set, with arbitrary names set in the `{limit_name`} placeholder, like `config.limits.sms.minute=20` if your object is called "SMS".
     - name: limits.{limit_name}.second
       required: semi

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -12,7 +12,7 @@ description: |
   rate-limiting object can limit the inbound requests per seconds, minutes, hours,
   days, months, or years.
 
-  If the underlying Service/Route (or deprecated API entity) has no authentication
+  If the underlying Service/Route has no authentication
   layer, the **Client IP** address will be used; otherwise, the Consumer will be
   used if an authentication plugin has been configured.
 
@@ -55,7 +55,7 @@ kong_version_compatibility:
 
 params:
   name: response-ratelimiting
-  api_id: true
+  api_id: false
   service_id: true
   route_id: true
   consumer_id: true

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -47,7 +47,7 @@ kong_version_compatibility:
     enterprise_edition:
       compatible:
         - 2.3.x
-        - 2.2.x 
+        - 2.2.x
         - 2.1.x
         - 1.5.x
         - 1.3-x
@@ -71,67 +71,85 @@ params:
     - name: limits.{limit_name}
       required: true
       value_in_examples: <SMS>
+      datatype:
       description: This is a list of custom objects that you can set, with arbitrary names set in the `{limit_name`} placeholder, like `config.limits.sms.minute=20` if your object is called "SMS".
     - name: limits.{limit_name}.second
       required: semi
+      datatype: number
       description: The amount of HTTP requests the developer can make per second. At least one limit must exist.
     - name: limits.{limit_name}.minute
       required: semi
       value_in_examples: 10
+      datatype: number
       description: The amount of HTTP requests the developer can make per minute. At least one limit must exist.
     - name: limits.{limit_name}.hour
       required: semi
+      datatype: number
       description: The amount of HTTP requests the developer can make per hour. At least one limit must exist.
     - name: limits.{limit_name}.day
       required: semi
+      datatype: number
       description: The amount of HTTP requests the developer can make per day. At least one limit must exist.
     - name: limits.{limit_name}.month
       required: semi
+      datatype: number
       description: The amount of HTTP requests the developer can make per month. At least one limit must exist.
     - name: limits.{limit_name}.year
       required: semi
+      datatype: number
       description: The amount of HTTP requests the developer can make per year. At least one limit must exist.
     - name: header_name
       required: false
       default: "`X-Kong-Limit`"
+      datatype: string
       description: The name of the response header used to increment the counters.
     - name: block_on_first_violation
-      required: false
+      required: true
       default: "`false`"
+      datatype: boolean
       description: A boolean value that determines if the requests should be blocked as soon as one limit is being exceeded. This will block requests that are supposed to consume other limits too.
     - name: limit_by
       required: false
       default: "`consumer`"
+      datatype: string
       description: "The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`."
     - name: policy
       required: false
       default: "`cluster`"
-      description: The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes) and `redis` (counters are stored on a Redis server and will be shared across the nodes).
+      datatype: string
+      description: The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes), and `redis` (counters are stored on a Redis server and will be shared across the nodes).
     - name: fault_tolerant
-      required: false
+      required: true
       default: "`true`"
+      datatype: boolean
       description: A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors.
     - name: hide_client_headers
-      required: false
+      required: true
       default: "`false`"
+      datatype: boolean
       description: Optionally hide informative response headers.
     - name: redis_host
       required: semi
+      datatype: string
       description: When using the `redis` policy, this property specifies the address to the Redis server.
     - name: redis_port
       required: false
       default: "`6379`"
+      datatype: integer
       description: When using the `redis` policy, this property specifies the port of the Redis server.
     - name: redis_password
       required: false
+      datatype: string
       description: When using the `redis` policy, this property specifies the password to connect to the Redis server.
     - name: redis_timeout
       required: false
       default: "`2000`"
+      datatype: number
       description: When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.
     - name: redis_database
       required: false
       default: "`0`"
+      datatype: number
       description: When using the `redis` policy, this property specifies Redis database to use.
 
 ---


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/response-ratelimiting/schema.lua

@murillopaula not clear on how to phrase datatype for limits. Map of key:values? Went with string, please let me know if that is correct.

![image](https://user-images.githubusercontent.com/3756245/108785322-d0669680-7536-11eb-95ea-0d729b086aee.png)

Direct review link:

https://deploy-preview-2617--kongdocs.netlify.app/hub/kong-inc/response-ratelimiting/
