### PR TITLE
fix(kic) add SANs to example certificate command

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/deployment/admission-webhook.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/admission-webhook.md
@@ -48,7 +48,9 @@ Use openssl to generate a self-signed certificate:
 
 ```bash
 $ openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 365  \
-    -nodes -subj "/CN=kong-validation-webhook.kong.svc"
+    -nodes -subj "/CN=kong-validation-webhook.kong.svc" \
+    -extensions EXT -config <( \
+   printf "[dn]\nCN=kong-validation-webhook.kong.svc\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:kong-validation-webhook.kong.svc\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 Generating a 2048 bit RSA private key
 ..........................................................+++
 .............+++

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/admission-webhook.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/admission-webhook.md
@@ -48,7 +48,9 @@ Use openssl to generate a self-signed certificate:
 
 ```bash
 $ openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 365  \
-    -nodes -subj "/CN=kong-validation-webhook.kong.svc"
+    -nodes -subj "/CN=kong-validation-webhook.kong.svc" \
+    -extensions EXT -config <( \
+   printf "[dn]\nCN=kong-validation-webhook.kong.svc\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:kong-validation-webhook.kong.svc\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 Generating a 2048 bit RSA private key
 ..........................................................+++
 .............+++


### PR DESCRIPTION
As of Go 1.15, certificates that use a CN hostname in their subject but do not have a SAN are not supported. We use Go 1.15 for controller versions 0.10 and onward.

This change updates our example certificate creation command to include a SAN.

Originally reported in DOCS-1560