### PR TITLE
Syslog plugin add datatypes and one_of options from schema

### DIFF
--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -56,14 +56,14 @@ params:
       datatype: string
       description: |
         An optional logging severity assigned to all the successful requests with a response
-        status code less then 400. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+        status code less then 400. Available options: `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: client_errors_severity
       required: false
       default: "`info`"
       datatype: string
       description: |
         An optional logging severity assigned to all the failed requests with a
-        response status code 400 or higher but less than 500. Available options are `debug`, `info`, `notice`,
+        response status code 400 or higher but less than 500. Available options: `debug`, `info`, `notice`,
         `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: server_errors_severity
       required: false
@@ -71,14 +71,14 @@ params:
       datatype: string
       description: |
         An optional logging severity assigned to all the failed requests with a
-        response status code 500 or higher. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+        response status code 500 or higher. Available options: `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: log_level
       required: false
       default: "`info`"
       datatype: string
       description: |
         An optional logging severity. Any request with equal or higher severity
-        will be logged to System log. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+        will be logged to System log. Available options: `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
 
 ---
 

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -53,19 +53,28 @@ params:
     - name: successful_severity
       required: false
       default: "`info`"
-      description: An optional logging severity assigned to all the successful requests with response status code less then 400.
+      datatype: string
+      description: An optional logging severity assigned to all the successful requests with a response
+      status code less then 400. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: client_errors_severity
       required: false
       default: "`info`"
-      description: An optional logging severity assigned to all the failed requests with response status code 400 or higher but less than 500.
+      datatype: string
+      description: An optional logging severity assigned to all the failed requests with a
+      response status code 400 or higher but less than 500. Available options are `debug`, `info`, `notice`,
+      `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: server_errors_severity
       required: false
       default: "`info`"
-      description: An optional logging severity assigned to all the failed requests with response status code 500 or higher.
+      datatype: string
+      description: An optional logging severity assigned to all the failed requests with a
+      response status code 500 or higher. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: log_level
       required: false
       default: "`info`"
-      description: An optional logging severity, any request with equal or higher severity will be logged to System log.
+      datatype: string
+      description: An optional logging severity. Any request with equal or higher severity
+      will be logged to System log. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
 
 ---
 

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -54,27 +54,31 @@ params:
       required: false
       default: "`info`"
       datatype: string
-      description: An optional logging severity assigned to all the successful requests with a response
-      status code less then 400. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+      description: |
+        An optional logging severity assigned to all the successful requests with a response
+        status code less then 400. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: client_errors_severity
       required: false
       default: "`info`"
       datatype: string
-      description: An optional logging severity assigned to all the failed requests with a
-      response status code 400 or higher but less than 500. Available options are `debug`, `info`, `notice`,
-      `warning`, `err`, `crit`, `alert`, `emerg`.
+      description: |
+        An optional logging severity assigned to all the failed requests with a
+        response status code 400 or higher but less than 500. Available options are `debug`, `info`, `notice`,
+        `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: server_errors_severity
       required: false
       default: "`info`"
       datatype: string
-      description: An optional logging severity assigned to all the failed requests with a
-      response status code 500 or higher. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+      description: |
+        An optional logging severity assigned to all the failed requests with a
+        response status code 500 or higher. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
     - name: log_level
       required: false
       default: "`info`"
       datatype: string
-      description: An optional logging severity. Any request with equal or higher severity
-      will be logged to System log. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+      description: |
+        An optional logging severity. Any request with equal or higher severity
+        will be logged to System log. Available options are `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
 
 ---
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters. I'm not logging Jira subtickets because it's a lot of overhead.

Schema link:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/syslog/schema.lua

Direct review link:

https://deploy-preview-2623--kongdocs.netlify.app/hub/kong-inc/syslog/

Reviewers: Some of these older plugins don't like colons within description text. It causes yaml errors. @lena-larionova do you know of any fix or workaround for that? It's not happy even with text after the colon. Why is it misinterpreting it here?

![image](https://user-images.githubusercontent.com/3756245/108927456-f018c000-7605-11eb-9769-091aa0d307a5.png)

Errors like I saw for CORS:

`[15:36:11]              Error: YAML Exception reading /Users/terryblessing/github/docs.konghq.com/app/_hub/kong-inc/cors/index.md: (<unknown>): mapping values are not allowed in this context at line 73 column 16`
