### PR TITLE
TCP Log plugin  add datatypes, missing TLS params

### DIFF
--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -58,19 +58,34 @@ params:
     - name: host
       required: true
       value_in_examples: 127.0.0.1
+      datatype: string
       description: The IP address or host name to send data to.
     - name: port
       required: true
       value_in_examples: 9999
+      datatype: integer
       description: The port to send data to on the upstream server.
     - name: timeout
       required: false
       default: "`10000`"
+      datatype: number
       description: An optional timeout in milliseconds when sending data to the upstream server.
     - name: keepalive
       required: false
       default: "`60000`"
-      description: An optional value in milliseconds that defines for how long an idle connection will live before being closed.
+      datatype: number
+      description: An optional value in milliseconds that defines how long an idle connection lives before being closed.
+    - name: tls
+      required: true
+      default: false
+      datatype: boolean
+      description: REVIEWERS description needed
+    - name: tls_sni
+      required: false
+      default:
+      datatype: string
+      description: REVIEWERS description needed
+
 
 ---
 

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -84,7 +84,7 @@ params:
       required: false
       default:
       datatype: string
-      description: An optional string that defines the SNI (Server Name Indication) hostname to send in the handshake.
+      description: An optional string that defines the SNI (Server Name Indication) hostname to send in the TLS handshake.
 
 
 ---

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -79,12 +79,12 @@ params:
       required: true
       default: false
       datatype: boolean
-      description: REVIEWERS description needed
+      description: Indicates whether to perform a TLS handshake against the remote server.
     - name: tls_sni
       required: false
       default:
       datatype: string
-      description: REVIEWERS description needed
+      description: An optional string that defines the SNI (Server Name Indication) hostname to send in the handshake.
 
 
 ---


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters. I'm not logging Jira subtickets because it's a lot of overhead.

Schema links:

https://github.com/Kong/kong-ee/blame/master/kong/plugins/tcp-log/schema.lua
https://github.com/Kong/kong/blob/master/kong/db/schema/typedefs.lua

Direct review link:

https://deploy-preview-2624--kongdocs.netlify.app/hub/kong-inc/tcp-log/

REVIEWERS: I noticed some fields in the schema that aren't present in the docs. There isn't a readme to go by that I can find either. Can you please assist? Update: Murillo to the rescue.

