### PR TITLE
[DOCS-1581] README: Add instructions for creating a new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ npm start
 
 ## Search
 
-We are using Algolia [docsearch](https://www.algolia.com/docsearch) for our
-documentation search. The algolia index for Kong is maintained by Algolia through their
+We use Algolia [docsearch](https://www.algolia.com/docsearch) for our
+documentation search. The Algolia index for Kong is maintained by Algolia through their
 docsearch service. Their [scraper](https://github.com/algolia/docsearch-scraper)
 runs every 24 hours. The config used by the scraper is open source for
 [docs.konghq.com](docs.konghq.com) and can be found [here](https://github.com/algolia/docsearch-configs/blob/master/configs/getkong.json).
@@ -76,12 +76,78 @@ test a config change locally, you will need to run their open source
 [scraper](https://github.com/algolia/docsearch-scraper) against your own
 scraper to test out config changes.
 
-The Enterprise documentation uses paid algolia indices, which auto-update every
-24 hours via a [github action here](/.github/workflows/algolia.yml)
+The rest of the documentation uses paid Algolia indices, which auto-update every
+24 hours via a [github action here](/.github/workflows/algolia.yml).
 
-## Generating the PDK, Admin API, CLI and Configuration Documentation
+## Versioning the docs
 
-The PDK docs, Admin API docs, `cli.md` and `configuration.md` on each release are generated from the Kong source code.
+The following instructions apply to the Kong Gateway OSS docs. For enterprise 
+docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/spaces/KD/pages/1053196506/Prepping+the+Private+Repo+for+a+Release).
+
+### Creating a new community doc release version
+
+1. Create release branch: `release/<version>`
+
+2. Copy the doc folders for Kong Gateway (OSS):
+
+    1. Copy the following latest `app/gateway-oss` version folder and all of its contents and
+    rename to the new major or minor version, with `x` for the patch level.
+
+        For example, copy `app/gateway-oss/2.3.x` and rename to
+        `app/gateway-oss/2.4.x`.
+
+    2. Copy the latest `app/getting-started-guide` version folder and rename it
+     to the new version.
+
+    3. Copy the latest `app/_includes/md/` version folder and rename it
+     to the new version.
+
+3. Add the newest CE version to `app/_data/kong_versions.yml`:
+
+    1. Copy the previous version section, which looks like the following:
+
+    ```yaml
+      release: "2.3.x"
+      version: "2.3.2"
+      edition: "gateway-oss"
+      luarocks_version: "2.3.2-0"
+      dependencies:
+        luajit: "2.1.0-beta3"
+        luarocks: "3.4.0"
+        cassandra: "3.x.x"
+        postgres: "9.5+"
+        openresty: "1.17.8.2"
+        openssl: "1.1.1i"
+        libyaml: "0.2.5"
+        pcre: "8.44"
+    ```
+
+    Update `release`, `version`, and any `dependencies`, if applicable.
+
+    2. Do the same for `getting-started-guide`, copying the latest version,
+    which looks like the following:
+
+      ```yaml
+        release: "2.3.x"
+        version: "2.3"
+        edition: "getting-started-guide"
+      ```
+
+3. Update the latest version in the full site Algolia configuration file:
+
+    1. Open  `/algolia/config-full-docs.json`
+    2. In the `start_urls`, update the `gateway-oss` URL to the latest `x`
+    version:
+
+      ```json
+      "url": "https://docs.konghq.com/gateway-oss/2.3.x/"
+      ```
+
+4. Commit and push release branch to GitHub.
+
+### Generating the PDK, Admin API, CLI and Configuration Documentation
+
+The PDK docs, Admin API docs, `cli.md` and `configuration.md` for each release are generated from the Kong source code.
 
 In order to generate them, please switch into the `Kong/kong` repo and run:
 
@@ -115,11 +181,10 @@ git push
 
 Then open a pull request against `release/2.3`.
 
-## Listing Your Extension in the Kong Hub
+## Listing Your Extension in the Plugin Hub
 
-We encourage developers to list their Kong plugins and integrations (which
-we refer to collectively as "extensions") in the
-[Kong Hub](https://docs.konghq.com/hub) with documentation hosted
-on the Kong website for ready access.
+We encourage developers to list their Kong Gateway plugins in the
+[Plugin Hub](https://docs.konghq.com/hub) with documentation hosted
+on the Kong docs website for ready access.
 
 See [CONTRIBUTING](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#contributing-to-kong-documentation-and-the-kong-hub) for more information.

--- a/README.md
+++ b/README.md
@@ -81,22 +81,22 @@ The rest of the documentation uses paid Algolia indices, which auto-update every
 
 ## Versioning the docs
 
-The following instructions apply to the Kong Gateway OSS docs. For enterprise 
+The following instructions apply to the Kong Gateway OSS docs. For enterprise
 docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/spaces/KD/pages/1053196506/Prepping+the+Private+Repo+for+a+Release).
 
 ### Creating a new community doc release version
 
 1. Create release branch: `release/<version>`
 
-2. Copy the doc folders for Kong Gateway (OSS):
+2. Copy the following doc folders for Kong Gateway (OSS):
 
-    1. Copy the following latest `app/gateway-oss` version folder and all of its contents and
-    rename to the new major or minor version, with `x` for the patch level.
+    1. Copy the latest `app/gateway-oss/` version folder and all of its contents.
+    Rename the folder to the new major or minor version, with `x` for the patch level.
 
         For example, copy `app/gateway-oss/2.3.x` and rename to
         `app/gateway-oss/2.4.x`.
 
-    2. Copy the latest `app/getting-started-guide` version folder and rename it
+    2. Copy the latest `app/getting-started-guide/` version folder and rename it
      to the new version.
 
     3. Copy the latest `app/_includes/md/` version folder and rename it
@@ -106,32 +106,32 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
 
     1. Copy the previous version section, which looks like the following:
 
-    ```yaml
-      release: "2.3.x"
-      version: "2.3.2"
-      edition: "gateway-oss"
-      luarocks_version: "2.3.2-0"
-      dependencies:
-        luajit: "2.1.0-beta3"
-        luarocks: "3.4.0"
-        cassandra: "3.x.x"
-        postgres: "9.5+"
-        openresty: "1.17.8.2"
-        openssl: "1.1.1i"
-        libyaml: "0.2.5"
-        pcre: "8.44"
-    ```
+        ```yaml
+          release: "2.3.x"
+          version: "2.3.2"
+          edition: "gateway-oss"
+          luarocks_version: "2.3.2-0"
+          dependencies:
+            luajit: "2.1.0-beta3"
+            luarocks: "3.4.0"
+            cassandra: "3.x.x"
+            postgres: "9.5+"
+            openresty: "1.17.8.2"
+            openssl: "1.1.1i"
+            libyaml: "0.2.5"
+            pcre: "8.44"
+        ```
 
     Update `release`, `version`, and any `dependencies`, if applicable.
 
     2. Do the same for `getting-started-guide`, copying the latest version,
     which looks like the following:
 
-      ```yaml
-        release: "2.3.x"
-        version: "2.3"
-        edition: "getting-started-guide"
-      ```
+        ```yaml
+          release: "2.3.x"
+          version: "2.3"
+          edition: "getting-started-guide"
+        ```
 
 3. Update the latest version in the full site Algolia configuration file:
 
@@ -139,9 +139,9 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
     2. In the `start_urls`, update the `gateway-oss` URL to the latest `x`
     version:
 
-      ```json
-      "url": "https://docs.konghq.com/gateway-oss/2.3.x/"
-      ```
+        ```json
+        "url": "https://docs.konghq.com/gateway-oss/2.3.x/"
+        ```
 
 4. Commit and push release branch to GitHub.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ npm start
 
 ## Search
 
-We use Algolia [docsearch](https://www.algolia.com/docsearch) for our
-documentation search. The Algolia index for Kong is maintained by Algolia through their
+Documentation for our open-source projects uses
+[Algolia](https://www.algolia.com/docsearch) for search. The Algolia index for
+OSS docs is maintained by Algolia through their
 docsearch service. Their [scraper](https://github.com/algolia/docsearch-scraper)
 runs every 24 hours. The config used by the scraper is open source for
 [docs.konghq.com](docs.konghq.com) and can be found [here](https://github.com/algolia/docsearch-configs/blob/master/configs/getkong.json).
@@ -76,8 +77,8 @@ test a config change locally, you will need to run their open source
 [scraper](https://github.com/algolia/docsearch-scraper) against your own
 scraper to test out config changes.
 
-The rest of the documentation uses paid Algolia indices, which auto-update every
-24 hours via a [github action here](/.github/workflows/algolia.yml).
+The rest of the Kong documentation uses paid Algolia indices, which auto-update 
+every 24 hours via a [github action here](/.github/workflows/algolia.yml).
 
 ## Versioning the docs
 
@@ -156,7 +157,7 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
 
 The PDK docs, Admin API docs, `cli.md` and `configuration.md` for each release are generated from the Kong source code.
 
-In order to generate them, please switch into the `Kong/kong` repo and run:
+To generate them, go to the `Kong/kong` repo and run:
 
 ```
 scripts/autodoc <docs-folder> <kong-version>
@@ -169,12 +170,15 @@ cd /path/to/kong
 scripts/autodoc ../docs.konghq.com 2.3.x
 ```
 
-Assumes that the `Kong/docs.konghq.com` repo is cloned next to the `Kong/kong` repo, and that you want to
-generate the docs for Kong version `2.3.x`.
+This example assumes that the `Kong/docs.konghq.com` repo is cloned into the
+same directory as the `Kong/kong` repo, and that you want to generate the docs
+for version `2.3.x`. Adjust the paths and version as needed.
 
-Once everything is generated, review, open a branch with the changes, send a pull request, and review the changes.
+Once everything is generated, review, open a branch with the changes, send a
+pull request, and review the changes.
 
-You usually want to open a pr against a `release/*` branch. For example on the case above the branch was `release/2.3`.
+You usually want to open a PR against a `release/*` branch. For example, in the
+example above the branch was `release/2.3`.
 
 ```
 cd docs.konghq.com

--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
 
 ### Creating a new community doc release version
 
-1. Create release branch: `release/<version>`
+1. Pull down the master branch of this repo and create a release branch
+(`release/<version>`):
+
+    ```sh
+    $ cd docs.konghq.com
+    $ git pull master
+    $ git checkout -b release/2.4
+    ```
 
 2. Copy the following doc folders for Kong Gateway (OSS):
 
@@ -122,7 +129,7 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
             pcre: "8.44"
         ```
 
-    Update `release`, `version`, and any `dependencies`, if applicable.
+        Update `release`, `version`, and any `dependencies`, if applicable.
 
     2. Do the same for `getting-started-guide`, copying the latest version,
     which looks like the following:
@@ -136,8 +143,8 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
 3. Update the latest version in the full site Algolia configuration file:
 
     1. Open  `/algolia/config-full-docs.json`
-    2. In the `start_urls`, update the `gateway-oss` URL to the latest `x`
-    version:
+    2. In the `start_urls` section, update the `gateway-oss` URL to the latest
+    `x.x.x` version:
 
         ```json
         "url": "https://docs.konghq.com/gateway-oss/2.3.x/"
@@ -145,7 +152,7 @@ docs, see the instructions on the [docs wiki](https://konghq.atlassian.net/wiki/
 
 4. Commit and push release branch to GitHub.
 
-### Generating the PDK, Admin API, CLI and Configuration Documentation
+### Generating the PDK, Admin API, CLI, and Configuration Documentation
 
 The PDK docs, Admin API docs, `cli.md` and `configuration.md` for each release are generated from the Kong source code.
 


### PR DESCRIPTION
With our incremental changes, the latest being the new landing page, the process for updating the community docs has changed over time. Updating the instructions so that anyone on the open-source team can make a new doc version when needed.