### PR TITLE
[DOCS-1606] Build/test action adjustments

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,10 @@
 name: Build and Test
-on: [push]
+on:
+  pull_request:
+    types: [synchronize, ready_for_review]
 jobs:
   build:
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 on:
   pull_request:
-    types: [synchronize, ready_for_review]
+    types: [synchronize, ready_for_review, opened]
 jobs:
   build:
     if: github.event.pull_request.draft != true


### PR DESCRIPTION
Attempting to adjust our build/test github action once again. That is, only this check:
![Screen Shot 2021-02-23 at 7 00 09 PM](https://user-images.githubusercontent.com/54370747/108941134-679c1e80-7609-11eb-8282-c056a1d5dc48.png)

### Changes
Instead of building on push, it should build on changes to PRs:
* `opened`  (does not apply to draft PRs)
* marked `ready_for_review`
* `synchronized `: commits were pushed to the branch. This means that a push will still trigger a build, but only if you have an open PR.

Any PRs marked as “draft” will not be built. The build kicks off once you mark it “ready for review”. 
![Screen Shot 2021-02-23 at 6 25 09 PM](https://user-images.githubusercontent.com/54370747/108938211-7fbd6f00-7604-11eb-8a0c-bbd9744356cc.png)

### Testing
Tested this in a bunch of situations:
* No PR = no build
* Open draft PR = no build
* Push to draft PR = no build
* Create PR from a branch with multiple commits: build/test runs on the latest commit only
* Push a bunch of commits to an open PR, not in draft mode: build/test runs on the latest commit only

Am I missing anything?

### Previews
N/A - though if you click on the green checkmark next to the last commit in this PR, you'll notice a skipped build. This was skipped automatically when the PR was in draft mode.