### PR TITLE
add info on new config properties introduced in 2.2.1.0

### DIFF
--- a/app/enterprise/2.2.x/property-reference.md
+++ b/app/enterprise/2.2.x/property-reference.md
@@ -3178,6 +3178,55 @@ Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
 
 ---
 
+#### untrusted_lua
+
+Accepted values are:
+
+- `off`: disallow any loading of Lua functions from admin supplied sources
+  (such as via the Admin API).
+
+Note using the `off` option will render plugins such as Serverless Functions
+unusable.
+
+- `sandbox`: allow loading of Lua functions from admin supplied sources, but
+  use a sandbox when executing them. The sandboxed function will have restricted
+  access to the global environment and only have access to standard Lua
+  functions that will generally not cause harm to the Kong node.
+
+In this mode, the `require` function inside the sandbox only allows loading
+external Lua modules that are explicitly listed in
+`untrusted_lua_sandbox_requires` below.
+
+LuaJIT bytecode loading is disabled.
+
+Warning: LuaJIT is not designed as a secure runtime for running malicious code,
+therefore, you should properly protect your Admin API endpoint even with
+sandboxing enabled. The sandbox only provides protection against trivial
+attackers or unintentional modification of the Kong global environment.
+
+- `on`: allow loading of Lua functions from admin supplied sources and do not
+  use a sandbox when executing them. Functions will have unrestricted access to
+  global environment and able to load any Lua modules. This is similar to the
+  behavior in Kong prior to 2.3.0.
+
+LuaJIT bytecode loading is disabled.
+
+untrusted_lua_sandbox_requires = Comma-separated list of modules allowed to be
+loaded with `require` inside the sandboxed environment. Ignored if
+`untrusted_lua` is not `sandbox`.
+
+Note: certain modules, when allowed, may cause sandbox escaping trivial.
+
+untrusted_lua_sandbox_environment = Comma-separated list of global Lua
+variables that should be made available inside the sandboxed environment.
+Ignored if `untrusted_lua` is not `sandbox`.
+
+Note: certain variables, when made available, may cause sandbox escaping
+trivial.
+
+**Default:** `on`
+
+---
 
 
 [Penlight]: http://stevedonovan.github.io/Penlight/api/index.html

--- a/app/enterprise/2.2.x/property-reference.md
+++ b/app/enterprise/2.2.x/property-reference.md
@@ -3206,25 +3206,34 @@ attackers or unintentional modification of the Kong global environment.
 
 - `on`: allow loading of Lua functions from admin supplied sources and do not
   use a sandbox when executing them. Functions will have unrestricted access to
-  global environment and able to load any Lua modules. This is similar to the
-  behavior in Kong prior to 2.3.0.
+  global environment and able to load any Lua modules.
 
 LuaJIT bytecode loading is disabled.
 
-untrusted_lua_sandbox_requires = Comma-separated list of modules allowed to be
-loaded with `require` inside the sandboxed environment. Ignored if
-`untrusted_lua` is not `sandbox`.
+**Default:** `sandbox`
+
+---
+
+#### untrusted_lua_sandbox_requires
+
+Comma-separated list of modules allowed to be loaded with `require` inside the
+sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
 Note: certain modules, when allowed, may cause sandbox escaping trivial.
 
-untrusted_lua_sandbox_environment = Comma-separated list of global Lua
-variables that should be made available inside the sandboxed environment.
-Ignored if `untrusted_lua` is not `sandbox`.
+**Default:** none
+
+---
+
+#### untrusted_lua_sandbox_environment
+
+Comma-separated list of global Lua variables that should be made available
+inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
 Note: certain variables, when made available, may cause sandbox escaping
 trivial.
 
-**Default:** `on`
+**Default:** none
 
 ---
 

--- a/app/enterprise/2.3.x/property-reference.md
+++ b/app/enterprise/2.3.x/property-reference.md
@@ -3270,25 +3270,34 @@ attackers or unintentional modification of the Kong global environment.
 
 - `on`: allow loading of Lua functions from admin supplied sources and do not
   use a sandbox when executing them. Functions will have unrestricted access to
-  global environment and able to load any Lua modules. This is similar to the
-  behavior in Kong prior to 2.3.0.
+  global environment and able to load any Lua modules.
 
 LuaJIT bytecode loading is disabled.
 
-untrusted_lua_sandbox_requires = Comma-separated list of modules allowed to be
-loaded with `require` inside the sandboxed environment. Ignored if
-`untrusted_lua` is not `sandbox`.
+**Default:** `sandbox`
+
+---
+
+#### untrusted_lua_sandbox_requires
+
+Comma-separated list of modules allowed to be loaded with `require` inside the
+sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
 Note: certain modules, when allowed, may cause sandbox escaping trivial.
 
-untrusted_lua_sandbox_environment = Comma-separated list of global Lua
-variables that should be made available inside the sandboxed environment.
-Ignored if `untrusted_lua` is not `sandbox`.
+**Default:** none
+
+---
+
+#### untrusted_lua_sandbox_environment
+
+Comma-separated list of global Lua variables that should be made available
+inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
 Note: certain variables, when made available, may cause sandbox escaping
 trivial.
 
-**Default:** `sandbox`
+**Default:** none
 
 ---
 


### PR DESCRIPTION
Copied the doc section from 2.3.x version docs.

The additional configuration was added in 2.2.1.0 to match 2.3.0.0. The default value for `untrusted_lua` is different from 2.3.0.0.

FT-1688