### PR TITLE
UDP Log plugin add datatypes from schemas

### DIFF
--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -57,16 +57,19 @@ params:
     - name: host
       required: true
       value_in_examples: 127.0.0.1
+      datatype: string
       description: The IP address or host name to send data to.
     - name: port
       required: true
       value_in_examples: 9999
-      description: The port to send data to on the upstream server
+      datatype: integer
+      description: The port to send data to on the upstream server.
     - name: timeout
       required: false
       default: "`10000`"
       value_in_examples: 10000
-      description: An optional timeout in milliseconds when sending data to the upstream server
+      datatype: number
+      description: An optional timeout in milliseconds when sending data to the upstream server.
 
 ---
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters. I'm not logging Jira subtickets because it's a lot of overhead.

Schema links:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/udp-log/schema.lua
https://github.com/Kong/kong/blob/master/kong/db/schema/typedefs.lua (host and port)

Direct review link:

https://deploy-preview-2629--kongdocs.netlify.app/hub/kong-inc/udp-log/