### PR TITLE
[DOCS-1608][DOCS-1609] Patch release notes for 2.1.4.4, 2.2.1.1, and 1.5.0.10

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -307,7 +307,7 @@ request's URI before matching against the Router.
 - Before, when enabling application registration with key authentication, developers who created 
 applications were able to see all Services for which the application registration plugin was enabled,
 regardless of the permissions granted to their role. With this fix, developers who create applications 
-will only see services if the role they are assigned to has been granted permissions to the relevant  
+will only see Services if the role they are assigned to has been granted permissions to the relevant  
 specs.
 
 #### Plugins
@@ -320,7 +320,7 @@ specs.
 ##### Plugin Dependencies
 - **OpenID Connect Library**
   - Token introspection now checks the status code properly.
-  - More consistent response body checks on `HTTP` requests.
+  - Added more consistent response body checks on `HTTP` requests.
 
 
 ## 2.2.1.0
@@ -679,7 +679,7 @@ Kong will set the content of the header to the request's URI.
 - Before, when enabling application registration with key authentication, developers who created 
 applications were able to see all Services for which the application registration plugin was enabled,
 regardless of the permissions granted to their role. With this fix, developers who create applications 
-will only see services if the role they are assigned to has been granted permissions to the relevant  
+will only see Services if the role they are assigned to has been granted permissions to the relevant  
 specs.
 
 #### Plugins
@@ -693,7 +693,7 @@ specs.
 ##### Plugin Dependencies
 - **OpenID Connect Library**
   - Token introspection now checks the status code properly.
-  - More consistent response body checks on `HTTP` requests.
+  - Added more consistent response body checks on `HTTP` requests.
 
 ## 2.1.4.3
 **Release Date** 2020/12/31

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -287,6 +287,41 @@ fixed causing a 500 auth error when falling back to an anonymous user.
 #### Distributions
 - Support for CentOS-6 is removed and entered end-of-life on Nov 30, 2020.
 
+## 2.2.1.1
+**Release Date** 2020/02/24
+
+### Fixes
+
+#### Core
+- Certain incoming URI made it possible to bypass security rules applied on Route objects. 
+With this fix, such attacks are now more difficult because the incoming request's URI is 
+always normalized before matching against the Router. [FT-1679]
+
+#### Enterprise
+- Kong now display errors to better identify the issue when `validate_key` fails. [FTI-2237]
+- Kong now uses the correct workspace ID when selecting SNI in dbless/hybrid mode. [FTI-2165]
+- Fixed verification when using combined certificates.
+- Corrected healthchecker thresholds.
+
+#### DevPortal
+- Before, when enabling application registration with key authentication, developers who created 
+applications were able to see all Services for which the application registration plugin was enabled,
+regardless of the permissions granted to their role. With this fix, developers who create applications 
+will only see services if the role they are assigned to has been granted permissions to the relevant  
+specs. [FTI-2204]
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  - Fixed init workers that were prolonging Kong startup time. [FTI-2002]
+  - Fixed consumer and discovery invalidation events that were returning when the operation
+  was `create`. This could leave some cache entries in cache that need to be invalidated.
+  - Fixed a circular dependency issue with the redirect function.
+
+##### Plugin Dependencies
+- **OpenID Connect Library**
+  - Token introspection now checks the status code properly.
+  - More consistent response body checks on `HTTP` requests.
+
 
 ## 2.2.1.0
 **Release Date** 2020/12/31

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -10,12 +10,10 @@ skip_read_time: true
 ### Features
 
 #### Plugins
-- [Request Validator](/hub/kong-inc/request-validator) (updated to 1.1.3)
+- [Request Validator](/hub/kong-inc/request-validator) (`request-validator`) (updated to 1.1.3)
   - Content-type failures are now reported as such when `verbose_response` is enabled.
 - [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (updated to v1.4.1)
   - Disallows decimal values between 0,1 in `sync_rate`.
-- [Request Validator](/hub/kong-inc/request-validator) (updated to v1.1.3)
-  - Content-type failures are now reported as such when verbose_response is enabled.
 
 ### Fixes
 - Adjusted the `systemd reload` command to do a `kong prepare`.
@@ -42,7 +40,7 @@ for dbless or hybrid modes.
 core entities but don't explicitly depend on them.
 
 #### Plugins
-- [OpenID Connect](/hub/kong-inc/openid-connect) (updated to v1.9.0)
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`) (updated to v1.9.0)
   - Add `config.disable_session` to be able to disable session creation with
     specified authentication methods.
   - Changed `Cache-Control="no-store"` instead of `Cache-Control="no-cache, no-store"`,
@@ -52,21 +50,21 @@ core entities but don't explicitly depend on them.
   - Token introspection now checks the status code properly.
   - More consistent response body checks on HTTP requests.
   - Fixed an issue where enabling zlib compressor did not affect the size of the session cookie.
-- [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (updated to v1.4.1)
+- [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`) (updated to v1.4.1)
   - Now the plugin does not pre-create namespaces on `init-worker`. As a side effect to this patch
     the plugin will create namespaces on the fly. This may result in a slightly (10-20%) increased
     response time on the first request.
-- [Request Validator](/hub/kong-inc/request-validator) (updated to v1.1.3)
+- [Request Validator](/hub/kong-inc/request-validator) (`request-validator`) (updated to v1.1.3)
   - Now the plugin correctly decodes and normalizes arrays when there are multiple headers with
     the same field-name.
-- [Mutual TSL Authentication](/hub/kong-inc/mtls-auth) (updated to v0.3.1)
+- [Mutual TSL Authentication](/hub/kong-inc/mtls-auth) (`mtls-auth`) (updated to v0.3.1)
   - Remove CA existence check on plugin creation - the check was not compatible with DB-less mode.
   - Correctly fetch certificates from the end of the proof chain when consumer credentials are used.
-- [AWS Lambda](/hub/kong-inc/aws-lambda) (updated to v3.5.4)
+- [AWS Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) (updated to v3.5.4)
   - The plugin now respects `skip_large_bodies` config setting when using AWS API Gateway compatibility.
-- [ACME](hub/kong-inc/acme) (updated to v0.2.14)
+- [ACME](hub/kong-inc/acme) (`acme`) (updated to v0.2.14)
   - Bump `lua-resty-acme` to 0.6.x; this fixes several issues with Pebble test server.
-- [OAuth 2.0 Authentication](/hub/kong-inc/oauth2)
+- [OAuth 2.0 Authentication](/hub/kong-inc/oauth2) (`oauth2`)
   - The plugin now has better handling for multiple cases of client invalid token generation.
 
 ## 2.3.2.0
@@ -395,11 +393,11 @@ specs.
   - More consistent response body checks on HTTP requests.
   - Fixed an issue where enabling zlib compressor the size of the session cookie was not
     changing in value.
-- [AWS Lambda](/hub/kong-inc/aws-lambda) (updated to v3.5.4)
+- [AWS Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) (updated to v3.5.4)
   - The plugin now respects `skip_large_bodies` config setting when using AWS API Gateway compatibility.
 - [ACME](hub/kong-inc/acme) (updated to v0.2.14)
   - Bump `lua-resty-acme` to 0.6.x; this fixes several issues with Pebble test server.
-- [Exit Transformer](/hub/kong-inc/exit-transformer)
+- [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
   - The plugin now allows access to Kong modules within the sandbox, not only to `kong.request`.
 
 #### Plugin Dependencies
@@ -786,9 +784,9 @@ specs.
   - Token introspection now checks the status code properly.
   - More consistent response body checks on HTTP requests.
   - Fixed an issue where enabling zlib compressor did not affect the size of the session cookie.
-- [ACME](hub/kong-inc/acme) (updated to v0.2.14)
+- [ACME](hub/kong-inc/acme) (`acme`) (updated to v0.2.14)
   - Bump `lua-resty-acme` to 0.6.x; this fixes several issues with Pebble test server.
-- [Exit Transformer](/hub/kong-inc/exit-transformer)
+- [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
   - The plugin now allows access to Kong modules within the sandbox, not only to `kong.request`.
 
 #### Plugin Dependencies

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -293,13 +293,13 @@ fixed causing a 500 auth error when falling back to an anonymous user.
 ### Fixes
 
 #### Core
-- Certain incoming URI made it possible to bypass security rules applied on Route objects. 
-With this fix, such attacks are now more difficult because the incoming request's URI is 
-always normalized before matching against the Router. [FT-1679]
+- Fixed an issue where certain incoming URI may make it possible to bypass security rules applied
+on Route objects. This fix make such attacks more difficult by always normalizing the incoming
+request's URI before matching against the Router.
 
 #### Enterprise
-- Kong now display errors to better identify the issue when `validate_key` fails. [FTI-2237]
-- Kong now uses the correct workspace ID when selecting SNI in dbless/hybrid mode. [FTI-2165]
+- Kong now display errors to better identify the issue when `validate_key` fails.
+- Kong now uses the correct workspace ID when selecting SNI in dbless/hybrid mode.
 - Fixed verification when using combined certificates.
 - Corrected healthchecker thresholds.
 
@@ -308,11 +308,11 @@ always normalized before matching against the Router. [FT-1679]
 applications were able to see all Services for which the application registration plugin was enabled,
 regardless of the permissions granted to their role. With this fix, developers who create applications 
 will only see services if the role they are assigned to has been granted permissions to the relevant  
-specs. [FTI-2204]
+specs.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  - Fixed init workers that were prolonging Kong startup time. [FTI-2002]
+  - Fixed init workers that were prolonging Kong startup time.
   - Fixed consumer and discovery invalidation events that were returning when the operation
   was `create`. This could leave some cache entries in cache that need to be invalidated.
   - Fixed a circular dependency issue with the redirect function.
@@ -667,24 +667,24 @@ open-source **Kong Gateway 2.2.0.0**:
 ### Fixes
 
 #### Core
-- Certain incoming URI made it possible to bypass security rules applied on Route objects. 
-With this fix, such attacks are now more difficult because the incoming request's URI is 
-always normalized before matching against the Router. [FT-1679]
+- Fixed an issue where certain incoming URI may make it possible to bypass security rules applied
+on Route objects. This fix make such attacks more difficult by always normalizing the incoming
+request's URI before matching against the Router.
 
 #### Enterprise
 - If a trusted source provides an `X-Forwarded-Path` header, it's proxied as-is; otherwise, 
-Kong will set the content of the header to the request's URI. [FT-1679]
+Kong will set the content of the header to the request's URI. 
 
 #### DevPortal
 - Before, when enabling application registration with key authentication, developers who created 
 applications were able to see all Services for which the application registration plugin was enabled,
 regardless of the permissions granted to their role. With this fix, developers who create applications 
 will only see services if the role they are assigned to has been granted permissions to the relevant  
-specs. [FTI-2204]
+specs.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  - Fixed init workers that were prolonging Kong startup time. [FTI-2002]
+  - Fixed init workers that were prolonging Kong startup time.
   - Fixed consumer and discovery invalidation events that were returning when the operation
   was `create`. This could leave some cache entries in cache that need to be invalidated.
   - Fixed a circular dependency issue with the redirect function.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -353,7 +353,7 @@ fixed causing a 500 auth error when falling back to an anonymous user.
 - Support for CentOS-6 is removed and entered end-of-life on Nov 30, 2020.
 
 ## 2.2.1.1
-**Release Date** 2020/02/24
+**Release Date** 2020/03/26
 
 ### Fixes
 
@@ -747,7 +747,7 @@ open-source **Kong Gateway 2.2.0.0**:
   the new `shorthand_fields` top-level attribute.
 
 ## 2.1.4.4
-**Release Date** 2021/02/24
+**Release Date** 2021/03/26
 
 ### Fixes
 
@@ -1182,7 +1182,7 @@ Kong Enterprise 2.1.3.0 version includes 2.1.0.0 (beta) features, fixes, known i
 
 
 ## 1.5.0.10
-**Release Date** 2021/03/??
+**Release Date** 2021/03/26
 
 ### Fixes
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -626,6 +626,39 @@ open-source **Kong Gateway 2.2.0.0**:
 - The `shorthands` attribute in schema definitions is deprecated in favor of
   the new `shorthand_fields` top-level attribute.
 
+## 2.1.4.4
+**Release Date** 2021/02/24
+
+### Fixes
+
+#### Core
+- Certain incoming URI made it possible to bypass security rules applied on Route objects. 
+With this fix, such attacks are now more difficult because the incoming request's URI is 
+always normalized before matching against the Router. [FT-1679]
+
+#### Enterprise
+- If a trusted source provides an `X-Forwarded-Path` header, it's proxied as-is; otherwise, 
+Kong will set the content of the header to the request's URI. [FT-1679]
+
+#### DevPortal
+- Before, when enabling application registration with key authentication, developers who created 
+applications were able to see all Services for which the application registration plugin was enabled,
+regardless of the permissions granted to their role. With this fix, developers who create applications 
+will only see services if the role they are assigned to has been granted permissions to the relevant  
+specs. [FTI-2204]
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  - Fixed init workers that were prolonging Kong startup time. [FTI-2002]
+  - Fixed consumer and discovery invalidation events that were returning when the operation
+  was `create`. This could leave some cache entries in cache that need to be invalidated.
+  - Fixed a circular dependency issue with the redirect function.
+  - Bumped `lua-resty-session` dependency to 3.8.
+
+##### Plugin Dependencies
+- **OpenID Connect Library**
+  - Token introspection now checks the status code properly.
+  - More consistent response body checks on `HTTP` requests.
 
 ## 2.1.4.3
 **Release Date** 2020/12/31

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -317,8 +317,8 @@ specs.
   was `create`. This could leave some cache entries in cache that need to be invalidated.
   - Fixed a circular dependency issue with the redirect function.
 
-##### Plugin Dependencies
-- **OpenID Connect Library**
+#### Plugin Dependencies
+- OpenID Connect Library
   - Token introspection now checks the status code properly.
   - Added more consistent response body checks on `HTTP` requests.
 
@@ -690,8 +690,8 @@ specs.
   - Fixed a circular dependency issue with the redirect function.
   - Bumped `lua-resty-session` dependency to 3.8.
 
-##### Plugin Dependencies
-- **OpenID Connect Library**
+#### Plugin Dependencies
+- OpenID Connect Library
   - Token introspection now checks the status code properly.
   - Added more consistent response body checks on `HTTP` requests.
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -1080,6 +1080,31 @@ Kong Enterprise 2.1.3.0 version includes 2.1.0.0 (beta) features, fixes, known i
   * The ability to share an entity between Workspaces is no longer supported. The new method requires a copy of the entity to be created in the other Workspaces.
 
 
+## 1.5.0.10
+**Release Date** 2021/03/??
+
+### Fixes
+
+#### Core
+- Fixed an issue where certain incoming URI may make it possible to bypass security rules applied
+on Route objects. This fix make such attacks more difficult by always normalizing the incoming
+request's URI before matching against the Router.
+- Sanitize path postfix for additional security.
+
+#### Enterprise
+- Added pgp signature to Bintray-rpm package of kong-enterprise, version 1.5.0.9.
+- Added the following updates with backport of bypass security vulnerability:
+  - Support for read transformations
+  - Support for `X-Forwarded-Prefix`
+  - `X-Forwarded-Path` heaader
+
+#### Developer Portal
+- Before, when enabling application registration with key authentication, developers who created 
+applications were able to see all Services for which the application registration plugin was enabled,
+regardless of the permissions granted to their role. With this fix, developers who create applications 
+will only see Services if the role they are assigned to has been granted permissions to the relevant  
+specs.
+
 ## 1.5.0.9
 **Release Date** 2020/12/31
 


### PR DESCRIPTION
I added the release notes for the [2.1.4.4](https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule#KongEnterprise-Changelog,Features&ReleaseSchedule-KongEnterprise2.1.4.4) and [2.2.1.1](https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule#KongEnterprise-Changelog,Features&ReleaseSchedule-KongEnterprise2.2.1.1) patch releases based on the Confluence changelog.

I have also added [1.5.0.10](https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule#KongEnterprise-Changelog%2CFeatures%26ReleaseSchedule-KongEnterprise1.5.0.10) and [2.3.3.0](https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule#KongEnterprise-Changelog%2CFeatures%26ReleaseSchedule-KongEnterprise2.3.3.0).

I added the Jira issue numbers for the items I was able to discern, but can remove them if would cause confusing for customers. I believe customer success said it was helpful for them, but maybe not in the changelong and only on major releases? 

Terry - can you take a look at the plugin updates? 

[2.2.1.1](https://deploy-preview-2630--kongdocs.netlify.app/enterprise/changelog/)

[2.1.4.4](https://deploy-preview-2630--kongdocs.netlify.app/enterprise/changelog/)

