### PR TITLE
[no ticket] Add scroll to top button for plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -879,6 +879,9 @@ plugins:
       </div>
     </div>
   </div>
+  <div id="scroll-to-top-button">
+    <i class="fas fa-chevron-up"></i>
+  </div>
   {% if page.feedback != false %}
   {% include feedback-widget.html %}
   {% endif %}


### PR DESCRIPTION
### Summary
After getting frustrated with the OpenID Connect plugin doc for the umpteenth time, realized that the plugin docs don't have a scroll-to-top button. Adding that.

### Reason
https://docs.konghq.com/hub/kong-inc/openid-connect/ - this. this is the reason.
But seriously: the plugin docs arguably have more need for a scroll-to-top button than the main site, as plugin references are often lengthy and the page nav doesn't follow the reader down the page.

### Test/Review
https://deploy-preview-2635--kongdocs.netlify.app/hub/kong-inc/openid-connect/ - scroll some ways down the page, close the cookie banner, and click the `^` button in the bottom right corner.