### PR TITLE
HTTP log logging plugin add datatypes, missing param

### DIFF
--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -58,7 +58,7 @@ params:
       default:
       value_in_examples: http://mockbin.org/bin/:id
       datatype: string
-      description: The HTTP endpoint (including the protocol to use) to which the data is sent.
+      description: The HTTP URL endpoint (including the protocol to use) to which the data is sent.
     - name: method
       required: false
       default: "`POST`"

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -57,41 +57,57 @@ params:
       required: true
       default:
       value_in_examples: http://mockbin.org/bin/:id
+      datatype: Reviewers cannot locate in typedefs schema, where is typedefs.url schema?
       description: The HTTP endpoint (including the protocol to use) to which the data is sent.
     - name: method
       required: false
       default: "`POST`"
       value_in_examples: POST
+      datatype: string
       description: |
-        An optional method used to send data to the HTTP server. Supported values are `POST` (default), `PUT`, and `PATCH`.
+        An optional method used to send data to the HTTP server. Supported values are
+        `POST` (default), `PUT`, and `PATCH`.
+    - name: content_type
+      required: false
+      default: "`application/json`"
+      value_in_examples:
+      datatype: string
+      description: |
+      REVIEWERS need description. The only available option is `application/json`.
     - name: timeout
       required: false
       default: "`10000`"
       value_in_examples: 1000
+      datatype: number
       description: An optional timeout in milliseconds when sending data to the upstream server.
     - name: keepalive
       required: false
       default: "`60000`"
       value_in_examples: 1000
+      datatype: number
       description: An optional value in milliseconds that defines how long an idle connection will live before being closed.
     - name: flush_timeout
       required: false
       default: "`2`"
       value_in_examples: 2
+      datatype: number
       description: |  
         Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.    
     - name: retry_count
       required: false
       default: 10
       value_in_examples: 15
+      datatype: integer
       description: Number of times to retry when sending data to the upstream server.
     - name: queue_size
       required: false
       default: 1
+      datatype: integer
       description: Max number of log entries to be sent on each message to the upstream server.
     - name: headers
       required: false
       default: empty table
+      datatype: array of string elements
       description: An optional table of headers added to the HTTP message to the upstream server.
   extra: |
     **NOTE:** If the `config.http_endpoint` contains a username and password (for example,

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -73,7 +73,7 @@ params:
       value_in_examples:
       datatype: string
       description: |
-      REVIEWERS need description. The only available option is `application/json`.
+        REVIEWERS need description. The only available option is `application/json`.
     - name: timeout
       required: false
       default: "`10000`"
@@ -108,7 +108,12 @@ params:
       required: false
       default: empty table
       datatype: array of string elements
-      description: An optional table of headers added to the HTTP message to the upstream server.
+      description: |
+        An optional table of headers added to the HTTP message to the upstream server. The following
+        headers are not allowed: `Host`, `Content-Length`, `Content-Type`.
+
+        **Note:** This parameter is only available for versions
+        2.3.x and later.
   extra: |
     **NOTE:** If the `config.http_endpoint` contains a username and password (for example,
     `http://bob:password@example.com/logs`), then Kong Gateway automatically includes

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -57,7 +57,7 @@ params:
       required: true
       default:
       value_in_examples: http://mockbin.org/bin/:id
-      datatype: Reviewers cannot locate in typedefs schema, where is typedefs.url schema?
+      datatype: string
       description: The HTTP endpoint (including the protocol to use) to which the data is sent.
     - name: method
       required: false

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -73,7 +73,7 @@ params:
       value_in_examples:
       datatype: string
       description: |
-        REVIEWERS need description. The only available option is `application/json`.
+        Indicates the type of data sent. The only available option is `application/json`.
     - name: timeout
       required: false
       default: "`10000`"


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1396 epic to add datatypes to plugins beyond the few template-autogenerated parameters. I'm not logging Jira subtickets because it's a lot of overhead.

Schema links:

- https://github.com/Kong/kong-ee/blob/master/kong/plugins/http-log/schema.lua
- typedefs.url-where is this schema @Murillo? Answer: https://github.com/Kong/kong-ee/blob/master/kong/db/schema/typedefs.lua#L295-L298
- Also, need a description for content_type, which was missing from doc.  (Update: @javierguerragiraldez had said not to doc content_type in PR 2393 but I think that time has come now). Schemas do not contain descriptions of fields. And there isn't a readme either. Attempted a description in commit 46f3758.


Direct review link:

https://deploy-preview-2636--kongdocs.netlify.app/hub/kong-inc/http-log/


Please see reviewer questions directly in doc.

Also note the PR that was most recent for this plugin update https://github.com/Kong/docs.konghq.com/pull/2393 and an issue with version confusion ticket for a new field https://konghq.atlassian.net/browse/DOCS-1613. See commit f298b1a.

