### PR TITLE
[DOCS-1564] Add canonical links for all version URLs

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -163,7 +163,7 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
   {% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
 
   {% if page.kong_version == page.kong_latest.release and page.no_version != true %}<link rel="canonical" href="{{ site.links.web }}{{ page.url }}" />
-    {% elsif latest_page_exists == 'true' %}<link rel="canonical" href="{% capture latest_path %}{{ site.links.web }}{% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}{{ latest_page_url }}{% endcapture %}{{ latest_path }}" />
+    {% elsif latest_page_exists == 'true' %}<link rel="canonical" href="{% capture latest_path %}{{ site.links.web }}{{ latest_page_url }}{% endcapture %}{{ latest_path }}" />
   {% endif %}
 
 </head>

--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -158,6 +158,13 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
     href="/assets/hub.css?v={{ site.time | date: '%s' }}"
   />
   {% endif %}
+
+  {% if page.no_version != true %}
+  {% if page.kong_version == site.data.kong_latest.release %}<link rel="canonical" href="{{ site.links.web }}{{ page.url }}" />{% else %}<link rel="canonical" href="{{ site.links.web }}{% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}{% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}FOUR{% endcapture %}{{ latest_page_url }}" />{%endif%}
+  {% endif %}
+
+
+
 </head>
 
 <!-- Kong Cookie Policy -->

--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -159,11 +159,12 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
   />
   {% endif %}
 
-  {% if page.no_version != true %}
-  {% if page.kong_version == site.data.kong_latest.release %}<link rel="canonical" href="{{ site.links.web }}{{ page.url }}" />{% else %}<link rel="canonical" href="{{ site.links.web }}{% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}{% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}FOUR{% endcapture %}{{ latest_page_url }}" />{%endif%}
+  {% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}
+  {% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
+
+  {% if page.kong_version == site.data.kong_latest.release and page.no_version != true %}<link rel="canonical" href="{{ site.links.web }}{{ page.url }}" />
+    {% elsif latest_page_exists == 'true' %}<link rel="canonical" href="{% capture latest_path %}{{ site.links.web }}{% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}{{ latest_page_url }}{% endcapture %}{{ latest_path }}" />
   {% endif %}
-
-
 
 </head>
 

--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -162,7 +162,7 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
   {% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}
   {% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
 
-  {% if page.kong_version == site.data.kong_latest.release and page.no_version != true %}<link rel="canonical" href="{{ site.links.web }}{{ page.url }}" />
+  {% if page.kong_version == page.kong_latest.release and page.no_version != true %}<link rel="canonical" href="{{ site.links.web }}{{ page.url }}" />
     {% elsif latest_page_exists == 'true' %}<link rel="canonical" href="{% capture latest_path %}{{ site.links.web }}{% assign latest_page_url = page.url | replace: page.kong_version, page.kong_latest.release %}{{ latest_page_url }}{% endcapture %}{{ latest_path }}" />
   {% endif %}
 


### PR DESCRIPTION
### Summary
* conditionally add <link rel=“canonical”> in head of URL paths with versions directing to latest versioned pages for improved search indexing

Sample output:
![Screenshot of preview version canonical versus URL](https://puu.sh/Hk3BR/02c3ab9d1b.png)

![Screenshot of preview version canonical with subdirectory](https://puu.sh/Hk3Ej/c74257724f.png)

![Screenshot of self-referencing canonical](https://puu.sh/Hk3Hw/f360863047.png)

* I've chosen to leave in self-referencing canonicals as this is acceptable practice and some argue it improves indexing structures.

* In order to fully ensure proper indexing after each version update it may be necessary to manually force a recrawl via Google Webmaster Tools





