### PR TITLE
[DOCS-1614] Fix Plugin compatibility list for community versions

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -849,7 +849,7 @@ plugins:
                 {% endif %}
               {% endfor %}
               </ul><ul class="compat-list">
-              {% for v in site.data.kong_versions reversed %}
+              {% for v in site.data.kong_versions_ce reversed %}
                 {% if ce_compatible contains v.release or ce_incompatible contains v.release %}
                   {% unless first_ce %}
                   <h6>{{site.ce_product_name}}</h6>{% assign first_ce = true %}


### PR DESCRIPTION
### Summary
Fixing plugin compatibility list.

### Reason
Compatibility list is listing all product versions, for every single product.

### Testing
Check that the listed versions under Kong Gateway aren't duplicated (bottom right in the page sidebar). For example: https://deploy-preview-2640--kongdocs.netlify.app/hub/kong-inc/basic-auth/