### PR TITLE
[DOCS-1617] added update to KE 2.3.2.0 changelog

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -133,6 +133,10 @@ being shown in the logs.
 - Fixed an issue that incorrectly enforced plugins when they exist in the default and a named workspace.
    The plugin configuration in the default workspace was incorrectly overriding the disabled plugin
    configuration in the named workspace (FTI-2049, FTI-2228).
+- Fixed an issue for vitals when proxy-cached-advanced or forward-proxy plugins (possibly others) 
+are in use. 
+   Requests that received a cache hit using the plugins were not showing up under 
+   service/route vitals, but were visible under workspace vitals. 
 
 #### CLI
 - Fixed issue where `kong reload -c <config>` would fail.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -132,10 +132,10 @@ being shown in the logs.
 #### Enterprise
 - Fixed an issue that incorrectly enforced plugins when they exist in the default and a named workspace.
    The plugin configuration in the default workspace was incorrectly overriding the disabled plugin
-   configuration in the named workspace (FTI-2049, FTI-2228).
+   configuration in the named workspace.
 - Fixed an issue for vitals when proxy-cached-advanced or forward-proxy plugins (possibly others) 
 are in use. 
-   Requests that received a cache hit using the plugins were not showing up under 
+- Requests that received a cache hit using the plugins were not showing up under 
    service/route vitals, but were visible under workspace vitals. 
 
 #### CLI


### PR DESCRIPTION
@GayleNeumann - I did not include the Jira issue number bc we discussed they shouldn't be added, but I noticed the other fix under Enterprise includes Jiras . . . Wasn't sure if I should remove those or not . . .

### Summary
Added FTI-2038 fix to KE 2.3.2.0 changelog per @jeremymv2 's request in Slack.

### Reason
DOCS-1617

### Testing

[Sample build link](https://deploy-preview-2643--kongdocs.netlify.app/enterprise/changelog/#enterprise-1)
