### PR TITLE
Update OIDC plugin reference with corrected Keycloak docs link

### DIFF
--- a/app/_hub/kong-inc/openid-connect/0.31-x.md
+++ b/app/_hub/kong-inc/openid-connect/0.31-x.md
@@ -1610,5 +1610,5 @@ Provider                                                        | Information
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks)
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) / Discovery / Keys
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) / Discovery / Keys
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) / Discovery / Keys
+[Keycloak](https://www.keycloak.org/)                           | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients) / Discovery / Keys
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) / Discovery / Keys

--- a/app/_hub/kong-inc/openid-connect/0.32-x.md
+++ b/app/_hub/kong-inc/openid-connect/0.32-x.md
@@ -1971,6 +1971,6 @@ Provider                                                        | Information
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks)
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect)
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/)
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html)
+[Keycloak](https://www.keycloak.org/)                            | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients)
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md)
 [WSO2](https://wso2.com/)                                       | [Docs](https://docs.wso2.com/display/IS541/OpenID+Connect)

--- a/app/_hub/kong-inc/openid-connect/0.33-x.md
+++ b/app/_hub/kong-inc/openid-connect/0.33-x.md
@@ -1961,6 +1961,6 @@ Provider                                                        | Information
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks)
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect)
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/)
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html)
+[Keycloak](https://www.keycloak.org/)                           | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients)
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md)
 [WSO2](https://wso2.com/)                                       | [Docs](https://docs.wso2.com/display/IS541/OpenID+Connect)

--- a/app/_hub/kong-inc/openid-connect/0.34-x.md
+++ b/app/_hub/kong-inc/openid-connect/0.34-x.md
@@ -2567,7 +2567,7 @@ Provider                                                        | Information
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks)
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect)
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/)
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html)
+[Keycloak](https://www.keycloak.org/)                           | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients)
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md)
 [WSO2](https://wso2.com/)                                       | [Docs](https://docs.wso2.com/display/IS541/OpenID+Connect)
 

--- a/app/_hub/kong-inc/openid-connect/0.35-x.md
+++ b/app/_hub/kong-inc/openid-connect/0.35-x.md
@@ -2568,7 +2568,7 @@ Provider                                                        | Information
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks)
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect)
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/)
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html)
+[Keycloak](http://www.keycloak.org/)                            | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients)
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md)
 [WSO2](https://wso2.com/)                                       | [Docs](https://docs.wso2.com/display/IS541/OpenID+Connect)
 

--- a/app/_hub/kong-inc/openid-connect/1.3-x.md
+++ b/app/_hub/kong-inc/openid-connect/1.3-x.md
@@ -2821,7 +2821,7 @@ Provider                                                        | Information  |
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) | - |
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) | - |
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks) | - |
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) | - |
+[Keycloak](https://www.keycloak.org/)                           | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients) | - |
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) | - |
 [PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/) | - |
 [WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect) | - |

--- a/app/_hub/kong-inc/openid-connect/1.5.x.md
+++ b/app/_hub/kong-inc/openid-connect/1.5.x.md
@@ -3112,7 +3112,7 @@ Provider                                                        | Information  |
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) | - |
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) | - |
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks) | - |
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) | - |
+[Keycloak](https://www.keycloak.org/)                           | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients) | - |
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) | - |
 [PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/) | - |
 [WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect) | - |

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -3179,7 +3179,7 @@ Provider                                                        | Information  |
 [Dex](https://github.com/coreos/dex)                            | [Docs](https://github.com/coreos/dex/blob/master/Documentation/openid-connect.md) | - |
 [Gluu](https://gluu.org/)                                       | [Docs](https://gluu.org/docs/ce/api-guide/openid-connect-api/) | - |
 [IdentityServer4](http://identityserver.io/)                    | [Docs](https://identityserver4.readthedocs.io/) / [Discovery](https://demo.identityserver.io/.well-known/openid-configuration) / [Keys](https://demo.identityserver.io/.well-known/openid-configuration/jwks) | - |
-[Keycloak](http://www.keycloak.org/)                            | [Docs](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/oidc-generic.html) | - |
+[Keycloak](https://www.keycloak.org/)                            | [Docs](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients) | - |
 [OpenAM](https://www.forgerock.com/platform/access-management/) | [Docs](https://backstage.forgerock.com/docs/openam/13.5/admin-guide/chap-openid-connect) | - |
 [PingFederate](https://www.pingidentity.com/)                   | [Docs](https://documentation.pingidentity.com/pingfederate/pf84/) | - |
 [WSO2](https://wso2.com/)                                       | [Docs](https://is.docs.wso2.com/en/latest/learn/openid-connect) | - |


### PR DESCRIPTION
### Review

@reviewer

### Summary
Updates an outdated link in the OIDC plugin reference for Keycloak.

### Reason
Current link is generating a 404.

### Testing
Validate that the link is no longer generating 404s.