### PR TITLE
follow up to public contributor PR, fix other versions

### DIFF
--- a/app/gateway-oss/2.1.x/pdk/kong.response.md
+++ b/app/gateway-oss/2.1.x/pdk/kong.response.md
@@ -496,7 +496,6 @@ return kong.response.exit(403, { message = "Access Forbidden" }, {
 
 ---
 
-```lua
 -- In L4 proxy mode
 return kong.response.exit(200, "Success")
 ```

--- a/app/gateway-oss/2.1.x/pdk/kong.response.md
+++ b/app/gateway-oss/2.1.x/pdk/kong.response.md
@@ -500,7 +500,6 @@ return kong.response.exit(403, { message = "Access Forbidden" }, {
 -- In L4 proxy mode
 return kong.response.exit(200, "Success")
 ```
-```
 
 [Back to top](#kongresponse)
 
@@ -569,4 +568,3 @@ return kong.response.error(403)
 ```
 
 [Back to top](#kongresponse)
-

--- a/app/gateway-oss/2.2.x/pdk/kong.response.md
+++ b/app/gateway-oss/2.2.x/pdk/kong.response.md
@@ -496,7 +496,6 @@ return kong.response.exit(403, { message = "Access Forbidden" }, {
 
 ---
 
-```lua
 -- In L4 proxy mode
 return kong.response.exit(200, "Success")
 ```

--- a/app/gateway-oss/2.2.x/pdk/kong.response.md
+++ b/app/gateway-oss/2.2.x/pdk/kong.response.md
@@ -500,7 +500,6 @@ return kong.response.exit(403, { message = "Access Forbidden" }, {
 -- In L4 proxy mode
 return kong.response.exit(200, "Success")
 ```
-```
 
 [Back to top](#kongresponse)
 
@@ -569,4 +568,3 @@ return kong.response.error(403)
 ```
 
 [Back to top](#kongresponse)
-


### PR DESCRIPTION
Follow up to public contributor PR https://github.com/Kong/docs.konghq.com/pull/2642.

Minor format error also in versions 2.2 and 2.1.

Direct review links:

https://deploy-preview-2646--kongdocs.netlify.app/gateway-oss/2.2.x/pdk/kong.response/#kongresponseexitstatus-body-headers

https://deploy-preview-2646--kongdocs.netlify.app/gateway-oss/2.1.x/pdk/kong.response/#kongresponseexitstatus-body-headers

> The second half of the problem is in line 499, where it starts a `lua` codeblock. That line should be removed - someone accidentally formatted a codeblock inside a codeblock.
> 
> Since this doc is generated from the code, can you also open a PR against the source file in kong/kong: https://github.com/Kong/kong/blob/master/kong/pdk/response.lua#L773 - this line and line 776 should be removed, otherwise the error will return in the next release.

@lena-larionova I see what you're saying:

![image](https://user-images.githubusercontent.com/3756245/109697176-83e11380-7b53-11eb-97d4-c7b2b4db01fd.png)

I'll log a ticket to get it fixed in the source.