### PR TITLE
[DOCS-1604] remove erroneous statements Redis not supported

### DIFF
--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -1920,22 +1920,22 @@ Redis connection timeout in milliseconds.
 
 #### config.session_redis_read_timeout
 
-Redis read timeout in milliseconds (not supported with Redis cluster).
+Redis read timeout in milliseconds for the Redis client.
 
 
 #### config.session_redis_send_timeout
 
-Redis send timeout in milliseconds (not supported with Redis cluster).
+Redis send timeout in milliseconds for the Redis client.
 
 
 #### config.session_redis_ssl
 
-Use SSL/TLS for Redis connection (not supported with Redis cluster).
+Use SSL/TLS for Redis connection.
 
 
 #### config.session_redis_ssl_verify
 
-Verify Redis server certificate (not supported with Redis cluster).
+Verify Redis server certificate.
 
 
 #### config.session_redis_cluster_nodes

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -1920,12 +1920,12 @@ Redis connection timeout in milliseconds.
 
 #### config.session_redis_read_timeout
 
-Redis read timeout in milliseconds for the Redis client.
+The read timeout in milliseconds for the Redis client.
 
 
 #### config.session_redis_send_timeout
 
-Redis send timeout in milliseconds for the Redis client.
+The send timeout in milliseconds for the Redis client.
 
 
 #### config.session_redis_ssl


### PR DESCRIPTION

### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
https://konghq.atlassian.net/browse/DOCS-1604 Update OIDC plugin TLS now supported with Redis cluster

See slack convo https://kongstrong.slack.com/archives/C4CA2EP1S/p1613693676119600

### Reason

This was brought up by @morals415 in the # open_id_connect_idp channel.

### Testing

I did not test this. It was confirmed as working by Murillo and Aapo. Aapo updated the readme but not the plugin hub docs.
I'm not sure which version this was updated, so the change was made directly to the index file (2.2.x). Reviewers: If that is not correct, please let me know.

Direct review link:
