### PR TITLE
[DOCS-1582] updated titles, version numbers, and minor formatting issues for 2.3.x

### DIFF
--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -122,7 +122,7 @@
           url: /kong-security-update-process
     - text: Upgrades and Migrations
       items:
-        - text: Migrating Kong Gateway to Latest Version
+        - text: Migrating to the latest version
           url: /deployment/upgrades/migrations
         - text: Migrating from OSS to Enterprise
           url: /deployment/upgrades/migrate-ce-to-ke

--- a/app/enterprise/2.3.x/deployment/upgrades/migrate-ce-to-ke.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrate-ce-to-ke.md
@@ -3,15 +3,17 @@ title: Migrating from Kong Community Gateway to Kong Enterprise
 toc: true
 ---
 
-## Migrating from Kong Community Gateway 2.2.x to Kong Enterprise 2.2.x {#migrate-ce-ee}
+## Migrating from Kong Community Gateway 2.3.x to Kong Enterprise 2.3.x {#migrate-ce-ee}
 
 As of {{site.ee_product_name}} version 2.1.x and later, it is no longer necessary to explicitly
 run the `migrate-community-to-enterprise` command parameter to to migrate all
 Kong Gateway entities to Kong Enterprise. Running the `kong migrations` commands
 performs that migration command on your behalf.
 
-**Important:** You can only migrate to a {{site.ee_product_name}} version that
+<div class="alert alert-ee blue">
+<strong>Important:</strong> You can only migrate to a {{site.ee_product_name}} version that
 supports the same {{site.ce_product_name}} version.
+</div>
 
 ### Prerequisites
 
@@ -21,16 +23,16 @@ supports the same {{site.ce_product_name}} version.
      {{site.ce_product_name}} to {{site.ee_product_name}}.
 </div>
 
-* If running a version of {{site.ce_product_name}} earlier than 2.2.x,
-  [upgrade to Kong 2.2.x](/2.2.x/upgrading/) before migrating
-  {{site.ce_product_name}} to {{site.ee_product_name}} 2.2.x.
+* If running a version of {{site.ce_product_name}} earlier than 2.3.x,
+  [upgrade to Kong 2.3.x](/2.3.x/upgrading/) before migrating
+  {{site.ce_product_name}} to {{site.ee_product_name}} 2.3.x.
 
-#### Migration Steps
+#### Migration steps
 
 The following steps guide you through the migration process.
 
-1. Download {{site.ee_product_name}} 2.2.x and configure it to point to the
-   same datastore as your {{site.ce_product_name}} 2.2.x node. The migration
+1. Download {{site.ee_product_name}} 2.3.x and configure it to point to the
+   same datastore as your {{site.ce_product_name}} 2.3.x node. The migration
    command expects the datastore to be up-to-date on any pending migration:
 
    ```shell

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -1,5 +1,5 @@
 ---
-title: Migrating Kong Enterprise from 2.1.x to 2.2.x
+title: Migrating Kong Gateway from 2.2.x to 2.3.x
 toc: true
 ---
 
@@ -15,25 +15,25 @@ to {{site.ee_product_name}}. See
 If you experience any issues when running migrations, contact
 [Kong Support](https://support.konghq.com/support/s/) for assistance.
 
-## Upgrade Path for Kong Enterprise Releases
+## Upgrade path for Kong Gateway releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
 distinction between major, minor, and [patch](#patch) versions. The upgrade path
 for major and minor versions differs depending on the previous version from which
 you are migrating:
 
-- Upgrading from 2.1.x to 2.2.x is a minor upgrade; however, read below for important
+- Upgrading from 2.2.x to 2.3.x is a minor upgrade; however, read below for important
 instructions on [database migration](#migrate-db), especially for Cassandra users.
 
 - Upgrading from from 1.x is a major upgrade. Follow the [Version Prerequisites](#prereqs-v).
 Be aware of any noted breaking changes as documented in the version to which you are upgrading.
 
-### Version Prerequisites for Migrating to Kong Enterprise 2.2.x {#prereqs-v}
+### Version prerequisites for migrating to Kong Gateway 2.3.x {#prereqs-v}
 
-If you are not on {{site.ee_product_name}} 2.1.x, you must first incrementally
-upgrade to 2.1.x before upgrading to 2.2.x. Zero downtime is possible but _not_
+If you are not on {{site.ee_product_name}} 2.2.x, you must first incrementally
+upgrade to 2.2.x before upgrading to 2.3.x. Zero downtime is possible but _not_
 guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1.3.x to
-1.5.x to 2.1.x to 2.2.x. Plan accordingly.
+1.5.x to 2.1.x to 2.2.x to 2.3.x. Plan accordingly.
 
 * If running a version of {{site.ee_product_name}} earlier than 1.3,
   [migrate to 1.3](/enterprise/1.3-x/deployment/migrations/) first.
@@ -41,39 +41,47 @@ guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1
   [migrate to 1.5](/enterprise/1.5.x/deployment/migrations/) first.
 * If running a version of {{site.ee_product_name}} earlier than 2.1,
   [migrate to 2.1](/enterprise/2.1.x/deployment/upgrades/migrations/) first.
+* If running a version of {{site.ee_product_name}} earlier than 2.2,
+  [migrate to 2.2](/enterprise/2.2.x/deployment/upgrades/migrations/) first.
 
-#### Dev Portal Migrations
+#### Dev Portal migrations
 
-There are no migrations necessary for the Dev Portal when upgrading from 2.1.x to
-2.2.x.
+There are no migrations necessary for the Dev Portal when upgrading from 2.2.x to
+2.3.x.
 
 If you are currently using the Developer Portal in 1.5.x, it will no longer work without
 [manually migrating files](/enterprise/2.1.x/developer-portal/latest-migrations) to version 2.1.x.
 
 
-### Upgrade Considerations
+### Upgrade considerations
 
 Before upgrading, review this list for any configuration or breaking changes that
 affect your current installation.
 
-* [Hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/):
-  * **Important:** If you are currently running in hybrid mode, upgrade the Control Plane first, and
-    then the Data Planes.
-  * If you are currently running 2.2.x in classic (traditional)
-  mode and want to run in hybrid mode instead, follow the hybrid mode
-  [installation instructions](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)
-  after running the migration.
-  * Custom plugins (either your own plugins or third-party plugins that are not shipped with Kong)
-  need to be installed on both the Control Plane and the Data Planes in Hybrid mode. Install the
-  plugins on the Control Plane first, and then the Data Planes.
-  * The [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) plugin does not
-    support the `cluster` strategy in hybrid mode. The `redis` strategy must be used instead.
 * If you are adding a new plugin to your installation, you need to run
   `kong migrations up` with the plugin name specified. For example,
   `KONG_PLUGINS=oauth2`.
 
+### Hybrid mode considerations
 
-### Migrating Databases for a Major or Minor Version Release {#migrate-db}
+<div class="alert alert-ee blue">
+<strong>Important:</strong> If you are currently running in 
+[hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
+upgrade the Control Plane first, and then the Data Planes.
+</div>
+
+* If you are currently running 2.3.x in classic (traditional)
+  mode and want to run in hybrid mode instead, follow the hybrid mode
+  [installation instructions](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)
+  after running the migration.
+* Custom plugins (either your own plugins or third-party plugins that are not shipped with Kong)
+  need to be installed on both the Control Plane and the Data Planes in Hybrid mode. Install the
+  plugins on the Control Plane first, and then the Data Planes.
+* The [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) plugin does not
+    support the `cluster` strategy in hybrid mode. The `redis` strategy must be used instead.
+
+
+### Migrating databases for a major or minor version release {#migrate-db}
 
 {{site.ee_product_name}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two Kong clusters with different
@@ -92,44 +100,46 @@ decommission it. For this reason, the full migration is split into two commands:
 
 #### Postgres
 
-1. Download 2.2.x, and configure it to point to the same datastore as your old
-   2.1.x (or 2.2.x-beta) cluster.
+1. Download 2.3.x, and configure it to point to the same datastore as your old
+   2.2.x (or 2.3.x-beta) cluster.
 2. Run `kong migrations up`.
-3. After that finishes running, both the old (2.1.x) and new (2.2.x) clusters can
-   now run simultaneously on the same datastore. Start provisioning 2.2.x nodes,
+3. After that finishes running, both the old (2.2.x) and new (2.3.x) clusters can
+   now run simultaneously on the same datastore. Start provisioning 2.3.x nodes,
    but do _not_ use their Admin API yet.
 
-   **Important:** If you need to make Admin API requests,
+   <div class="alert alert-ee blue">
+   <strong>Important:</strong> If you need to make Admin API requests,
    these should be made to the old cluster's nodes. This prevents
    the new cluster from generating data that is not understood by the old
    cluster.
+   </div>
 
 4. Gradually divert traffic away from your old nodes, and redirect traffic to
-   your 2.2.x cluster. Monitor your traffic to make sure everything
+   your 2.3.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-5. When your traffic is fully migrated to the 2.2.x cluster, decommission your
-   old 2.1.x (or 2.2.x-beta) nodes.
-6. From your 2.2.x cluster, run `kong migrations finish`. From this point onward,
-   it is no longer possible to start nodes in the old 2.1.x (or 2.2.x-beta) cluster
+5. When your traffic is fully migrated to the 2.3.x cluster, decommission your
+   old 2.2.x (or 2.3.x-beta) nodes.
+6. From your 2.3.x cluster, run `kong migrations finish`. From this point onward,
+   it is no longer possible to start nodes in the old 2.2.x (or 2.3.x-beta) cluster
    that still points to the same datastore. Run this command _only_ when you are
    confident that your migration was successful. From now on, you can safely make
-   Admin API requests to your 2.2.x nodes.
+   Admin API requests to your 2.3.x nodes.
 
 #### Cassandra
 
-Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.1.x on Cassandra
-are incompatible with those used by {{site.ee_product_name}} 2.2.x. Migrating using the usual commands
+Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.2.x on Cassandra
+are incompatible with those used by {{site.ee_product_name}} 2.3.x. Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
 database at the same time. Alternatively, to keep your previous version fully
 operational while the new one initializes, you will need to transfer the
 data to a new keyspace using a database dump, as described below:
 
-1. Download 2.2.x, and configure it to point to a new keyspace.
+1. Download 2.3.x, and configure it to point to a new keyspace.
 
 2. Run `kong migrations bootstrap`.
 
-   Once that finishes running, both the old (2.1.x) and new (2.2.x)
+   Once that finishes running, both the old (2.2.x) and new (2.3.x)
    clusters can now run simultaneously, but the new cluster does not
    have any data yet.
 3. On the old cluster, run `kong config db_export`. This will create
@@ -137,16 +147,16 @@ data to a new keyspace using a database dump, as described below:
 4. Transfer the file to the new cluster and run
    `kong config db_import kong.yml`. This will load the data into the new cluster.
 5. Gradually divert traffic away from your old nodes, and into
-   your 2.2.x cluster. Monitor your traffic to make sure everything
+   your 2.3.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-6. When your traffic is fully migrated to the 2.2.x cluster,
+6. When your traffic is fully migrated to the 2.3.x cluster,
    decommission your old nodes.
 
-### Installing 2.2.x on a fresh datastore
+### Installing 2.3.x on a fresh datastore
 
-For installing on a fresh datastore, {{site.ee_product_name}} 2.2.x has the
+For installing on a fresh datastore, {{site.ee_product_name}} 2.3.x has the
 `kong migrations bootstrap` command. Run the following commands to
-prepare a new 2.2.x cluster from a fresh datastore. By default, the `kong` CLI tool
+prepare a new 2.3.x cluster from a fresh datastore. By default, the `kong` CLI tool
 loads the configuration from `/etc/kong/kong.conf`, but you can optionally use
 the `-c` flag to indicate the path to your configuration file:
 
@@ -155,7 +165,7 @@ $ kong migrations bootstrap [-c /path/to/kong.conf]
 $ kong start [-c /path/to/kong.conf]
 ```
 
-## Patch Releases {#patch}
+## Patch releases {#patch}
 
 There are no migrations in upgrades between current or
 future patch releases of the same minor release of {{site.ee_product_name}}
@@ -185,8 +195,9 @@ process is typically simpler for both minor and patch releases.
    ```shell
    $ kong reload [-c configuration_file]
    ```
-
-**Reminder:** The `kong reload` command leverages the Nginx `reload` signal that
+<div class="alert alert-ee blue">
+<strong>Reminder:</strong> The `kong reload` command leverages the Nginx `reload` signal that
 seamlessly starts new workers, which then take over from old workers before they
 are terminated. Kong serves new requests using the new
 configuration without dropping existing in-flight connections.
+</div>

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -94,7 +94,7 @@ In the event of any issues, this will help clarify whether the issue stems from 
 Kubernetes resources or changes in Kong.
 
 
-For specific Kong for kubernetes version upgrade considerations, see 
+For specific Kong for Kubernetes version upgrade considerations, see 
 [Upgrade considerations](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
 
 #### Kong deployment split across multiple releases

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -93,10 +93,6 @@ Although not required, users should upgrade their chart version and Kong version
 In the event of any issues, this will help clarify whether the issue stems from changes in 
 Kubernetes resources or changes in Kong.
 
-Users may encounter an error when upgrading which displays a large block of text ending with 
-`field is immutable`. This is typically due to a bug with the `init-migrations` job, which was 
-not removed automatically prior to 1.5.0. If you encounter this error, deleting any existing 
-`init-migrations` jobs will clear it.
 
 For specific Kong for kubernetes version upgrade considerations, see 
 [Upgrade considerations](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -77,7 +77,7 @@ upgrade the Control Plane first, and then the Data Planes.
 * The [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) plugin does not
     support the `cluster` strategy in hybrid mode. The `redis` strategy must be used instead.
 
-### Kong for kubernetes considerations
+### Kong for Kubernetes considerations
 
 The Helm chart automates the upgrade migration process. When running `helm upgrade`, 
 the chart spawns an initial job to run `kong migrations up` and then spawns new 

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -35,8 +35,6 @@ upgrade to 2.2.x before upgrading to 2.3.x. Zero downtime is possible but _not_
 guaranteed if you are upgrading incrementally between versions, from 0.36.x to 1.3.x to
 1.5.x to 2.1.x to 2.2.x to 2.3.x. Plan accordingly.
 
-* If running a version of {{site.ee_product_name}} earlier than 1.3,
-  [migrate to 1.3](/enterprise/1.3-x/deployment/migrations/) first.
 * If running a version of {{site.ee_product_name}} earlier than 1.5,
   [migrate to 1.5](/enterprise/1.5.x/deployment/migrations/) first.
 * If running a version of {{site.ee_product_name}} earlier than 2.1,
@@ -51,7 +49,6 @@ There are no migrations necessary for the Dev Portal when upgrading from 2.2.x t
 
 If you are currently using the Developer Portal in 1.5.x, it will no longer work without
 [manually migrating files](/enterprise/2.1.x/developer-portal/latest-migrations) to version 2.1.x.
-
 
 ### Upgrade considerations
 
@@ -127,8 +124,8 @@ decommission it. For this reason, the full migration is split into two commands:
 
 #### Cassandra
 
-Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.2.x on Cassandra
-are incompatible with those used by {{site.ee_product_name}} 2.3.x. Migrating using the usual commands
+Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.3.x on Cassandra
+are incompatible with those used by {{site.ee_product_name}} 2.0.x. Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
 database at the same time. Alternatively, to keep your previous version fully

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -63,7 +63,7 @@ affect your current installation.
 
 <div class="alert alert-ee blue">
 <strong>Important:</strong> If you are currently running in 
-[hybrid mode](/enterprise/{{page.kong_version}}/deployment/hybrid-mode/), 
+<a href="/enterprise/{{page.kong_version}}/deployment/hybrid-mode/">hybrid mode</a>, 
 upgrade the Control Plane first, and then the Data Planes.
 </div>
 
@@ -110,15 +110,25 @@ To handle clusters split across multiple releases, you should:
 
 1. Upgrade one of the releases with:
 
- `helm upgrade RELEASENAME -f values.yaml --set migrations.preUpgrade=true --set migrations.postUpgrade=false`
-
+   ```shell
+   helm upgrade RELEASENAME -f values.yaml \
+   --set migrations.preUpgrade=true \
+   --set migrations.postUpgrade=false
+   ```
 2. Upgrade all but one of the remaining releases with:
 
- `helm upgrade RELEASENAME -f values.yaml --set migrations.preUpgrade=false --set migrations.postUpgrade=false`
-
+   ```shell
+   helm upgrade RELEASENAME -f values.yaml \
+   --set migrations.preUpgrade=false \
+   --set migrations.postUpgrade=false
+   ```
 3. Upgrade the final release with: 
 
- `helm upgrade RELEASENAME -f values.yaml --set migrations.preUpgrade=false --set migrations.postUpgrade=true`
+   ```shell
+   helm upgrade RELEASENAME -f values.yaml \
+   --set migrations.preUpgrade=false \
+   --set migrations.postUpgrade=true
+   ```
 
 This ensures that all instances are using the new Kong package before running kong migrations finish.
 


### PR DESCRIPTION
### Review
@reviewer - TBD
@rainest @kallecaco3 suggested the Kong for kubernetes content be added to this doc for users upgrading to the next version of Kong. I selected some of the text from the [README.md](https://github.com/Kong/charts/blob/main/charts/kong/README.md#separate-admin-and-proxy-nodes) and [Upgrade.md](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md) docs that I think is relevant. Can you take a look and tell me if what I selected is appropriate or if more/less needs to be in this guide to help users upgrading on kubernetes? Thanks!

### Summary
The upgrade guides for upgrading from 2.2.x to 2.3.x and 2.3.x OSS to 2.3.x Enterprise need updating after the 2.3.x release.

### Reason
[DOCS-1582](https://konghq.atlassian.net/browse/DOCS-1582?focusedCommentId=38123&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-38123)

### Testing
[Link to KE upgrade guide updates](https://deploy-preview-2652--kongdocs.netlify.app/enterprise/2.3.x/deployment/upgrades/migrations/)