### PR TITLE
[DOCS-1601] Go plugin doc corrections per customer issues

### DIFF
--- a/app/enterprise/2.3.x/external-plugins.md
+++ b/app/enterprise/2.3.x/external-plugins.md
@@ -45,7 +45,7 @@ pluginserver_go_socket = /usr/local/kong/go_pluginserver.sock
 pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-plugins
 pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-directory /usr/local/kong/go-plugins
 
-pluginserver_python_socket = /usr/local/kong/pyton_pluginserver.socket
+pluginserver_python_socket = /usr/local/kong/python_pluginserver.sock
 pluginserver_python_start_cmd = pypluginserver.py
 pluginserver_python_query_cmd = pypluginserver.py -dump
 ```

--- a/app/enterprise/2.3.x/external-plugins.md
+++ b/app/enterprise/2.3.x/external-plugins.md
@@ -41,7 +41,7 @@ an hypothetical Python plugin server called `pypluginserver.py`):
 ```
 pluginserver_names = go,python
 
-pluginserver_go_socket = /usr/local/kong/go_pluginserver.socket
+pluginserver_go_socket = /usr/local/kong/go_pluginserver.sock
 pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-plugins
 pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-directory /usr/local/kong/go-plugins
 

--- a/app/enterprise/2.3.x/external-plugins.md
+++ b/app/enterprise/2.3.x/external-plugins.md
@@ -42,7 +42,7 @@ an hypothetical Python plugin server called `pypluginserver.py`):
 pluginserver_names = go,python
 
 pluginserver_go_socket = /usr/local/kong/go_pluginserver.socket
-pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-dir /usr/local/kong/go-plugins
+pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-plugins
 pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-dir /usr/local/kong/go-plugins
 
 pluginserver_python_socket = /usr/local/kong/pyton_pluginserver.socket

--- a/app/enterprise/2.3.x/external-plugins.md
+++ b/app/enterprise/2.3.x/external-plugins.md
@@ -43,7 +43,7 @@ pluginserver_names = go,python
 
 pluginserver_go_socket = /usr/local/kong/go_pluginserver.socket
 pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-plugins
-pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-dir /usr/local/kong/go-plugins
+pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-directory /usr/local/kong/go-plugins
 
 pluginserver_python_socket = /usr/local/kong/pyton_pluginserver.socket
 pluginserver_python_start_cmd = pypluginserver.py

--- a/app/gateway-oss/2.3.x/external-plugins.md
+++ b/app/gateway-oss/2.3.x/external-plugins.md
@@ -45,7 +45,7 @@ pluginserver_go_socket = /usr/local/kong/go_pluginserver.sock
 pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-plugins
 pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-directory /usr/local/kong/go-plugins
 
-pluginserver_python_socket = /usr/local/kong/pyton_pluginserver.socket
+pluginserver_python_socket = /usr/local/kong/python_pluginserver.sock
 pluginserver_python_start_cmd = pypluginserver.py
 pluginserver_python_query_cmd = pypluginserver.py -dump
 ```

--- a/app/gateway-oss/2.3.x/external-plugins.md
+++ b/app/gateway-oss/2.3.x/external-plugins.md
@@ -41,9 +41,9 @@ an hypothetical Python plugin server called `pypluginserver.py`):
 ```
 pluginserver_names = go,python
 
-pluginserver_go_socket = /usr/local/kong/go_pluginserver.socket
-pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-dir /usr/local/kong/go-plugins
-pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-dir /usr/local/kong/go-plugins
+pluginserver_go_socket = /usr/local/kong/go_pluginserver.sock
+pluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-plugins
+pluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-directory /usr/local/kong/go-plugins
 
 pluginserver_python_socket = /usr/local/kong/pyton_pluginserver.socket
 pluginserver_python_start_cmd = pypluginserver.py


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1601 Customer corrections to syntax as reported to @lchari77.  Ticket details:

> Simon Markets submitted this request via email:
> 
> Recently I've been working on configuring local environment for developing plugins for Kong. While doing this, I found a couple errors in documentation that I would like share.
> 
> https://docs.konghq.com/enterprise/2.3.x/external-plugins/#kong-gateway-plugin-server-configuration
> 
> Documentation provides this example of config for Go serverpluginserver_go_socket = /usr/local/kong/go_pluginserver.socketpluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-dir /usr/local/kong/go-pluginspluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-dir /usr/local/kong/go-plugins1) There is no `-plugins-dir`​ flag. It should be called `-plugins-directory`. (https://github.com/Kong/go-pluginserver/blob/master/main.go#L28)
> 
> 2) Go plugin server creates a socket named `go_pluginserver.sock` instead of `go_pluginserver.socket`. (https://github.com/Kong/go-pluginserver/blob/master/main.go#L36). This error was painful to find because standalone Go plugins indeed use `<name>.socket`​ path (https://github.com/Kong/go-pdk/blob/master/server/server.go#L57)
> 
> These settings worked fine for mepluginserver_go_socket = /usr/local/kong/go_pluginserver.sockpluginserver_go_start_cmd = go-pluginserver -kong-prefix /usr/local/kong/ -plugins-directory /usr/local/kong/go-pluginspluginserver_go_query_cmd = go-pluginserver -dump-all-plugins -plugins-directory /usr/local/kong/go-plugins
> 
> Customer's comments: Those two errors might look minor, but they cost me several hours. Initially I thought I was doing something wrong.


### Direct review links

Community:

https://deploy-preview-2654--kongdocs.netlify.app/gateway-oss/2.3.x/external-plugins/#kong-gateway-plugin-server-configuration

Enterprise:

https://deploy-preview-2654--kongdocs.netlify.app/enterprise/2.3.x/external-plugins/#kong-gateway-plugin-server-configuration