### PR TITLE
[DOCS-1627] Update untrusted_lua config properties

### DIFF
--- a/app/enterprise/2.2.x/property-reference.md
+++ b/app/enterprise/2.2.x/property-reference.md
@@ -3180,35 +3180,46 @@ Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
 
 #### untrusted_lua
 
-Accepted values are:
+Controls loading of Lua functions from admin-supplied sources such as the Admin
+API. LuaJIT bytecode loading is always disabled.
 
-- `off`: disallow any loading of Lua functions from admin supplied sources
-  (such as via the Admin API).
-
-Note using the `off` option will render plugins such as Serverless Functions
-unusable.
-
-- `sandbox`: allow loading of Lua functions from admin supplied sources, but
-  use a sandbox when executing them. The sandboxed function will have restricted
-  access to the global environment and only have access to standard Lua
-  functions that will generally not cause harm to the Kong node.
-
-In this mode, the `require` function inside the sandbox only allows loading
-external Lua modules that are explicitly listed in
-`untrusted_lua_sandbox_requires` below.
-
-LuaJIT bytecode loading is disabled.
-
-Warning: LuaJIT is not designed as a secure runtime for running malicious code,
-therefore, you should properly protect your Admin API endpoint even with
+**Warning:** LuaJIT is not designed as a secure runtime for running malicious
+code, therefore you should properly protect your Admin API endpoint even with
 sandboxing enabled. The sandbox only provides protection against trivial
 attackers or unintentional modification of the Kong global environment.
 
-- `on`: allow loading of Lua functions from admin supplied sources and do not
-  use a sandbox when executing them. Functions will have unrestricted access to
-  global environment and able to load any Lua modules.
+Accepted values are: `off`, `sandbox`, or `on`:
 
-LuaJIT bytecode loading is disabled.
+* `off`: Disallow loading of any arbitrary Lua functions. The `off` option
+disables any functionality that runs arbitrary Lua code, including the
+Serverless Functions plugins and any transformation plugin that allows custom
+Lua functions.
+
+* `sandbox`: Allow loading of Lua functions, but use a sandbox when executing
+them. The sandboxed function has restricted access to the global environment and
+only has access to standard Lua functions that will generally not cause harm to
+the Kong Gateway node.
+
+* `on`: Functions have unrestricted access to the global environment and can
+load any Lua modules. This is similar to the behavior in Kong Gateway prior to
+2.3.0.
+
+The default `sandbox` environment does not allow importing other modules or
+libraries, or executing anything at the OS level (for example, file read/write).
+The global environment is also not accessible.
+
+Examples of `untrusted_lua = sandbox` behavior:
+
+* You can't access or change global values such as
+`kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 +
+1`. However, OS level functions are not allowed, like: `os.execute('rm -rf
+/*')`.
+
+For a full allowed/disallowed list, see:
+https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua
+
+To customize the sandbox environment, use the `untrusted_lua_sandbox_requires`
+and `untrusted_lua_sandbox_environment` parameters below.
 
 **Default:** `sandbox`
 
@@ -3219,7 +3230,22 @@ LuaJIT bytecode loading is disabled.
 Comma-separated list of modules allowed to be loaded with `require` inside the
 sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
-Note: certain modules, when allowed, may cause sandbox escaping trivial.
+For example, say you have configured the Serverless pre-function plugin and it
+contains the following `requires`:
+
+```
+local template = require "resty.template"
+local split = require "kong.tools.utils".split
+```
+
+To run the plugin, add the modules to the allowed list:
+
+```
+untrusted_lua_sandbox_requires = resty.template, kong.tools.utils
+```
+
+**Warning:** Allowing certain modules may create opportunities to escape the
+sandbox. For example, allowing `os` or `luaposix` may be unsafe.
 
 **Default:** none
 
@@ -3230,8 +3256,8 @@ Note: certain modules, when allowed, may cause sandbox escaping trivial.
 Comma-separated list of global Lua variables that should be made available
 inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
-Note: certain variables, when made available, may cause sandbox escaping
-trivial.
+**Warning**: Certain variables, when made available, may create opportunities
+to escape the sandbox.
 
 **Default:** none
 

--- a/app/enterprise/2.3.x/property-reference.md
+++ b/app/enterprise/2.3.x/property-reference.md
@@ -3244,35 +3244,46 @@ Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
 
 #### untrusted_lua
 
-Accepted values are:
+Controls loading of Lua functions from admin-supplied sources such as the Admin
+API. LuaJIT bytecode loading is always disabled.
 
-- `off`: disallow any loading of Lua functions from admin supplied sources
-  (such as via the Admin API).
-
-Note using the `off` option will render plugins such as Serverless Functions
-unusable.
-
-- `sandbox`: allow loading of Lua functions from admin supplied sources, but
-  use a sandbox when executing them. The sandboxed function will have restricted
-  access to the global environment and only have access to standard Lua
-  functions that will generally not cause harm to the Kong node.
-
-In this mode, the `require` function inside the sandbox only allows loading
-external Lua modules that are explicitly listed in
-`untrusted_lua_sandbox_requires` below.
-
-LuaJIT bytecode loading is disabled.
-
-Warning: LuaJIT is not designed as a secure runtime for running malicious code,
-therefore, you should properly protect your Admin API endpoint even with
+**Warning:** LuaJIT is not designed as a secure runtime for running malicious
+code, therefore you should properly protect your Admin API endpoint even with
 sandboxing enabled. The sandbox only provides protection against trivial
 attackers or unintentional modification of the Kong global environment.
 
-- `on`: allow loading of Lua functions from admin supplied sources and do not
-  use a sandbox when executing them. Functions will have unrestricted access to
-  global environment and able to load any Lua modules.
+Accepted values are: `off`, `sandbox`, or `on`:
 
-LuaJIT bytecode loading is disabled.
+* `off`: Disallow loading of any arbitrary Lua functions. The `off` option
+disables any functionality that runs arbitrary Lua code, including the
+Serverless Functions plugins and any transformation plugin that allows custom
+Lua functions.
+
+* `sandbox`: Allow loading of Lua functions, but use a sandbox when executing
+them. The sandboxed function has restricted access to the global environment and
+only has access to standard Lua functions that will generally not cause harm to
+the Kong Gateway node.
+
+* `on`: Functions have unrestricted access to the global environment and can
+load any Lua modules. This is similar to the behavior in Kong Gateway prior to
+2.3.0.
+
+The default `sandbox` environment does not allow importing other modules or
+libraries, or executing anything at the OS level (for example, file read/write).
+The global environment is also not accessible.
+
+Examples of `untrusted_lua = sandbox` behavior:
+
+* You can't access or change global values such as
+`kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 +
+1`. However, OS level functions are not allowed, like: `os.execute('rm -rf
+/*')`.
+
+For a full allowed/disallowed list, see:
+https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua
+
+To customize the sandbox environment, use the `untrusted_lua_sandbox_requires`
+and `untrusted_lua_sandbox_environment` parameters below.
 
 **Default:** `sandbox`
 
@@ -3283,7 +3294,22 @@ LuaJIT bytecode loading is disabled.
 Comma-separated list of modules allowed to be loaded with `require` inside the
 sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
-Note: certain modules, when allowed, may cause sandbox escaping trivial.
+For example, say you have configured the Serverless pre-function plugin and it
+contains the following `requires`:
+
+```
+local template = require "resty.template"
+local split = require "kong.tools.utils".split
+```
+
+To run the plugin, add the modules to the allowed list:
+
+```
+untrusted_lua_sandbox_requires = resty.template, kong.tools.utils
+```
+
+**Warning:** Allowing certain modules may create opportunities to escape the
+sandbox. For example, allowing `os` or `luaposix` may be unsafe.
 
 **Default:** none
 
@@ -3294,8 +3320,8 @@ Note: certain modules, when allowed, may cause sandbox escaping trivial.
 Comma-separated list of global Lua variables that should be made available
 inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
 
-Note: certain variables, when made available, may cause sandbox escaping
-trivial.
+**Warning**: Certain variables, when made available, may create opportunities
+to escape the sandbox.
 
 **Default:** none
 

--- a/app/gateway-oss/2.3.x/configuration.md
+++ b/app/gateway-oss/2.3.x/configuration.md
@@ -1850,54 +1850,88 @@ Default: `30`
 
 #### untrusted_lua
 
-Accepted values are:
+Controls loading of Lua functions from admin-supplied sources such as the Admin
+API. LuaJIT bytecode loading is always disabled.
 
-- `off`: disallow any loading of Lua functions from admin supplied sources
-  (such as via the Admin API).
-
-Note using the `off` option will render plugins such as Serverless Functions
-unusable.
-
-- `sandbox`: allow loading of Lua functions from admin supplied sources, but
-  use a sandbox when executing them. The sandboxed function will have restricted
-  access to the global environment and only have access to standard Lua
-  functions that will generally not cause harm to the Kong node.
-
-In this mode, the `require` function inside the sandbox only allows loading
-external Lua modules that are explicitly listed in
-`untrusted_lua_sandbox_requires` below.
-
-LuaJIT bytecode loading is disabled.
-
-Warning: LuaJIT is not designed as a secure runtime for running malicious code,
-therefore, you should properly protect your Admin API endpoint even with
+**Warning:** LuaJIT is not designed as a secure runtime for running malicious
+code, therefore you should properly protect your Admin API endpoint even with
 sandboxing enabled. The sandbox only provides protection against trivial
 attackers or unintentional modification of the Kong global environment.
 
-- `on`: allow loading of Lua functions from admin supplied sources and do not
-  use a sandbox when executing them. Functions will have unrestricted access to
-  global environment and able to load any Lua modules. This is similar to the
-  behavior in Kong prior to 2.3.0.
+Accepted values are: `off`, `sandbox`, or `on`:
 
-LuaJIT bytecode loading is disabled.
+* `off`: Disallow loading of any arbitrary Lua functions. The `off` option
+disables any functionality that runs arbitrary Lua code, including the
+Serverless Functions plugins and any transformation plugin that allows custom
+Lua functions.
 
-untrusted_lua_sandbox_requires = Comma-separated list of modules allowed to be
-loaded with `require` inside the sandboxed environment. Ignored if
-`untrusted_lua` is not `sandbox`.
+* `sandbox`: Allow loading of Lua functions, but use a sandbox when executing
+them. The sandboxed function has restricted access to the global environment and
+only has access to standard Lua functions that will generally not cause harm to
+the Kong Gateway node.
 
-Note: certain modules, when allowed, may cause sandbox escaping trivial.
+* `on`: Functions have unrestricted access to the global environment and can
+load any Lua modules. This is similar to the behavior in Kong Gateway prior to
+2.3.0.
 
-untrusted_lua_sandbox_environment = Comma-separated list of global Lua
-variables that should be made available inside the sandboxed environment.
-Ignored if `untrusted_lua` is not `sandbox`.
+The default `sandbox` environment does not allow importing other modules or
+libraries, or executing anything at the OS level (for example, file read/write).
+The global environment is also not accessible.
 
-Note: certain variables, when made available, may cause sandbox escaping
-trivial.
+Examples of `untrusted_lua = sandbox` behavior:
 
-Default: `sandbox`
+* You can't access or change global values such as
+`kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 +
+1`. However, OS level functions are not allowed, like: `os.execute('rm -rf
+/*')`.
+
+For a full allowed/disallowed list, see:
+https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua
+
+To customize the sandbox environment, use the `untrusted_lua_sandbox_requires`
+and `untrusted_lua_sandbox_environment` parameters below.
+
+**Default:** `sandbox`
 
 ---
 
+#### untrusted_lua_sandbox_requires
+
+Comma-separated list of modules allowed to be loaded with `require` inside the
+sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
+
+For example, say you have configured the Serverless pre-function plugin and it
+contains the following `requires`:
+
+```
+local template = require "resty.template"
+local split = require "kong.tools.utils".split
+```
+
+To run the plugin, add the modules to the allowed list:
+
+```
+untrusted_lua_sandbox_requires = resty.template, kong.tools.utils
+```
+
+**Warning:** Allowing certain modules may create opportunities to escape the
+sandbox. For example, allowing `os` or `luaposix` may be unsafe.
+
+**Default:** none
+
+---
+
+#### untrusted_lua_sandbox_environment
+
+Comma-separated list of global Lua variables that should be made available
+inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
+
+**Warning**: Certain variables, when made available, may create opportunities
+to escape the sandbox.
+
+**Default:** none
+
+---
 
 
 [Penlight]: http://stevedonovan.github.io/Penlight/api/index.html


### PR DESCRIPTION
### Summary
Updating `unstrusted_lua` properties with doc recently updated in the kong/kong repo: https://github.com/Kong/kong/pull/6881

**Note to reviewers:** The content in this doc is autogenerated and was already reviewed in the original PR. This is simply generating the markdown version of said doc.

### Reason
Properties were lacking information and examples, plus the formatting was broken.
Changes have also been backported into 2.2, where they got missed originally. 

### Testing
https://deploy-preview-2661--kongdocs.netlify.app/enterprise/2.3.x/property-reference/#untrusted_lua
https://deploy-preview-2661--kongdocs.netlify.app/enterprise/2.2.x/property-reference/#untrusted_lua
https://deploy-preview-2661--kongdocs.netlify.app/gateway-oss/2.3.x/configuration/#untrusted_lua
https://deploy-preview-2661--kongdocs.netlify.app/gateway-oss/2.3.x/configuration/#untrusted_lua
