### PR TITLE
fix(analytics) Remove duplicate event tracker

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -391,10 +391,6 @@ $(function () {
     });
   });
 
-  analytics.track(
-    "Viewed " + $.trim(document.title.split("|").shift()) + " page"
-  );
-
   $(".plugin-plate-link").each(function () {
     analytics.trackLink(this, "Click on plugin", {
       plugin_type: $(this).closest(".plugin-plate").find("h3").text(),


### PR DESCRIPTION
### Summary
Removing an event that triggers on every single page view in docs, giving us a really weird bounce rate.

### Reason
To remove a duplicate google analytics event:
![Screen Shot 2021-03-05 at 1 14 19 PM](https://user-images.githubusercontent.com/54370747/110174335-da00c180-7db4-11eb-98ac-4398d4c3b221.png)

### Testing
TBA
