### PR TITLE
Minor edit to setup Kong in hybrid mode docs

### DIFF
--- a/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
@@ -503,12 +503,12 @@ following on a Control Plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-$ curl -i -X GET http://<admin-hostname>:8001/clustering/data_planes
+$ curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}
 ```bash
-$ http :8001/clustering/data_planes
+$ http :8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Review
@srAtKong 
@lena-larionova 

### Summary
According to a Slack message -  @srAtKong - was attempting to setup Kong in hybrid mode with one cp and one dp, using the docs and in step 4, the DP could not see the CP. He was getting a 404 not found when he did an http on `<control-plane>:8001/clustering/data_planes` . He says it was fixed by updating `<control-plane>:8001/clustering/data_planes` to `<control-plane>:8001/clustering/data-planes` - so the docs should be updated.

### Reason
[Slack message](https://kongstrong.slack.com/archives/C0DSXDXV1/p1615266321220000?thread_ts=1615264229.219500&cid=C0DSXDXV1)

### Testing
[Link to corrected step](https://deploy-preview-2673--kongdocs.netlify.app/enterprise/2.3.x/deployment/hybrid-mode-setup/#step-4-verify-that-nodes-are-connected)
