### PR TITLE
[DOCS-1625] Konnect: Add step for HTTP method when adding a route

### DIFF
--- a/app/konnect/getting-started/implement-service.md
+++ b/app/konnect/getting-started/implement-service.md
@@ -36,13 +36,15 @@ implementation to associate with your Service version.
 
     For this example, enter the following:
 
-    1. For Name, enter `mockbin`.
+    1. For **Name**, enter `mockbin`.
 
-    2. For Path(s), click **Add Path** and enter `/mock`.
+    2. For **Method**, enter `GET`.
 
-    3. For the remaining fields, use the default values listed.
+    3. For **Path(s)**, click **Add Path** and enter `/mock`.
 
-    4. Click **Create**.
+    4. For the remaining fields, use the default values listed.
+
+    5. Click **Create**.
 
     The **v.1** Service Version overview displays.
 
@@ -55,7 +57,7 @@ If you used the Docker script to create a container
 earlier in [Configure a Runtime](/konnect/getting-started/configure-runtime),
 your runtime's default proxy URL is `localhost:8000`.
 
-Enter the proxy URL into your browser’s address bar and append the route path 
+Enter the proxy URL into your browser’s address bar and append the route path
 you just set. The final URL should look something like this:
 
 ```

--- a/app/konnect/servicehub/manage-services.md
+++ b/app/konnect/servicehub/manage-services.md
@@ -94,16 +94,21 @@ details for the upstream service.
         This Route name must be unique in the account. Variations on
         capitalization are considered unique, for example, `foo` and `Foo`.
 
-    2. For **Path(s)**, click **Add Path** and enter a path in the format
+    2. For **Method**, enter an HTTP method or a comma-separated list of methods
+    that match this Route.
+
+        For example, `GET` or `GET, POST`.
+
+    3. For **Path(s)**, click **Add Path** and enter a path in the format
     `/<path>`.
 
-    3. (Optional) Click **View 4 Advanced Fields** to see all options.
+    4. (Optional) Click **View 4 Advanced Fields** to see all options.
     You can accept the defaults, or further customize your Route.
 
         See the [Route Object](/enterprise/latest/admin-api/#route-object)
         documentation for parameter descriptions.
 
-    4. Click **Create**.
+    5. Click **Create**.
 
     The Service version overview displays.
 
@@ -130,7 +135,7 @@ For any runtime instance created with the provided Docker script (see
 [Setting up a Kong Gateway Runtime](/konnect/runtime-manager/)),
 the default proxy URL is `localhost:8000`.
 
-Enter the proxy URL into your browser’s address bar and append any route path. 
+Enter the proxy URL into your browser’s address bar and append any route path.
 The final URL should look something like this:
 
 ```


### PR DESCRIPTION
### Summary
Adding a step to configure the HTTP method for a Route during implementation, or when adding a Route separately in the ServiceHub.

### Reason
User pointed out that not setting a method during Route configuration could cause jumbled output.

### Testing
https://deploy-preview-2677--kongdocs.netlify.app/konnect/getting-started/implement-service/
https://deploy-preview-2677--kongdocs.netlify.app/konnect/servicehub/manage-services/#implement-service-version
