### PR TITLE
Correct invalid Deployment apiVersion

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/configuring-fallback-service.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/configuring-fallback-service.md
@@ -39,8 +39,8 @@ This is expected as Kong does not yet know how to proxy the request.
 
 ## Setup a Sample Service
 
-For the purpose of this guide, we will setup an [httpbin](https://httpbin.org)
-service in the cluster and proxy it.
+For the purpose of this guide, we will setup a simple HTTP service in the
+cluster and proxy it.
 
 ```bash
 $ echo '

--- a/app/kubernetes-ingress-controller/1.0.x/guides/configuring-fallback-service.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/configuring-fallback-service.md
@@ -43,9 +43,53 @@ For the purpose of this guide, we will setup an [httpbin](https://httpbin.org)
 service in the cluster and proxy it.
 
 ```bash
-$ kubectl apply -f https://bit.ly/k8s-httpbin
-service/httpbin created
-deployment.apps/httpbin created
+$ echo '
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fallback-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fallback-svc
+  template:
+    metadata:
+      labels:
+        app: fallback-svc
+    spec:
+      containers:
+      - name: fallback-svc
+        image: hashicorp/http-echo
+        args:
+        - "-text"
+        - "This is not the path you are looking for. - Fallback service"
+        ports:
+        - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fallback-svc
+  labels:
+    app: fallback-svc
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 5678
+    protocol: TCP
+    name: http
+  selector:
+    app: fallback-svc
+' | kubectl apply -f -
+```
+
+Result:
+
+```bash
+deployment.apps/fallback-svc created
+service/fallback-svc created
 ```
 
 Create an Ingress rule to proxy the httpbin service we just created:

--- a/app/kubernetes-ingress-controller/1.1.x/guides/configuring-fallback-service.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/configuring-fallback-service.md
@@ -39,8 +39,8 @@ This is expected as Kong does not yet know how to proxy the request.
 
 ## Setup a Sample Service
 
-For the purpose of this guide, we will setup an [httpbin](https://httpbin.org)
-service in the cluster and proxy it.
+For the purpose of this guide, we will setup a simple HTTP service in the
+cluster and proxy it.
 
 ```bash
 $ echo '

--- a/app/kubernetes-ingress-controller/1.1.x/guides/configuring-fallback-service.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/configuring-fallback-service.md
@@ -43,9 +43,53 @@ For the purpose of this guide, we will setup an [httpbin](https://httpbin.org)
 service in the cluster and proxy it.
 
 ```bash
-$ kubectl apply -f https://bit.ly/k8s-httpbin
-service/httpbin created
-deployment.apps/httpbin created
+$ echo '
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fallback-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fallback-svc
+  template:
+    metadata:
+      labels:
+        app: fallback-svc
+    spec:
+      containers:
+      - name: fallback-svc
+        image: hashicorp/http-echo
+        args:
+        - "-text"
+        - "This is not the path you are looking for. - Fallback service"
+        ports:
+        - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fallback-svc
+  labels:
+    app: fallback-svc
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 5678
+    protocol: TCP
+    name: http
+  selector:
+    app: fallback-svc
+' | kubectl apply -f -
+```
+
+Result:
+
+```bash
+deployment.apps/fallback-svc created
+service/fallback-svc created
 ```
 
 Create an Ingress rule to proxy the httpbin service we just created:


### PR DESCRIPTION
### Summary
Pull fallback-svc example out of bit.ly/fallback-svc and correct the apiVersion for its Deployment.

### Reason
The original link was a specific gist version with an error, and can't be modified without creating a new link. The example here is short enough that we can pull it out.

Originally reported by https://twitter.com/SixteenOne/status/1368510931211259921

