### PR TITLE
[DOCS-1665] Fix license command and clean up Dev Portal setup

### DIFF
--- a/app/enterprise/2.3.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.3.x/deployment/installation/amazon-linux-2.md
@@ -243,29 +243,38 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
-This feature is only available with a {{site.konnect_product_name}} Enterprise subscription.
+This feature is only available with a
+<a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+{{site.konnect_product_name}} Enterprise subscription</a>.
 </div>
 
-1. The Dev Portal can be enabled by setting the `portal` property to `on` and setting the `portal_gui_host` property to the DNS, or IP address, of the Amazon Linux system. For example:
+1. [Deploy a license](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+
+2. Enable the Dev Portal by setting the `portal` property to `on` and the
+`portal_gui_host` property to the DNS or IP address of the Amazon Linux system.
+For example:
 
     ```
     portal = on
     portal_gui_host = <DNSorIP>:8003
     ```
 
-2. Restart Kong for the setting to take effect:
+3. Restart {{site.base_gateway}} for the setting to take effect:
 
     ```bash
     $ sudo /usr/local/bin/kong restart
     ```
 
-3. The final step is to enable the Developer Portal. To do this, execute the following command, updating `DNSorIP` to reflect the IP or valid DNS for the Amazon Linux system.
+4. Enable the Dev Portal for a workspace. Execute the following command,
+updating `DNSorIP` to reflect the IP or valid DNS for the Amazon Linux system:
 
     ```bash
-    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default   --data "config.portal=true"
+    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
+      --data "config.portal=true"
     ```
 
-4. You can now access the Developer Portal on the default workspace with a URL like:
+5. Access the Dev Portal for the default workspace using the following URL,
+substituting your own DNS or IP:
 
     ```
     http://<DNSorIP>:8003/default

--- a/app/enterprise/2.3.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.3.x/deployment/installation/amazon-linux.md
@@ -244,29 +244,37 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
-This feature is only available with a {{site.konnect_product_name}} Enterprise subscription.
+This feature is only available with a
+<a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+{{site.konnect_product_name}} Enterprise subscription</a>.
 </div>
 
-1. The Dev Portal can be connected by setting the `portal` property to `on` and setting the `portal_gui_host` property to the EC2 instance's `IPv4` address
+1. [Deploy a license](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+
+2. Enable the Dev Portal by setting the `portal` property to `on` and
+the `portal_gui_host` property to the EC2 instance's `IPv4` address:
 
     ```
     portal = on
     portal_gui_host = <DNSorIP>:8003
     ```
 
-2. Restart Kong for the setting to take effect:
+3. Restart {{site.base_gateway}} for the setting to take effect:
 
     ```bash
     $ sudo /usr/local/bin/kong restart
     ```
 
-3. The final step is to enable the Developer Portal. To do this, execute the following command, updating `DNSorIP` to reflect the IP or valid DNS for the Amazon Linux system.
+4. Enable the Dev Portal for a workspace. Execute the following command,
+updating `DNSorIP` to reflect the IP or valid DNS for the Amazon Linux system:
 
     ```bash
-    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default   --data "config.portal=true"
+    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
+      --data "config.portal=true"
     ```
 
-4. You can now access the Developer Portal on the default workspace with a URL like:
+5. Access the Dev Portal for the default workspace using the following URL,
+substituting your own DNS or IP:
 
     ```
     http://<DNSorIP>:8003/default

--- a/app/enterprise/2.3.x/deployment/installation/centos.md
+++ b/app/enterprise/2.3.x/deployment/installation/centos.md
@@ -256,29 +256,38 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
-This feature is only available with a {{site.konnect_product_name}} Enterprise subscription.
+This feature is only available with a
+<a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+{{site.konnect_product_name}} Enterprise subscription</a>.
 </div>
 
-1. The Dev Portal can be enabled by setting the `portal` property to `on` and setting the `portal_gui_host` property to the DNS, or IP address, of the CentOS system. For example:
+1. [Deploy a license](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
+
+2. Enable the Dev Portal by setting the `portal` property to `on` and the
+`portal_gui_host` property to the DNS or IP address of the CentOS system. For
+example:
 
     ```
     portal = on
     portal_gui_host = <DNSorIP>:8003
     ```
 
-2. Restart Kong for the setting to take effect:
+3. Restart {{site.base_gateway}} for the setting to take effect:
 
     ```bash
     $ sudo /usr/local/bin/kong restart
     ```
 
-3. The final step is to enable the Developer Portal. To do this, execute the following command, updating `DNSorIP` to reflect the IP or valid DNS for the CentOS system.
+4. Enable the Dev Portal for a workspace. Execute the following command,
+updating `DNSorIP` to reflect the IP or valid DNS for the CentOS system:
 
     ```bash
-    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default --data "config.portal=true"
+    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
+      --data "config.portal=true"
     ```
 
-4. You can now access the Developer Portal on the default workspace with a URL like:
+5. Access the Dev Portal for the default workspace using the following URL,
+substituting your own DNS or IP:
 
     ```
     http://<DNSorIP>:8003/default

--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -84,7 +84,7 @@ $ docker run --rm --network=kong-ee-net \
 
 **Note**: For `KONG_PASSWORD`, replace `<SOMETHING-YOU-KNOW>` with a valid password that only you know.
 
-## Step 5. Start the gateway with Kong Manager
+## Step 5. Start the gateway with Kong Manager {#start-gateway}
 
 ```bash
 $ docker run -d --name kong-ee --network=kong-ee-net \
@@ -96,7 +96,6 @@ $ docker run -d --name kong-ee --network=kong-ee-net \
   -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
   -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
   -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
-  -e "KONG_PORTAL_GUI_HOST=<DNSorIP>:8003" \
   -e "KONG_ADMIN_GUI_URL=http://<DNSorIP>:8002" \
   -p 8000:8000 \
   -p 8443:8443 \
@@ -108,43 +107,68 @@ $ docker run -d --name kong-ee --network=kong-ee-net \
   -p 8004:8004 \
   kong-ee
 ```
-
-**Notes**
-- For `KONG_PORTAL_GUI_HOST` and `KONG_ADMIN_GUI_URL`, replace `<DNSorIP>` with with the DNS name or IP of the Docker host.
-  * The DNS or IP address for `KONG_PORTAL_GUI_HOST` should _not_ be preceded with a protocol, e.g. `http://`.
-  * `KONG_ADMIN_GUI_URL` _should_ have a protocol, e.g., `http://`.
+<div class="alert alert-ee">
+<b>Note:</b> For <code>KONG_ADMIN_GUI_URL</code>, replace <code>&lt;DNSorIP&gt;</code>
+with with the DNS name or IP of the Docker host. <code>KONG_ADMIN_GUI_URL</code>
+<i>should</i> have a protocol, for example, <code>http://</code>.
+</div>
 
 ## Step 6. Verify your installation
 
-```bash
-$ curl -i -X GET --url http://<DNSorIP>:8001/services
-```
+1. Access the `/services` endpoint using the Admin API:
 
-You should receive an `HTTP/1.1 200 OK` message.
+    ```bash
+    $ curl -i -X GET --url http://<DNSorIP>:8001/services
+    ```
 
-Verify that Kong Manager is running by accessing it using the URL specified in `KONG_ADMIN_GUI_URL` in [Step 6](#step-6-start-kong-enterprise-with-kong-manager-and-kong-developer-portal-enabled).
+    You should receive an `HTTP/1.1 200 OK` message.
+
+2. Verify that Kong Manager is running by accessing it using the URL specified
+in `KONG_ADMIN_GUI_URL` in [Step 5](#start-gateway):
+
+    ```
+    http://<DNSorIP>:8002
+    ```
 
 ## Step 7. (Optional) Enable the Dev Portal
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
-This feature is only available with a {{site.konnect_product_name}} Enterprise subscription.
+This feature is only available with a
+<a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+{{site.konnect_product_name}} Enterprise subscription</a>.
 </div>
 
-In your container, set `KONG_PORTAL` to `on`:
+1. [Deploy a license](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
 
-```sh
-$ echo "KONG_PORTAL=on \
-  kong reload exit" | docker exec -i <kong-container-id> /bin/sh
-```
+2. In your container, set the Portal URL and set `KONG_PORTAL` to `on`:
 
-Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of your Docker host:
+    ```sh
+    $ echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=off kong reload exit" \
+      | docker exec -i kong-ee /bin/sh
+    ```
 
-  ```bash
-  $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default --data "config.portal=true"
-  ```
+    <div class="alert alert-ee">
+    <b>Note:</b> For <code>KONG_PORTAL_GUI_HOST</code>, replace
+    <code>&lt;DNSorIP&gt;</code> with with the DNS name or IP of the Docker host.
+    The DNS or IP address for <code>KONG_PORTAL_GUI_HOST</code> should <i>not</i>
+    be preceded by a protocol, for example, <code>http://</code>.
+    </div>
 
-Verify the Developer Portal is running by accessing it at the URL specified in the `KONG_PORTAL_GUI_HOST` variable in [Step 6](#step-6-start-kong-enterprise-with-kong-manager-and-kong-developer-portal-enabled).
+3. Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of
+your Docker host:
+
+    ```bash
+    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
+      --data "config.portal=true"
+    ```
+
+4. Access the Dev Portal for the default workspace using the URL specified
+in the `KONG_PORTAL_GUI_HOST` variable:
+
+    ```
+    http://<DNSorIP>:8003/default
+    ```
 
 ## Troubleshooting
 

--- a/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
@@ -55,7 +55,7 @@ $ oc new-project kong
 {% endnavtabs %}
 <!--end codeblock navtabs-->
 
-## Step 2. Set up license secret
+## Step 2. Set up license secret {#license}
 
 {% navtabs %}
 {% navtab Free mode %}
@@ -152,7 +152,15 @@ In the following steps, replace `<your-password>` with a secure password.
     ```bash
     $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
     ```
-2. (Optional, only with a license) Create a sessions config file for Kong Dev Portal:
+2. (Optional, only with a [license](#license)) Create a sessions config file for Kong Dev Portal:
+
+    <div class="alert alert-ee">
+    <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
+    This feature is only available with a
+    <a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+    {{site.konnect_product_name}} Enterprise subscription</a>.
+    </div>
+
     ```bash
     $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
@@ -180,10 +188,19 @@ In the following steps, replace `<your-password>` with a secure password.
     ```bash
     $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
     ```
-2. (Optional, only with a license) Create a sessions config file for Kong Dev Portal:
+2. (Optional, only with a [license](#license)) Create a sessions config file for Kong Dev Portal:
+
+    <div class="alert alert-ee">
+    <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
+    This feature is only available with a
+    <a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+    {{site.konnect_product_name}} Enterprise subscription</a>.
+    </div>
+
     ```bash
     $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
+
 3. Create the secret.
 
     With Kong Manager only:

--- a/app/enterprise/2.3.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.3.x/deployment/installation/rhel.md
@@ -251,29 +251,38 @@ This setting needs to resolve to a network path that will reach the RHEL host.
 
 <div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
-This feature is only available with a {{site.konnect_product_name}} Enterprise subscription.
+This feature is only available with a
+<a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+{{site.konnect_product_name}} Enterprise subscription</a>.
 </div>
 
-The Dev Portal can be enabled by setting the `portal` property to `on` and setting the `portal_gui_host` property to the DNS, or IP address, of the RHEL system. For example:
+1. [Deploy a license](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
 
-```
-portal = on
-portal_gui_host = <DNSorIP>:8003
-```
+2. Enable the Dev Portal by setting the `portal` property to `on` and the
+`portal_gui_host` property to the DNS or IP address of the RHEL system. For
+example:
 
-1. Restart {{site.base_gateway}} for the setting to take effect:
+    ```
+    portal = on
+    portal_gui_host = <DNSorIP>:8003
+    ```
+
+3. Restart {{site.base_gateway}} for the setting to take effect:
 
     ```bash
     $ sudo /usr/local/bin/kong restart
     ```
 
-2. The final step is to enable the Developer Portal. To do this, execute the following command, updating `DNSorIP` to reflect the IP or valid DNS for the RHEL system.
+4. Enable the Dev Portal for a workspace. Execute the following command,
+ updating `DNSorIP` to reflect the IP or valid DNS for the RHEL system:
 
     ```bash
-    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default   --data "config.portal=true"
+    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
+      --data "config.portal=true"
     ```
 
-3. You can now access the Developer Portal on the default workspace with a URL like:
+5. Access the Dev Portal for the default workspace using the following URL,
+substituting your own DNS or IP:
 
     ```
     http://<DNSorIP>:8003/default

--- a/app/enterprise/2.3.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.3.x/deployment/installation/ubuntu.md
@@ -171,12 +171,16 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 ### (Optional) Enable the Dev Portal
 
-<div class="alert alert-ee blue">
+<div class="alert alert-ee">
 <img class="no-image-expand" src="/assets/images/icons/documentation/icn-enterprise-blue.svg" alt="Enterprise" />
-This feature is only available with a {{site.konnect_product_name}} Enterprise subscription.
+This feature is only available with a
+<a href="/enterprise/{{page.kong_version}}/deployment/licensing">
+{{site.konnect_product_name}} Enterprise subscription</a>.
 </div>
 
-1. Enable the Dev Portal by updating `/etc/kong/kong.conf` to set the `portal` property to `on` and the `portal_gui_host` property to the DNS or IP address of the system. For example:
+1. Enable the Dev Portal by updating `/etc/kong/kong.conf` to set the `portal`
+property to `on` and the `portal_gui_host` property to the DNS or IP address of
+the system. For example:
 
     ```
     portal = on
@@ -189,13 +193,16 @@ This feature is only available with a {{site.konnect_product_name}} Enterprise s
     $ sudo /usr/local/bin/kong restart
     ```
 
-3. The final step is to enable the Developer Portal. To do this, execute the following command, updating `DNSorIP` to reflect the IP or valid DNS for the system.
+4. Enable the Dev Portal for a workspace. Execute the following command,
+  updating `DNSorIP` to reflect the IP or valid DNS for the system:
 
     ```bash
-    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default --data "config.portal=true"
+    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
+      --data "config.portal=true"
     ```
 
-4. You can now access the Developer Portal on the default workspace with a URL like:
+5. Access the Dev Portal for the default workspace using the following URL,
+  substituting your own DNS or IP:
 
     ```
     http://<DNSorIP>:8003/default

--- a/app/enterprise/2.3.x/deployment/licenses/deploy-license.md
+++ b/app/enterprise/2.3.x/deployment/licenses/deploy-license.md
@@ -36,7 +36,7 @@ but provide your own content.
 {% navtab cURL %}
 ```bash
 $ curl -i -X POST http://<hostname>:8001/licenses \
-  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
+  -d payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@liyangau 

### Summary
* Fix curl command for adding a license
* Add step to Dev Portal instructions to set up a license before enabling the Portal
* Clean up Dev Portal sections
* For Docker install: move Dev Portal URL env variable into Dev Portal section and split note

### Reason
Doc ticket filed about incorrect curl command and confusing order of instructions causing errors.

### Testing
[Deploy license ](https://deploy-preview-2681--kongdocs.netlify.app/enterprise/2.3.x/deployment/licenses/deploy-license/ )- curl command here

Dev Portal sections:
[Docker](https://deploy-preview-2681--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/docker/#step-7-optional-enable-the-dev-portal) 
[K8s](https://deploy-preview-2681--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes/#step-5-prepare-the-sessions-plugin-for-kong-manager-and-dev-portal)
[Everything else (sample)](https://deploy-preview-2681--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/amazon-linux/#optional-enable-the-dev-portal
)
