### PR TITLE
[DOCS-1673] Konnect updates 2021-03-16

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -7,10 +7,15 @@
       url: /using-konnect-docs
     - text: Key Concepts and Terms
       url: /key-concepts-and-terms
-    - text: Konnect SaaS Updates
-      url: /updates
+
     - text: Access a Kong Konnect Account
       url: /access-account
+
+- title: Release Notes
+  icon: /assets/images/icons/documentation/icn-references-color.svg
+  items:
+    - text: Konnect SaaS Updates
+      url: /updates
 
 - title: Deployment
   icon: /assets/images/icons/documentation/icn-deployment-color.svg

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -7,7 +7,6 @@
       url: /using-konnect-docs
     - text: Key Concepts and Terms
       url: /key-concepts-and-terms
-
     - text: Access a Kong Konnect Account
       url: /access-account
 

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -13,7 +13,7 @@
 - title: Release Notes
   icon: /assets/images/icons/documentation/icn-references-color.svg
   items:
-    - text: Konnect SaaS Updates
+    - text: Updates
       url: /updates
 
 - title: Deployment

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -11,6 +11,12 @@ services.
 
 ## February 2021
 
+### 2021.03.16
+**Runtime setup improvement**
+: Quick setup just got a little bit faster. When configuring a new runtime 
+through the Runtime Manager, HTTPie is no longer required for the 
+quick setup script.
+
 ### 2021.02.23
 
 **{{site.base_gateway}} 2.3 support**

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -9,7 +9,9 @@ SaaS, an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
-### February 23, 2021
+## February 2021
+
+### 2021.02.23
 
 **{{site.base_gateway}} 2.3 support**
 : {{site.konnect_short_name}} SaaS now supports {{site.base_gateway}} 2.3
@@ -35,7 +37,7 @@ through {{site.konnect_short_name}} SaaS. This includes:
 * [TCP Log](/hub/kong-inc/tcp-log)
 * [UDP Log](/hub/kong-inc/udp-log)
 
-### February 10, 2021
+### 2021.02.10
 
 **Portal authentication**
 : You can now [disable authentication on a Dev Portal](/konnect/dev-portal/administrators/public-portal/),
@@ -43,7 +45,7 @@ which exposes the Dev Portal publicly to anyone with the link. No one needs to r
 for Dev Portal access.
 : New application registrations aren't available through a public-facing portal.
 
-### February 1, 2021
+### 2021.02.01
 
 {{site.konnect_product_name}} ({{site.konnect_short_name}}) is now generally available!
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -9,13 +9,15 @@ SaaS, an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
-## February 2021
+## March 2021
 
 ### 2021.03.16
 **Runtime setup improvement**
 : Quick setup just got a little bit faster. When configuring a new runtime 
 through the Runtime Manager, HTTPie is no longer required for the 
 quick setup script.
+
+## February 2021
 
 ### 2021.02.23
 


### PR DESCRIPTION
### Review
@GayleNeumann 

### Summary
* Moving Konnect SaaS Updates to a new Release Notes section; went with "Release Notes" instead of Updates for consistency with the rest of the docs - @GayleNeumann what do you think?
* Add a heading for the month and change subheading to international standard date format 
  * Went back and forth between the ISO format (YYYY-MM-DD) or an abbreviated Month Day (Feb 28). Went with the ISO format, but could be convinced otherwise. 
* Entry for March 16th deploy

### Reason
* New deploy of Konnect
* Getting feedback that updates are currently hard to find.

### Testing
https://deploy-preview-2682--kongdocs.netlify.app/konnect/updates/