### PR TITLE
Correct K8S HTTPS redirect annotation name

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/configuring-https-redirect.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/configuring-https-redirect.md
@@ -93,7 +93,7 @@ HTTPS, update its annotations to limit its protocols to HTTPS only and
 issue a 301 redirect:
 
 ```bash
-$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"https","konghq.com/https_redirect_status_code":"301"}}}'
+$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"https","konghq.com/https-redirect-status-code":"301"}}}'
 ingress.extensions/demo patched
 ```
 

--- a/app/kubernetes-ingress-controller/1.1.x/guides/configuring-https-redirect.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/configuring-https-redirect.md
@@ -93,7 +93,7 @@ HTTPS, update its annotations to limit its protocols to HTTPS only and
 issue a 301 redirect:
 
 ```bash
-$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"https","konghq.com/https_redirect_status_code":"301"}}}'
+$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"https","konghq.com/https-redirect-status-code":"301"}}}'
 ingress.extensions/demo patched
 ```
 


### PR DESCRIPTION
### Summary
Like all our annotations, the [HTTPS redirect annotation](https://docs.konghq.com/kubernetes-ingress-controller/1.1.x/references/annotations/#konghqcomhttps-redirect-status-code) uses dashes, not underscores.

### Reason
Community report from https://discuss.konghq.com/t/404-error-while-creating-kongconsumer-using-kubernetes-api-with-python/8038