### PR TITLE
docs(changelog) kong user change arrived in EE 2.2.1.0 not EE 2.3.0.0…

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -269,10 +269,6 @@ being shown in the logs.
   `lua-resty-healthcheck`.
 - Certificates for database connections now are loaded in the right order
   avoiding failures to connect to Postgres databases.
-  
-#### Configuration
-- Kong now runs as a `kong` user if it exists; if user does not exist
-  in the system, the `nobody` user is used, as before.
 
 #### CLI
 - Fixed issue where `kong reload -c <config>` would fail.
@@ -343,6 +339,11 @@ fixed causing a 500 auth error when falling back to an anonymous user.
 - [Session](/hub/kong-inc/session) (`session`)
   - Added endpoint key to Admin API.
   - Bumped `lua-resty-session` dependency to 3.8.
+
+#### Configuration
+
+- Kong now runs as a `kong` user if it exists; if user does not exist
+  in the system, the `nobody` user is used, as before.
 
 #### Breaking Changes
 - See *RCE (Remote Code Execution) Plugin Mitigations* in the Kong Enterprise section.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -241,6 +241,8 @@ and where only Kong PDK, OpenResty `ngx` APIs, and Lua standard libraries are al
   as the default fallback certificate; on old cipher suite, the RSA
   certificate remains as the default. On custom certificates, the first
   certificate specified in the array is used.
+- Kong now runs as a `kong` user if it exists; if user does not exist
+  in the system, the `nobody` user is used, as before.
 
 ### Dependencies
 - Bumped `kong-plugin-serverless-functions` from 1.0 to 2.1.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -241,8 +241,6 @@ and where only Kong PDK, OpenResty `ngx` APIs, and Lua standard libraries are al
   as the default fallback certificate; on old cipher suite, the RSA
   certificate remains as the default. On custom certificates, the first
   certificate specified in the array is used.
-- Kong now runs as a `kong` user if it exists; if user does not exist
-  in the system, the `nobody` user is used, as before.
 
 ### Dependencies
 - Bumped `kong-plugin-serverless-functions` from 1.0 to 2.1.
@@ -269,6 +267,10 @@ being shown in the logs.
   `lua-resty-healthcheck`.
 - Certificates for database connections now are loaded in the right order
   avoiding failures to connect to Postgres databases.
+  
+#### Configuration
+- Kong now runs as a `kong` user if it exists; if user does not exist
+  in the system, the `nobody` user is used, as before.
 
 #### CLI
 - Fixed issue where `kong reload -c <config>` would fail.


### PR DESCRIPTION
I think this was inherited from the OSS changelog: https://github.com/Kong/kong/blob/master/CHANGELOG.md#configuration

But in EE, it arrived first in EE 2.2.1.0.

Sometimes the things inherited from the OSS changelog don’t necessarily map 1:1 to the EE changelog.

In my case for example, I had this changed merged into CE master that arrived first in CE 2.3.0 but because of the CE->EE merges, it went to EE 2.2.1.0 first, not EE 2.3.0.0 first.