### PR TITLE
[DOCS-1675] Remove read time from docs layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,9 +397,6 @@ toc: false
 # Disables the right-hand nav for the page; useful if the page is short and has
 # one or no headers.
 
-skip_read_time: true
-# Disables estimated read time; useful for long reference content.
-
 beta: true
 alpha: true
 # Labels the page as beta or alpha; adds a banner to the top of the page.
@@ -524,14 +521,14 @@ will be the one displayed.
 
 ##### Navtabs for codeblocks
 
-A specialized use of navtabs is the `codeblock` style. This will create copyable 
-tabbed codeblocks for easy code comparison and better use of space. See 
-[here](https://docs.konghq.com/enterprise/2.1.x/deployment/installation/kong-for-kubernetes/) 
+A specialized use of navtabs is the `codeblock` style. This will create copyable
+tabbed codeblocks for easy code comparison and better use of space. See
+[here](https://docs.konghq.com/enterprise/2.1.x/deployment/installation/kong-for-kubernetes/)
 for an example of this style in use.
 
 > **Important!** Codeblock navtabs must contain codeblocks and **nothing else**.
 
-To create a tabbed codeblock, specify the `codeblock` class in the first element 
+To create a tabbed codeblock, specify the `codeblock` class in the first element
 when creating a `navtabs` group:
 
     {% navtabs codeblock %}

--- a/app/404.html
+++ b/app/404.html
@@ -5,7 +5,6 @@ id: page-404
 sitemap: false
 toc: false
 feedback: false
-skip_read_time: true
 no_version: true
 no_search: true
 ---

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -699,7 +699,6 @@ $(function () {
    * ---
    * title: Install Kong Enterprise
    * toc: false
-   * skip_read_time: true
    * disable_image_expand: true
    * ---
    */

--- a/app/_includes/read_time.html
+++ b/app/_includes/read_time.html
@@ -1,9 +1,0 @@
-<span class="reading-time" title="Estimated reading time">
-  Estimated reading time:
-  {% assign words = content | number_of_words %}
-  {% if words < 360 %}
-    1 minute
-  {% else %}
-    {{ words | divided_by:180 }} minutes
-  {% endif %}
-</span>

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -63,10 +63,6 @@ id: documentation
           <h2 class="page-content-subtitle">{{page.subtitle | flatify }}</h2>
           {% endif %}
 
-          {% unless page.skip_read_time == true or page.path contains '/admin-api' or page.path contains '/pdk' or page.is_homepage %}
-          {% include read_time.html %}
-          {% endunless %}
-
           {{ content }}
 
         </div>

--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -143,11 +143,6 @@ id: documentation
           </div>
           {% endif %}
 
-          {% if page.edition == 'enterprise' %}
-          {% unless page.skip_read_time == true or page.path contains '/admin-api/'
-          or page.path contains '/pdk/' %}{% include read_time.html %}{% endunless %}
-          {% endif %}
-
           {% assign filename = page.path | split: '/' | last %}
           {% if page.toc == true or
           page.toc != false and filename != "index.md" %}

--- a/app/_layouts/getting-started-guide.html
+++ b/app/_layouts/getting-started-guide.html
@@ -89,7 +89,6 @@ id: getting-started-guide
               latest documentation here</a>.
           </div>
           {% endif %}
-          {% unless page.skip_read_time == true %}{% include read_time.html %}{% endunless %}
           {{ content }}
 
         </div>

--- a/app/enterprise/1.3-x/deployment/installation/overview.md
+++ b/app/enterprise/1.3-x/deployment/installation/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Install Kong Enterprise
 toc: false
-skip_read_time: true
 disable_image_expand: true
 ---
 

--- a/app/enterprise/1.3-x/index.md
+++ b/app/enterprise/1.3-x/index.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation for Kong Gateway (Enterprise)
 subtitle: Formerly known as Kong Enterprise, now part of Kong Konnect
-skip_read_time: true
 is_homepage: true
 ---
 

--- a/app/enterprise/1.3-x/property-reference.md
+++ b/app/enterprise/1.3-x/property-reference.md
@@ -1,6 +1,5 @@
 ---
 title: Configuration Property Reference for Kong Enterprise
-skip_read_time: true
 toc: false
 ---
 

--- a/app/enterprise/1.5.x/auth.md
+++ b/app/enterprise/1.5.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/cli.md
+++ b/app/enterprise/1.5.x/cli.md
@@ -1,6 +1,5 @@
 ---
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/clustering.md
+++ b/app/enterprise/1.5.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/db-encryption.md
+++ b/app/enterprise/1.5.x/db-encryption.md
@@ -1,6 +1,5 @@
 ---
 title: Keyring & Data Encryption
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/deployment/default-ports.md
+++ b/app/enterprise/1.5.x/deployment/default-ports.md
@@ -1,7 +1,6 @@
 ---
 title: Default Ports
 toc: false
-skip_read_time: true
 ---
 By default, Kong Enterprise Gateway listens on the following ports:
 

--- a/app/enterprise/1.5.x/deployment/installation/overview.md
+++ b/app/enterprise/1.5.x/deployment/installation/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Install Kong Enterprise
 toc: false
-skip_read_time: true
 disable_image_expand: true
 ---
 {% navtabs %}

--- a/app/enterprise/1.5.x/health-checks-circuit-breakers.md
+++ b/app/enterprise/1.5.x/health-checks-circuit-breakers.md
@@ -1,6 +1,5 @@
 ---
 title: Health Checks and Circuit Breakers Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/index.md
+++ b/app/enterprise/1.5.x/index.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation for Kong Gateway (Enterprise)
 subtitle: Formerly known as Kong Enterprise, now part of Kong Konnect
-skip_read_time: true
 is_homepage: true
 ---
 

--- a/app/enterprise/1.5.x/loadbalancing.md
+++ b/app/enterprise/1.5.x/loadbalancing.md
@@ -1,6 +1,5 @@
 ---
 title: Loadbalancing reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/logging.md
+++ b/app/enterprise/1.5.x/logging.md
@@ -1,6 +1,5 @@
 ---
 title: Logging Reference
-skip_read_time: true
 ---
 
 ## Log Levels

--- a/app/enterprise/1.5.x/property-reference.md
+++ b/app/enterprise/1.5.x/property-reference.md
@@ -1,6 +1,5 @@
 ---
 title: Configuration Property Reference for Kong Enterprise
-skip_read_time: true
 ---
 
 ## General

--- a/app/enterprise/1.5.x/proxy.md
+++ b/app/enterprise/1.5.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/secure-admin-api.md
+++ b/app/enterprise/1.5.x/secure-admin-api.md
@@ -1,6 +1,5 @@
 ---
 title: Securing the Admin API
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/1.5.x/studio/index.md
+++ b/app/enterprise/1.5.x/studio/index.md
@@ -1,7 +1,6 @@
 ---
 title: Kong Studio
 toc: false
-skip_read_time: true
 ---
 Kong Studio is a bundle for Kong Enterprise based on Insomnia Designer,
 which enables spec-first development for all REST and GraphQL services.

--- a/app/enterprise/2.1.x/auth.md
+++ b/app/enterprise/2.1.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/cli.md
+++ b/app/enterprise/2.1.x/cli.md
@@ -1,6 +1,5 @@
 ---
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/clustering.md
+++ b/app/enterprise/2.1.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/db-encryption.md
+++ b/app/enterprise/2.1.x/db-encryption.md
@@ -1,6 +1,5 @@
 ---
 title: Keyring & Data Encryption
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/deployment/default-ports.md
+++ b/app/enterprise/2.1.x/deployment/default-ports.md
@@ -1,7 +1,6 @@
 ---
 title: Default Ports
 toc: false
-skip_read_time: true
 ---
 By default, Kong Enterprise Gateway listens on the following ports:
 

--- a/app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Kong for Kubernetes Enterprise
-skip_read_time: true
 redirect_from: "/enteprise/2.1.x/kong-for-kubernetes/install"
 ---
 

--- a/app/enterprise/2.1.x/deployment/installation/overview.md
+++ b/app/enterprise/2.1.x/deployment/installation/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Install Kong Enterprise
 toc: false
-skip_read_time: true
 disable_image_expand: true
 ---
 {% navtabs %}

--- a/app/enterprise/2.1.x/health-checks-circuit-breakers.md
+++ b/app/enterprise/2.1.x/health-checks-circuit-breakers.md
@@ -1,6 +1,5 @@
 ---
 title: Health Checks and Circuit Breakers Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/index.md
+++ b/app/enterprise/2.1.x/index.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation for Kong Gateway (Enterprise)
 subtitle: Formerly known as Kong Enterprise, now part of Kong Konnect
-skip_read_time: true
 is_homepage: true
 ---
 

--- a/app/enterprise/2.1.x/loadbalancing.md
+++ b/app/enterprise/2.1.x/loadbalancing.md
@@ -1,6 +1,5 @@
 ---
 title: Loadbalancing reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/logging.md
+++ b/app/enterprise/2.1.x/logging.md
@@ -1,6 +1,5 @@
 ---
 title: Logging Reference
-skip_read_time: true
 ---
 
 ## Log Levels

--- a/app/enterprise/2.1.x/property-reference.md
+++ b/app/enterprise/2.1.x/property-reference.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf-ee
 #
 title: Configuration Property Reference for Kong Enterprise
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/enterprise/2.1.x/proxy.md
+++ b/app/enterprise/2.1.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/secure-admin-api.md
+++ b/app/enterprise/2.1.x/secure-admin-api.md
@@ -1,6 +1,5 @@
 ---
 title: Securing the Admin API
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.1.x/studio/index.md
+++ b/app/enterprise/2.1.x/studio/index.md
@@ -1,7 +1,6 @@
 ---
 title: Kong Studio
 toc: false
-skip_read_time: true
 ---
 Kong Studio is a bundle for Kong Enterprise based on Insomnia Designer,
 which enables spec-first development for all REST and GraphQL services.

--- a/app/enterprise/2.2.x/auth.md
+++ b/app/enterprise/2.2.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/cli.md
+++ b/app/enterprise/2.2.x/cli.md
@@ -1,6 +1,5 @@
 ---
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/clustering.md
+++ b/app/enterprise/2.2.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/db-encryption.md
+++ b/app/enterprise/2.2.x/db-encryption.md
@@ -1,6 +1,5 @@
 ---
 title: Keyring & Data Encryption
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/deployment/default-ports.md
+++ b/app/enterprise/2.2.x/deployment/default-ports.md
@@ -1,7 +1,6 @@
 ---
 title: Default Ports
 toc: false
-skip_read_time: true
 ---
 By default, Kong Enterprise Gateway listens on the following ports:
 

--- a/app/enterprise/2.2.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.2.x/deployment/installation/kong-for-kubernetes.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Kong for Kubernetes Enterprise
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Install Kong Gateway (Enterprise)
 toc: false
-skip_read_time: true
 disable_image_expand: true
 ---
 {% navtabs %}

--- a/app/enterprise/2.2.x/health-checks-circuit-breakers.md
+++ b/app/enterprise/2.2.x/health-checks-circuit-breakers.md
@@ -1,6 +1,5 @@
 ---
 title: Health Checks and Circuit Breakers Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/index.md
+++ b/app/enterprise/2.2.x/index.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation for Kong Gateway (Enterprise)
 subtitle: Formerly known as Kong Enterprise, now part of Kong Konnect
-skip_read_time: true
 is_homepage: true
 ---
 

--- a/app/enterprise/2.2.x/loadbalancing.md
+++ b/app/enterprise/2.2.x/loadbalancing.md
@@ -1,6 +1,5 @@
 ---
 title: Loadbalancing reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/logging.md
+++ b/app/enterprise/2.2.x/logging.md
@@ -1,6 +1,5 @@
 ---
 title: Logging Reference
-skip_read_time: true
 ---
 
 ## Log Levels

--- a/app/enterprise/2.2.x/property-reference.md
+++ b/app/enterprise/2.2.x/property-reference.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf-ee
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/enterprise/2.2.x/proxy.md
+++ b/app/enterprise/2.2.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/secure-admin-api.md
+++ b/app/enterprise/2.2.x/secure-admin-api.md
@@ -1,6 +1,5 @@
 ---
 title: Securing the Admin API
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.2.x/studio/index.md
+++ b/app/enterprise/2.2.x/studio/index.md
@@ -1,7 +1,6 @@
 ---
 title: Kong Studio
 toc: false
-skip_read_time: true
 ---
 Kong Studio is a bundle for {{site.ee_product_name}} based on Insomnia Designer,
 which enables spec-first development for all REST and GraphQL services.

--- a/app/enterprise/2.3.x/auth.md
+++ b/app/enterprise/2.3.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/cli.md
+++ b/app/enterprise/2.3.x/cli.md
@@ -1,6 +1,5 @@
 ---
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/clustering.md
+++ b/app/enterprise/2.3.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/db-encryption.md
+++ b/app/enterprise/2.3.x/db-encryption.md
@@ -1,6 +1,5 @@
 ---
 title: Keyring & Data Encryption
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/deployment/default-ports.md
+++ b/app/enterprise/2.3.x/deployment/default-ports.md
@@ -1,7 +1,6 @@
 ---
 title: Default Ports
 toc: false
-skip_read_time: true
 ---
 By default, Kong Enterprise Gateway listens on the following ports:
 

--- a/app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Kong for Kubernetes Enterprise
-skip_read_time: true
 ---
 
 <div class="alert alert-ee warning">

--- a/app/enterprise/2.3.x/deployment/installation/overview.md
+++ b/app/enterprise/2.3.x/deployment/installation/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Install Kong Gateway (Enterprise)
 toc: false
-skip_read_time: true
 disable_image_expand: true
 ---
 {% navtabs %}

--- a/app/enterprise/2.3.x/health-checks-circuit-breakers.md
+++ b/app/enterprise/2.3.x/health-checks-circuit-breakers.md
@@ -1,6 +1,5 @@
 ---
 title: Health Checks and Circuit Breakers Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/index.md
+++ b/app/enterprise/2.3.x/index.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation for Kong Gateway (Enterprise)
 subtitle: Formerly known as Kong Enterprise, now part of Kong Konnect
-skip_read_time: true
 is_homepage: true
 ---
 

--- a/app/enterprise/2.3.x/loadbalancing.md
+++ b/app/enterprise/2.3.x/loadbalancing.md
@@ -1,6 +1,5 @@
 ---
 title: Loadbalancing reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/logging.md
+++ b/app/enterprise/2.3.x/logging.md
@@ -1,6 +1,5 @@
 ---
 title: Logging Reference
-skip_read_time: true
 ---
 
 ## Log Levels

--- a/app/enterprise/2.3.x/property-reference.md
+++ b/app/enterprise/2.3.x/property-reference.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf-ee
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/enterprise/2.3.x/proxy.md
+++ b/app/enterprise/2.3.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/2.3.x/secure-admin-api.md
+++ b/app/enterprise/2.3.x/secure-admin-api.md
@@ -1,6 +1,5 @@
 ---
 title: Securing the Admin API
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -2,7 +2,6 @@
 title: Kong Gateway (Enterprise) Changelog
 no_search: true
 no_version: true
-skip_read_time: true
 ---
 ## 2.3.2.0
 **Release Date** 2021/02/11
@@ -133,10 +132,10 @@ being shown in the logs.
 - Fixed an issue that incorrectly enforced plugins when they exist in the default and a named workspace.
    The plugin configuration in the default workspace was incorrectly overriding the disabled plugin
    configuration in the named workspace.
-- Fixed an issue for vitals when proxy-cached-advanced or forward-proxy plugins (possibly others) 
-are in use. 
-- Requests that received a cache hit using the plugins were not showing up under 
-   service/route vitals, but were visible under workspace vitals. 
+- Fixed an issue for vitals when proxy-cached-advanced or forward-proxy plugins (possibly others)
+are in use.
+- Requests that received a cache hit using the plugins were not showing up under
+   service/route vitals, but were visible under workspace vitals.
 
 #### CLI
 - Fixed issue where `kong reload -c <config>` would fail.

--- a/app/enterprise/k8s-changelog.md
+++ b/app/enterprise/k8s-changelog.md
@@ -1,7 +1,6 @@
 ---
 title: Kong Enterprise k8s Changelog
 no_version: true
-skip_read_time: true
 ---
 
 <div class="alert alert-ee">

--- a/app/gateway-oss/2.0.x/admin-api.md
+++ b/app/gateway-oss/2.0.x/admin-api.md
@@ -7,7 +7,6 @@
 #
 title: Admin API
 toc: false
-skip_read_time: true
 
 service_body: |
     Attributes | Description
@@ -21,9 +20,9 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Defaults to `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Defaults to `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Defaults to `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service, for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service, for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never "returns" the url). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never "returns" the url).
 
 service_json: |
     {
@@ -81,19 +80,19 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Defaults to `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Defaults to `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Defaults to `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Defaults to `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Defaults to `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route, for grouping and filtering. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route, for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -155,9 +154,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer, for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer, for grouping and filtering.
 
 consumer_json: |
     {
@@ -186,14 +185,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Defaults to `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Defaults to `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated consumer.  Defaults to `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Defaults to `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Defaults to `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering.
 
 plugin_json: |
     {
@@ -239,8 +238,8 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate, for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate, for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -270,7 +269,7 @@ ca_certificate_body: |
     Attributes | Description
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate, for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate, for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -297,7 +296,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs, for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs, for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -358,7 +357,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Defaults to `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Defaults to `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Defaults to `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream, for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream, for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
 
 upstream_json: |
@@ -511,9 +510,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`1000`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Defaults to `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target, for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target, for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.0.x/auth.md
+++ b/app/gateway-oss/2.0.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.0.x/cli.md
+++ b/app/gateway-oss/2.0.x/cli.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-cli
 #
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.0.x/clustering.md
+++ b/app/gateway-oss/2.0.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.0.x/configuration.md
+++ b/app/gateway-oss/2.0.x/configuration.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf
 #
 title: Configuration Reference
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/gateway-oss/2.0.x/db-less-admin-api.md
+++ b/app/gateway-oss/2.0.x/db-less-admin-api.md
@@ -7,7 +7,6 @@
 #
 title: Admin API for DB-less Mode
 toc: false
-skip_read_time: true
 
 service_body: |
     Attributes | Description

--- a/app/gateway-oss/2.0.x/db-less-and-declarative-config.md
+++ b/app/gateway-oss/2.0.x/db-less-and-declarative-config.md
@@ -1,6 +1,5 @@
 ---
 title: DB-less and Declarative Configuration
-skip_read_time: true
 ---
 
 

--- a/app/gateway-oss/2.0.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.0.x/getting-started/adding-consumers.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Consumers
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.0.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.0.x/getting-started/configuring-a-grpc-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a gRPC Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.0.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.0.x/getting-started/configuring-a-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.0.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.0.x/getting-started/enabling-plugins.md
@@ -1,6 +1,5 @@
 ---
 title: Enabling Plugins
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.0.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.0.x/getting-started/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Welcome to Kong
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.0.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.0.x/getting-started/quickstart.md
@@ -1,6 +1,5 @@
 ---
 title: 5-minute Quickstart
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.0.x/proxy.md
+++ b/app/gateway-oss/2.0.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.1.x/admin-api.md
+++ b/app/gateway-oss/2.1.x/admin-api.md
@@ -6,7 +6,6 @@
 #  or its associated files instead.
 #
 title: Admin API
-skip_read_time: true
 toc: false
 
 service_body: |
@@ -21,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -93,19 +92,19 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -167,9 +166,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -198,14 +197,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -251,8 +250,8 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -283,7 +282,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -313,7 +312,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -374,7 +373,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -531,9 +530,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.1.x/auth.md
+++ b/app/gateway-oss/2.1.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.1.x/cli.md
+++ b/app/gateway-oss/2.1.x/cli.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-cli
 #
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.1.x/clustering.md
+++ b/app/gateway-oss/2.1.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.1.x/configuration.md
+++ b/app/gateway-oss/2.1.x/configuration.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf
 #
 title: Configuration Reference
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/gateway-oss/2.1.x/db-less-admin-api.md
+++ b/app/gateway-oss/2.1.x/db-less-admin-api.md
@@ -6,7 +6,6 @@
 #  or its associated files instead.
 #
 title: Admin API for DB-less Mode
-skip_read_time: true
 toc: false
 
 service_body: |
@@ -21,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -93,19 +92,19 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -167,9 +166,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -198,14 +197,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -251,8 +250,8 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -283,7 +282,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -313,7 +312,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -374,7 +373,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -531,9 +530,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.1.x/db-less-and-declarative-config.md
+++ b/app/gateway-oss/2.1.x/db-less-and-declarative-config.md
@@ -1,6 +1,5 @@
 ---
 title: DB-less and Declarative Configuration
-skip_read_time: true
 ---
 
 

--- a/app/gateway-oss/2.1.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.1.x/getting-started/adding-consumers.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Consumers
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.1.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.1.x/getting-started/configuring-a-grpc-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a gRPC Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.1.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.1.x/getting-started/configuring-a-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.1.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.1.x/getting-started/enabling-plugins.md
@@ -1,6 +1,5 @@
 ---
 title: Enabling Plugins
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.1.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.1.x/getting-started/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Welcome to Kong
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.1.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.1.x/getting-started/quickstart.md
@@ -1,6 +1,5 @@
 ---
 title: 5-minute Quickstart
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.1.x/proxy.md
+++ b/app/gateway-oss/2.1.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.1.x/upgrading.md
+++ b/app/gateway-oss/2.1.x/upgrading.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrade guide
-skip_read_time: true
 ---
 
 This document guides you through the process of upgrading Kong. First, check if

--- a/app/gateway-oss/2.2.x/admin-api.md
+++ b/app/gateway-oss/2.2.x/admin-api.md
@@ -6,7 +6,6 @@
 #  or its associated files instead.
 #
 title: Admin API
-skip_read_time: true
 toc: false
 
 service_body: |
@@ -21,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -93,21 +92,21 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
     `request_buffering` |  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.  Default: `true`.
     `response_buffering` |  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.  Default: `true`.
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -175,9 +174,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -206,14 +205,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -259,8 +258,8 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -291,7 +290,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -321,7 +320,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -382,7 +381,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -539,9 +538,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.2.x/auth.md
+++ b/app/gateway-oss/2.2.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.2.x/cli.md
+++ b/app/gateway-oss/2.2.x/cli.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/kong/tree/master/autodoc/cli
 #
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.2.x/clustering.md
+++ b/app/gateway-oss/2.2.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.2.x/configuration.md
+++ b/app/gateway-oss/2.2.x/configuration.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/kong/tree/master/autodoc/conf
 #
 title: Configuration Reference
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/gateway-oss/2.2.x/db-less-admin-api.md
+++ b/app/gateway-oss/2.2.x/db-less-admin-api.md
@@ -6,7 +6,6 @@
 #  or its associated files instead.
 #
 title: Admin API for DB-less Mode
-skip_read_time: true
 toc: false
 
 service_body: |
@@ -21,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -93,21 +92,21 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
     `request_buffering` |  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.  Default: `true`.
     `response_buffering` |  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.  Default: `true`.
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -175,9 +174,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -206,14 +205,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -259,8 +258,8 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -291,7 +290,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -321,7 +320,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -382,7 +381,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -539,9 +538,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.2.x/db-less-and-declarative-config.md
+++ b/app/gateway-oss/2.2.x/db-less-and-declarative-config.md
@@ -1,6 +1,5 @@
 ---
 title: DB-less and Declarative Configuration
-skip_read_time: true
 ---
 
 

--- a/app/gateway-oss/2.2.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.2.x/getting-started/adding-consumers.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Consumers
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.2.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.2.x/getting-started/configuring-a-grpc-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a gRPC Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.2.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.2.x/getting-started/configuring-a-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.2.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.2.x/getting-started/enabling-plugins.md
@@ -1,6 +1,5 @@
 ---
 title: Enabling Plugins
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.2.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.2.x/getting-started/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Welcome to Kong
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.2.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.2.x/getting-started/quickstart.md
@@ -1,6 +1,5 @@
 ---
 title: 5-minute Quickstart
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.2.x/proxy.md
+++ b/app/gateway-oss/2.2.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.2.x/upgrading.md
+++ b/app/gateway-oss/2.2.x/upgrading.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrade guide
-skip_read_time: true
 ---
 
 This document guides you through the process of upgrading Kong. First, check if

--- a/app/gateway-oss/2.3.x/admin-api.md
+++ b/app/gateway-oss/2.3.x/admin-api.md
@@ -6,7 +6,6 @@
 #  or its associated files instead.
 #
 title: Admin API
-skip_read_time: true
 toc: false
 
 service_body: |
@@ -21,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -93,21 +92,21 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
     `request_buffering` |  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.  Default: `true`.
     `response_buffering` |  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.  Default: `true`.
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -175,9 +174,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -206,14 +205,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -259,10 +258,10 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. 
-    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it.
+    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it.
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -299,7 +298,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -329,7 +328,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -390,7 +389,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -547,9 +546,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.3.x/auth.md
+++ b/app/gateway-oss/2.3.x/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Authentication Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.3.x/cli.md
+++ b/app/gateway-oss/2.3.x/cli.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/kong/tree/master/autodoc/cli
 #
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.3.x/clustering.md
+++ b/app/gateway-oss/2.3.x/clustering.md
@@ -1,6 +1,5 @@
 ---
 title: Clustering Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.3.x/configuration.md
+++ b/app/gateway-oss/2.3.x/configuration.md
@@ -5,7 +5,6 @@
 #  the files in https://github.com/Kong/kong/tree/master/autodoc/conf
 #
 title: Configuration Reference
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/app/gateway-oss/2.3.x/db-less-admin-api.md
+++ b/app/gateway-oss/2.3.x/db-less-admin-api.md
@@ -6,7 +6,6 @@
 #  or its associated files instead.
 #
 title: Admin API for DB-less Mode
-skip_read_time: true
 toc: false
 
 service_body: |
@@ -21,12 +20,12 @@ service_body: |
     `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
     `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
     `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
     `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
-    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected. 
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
     `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
     `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
-    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL). 
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
 
 service_json: |
     {
@@ -93,21 +92,21 @@ route_body: |
     ---:| ---
     `name`<br>*optional* | The name of the Route.
     `protocols` |  A list of the protocols this Route should allow. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS.  Default: `["http", "https"]`.
-    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route. 
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
     `hosts`<br>*semi-optional* |  A list of domain names that match this Route.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
     `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
-    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. 
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute.
     `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
     `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
     `strip_path`<br>*optional* |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
     `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
-    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`. 
+    `preserve_host`<br>*optional* |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
     `request_buffering` |  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.  Default: `true`.
     `response_buffering` |  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.  Default: `true`.
-    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing. 
-    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port". 
-    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering. 
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
     `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
 
 route_json: |
@@ -175,9 +174,9 @@ route_data: |
 consumer_body: |
     Attributes | Description
     ---:| ---
-    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request. 
-    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering. 
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
 
 consumer_json: |
     {
@@ -206,14 +205,14 @@ consumer_data: |
 plugin_body: |
     Attributes | Description
     ---:| ---
-    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately. 
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/). 
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Default: `true`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
 
 plugin_json: |
     {
@@ -259,10 +258,10 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate chain of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. 
-    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. 
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
-    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it. 
+    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it.
+    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it.
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
 
 certificate_json: |
     {
@@ -299,7 +298,7 @@ ca_certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the CA.
     `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
 
 ca_certificate_json: |
     {
@@ -329,7 +328,7 @@ sni_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
     `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
 
 sni_json: |
@@ -390,7 +389,7 @@ upstream_body: |
     `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
     `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
     `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
     `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
     `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
 
@@ -547,9 +546,9 @@ upstream_data: |
 target_body: |
     Attributes | Description
     ---:| ---
-    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record. 
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
     `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
-    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering. 
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
 
 target_json: |
     {

--- a/app/gateway-oss/2.3.x/db-less-and-declarative-config.md
+++ b/app/gateway-oss/2.3.x/db-less-and-declarative-config.md
@@ -1,6 +1,5 @@
 ---
 title: DB-less and Declarative Configuration
-skip_read_time: true
 ---
 
 

--- a/app/gateway-oss/2.3.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.3.x/getting-started/adding-consumers.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Consumers
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.3.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.3.x/getting-started/configuring-a-grpc-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a gRPC Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.3.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.3.x/getting-started/configuring-a-service.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Service
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.3.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.3.x/getting-started/enabling-plugins.md
@@ -1,6 +1,5 @@
 ---
 title: Enabling Plugins
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.3.x/getting-started/introduction.md
+++ b/app/gateway-oss/2.3.x/getting-started/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Welcome to Kong
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.3.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.3.x/getting-started/quickstart.md
@@ -1,6 +1,5 @@
 ---
 title: 5-minute Quickstart
-skip_read_time: true
 ---
 
 <div class="alert alert-warning">

--- a/app/gateway-oss/2.3.x/proxy.md
+++ b/app/gateway-oss/2.3.x/proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/app/gateway-oss/2.3.x/upgrading.md
+++ b/app/gateway-oss/2.3.x/upgrading.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrade guide
-skip_read_time: true
 ---
 
 This document guides you through the process of upgrading Kong. First, check if

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -1,7 +1,6 @@
 ---
 title: Konnect SaaS Updates
 no_version: true
-skip_read_time: true
 ---
 
 The updates contained in this topic apply to {{site.konnect_short_name}}
@@ -13,8 +12,8 @@ services.
 
 ### 2021.03.16
 **Runtime setup improvement**
-: Quick setup just got a little bit faster. When configuring a new runtime 
-through the Runtime Manager, HTTPie is no longer required for the 
+: Quick setup just got a little bit faster. When configuring a new runtime
+through the Runtime Manager, HTTPie is no longer required for the
 quick setup script.
 
 ## February 2021

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -2,7 +2,6 @@
 title: Kong Mesh Changelog
 no_search: true
 no_version: true
-skip_read_time: true
 ---
 
 ## 1.2.1

--- a/autodoc-cli/data.lua
+++ b/autodoc-cli/data.lua
@@ -8,7 +8,6 @@ data.header = [[
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-cli
 #
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/autodoc-conf-ee/data.lua
+++ b/autodoc-conf-ee/data.lua
@@ -8,7 +8,6 @@ data.header = [[
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf-ee
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
-skip_read_time: true
 ---
 
 ## Configuration loading

--- a/autodoc-conf/data.lua
+++ b/autodoc-conf/data.lua
@@ -8,7 +8,6 @@ data.header = [[
 #  the files in https://github.com/Kong/docs.konghq.com/tree/master/autodoc-conf
 #
 title: Configuration Reference
-skip_read_time: true
 ---
 
 ## Configuration loading


### PR DESCRIPTION
### Summary
Removing "Estimated read time" from docs. Also removing all instances of `skip_read_time` from page front matter so that it doesn't pollute docs for the future.

### Reason
Feedback that the information is unnecessary and blog-like. See ticket: https://konghq.atlassian.net/browse/DOCS-1675

### Testing
TBA