### PR TITLE
[DOCS-1684]  legacy portal no longer supported 2.1 release notes

### DIFF
--- a/app/enterprise/2.1.x/release-notes.md
+++ b/app/enterprise/2.1.x/release-notes.md
@@ -72,6 +72,8 @@ For more information, including instructions for switching images, see [Kong for
 
   * The ability to share an entity between Workspaces is no longer supported. The new method requires a copy of the entity to be created in the other Workspaces.
 
+  * The [legacy portal mode](/enterprise/2.1.x/developer-portal/legacy-migration/) is no longer supported.
+
 ## Deprecated Features
 
 Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.0 and later.


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1684

Direct review link:

https://deploy-preview-2694--kongdocs.netlify.app/enterprise/2.1.x/release-notes/#breaking-changes