### PR TITLE
[DOCS-1674] fixed link issue redirecting to wrong version

### DIFF
--- a/app/enterprise/2.1.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.1.x/deployment/classic-deployment.md
@@ -19,7 +19,7 @@ reside on the same node. This option is normally used for testing and developmen
 
 ![Classic embedded mode](/assets/images/docs/ee/deployment/deployment-classic-dev.png)
 
-To learn more, see the [installation documentation](/enterprise/{{page.kong_version}}/deployment/installation).
+To learn more, see the [installation documentation](/enterprise/{{page.kong_version}}/deployment/installation/overview).
 
 ## Distributed
 

--- a/app/enterprise/2.2.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.2.x/deployment/classic-deployment.md
@@ -19,7 +19,7 @@ reside on the same node. This option is normally used for testing and developmen
 
 ![Classic embedded mode](/assets/images/docs/ee/deployment/deployment-classic-dev.png)
 
-To learn more, see the [installation documentation](/enterprise/{{page.kong_version}}/deployment/installation).
+To learn more, see the [installation documentation](/enterprise/{{page.kong_version}}/deployment/installation/overview).
 
 ## Distributed
 

--- a/app/enterprise/2.3.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.3.x/deployment/classic-deployment.md
@@ -19,7 +19,7 @@ reside on the same node. This option is normally used for testing and developmen
 
 ![Classic embedded mode](/assets/images/docs/ee/deployment/deployment-classic-dev.png)
 
-To learn more, see the [installation documentation](/enterprise/{{page.kong_version}}/deployment/installation).
+To learn more, see the [installation documentation](/enterprise/{{page.kong_version}}/deployment/installation/overview).
 
 ## Distributed
 


### PR DESCRIPTION
### Review
Anyone on the docs team can take a look at this. It is just a link fix.

### Summary
Someone noticed that the link on the Classic Install page was redirecting to the wrong version. I noticed that part of the link was missing and it seems to have fixed it locally for me anyway. I looked and it was affecting all versions following 1.5 - seems like there was some rework.

### Reason
DOCS-1674

### Testing
Will include link to sample build when available.