### PR TITLE
update names of mesh components

### DIFF
--- a/app/mesh/1.2.x/installation/helm.md
+++ b/app/mesh/1.2.x/installation/helm.md
@@ -77,7 +77,7 @@ the API port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
@@ -120,7 +120,7 @@ the HTTP API listens on port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
@@ -134,7 +134,7 @@ the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
 service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Then run `kumactl`. For example:

--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -93,13 +93,13 @@ $ ln -s ./kumactl /usr/local/bin/kumactl
 <strong>Note:</strong> It may take a while for Kubernetes to start the
 {{site.mesh_product_name}} resources. You can check the status by executing:
 <pre class="highlight">
-<code>$ kubectl get pod -n kuma-system</code></pre>
+<code>$ kubectl get pod -n kong-mesh-system</code></pre>
 </div>
 
 ## 3. Verify the Installation
 
 Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
-created `kuma-system` namespace, you can access the control plane using either
+created `kong-mesh-system` namespace, you can access the control plane using either
 the GUI, `kubectl`, the HTTP API, or the CLI:
 
 {% navtabs %}
@@ -111,7 +111,7 @@ the API port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
@@ -154,7 +154,7 @@ the HTTP API listens on port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
@@ -168,7 +168,7 @@ the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
 service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Then run `kumactl`. For example:

--- a/app/mesh/1.2.x/installation/openshift.md
+++ b/app/mesh/1.2.x/installation/openshift.md
@@ -135,13 +135,13 @@ like _multi-zone_.
 <strong>Note:</strong> It may take a while for OpenShift to start the
 {{site.mesh_product_name}} resources. You can check the status by executing:
 <pre class="highlight">
-<code>$ oc get pod -n kuma-system</code></pre>
+<code>$ oc get pod -n kong-mesh-system</code></pre>
 </div>
 
 ## 3. Verify the Installation
 
 Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
-created `kuma-system` namespace, you can access the control plane using either
+created `kong-mesh-system` namespace, you can access the control plane using either
 the GUI, `oc`, the HTTP API, or the CLI:
 
 {% navtabs %}
@@ -153,7 +153,7 @@ the API port `5681` and defaults to `:5681/gui`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ oc port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
@@ -196,7 +196,7 @@ the HTTP API listens on port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ oc port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
@@ -210,7 +210,7 @@ the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
 service with:
 
 ```sh
-$ oc port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ oc port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Then run `kumactl`. For example:


### PR DESCRIPTION
### Review

@subnetmarco lmk if older versions also need to be changed. This PR addresses only v1.2. These are the only instances grep found ...

BUT note also that the Helm instructions include a user-provided namespace, and we currently suggest `kong-mesh-system` ... potential new confusion?

### Summary
Update names of mesh components

### Reason
Inaccurate names currently published

### Testing
Will post link to netlify preview after it builds