### PR TITLE
Fixed the namespace for Kong mesh

### DIFF
--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -93,13 +93,13 @@ $ ln -s ./kumactl /usr/local/bin/kumactl
 <strong>Note:</strong> It may take a while for Kubernetes to start the
 {{site.mesh_product_name}} resources. You can check the status by executing:
 <pre class="highlight">
-<code>$ kubectl get pod -n kuma-system</code></pre>
+<code>$ kubectl get pod -n kong-mesh-system</code></pre>
 </div>
 
 ## 3. Verify the Installation
 
 Now that {{site.mesh_product_name}} (`kuma-cp`) has been installed in the newly
-created `kuma-system` namespace, you can access the control plane using either
+created `kong-mesh-system` namespace, you can access the control plane using either
 the GUI, `kubectl`, the HTTP API, or the CLI:
 
 {% navtabs %}
@@ -111,7 +111,7 @@ the API port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kuma-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.

--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -111,7 +111,7 @@ the API port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kong-mesh-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681/gui` to see the GUI.
@@ -154,7 +154,7 @@ the HTTP API listens on port `5681`.
 To access {{site.mesh_product_name}}, port-forward the API service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Now you can navigate to `127.0.0.1:5681` to see the HTTP API.
@@ -168,7 +168,7 @@ the {{site.mesh_product_name}} HTTP API. To use it, first port-forward the API
 service with:
 
 ```sh
-$ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
+$ kubectl port-forward svc/kong-mesh-control-plane -n kong-mesh-system 5681:5681
 ```
 
 Then run `kumactl`. For example:


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@Kong/team-docs 

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
I've noticed the namespace Kong mesh actually create through the process has been changed from `kuma-system` to `kong-mesh-system`.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
