### PR TITLE
[DOCS-1646] gRPC Web plugin add datatypes

### DIFF
--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -42,6 +42,7 @@ params:
       required: false
       default:
       value_in_examples: path/to/hello.proto
+      datatype: string
       description: |
         If present, describes the gRPC types and methods.
         Required to support payload transcoding. When absent, the
@@ -50,6 +51,7 @@ params:
       required: false
       default:
       value_in_examples:
+      datatype: boolean
       description:
         If set to `true` causes the plugin to pass the stripped request path to
         the upstream gRPC service (see the `strip_path` Route attribute).


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1646 part of epic https://konghq.atlassian.net/browse/DOCS-1396.

Schema:

https://github.com/Kong/kong-plugin-grpc-web/blob/master/kong/plugins/grpc-web/schema.lua

Direct review link:

https://deploy-preview-2705--kongdocs.netlify.app/hub/kong-inc/grpc-web/