### PR TITLE
[DOCS-1660] Vault plugin add datatypes

### DIFF
--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -33,37 +33,44 @@ params:
     - name: access_token_name
       required: true
       default: "`access_token`"
+      datatype: array of string elements
       description: |
         Describes an array of comma-separated parameter names where the plugin will look for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
     - name: vault.id
       required: true
       default:
       value_in_examples: "<UUID>"
+      datatype: foreign
       description: |
         A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.
     - name: secret_token_name
       required: true
       default: "`secret_token`"
+      datatype: array of string elements
       description: |
         Describes an array of comma-separated parameter names where the plugin will look for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
     - name: key_in_body
       required: false
       default: "`false`"
+      datatype:
       description: |
         If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.
     - name: hide_credentials
       required: false
       default: "`false`"
+      datatype: boolean
       description: |
         An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the header or querystring containing the key) before proxying it.
     - name: anonymous
       required: false
       default:
+      datatype: string
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Note that this value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
     - name: run_on_preflight
       required: false
       default: "`true`"
+      datatype: boolean
       description: |
         A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests, if set to `false` then `OPTIONS` requests will always be allowed.
 

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -49,7 +49,7 @@ params:
       datatype: array of string elements
       description: |
         Describes an array of comma-separated parameter names where the plugin will look for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
-    - name: key_in_body
+    - name: tokens_in_body
       required: false
       default: "`false`"
       datatype:

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -39,7 +39,7 @@ params:
       required: true
       default:
       value_in_examples: "<UUID>"
-      datatype: foreign
+      datatype: foreign ID
       description: |
         A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.
     - name: secret_token_name
@@ -49,13 +49,13 @@ params:
       description: |
         Describes an array of comma-separated parameter names where the plugin will look for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
     - name: tokens_in_body
-      required: false
+      required: true
       default: "`false`"
-      datatype:
+      datatype: boolean
       description: |
         If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.
     - name: hide_credentials
-      required: false
+      required: true
       default: "`false`"
       datatype: boolean
       description: |
@@ -63,15 +63,15 @@ params:
     - name: anonymous
       required: false
       default:
-      datatype: string
+      datatype: string UUID
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Note that this value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
     - name: run_on_preflight
-      required: false
+      required: true
       default: "`true`"
       datatype: boolean
       description: |
-        A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests, if set to `false` then `OPTIONS` requests will always be allowed.
+        A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed.
 
 ---
 

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -39,7 +39,7 @@ params:
       required: true
       default:
       value_in_examples: "<UUID>"
-      datatype: foreign ID
+      datatype: foreign UUID
       description: |
         A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.
     - name: secret_token_name
@@ -65,8 +65,8 @@ params:
       default:
       datatype: string UUID
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. 
-        
+        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
+
         **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
     - name: run_on_preflight
       required: true

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -63,7 +63,7 @@ params:
     - name: anonymous
       required: false
       default:
-      datatype: string UUID
+      datatype: string
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
 

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -22,7 +22,6 @@ kong_version_compatibility:
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
 
 params:
   name: vault-auth
@@ -35,7 +34,7 @@ params:
       default: "`access_token`"
       datatype: array of string elements
       description: |
-        Describes an array of comma-separated parameter names where the plugin will look for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
+        Describes an array of comma-separated parameter names where the plugin will look for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
     - name: vault.id
       required: true
       default:
@@ -48,7 +47,7 @@ params:
       default: "`secret_token`"
       datatype: array of string elements
       description: |
-        Describes an array of comma-separated parameter names where the plugin will look for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
+        Describes an array of comma-separated parameter names where the plugin will look for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
     - name: tokens_in_body
       required: false
       default: "`false`"

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -34,7 +34,7 @@ params:
       default: "`access_token`"
       datatype: array of string elements
       description: |
-        Describes an array of comma-separated parameter names where the plugin will look for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
+        Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
     - name: vault.id
       required: true
       default:
@@ -47,7 +47,7 @@ params:
       default: "`secret_token`"
       datatype: array of string elements
       description: |
-        Describes an array of comma-separated parameter names where the plugin will look for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
+        Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].
     - name: tokens_in_body
       required: true
       default: "`false`"
@@ -65,7 +65,9 @@ params:
       default:
       datatype: string UUID
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Note that this value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. 
+        
+        **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
     - name: run_on_preflight
       required: true
       default: "`true`"


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1660 part of epic https://konghq.atlassian.net/browse/DOCS-1396.

Schema:

https://github.com/Kong/kong-plugin-vault-auth/blob/master/kong/plugins/vault-auth/schema.lua

Direct review link:

https://deploy-preview-2706--kongdocs.netlify.app/hub/kong-inc/vault-auth/

@murillopaula i'm not sure about the vault.id:

>      { vault = { type = "foreign", reference = "vaults", required = true } },

what is foreign? I just think of a foreign key in relational db.