### PR TITLE
[DOCS-1690] Switch Manager and Admin API tab order for 2.3.x

### DIFF
--- a/app/getting-started-guide/2.3.x/dev-portal.md
+++ b/app/getting-started-guide/2.3.x/dev-portal.md
@@ -14,6 +14,15 @@ Make sure the Dev Portal is on. You should have enabled it during [installation]
 ## Enable the Dev Portal for a Workspace
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+
+1. In Kong Manager, open the Workspaces tab and open your workspace (for example, SecureWorkspace).
+
+2. Scroll down in the sidebar, then click the **Overview** link under the Dev Portal section.
+
+3. Click **Enable Developer Portal** and refresh the browser page.
+
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 <!-- codeblock tabs -->
@@ -32,15 +41,6 @@ $ http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
 {% endnavtab %}
 {% endnavtabs %}
 <!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% navtab Using Kong Manager %}
-
-1. In Kong Manager, open the Workspaces tab and open your workspace (for example, SecureWorkspace).
-
-2. Scroll down in the sidebar, then click the **Overview** link under the Dev Portal section.
-
-3. Click **Enable Developer Portal** and refresh the browser page.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/getting-started-guide/2.3.x/expose-services.md
+++ b/app/getting-started-guide/2.3.x/expose-services.md
@@ -47,47 +47,6 @@ configuration, including adding Services and Routes, is done through requests to
 the Admin API.
 
 {% navtabs %}
-{% navtab Using the Admin API %}
-
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
-```sh
-$ curl -i -X POST http://<admin-hostname>:8001/services \
-  --data name=example_service \
-  --data url='http://mockbin.org'
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-$ http POST :8001/services \
-  name=example_service \
-  url='http://mockbin.org'
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-If the service is created successfully, you'll get a 201 success message.
-
-Verify the service’s endpoint:
-
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
-```sh
-$ curl -i http://<admin-hostname>:8001/services/example_service
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-$ http :8001/services/example_service
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
 {% navtab Using Kong Manager %}
 
 1. On the Workspaces tab in Kong Manager, scroll to the Workspace section and
@@ -139,6 +98,47 @@ gateway instance:
     ```
 
 {% endnavtab %}
+{% navtab Using the Admin API %}
+
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i -X POST http://<admin-hostname>:8001/services \
+  --data name=example_service \
+  --data url='http://mockbin.org'
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http POST :8001/services \
+  name=example_service \
+  url='http://mockbin.org'
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
+If the service is created successfully, you'll get a 201 success message.
+
+Verify the service’s endpoint:
+
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+$ curl -i http://<admin-hostname>:8001/services/example_service
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+$ http :8001/services/example_service
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
+{% endnavtab %}
 {% endnavtabs %}
 
 ## Add a Route
@@ -147,6 +147,29 @@ For the Service to be accessible through the API gateway, you need to add a
 Route to it.
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+1. From the `example_service` overview page, scroll down to the Routes section
+and click **Add Route**.  
+
+    The Create Route dialog displays with the Service field auto-populated with
+    the Service name and ID number. This field is required.
+
+    **Note:** If the Service field is not automatically populated, click
+    **Services** in the left navigation pane. Find your Service, click the
+    clipboard icon next to the id field, then go back to the Create Route
+    page and paste it into the Service field.
+
+2. Enter a name for the Route, and at least one of the following fields: Host,
+Methods, or Paths. For this example, use the following:
+      1. For **Name**, enter `mocking`.
+      2. For **Path(s)**, click **Add Path** and enter `/mock`.
+
+3. Click **Create**.
+
+The Route is created and you are automatically redirected back to the
+`example_service` overview page. The new Route appears under the Routes section.
+
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 Define a Route (`/mock`) for the Service (`example_service`) with a specific
@@ -173,29 +196,6 @@ $ http :8001/services/example_service/routes \
 <!-- end codeblock tabs -->
 
 A 201 message indicates the Route was created successfully.
-
-{% endnavtab %}
-{% navtab Using Kong Manager %}
-1. From the `example_service` overview page, scroll down to the Routes section
-and click **Add Route**.  
-
-    The Create Route dialog displays with the Service field auto-populated with
-    the Service name and ID number. This field is required.
-
-    **Note:** If the Service field is not automatically populated, click
-    **Services** in the left navigation pane. Find your Service, click the
-    clipboard icon next to the id field, then go back to the Create Route
-    page and paste it into the Service field.
-
-2. Enter a name for the Route, and at least one of the following fields: Host,
-Methods, or Paths. For this example, use the following:
-      1. For **Name**, enter `mocking`.
-      2. For **Path(s)**, click **Add Path** and enter `/mock`.
-
-3. Click **Create**.
-
-The Route is created and you are automatically redirected back to the
-`example_service` overview page. The new Route appears under the Routes section.
 
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
@@ -289,6 +289,13 @@ The Route is created and you are automatically redirected back to the
 ## Verify the Route is forwarding requests to the Service
 
 {% navtabs %}
+{% navtab Using a Web Browser %}
+
+By default, {{site.base_gateway}} handles proxy requests on port `:8000`.
+
+From a web browser, enter `http://<admin-hostname>:8000/mock`.
+
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 Using the Admin API, issue the following:
@@ -307,13 +314,6 @@ $ http :8000/mock/request
 {% endnavtab %}
 {% endnavtabs %}
 <!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% navtab Using a Web Browser %}
-
-By default, {{site.base_gateway}} handles proxy requests on port `:8000`.
-
-From a web browser, enter `http://<admin-hostname>:8000/mock`.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/getting-started-guide/2.3.x/improve-performance.md
+++ b/app/getting-started-guide/2.3.x/improve-performance.md
@@ -19,6 +19,29 @@ Use proxy caching so that Upstream services are not bogged down with repeated re
 ## Set up the Proxy Caching plugin
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+
+1. Access your Kong Manager instance and your **default** workspace.
+
+2. Go to **API Gateway** and click **Plugins**.
+
+3. Click **New Plugin**.
+
+4. Scroll down to the Traffic Control section and find the **Proxy Caching** plugin.
+
+5. Click **Enable**.
+
+6. Select to apply the plugin as **Global**. This means that proxy caching applies to all requests.
+
+7. Scroll down and complete only the following fields with the parameters listed.
+    1. config.cache_ttl: `30`
+    2. config.content_type: `application/json; charset=utf-8`
+    3. config.strategy: `memory`
+
+    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
+
+8. Click **Create**.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 Call the Admin API on port `8001` and configure plugins to enable in-memory caching globally, with a timeout of 30 seconds for Content-Type `application/json`.
@@ -46,29 +69,6 @@ $ http -f :8001/plugins \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-{% endnavtab %}
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-
-2. Go to **API Gateway** and click **Plugins**.
-
-3. Click **New Plugin**.
-
-4. Scroll down to the Traffic Control section and find the **Proxy Caching** plugin.
-
-5. Click **Enable**.
-
-6. Select to apply the plugin as **Global**. This means that proxy caching applies to all requests.
-
-7. Scroll down and complete only the following fields with the parameters listed.
-    1. config.cache_ttl: `30`
-    2. config.content_type: `application/json; charset=utf-8`
-    3. config.strategy: `memory`
-
-    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
-
-8. Click **Create**.
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
 
@@ -125,7 +125,8 @@ plugin with a timeout of 30 seconds for Content-Type
 
 ## Validate Proxy Caching
 
-Let’s check that proxy caching works.
+Let’s check that proxy caching works. You'll need the Kong Admin API for this
+step.
 
 Access the */mock* route using the Admin API and note the response headers:
 

--- a/app/getting-started-guide/2.3.x/load-balancing.md
+++ b/app/getting-started-guide/2.3.x/load-balancing.md
@@ -25,6 +25,21 @@ In the following example, you’ll use an application deployed across two differ
 In this section, you will create an Upstream named `upstream` and add two targets to it.
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+
+1. Access your Kong Manager instance and your **default** workspace.
+2. Go to **API Gateway** > **Upstreams**.
+3. Click **New Upstream**.
+4. For this example, enter `upstream` in the **Name** field.
+5. Scroll down and click **Create**.
+6. On the Upstreams page, find the new upstream service and click **View**.
+7. Scroll down and click **New Target**.
+8. In the target field, specify `httpbin.org` with port `80`, and click **Create**.
+9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
+10. Open the **Services** page.
+11. Find your `example_service` and click **Edit**.
+12. Change the **Host** field to `upstream`, then click **Update**.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 Call the Admin API on port `8001` and create an Upstream named `upstream`:
@@ -90,22 +105,6 @@ $ http POST :8001/upstreams/upstream/targets \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-{% endnavtab %}
-
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-2. Go to **API Gateway** > **Upstreams**.
-3. Click **New Upstream**.
-4. For this example, enter `upstream` in the **Name** field.
-5. Scroll down and click **Create**.
-6. On the Upstreams page, find the new upstream service and click **View**.
-7. Scroll down and click **New Target**.
-8. In the target field, specify `httpbin.org` with port `80`, and click **Create**.
-9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
-10. Open the **Services** page.
-11. Find your `example_service` and click **Edit**.
-12. Change the **Host** field to `upstream`, then click **Update**.
 {% endnavtab %}
 
 {% navtab Using decK (YAML) %}

--- a/app/getting-started-guide/2.3.x/prepare.md
+++ b/app/getting-started-guide/2.3.x/prepare.md
@@ -20,6 +20,16 @@ of your control plane instance.
 
 ## Verify the Kong Gateway configuration
 {% navtabs %}
+{% navtab Using Kong Manager %}
+As a {{site.ee_product_name}} user, you can use Kong Manager for environment
+administration. You’re going to use it later on in this guide, so first make s
+ure you can access Kong Manager.
+
+Open a web browser and navigate to `http://<admin-hostname>:8002`.
+
+If {{site.ee_product_name}} was installed correctly, it automatically logs you
+in and presents the Kong Manager Overview page.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 Ensure that you can send requests to the gateway's Admin API using either cURL
 or HTTPie.
@@ -43,17 +53,6 @@ $ http <admin-hostname>:8001
 <!-- end codeblock tabs -->
 
 The current configuration returns.
-{% endnavtab %}
-
-{% navtab Using Kong Manager %}
-As a {{site.ee_product_name}} user, you can use Kong Manager for environment
-administration. You’re going to use it later on in this guide, so first make s
-ure you can access Kong Manager.
-
-Open a web browser and navigate to `http://<admin-hostname>:8002`.
-
-If {{site.ee_product_name}} was installed correctly, it automatically logs you
-in and presents the Kong Manager Overview page.
 {% endnavtab %}
 
 {% navtab Using decK (YAML) %}

--- a/app/getting-started-guide/2.3.x/protect-services.md
+++ b/app/getting-started-guide/2.3.x/protect-services.md
@@ -20,6 +20,31 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 ## Set up Rate Limiting
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+
+1. Access your Kong Manager instance and your **default** workspace.
+
+2. Go to **API Gateway** > **Plugins**.
+
+3. Click **New Plugin**.
+
+4. Scroll down to **Traffic Control** and find the **Rate Limiting Advanced** plugin. Click **Enable**.
+
+5. Apply the plugin as **Global**, which means the rate limiting applies to all requests, including every Service and Route in the Workspace.
+
+    If you switched it to **Scoped**, the rate limiting would apply the plugin to only one Service, Route, or Consumer.
+
+    > **Note**: By default, the plugin is automatically enabled when the form is submitted. You can also toggle the **This plugin is Enabled** button at the top of the form to configure the plugin without enabling it. For this example, keep the plugin enabled.
+
+6. Scroll down and complete only the following fields with the following parameters.
+    1. config.limit: `5`
+    2. config.sync_rate: `-1`
+    3. config.window_size: `30`
+
+    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
+
+7. Click **Create**.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 <div class="alert alert-ee">
@@ -49,32 +74,6 @@ $ http -f post :8001/plugins \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-{% endnavtab %}
-
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-
-2. Go to **API Gateway** > **Plugins**.
-
-3. Click **New Plugin**.
-
-4. Scroll down to **Traffic Control** and find the **Rate Limiting Advanced** plugin. Click **Enable**.
-
-5. Apply the plugin as **Global**, which means the rate limiting applies to all requests, including every Service and Route in the Workspace.
-
-    If you switched it to **Scoped**, the rate limiting would apply the plugin to only one Service, Route, or Consumer.
-
-    > **Note**: By default, the plugin is automatically enabled when the form is submitted. You can also toggle the **This plugin is Enabled** button at the top of the form to configure the plugin without enabling it. For this example, keep the plugin enabled.
-
-6. Scroll down and complete only the following fields with the following parameters.
-    1. config.limit: `5`
-    2. config.sync_rate: `-1`
-    3. config.window_size: `30`
-
-    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
-
-7. Click **Create**.
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
 
@@ -138,6 +137,14 @@ and in-memory, on the node:
 ## Validate Rate Limiting
 
 {% navtabs %}
+{% navtab Using a Web Browser %}
+
+1. Enter `<admin-hostname>:8000/mock` and refresh your browser six times.
+    After the 6th request, you’ll receive an error message.
+2. Wait at least 30 seconds and try again.
+    The service will be accessible until the sixth (6th) access attempt within a 30-second window.
+
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 To validate rate limiting, access the API six (6) times from the CLI to confirm the requests are rate limited.
@@ -164,14 +171,6 @@ After the 6th request, you should receive a 429 "API rate limit exceeded" error:
 "message": "API rate limit exceeded"
 }
 ```
-{% endnavtab %}
-{% navtab Using a Web Browser %}
-
-1. Enter `<admin-hostname>:8000/mock` and refresh your browser six times.
-    After the 6th request, you’ll receive an error message.
-2. Wait at least 30 seconds and try again.
-    The service will be accessible until the sixth (6th) access attempt within a 30-second window.
-
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/getting-started-guide/2.3.x/secure-services.md
+++ b/app/getting-started-guide/2.3.x/secure-services.md
@@ -32,6 +32,25 @@ For more information, see [What is API Gateway Authentication?](https://konghq.c
 ## Set up the Key Authentication Plugin
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+
+1. Access your Kong Manager instance and your **default** workspace.
+2. Go to the **Routes** page and select the **mocking** route you created.
+3. Click **View**.
+4. On the Scroll down and select the **Plugins** tab, then click **Add a Plugin**.
+5. In the Authentication section, find the **Key Authentication** plugin and click **Enable**.
+6. In the **Create new key-auth plugin** dialog, the plugin fields are automatically scoped to the route because the plugin is selected from the mocking Routes page.
+
+    For this example, this means that you can use all of the default values.
+
+7. Click **Create**.
+
+    Once the plugin is enabled on the route, **key-auth** displays under the Plugins section on the route’s overview page.
+
+Now, if you try to access the route without providing an API key, the request will fail, and you’ll see the message `"No API key found in request".`
+
+Before Kong proxies requests for this route, it needs an API key. For this example, since you installed the Key Authentication plugin, you need to create a consumer with an associated key first.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 Call the Admin API on port `8001` and configure plugins to enable key
@@ -86,26 +105,6 @@ Before Kong proxies requests for this route, it needs an API key. For this
 example, since you installed the Key Authentication plugin, you need to create
 a consumer with an associated key first.
 
-{% endnavtab %}
-
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-2. Go to the **Routes** page and select the **mocking** route you created.
-3. Click **View**.
-4. On the Scroll down and select the **Plugins** tab, then click **Add a Plugin**.
-5. In the Authentication section, find the **Key Authentication** plugin and click **Enable**.
-6. In the **Create new key-auth plugin** dialog, the plugin fields are automatically scoped to the route because the plugin is selected from the mocking Routes page.
-
-    For this example, this means that you can use all of the default values.
-
-7. Click **Create**.
-
-    Once the plugin is enabled on the route, **key-auth** displays under the Plugins section on the route’s overview page.
-
-Now, if you try to access the route without providing an API key, the request will fail, and you’ll see the message `"No API key found in request".`
-
-Before Kong proxies requests for this route, it needs an API key. For this example, since you installed the Key Authentication plugin, you need to create a consumer with an associated key first.
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
 1. Under the `mocking` route in the `routes` section of the `kong.yaml` file,
@@ -166,6 +165,19 @@ a consumer with an associated key first.
 ## Set up Consumers and Credentials
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+
+1. In Kong Manager, go to **API Gateway** > **Consumers**.
+2. Click **New Consumer**.
+3. Enter the **Username** and **Custom ID**. For this example, use `consumer` for each field.
+4. Click **Create**.
+5. On the Consumers page, find your new consumer and click **View**.
+6. Scroll down the page and click the **Credentials** tab.
+7. Click **New Key Auth Credential**.
+8. Set the key to **apikey** and click **Create**.
+
+  The new Key Authentication ID displays on the **Consumers** page under the **Credentials** tab.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 To create a consumer, call the Admin API and the consumer’s endpoint.
@@ -230,19 +242,6 @@ HTTP/1.1 201 Created
 You now have a consumer with an API key provisioned to access the route.
 
 {% endnavtab %}
-{% navtab Using Kong Manager %}
-
-1. In Kong Manager, go to **API Gateway** > **Consumers**.
-2. Click **New Consumer**.
-3. Enter the **Username** and **Custom ID**. For this example, use `consumer` for each field.
-4. Click **Create**.
-5. On the Consumers page, find your new consumer and click **View**.
-6. Scroll down the page and click the **Credentials** tab.
-7. Click **New Key Auth Credential**.
-8. Set the key to **apikey** and click **Create**.
-
-  The new Key Authentication ID displays on the **Consumers** page under the **Credentials** tab.
-{% endnavtab %}
 {% navtab Using decK (YAML) %}
 1. Add a `consumers` section to your `kong.yaml` file and create a new consumer:
 
@@ -303,6 +302,14 @@ You now have a consumer with an API key provisioned to access the route.
 ## Validate Key Authentication
 
 {% navtabs %}
+{% navtab Using a Web Browser %}
+
+To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
+```
+http://<admin-hostname>:8000/mock/?apikey=apikey
+```
+
+{% endnavtab %}
 {% navtab Using the Admin API %}
 To validate the Key Authentication plugin, access the *mocking* route again, using the header `apikey` with a key value of `apikey`.
 
@@ -325,20 +332,16 @@ $ http :8000/mock/request apikey:apikey
 You should get an `HTTP/1.1 200 OK` message in response.
 
 {% endnavtab %}
-{% navtab Using a Web Browser %}
-
-To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
-```
-http://<admin-hostname>:8000/mock/?apikey=apikey
-```
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ## (Optional) Disable the plugin
 If you are following this getting started guide topic by topic, you will need to use this API key in any requests going forward. If you don’t want to keep specifying the key, disable the plugin before moving on.
 
 {% navtabs %}
+{% navtab Using Kong Manager %}
+1. Go to the Plugins page and click on **View** for the key-auth row.
+2. Use the toggle at the top of the page to switch the plugin from **Enabled** to **Disabled**.
+{% endnavtab %}
 {% navtab Using the Admin API %}
 
 Find the plugin ID and copy it:
@@ -382,11 +385,6 @@ $ http -f patch :8001/routes/mocking/plugins/{<plugin-id>} \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-{% endnavtab %}
-
-{% navtab Using Kong Manager %}
-1. Go to the Plugins page and click on **View** for the key-auth row.
-2. Use the toggle at the top of the page to switch the plugin from **Enabled** to **Disabled**.
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
 


### PR DESCRIPTION
### Summary
Switching Manager and Admin API tabs around.

### Reason
Manager is available in free mode, and we want to promote it. 
https://konghq.atlassian.net/browse/DOCS-1690

### Testing
https://deploy-preview-2707--kongdocs.netlify.app/getting-started-guide/2.3.x/prepare/ - sample topic in getting started guide, just flip through the pages to make sure Manager comes up as the first tab wherever it appears