### PR TITLE
[DOCS-1636] ldap adv plugin datatypes

### DIFF
--- a/app/_data/extensions/kong-inc/ldap-auth-advanced/versions.yml
+++ b/app/_data/extensions/kong-inc/ldap-auth-advanced/versions.yml
@@ -1,6 +1,4 @@
 - release: 2.3.x
+- release: 2.2.x
 - release: 1.3.x
 - release: 0.36-x
-- release: 0.35-x
-- release: 0.34-x
-- release: 0.33-x

--- a/app/_hub/kong-inc/ldap-auth-advanced/2.2.x.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/2.2.x.md
@@ -2,8 +2,7 @@
 
 name: LDAP Authentication Advanced
 publisher: Kong Inc.
-version: 2.3.x
-# internal handler version 1.1.0
+version: 1.3-x
 
 desc: Secure Kong clusters, Routes, and Services with username and password protection
 description: |

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -143,14 +143,17 @@ params:
       value_in_examples:
       datatype: boolean
       description: |
-        Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user. If `consumer_optional=false`, LDAP authenticated users can still access upstream resources. To prevent access from LDAP users that are not associated with consumers, set `consumer_optional=false`, set the `anonymous` field to an existing `consumer_id`, then use the Request Termination plugin to deny any requests from the anonymous consumer.
+        Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the
+        LDAP authenticated user. If `consumer_optional=false`, LDAP authenticated users can still access upstream resources.
+        To prevent access from LDAP users that are not associated with consumers, set `consumer_optional=false`, set the `anonymous` field to an
+        existing `consumer_id`, then use the [Request Termination plugin](/hub/kong-inc/request-termination/) to deny any requests from the anonymous consumer.
     - name: consumer_by
       required: false
       default: '`[ "username", "custom_id" ]`'
       value_in_examples:
-      datatype:
+      datatype: array of string elements
       description: |
-        Whether to authenticate Consumers based on `username` and/or `custom_id`.
+        Whether to authenticate consumers based on `username`, `custom_id`, or both.
     - name: hide_credentials
       required: true
       default: "`false`"
@@ -193,6 +196,7 @@ params:
       required: false
       default: "`false`"
       value_in_examples:
+      datatype: boolean
       description: |
         Displays all the LDAP search results received from the LDAP
         server for debugging purposes. Not recommended to be enabled in

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -40,12 +40,14 @@ params:
       required: true
       default:
       value_in_examples: ldap.example.com
+      datatype: string
       description: |
         Host on which the LDAP server is running.
     - name: ldap_port
       required: true
       default: 389
       value_in_examples: 389
+      datatype: number
       description: |
         TCP port where the LDAP server is listening. 389 is the default
         port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is
@@ -54,12 +56,14 @@ params:
       required:
       default:
       value_in_examples:
+      datatype: string
       description: |
         The password to the LDAP server.
     - name: start_tls
       required: true
       default: "`false`"
       value_in_examples: true
+      datatype: boolean
       description: |
         Set it to `true` to issue StartTLS (Transport Layer Security) extended operation
         over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps`
@@ -68,6 +72,7 @@ params:
       required: true
       default: "`false`"
       value_in_examples:
+      datatype: boolean
       description: |
         Set it to `true` to use `ldaps`, a secure protocol (that can be configured
         to TLS) to connect to the LDAP server. When `ldaps` is
@@ -77,72 +82,84 @@ params:
       required: true
       default:
       value_in_examples: dc=example,dc=com
+      datatype: string
       description: |
         Base DN as the starting point for the search; e.g., "dc=example,dc=com".
     - name: verify_ldap_host
       required: true
       default: "`false`"
       value_in_examples: false
+      datatype: boolean
       description: |
         Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.
     - name: attribute
       required: true
       default:
       value_in_examples: cn
+      datatype: string
       description: |
         Attribute to be used to search the user; e.g., "cn".
     - name: cache_ttl
       required: true
       default: "`60`"
       value_in_examples: 60
+      datatype: number
       description: |
         Cache expiry time in seconds.
     - name: timeout
       required: false
       default: "`10000`"
       value_in_examples:
+      datatype: number
       description: |
         An optional timeout in milliseconds when waiting for connection with LDAP server.
     - name: keepalive
       required: false
       default: "`10000`"
       value_in_examples:
+      datatype: number
       description: |
         An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.
     - name: anonymous
       required: false
       default:
       value_in_examples:
+      datatype: string
       description: |
         An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
     - name: header_type
       required: false
       default: "`ldap`"
       value_in_examples: ldap
+      datatype: string
       description: |
         An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
     - name: consumer_optional
       required: false
       default: "`false`"
       value_in_examples:
+      datatype: boolean
       description: |
         Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user. If `consumer_optional=false`, LDAP authenticated users can still access upstream resources. To prevent access from LDAP users that are not associated with consumers, set `consumer_optional=false`, set the `anonymous` field to an existing `consumer_id`, then use the Request Termination plugin to deny any requests from the anonymous consumer.
     - name: consumer_by
       required: false
       default: '`[ "username", "custom_id" ]`'
       value_in_examples:
+      datatype:
       description: |
         Whether to authenticate Consumers based on `username` and/or `custom_id`.
     - name: hide_credentials
       required: false
       default: "`false`"
       value_in_examples:
+      datatype: boolean
       description: |
         An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.
     - name: bind_dn
-      required:
+      required: false
       default:
       value_in_examples:
+      datatype: string
       description: |
         The DN to bind to. Used to perform LDAP search of user. This `bind_dn`
         should have permissions to search for the user being authenticated.
@@ -150,12 +167,14 @@ params:
       required:
       default: "matches `conf.base_dn`"
       value_in_examples:
+      datatype: string
       description: |
         Sets a distinguished name (DN) for the entry where LDAP searches for groups begin. This field is case-insensitive.
     - name: group_name_attribute
       required:
       default: "matches `conf.attribute`"
       value_in_examples:
+      datatype: string
       description: |
         Sets the attribute holding the name of a group, typically
         called `name` (in Active Directory) or `cn` (in OpenLDAP). This

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -26,8 +26,6 @@ kong_version_compatibility:
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
-        - 0.34-x
 
 params:
   name: ldap-auth-advanced

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -149,7 +149,7 @@ params:
       description: |
         Whether to authenticate Consumers based on `username` and/or `custom_id`.
     - name: hide_credentials
-      required: false
+      required: true
       default: "`false`"
       value_in_examples:
       datatype: boolean

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -115,7 +115,7 @@ params:
         An optional timeout in milliseconds when waiting for connection with LDAP server.
     - name: keepalive
       required: false
-      default: "`10000`"
+      default: "`60000`"
       value_in_examples:
       datatype: number
       description: |
@@ -183,6 +183,7 @@ params:
       required:
       default: "`memberOf`"
       value_in_examples:
+      datatype: string
       description: |
         Sets the attribute holding the members of the LDAP group. This field is case-sensitive.
     - name: log_search_results

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -29,7 +29,6 @@ kong_version_compatibility:
 
 params:
   name: ldap-auth-advanced
-  api_id: false
   service_id: true
   route_id: true
   consumer_id: false
@@ -127,7 +126,9 @@ params:
       datatype: string
       description: |
         An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the
-        request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
+        request will fail with an authentication failure `4xx`. 
+        
+        **Note:** The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
     - name: header_type
       required: false
       default: "`ldap`"
@@ -145,6 +146,7 @@ params:
       description: |
         Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the
         LDAP authenticated user. If `consumer_optional=false`, LDAP authenticated users can still access upstream resources.
+        
         To prevent access from LDAP users that are not associated with consumers, set `consumer_optional=false`, set the `anonymous` field to an
         existing `consumer_id`, then use the [Request Termination plugin](/hub/kong-inc/request-termination/) to deny any requests from the anonymous consumer.
     - name: consumer_by

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -126,14 +126,17 @@ params:
       value_in_examples:
       datatype: string
       description: |
-        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the
+        request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
     - name: header_type
       required: false
       default: "`ldap`"
       value_in_examples: ldap
       datatype: string
       description: |
-        An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
+        An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this:
+        `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be
+        `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
     - name: consumer_optional
       required: false
       default: "`false`"

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -29,7 +29,7 @@ kong_version_compatibility:
 
 params:
   name: ldap-auth-advanced
-  api_id: true
+  api_id: false
   service_id: true
   route_id: true
   consumer_id: false


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1636 part of epic https://konghq.atlassian.net/browse/DOCS-1396.

Schema:

https://github.com/Kong/kong-plugin-enterprise-ldap-auth/blob/master/kong/plugins/ldap-auth-advanced/schema.lua

Direct review link:

https://deploy-preview-2708--kongdocs.netlify.app/hub/kong-inc/ldap-auth-advanced/

I noticed that the index file listed 1.3.x as the version, and there was also a 1.3.x file. I did a diff and ended up making the current index 2.2.x and then the current index is 2.3.x. @Murillo, please let me know if I should just delete 2.2.x. Also, can we skip the scope creep for required fields in this PR? There are multiple descriptions that state optional in the descriptions even though they have a default, and the schema does not explicitly say required:

    - name: header_type
      required: false
      default: "`ldap`"
      value_in_examples: ldap
      datatype: string
      description: |
        An optional string

![image](https://user-images.githubusercontent.com/3756245/112155190-1012b380-8bb3-11eb-814c-94e4476989d4.png)
