### PR TITLE
[DOCS-1647] Datadog add datatypes

### DIFF
--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -86,9 +86,9 @@ params:
 ---
 
 ## Metrics
-Plugin currently logs the following metrics to the Datadog server about a Service or Route.
+The Datadog plugin currently logs the following metrics to the Datadog server about a Service or Route.
 
-Metric                     | description | namespace
+Metric                     | Description | Namespace
 ---                        | ---         | ---
 `request_count`            | tracks the request | kong.request.count
 `request_size`             | tracks the request's body size in bytes | kong.request.size
@@ -103,22 +103,22 @@ The metrics will be sent with the tags `name` and `status` carrying the API name
 
 Plugin can be configured with any combination of [Metrics](#metrics), with each entry containing the following fields.
 
-Field           | description                                           | allowed values
----             | ---                                                   | ---
-`name`          | Datadog metric's name                                 | [Metrics](#metrics)
-`stat_type`     | determines what sort of event the metric represents   | `gauge`, `timer`, `counter`, `histogram`, `meter` and `set`
-`sample_rate`<br>*conditional*   | sampling rate                        | `number`
-`consumer_identifier`<br>*conditional*| authenticated user detail       | `consumer_id`, `custom_id`, `username`
-`tags`<br>*optional*| List of tags                                      | `key[:value]`
+Field           | Description                                           | Datatypes   | Allowed values
+---             | ---                                                   | ---         | ---
+`name`          | Datadog metric's name                                 | String      | [Metrics](#metrics)
+`stat_type`     | determines what sort of event the metric represents   | String      | `gauge`, `timer`, `counter`, `histogram`, `meter` and `set`
+`sample_rate`<br>*conditional*   | sampling rate                        | Number      | `number`
+`consumer_identifier`<br>*conditional*| authenticated user detail       | String      | `consumer_id`, `custom_id`, `username`
+`tags`<br>*optional*| List of tags                                      | Array of strings    | `key[:value]`
 
 ### Metric requirements
 
-1.  by default all metrics get logged.
-2.  metric with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
+1.  All metrics get logged by default.
+2.  Metrics with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
 
 ## Migrating Datadog queries
 The plugin updates replace the api, status, and consumer-specific metrics with a generic metric name.
-You have to change your Datadog queries in dashboards and alerts to reflect the metrics updates.
+You must change your Datadog queries in dashboards and alerts to reflect the metrics updates.
 
 For example, the following query:
 ```

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -59,23 +59,27 @@ params:
   dbless_compatible: yes
   config:
     - name: host
-      required: false
+      required: true
       default: "`127.0.0.1`"
       value_in_examples: 127.0.0.1
+      datatype: string
       description: The IP address or host name to send data to.
     - name: port
-      required: false
+      required: true
       default: "`8125`"
       value_in_examples: 8125
+      datatype: integer
       description: The port to send data to on the upstream server
     - name: metrics
-      required: false
+      required: true
       default: All metrics are logged
+      datatype: array of record elements
       description: |
         List of Metrics to be logged. Available values are described at [Metrics](#metrics).
     - name: prefix
-      required: false
+      required: true
       default: "`kong`"
+      datatype: string
       description: String to be attached as prefix to metric's name.
 
 ---

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -1,7 +1,8 @@
 ---
 name: Datadog
 publisher: Kong Inc.
-version: 3.0.0
+version: 3.0.x
+# internal handler version 3.0.1
 
 desc: Visualize metrics on Datadog
 description: |

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -61,7 +61,7 @@ params:
   config:
     - name: host
       required: true
-      default: "`127.0.0.1`"
+      default: "`localhost`"
       value_in_examples: 127.0.0.1
       datatype: string
       description: The IP address or host name to send data to.


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1647 part of epic https://konghq.atlassian.net/browse/DOCS-1396.

Schema:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/datadog/schema.lua

This also references the typedefs schema.

Direct review link:

https://deploy-preview-2711--kongdocs.netlify.app/hub/kong-inc/datadog/#parameters