### PR TITLE
[DOCS-1653] Zipkin tracing plugin bump version, add missing configs (2.4 CE beta/GA), add datatypes

### DIFF
--- a/app/_data/extensions/kong-inc/zipkin/versions.yml
+++ b/app/_data/extensions/kong-inc/zipkin/versions.yml
@@ -1,3 +1,4 @@
+- release: 1.3.x
 - release: 1.2.x
 - release: 1.1.x
 - release: 1.0.x

--- a/app/_hub/kong-inc/zipkin/1.0.x.md
+++ b/app/_hub/kong-inc/zipkin/1.0.x.md
@@ -66,10 +66,6 @@ params:
       description: |
         How often to sample requests that do not contain trace ids.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests.
-    - name: default_service_name
-      required: false
-      description: |
-        The default service name to override the unknown-service-name spans.
     - name: include_credential
       required: true
       default: true

--- a/app/_hub/kong-inc/zipkin/1.1.x.md
+++ b/app/_hub/kong-inc/zipkin/1.1.x.md
@@ -68,10 +68,6 @@ params:
       description: |
         How often to sample requests that do not contain trace ids.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests.
-    - name: default_service_name
-      required: false
-      description: |
-        The default service name to override the unknown-service-name spans.
     - name: include_credential
       required: true
       default: true

--- a/app/_hub/kong-inc/zipkin/1.2.x.md
+++ b/app/_hub/kong-inc/zipkin/1.2.x.md
@@ -3,7 +3,7 @@ name: Zipkin
 publisher: Kong Inc.
 redirect_from:
   - /hub/kong-inc/zipkin/http-log/
-version: 1.3.x
+version: 1.2.0
 
 source_url: https://github.com/Kong/kong-plugin-zipkin
 
@@ -52,7 +52,6 @@ params:
       required: false
       default: ''
       value_in_examples: http://your.zipkin.collector:9411/api/v2/spans
-      datatype:
       description: |
         The full HTTP(S) endpoint to which Zipkin spans should be sent by Kong.
         If not specified, the Zipkin plugin will only act as a tracing header
@@ -61,66 +60,51 @@ params:
       required: false
       default: '`0.001`'
       value_in_examples: 0.001
-      datatype: number
       description: |
         How often to sample requests that do not contain trace ids.
-        Set to `0` to turn sampling off, or to `1` to sample **all** requests. The
-        value must be between zero (0) and one (1), inclusive.
+        Set to `0` to turn sampling off, or to `1` to sample **all** requests.
     - name: default_service_name
       required: false
-      datatype: string
       description: |
-        The default service name to override the unknown-service-name spans. XX REVIEWERS this option does not appear in the schema?
+        The default service name to override the unknown-service-name spans.
     - name: include_credential
       required: true
       default: true
       value_in_examples: true
-      datatype: boolean
       description: |
         Should the credential of the currently authenticated consumer be included in metadata sent to the Zipkin server?
     - name: traceid_byte_count
       required: true
       default: 16
-      datatype: integer
       description: |
-        The length in bytes of each request's Trace ID. The value can be either `8` or `16`.
+        The length in bytes of each request's Trace ID.
     - name: header_type
       required: true
       default: preserve
-      datatype: string
       description: |
         All HTTP requests going through the plugin will be tagged with a tracing HTTP request.
         This property codifies what kind of tracing header the plugin expects on incoming requests.
-        Possible values are `b3`, `b3-single`, `w3c`, `preserve`, `jaeger`, or `ot`. The `b3` option means that
+        Possible values are `b3`, `b3-single`, `w3c`, or `preserve`. The `b3` option means that
         the plugin expects [Zipkin's B3 multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers)
         on incoming requests, and will add them to the transmitted requests if they are missing from it.
         The `b3-single` option expects or adds Zipkin's B3 single-header tracing headers.
         The `w3c` option expects or adds W3C's traceparent tracing header. The `preserve` option
-        does not expect any format, and will transmit whatever header is recognized or present,
-        with a default of `b3` if none is found. In case of a mismatch between the expected and incoming
+        does not expect any format, and will  transmit whatever header is recognized or present,
+        defaulting to `b3` if none is found. In case of mismatch between the expected and incoming
         tracing headers (for example, when `header_type` is set to `b3` but a w3c-style tracing header is
         found in the incoming request), then the plugin will add both kinds of tracing headers
-        to the request and generate a mismatch warning in the logs. XX REVIEWERS need a description for jaeger and ot.
+        to the request and generate a mismatch warning in the logs.
     - name: default_header_type
       required: true
       default: b3
-      datatype: string
       description: |
         Allows specifying the type of header to be added to requests with no pre-existing tracing headers
         and when `config.header_type` is set to `"preserve"`.
-        When `header_type` is set to any other value, `default_header_type` is ignored. Possible values are
-        `b3`, `b3-single`, `w3c`, `jaeger`, or `ot`.
-    - name: tags_header
-      required: true
-      default: Zipkin-Tags
-      datatype: string
-      description: |
-      XX REVIEWERS need a description
+        When `header_type` is set to any other value, `default_header_type` is ignored.
     - name: static_tags
       required: false
       default: {}
       value_in_examples: { { name = "color", value = "red" } }
-      datatype: array
       description: |
         The tags specified on this property will be added to the generated request traces.
 

--- a/app/_hub/kong-inc/zipkin/1.2.x.md
+++ b/app/_hub/kong-inc/zipkin/1.2.x.md
@@ -3,7 +3,7 @@ name: Zipkin
 publisher: Kong Inc.
 redirect_from:
   - /hub/kong-inc/zipkin/http-log/
-version: 1.2.0
+version: 1.2.x
 
 source_url: https://github.com/Kong/kong-plugin-zipkin
 
@@ -63,10 +63,6 @@ params:
       description: |
         How often to sample requests that do not contain trace ids.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests.
-    - name: default_service_name
-      required: false
-      description: |
-        The default service name to override the unknown-service-name spans.
     - name: include_credential
       required: true
       default: true
@@ -103,8 +99,8 @@ params:
         When `header_type` is set to any other value, `default_header_type` is ignored.
     - name: static_tags
       required: false
-      default: []
-      value_in_examples: [ { name = "color", value = "red" } ]
+      default: {}
+      value_in_examples: { { name = "color", value = "red" } }
       description: |
         The tags specified on this property will be added to the generated request traces.
 

--- a/app/_hub/kong-inc/zipkin/1.2.x.md
+++ b/app/_hub/kong-inc/zipkin/1.2.x.md
@@ -103,8 +103,8 @@ params:
         When `header_type` is set to any other value, `default_header_type` is ignored.
     - name: static_tags
       required: false
-      default: {}
-      value_in_examples: { { name = "color", value = "red" } }
+      default: []
+      value_in_examples: [ { name = "color", value = "red" } ]
       description: |
         The tags specified on this property will be added to the generated request traces.
 

--- a/app/_hub/kong-inc/zipkin/1.2.x.md
+++ b/app/_hub/kong-inc/zipkin/1.2.x.md
@@ -99,10 +99,11 @@ params:
         When `header_type` is set to any other value, `default_header_type` is ignored.
     - name: static_tags
       required: false
-      default: {}
-      value_in_examples: [ { name = "color", value = "red" } ]
+      default: []
+      value_in_examples:
       description: |
-        The tags specified on this property will be added to the generated request traces.
+        The tags specified on this property will be added to the generated request traces. For example:
+        `[ { "name": "color", "value": "red" } ]`.
 
 ---
 

--- a/app/_hub/kong-inc/zipkin/1.2.x.md
+++ b/app/_hub/kong-inc/zipkin/1.2.x.md
@@ -100,7 +100,7 @@ params:
     - name: static_tags
       required: false
       default: {}
-      value_in_examples: { { name = "color", value = "red" } }
+      value_in_examples: [ { name = "color", value = "red" } ]
       description: |
         The tags specified on this property will be added to the generated request traces.
 

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -4,6 +4,7 @@ publisher: Kong Inc.
 redirect_from:
   - /hub/kong-inc/zipkin/http-log/
 version: 1.3.x
+# internal handler version 1.3.0 4-26-2021
 
 source_url: https://github.com/Kong/kong-plugin-zipkin
 
@@ -19,6 +20,7 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x
@@ -95,7 +97,9 @@ params:
         with a default of `b3` if none is found. In case of a mismatch between the expected and incoming
         tracing headers (for example, when `header_type` is set to `b3` but a w3c-style tracing header is
         found in the incoming request), then the plugin will add both kinds of tracing headers
-        to the request and generate a mismatch warning in the logs. `jaeger` will use and expect [Jaeger-style tracing headers](https://www.jaegertracing.io/docs/1.22/client-libraries/#propagation-format) (`uber-trace-id`). The `ot` option is for [OpenTelemetry tracing headers](https://github.com/open-telemetry/opentelemetry-java/blob/96e8523544f04c305da5382854eee06218599075/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java) of the form `ot-tracer-*`.
+        to the request and generate a mismatch warning in the logs. `jaeger` will use and expect
+        [Jaeger-style tracing headers](https://www.jaegertracing.io/docs/1.22/client-libraries/#propagation-format) (`uber-trace-id`).
+        The `ot` option is for [OpenTelemetry tracing headers](https://github.com/open-telemetry/opentelemetry-java/blob/96e8523544f04c305da5382854eee06218599075/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java) of the form `ot-tracer-*`.
     - name: default_header_type
       required: true
       default: b3

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -66,11 +66,6 @@ params:
         How often to sample requests that do not contain trace ids.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests. The
         value must be between zero (0) and one (1), inclusive.
-    - name: default_service_name
-      required: false
-      datatype: string
-      description: |
-        The default service name to override the unknown-service-name spans. XX REVIEWERS this option does not appear in the schema?
     - name: include_credential
       required: true
       default: true

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -52,7 +52,7 @@ params:
       required: false
       default: ''
       value_in_examples: http://your.zipkin.collector:9411/api/v2/spans
-      datatype: REVIEWERS
+      datatype: string
       description: |
         The full HTTP(S) endpoint to which Zipkin spans should be sent by Kong.
         If not specified, the Zipkin plugin will only act as a tracing header
@@ -100,7 +100,7 @@ params:
         with a default of `b3` if none is found. In case of a mismatch between the expected and incoming
         tracing headers (for example, when `header_type` is set to `b3` but a w3c-style tracing header is
         found in the incoming request), then the plugin will add both kinds of tracing headers
-        to the request and generate a mismatch warning in the logs. XX REVIEWERS need a description for jaeger and ot.
+        to the request and generate a mismatch warning in the logs. `jaeger` will use and expect [Jaeger-style tracing headers](https://www.jaegertracing.io/docs/1.22/client-libraries/#propagation-format) (`uber-trace-id`). The `ot` option is for [OpenTelemetry tracing headers](https://github.com/open-telemetry/opentelemetry-java/blob/96e8523544f04c305da5382854eee06218599075/extensions/trace_propagators/src/main/java/io/opentelemetry/extensions/trace/propagation/OtTracerPropagator.java) of the form `ot-tracer-*`.
     - name: default_header_type
       required: true
       default: b3
@@ -118,9 +118,8 @@ params:
         XX REVIEWERS need a description
     - name: static_tags
       required: false
-      default: {}
-      value_in_examples: { { name = "color", value = "red" } }
-      datatype: array
+      default: []
+      value_in_examples: [ { name = "color", value = "red" } ]
       description: |
         The tags specified on this property will be added to the generated request traces.
 

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -114,7 +114,12 @@ params:
       default: Zipkin-Tags
       datatype: string
       description: |
-        XX REVIEWERS need a description
+        The Zipkin plugin will add extra headers to the tags associated with any HTTP
+        requests that come with a header named as configured by this property. The 
+        format is `name_of_tag=value_of_tag`, separated by commas. For example: 
+        with the default value, a request with the header 
+        `Zipkin-Tags: fg=blue, bg=red` will generate a trace with the tag `fg` with 
+        value `blue`, and another tag called `bg` with value `red`.
     - name: static_tags
       required: false
       default: []

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -52,7 +52,7 @@ params:
       required: false
       default: ''
       value_in_examples: http://your.zipkin.collector:9411/api/v2/spans
-      datatype:
+      datatype: REVIEWERS
       description: |
         The full HTTP(S) endpoint to which Zipkin spans should be sent by Kong.
         If not specified, the Zipkin plugin will only act as a tracing header
@@ -115,7 +115,7 @@ params:
       default: Zipkin-Tags
       datatype: string
       description: |
-      XX REVIEWERS need a description
+        XX REVIEWERS need a description
     - name: static_tags
       required: false
       default: {}

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -115,15 +115,15 @@ params:
       datatype: string
       description: |
         The Zipkin plugin will add extra headers to the tags associated with any HTTP
-        requests that come with a header named as configured by this property. The 
-        format is `name_of_tag=value_of_tag`, separated by commas. For example: 
-        with the default value, a request with the header 
-        `Zipkin-Tags: fg=blue, bg=red` will generate a trace with the tag `fg` with 
+        requests that come with a header named as configured by this property. The
+        format is `name_of_tag=value_of_tag`, separated by commas. For example:
+        with the default value, a request with the header
+        `Zipkin-Tags: fg=blue, bg=red` will generate a trace with the tag `fg` with
         value `blue`, and another tag called `bg` with value `red`.
     - name: static_tags
       required: false
       default: []
-      value_in_examples: [ { name = "color", value = "red" } ]
+      value_in_examples: [ { name: "color", value: "red" } ]
       description: |
         The tags specified on this property will be added to the generated request traces.
 

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -123,9 +123,11 @@ params:
     - name: static_tags
       required: false
       default: []
-      value_in_examples: [ { name: "color", value: "red" } ]
+      value_in_examples:
+      datatype: array of string tags
       description: |
-        The tags specified on this property will be added to the generated request traces.
+        The tags specified on this property will be added to the generated request traces. For example:
+        `[ { "name": "color", "value": "red" } ]`.
 
 ---
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1653 part of epic https://konghq.atlassian.net/browse/DOCS-1396.

Schema link:

https://github.com/Kong/kong-plugin-zipkin/blob/master/kong/plugins/zipkin/schema.lua

Direct review link:

https://deploy-preview-2713--kongdocs.netlify.app/hub/kong-inc/zipkin/ 

Doc reviewers: focus mainly on the index.md file for review. The older versions had some feedback applied as requested by the SME.

Reviewers: @gszr and @kikito I noticed that this plugin was recently updated to 1.3.x, so I bumped the version while I'm adding datatypes. I noticed some fields in the schema not in the docs, and some fields in the docs not in the schema. I noted that in the index file. I'll need new descriptions as I requested directly in the source. If you were planning to update the plugin docs, please feel free to work directly in this PR.

(Update) I just saw the announcement for 2.4 beta https://kongstrong.slack.com/archives/C0DS8F44W/p1616543679040800, and this plugin was mentioned in the changelog:

https://github.com/Kong/kong/blob/2.4.0-beta.1/CHANGELOG.md#plugins