### PR TITLE
(no ticket) Add links to github from main doc set

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -561,6 +561,44 @@
     font: normal 14px/16px Roboto;
   }
 
+  .github-links {
+    margin-bottom: 1.5em;
+
+    p {
+      padding: 0;
+      position: relative;
+      margin: 0;
+      border: none;
+      padding-bottom: 3px;
+      vertical-align: text-top;
+
+        a {
+          font: normal 14px/22px Roboto;
+          color: #043558;
+
+            img, i {
+              float: left;
+              padding-right: 12px;
+              display: inline-block;
+              width: 16px;
+              opacity: 0.4;
+              position: relative;
+              top: 6px;
+              }
+
+            i {
+              opacity: 1;
+              font-size: 14px;
+              left: 1.5px;
+            }
+
+            &:hover {
+            color: #1155cb;
+            }
+          }
+        }
+      }
+
   ul {
     margin: 0 0 0 4px;
     padding: 0;
@@ -626,6 +664,10 @@
     &.collapsed {
       width: 50px;
       overflow-y: hidden;
+
+      .github-links {
+        visibility: hidden;
+      }
 
       .docs-toc-title,
       > ul {

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -17,6 +17,16 @@ id: documentation
       <i class="fa fa-times close-sidebar"></i>
       <i class="fa fa-chevron-right collapse-toc"></i>
       <i class="far fa-list-alt expand-toc"></i>
+      <div class="github-links">
+        <p>
+            <a href="https://github.com/Kong/docs.konghq.com/edit/master/app/{{page.path}}" target="_blank">
+            <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
+          </p>
+          <p>
+            <a href="https://github.com/Kong/docs.konghq.com/issues" target="_blank">
+            <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue"/>Report an issue</a>
+          </p>
+      </div>
       <div class="docs-toc-title">On this page</div>
       {% include toc.html html=content anchor_class="scroll-to" h_min=2 h_max=3 %}
     </aside>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -251,12 +251,12 @@ breadcrumbs:
             <i class="fa fa-chevron-left"></i>Back to Kong Plugin Hub</a>
           </li>
           <li>
-            <a href="https://github.com/Kong/docs.konghq.com/tree/master/app/{{page.path}}">
-            <img src="/assets/images/logos/logo-github.svg" alt="github"/>Edit this page</a>
+            <a href="https://github.com/Kong/docs.konghq.com/edit/master/app/{{page.path}}" target="_blank">
+            <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
           </li>
           <li>
             <a href="https://github.com/Kong/docs.konghq.com/issues">
-            <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue"/>Report an issue</a>
+            <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue" target="_blank"/>Report an issue</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
### Summary
Adding links to edit this page and open an issue to the right sidebar, above "On this page". 
Changing the existing links on the plugins layout to open in a new tab and directly to editing status.

### Reason
Link to github was removed and overlooked during site redesign. Issue was recently brought up on Slack.

### Testing
Netlify links TBA.