### PR TITLE
[DOCS-1637] LDAP plugin datatypes; advertise enterprise version of plugin

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -21,6 +21,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.3.x
         - 2.2.x
         - 2.1.x
         - 1.5.x
@@ -126,8 +127,8 @@ params:
       datatype: string
       description: |
         An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the
-        request will fail with an authentication failure `4xx`. 
-        
+        request will fail with an authentication failure `4xx`.
+
         **Note:** The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
     - name: header_type
       required: false
@@ -146,7 +147,7 @@ params:
       description: |
         Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the
         LDAP authenticated user. If `consumer_optional=false`, LDAP authenticated users can still access upstream resources.
-        
+
         To prevent access from LDAP users that are not associated with consumers, set `consumer_optional=false`, set the `anonymous` field to an
         existing `consumer_id`, then use the [Request Termination plugin](/hub/kong-inc/request-termination/) to deny any requests from the anonymous consumer.
     - name: consumer_by

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -11,6 +11,17 @@ description: |
   checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
+  <div class="alert alert-ee blue"><strong>Tip:</strong> The LDAP Authentication Advanced plugin
+  provides additional features not available in the open source <a href="/hub/kong-inc/ldap-auth">LDAP Authentication plugin</a>, 
+  such as LDAP searches for group and consumer mapping:
+
+  <ul>
+  <li>Ability to authenticate based on username or custom ID.</li>
+  <li>The ability to bind to an enterprise LDAP directory with a password.</li>
+  <li>The ability to authenticate/authorize using a group base DN and specific group member or group name attributes.</li>
+  </ul>
+  </div>
+
 enterprise: true
 type: plugin
 categories:

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -10,12 +10,16 @@ description: |
   checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
-  <div class="alert alert-warning">
-    <strong>Note:</strong> The functionality of this plugin as bundled
-    with versions of Kong prior to 0.14.1 and Kong Enterprise prior to 0.34
-    differs from what is documented herein. Refer to the
-    <a href="https://github.com/Kong/kong/blob/master/CHANGELOG.md">CHANGELOG</a>
-    for details.
+  <div class="alert alert-ee blue"><strong>Tip:</strong> The
+  <a href="/hub/kong-inc/ldap-auth-advanced/">LDAP Authentication Advanced plugin</a> provides
+  additional features not available in this open source LDAP plugin, such as LDAP searches
+  for group and consumer mapping:
+
+  <ul>
+  <li>Ability to authenticate based on username or custom ID.</li>
+  <li>The ability to bind to an enterprise LDAP directory with a password.</li>
+  <li>The ability to authenticate/authorize using a group base DN and specific group member or group name attributes.</li>
+  </ul>
   </div>
 
 type: plugin

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -1,7 +1,8 @@
 ---
 name: LDAP Authentication
 publisher: Kong Inc.
-version: 2.2.0
+version: 2.2.x
+# internal handler version 2.2.0
 
 desc: Integrate Kong with an LDAP server
 description: |
@@ -59,25 +60,30 @@ params:
   dbless_compatible: yes
   config:
     - name: hide_credentials
-      required: false
+      required: true
       default: "`false`"
       value_in_examples: true
+      datatype: boolean
       description: An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.
     - name: ldap_host
       required: true
       default:
       value_in_examples: ldap.example.com
+      datatype: string
       description: Host on which the LDAP server is running.
     - name: ldap_port
       required: true
       default: 389
       value_in_examples: 389
-      description: TCP port where the LDAP server is listening.  389 is the default
+      datatype: number
+      description: |
+        TCP port where the LDAP server is listening. 389 is the default
         port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is
         configured, you must use port 636.
     - name: start_tls
       required: true
       default: "`false`"
+      datatype: boolean
       description: |
         Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap`
         connection. If the `start_tls` setting is enabled, ensure the `ldaps`
@@ -85,6 +91,7 @@ params:
     - name: ldaps
       required: true
       default: "`false`"
+      datatype: boolean
       description: |
         Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is
         configured, you must use port 636. If the `ldap` setting is enabled, ensure the
@@ -93,38 +100,49 @@ params:
       required: true
       default:
       value_in_examples: dc=example,dc=com
+      datatype: string
       description: Base DN as the starting point for the search; e.g., "dc=example,dc=com".
     - name: verify_ldap_host
       required: true
       default: "`false`"
+      datatype: boolean
       description: |
         Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.
     - name: attribute
       required: true
       default:
       value_in_examples: cn
+      datatype: string
       description: Attribute to be used to search the user; e.g., "cn".
     - name: cache_ttl
       required: true
       default: "`60`"
+      datatype: number
       description: Cache expiry time in seconds.
     - name: timeout
       required: false
       default: "`10000`"
+      datatype: number
       description: An optional timeout in milliseconds when waiting for connection with LDAP server.
     - name: keepalive
       required: false
       default: "`60000`"
-      description: An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.
+      datatype: number
+      description: |
+        An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.
     - name: anonymous
       required: false
       default:
+      datatype: string
       description: |
-        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
+
+        **Note:** The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
     - name: header_type
       required: false
       default: "`ldap`"
       value_in_examples: ldap
+      datatype: string
       description: |
         An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
   extra:


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1637  part of epic https://konghq.atlassian.net/browse/DOCS-1396.

This PR also adds xrefs and advertising of enterprise plugins per @eskibars request  https://konghq.atlassian.net/browse/DOCS-1417 (still in progress):

![image](https://user-images.githubusercontent.com/3756245/112389654-1728e700-8cc3-11eb-8bcc-c1690704f85d.png)

![image](https://user-images.githubusercontent.com/3756245/112389668-1ee88b80-8cc3-11eb-867c-7b98d15f7a80.png)

If anyone has better copy than the items above from the spreadsheets attached to that ticket, that would be most appreciated.


Schema:

https://github.com/Kong/kong-ee/blob/master/kong/plugins/ldap-auth/schema.lua

Direct review link:

https://deploy-preview-2715--kongdocs.netlify.app/hub/kong-inc/ldap-auth/
