### PR TITLE
(no ticket) Remove empty readmes from ee docs [skip ci]

### DIFF
--- a/app/enterprise/0.35-x/README.md
+++ b/app/enterprise/0.35-x/README.md
@@ -1,3 +1,0 @@
-# 0.35 Release
-
-## Add your 0.35 documents to this folder

--- a/app/enterprise/0.36-x/README.md
+++ b/app/enterprise/0.36-x/README.md
@@ -1,3 +1,0 @@
-# 0.35 Release
-
-## Add your 0.35 documents to this folder

--- a/app/enterprise/1.3-x/README.md
+++ b/app/enterprise/1.3-x/README.md
@@ -1,3 +1,0 @@
-# Enterprise 1.3 Release
-
-## Add your 1.3 documents to this folder

--- a/app/enterprise/1.5.x/README.md
+++ b/app/enterprise/1.5.x/README.md
@@ -1,3 +1,0 @@
-# Enterprise 1.5 Release
-
-## Add your 1.5 documents to this folder

--- a/app/enterprise/2.1.x/README.md
+++ b/app/enterprise/2.1.x/README.md
@@ -1,3 +1,0 @@
-# Enterprise 1.5 Release
-
-## Add your 1.5 documents to this folder

--- a/app/enterprise/2.2.x/README.md
+++ b/app/enterprise/2.2.x/README.md
@@ -1,3 +1,0 @@
-# Enterprise 1.5 Release
-
-## Add your 1.5 documents to this folder

--- a/app/enterprise/2.3.x/README.md
+++ b/app/enterprise/2.3.x/README.md
@@ -1,3 +1,0 @@
-# Enterprise 1.5 Release
-
-## Add your 1.5 documents to this folder


### PR DESCRIPTION
### Summary
Removing empty readme files from enterprise pages.

### Reason
These files aren't used for anything. Mostly, they just cause confusion when someone links to the source folder on github: for example, the README in 2.3.x says "Enterprise 1.5 Release; add your 1.5 documents to this folder".

Noticed this when someone on Slack said they were sending doc source links to customers.

### Testing
N/A (purposely skipping netlify build on this as these files are not built with the site)