### PR TITLE
[DOCS-1640] OAuth2 Introspection plugin add datatypes per schema

### DIFF
--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -3,6 +3,7 @@
 name: OAuth 2.0 Introspection
 publisher: Kong Inc.
 version: 1.3-x
+# internal handler version 0.5.2 as of 4-25-2021
 
 desc: Integrate Kong with a third-party OAuth 2.0 Authorization Server
 description: |
@@ -46,88 +47,101 @@ params:
       required: true
       default:
       value_in_examples: https://example-url.com
+      datatype: string
       description: |
-        The full URL to the third-party introspection endpoint
+        The full URL to the third-party introspection endpoint.
     - name: authorization_value
       required: true
       default:
       value_in_examples: Basic MG9hNWlpbjpPcGVuU2VzYW1l
+      datatype: string
       description: |
         The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`).
     - name: token_type_hint
       required: false
       default:
       value_in_examples:
+      datatype: string
       description: |
-        The token_type_hint value to associate to introspection requests
+        The `token_type_hint` value to associate to introspection requests.
     - name: ttl
       required: false
-      default: 60
+      default: 30
       value_in_examples:
+      datatype: number
       description: |
-        The TTL in seconds for the introspection response - set to 0 to disable the expiration
+        The TTL in seconds for the introspection response. Set to 0 to disable the expiration.
     - name: hide_credentials
       required: false
       default:
       value_in_examples:
+      datatype: boolean
       description: |
         An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request.
     - name: timeout
       required: false
       default: 10000
       value_in_examples:
+      datatype: integer
       description: |
-        An optional timeout in milliseconds when sending data to the upstream server
+        An optional timeout in milliseconds when sending data to the upstream server.
     - name: keepalive
       required: false
       default: 60000
       value_in_examples:
+      datatype: integer
       description: |
-        An optional value in milliseconds that defines for how long an idle connection will live before being closed
+        An optional value in milliseconds that defines how long an idle connection lives before being closed.
     - name: anonymous
       required: false
       default:
       value_in_examples:
+      datatype: string
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure 4xx.
     - name: run_on_preflight
       required: false
       default: true
       value_in_examples:
+      datatype: boolean
       description: |
-        A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false` then `OPTIONS` requests will always be allowed.
+        A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed.
     - name: consumer_by
-      required: false
-      default: username
+      required: true
+      default: CONSUMER_BY_DEFAULT
       value_in_examples: username
+      datatype: string
       description: |
-        A string indicating whether to associate oauth2 `username` or `client_id`
-        with the consumer's username. Oauth2 `username` is mapped to a consumer's
-        `username` field, while an oauth2 `client_id` maps to a consumer's
-        `custom_id`
+        A string indicating whether to associate OAuth2 `username` or `client_id`
+        with the consumer's username. OAuth2 `username` is mapped to a consumer's
+        `username` field, while an OAuth2 `client_id` maps to a consumer's
+        `custom_id`.
     - name: introspect_request
-      required: false
+      required: true
       default: false
       value_in_examples:
+      datatype: boolean
       description: |
         A boolean indicating whether to forward information about the current
         downstream request to the introspect endpoint. If true, headers
-        `X-Request-Path` and `X-Request-Http-Method` will be inserted in the
-        introspect request
+        `X-Request-Path` and `X-Request-Http-Method` will be inserted into the
+        introspect request.
     - name: custom_introspection_headers
-      required: false
+      required: true
       default:
       value_in_examples:
+      datatype: map of string values
       description: |
-        A list of custom headers to be added in the introspection request
+        A list of custom headers to be added in the introspection request.
     - name: custom_claims_forward
-      required: false
+      required: true
       default:
       value_in_examples:
+      datatype: set of string elements
       description: |
         A list of custom claims to be forwarded from the introspection response
         to the upstream request. Claims are forwarded in headers with prefix
-        `X-Credential-{claim-name}`
+        `X-Credential-{claim-name}`.
 ---
 
 ### Flow

--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -130,7 +130,7 @@ params:
       required: true
       default:
       value_in_examples:
-      datatype: map of string values
+      datatype: map of string keys and string values
       description: |
         A list of custom headers to be added in the introspection request.
     - name: custom_claims_forward


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCS-1640 part of epic https://konghq.atlassian.net/browse/DOCS-1396.

Schema links:

- https://github.com/Kong/kong-plugin-enterprise-oauth2-introspection/blob/master/kong/plugins/oauth2-introspection/schema.lua
- https://github.com/Kong/kong/blob/master/kong/db/schema/typedefs.lua (URL)

Direct review link:

https://deploy-preview-2718--kongdocs.netlify.app/hub/kong-inc/oauth2-introspection/