### PR TITLE
(no ticket) Limit existing GH actions to public repo only

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -4,6 +4,7 @@ on:
 name: Update indices every day
 jobs:
   updateAlgoliaIndexFullDocs:
+    if: github.repository == 'kong/docs.konghq.com'
     name: Index Full Kong Docs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on:
     types: [synchronize, ready_for_review, opened]
 jobs:
   build:
-    if: github.event.pull_request.draft != true
+    if: github.event.pull_request.draft != true && github.repository == 'kong/docs.konghq.com'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
### Summary
Setting an if condition on the build/test and algolia index workflows so that they will only run in the public repo.

### Reason
Working on introducing repo sync, which means I'll need to re-enable github actions on the docs private repo. Don't want every single action running in both repos.

### Testing
N/A
