### PR TITLE
[DOCS-1361] Line numbers for codeblocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Consult the Table of Contents below, and jump to the desired section.
     - [Links](#links)
     - [Info Blocks](#info-blocks)
     - [Table of Contents generator](#table-of-contents-generator)
+    - [Codeblocks](#codeblocks)
     - [Using navtabs within topics](#using-navtabs-within-topics)
   - [Contributor T-shirt](#contributor-t-shirt)
 
@@ -501,7 +502,9 @@ Codeblocks are containers for your code examples. In Markdown, you can create
 them using three backticks, aka fenced codeblocks:
 
 \```bash
+
 some code here
+
 \```
 
 Include a language whenever possible (in the example above, that language is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,6 +408,7 @@ class: no-copy-code
 # Disables the copy code button in any code blocks on the page.
 ```
 
+[Back to TOC](#table-of-contents)
 
 #### Variables
 Use variables for product names and release versions.
@@ -416,6 +417,7 @@ Use variables for product names and release versions.
 - `{{site.ee_product_name}}` - Kong Enterprise
 - `{{site.ce_product_name}}` - Kong Gateway
 
+[Back to TOC](#table-of-contents)
 
 #### Links
 In markdown(`.md`) files, use relative links with a version variable.
@@ -428,6 +430,8 @@ relative to the versioned folder.
 
 For example, if the project path is `app/enterprise/2.1.x/overview`, the path in
 the nav file would be `/overview`.
+
+[Back to TOC](#table-of-contents)
 
 #### Info Blocks
 
@@ -459,6 +463,8 @@ For a breaking issue or notice of alpha/beta, use:
 </div>
 ```
 
+[Back to TOC](#table-of-contents)
+
 #### Table of Contents generator
 
 Almost all pages have an automatic Table of Contents (ToC) added to the right of
@@ -489,6 +495,34 @@ will cause the first H3 to be skipped, and should be corrected to:
 
 [Back to TOC](#table-of-contents)
 
+#### Codeblocks
+
+Codeblocks are containers for your code examples. In Markdown, you can create
+them using three backticks, aka fenced codeblocks:
+
+\```bash
+some code here
+\```
+
+Include a language whenever possible (in the example above, that language is
+`bash`). This will format your codeblocks using language-specific syntax.
+
+You can also create tabbed codeblocks, so that users can easily switch to
+their preferred format. See [navtabs for codeblocks](#navtabs-for-codeblocks).
+
+##### Line numbers
+By default, every codeblock is generated with line numbers, which is useful for
+calling out specific sections of code. If you need to disable the line numbers,
+use the `{% highlight %}` tag with an optional language class instead of
+ backticks. For example:
+
+```
+{% highlight bash %}
+some code here
+{% endhighlight %}
+```
+
+[Back to TOC](#table-of-contents)
 
 #### Using navtabs within topics
 
@@ -527,6 +561,7 @@ tabbed codeblocks for easy code comparison and better use of space. See
 for an example of this style in use.
 
 > **Important!** Codeblock navtabs must contain codeblocks and **nothing else**.
+Additionally, tabbed codeblocks can't be used in lists or steps.
 
 To create a tabbed codeblock, specify the `codeblock` class in the first element
 when creating a `navtabs` group:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,11 +501,11 @@ will cause the first H3 to be skipped, and should be corrected to:
 Codeblocks are containers for your code examples. In Markdown, you can create
 them using three backticks, aka fenced codeblocks:
 
-\```bash
-
-some code here
-
-\```
+<code>
+```bash</br>
+some code here</br>
+```
+</code>
 
 Include a language whenever possible (in the example above, that language is
 `bash`). This will format your codeblocks using language-specific syntax.
@@ -551,7 +551,7 @@ Here's some more content.
 {% endnavtabs %}
 ```
 
-On initial page load, the first tab ("<your title here>" in the example above)
+On initial page load, the first tab (`"<your title here>"` in the example above)
 will be the one displayed.
 
 > **Note:** You can’t nest navtabs within navtabs.

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -660,7 +660,7 @@ $(function () {
       copyInput.text(
         snippet.data("copy-code") ||
           snippet
-            .find("code")
+            .find(".rouge-code")
             .text()
             .replace(/^\s*\$\s*/gi, "")
       );

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -881,6 +881,47 @@
     }
   }
 
+  /* Rouge syntax and line numbers */
+
+  pre.highlight {
+      padding: 1rem 1.5rem;
+      overflow: auto;
+      line-height: 1.4rem;
+      position: relative;
+  }
+
+  table.rouge-table,
+  table.rouge-table tr,
+  table.rouge-table td,
+  table.rouge-table pre {
+      border: 0;
+      padding: 0;
+      margin: 0;
+      overflow: visible;
+      display: inline-block;
+      font-family: @family-code;
+  }
+
+  table.rouge-table td.rouge-gutter {
+      padding-right: 0.8rem;
+      border-right: 1px solid @gray;
+  }
+
+  table.rouge-table td.rouge-code {
+      padding-left: 0.8em;
+  }
+
+  figure pre {
+      margin-bottom: 0;
+  }
+
+  .lineno {
+      text-align: center;
+      height: 100%;
+      min-width: 1.6rem;
+      color: @gray-dark;
+  }
+
   blockquote {
     opacity: 0.8;
     margin-left: 0;
@@ -1010,8 +1051,8 @@ Generic Styling for Desktop
     grid-column-gap: 16px;
     grid-row-gap: 16px;
     margin: 0;
-    justify-content: start;
-    align-content: start;
+    justify-content: flex-start;
+    align-content: flex-start;
 
     &:after {
       content: " ";
@@ -1029,7 +1070,7 @@ Generic Styling for Desktop
       flex-direction: column;
       -webkit-box-pack: justify;
       -ms-flex-pack: justify;
-      justify-content: start;
+      justify-content: flex-start;
       padding: 16px;
       text-decoration: none;
       margin-top: 0;
@@ -1071,8 +1112,8 @@ Generic Styling for Desktop
     grid-row-gap: 16px;
     max-width: 600px;
     margin: 0;
-    justify-content: start;
-    align-content: start;
+    justify-content: flex-start;
+    align-content: flex-start;
 
     .docs-grid-install-block {
       border: 1px solid #9dc6e3;
@@ -1084,7 +1125,7 @@ Generic Styling for Desktop
       align-items: center;
       -webkit-box-pack: justify;
       -ms-flex-pack: justify;
-      justify-content: start;
+      justify-content: flex-start;
       padding: 16px;
       text-decoration: none;
 

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -905,6 +905,10 @@
   table.rouge-table td.rouge-gutter {
       padding-right: 0.8rem;
       border-right: 1px solid @gray;
+
+      @media (max-width: 1100px) {
+        margin-left: -1.2rem;
+      }
   }
 
   table.rouge-table td.rouge-code {
@@ -918,7 +922,7 @@
   .lineno {
       text-align: center;
       height: 100%;
-      min-width: 1.6rem;
+      min-width: 1.8rem;
       color: @gray-dark;
   }
 

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -144,8 +144,8 @@
 
     table.indent {
       width: -moz-available;
-      width: -webkit-fill-available;
-      width: fill-available;
+      width: -webkit-stretch;
+      width: stretch;
     }
 
     // titles proportions overridden from base.less

--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -29,17 +29,17 @@ To complete this installation you will need a Docker-enabled system with proper
 
 Using Docker, pull the following Docker image:
 
-{% highlight bash %}
+```bash
 $ docker pull kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[10].version}}-alpine
-{% endhighlight %}
+```
 
 You should now have your {{site.base_gateway}} image locally.
 
 Verify that it worked, and find the image ID matching your repository:
 
-{% highlight bash %}
+```bash
 $ docker images
-{% endhighlight %}
+```
 
 Tag the image ID for easier use:
 
@@ -73,14 +73,14 @@ $ docker run -d --name kong-ee-database \
 
 ## Step 4. Prepare the Kong database
 
-{% highlight bash %} 
+```bash
 $ docker run --rm --network=kong-ee-net \
   -e "KONG_DATABASE=postgres" \
   -e "KONG_PG_HOST=kong-ee-database" \
   -e "KONG_PG_PASSWORD=kong" \
   -e "KONG_PASSWORD=<SOMETHING-YOU-KNOW>" \
   kong-ee kong migrations bootstrap
-{% endhighlight %}
+```
 
 **Note**: For `KONG_PASSWORD`, replace `<SOMETHING-YOU-KNOW>` with a valid password that only you know.
 
@@ -107,6 +107,7 @@ $ docker run -d --name kong-ee --network=kong-ee-net \
   -p 8004:8004 \
   kong-ee
 ```
+
 <div class="alert alert-ee">
 <b>Note:</b> For <code>KONG_ADMIN_GUI_URL</code>, replace <code>&lt;DNSorIP&gt;</code>
 with with the DNS name or IP of the Docker host. <code>KONG_ADMIN_GUI_URL</code>

--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -29,17 +29,17 @@ To complete this installation you will need a Docker-enabled system with proper
 
 Using Docker, pull the following Docker image:
 
-```bash
+{% highlight bash %}
 $ docker pull kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[10].version}}-alpine
-```
+{% endhighlight %}
 
 You should now have your {{site.base_gateway}} image locally.
 
 Verify that it worked, and find the image ID matching your repository:
 
-```bash
+{% highlight bash %}
 $ docker images
-```
+{% endhighlight %}
 
 Tag the image ID for easier use:
 
@@ -73,14 +73,14 @@ $ docker run -d --name kong-ee-database \
 
 ## Step 4. Prepare the Kong database
 
-```bash
+{% highlight bash %} 
 $ docker run --rm --network=kong-ee-net \
   -e "KONG_DATABASE=postgres" \
   -e "KONG_PG_HOST=kong-ee-database" \
   -e "KONG_PG_PASSWORD=kong" \
   -e "KONG_PASSWORD=<SOMETHING-YOU-KNOW>" \
   kong-ee kong migrations bootstrap
-```
+{% endhighlight %}
 
 **Note**: For `KONG_PASSWORD`, replace `<SOMETHING-YOU-KNOW>` with a valid password that only you know.
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -6,8 +6,6 @@ timezone: America/San_Francisco
 markdown: kramdown
 kramdown:
   syntax_highlighter_opts:
-    formatter: Rouge::Formatters::HTMLLineTable
-    default_lang: html
     css_class: 'highlight'
     span:
       line_numbers: false

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -4,6 +4,16 @@ destination: dist
 permalink: pretty
 timezone: America/San_Francisco
 markdown: kramdown
+kramdown:
+  syntax_highlighter_opts:
+    formatter: Rouge::Formatters::HTMLLineTable
+    default_lang: html
+    css_class: 'highlight'
+    span:
+      line_numbers: false
+    block:
+      line_numbers: true
+      start_line: 1
 incremental: true
 
 keep_files:

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -6,8 +6,6 @@ timezone: America/San_Francisco
 markdown: kramdown
 kramdown:
   syntax_highlighter_opts:
-    formatter: Rouge::Formatters::HTMLLineTable
-    default_lang: html
     css_class: 'highlight'
     span:
       line_numbers: false

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -4,6 +4,16 @@ destination: dist
 permalink: pretty
 timezone: America/San_Francisco
 markdown: kramdown
+kramdown:
+  syntax_highlighter_opts:
+    formatter: Rouge::Formatters::HTMLLineTable
+    default_lang: html
+    css_class: 'highlight'
+    span:
+      line_numbers: false
+    block:
+      line_numbers: true
+      start_line: 1
 incremental: true
 
 keep_files:


### PR DESCRIPTION
### Summary
Adding line numbers to codeblocks by default. 

With this feature, all codeblocks in the docs will have numbered lines. This will help authors call out specific content in the docs, and when referencing code examples externally (for support, for example). 

One-line codeblocks will also be numbered. This is mainly for visual consistency and alignment; it would also be a decent chunk of work to get one-liners to pick up a different style by default, so ideally we won't be doing that. 

#### Using codeblocks without line numbers
You can disable line numbers for a codeblock by using liquid tags instead of fenced codeblocks.

Default (fenced code blocks):
\```bash
some code here
\```

To remove line numbers, use the `{% highlight %}` tag with an optional language class:

{% highlight bash %}
some code here
{% endhighlight %}

### Reason
https://konghq.atlassian.net/browse/DOCS-1361

### Testing
Anywhere that codeblocks exist in the docs. Eg https://deploy-preview-2724--kongdocs.netlify.app/hub/kong-inc/application-registration/