### PR TITLE
docs(plugins) logging customizability

### DIFF
--- a/app/_hub/kong-inc/file-log/2.0.x.md
+++ b/app/_hub/kong-inc/file-log/2.0.x.md
@@ -1,12 +1,18 @@
 ---
-name: UDP Log
+name: File Log
 publisher: Kong Inc.
-version: 2.1.x
-# internal handler version 2.1.0
+version: 2.0.x
+# internal handler version 2.0.2
 
-desc: Send request and response logs to a UDP server
+desc: Append request and response data to a log file
 description: |
-  Log request and response data to an UDP server.
+  Append request and response data in JSON format to a log file. You can also specify
+  streams (for example, `/dev/stdout` and `/dev/stderr`), which is especially useful
+  when running Kong in Kubernetes.
+
+  This plugin uses blocking I/O, which could affect performance when writing
+  to physical files on slow (spinning) disks.
+
 
 type: plugin
 categories:
@@ -15,12 +21,11 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x
+        - 1.5.x      
         - 1.4.x
         - 1.3.x
         - 1.2.x
@@ -38,10 +43,8 @@ kong_version_compatibility:
         - 0.5.x
         - 0.4.x
         - 0.3.x
-        - 0.2.x
     enterprise_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -49,30 +52,30 @@ kong_version_compatibility:
         - 1.3-x
         - 0.36-x
 
+
 params:
-  name: udp-log
+  name: file-log
   service_id: true
   route_id: true
   consumer_id: true
   protocols: ["http", "https", "grpc", "grpcs", "tcp", "tls", "udp"]
   dbless_compatible: yes
   config:
-    - name: host
+    - name: path
       required: true
-      value_in_examples: 127.0.0.1
+      default:
+      value_in_examples: "/tmp/file.log"
       datatype: string
-      description: The IP address or host name to send data to.
-    - name: port
+      description: |
+        The file path of the output log file. The plugin creates the log file if it doesn't exist yet. Make sure Kong has write permissions to this file.
+    - name: reopen
       required: true
-      value_in_examples: 9999
-      datatype: integer
-      description: The port to send data to on the upstream server.
-    - name: timeout
-      required: false
-      default: "`10000`"
-      value_in_examples: 10000
-      datatype: number
-      description: An optional timeout in milliseconds when sending data to the upstream server.
+      default: "`false`"
+      datatype: boolean
+      description: |
+        Determines whether the log file is closed and reopened on every request. If the file
+        is not reopened, and has been removed/rotated, the plugin keeps writing to the
+        stale file descriptor, and hence loses information.
 
 ---
 

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -1,8 +1,8 @@
 ---
 name: File Log
 publisher: Kong Inc.
-version: 2.0.x
-# internal handler version 2.0.2
+version: 2.1.x
+# internal handler version 2.1.0
 
 desc: Append request and response data to a log file
 description: |
@@ -21,11 +21,12 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x      
+        - 1.5.x
         - 1.4.x
         - 1.3.x
         - 1.2.x
@@ -45,6 +46,7 @@ kong_version_compatibility:
         - 0.3.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/file-log/index.md
+++ b/app/_hub/kong-inc/file-log/index.md
@@ -78,6 +78,14 @@ params:
         Determines whether the log file is closed and reopened on every request. If the file
         is not reopened, and has been removed/rotated, the plugin keeps writing to the
         stale file descriptor, and hence loses information.
+    - name: custom_fields_by_lua
+      required: false
+      default:
+      datatype: map
+      description: |
+        A list of key-value pairs, where the key is the name of a log field and
+        the value is a chunk of Lua code, whose return value sets or replaces
+        the log field value.
 
 ---
 
@@ -92,3 +100,7 @@ params:
 ## Kong process errors
 
 {% include /md/plugins-hub/kong-process-errors.md %}
+
+## Custom Fields by Lua
+
+{% include /md/plugins-hub/log_custom_fields_by_lua.md %}

--- a/app/_hub/kong-inc/http-log/2.0.x.md
+++ b/app/_hub/kong-inc/http-log/2.0.x.md
@@ -1,8 +1,8 @@
 ---
 name: HTTP Log
 publisher: Kong Inc.
-version: 2.1.x
-# internal handler version 2.1.0
+version: 2.0.x
+# internal handler version 2.0.1
 
 desc: Send request and response logs to an HTTP server
 description: |
@@ -15,7 +15,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -40,7 +39,6 @@ kong_version_compatibility:
         - 0.3.x
     enterprise_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -121,6 +121,14 @@ params:
     **NOTE:** If the `config.http_endpoint` contains a username and password (for example,
     `http://bob:password@example.com/logs`), then Kong Gateway automatically includes
     a basic-auth `Authorization` header in the log requests.
+    - name: custom_fields_by_lua
+      required: false
+      default:
+      datatype: map
+      description: |
+        A list of key-value pairs, where the key is the name of a log field and
+        the value is a chunk of Lua code, whose return value sets or replaces
+        the log field value.
 
 ---
 
@@ -137,3 +145,7 @@ params:
 ## Kong process errors
 
 {% include /md/plugins-hub/kong-process-errors.md %}
+
+## Custom Fields by Lua
+
+{% include /md/plugins-hub/log_custom_fields_by_lua.md %}

--- a/app/_hub/kong-inc/loggly/2.0.x.md
+++ b/app/_hub/kong-inc/loggly/2.0.x.md
@@ -1,8 +1,8 @@
 ---
 name: Loggly
 publisher: Kong Inc.
-version: 2.1.x
-# internal handler version 2.1.0
+version: 2.0.x
+# internal handler version 2.0.1
 
 desc: Send request and response logs to Loggly
 description: |
@@ -15,12 +15,11 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
         - 2.0.x
-        - 1.5.x
+        - 1.5.x      
         - 1.4.x
         - 1.3.x
         - 1.2.x
@@ -37,7 +36,6 @@ kong_version_compatibility:
         - 0.6.x
     enterprise_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -113,6 +113,14 @@ params:
         An optional logging severity, any request with equal or higher severity will be
         logged to Loggly. Available options: `debug`, `info`, `notice`, `warning`, `err`,
         `crit`, `alert`, `emerg`.
+    - name: custom_fields_by_lua
+      required: false
+      default:
+      datatype: map
+      description: |
+        A list of key-value pairs, where the key is the name of a log field and
+        the value is a chunk of Lua code, whose return value sets or replaces
+        the log field value.
 
 ---
 
@@ -133,3 +141,7 @@ logging level severity the same as or lower than the set `config.log_level` for 
 ## Kong process errors
 
 {% include /md/plugins-hub/kong-process-errors.md %}
+
+## Custom Fields by Lua
+
+{% include /md/plugins-hub/log_custom_fields_by_lua.md %}

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -273,31 +273,7 @@ without requiring redeploying or restarting Kong.
 
 Starting with version 2.0 of the plugin, the provided Lua environment is sandboxed.
 
-The sandboxing consists of several limitations in the way the Lua code can be executed,
-for heightened security.
-
-The following functions are not available because they can be used to abuse the system:
-
-* `string.rep`: Can be used to allocate millions of bytes in one operation.
-* `{set|get}metatable`: Can be used to modify the metatables of global objects (strings, numbers).
-* `collectgarbage`: Can be abused to kill the performance of other workers.
-* `_G`: Is the root node which has access to all functions. It is masked by a temporary table.
-* `load{file|string}`: Is deemed unsafe because it can grant access to global environment.
-* `raw{get|set|equal}`: Potentially unsafe because the sandboxing relies on some metatable manipulation.
-* `string.dump`: Can display confidential server information (such as implementation of functions).
-* `math.randomseed`: Can affect the host system. {{site.base_gateway}} already seeds the random number generator properly.
-* All `os.*` (except `os.clock`, `os.difftime`, and `os.time`). `os.execute` can significantly alter the host system.
-* `io.*`: Provides access to the hard drive.
-* `dofile|require`: Provides access to the hard drive.
-
-The exclusion of `require` means that Plugins must only use PDK functions `kong.*`. The `ngx.*` abstraction is
-also available, but it is not guaranteed to be present in future versions of the plugin.
-
-In addition to the above restrictions:
-
-* All the provided modules (like `string` or `table`) are read-only and can't be modified.
-* Bytecode execution is disabled.
-
+{% include /md/plugins-hub/sandbox.md %}
 
 #### Upvalues
 

--- a/app/_hub/kong-inc/syslog/2.0.x.md
+++ b/app/_hub/kong-inc/syslog/2.0.x.md
@@ -1,8 +1,8 @@
 ---
 name: Syslog
 publisher: Kong Inc.
-version: 2.1.x
-# internal handler version 2.1.0
+version: 2.0.x
+# internal handler version 2.0.1
 
 desc: Send request and response logs to Syslog
 description: |
@@ -15,7 +15,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -37,7 +36,6 @@ kong_version_compatibility:
         - 0.6.x
     enterprise_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -82,6 +82,14 @@ params:
       description: |
         An optional logging severity. Any request with equal or higher severity
         will be logged to System log. Available options: `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `emerg`.
+    - name: custom_fields_by_lua
+      required: false
+      default:
+      datatype: map
+      description: |
+        A list of key-value pairs, where the key is the name of a log field and
+        the value is a chunk of Lua code, whose return value sets or replaces
+        the log field value.
 
 ---
 
@@ -102,3 +110,7 @@ logging level severity the same as or lower than the set `config.log_level` for 
 ## Kong process errors
 
 {% include /md/plugins-hub/kong-process-errors.md %}
+
+## Custom Fields by Lua
+
+{% include /md/plugins-hub/log_custom_fields_by_lua.md %}

--- a/app/_hub/kong-inc/tcp-log/2.0.x.md
+++ b/app/_hub/kong-inc/tcp-log/2.0.x.md
@@ -1,12 +1,13 @@
 ---
-name: UDP Log
+name: TCP Log
 publisher: Kong Inc.
-version: 2.1.x
-# internal handler version 2.1.0
+version: 2.0.x
+# internal handler version 2.0.1
 
-desc: Send request and response logs to a UDP server
+desc: Send request and response logs to a TCP server
 description: |
-  Log request and response data to an UDP server.
+  Log request and response data to a TCP server.
+
 
 type: plugin
 categories:
@@ -15,7 +16,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -41,7 +41,6 @@ kong_version_compatibility:
         - 0.2.x
     enterprise_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -50,7 +49,7 @@ kong_version_compatibility:
         - 0.36-x
 
 params:
-  name: udp-log
+  name: tcp-log
   service_id: true
   route_id: true
   consumer_id: true
@@ -70,9 +69,23 @@ params:
     - name: timeout
       required: false
       default: "`10000`"
-      value_in_examples: 10000
       datatype: number
       description: An optional timeout in milliseconds when sending data to the upstream server.
+    - name: keepalive
+      required: false
+      default: "`60000`"
+      datatype: number
+      description: An optional value in milliseconds that defines how long an idle connection lives before being closed.
+    - name: tls
+      required: true
+      default: false
+      datatype: boolean
+      description: Indicates whether to perform a TLS handshake against the remote server.
+    - name: tls_sni
+      required: false
+      default:
+      datatype: string
+      description: An optional string that defines the SNI (Server Name Indication) hostname to send in the TLS handshake.
 
 ---
 

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -1,8 +1,8 @@
 ---
 name: TCP Log
 publisher: Kong Inc.
-version: 2.0.x
-# internal handler version 2.0.1
+version: 2.1.x
+# internal handler version 2.1.0
 
 desc: Send request and response logs to a TCP server
 description: |
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -41,6 +42,7 @@ kong_version_compatibility:
         - 0.2.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -88,6 +88,14 @@ params:
       default:
       datatype: string
       description: An optional string that defines the SNI (Server Name Indication) hostname to send in the TLS handshake.
+    - name: custom_fields_by_lua
+      required: false
+      default:
+      datatype: map
+      description: |
+        A list of key-value pairs, where the key is the name of a log field and
+        the value is a chunk of Lua code, whose return value sets or replaces
+        the log field value.
 
 ---
 
@@ -102,3 +110,7 @@ params:
 ## Kong process errors
 
 {% include /md/plugins-hub/kong-process-errors.md %}
+
+## Custom Fields by Lua
+
+{% include /md/plugins-hub/log_custom_fields_by_lua.md %}

--- a/app/_hub/kong-inc/udp-log/2.0.x.md
+++ b/app/_hub/kong-inc/udp-log/2.0.x.md
@@ -1,8 +1,8 @@
 ---
 name: UDP Log
 publisher: Kong Inc.
-version: 2.1.x
-# internal handler version 2.1.0
+version: 2.0.x
+# internal handler version 2.0.1
 
 desc: Send request and response logs to a UDP server
 description: |
@@ -15,7 +15,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
@@ -41,7 +40,6 @@ kong_version_compatibility:
         - 0.2.x
     enterprise_edition:
       compatible:
-        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -73,6 +73,14 @@ params:
       value_in_examples: 10000
       datatype: number
       description: An optional timeout in milliseconds when sending data to the upstream server.
+    - name: custom_fields_by_lua
+      required: false
+      default:
+      datatype: map
+      description: |
+        A list of key-value pairs, where the key is the name of a log field and
+        the value is a chunk of Lua code, whose return value sets or replaces
+        the log field value.
 
 ---
 
@@ -87,3 +95,7 @@ params:
 ## Kong process errors
 
 {% include /md/plugins-hub/kong-process-errors.md %}
+
+## Custom Fields by Lua
+
+{% include /md/plugins-hub/log_custom_fields_by_lua.md %}

--- a/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
+++ b/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
@@ -1,0 +1,29 @@
+The `custom_fields_by_lua` configuration allows for the dynamic modification of
+log fields using Lua code. Below is an example configuration that removes the
+existing `route` field in the logs:
+
+```
+curl -i -X POST --url http://kong:8001/plugins ... --data config.custom_fields_by_lua.route="return nil"
+```
+
+Similarly, new fields can be added:
+
+```
+curl -i -X POST --url http://kong:8001/plugins ... --data config.custom_fields_by_lua.header="return kong.request.get_header('h1')"
+```
+
+### Limitations
+
+Lua code runs in a restricted sandbox environment, whose behavior is governed
+by the `untrusted_lua` [configuration properties][configuration] configuration
+properties.
+
+{% include /md/plugins-hub/sandbox.md %}
+
+Further, as code runs in the context of the log phase, only [PDK][pdk] methods
+that can run in said phase can be used.
+
+---
+
+[configuration]: /latest/configuration
+[pdk]: /latest/pdk

--- a/app/_includes/md/plugins-hub/sandbox.md
+++ b/app/_includes/md/plugins-hub/sandbox.md
@@ -1,0 +1,26 @@
+<!---shared with plugins that accept custom lua code --->
+
+The sandboxing consists of several limitations in the way the Lua code can be executed,
+for heightened security.
+
+The following functions are not available because they can be used to abuse the system:
+
+* `string.rep`: Can be used to allocate millions of bytes in one operation.
+* `{set|get}metatable`: Can be used to modify the metatables of global objects (strings, numbers).
+* `collectgarbage`: Can be abused to kill the performance of other workers.
+* `_G`: Is the root node which has access to all functions. It is masked by a temporary table.
+* `load{file|string}`: Is deemed unsafe because it can grant access to global environment.
+* `raw{get|set|equal}`: Potentially unsafe because the sandboxing relies on some metatable manipulation.
+* `string.dump`: Can display confidential server information (such as implementation of functions).
+* `math.randomseed`: Can affect the host system. {{site.base_gateway}} already seeds the random number generator properly.
+* All `os.*` (except `os.clock`, `os.difftime`, and `os.time`). `os.execute` can significantly alter the host system.
+* `io.*`: Provides access to the hard drive.
+* `dofile|require`: Provides access to the hard drive.
+
+The exclusion of `require` means that Plugins must only use PDK functions `kong.*`. The `ngx.*` abstraction is
+also available, but it is not guaranteed to be present in future versions of the plugin.
+
+In addition to the above restrictions:
+
+* All the provided modules (like `string` or `table`) are read-only and can't be modified.
+* Bytecode execution is disabled.

--- a/app/_includes/md/plugins-hub/sandbox.md
+++ b/app/_includes/md/plugins-hub/sandbox.md
@@ -1,6 +1,6 @@
 <!---shared with plugins that accept custom lua code --->
 
-The sandboxing consists of several limitations in the way the Lua code can be executed,
+Sandboxing consists of several limitations in the way the Lua code can be executed,
 for heightened security.
 
 The following functions are not available because they can be used to abuse the system:
@@ -9,15 +9,15 @@ The following functions are not available because they can be used to abuse the 
 * `{set|get}metatable`: Can be used to modify the metatables of global objects (strings, numbers).
 * `collectgarbage`: Can be abused to kill the performance of other workers.
 * `_G`: Is the root node which has access to all functions. It is masked by a temporary table.
-* `load{file|string}`: Is deemed unsafe because it can grant access to global environment.
-* `raw{get|set|equal}`: Potentially unsafe because the sandboxing relies on some metatable manipulation.
+* `load{file|string}`: Is deemed unsafe because it can grant access to the global environment.
+* `raw{get|set|equal}`: Potentially unsafe because sandboxing relies on some metatable manipulation.
 * `string.dump`: Can display confidential server information (such as implementation of functions).
 * `math.randomseed`: Can affect the host system. {{site.base_gateway}} already seeds the random number generator properly.
 * All `os.*` (except `os.clock`, `os.difftime`, and `os.time`). `os.execute` can significantly alter the host system.
 * `io.*`: Provides access to the hard drive.
 * `dofile|require`: Provides access to the hard drive.
 
-The exclusion of `require` means that Plugins must only use PDK functions `kong.*`. The `ngx.*` abstraction is
+The exclusion of `require` means that plugins must only use PDK functions `kong.*`. The `ngx.*` abstraction is
 also available, but it is not guaranteed to be present in future versions of the plugin.
 
 In addition to the above restrictions:


### PR DESCRIPTION
### Review

@reviewer @Kong/team-docs 

### Summary

- Create a `sandbox.md` include (with contents currently present in serverless-plugin sandbox section), to be shared among plugins that leverage Kong's sandbox
- Add new version to logging plugins - http-log, tcp-log, udp-log, file-log, syslog, loggly
- Add docs for "custom fields by lua" feature to logging plugins