### PR TITLE
(no ticket) Fix edit this page links and adjust spacing

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -569,7 +569,7 @@
       position: relative;
       margin: 0;
       border: none;
-      padding-bottom: 3px;
+      padding-bottom: 6px;
       vertical-align: text-top;
 
         a {

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -19,7 +19,7 @@ id: documentation
       <i class="far fa-list-alt expand-toc"></i>
       <div class="github-links">
         <p>
-            <a href="https://github.com/Kong/docs.konghq.com/edit/master/app/{{page.path}}" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/edit/main/app/{{page.path}}" target="_blank">
             <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
           </p>
           <p>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -251,7 +251,7 @@ breadcrumbs:
             <i class="fa fa-chevron-left"></i>Back to Kong Plugin Hub</a>
           </li>
           <li>
-            <a href="https://github.com/Kong/docs.konghq.com/edit/master/app/{{page.path}}" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/edit/main/app/{{page.path}}" target="_blank">
             <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
           </li>
           <li>


### PR DESCRIPTION
### Summary
Fixing links to edit this page and making a minor adjustment to line spacing.

### Reason
Links to "edit this page" are going to the now non-existent `master` branch and not getting redirected to `main`.

Issue reported on Slack.

### Testing
Spot-check a couple of "edit this page" links and make sure they don't 404: 
https://deploy-preview-2732--kongdocs.netlify.app/enterprise/2.3.x/introduction/
https://deploy-preview-2732--kongdocs.netlify.app/hub/kong-inc/application-registration/