### PR TITLE
(no ticket) Fix key_name syntax for key auth plugins

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/1.0.x.md
+++ b/app/_hub/kong-inc/key-auth-enc/1.0.x.md
@@ -33,6 +33,7 @@ params:
     - name: key_names
       required: false
       default: "`apikey`"
+      value_in_examples: ["apikey"]
       description: |
         Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the query string parameter with the same name.<br><br>**Note**: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
     - name: key_in_body

--- a/app/_hub/kong-inc/key-auth-enc/index.md
+++ b/app/_hub/kong-inc/key-auth-enc/index.md
@@ -42,6 +42,7 @@ params:
     - name: key_names
       required: true
       default: "`apikey`"
+      value_in_examples: ["apikey"]
       datatype: array of strings
       description: |
         Describes an array of parameter names where the plugin will look for a key. The client must send the

--- a/app/_hub/kong-inc/key-auth/0.2.x.md
+++ b/app/_hub/kong-inc/key-auth/0.2.x.md
@@ -52,6 +52,7 @@ params:
     - name: key_names
       required: false
       default: "`apikey`"
+      value_in_examples: ["apikey"]
       description: |
         Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-]. Underscores are not permitted for keys in headers due to [additional restrictions in the NGINX defaults](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers).
     - name: key_in_body

--- a/app/_hub/kong-inc/key-auth/2.1.x.md
+++ b/app/_hub/kong-inc/key-auth/2.1.x.md
@@ -68,6 +68,7 @@ params:
     - name: key_names
       required: false
       default: "`apikey`"
+      value_in_examples: ["apikey"]
       description: |
         Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the query string parameter with the same name.<br><br>**Note**: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
     - name: key_in_body

--- a/app/_hub/kong-inc/key-auth/2.2.x.md
+++ b/app/_hub/kong-inc/key-auth/2.2.x.md
@@ -72,6 +72,7 @@ params:
     - name: key_names
       required: true
       default: "`apikey`"
+      value_in_examples: ["apikey"]
       datatype: array of strings
       description: |
         Describes an array of parameter names where the plugin will look for a key. The client must send the

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -70,6 +70,7 @@ params:
     - name: key_names
       required: true
       default: "`apikey`"
+      value_in_examples: ["apikey"]
       datatype: array of strings
       description: |
         Describes an array of parameter names where the plugin will look for a key. The client must send the

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -48,8 +48,7 @@ endcapture %}
 %}{% endcapture %}
 
 <!-- Generate declarative yaml examples -->
-{% capture config_required_fields_yaml %}config: {% for field in page.params.config %}{% if field.value_in_examples != nil %}{% if field.value_in_examples.first %}
-        {% if field.name contains "." %}{% assign names = field.name | split: "." %}{{ names[0] }}:{%
+{% capture config_required_fields_yaml %}config: {% for field in page.params.config %}{% if field.value_in_examples != nil %}{% if field.value_in_examples.first %}{% if field.name contains "." %}{% assign names = field.name | split: "." %}{{ names[0] }}:{%
       for name in names offset:1 %}
       {{ name }}:{% endfor %}{%
       for value in field.value_in_examples %}


### PR DESCRIPTION
### Review
@ashosborne 

### Summary
Add `value_in_examples` to display the desired array syntax for the `key_name` value in the key auth plugins.
Also fixing the extra blank space that appears before declarative config example arrays.

### Reason
The `key_name` value is not displaying correctly in declarative examples. It should be an array.

Issue reported on Slack.

### Testing
See the declarative tab in
https://deploy-preview-2733--kongdocs.netlify.app/hub/kong-inc/key-auth-enc/ and
https://deploy-preview-2733--kongdocs.netlify.app/hub/kong-inc/key-auth/
