### PR TITLE
added ee 2.1.4.5 changelog entry

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -756,7 +756,6 @@ open-source **Kong Gateway 2.2.0.0**:
 ### Fixes
 
 #### Enterprise
-
 Fixed an issue when upgrading Kong Enterprise Gateway from v1.5.x to v2.1.x. Before the fix, when admin consumers were shared across multiple workspaces, it was possible for the migration to fail. This happened because plugin entities that depend on consumer entities must live in the same workspace as the consumer entity. This fix migrates these plugin entities to the same workspace as the consumer entities. Customers affected by this issue will need to upgrade to at least v2.1.4.5 before attempting to migrate from v1.5.x to v2.1.x.
 
 ## 2.1.4.4

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -750,6 +750,15 @@ open-source **Kong Gateway 2.2.0.0**:
 - The `shorthands` attribute in schema definitions is deprecated in favor of
   the new `shorthand_fields` top-level attribute.
 
+## 2.1.4.5
+**Release Date** 2021/31/03
+
+### Fixes
+
+#### Enterprise
+
+Fixed an issue when upgrading Kong Enterprise Gateway from v1.5.x to v2.1.x. Before the fix, when admin consumers were shared across multiple workspaces, it was possible for the migration to fail. This happened because plugin entities that depend on consumer entities must live in the same workspace as the consumer entity. This fix migrates these plugin entities to the same workspace as the consumer entities. Customers affected by this issue will need to upgrade to at least v2.1.4.5 before attempting to migrate from v1.5.x to v2.1.x.
+
 ## 2.1.4.4
 **Release Date** 2021/03/26
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -751,7 +751,7 @@ open-source **Kong Gateway 2.2.0.0**:
   the new `shorthand_fields` top-level attribute.
 
 ## 2.1.4.5
-**Release Date** 2021/31/03
+**Release Date** 2021/03/31
 
 ### Fixes
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -756,7 +756,7 @@ open-source **Kong Gateway 2.2.0.0**:
 ### Fixes
 
 #### Enterprise
-Fixed an issue when upgrading Kong Enterprise Gateway from v1.5.x to v2.1.x. Before the fix, when admin consumers were shared across multiple workspaces, it was possible for the migration to fail. This happened because plugin entities that depend on consumer entities must live in the same workspace as the consumer entity. This fix migrates these plugin entities to the same workspace as the consumer entities. Customers affected by this issue will need to upgrade to at least v2.1.4.5 before attempting to migrate from v1.5.x to v2.1.x.
+Fixed an issue when upgrading Kong Gateway (Enterprise) from v1.5.x to v2.1.x. Before the fix, when admin consumers were shared across multiple workspaces, it was possible for the migration to fail. This happened because plugin entities that depend on consumer entities must live in the same workspace as the consumer entity. This fix migrates these plugin entities to the same workspace as the consumer entities. Customers affected by this issue will need to upgrade to at least v2.1.4.5 before attempting to migrate from v1.5.x to v2.1.x.
 
 ## 2.1.4.4
 **Release Date** 2021/03/26

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -756,7 +756,7 @@ open-source **Kong Gateway 2.2.0.0**:
 ### Fixes
 
 #### Enterprise
-Fixed an issue when upgrading Kong Gateway (Enterprise) from v1.5.x to v2.1.x. Before the fix, when admin consumers were shared across multiple workspaces, it was possible for the migration to fail. This happened because plugin entities that depend on consumer entities must live in the same workspace as the consumer entity. This fix migrates these plugin entities to the same workspace as the consumer entities. Customers affected by this issue will need to upgrade to at least v2.1.4.5 before attempting to migrate from v1.5.x to v2.1.x.
+Fixed an issue when upgrading Kong Gateway (Enterprise) from v1.5.x to v2.1.x. Before the fix, when admin consumers were shared across multiple workspaces, it was possible for the migration to fail. The upgrade would fail because plugin entities that depend on consumer entities must live in the same workspace as the consumer entity. This fix migrates these plugin entities to the same workspace as the consumer entities. Customers affected by this issue will need to upgrade their 2.1 install to at least 2.1.4.5 before attempting to migrate from 1.5 to 2.1.
 
 ## 2.1.4.4
 **Release Date** 2021/03/26


### PR DESCRIPTION
### Review
@tyler-ball 

### Summary
The Fast Track team released a patch release yesterday to fix an issue users were having when migrating from 1.5 to 2.1.

### Reason
Need to add 2.1.4.5 patch release note to inform users of the fix.

### Testing
[2.1.4.5 changelog](https://deploy-preview-2735--kongdocs.netlify.app/enterprise/changelog/#2145)