### PR TITLE
[DOCU-1389] update CE/EE plugins compatible with CE/EE 2.4

### DIFF
--- a/app/_hub/kong-inc/acl/index.md
+++ b/app/_hub/kong-inc/acl/index.md
@@ -51,6 +51,7 @@ kong_version_compatibility:
         - 0.5.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -23,7 +23,7 @@ kong_version_compatibility:
         - 2.0.x
     enterprise_edition:
       compatible:
-       - 2.4.x
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -23,6 +23,7 @@ kong_version_compatibility:
         - 2.0.x
     enterprise_edition:
       compatible:
+       - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/application-registration/index.md
+++ b/app/_hub/kong-inc/application-registration/index.md
@@ -36,6 +36,7 @@ categories:
 kong_version_compatibility:
   enterprise_edition:
     compatible:
+    - 2.4.x
     - 2.3.x
     - 2.2.x
     - 2.1.x

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -42,6 +42,7 @@ kong_version_compatibility:
         - 0.10.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x      
         - 2.1.x

--- a/app/_hub/kong-inc/azure-functions/index.md
+++ b/app/_hub/kong-inc/azure-functions/index.md
@@ -33,6 +33,7 @@ kong_version_compatibility:
         - 0.14.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/basic-auth/index.md
+++ b/app/_hub/kong-inc/basic-auth/index.md
@@ -42,6 +42,7 @@ kong_version_compatibility:
         - 0.2.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/bot-detection/index.md
+++ b/app/_hub/kong-inc/bot-detection/index.md
@@ -33,6 +33,7 @@ kong_version_compatibility:
         - 0.9.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/canary/index.md
+++ b/app/_hub/kong-inc/canary/index.md
@@ -3,6 +3,7 @@
 name: Canary Release
 publisher: Kong Inc.
 version: 2.2.x
+# internal handler version 0.3.0 4/7/2021
 
 desc: Slowly roll out software changes to a subset of users
 description: |
@@ -23,6 +24,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -34,6 +34,7 @@ kong_version_compatibility:
         - 0.8.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/cors/index.md
+++ b/app/_hub/kong-inc/cors/index.md
@@ -41,6 +41,7 @@ kong_version_compatibility:
         - 0.2.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -46,6 +46,7 @@ kong_version_compatibility:
         - 0.6.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/degraphql/index.md
+++ b/app/_hub/kong-inc/degraphql/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -18,6 +18,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -22,6 +22,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/index.md
@@ -19,6 +19,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -19,6 +19,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -26,6 +26,7 @@ kong_version_compatibility:
       - 2.1.x
   enterprise_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -27,6 +27,7 @@ kong_version_compatibility:
 
   enterprise_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x

--- a/app/_hub/kong-inc/hmac-auth/index.md
+++ b/app/_hub/kong-inc/hmac-auth/index.md
@@ -42,6 +42,7 @@ kong_version_compatibility:
         - 0.5.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/ip-restriction/index.md
+++ b/app/_hub/kong-inc/ip-restriction/index.md
@@ -38,6 +38,7 @@ kong_version_compatibility:
         - 0.4.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/jwt-signer/index.md
+++ b/app/_hub/kong-inc/jwt-signer/index.md
@@ -23,6 +23,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/kafka-log/index.md
+++ b/app/_hub/kong-inc/kafka-log/index.md
@@ -20,6 +20,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/kafka-upstream/index.md
+++ b/app/_hub/kong-inc/kafka-upstream/index.md
@@ -23,6 +23,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/key-auth-enc/index.md
+++ b/app/_hub/kong-inc/key-auth-enc/index.md
@@ -20,6 +20,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -48,6 +48,7 @@ kong_version_compatibility:
         - 0.2.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/kong-terraform-aws/index.md
+++ b/app/_hub/kong-inc/kong-terraform-aws/index.md
@@ -37,6 +37,7 @@ kong_version_compatibility:
 
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -12,7 +12,7 @@ description: |
   (in that order).
 
   <div class="alert alert-ee blue"><strong>Tip:</strong> The LDAP Authentication Advanced plugin
-  provides additional features not available in the open source <a href="/hub/kong-inc/ldap-auth">LDAP Authentication plugin</a>, 
+  provides additional features not available in the open source <a href="/hub/kong-inc/ldap-auth">LDAP Authentication plugin</a>,
   such as LDAP searches for group and consumer mapping:
 
   <ul>
@@ -32,6 +32,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -49,6 +49,7 @@ kong_version_compatibility:
         - 0.8.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -18,6 +18,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -29,6 +29,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -52,6 +52,7 @@ kong_version_compatibility:
         - 0.4.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -122,6 +122,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
 

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x      
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -28,6 +28,7 @@ kong_version_compatibility:
         - 0.14.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/proxy-cache-advanced/index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/index.md
@@ -24,6 +24,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -15,6 +15,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/proxy-cache/index.md
+++ b/app/_hub/kong-inc/proxy-cache/index.md
@@ -26,6 +26,7 @@ kong_version_compatibility:
         - 1.2.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -22,14 +22,14 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
-        - 0.34-x
+
 
 params:
   name: rate-limiting-advanced

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -48,6 +48,7 @@ kong_version_compatibility:
       - 0.2.x
   enterprise_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -23,6 +23,7 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -44,17 +44,14 @@ kong_version_compatibility:
         - 0.3.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
-        - 0.34-x
-        - 0.33-x
-        - 0.32-x
-        - 0.31-x
+
 
 params:
   name: request-size-limiting

--- a/app/_hub/kong-inc/request-size-limiting/index.md
+++ b/app/_hub/kong-inc/request-size-limiting/index.md
@@ -19,6 +19,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x      
         - 2.1.x

--- a/app/_hub/kong-inc/request-termination/index.md
+++ b/app/_hub/kong-inc/request-termination/index.md
@@ -33,6 +33,7 @@ kong_version_compatibility:
         - 0.11.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -21,6 +21,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -39,6 +39,7 @@ kong_version_compatibility:
         - 0.3.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x       
         - 2.1.x

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -14,6 +14,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/request-validator/index.md
+++ b/app/_hub/kong-inc/request-validator/index.md
@@ -17,6 +17,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -47,6 +47,7 @@ kong_version_compatibility:
         - 0.5.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -39,6 +39,7 @@ enterprise: true
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -47,6 +47,7 @@ kong_version_compatibility:
         - 0.5.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -24,6 +24,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/route-by-header/index.md
+++ b/app/_hub/kong-inc/route-by-header/index.md
@@ -18,12 +18,14 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
+        - 2.3.x
         - 2.2.x
+        - 2.1.x
         - 1.5.x
         - 1.3-x
         - 0.36-x
-        - 0.35-x
-        - 0.34-x
+
 
 params:
   name: route-by-header

--- a/app/_hub/kong-inc/route-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/index.md
@@ -17,6 +17,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -29,6 +29,7 @@ kong_version_compatibility:
         - 2.1.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/serverless-functions/index.md
+++ b/app/_hub/kong-inc/serverless-functions/index.md
@@ -23,6 +23,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/session/index.md
+++ b/app/_hub/kong-inc/session/index.md
@@ -37,13 +37,14 @@ kong_version_compatibility:
       - 1.2.x
   enterprise_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x
       - 1.5.x
       - 1.3-x
       - 0.36-x
-      - 0.35-x
+
 
 params:
   name: session

--- a/app/_hub/kong-inc/session/index.md
+++ b/app/_hub/kong-inc/session/index.md
@@ -26,6 +26,7 @@ source_url: https://github.com/Kong/kong-plugin-session
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x     
       - 2.1.x
@@ -37,7 +38,7 @@ kong_version_compatibility:
   enterprise_edition:
     compatible:
       - 2.3.x
-      - 2.2.x 
+      - 2.2.x
       - 2.1.x
       - 1.5.x
       - 1.3-x

--- a/app/_hub/kong-inc/statsd-advanced/index.md
+++ b/app/_hub/kong-inc/statsd-advanced/index.md
@@ -34,6 +34,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -28,6 +28,7 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -48,6 +48,7 @@ kong_version_compatibility:
         - 0.8.x
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -16,6 +16,7 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
+        - 2.4.x
         - 2.3.x
         - 2.2.x
         - 2.1.x

--- a/app/_hub/kong-inc/zipkin/index.md
+++ b/app/_hub/kong-inc/zipkin/index.md
@@ -34,6 +34,7 @@ kong_version_compatibility:
       - 0.14.x
   enterprise_edition:
     compatible:
+      - 2.4.x
       - 2.3.x
       - 2.2.x
       - 2.1.x


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DT-1389

Direct review links: plugin hub

https://deploy-preview-2740--kongdocs.netlify.app/hub/

Some plugins were already updated in other PRs (logging, pending jwt pr)