### PR TITLE
Mark Okta as an enterprise integration

### DIFF
--- a/app/_hub/okta/okta/index.md
+++ b/app/_hub/okta/okta/index.md
@@ -7,6 +7,8 @@ categories:
 
 type: integration
 
+enterprise: true
+
 desc: Integrate Okta's API Access Management (OAuth as a Service) with Kong API Gateway.
 
 description: |


### PR DESCRIPTION
The Okta integration guide requires a Kong Enterprise license, as it makes use of the Kong OIDC Enterprise plugin

### Summary
Document Okta integration guide as "enterprise" 

### Reason
The Okta integration guide is not marked as enterprise, however the instructions in the guide requires you to have an enterprise account

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
