### PR TITLE
fix(kic) correct IngressClass example

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -114,6 +114,7 @@ kind: IngressClass
 metadata:
   name: kong
 spec:
+  controller: ingress-controllers.konghq.com/kong
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-versions.md
@@ -114,6 +114,7 @@ kind: IngressClass
 metadata:
   name: kong
 spec:
+  controller: ingress-controllers.konghq.com/kong
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-versions.md
@@ -114,6 +114,7 @@ kind: IngressClass
 metadata:
   name: kong
 spec:
+  controller: ingress-controllers.konghq.com/kong
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
### Summary
Add a controller field to the IngressClass example. Although we don't yet make use of this value in our implementation, Kubernetes requires it.

### Reason
Fix #2585