### PR TITLE
[DOCU-685] mTLS plugin add datatypes, formatting, editing

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -29,44 +29,78 @@ params:
   name: mtls-auth
   service_id: true
   route_id: true
+  protocols: ["http", "https", "grpc", "grpcs", "tcp", "tls", "udp"]
   config:
     - name: anonymous
       required: false
+      datatype: string
       description: |
-        An optional string (consumer UUID) value to use as an "anonymous" **Consumer** if authentication fails. If the request is left empty (which it is by default), it will fail with an authentication failure of either `HTTP 495` if the client presented a certificate that is not acceptable, or `HTTP 496` if the client failed to present certificate as requested. Please note that this value must refer to the **Consumer** `id` attribute, which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an "anonymous" **Consumer** if authentication fails.
+        If the request is left empty (which it is by default), it will fail with an authentication failure of either
+        `HTTP 495` if the client presented a certificate that is not acceptable, or `HTTP 496` if the client failed
+        to present certificate as requested. Please note that this value must refer to the **Consumer** `id`
+        attribute, which is internal to Kong, and **not** its `custom_id`.
     - name: consumer_by
       required: false
       default: '`[ "username", "custom_id" ]`'
+      datatype: array of string elements
       description: |
-        Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array) then auto-matching is disabled.
+        Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array), then auto-matching is disabled.
     - name: ca_certificates
       required: true
       value_in_examples: [ "fdac360e-7b19-4ade-a553-6dd22937c82f" ]
+      datatype: array of string elements
       description: |
-        List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`).
+        List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate.
+        At least one is required but you can specify as many as needed. The value of this array is comprised
+        of primary keys (`id`).
     - name: skip_consumer_lookup
       default: "`false`"
+      required: true
+      datatype: boolean
       description: |
-        Skip consumer look once certificate is trusted against the configured CA list.
+        Skip consumer lookup once certificate is trusted against the configured CA list.
     - name: authenticated_group_by
       default: "`CN`"
-      required: true
+      required: false
+      datatype: string
       description: |
-        Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API. To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users.
+        Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or
+        `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a
+        valid certificate can access the Service/API. To restrict usage to only some of the authenticated users,
+        also add the ACL plugin (not covered here) and create allowed or denied groups of users.
     - name: revocation_check_mode
       default: "`IGNORE_CA_ERROR`"
+      required: false
+      datatype: string
       description: |
-        >**Known Issue:** The default value `IGNORE_CA_ERROR` has a known issue in versions 1.5.0.0 and later. As a workaround, manually set the value to `SKIP`.
+        >**Known Issue:** The default value `IGNORE_CA_ERROR` has a known issue in versions 1.5.0.0 and later.
+        As a workaround, manually set the value to `SKIP`.
 
-        Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR`, or `STRICT`. If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`, the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status. If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check CRL URL if it can't communicate with the OCSP server.
+        Controls client certificate revocation check behavior. Valid values are `SKIP`, `IGNORE_CA_ERROR`, or `STRICT`.
+        If set to `SKIP`, no revocation check will be performed. If set to `IGNORE_CA_ERROR`, the plugin will respect
+        the revocation status when either OCSP or CRL URL is set, and will not fail on network issues. If set to `STRICT`,
+        the plugin will only treat the certificate as valid when it's able to verify the revocation status, and a missing
+        OCSP or CRL URL in the certificate or a failure to connect to the server will result in a revoked status.
+        If both OCSP and CRL URL are set, the plugin always checks OCSP first, and will only check the CRL URL if
+        it can't communicate with the OCSP server.
     - name: http_timeout
       default: "30000"
+      datatype: number
       description: |
-        HTTP timeout threshold, in milliseconds, when communicating with the OCSP server or downloading CRL.
+        HTTP timeout threshold in milliseconds when communicating with the OCSP server or downloading CRL.
     - name: cert_cache_ttl
       default: "60000"
+      datatype: number
       description: |
-        The length of time, in milliseconds, between refreshes of the revocation check status cache.
+        The length of time in milliseconds between refreshes of the revocation check status cache.
+    - name: cache_ttl
+      default: "60"
+      required: true
+      datatype: number
+      description: |
+        Cache expiry time in seconds.
+
 
 ---
 
@@ -75,31 +109,46 @@ params:
 In order to authenticate the **Consumer**, it must provide a valid certificate and
 complete mutual TLS handshake with Kong.
 
-The plugin will validate the certificate provided against the configured CA list based on the requested **Route** or **Service**.
-If the certificate is not trusted or has expired, the response will be `HTTP 401` "TLS certificate failed verification."
-If **Consumer** did not present a valid certificate (this includes requests not sent to the HTTPS port),
-then the response will be `HTTP 401` "No required TLS certificate was sent". That exception is if the `config.anonymous`
-option was configured on the plugin, in which case the anonymous **Consumer** will be used
-and the request will be allowed to proceed.
+The plugin will validate the certificate provided against the configured CA list based on the
+requested **Route** or **Service**.
+- If the certificate is not trusted or has expired, the response will be
+  `HTTP 401 TLS certificate failed verification`.
+- If **Consumer** did not present a valid certificate (this includes requests not
+  sent to the HTTPS port), then the response will be `HTTP 401 No required TLS certificate was sent`.
+  The exception is if the `config.anonymous` option was configured on the plugin, in which
+  case the anonymous **Consumer** will be used and the request will be allowed to proceed.
 
 
 ### Client Certificate request
-Client certificates are requested in `ssl_certifica_by_lua` phase where Kong does not have access to `route` and `workspace` information. Due to this information gap, Kong will ask for the client certificate on every handshake if the mtls-auth plugin is configured on any Route or Service. In most cases, the failure of the client to present a client certificate is not going to affect subsequent proxying if that Route or Service does not have the mtls-auth plugin applied. The exception is where the client is a desktop browser which will prompt the end user to choose the client cert to send and lead to User Experience issues rather than proxy behavior problems.
-To improve this situation, Kong builds an in-memory map of SNIs from the configured Kong Routes that should present a client certificate. To limit client certificate requests during handshake while ensuring the client certificate is requested when needed, the in memory map is dependent on all the Routes in Kong having the SNIs attribute set. When any routes do not have SNIs set, Kong must request the client certificate during every TLS handshake.
+Client certificates are requested in the `ssl_certifica_by_lua` phase where Kong does not
+have access to `route` and `workspace` information. Due to this information gap, Kong will ask for
+the client certificate on every handshake if the `mtls-auth` plugin is configured on any Route or Service.
+In most cases, the failure of the client to present a client certificate is not going to affect subsequent
+proxying if that Route or Service does not have the `mtls-auth` plugin applied. The exception is where
+the client is a desktop browser, which will prompt the end user to choose the client cert to send and
+lead to user experience issues rather than proxy behavior problems. To improve this situation,
+Kong builds an in-memory map of SNIs from the configured Kong Routes that should present a client
+certificate. To limit client certificate requests during handshake while ensuring the client
+certificate is requested when needed, the in-memory map is dependent on all the Routes in
+Kong having the SNIs attribute set. When any routes do not have SNIs set, Kong must request
+the client certificate during every TLS handshake:
 
-- On every request irrespective of Workspace when plugin enabled in global Workspace scope.
-- On every request irrespective of Workspace when plugin applied at Service level
+- On every request irrespective of Workspace when the plugin is enabled in global Workspace scope.
+- On every request irrespective of Workspace when the plugin is applied at the Service level
   and one or more of the Routes *do not* have SNIs set.
-- On every request irrespective of Workspace when plugin applied at Route level
+- On every request irrespective of Workspace when the plugin is applied at the Route level
   and one or more Routes *do not* have SNIs set.
-- On specific request only when plugin applied at route level and all Routes have SNIs set.
+- On specific requests only when the plugin is applied at the Route level and all Routes have SNIs set.
 
-The result is all Routes must have SNIs if you wish to restrict the handshake request for client certificates to specific requests.
-
+The result is all Routes must have SNIs if you want to restrict the handshake request
+for client certificates to specific requests.
 
 ### Adding certificate authorities
 
-In order to use this plugin, you must add certificate authority certificates. These are stored in a separate ca-certificates store rather than the main certificates store, as they do not require private keys. To add one, obtain a PEM-encoded copy of your CA certificate and POST it to `/ca_certificates`:
+To use this plugin, you must add certificate authority (CA) certificates. These are
+stored in a separate `ca_certificates` store rather than the main certificates store because
+they do not require private keys. To add one, obtain a PEM-encoded copy of your CA certificate
+and POST it to `/ca_certificates`:
 
 ```bash
 $ curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
@@ -120,8 +169,8 @@ that contain a field value not directly associated with **Consumer** objects. In
 situations, you may manually assign one or more subject names to the **Consumer** object for
 identifying the correct Consumer.
 
-> **Note:** "Subject names" refers to the certificate's Subject Alternative Names (SAN) or
-"Common Name" (CN). CN will only be used if the SAN extension does not exist.
+> **Note:** Subject names refer to the certificate's Subject Alternative Names (SAN) or
+Common Name (CN). CN will only be used if the SAN extension does not exist.
 
 {% navtabs %}
 {% navtab Kong Admin API %}
@@ -207,7 +256,8 @@ When `skip_consumer_lookup` is set to `true`, consumer lookup will be skipped an
 * `X-Client-Cert-San`, SAN of the client certificate
 
 Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API.
-To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users using same
+To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create
+allowed or denied groups of users using the same
 certificate property being set in `authenticated_group_by`.
 
 ### Troubleshooting

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -29,7 +29,7 @@ params:
   name: mtls-auth
   service_id: true
   route_id: true
-  protocols: ["http", "https", "grpc", "grpcs", "tcp", "tls", "udp"]
+  protocols: ["http", "https", "grpc", "grpcs"]
   config:
     - name: anonymous
       required: false


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-685 as part of epic https://konghq.atlassian.net/browse/DOCU-301. The doc jira board shuffling/renaming has deleted links to child tickets.

Schema link:

https://github.com/Kong/kong-plugin-mtls-auth/blob/master/kong/plugins/mtls-auth/schema.lua

Direct review link:

https://deploy-preview-2751--kongdocs.netlify.app/hub/kong-inc/mtls-auth/
