### PR TITLE
(no ticket, fix) Simplify Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM jekyll/jekyll:3.8.6
 RUN apk add --update autoconf automake file build-base nasm musl libpng-dev zlib-dev curl
 RUN apk add --update-cache --upgrade curl
 
+# install latest npm
+RUN npm install -g npm@latest
+
 WORKDIR /srv/jekyll
 COPY Makefile /srv/jekyll/Makefile
 
@@ -17,4 +20,4 @@ RUN chmod -R 777 /usr/lib/node_modules \
 
 EXPOSE 3000 3001
 
-HEALTHCHECK CMD curl --fail http://localhost:5000/ || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:3000/ || exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,11 @@
 install-prerequisites:
-	npm install -g yarn
 	npm install -g gulp
 
 install:
-	-mkdir node_modules
+	-mkdir -p node_modules
 	chmod 777 node_modules
-	npm install
 	bundle install
 	yarn --ignore-engines
-	yarn upgrade
 	touch install
 
 run: install


### PR DESCRIPTION
### Summary
Simplifying the Dockerfile and Makefile.

### Reason
Doc site build process is long. This removes some extra steps and should hopefully make it a bit more efficient.

Thanks @gszr for contributing this change!

### Testing
Watch the checks, make sure they work, and hope that they're shorter.
