### PR TITLE
Remove duplicate ToC entry

### DIFF
--- a/app/_data/docs_nav_ce_2.3.x.yml
+++ b/app/_data/docs_nav_ce_2.3.x.yml
@@ -132,9 +132,6 @@
       - text: kong.client.tls
         url: /pdk/kong.client.tls
 
-      - text: kong.node
-        url: /pdk/kong.node
-
       - text: kong.ctx
         url: /pdk/kong.ctx
 


### PR DESCRIPTION
### Summary
Removing duplicate entry for kong.node.
Doing this manually, as we don't normally regenerate older docs.

### Reason
https://github.com/Kong/docs.konghq.com/issues/2679

Fixed in 2.4.x (was an autodoc error).

### Testing
TBA