### PR TITLE
Okta integration remove incompatible versions

### DIFF
--- a/app/_hub/okta/okta/index.md
+++ b/app/_hub/okta/okta/index.md
@@ -23,29 +23,13 @@ source_url: https://github.com/tom-smith-okta/okta-api-center/tree/master/gatewa
 kong_version_compatibility:
     community_edition:
       compatible:
-      incompatible:
-        - 0.14.x
-        - 0.13.x
-        - 0.12.x
-        - 0.11.x
-        - 0.10.x
-        - 0.9.x
-        - 0.8.x
-        - 0.7.x
-        - 0.6.x
-        - 0.5.x
-        - 0.4.x
-        - 0.3.x
-        - 0.2.x
+
     enterprise_edition:
       compatible:
         - 0.34-x
         - 0.33-x
         - 0.32-x
-      incompatible:
-        - 0.31-x
-        - 0.30-x
-        - 0.29-x
+
 
 ###############################################################################
 # END YAML DATA


### PR DESCRIPTION
Remove cluttering incompatible versions. The versions listed for EE are no longer supported. Need to review and discuss with @eskibars what Enterprise versions are currently supported.



