### PR TITLE
Splunk 3rd party plugin

### DIFF
--- a/app/_hub/optum/kong-splunk-log/index.md
+++ b/app/_hub/optum/kong-splunk-log/index.md
@@ -23,26 +23,13 @@ kong_version_compatibility:
     compatible:
       - 0.14.x
       - 0.13.x
-    incompatible:
-      - 0.12.x
-      - 0.11.x
-      - 0.10.x
-      - 0.9.x
-      - 0.8.x
-      - 0.7.x
-      - 0.6.x
-      - 0.5.x
-      - 0.3.x
-      - 0.2.x
+
   enterprise_edition:
     compatible:
       - 0.34-x
       - 0.33-x
       - 0.32-x
-    incompatible:
-      - 0.31-x
-      - 0.30-x
-      - 0.29-x
+
 
 params:
   name: kong-splunk-log


### PR DESCRIPTION
remove incompatible versions. This list if accurate would get very long.

