### PR TITLE
Update EE metadata to latest patch version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -323,7 +323,7 @@
   lua_doc: true
 -
   release: "2.3.x"
-  version: "2.3.2.0"
+  version: "2.3.3.0"
   edition: "enterprise"
   luarocks_version: "2.2.0.0"
   dependencies:


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
Updating latest real version of Kong Gateway (Enterprise) 2.3.

### Reason
This version is used for installation docs.

### Testing
Check that installation docs are using the new version, eg: https://deploy-preview-2765--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/ubuntu/