### PR TITLE
[DOCU-681][DOCU-158] Request Transformer plugin datatypes, formatting, editing, versioning

### DIFF
--- a/app/_data/extensions/kong-inc/request-transformer/versions.yml
+++ b/app/_data/extensions/kong-inc/request-transformer/versions.yml
@@ -1,2 +1,3 @@
-- release: 1.0-x
+- release: 1.3.x
+- release: 1.2.x
 - release: 0.1-x

--- a/app/_hub/kong-inc/request-transformer/0.1-x.md
+++ b/app/_hub/kong-inc/request-transformer/0.1-x.md
@@ -114,19 +114,6 @@ params:
 
 ---
 
-## Dynamic Transformation Based on Request Content
-
-The Request Transformer plugin bundled with Kong Enterprise Edition allows for
-adding or replacing content in the upstream request based on variable data found
-in the client request, such as request headers, query string parameters, or URI
-parameters as defined by a URI capture group.
-
-If you already are a Kong Enterprise customer, you can request access to this
-plugin functionality by opening a support ticket using your Enterprise support
-channels.
-
-If you are not a Kong Enterprise customer, you can inquire about our
-Enterprise offering by [contacting us](/enterprise).
 
 ## Order of execution
 

--- a/app/_hub/kong-inc/request-transformer/1.2.x.md
+++ b/app/_hub/kong-inc/request-transformer/1.2.x.md
@@ -1,15 +1,11 @@
 ---
 name: Request Transformer
 publisher: Kong Inc.
-version: 1.3.x
-# internal version handler is currently (4-8-2021) 1.3.2.
+version: 1.0.x
 
 desc: Use regular expressions, variables, and templates to transform requests
 description: |
-  The Request Transformer plugin for Kong allows simple transformation of requests
-  before they reach the upstream server. These transformations can be simple substitutions
-  or complex ones matching portions of incoming requests using regular expressions, saving
-  those matched strings into variables, and substituting those strings into transformed requests using flexible templates.
+  The Request Transformer plugin for Kong allows simple transformation of requests before they reach the upstream server. These transformations can be simple substitutions or complex ones matching portions of incoming requests using regular expressions, saving those matched strings into variables, and substituting those strings into transformed requests using flexible templates.
 
 type: plugin
 categories:
@@ -60,136 +56,78 @@ params:
   config:
     - name: http_method
       required: false
-      datatype: string
       description: Changes the HTTP method for the upstream request.
     - name: remove.headers
       required: false
       value_in_examples: [ "x-toremove", "x-another-one" ]
-      datatype: array of string elements
-      description: List of header names. Unset the headers with the given name.
+      description: List of header names. Unset the header(s) with the given name.
     - name: remove.querystring
       required: false
       value_in_examples: [ "qs-old-name:qs-new-name", "qs2-old-name:qs2-new-name" ]
-      datatype: array of string elements
       description: List of querystring names. Remove the querystring if it is present.
     - name: remove.body
       required: false
       value_in_examples: [ "formparam-toremove", "formparam-another-one" ]
-      datatype: array of string elements
-      description: |
-        List of parameter names. Remove the parameter if and only if content-type is one the following:
-        [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is present.
+      description: List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`, `multipart/form-data`,  `application/x-www-form-urlencoded`] and parameter is present.
     - name: replace.uri
       required: false
-      datatype: string
-      description: |
-        Updates the upstream request URI with a given value. This value can be used to update
-        only the path part of the URI, not the scheme or the hostname.
+      description: Updates the upstream request URI with a given value. This value can be used to update only the path part of the URI, not the scheme or the hostname.
     - name: replace.body
       required: false
       value_in_examples: [ "body-param1:new-value-1", "body-param2:new-value-2" ]
-      datatype: array of string elements
-      description: |
-        List of `paramname:value` pairs. If and only if content-type is one the following
-        [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the
-        parameter is already present, replace its old value with the new one. Ignored if
-        the parameter is not already present.
+      description: List of paramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
     - name: replace.headers
       required: false
-      datatype: array of string elements
-      description: |
-        List of `headername:value` pairs. If and only if the header is already set, replace
-        its old value with the new one. Ignored if the header is not already set.
+      description: List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
     - name: replace.querystring
       required: false
-      datatype: array of string elements
-      description: |
-        List of `queryname:value pairs`. If and only if the field name is already set,
-        replace its old value with the new one. Ignored if the field name is not already set.
+      description: List of queryname:value pairs. If and only if the field name is already set, replace its old value with the new one. Ignored if the field name is not already set.
     - name: rename.headers
       required: false
       value_in_examples: [ "header-old-name:header-new-name", "another-old-name:another-new-name" ]
-      datatype: array of string elements
-      description: |
-        List of `headername:value` pairs. If and only if the header is already set, rename
-        the header. The value is unchanged. Ignored if the header is not already set.
+      description: List of headername:value pairs. If and only if the header is already set, rename the header. The value is unchanged. Ignored if the header is not already set.
     - name: rename.querystring
       required: false
       value_in_examples: [ "qs-old-name:qs-new-name", "qs2-old-name:qs2-new-name" ]
-      datatype: array of string elements
-      description: |
-        List of queryname:value pairs. If and only if the field name is already set, rename the field name.
-        The value is unchanged. Ignored if the field name is not already set.
+      description: List of queryname:value pairs. If and only if the field name is already set, rename the field name. The value is unchanged. Ignored if the field name is not already set.
     - name: rename.body
       required: false
       value_in_examples: [ "param-old:param-new", "param2-old:param2-new" ]
-      datatype: array of string elements
-      description: |
-        List of `paramname:value` pairs. Rename the parameter name if and only if
-        content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`]
-        and the parameter is present.
+      description: List of parameter name:value pairs. Rename the parameter name if and only if content-type is one the following [`application/json`, `multipart/form-data`,  `application/x-www-form-urlencoded`] and parameter is present.
     - name: replace.body
       required: false
-      datatype: array of string elements
-      description: |
-        List of `paramname:value` pairs. If and only if content-type is one the following
-        [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter
-        is already present, replace its old value with the new one. Ignored if the parameter is not already present.
+      description: List of paramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
     - name: add.headers
       required: false
       value_in_examples: [ "x-new-header:value", "x-another-header:something" ]
-      datatype: array of string elements
-      description: |
-        List of `headername:value` pairs. If and only if the header is not already set, set a new header
-        with the given value. Ignored if the header is already set.
+      description: List of headername:value pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
     - name: add.querystring
       required: false
       value_in_examples: [ "new-param:some_value", "another-param:some_value" ]
-      datatype: array of string elements
-      description: |
-        List of `queryname:value` pairs. If and only if the querystring is not already set, set a new
-        querystring with the given value. Ignored if the header is already set.
+      description: List of queryname:value pairs. If and only if the querystring is not already set, set a new querystring with the given value. Ignored if the header is already set.
     - name: add.body
       required: false
       value_in_examples: [ "new-form-param:some_value", "another-form-param:some_value" ]
-      datatype: array of string elements
-      description: |
-        List of `paramname:value` pairs. If and only if content-type is one the
-        following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`]
-        and the parameter is not present, add a new parameter with the given value to the form-encoded
-        body. Ignored if the parameter is already present.
+      description: List of pramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is not present, add a new parameter with the given value to form-encoded body. Ignored if the parameter is already present.
     - name: append.headers
       required: false
-      datatype: array of string elements
-      description: |
-        List of `headername:value` pairs. If the header is not set, set it with the given value.
-        If it is already set, an additional new header with the same name and the new value will be appended.
+      description: List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, an additional new header with the same name and the new value will be appended.
     - name: append.querystring
       required: false
-      datatype: array of string elements
-      description: List of `queryname:value` pairs. If the querystring is not set, set it with the given value. If it is already set, a new querystring with the same name and the new value will be set.
+      description: List of queryname:value pairs. If the querystring is not set, set it with the given value. If it is already set, a new querystring with the same name and the new value will be set.
     - name: append.body
       required: false
-      datatype: array of string elements
-      description: |
-        List of `paramname:value` pairs. If the content-type is one the following
-        [`application/json`, `application/x-www-form-urlencoded`], add a new parameter
-        with the given value if the parameter is not present. Otherwise, if it is already present,
-        aggregate the two values (old and new) in an array.
+      description: List of paramname:value pairs. If the content-type is one the following [`application/json`, `application/x-www-form-urlencoded`], add a new parameter with the given value if the parameter is not present, otherwise if it is already present, the two values (old and new) will be aggregated in an array.
   extra: |
     **Notes**:
-    * If the value contains a `,` (comma), then the comma-separated format for lists cannot be used. The array
-    notation must be used instead.
-    * The `X-Forwarded-*` fields are non-standard header fields written by Nginx to inform the upstream about
-    client details and can't be overwritten by this plugin. If you need to overwrite these header fields, see the
-    [post-function plugin in Serverless Functions](https://docs.konghq.com/hub/kong-inc/serverless-functions/).
+    * If the value contains a `,` then the comma-separated format for lists cannot be used. The array notation must be used instead.
+    * The `X-Forwarded-*` fields are non-standard header fields written by Nginx to inform the upstream about client details and can't be overwritten by this plugin. If you need to overwrite these header fields, see the [post-function plugin in Serverless Functions](https://docs.konghq.com/hub/kong-inc/serverless-functions/).
 
 ---
 
-## Template as a Value
+## Template as Value
 
-You can use any of the current request headers, query params, and captured URI groups as a
-template to populate the above supported configuration fields.
+You can use any of the current request headers, query params, and captured URI groups as a template to populate the above supported configuration fields.
 
 | Request Param | Template
 | ------------- | -----------
@@ -200,9 +138,7 @@ template to populate the above supported configuration fields.
 To escape a template, wrap it inside quotes and pass it inside another template.<br>
 `$('$(some_escaped_template)')`
 
-Note: The plugin creates a non-mutable table of request headers, querystrings, and captured URIs
-before transformation. Therefore, any update or removal of params used in a template
-does not affect the rendered value of a template.
+Note: The plugin creates a non-mutable table of request headers, querystrings, and captured URIs before transformation. Therefore, any update or removal of params used in template does not affect the rendered value of a template.
 
 ### Advanced templates
 
@@ -240,7 +176,7 @@ already there:
       end)())
 
 *NOTE:* Especially in multi-line templates like the example above, make sure not
-to add any trailing white space or new lines. Because these would be outside the
+to add any trailing white-space or new-lines. Because these would be outside the
 placeholders, they would be considered part of the template, and hence would be
 appended to the generated value.
 
@@ -248,9 +184,9 @@ The environment is sandboxed, meaning that Lambdas will not have access to any
 library functions, except for the string methods (like `sub()` in the example
 above).
 
-### Examples Using Template as a Value
+### Examples Using Template as Value
 
-Add an API `test` with `uris` configured with a named capture group `user_id`:
+Add an API `test` with `uris` configured with a named capture group `user_id`
 
 ```bash
 $ curl -X POST http://localhost:8001/apis \
@@ -262,7 +198,7 @@ $ curl -X POST http://localhost:8001/apis \
 
 Enable the `request-transformer` plugin to add a new header `x-consumer-id`
 whose value is being set with the value sent with header `x-user-id` or
-with the default value `alice`. The `header` is missing.
+with the default value `alice` is `header` is missing.
 
 ```bash
 $ curl -X POST http://localhost:8001/apis/test/plugins \
@@ -271,24 +207,22 @@ $ curl -X POST http://localhost:8001/apis/test/plugins \
     --data "config.remove.headers=x-user-id"
 ```
 
-Now send a request without setting header `x-user-id`:
+Now send a request without setting header `x-user-id`
 
 ```bash
 $ curl -i -X GET localhost:8000/requests/user/foo
 ```
 
-The plugin adds a new header `x-consumer-id` with value `alice` before proxying
-request upstream.
-
-Now try sending request with header `x-user-id` set:
+Plugin will add a new header `x-consumer-id` with value `alice` before proxying
+request upstream. Now try sending request with header `x-user-id` set
 
 ```bash
 $ curl -i -X GET localhost:8000/requests/user/foo \
   -H "X-User-Id:bob"
 ```
 
-This time, the plugin adds a new header `x-consumer-id` with the value sent along
-with the header `x-user-id`, i.e.`bob`.
+This time the plugin will add a new header `x-consumer-id` with the value sent along
+with the header `x-user-id`, i.e.`bob`
 
 ## Order of execution
 
@@ -307,10 +241,10 @@ Plugin performs the response transformation in the following order:
   will obtain the value of the first capture group.
 </div>
 
-In the following examples, the plugin enabled on a Service. This would work
+In these examples we have the plugin enabled on a Service. This would work
 similarly for Routes.
 
-- Add multiple headers by passing each `header:value` pair separately:
+- Add multiple headers by passing each header:value pair separately:
 
 {% navtabs %}
 {% navtab With a database %}
@@ -348,7 +282,7 @@ plugins:
   </tr>
 </table>
 
-- Add multiple headers by passing comma-separated `header:value` pair (only possible with a database):
+- Add multiple headers by passing comma separated header:value pair (only possible with a database):
 
 ```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \
@@ -372,7 +306,7 @@ $ curl -X POST http://localhost:8001/services/example-service/plugins \
   </tr>
 </table>
 
-- Add multiple headers passing config as a JSON body (only possible with a database):
+- Add multiple headers passing config as JSON body (only possible with a database):
 
 ```bash
 $ curl -X POST http://localhost:8001/services/example-service/plugins \

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -61,7 +61,7 @@ params:
     - name: http_method
       required: false
       datatype: string
-      description: Changes the HTTP method for the upstream request.
+      description: Sets the HTTP method for the upstream request.
     - name: remove.headers
       required: false
       value_in_examples: [ "x-toremove", "x-another-one" ]


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-681 add datatypes
https://konghq.atlassian.net/browse/DOCU-158 remove vestige from when there was differentiation between the open source and enterprise plugins. It's confusing and doesn't add value. The EE Request Transformer Advanced plugin is slated for  future deprecation per @eskibars since its functionality was ported to this OSS CE plugin and there is no longer a discernible difference.

Schema:

https://github.com/Kong/kong-plugin-request-transformer/blob/master/kong/plugins/request-transformer/schema.lua

Direct review link:

https://deploy-preview-2766--kongdocs.netlify.app/hub/kong-inc/request-transformer/