### PR TITLE
docs(gateway/proxy) add more detailed description of the regex matching

### DIFF
--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -716,7 +716,7 @@ used for incoming request URIs, which are selected because they generally do not
 semantics of the request URI:
 
 1. Percent-encoded triplets are converted to uppercase.  For example: `/foo%3a` becomes `/foo%3A`.
-2. Percent-encoded triplets of unreserved characters will be decoded. e.g. `/fo%6F` will become `/foo`.
+2. Percent-encoded triplets of unreserved characters are decoded. For example: `/fo%6F` becomes `/foo`.
 3. Dot-segments are removed as necessary. e.g. `/foo/./bar/../baz` will become `/foo/baz`.
 4. Duplicate slashes are merged. e.e. `/foo//bar` will become `/foo/bar`.
 

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -717,8 +717,8 @@ semantics of the request URI:
 
 1. Percent-encoded triplets are converted to uppercase.  For example: `/foo%3a` becomes `/foo%3A`.
 2. Percent-encoded triplets of unreserved characters are decoded. For example: `/fo%6F` becomes `/foo`.
-3. Dot-segments are removed as necessary. e.g. `/foo/./bar/../baz` will become `/foo/baz`.
-4. Duplicate slashes are merged. e.e. `/foo//bar` will become `/foo/bar`.
+3. Dot segments are removed as necessary.  For example: `/foo/./bar/../baz` becomes `/foo/baz`.
+4. Duplicate slashes are merged. For example: `/foo//bar` becomes `/foo/bar`.
 
 The `paths` attribute of the Route object are also normalized. It is achieved by first determining
 if the path is a plain text or regex path. Based on the result, different normalization techniques
@@ -726,14 +726,14 @@ are used.
 
 For plain text Route path:
 
-Same normalization technique as above is used, that is, method 1 through 4.
+Same normalization technique as above is used, that is, methods 1 through 4.
 
 For regex Route path:
 
-Only method 1 and 2 are used. In addition, if the decoded character becomes a regex
+Only methods 1 and 2 are used. In addition, if the decoded character becomes a regex
 meta character, it will be escaped with backslash.
 
-Please note that Kong normalizes any incoming request URI before performing router
+Kong normalizes any incoming request URI before performing router
 matches. As a result, any request URI sent over to the upstream services will also
 be in normalized form that preserves the original URI semantics.
 

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -709,7 +709,7 @@ Host: ...
 
 #### Normalization behavior
 
-In order to prevent trivial Route match bypass, the incoming request URI from client
+To prevent trivial Route match bypass, the incoming request URI from client
 is always normalized according to [RFC 3986](https://tools.ietf.org/html/rfc3986)
 before router match occurs. Specifically, the following normalization techniques are
 used for incoming request URIs which are selected because they generally do not change

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -513,7 +513,7 @@ For a path to be considered as regex, it must fall **outside** of the following 
 ```
 
 In other words, if a path contains any character that is **not** alphanumerical, dot (`.`),
-dash (`-`), underscore (`_`), tilde (`~`), forward-slash (`/`) or percent (`%`), then
+dash (`-`), underscore (`_`), tilde (`~`), forward-slash (`/`), or percent (`%`), then
 it will be considered a regex path. Please note this determination is done on a per-path basis
 and it is allowed to mix plain text and regex paths inside the same `paths` array of the same
 Route object.

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -711,7 +711,7 @@ Host: ...
 
 To prevent trivial Route match bypass, the incoming request URI from client
 is always normalized according to [RFC 3986](https://tools.ietf.org/html/rfc3986)
-before router match occurs. Specifically, the following normalization techniques are
+before router matching occurs. Specifically, the following normalization techniques are
 used for incoming request URIs which are selected because they generally do not change
 semantics of the request URI:
 

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -514,7 +514,7 @@ For a path to be considered as regex, it must fall **outside** of the following 
 
 In other words, if a path contains any character that is **not** alphanumerical, dot (`.`),
 dash (`-`), underscore (`_`), tilde (`~`), forward-slash (`/`), or percent (`%`), then
-it will be considered a regex path. Please note this determination is done on a per-path basis
+it will be considered a regex path. This determination is done on a per-path basis
 and it is allowed to mix plain text and regex paths inside the same `paths` array of the same
 Route object.
 

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -722,7 +722,7 @@ semantics of the request URI:
 
 The `paths` attribute of the Route object are also normalized. It is achieved by first determining
 if the path is a plain text or regex path. Based on the result, different normalization techniques
-are used:
+are used.
 
 For plain text Route path:
 

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -715,7 +715,7 @@ before router matching occurs. Specifically, the following normalization techniq
 used for incoming request URIs, which are selected because they generally do not change
 semantics of the request URI:
 
-1. Percent-encoded triplets will be converted to uppercase. e.g. `/foo%3a` will become `/foo%3A`.
+1. Percent-encoded triplets are converted to uppercase.  For example: `/foo%3a` becomes `/foo%3A`.
 2. Percent-encoded triplets of unreserved characters will be decoded. e.g. `/fo%6F` will become `/foo`.
 3. Dot-segments are removed as necessary. e.g. `/foo/./bar/../baz` will become `/foo/baz`.
 4. Duplicate slashes are merged. e.e. `/foo//bar` will become `/foo/bar`.

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -712,7 +712,7 @@ Host: ...
 To prevent trivial Route match bypass, the incoming request URI from client
 is always normalized according to [RFC 3986](https://tools.ietf.org/html/rfc3986)
 before router matching occurs. Specifically, the following normalization techniques are
-used for incoming request URIs which are selected because they generally do not change
+used for incoming request URIs, which are selected because they generally do not change
 semantics of the request URI:
 
 1. Percent-encoded triplets will be converted to uppercase. e.g. `/foo%3a` will become `/foo%3A`.

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -720,7 +720,7 @@ semantics of the request URI:
 3. Dot-segments are removed as necessary. e.g. `/foo/./bar/../baz` will become `/foo/baz`.
 4. Duplicate slashes are merged. e.e. `/foo//bar` will become `/foo/bar`.
 
-`paths` attribute of the Route object are also normalized. It is achieved by first determining
+The `paths` attribute of the Route object are also normalized. It is achieved by first determining
 if the path is a plain text or regex path. Based on the result, different normalization techniques
 are used:
 


### PR DESCRIPTION
behavior. add description of URI normalization methods used by the router.