### PR TITLE
Update decK version to 1.6.0 and adjust dockerfile with build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM jekyll/jekyll:3.8.6
 RUN apk add --update autoconf automake file build-base nasm musl libpng-dev zlib-dev curl
 RUN apk add --update-cache --upgrade curl
 
+# To handle 'not get uid/gid'
+RUN npm config set unsafe-perm true
+
 # install latest npm
 RUN npm install -g npm@latest
 
 WORKDIR /srv/jekyll
 COPY Makefile /srv/jekyll/Makefile
-
-# To handle 'not get uid/gid'
-RUN npm config set unsafe-perm true
 
 RUN make install-prerequisites
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update-cache --upgrade curl
 RUN npm config set unsafe-perm true
 
 # install latest npm
-RUN npm install -g npm@latest
+RUN npm install -g npm@7.9.0
 
 WORKDIR /srv/jekyll
 COPY Makefile /srv/jekyll/Makefile

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -414,7 +414,7 @@
   version: "2.3"
   edition: "getting-started-guide"
 -
-  version: "1.3.0"
+  version: "1.6.0"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Summary
Updating decK version in doc metadata.

### Reason
New version of decK released yesterday: https://github.com/kong/deck/releases

### Testing
TBA
