### PR TITLE
[DOCU-1083] updated property reference with granular tracing trace types definitions

### DIFF
--- a/app/enterprise/2.3.x/property-reference.md
+++ b/app/enterprise/2.3.x/property-reference.md
@@ -3061,9 +3061,22 @@ Trace types not defined in this list are ignored, regardless of their lifetime.
 The default special value of `all` results in all trace types being written,
 regardless of type.
 
-Included trace types are: `query`, `legacy_query`, `router`,
-`balancer.getPeer`, `balancer.toip`, `connect.toip`, `access.before`, and
-`access.after`, `cassandra_iterate`, and `plugin`.
+The following trace types are included:
+
+- `query`: trace the database query
+- `legacy_query`: (deprecated) trace the database query with legacy DAO
+- `router`: trace Kong routing the request; internal routing time
+- `balancer`: trace the execution of the overall balancer phase
+- `balancer.getPeer`: trace Kong selecting an upstream peer from the
+  ring-balancer
+- `balancer.toip`: trace balancer to resolve peer's host to IP
+- `connect.toip`: trace cosocket to resolve target's host to IP
+- `access.before`: trace the preprocessing of access phase, like parameter
+  parsing, route matching, and balance preparation
+- `access.after`: trace the postprocess of access phase, like balancer
+  execution and internal variable assigning
+- `cassandra_iterate`: trace Cassandra driver to paginate over results
+- `plugin`: trace plugins phase handlers
 
 **Default:** `all`
 


### PR DESCRIPTION
### Review
Docs team - added some definitions for the different tracing types. I only added this one section to doc as some of the other updates to this file will be for the 2.4 release. This update is just to make the content better.

### Summary
Added some definitions to the different tracing types included when using granular tracing, an enterprise feature.

### Reason
[DOCU-1083](https://konghq.atlassian.net/browse/DOCU-1083)

### Testing
[Granular tracing - tracing_types](https://deploy-preview-2771--kongdocs.netlify.app/enterprise/2.3.x/property-reference/#tracing_types)
