### PR TITLE
fix curl command url 

### DIFF
--- a/app/getting-started-guide/2.3.x/secure-services.md
+++ b/app/getting-started-guide/2.3.x/secure-services.md
@@ -61,7 +61,7 @@ created:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-$ curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
+$ curl -X POST http://<admin-hostname>:8001/services/mocking/plugins \
   --data name=key-auth
 ```
 {% endnavtab %}


### PR DESCRIPTION
This proposition is to fix a mistake in url in curl command in Set up the Key Authentication Plugin

### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
In Set up the Key Authentication Plugin part
This PR fix the URI example for curl command

### Reason
because Set up the Key Authentication Plugin the URI routes is not existing in this case

### Testing
In Set up the Key Authentication Plugin
By following the example in CURL mode you can reproduce the issue.
And the fix correct this
