### PR TITLE
docs(ldap-auth-advanced) fix EE-only feature (groups) description

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -18,7 +18,7 @@ description: |
   <ul>
   <li>Ability to authenticate based on username or custom ID.</li>
   <li>The ability to bind to an enterprise LDAP directory with a password.</li>
-  <li>The ability to obtain LDAP groups and set them in a header to the request before proxying to the upstream which is useful for the Kong Manager role mapping, for example.</li>
+  <li>The ability to obtain LDAP groups and set them in a header to the request before proxying to the upstream. This is useful for Kong Manager role mapping.</li>
   </ul>
   </div>
 

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -18,7 +18,7 @@ description: |
   <ul>
   <li>Ability to authenticate based on username or custom ID.</li>
   <li>The ability to bind to an enterprise LDAP directory with a password.</li>
-  <li>The ability to authenticate/authorize using a group base DN and specific group member or group name attributes.</li>
+  <li>The ability to obtain LDAP groups and set them in a header to the request before proxying to the upstream which is useful for the Kong Manager role mapping, for example.</li>
   </ul>
   </div>
 


### PR DESCRIPTION
The LDAP Advanced plugin does not support the ability to authorize based on groups, instead the plugin gives the ability to obtain LDAP groups and set them in a header to the request before proxying to the upstream which is useful for the Kong Manager role mapping, for example.