### PR TITLE
docs(ldap-auth-advanced) add more notes

### DIFF
--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -298,6 +298,8 @@ back to the plugin.
 The plugin doesn’t authenticate users (allow/deny requests) based on group
 membership. For example:
 - If the user is a member of an LDAP group, the request is allowed.
-- if the user is not a member of an LDAP group, the request is still be allowed.
+- if the user is not a member of an LDAP group, the request is still allowed.
 
-The plugin obtains LDAP groups and sets them in a header, `x-authenticated-groups`, to the request before proxying to the upstream. This is useful for Kong Manager role mapping.
+The plugin obtains LDAP groups and sets them in a header, `x-authenticated-groups`,
+to the request before proxying to the upstream. This is useful for Kong Manager role
+mapping.

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -290,12 +290,12 @@ example, considering a case where there are nested `"OU's"`. If a
 top-level DN such as `"ou=dev,o=company"` is specified instead of
 `"ou=role,ou=groups,ou=dev,o=company"`, the authentication will fail.
 
-Referrals are not supported in the plugin. One way to work around this is
+Referrals are not supported in the plugin. A workaround is
 to hit the LDAP Global Catalog instead, which is usually listenning on a
-different port than the default `389`. This way, referrals don't get sent
+different port than the default `389`. That way, referrals don't get sent
 back to the plugin.
 
 The plugin doesn’t authenticate users (allow/deny requests) based on group
 membership. For example:
-- if the user is member of an LDAP group, the request will be allowed -> 200 OK
-- if the user is _not_ member of a group, the request will still be allowed -> 200 OK
+- If the user is a member of an LDAP group, the request is allowed.
+- if the user is not member of an LDAP group, the request will still be allowed -> 200 OK

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -289,3 +289,13 @@ is specified a more generic DN, therefore it needs to be specific. For
 example, considering a case where there are nested `"OU's"`. If a
 top-level DN such as `"ou=dev,o=company"` is specified instead of
 `"ou=role,ou=groups,ou=dev,o=company"`, the authentication will fail.
+
+Referrals are not supported in the plugin. One way to work around this is
+to hit the LDAP Global Catalog instead, which is usually listenning on a
+different port than the default `389`. This way, referrals don't get sent
+back to the plugin.
+
+The plugin doesn’t authenticate users (allow/deny requests) based on group
+membership. For example:
+- if the user is member of an LDAP group, the request will be allowed -> 200 OK
+- if the user is _not_ member of a group, the request will still be allowed -> 200 OK

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -291,7 +291,7 @@ top-level DN such as `"ou=dev,o=company"` is specified instead of
 `"ou=role,ou=groups,ou=dev,o=company"`, the authentication will fail.
 
 Referrals are not supported in the plugin. A workaround is
-to hit the LDAP Global Catalog instead, which is usually listenning on a
+to hit the LDAP Global Catalog instead, which is usually listening on a
 different port than the default `389`. That way, referrals don't get sent
 back to the plugin.
 

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -298,4 +298,6 @@ back to the plugin.
 The plugin doesn’t authenticate users (allow/deny requests) based on group
 membership. For example:
 - If the user is a member of an LDAP group, the request is allowed.
-- if the user is not member of an LDAP group, the request will still be allowed -> 200 OK
+- if the user is not a member of an LDAP group, the request is still be allowed.
+
+The plugin obtains LDAP groups and sets them in a header, `x-authenticated-groups`, to the request before proxying to the upstream. This is useful for Kong Manager role mapping.


### PR DESCRIPTION
Referrals are not supported in the plugin. One way to work around this is
to hit the LDAP Global Catalog instead, which is usually listenning on a
different port than the default `389`. This way, referrals don't get sent
back to the plugin.

The plugin doesn’t authenticate users (allow/deny requests) based on group
membership. For example:
- if the user is member of an LDAP group, the request will be allowed -> 200 OK
- if the user is _not_ member of a group, the request will still be allowed -> 200 OK

### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
