### PR TITLE
[DOCU-1401] Adds 2.4.0.0 beta change log entry

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -29,7 +29,7 @@ no_version: true
   This update ensures that `luasec` will negotiate the most secure protocol available if not otherwise set.
 
 #### PDK
-- This release includes a new JavaScript Plugin Development Kit (PDK). This addition to the PDK
+- This release includes a new JavaScript Plugin Development Kit (PDK). This addition
   allows users to write Kong plugins in JavaScript and TypeScript.
 - This release includes support for Protobuf plugin communication protocol, which can be used in
   place of MessagePack to communicate with non-Lua plugins. [6941](https://github.com/Kong/kong/pull/6941)
@@ -47,11 +47,11 @@ no_version: true
     in production environment.**
 - [Zipkin](/hub/kong-inc/zipkin) (`zipkin`)
   - The plugin now supports OT and Jaeger style `uber-trace-id` headers. See `config.header_type` in
-    the Parameters section of the Zipkin plugin documentation for more information.
-    [101](https://github.com/Kong/kong-plugin-zipkin/pull/101 )
+    the [Parameters](https://docs.konghq.com/hub/kong-inc/zipkin/#parameters) section of the Zipkin
+    plugin documentation for more information. [101](https://github.com/Kong/kong-plugin-zipkin/pull/101 )
   - The plugin now allows insertion of custom tags on the Zipkin request trace. See `config.tags_header`
-    in the Parameters section of the Zipkin plugin documentation for more information.
-    [102](https://github.com/Kong/kong-plugin-zipkin/pull/102)
+    in the [Parameters](https://docs.konghq.com/hub/kong-inc/zipkin/#parameters) section of the Zipkin
+    plugin documentation for more information. [102](https://github.com/Kong/kong-plugin-zipkin/pull/102)
   - The plugin now allows the creation of baggage items on child spans.
     [98](https://github.com/Kong/kong-plugin-zipkin/pull/98)
 - [JWT](/hub/kong-inc/jwt) (`jwt`) 
@@ -99,11 +99,11 @@ no_version: true
   records and injects the new field on each copy.
   [6843](https://github.com/Kong/kong/commit/5f2a87259e3b474ec6129490bba82dac0aeba1cf)
 - The host header is updated between balancer retries. Before Kong set the `Host` header during
-  the access phase only and would send the wrong header if a target failed to server and needed
+  the access phase only and would send the wrong header if a target failed to serve and needed
   to be retried. [6796](https://github.com/Kong/kong/pull/6796)
 - The router prioritizes the route with most matching headers when matching headers.
   [6638](https://github.com/Kong/kong/pull/6638)
-- Fixed an edge case on multipart/form-data boundary check. [6638](https://github.com/Kong/kong/pull/6638)
+- Fixed an issue involving multipart/form-data boundary checks. [6638](https://github.com/Kong/kong/pull/6638)
 - Fixed an issue that occurred when using upstreams for load balancing, where Kong was attempting
   to resolve the upstream name instead of the hostname and failing with the errors `name resolution failed`
   and `dns server error: 3 name error`. The following updates correct the issue:
@@ -116,7 +116,7 @@ no_version: true
 - Now Kong does not leave plugin servers alive after exiting and does not try to
   start them in the unsupported stream subsystem. [6849](https://github.com/Kong/kong/pull/6849)
 - Golang does not cache `kong.log` methods. The `kong` table has some special-case logic
-  for the `.log` subtable, and avoiding cacheing preserves this. [6701](https://github.com/Kong/kong/pull/6701)
+  for the `.log` subtable, and avoiding cacheing preserves this logic. [6701](https://github.com/Kong/kong/pull/6701)
 - The `response` phase is now included on the list of public phases. [6638](https://github.com/Kong/kong/pull/6638)
 - Config file style and options case are now consistent. [6981](https://github.com/Kong/kong/pull/6981)
 - Added correct Protobuf MacOS path to enable external plugins in Homebrew installations. [6980](https://github.com/Kong/kong/pull/6980)
@@ -146,7 +146,7 @@ no_version: true
     - Treats JWE tokens as opaque, so that they can be introspected.
     - Adds support for Ed448 curve in EdDSA signing and verification and JWKS key generation.
 - [Kong JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
-  - Cache now uses upsert instead of insert/update with database.
+  - Cache now uses upsert instead of insert/update with databases.
   - Key rotation is now more resilient on errors.
   - Adds Db-less improvements.
 - [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -18,7 +18,7 @@ no_version: true
     a version newer than the control plane’s version, or missing plugins from the control plane.
   </div>
 - UTF-8 characters can now be used in tags. This update expands the range of
-  accepted characters in tags from a limited set of ASCII characters to almost all of UTF-8 sequences.
+  accepted characters in tags from a limited set of ASCII characters to almost all UTF-8 sequences.
   Exceptions:
   - `,` and `/` are reserved for filtering tags with "and" and "or", and are not allowed in tags.
   - Non-printable ASCII (like the space character) is not allowed.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -9,7 +9,7 @@ no_version: true
 ### Features
 
 #### Core
-- This Kong version includes relaxed version check in hybrid mode between control planes
+- This Kong Gateway version introduces relaxed version checks in hybrid mode between control planes
   and data planes, allowing data planes that are missing minor updates (up to two) to
   still connect to the control plane. Also, data planes are allowed to have a superset
   of plugins in addition to the control plane plugins. [6932](https://github.com/Kong/kong/pull/6932)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -61,7 +61,7 @@ no_version: true
   and [HTTP Log](/hub/kong-inc/http-log)
   - Kong administrators now have a powerful new capability to transform logs to any format that’s needed
     for capturing, indexing, and correlating logs. When formatting, developers also have the ability to
-    execute custom Lua code - opening up a new range of possibilities for generating logs to a specification
+    execute custom Lua code, opening up a new range of possibilities for generating logs to whichever specification
     that administrators need the most. This feature uses the new PDK method `kong.log.set_serialize_value`,
     as well as the new sandbox capability, both introduced in Kong v2.3. [6944](https://github.com/Kong/kong/pull/6944)
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -22,7 +22,7 @@ no_version: true
   Exceptions:
   - `,` and `/` are reserved for filtering tags with "and" and "or", and are not allowed in tags.
   - Non-printable ASCII (for example, the space character) is not allowed.
-- This Kong version supports Online Certificate Status Protocol (OCSP) responder in cluster for
+- Kong Gateway now supports using an Online Certificate Status Protocol (OCSP) responder in the cluster for
   hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
   [6887](https://github.com/Kong/kong/pull/6887)
 - In this Kong version, Postgres `ssl_version` configuration now supports 'any' and will negotiate with server.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -37,8 +37,8 @@ no_version: true
   [6873](https://github.com/Kong/kong/pull/6873)
 
 #### Plugins
-- [OPA](/hub/kong-inc/opa) (`opa`)
-  - New OPA plugin forwards requests to an Open Policy Agent and processes the request
+- **New plugin:** [OPA](/hub/kong-inc/opa) (`opa`)
+  - The OPA plugin forwards requests to an Open Policy Agent and processes the request
     only if the authorization policy allows for it. **Released as BETA and should not be deployed
     in production environment.**
 - Mocking (`mocking`)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -47,10 +47,10 @@ no_version: true
     in production environment.**
 - [Zipkin](/hub/kong-inc/zipkin) (`zipkin`)
   - The plugin now supports OT and Jaeger style `uber-trace-id` headers. See `config.header_type` in
-    the [Parameters](https://docs.konghq.com/hub/kong-inc/zipkin/#parameters) section of the Zipkin
+    the [Parameters](/hub/kong-inc/zipkin/#parameters) section of the Zipkin
     plugin documentation for more information. [101](https://github.com/Kong/kong-plugin-zipkin/pull/101 )
   - The plugin now allows insertion of custom tags on the Zipkin request trace. See `config.tags_header`
-    in the [Parameters](https://docs.konghq.com/hub/kong-inc/zipkin/#parameters) section of the Zipkin
+    in the [Parameters](/hub/kong-inc/zipkin/#parameters) section of the Zipkin
     plugin documentation for more information. [102](https://github.com/Kong/kong-plugin-zipkin/pull/102)
   - The plugin now allows the creation of baggage items on child spans.
     [98](https://github.com/Kong/kong-plugin-zipkin/pull/98)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -17,7 +17,7 @@ no_version: true
     Data planes are not allowed to connect to control planes if they are a different major version,
     a version newer than the control plane’s version, or missing plugins from the control plane.
   </div>
-- This Kong version allows UTF-8 characters in tags. This update expands the range of
+- UTF-8 characters can now be used in tags. This update expands the range of
   accepted characters in tags from a limited set of ASCII characters to almost all of UTF-8 sequences.
   Exceptions:
   - `,` and `/` are reserved for filtering tags with "and" and "or", and are not allowed in tags.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -130,11 +130,11 @@ no_version: true
   plugins included default options that did not work well with DB-less or hybrid deployments mostly because the
   database was not available on gateway nodes. With this fix, the default values and validation rules are now
   compatible with DB-less or hybrid modes. [6885](https://github.com/Kong/kong/pull/6885)
-- [OAuth 2.0](/hub/kong-inc/oauth2): 
+- [OAuth 2.0](/hub/kong-inc/oauth2) (`oauth2`) 
   - To improve user experience and limit confusion, the plugin now handles cases of client invalid
     token generation in a more predictable way. Before the resulting error codes were confusing and
     unhelpful, often leading users to the wrong conclusions. [6594](https://github.com/Kong/kong/pull/6594)
-- [Zipkin](/hub/kong-inc/zipkin)
+- [Zipkin](/hub/kong-inc/zipkin) (`zipkin`)
   - The W3C parsing function was returning a non-used extra value that has been removed, and the plugin
     now early-exits if there is a problem with the W3C Trace Context header.
     [100](https://github.com/Kong/kong-plugin-zipkin/pull/100)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -148,7 +148,7 @@ no_version: true
 - [Kong JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
   - Cache now uses upsert instead of insert/update with databases.
   - Key rotation is now more resilient on errors.
-  - Adds Db-less improvements.
+  - Adds DB-less improvements.
 - [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
   - The plugin was not allowing access to Kong module within the sandbox, only to `kong.request`,
     which prevented access to `kong.log` for example.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -21,7 +21,7 @@ no_version: true
   accepted characters in tags from a limited set of ASCII characters to almost all UTF-8 sequences.
   Exceptions:
   - `,` and `/` are reserved for filtering tags with "and" and "or", and are not allowed in tags.
-  - Non-printable ASCII (like the space character) is not allowed.
+  - Non-printable ASCII (for example, the space character) is not allowed.
 - This Kong version supports Online Certificate Status Protocol (OCSP) responder in cluster for
   hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
   [6887](https://github.com/Kong/kong/pull/6887)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -25,7 +25,7 @@ no_version: true
 - Kong Gateway now supports using an Online Certificate Status Protocol (OCSP) responder in the cluster for
   hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
   [6887](https://github.com/Kong/kong/pull/6887)
-- Postgres `ssl_version` configuration now defaults to `any`. If `ssl_versio`n is not explicitly set,
+- Postgres `ssl_version` configuration now defaults to `any`. If `ssl_version` is not explicitly set,
   the `any` option ensures that `luasec` will negotiate the most secure protocol available.
 
 #### PDK

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -90,7 +90,7 @@ no_version: true
   using upstreams for load balancing. When caching services, Kong does not warmup upstream
   names used as service hosts entries when warming up DNS entries, as they are not real DNS
   entries. [6891](https://github.com/Kong/kong/pull/6891)
-- Migrations order is now guaranteed to be always the same. Before the order in which the
+- Migrations order is now guaranteed to be always the same. Before, the order in which the
   subsystems were loaded changed randomly. Now, subsystems are sorted alphabetically, so the
   order in which migrations are executed is constant. [6901](https://github.com/Kong/kong/pull/6901)
 - Buffered responses are disabled on connection upgrades. Kong cannot do buffered responses with,

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -56,7 +56,7 @@ no_version: true
     [98](https://github.com/Kong/kong-plugin-zipkin/pull/98)
 - [JWT](/hub/kong-inc/jwt) (`jwt`) 
   - The plugin now supports ES384 JWTs signature validation. [6854](https://github.com/Kong/kong/pull/6854)
-- Several plugins including: [File Log](/hub/kong-inc/file-log), [Loggly](/hub/kong-inc/loggly),
+- Logging plugins: [File Log](/hub/kong-inc/file-log), [Loggly](/hub/kong-inc/loggly),
   [Syslog](/hub/kong-inc/syslog), [TCP Log](/hub/kong-inc/tcp-log), [UDP Log](/hub/kong-inc/udp-log),
   and [HTTP Log](/hub/kong-inc/http-log)
   - Kong administrators now have a powerful new capability to transform logs to any format that’s needed

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -31,7 +31,7 @@ no_version: true
 #### PDK
 - This release includes a new JavaScript Plugin Development Kit (PDK). This addition
   allows users to write Kong plugins in JavaScript and TypeScript.
-- This release includes support for Protobuf plugin communication protocol, which can be used in
+- This release includes support for the Protobuf plugin communication protocol, which can be used in
   place of MessagePack to communicate with non-Lua plugins. [6941](https://github.com/Kong/kong/pull/6941)
 - This release enables `ssl_certificate` phase on plugins in `stream` module.
   [6873](https://github.com/Kong/kong/pull/6873)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -98,7 +98,7 @@ no_version: true
 - Entity relationships are now traverse-order-independent. This fix keeps track of all copied
   records and injects the new field on each copy.
   [6843](https://github.com/Kong/kong/commit/5f2a87259e3b474ec6129490bba82dac0aeba1cf)
-- The host header is updated between balancer retries. Before Kong set the `Host` header during
+- The host header is updated between balancer retries. Before, Kong Gateway set the `Host` header during
   the access phase only and would send the wrong header if a target failed to serve and needed
   to be retried. [6796](https://github.com/Kong/kong/pull/6796)
 - The router prioritizes the route with most matching headers when matching headers.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -81,7 +81,7 @@ no_version: true
 - Users can proxy websockets through Kong when using Chrome or Firefox. `HTTP Connection`
   headers usually carry a list of headers meant for receivers (in this case a proxy) that
   are not meant to be proxied further (hop-by-hop headers). The Kong Gateway correctly
-  cleans these headers, but it was a bit too aggressive and the`Upgrade` header was cleared
+  cleans these headers, but it was a bit too aggressive and the `Upgrade` header was cleared
   from response `Connection` headers, causing the connections to fail when using Firefox
   or Chrome. [6929](https://github.com/Kong/kong/pull/6929)
 - Kong now accepts fully-qualified domain names ending in dots to be compliant with RFC internet standards.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -150,8 +150,8 @@ no_version: true
   - Key rotation is now more resilient on errors.
   - Adds DB-less improvements.
 - [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
-  - The plugin was not allowing access to Kong module within the sandbox, only to `kong.request`,
-    which prevented access to `kong.log` for example.
+  - The plugin was not allowing access to any Kong modules within the sandbox except `kong.request`,
+    which prevented access to other necessary modules such as `kong.log`.
 
 ## 2.3.3.0
 **Release Date** 2021/03/26

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -22,7 +22,7 @@ no_version: true
   Exceptions:
   - ',' and '/' are reserved for filtering tags with "and" and "or" and are not allowed in tags.
   - Non-printable ASCII (like the space character) is not allowed.
-- This Kong version supports Online Certicate Status Protocol (OCSP) responder in cluster for
+- This Kong version supports Online Certificate Status Protocol (OCSP) responder in cluster for
   hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
   [6887](https://github.com/Kong/kong/pull/6887)
 - In this Kong version, Postgres `ssl_version` configuration now supports 'any' and will negotiate with server.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -107,8 +107,8 @@ no_version: true
 - Fixed an issue that occurred when using upstreams for load balancing, where Kong was attempting
   to resolve the upstream name instead of the hostname and failing with the errors `name resolution failed`
   and `dns server error: 3 name error`. The following updates correct the issue:
-  - [Kong does not cache empty upstream name dictionaries.](https://github.com/Kong/kong/pull/7002)
-  - [Kong does not assume upstreams don't exist after init phases.](https://github.com/Kong/kong/pull/7010)
+  - Kong does not cache empty upstream name dictionaries. [7002](https://github.com/Kong/kong/pull/7002)
+  - Kong does not assume upstreams don't exist after init phases. [7010](https://github.com/Kong/kong/pull/7010)
 - Opentracing libraries (opentracing, jaegar,datadog) bumped to latest versions.
 - The Developer Portal is now disabled when running without a license.
 
@@ -152,7 +152,7 @@ no_version: true
 - [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
   - The plugin was not allowing access to Kong module within the sandbox, only to `kong.request`,
     which prevented access to `kong.log` for example.
-    
+
 ## 2.3.3.0
 **Release Date** 2021/03/26
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -127,7 +127,7 @@ no_version: true
 
 #### Plugins
 - The [Rate Limiting](/hub/kong-inc/rate-limiting) and [Response Rate Limiting](/hub/kong-inc/response-ratelimiting)
-  plugins included default options that did not work well with DB-less or hybrid deployments mostly because the
+  plugins included default options that did not work well with DB-less or hybrid deployments because the
   database was not available on gateway nodes. With this fix, the default values and validation rules are now
   compatible with DB-less or hybrid modes. [6885](https://github.com/Kong/kong/pull/6885)
 - [OAuth 2.0](/hub/kong-inc/oauth2) (`oauth2`) 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -33,7 +33,7 @@ no_version: true
   allows users to write Kong plugins in JavaScript and TypeScript.
 - This release includes support for the Protobuf plugin communication protocol, which can be used in
   place of MessagePack to communicate with non-Lua plugins. [6941](https://github.com/Kong/kong/pull/6941)
-- This release enables `ssl_certificate` phase on plugins in `stream` module.
+- This release enables the `ssl_certificate` phase on plugins in the `stream` module.
   [6873](https://github.com/Kong/kong/pull/6873)
 
 #### Plugins

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -120,7 +120,7 @@ no_version: true
 - The `response` phase is now included on the list of public phases. [6638](https://github.com/Kong/kong/pull/6638)
 - Config file style and options case are now consistent. [6981](https://github.com/Kong/kong/pull/6981)
 - Added correct Protobuf MacOS path to enable external plugins in Homebrew installations. [6980](https://github.com/Kong/kong/pull/6980)
-- Now Kong auto-escapes upstream paths(`kong.service.request.set_path()`) to avoid proxying errors.
+- Kong Gateway now auto-escapes upstream paths (`kong.service.request.set_path()`) to avoid proxying errors.
   [6978](https://github.com/Kong/kong/pull/6978)
 - In the Golang PDK, ports are now declared as `Int`. Before they were incorrectly declared
   `Strings`. [6994](https://github.com/Kong/kong/pull/6994)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -60,7 +60,7 @@ no_version: true
   [Syslog](/hub/kong-inc/syslog), [TCP Log](/hub/kong-inc/tcp-log), [UDP Log](/hub/kong-inc/udp-log),
   and [HTTP Log](/hub/kong-inc/http-log)
   - Kong administrators now have a powerful new capability to transform logs to any format that’s needed
-    for capturing, indexing and correlating logs  When formatting, developers also have the ability to
+    for capturing, indexing, and correlating logs. When formatting, developers also have the ability to
     execute custom Lua code - opening up a new range of possibilities for generating logs to a specification
     that administrators need the most. This feature uses the new PDK method `kong.log.set_serialize_value`,
     as well as the new sandbox capability, both introduced in Kong v2.3. [6944](https://github.com/Kong/kong/pull/6944)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -109,7 +109,7 @@ no_version: true
   and `dns server error: 3 name error`. The following updates correct the issue:
   - Kong does not cache empty upstream name dictionaries. [7002](https://github.com/Kong/kong/pull/7002)
   - Kong does not assume upstreams don't exist after init phases. [7010](https://github.com/Kong/kong/pull/7010)
-- Opentracing libraries (opentracing, jaegar,datadog) bumped to latest versions.
+- Opentracing libraries (opentracing, jaegar, datadog) bumped to latest versions.
 - The Developer Portal is now disabled when running without a license.
 
 #### PDK

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -128,7 +128,7 @@ no_version: true
 #### Plugins
 - The [Rate Limiting](/hub/kong-inc/rate-limiting) and [Response Rate Limiting](/hub/kong-inc/response-ratelimiting)
   plugins included default options that did not work well with DB-less or hybrid deployments because the
-  database was not available on gateway nodes. With this fix, the default values and validation rules are now
+  database is not available on data plane nodes. With this fix, the default values and validation rules are now
   compatible with DB-less or hybrid modes. [6885](https://github.com/Kong/kong/pull/6885)
 - [OAuth 2.0](/hub/kong-inc/oauth2) (`oauth2`) 
   - To improve user experience and limit confusion, the plugin now handles cases of client invalid

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -3,6 +3,156 @@ title: Kong Gateway (Enterprise) Changelog
 no_search: true
 no_version: true
 ---
+## 2.4.0.0 (beta)
+**Release Date** 2021/04/13
+
+### Features
+
+#### Core
+- This Kong version includes relaxed version check in hybrid mode between control planes
+  and data planes, allowing data planes that are missing minor updates (up to two) to
+  still connect to the control plane. Also, data planes are allowed to have a superset
+  of plugins in addition to the control plane plugins. [6932](https://github.com/Kong/kong/pull/6932)
+  <div class="alert alert-ee blue">
+    Data planes are not allowed to connect to control planes if they are a different major version,
+    a version newer than the control plane’s version, or missing plugins from the control plane.
+  </div>
+- This Kong version allows UTF-8 characters in tags. This update expands the range of
+  accepted characters in tags from a limited set of ASCII characters to almost all of UTF-8 sequences.
+  Exceptions:
+  - ',' and '/' are reserved for filtering tags with "and" and "or" and are not allowed in tags.
+  - Non-printable ASCII (like the space character) is not allowed.
+- This Kong version supports Online Certicate Status Protocol (OCSP) responder in cluster for
+  hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
+  [6887](https://github.com/Kong/kong/pull/6887)
+- In this Kong version, Postgres `ssl_version` configuration now supports 'any' and will negotiate with server.
+  This update ensures that `luasec` will negotiate the most secure protocol available if not otherwise set.
+
+#### PDK
+- This release includes a new JavaScript Plugin Development Kit (PDK). This addition to the PDK
+  allows users to write Kong plugins in JavaScript and TypeScript.
+- This release includes support for Protobuf plugin communication protocol, which can be used in
+  place of MessagePack to communicate with non-Lua plugins. [6941](https://github.com/Kong/kong/pull/6941)
+- This release enables `ssl_certificate` phase on plugins in `stream` module.
+  [6873](https://github.com/Kong/kong/pull/6873)
+
+#### Plugins
+- [OPA](/hub/kong-inc/opa) (`opa`)
+  - New OPA plugin forwards requests to an Open Policy Agent and processes the request
+    only if the authorization policy allows for it. **Released as BETA and should not be deployed
+    in production environment.**
+- [Mocking] (`mocking`)
+  - New Kong Mocking plugin leverages standards-based Open API Specifications (OAS)
+    for sending out mock responses to APIs. **Released as BETA and should not be deployed
+    in production environment.**
+- [Zipkin](/hub/kong-inc/zipkin) (`zipkin`)
+  - The plugin now supports OT and Jaeger style `uber-trace-id` headers. See `config.header_type` in
+    the Parameters section of the Zipkin plugin documentation for more information.
+    [101](https://github.com/Kong/kong-plugin-zipkin/pull/101 )
+  - The plugin now allows insertion of custom tags on the Zipkin request trace. See `config.tags_header`
+    in the Parameters section of the Zipkin plugin documentation for more information.
+    [102](https://github.com/Kong/kong-plugin-zipkin/pull/102)
+  - The plugin now allows the creation of baggage items on child spans.
+    [98](https://github.com/Kong/kong-plugin-zipkin/pull/98)
+- [JWT](/hub/kong-inc/jwt) (`jwt`) 
+  - The plugin now supports ES384 JWTs signature validation. [6854](https://github.com/Kong/kong/pull/6854)
+- Several plugins including: [File Log](/hub/kong-inc/file-log), [Loggly](/hub/kong-inc/loggly),
+  [Syslog](/hub/kong-inc/syslog), [TCP Log](/hub/kong-inc/tcp-log), [UDP Log](/hub/kong-inc/udp-log),
+  and [HTTP Log](/hub/kong-inc/http-log)
+  - Kong administrators now have a powerful new capability to transform logs to any format that’s needed
+    for capturing, indexing and correlating logs  When formatting, developers also have the ability to
+    execute custom Lua code - opening up a new range of possibilities for generating logs to a specification
+    that administrators need the most. This feature uses the new PDK method `kong.log.set_serialize_value`,
+    as well as the new sandbox capability, both introduced in Kong v2.3. [6944](https://github.com/Kong/kong/pull/6944)
+
+### Fixes
+
+#### Core
+- Topological sort now prioritizes core, avoiding problems when plugin entities use core entities but
+  don't explicitly depend on them. [6880](https://github.com/Kong/kong/pull/6880)
+- If needed, `Host` header is now updated between balancer retries.
+  [6796](https://github.com/Kong/kong/pull/6796)
+- Schema validations now log more descriptive error messages when types are invalid.
+  [6593](https://github.com/Kong/kong/pull/6593)
+- Kong now ignores tags in Cassandra when filtering by multiple entities, which is the
+  expected behavior and the one already existent when using Postgres databases.
+  See [Tags](https://docs.konghq.com/enterprise/2.3.x/admin-api/#tags) in the Admin API
+  documentation for more information. [6931](https://github.com/Kong/kong/pull/6931)
+- Users can proxy websockets through Kong when using Chrome or Firefox. `HTTP Connection`
+  headers usually carry a list of headers meant for receivers (in this case a proxy) that
+  are not meant to be proxied further (hop-by-hop headers). The Kong gateway correctly
+  cleans these headers, but it was a bit too aggressive and the`Upgrade` header was cleared
+  from response `Connection` headers, causing the connections to fail when using Firefox
+  or Chrome. [6929](https://github.com/Kong/kong/pull/6929)
+- Kong now accepts fully-qualified domain names ending in dots to be compliant with RFC internet standards.
+  [6864](https://github.com/Kong/kong/pull/6864)
+- Kong has removed unnecessary load from DNS servers by resolving an issue occuring when
+  using upstreams for load balancing. When caching services, Kong does not warmup upstream
+  names used as service hosts entries when warming up DNS entries, as they are not real DNS
+  entries. [6891](https://github.com/Kong/kong/pull/6891)
+- Migrations order is now guaranteed to be always the same. Before the order in which the
+  subsystems were loaded changed randomly. Now, subsystems are sorted alphabetically, so the
+  order in which migrations are executed is constant. [6901](https://github.com/Kong/kong/pull/6901)
+- Buffered responses are disabled on connection upgrades. Kong cannot do buffered responses with,
+  for example, websocket connection upgrades. [6902](https://github.com/Kong/kong/pull/6902)
+- Entity relationships are now traverse-order-independent. This fix keeps track of all copied
+  records and injects the new field on each copy.
+  [6843](https://github.com/Kong/kong/commit/5f2a87259e3b474ec6129490bba82dac0aeba1cf)
+- The host header is updated between balancer retries. Before Kong set the `Host` header during
+  the access phase only and would send the wrong header if a target failed to server and needed
+  to be retried. [6796](https://github.com/Kong/kong/pull/6796)
+- The router prioritizes the route with most matching headers when matching headers.
+  [6638](https://github.com/Kong/kong/pull/6638)
+- Fixed an edge case on multipart/form-data boundary check. [6638](https://github.com/Kong/kong/pull/6638)
+- Fixed an issue that occurred when using upstreams for load balancing, where Kong was attempting
+  to resolve the upstream name instead of the hostname and failing with the errors `name resolution failed`
+  and `dns server error: 3 name error`. The following updates correct the issue:
+  - [Kong does not cache empty upstream name dictionaries.](https://github.com/Kong/kong/pull/7002)
+  - [Kong does not assume upstreams don't exist after init phases.](https://github.com/Kong/kong/pull/7010)
+- Opentracing libraries (opentracing, jaegar,datadog) bumped to latest versions.
+- The Developer Portal is now disabled when running without a license.
+
+#### PDK
+- Now Kong does not leave plugin servers alive after exiting and does not try to
+  start them in the unsupported stream subsystem. [6849](https://github.com/Kong/kong/pull/6849)
+- Golang does not cache `kong.log` methods. The `kong` table has some special-case magic
+  for the `.log` subtable, and avoiding cacheing preserves this. [6701](https://github.com/Kong/kong/pull/6701)
+- The `response` phase is now included on the list of public phases. [6638](https://github.com/Kong/kong/pull/6638)
+- Config file style and options case are now consistent. [6981](https://github.com/Kong/kong/pull/6981)
+- Added correct Protobuf MacOS path to enable external plugins in Homebrew installations. [6980](https://github.com/Kong/kong/pull/6980)
+- Now Kong auto-escapes upstream paths(`kong.service.request.set_path()`) to avoid proxying errors.
+  [6978](https://github.com/Kong/kong/pull/6978)
+- In the Golang PDK, ports are now declared as `Int`. Before they were incorrectly declared
+  `Strings`. [6994](https://github.com/Kong/kong/pull/6994)
+
+#### Plugins
+- The [Rate Limiting](/hub/kong-inc/rate-limiting) and [Response Rate Limiting](/hub/kong-inc/response-ratelimiting)
+  plugins included default options that did not work well with DB-less or hybrid deployments mostly because the
+  database was not available on gateway nodes. With this fix, the default values and validation rules are now
+  compatible with DB-less or hybrid modes. [6885](https://github.com/Kong/kong/pull/6885)
+- [OAuth 2.0](/hub/kong-inc/oauth2): 
+  - To improve user experience and limit confusion, the plugin now handles cases of client invalid
+    token generation in a more predictable way. Before the resulting error codes were confusing and
+    unhelpful, often leading users to the wrong conclusions. [6594](https://github.com/Kong/kong/pull/6594)
+- [Zipkin](/hub/kong-inc/zipkin)
+  - The W3C parsing function was returning a non-used extra value that has been removed, and the plugin
+    now early-exits if there is a problem with the W3C Trace Context header.
+    [100](https://github.com/Kong/kong-plugin-zipkin/pull/100)
+  - Fixed a bug which randomly caused requests to fail with a 400 error code during span timestamping if
+    the access phase was skipped. [105](https://github.com/Kong/kong-plugin-zipkin/pull/105)
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  - `kong-openid-connect` library updated to v2.1.0
+    - Updates `lua-resty-nettle` dependency to v2.0.
+    - Treats JWE tokens as opaque, so that they can be introspected.
+    - Adds support for Ed448 curve in EdDSA signing and verification and JWKS key generation.
+- [Kong JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
+  - Cache now uses upsert instead of insert/update with database.
+  - Key rotation is now more resilient on errors.
+  - Adds Db-less improvements.
+- [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
+  - The plugin was not allowing access to Kong module within the sandbox, only to `kong.request`,
+    which prevented access to `kong.log` for example.
+    
 ## 2.3.3.0
 **Release Date** 2021/03/26
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -62,7 +62,7 @@ no_version: true
   - Kong administrators now have a powerful new capability to transform logs to any format that’s needed
     for capturing, indexing, and correlating logs. When formatting, developers also have the ability to
     execute custom Lua code, opening up a new range of possibilities for generating logs to whichever specification
-    that administrators need the most. This feature uses the new PDK method `kong.log.set_serialize_value`,
+    administrators need the most. This feature uses the new PDK method `kong.log.set_serialize_value`,
     as well as the new sandbox capability, both introduced in Kong v2.3. [6944](https://github.com/Kong/kong/pull/6944)
 
 ### Fixes

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -25,8 +25,8 @@ no_version: true
 - Kong Gateway now supports using an Online Certificate Status Protocol (OCSP) responder in the cluster for
   hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
   [6887](https://github.com/Kong/kong/pull/6887)
-- In this Kong version, Postgres `ssl_version` configuration now supports 'any' and will negotiate with server.
-  This update ensures that `luasec` will negotiate the most secure protocol available if not otherwise set.
+- Postgres `ssl_version` configuration now defaults to `any`. If `ssl_versio`n is not explicitly set,
+  the `any` option ensures that `luasec` will negotiate the most secure protocol available.
 
 #### PDK
 - This release includes a new JavaScript Plugin Development Kit (PDK). This addition

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -116,7 +116,7 @@ no_version: true
 - Kong Gateway no longer leaves plugin servers alive after exiting and does not try to
   start them in the unsupported stream subsystem. [6849](https://github.com/Kong/kong/pull/6849)
 - Golang does not cache `kong.log` methods. The `kong` table has some special-case logic
-  for the `.log` subtable, and avoiding cacheing preserves this logic. [6701](https://github.com/Kong/kong/pull/6701)
+  for the `.log` subtable, and avoiding caching preserves this logic. [6701](https://github.com/Kong/kong/pull/6701)
 - The `response` phase is now included on the list of public phases. [6638](https://github.com/Kong/kong/pull/6638)
 - Config file style and options case are now consistent. [6981](https://github.com/Kong/kong/pull/6981)
 - Added correct Protobuf MacOS path to enable external plugins in Homebrew installations. [6980](https://github.com/Kong/kong/pull/6980)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -115,7 +115,7 @@ no_version: true
 #### PDK
 - Now Kong does not leave plugin servers alive after exiting and does not try to
   start them in the unsupported stream subsystem. [6849](https://github.com/Kong/kong/pull/6849)
-- Golang does not cache `kong.log` methods. The `kong` table has some special-case magic
+- Golang does not cache `kong.log` methods. The `kong` table has some special-case logic
   for the `.log` subtable, and avoiding cacheing preserves this. [6701](https://github.com/Kong/kong/pull/6701)
 - The `response` phase is now included on the list of public phases. [6638](https://github.com/Kong/kong/pull/6638)
 - Config file style and options case are now consistent. [6981](https://github.com/Kong/kong/pull/6981)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -41,7 +41,7 @@ no_version: true
   - New OPA plugin forwards requests to an Open Policy Agent and processes the request
     only if the authorization policy allows for it. **Released as BETA and should not be deployed
     in production environment.**
-- [Mocking] (`mocking`)
+- Mocking (`mocking`)
   - New Kong Mocking plugin leverages standards-based Open API Specifications (OAS)
     for sending out mock responses to APIs. **Released as BETA and should not be deployed
     in production environment.**

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -80,7 +80,7 @@ no_version: true
   documentation for more information. [6931](https://github.com/Kong/kong/pull/6931)
 - Users can proxy websockets through Kong when using Chrome or Firefox. `HTTP Connection`
   headers usually carry a list of headers meant for receivers (in this case a proxy) that
-  are not meant to be proxied further (hop-by-hop headers). The Kong gateway correctly
+  are not meant to be proxied further (hop-by-hop headers). The Kong Gateway correctly
   cleans these headers, but it was a bit too aggressive and the`Upgrade` header was cleared
   from response `Connection` headers, causing the connections to fail when using Firefox
   or Chrome. [6929](https://github.com/Kong/kong/pull/6929)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -20,7 +20,7 @@ no_version: true
 - This Kong version allows UTF-8 characters in tags. This update expands the range of
   accepted characters in tags from a limited set of ASCII characters to almost all of UTF-8 sequences.
   Exceptions:
-  - ',' and '/' are reserved for filtering tags with "and" and "or" and are not allowed in tags.
+  - `,` and `/` are reserved for filtering tags with "and" and "or", and are not allowed in tags.
   - Non-printable ASCII (like the space character) is not allowed.
 - This Kong version supports Online Certificate Status Protocol (OCSP) responder in cluster for
   hybrid mode control planes. This new feature can be configured in the `kong.conf` file.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -41,8 +41,8 @@ no_version: true
   - The OPA plugin forwards requests to an Open Policy Agent and processes the request
     only if the authorization policy allows for it. **Released as BETA and should not be deployed
     in production environment.**
-- Mocking (`mocking`)
-  - New Kong Mocking plugin leverages standards-based Open API Specifications (OAS)
+- **New plugin:** Mocking (`mocking`)
+  - The Kong Mocking plugin leverages standards-based Open API Specifications (OAS)
     for sending out mock responses to APIs. **Released as BETA and should not be deployed
     in production environment.**
 - [Zipkin](/hub/kong-inc/zipkin) (`zipkin`)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -12,7 +12,9 @@ no_version: true
 - This Kong Gateway version introduces relaxed version checks in hybrid mode between control planes
   and data planes, allowing data planes that are missing minor updates (up to two) to
   still connect to the control plane. Also, data planes are allowed to have a superset
-  of plugins in addition to the control plane plugins. [6932](https://github.com/Kong/kong/pull/6932)
+  of plugins in addition to the control plane plugins. See [Managing the cluster using Control Plane
+  nodes](/gateway-oss/2.4.x/hybrid-mode/#managing-the-cluster-using-control-plane-nodes) for
+  more information. [6932](https://github.com/Kong/kong/pull/6932)
   <div class="alert alert-ee blue">
     Data planes are not allowed to connect to control planes if they are a different major version,
     a version newer than the control plane’s version, or missing plugins from the control plane.
@@ -22,15 +24,19 @@ no_version: true
   Exceptions:
   - `,` and `/` are reserved for filtering tags with "and" and "or", and are not allowed in tags.
   - Non-printable ASCII (for example, the space character) is not allowed.
+  See [Tags](/gateway-oss/2.4.x/admin-api/#tags) in the Admin API documentation for more information.
 - Kong Gateway now supports using an Online Certificate Status Protocol (OCSP) responder in the cluster for
-  hybrid mode control planes. This new feature can be configured in the `kong.conf` file.
-  [6887](https://github.com/Kong/kong/pull/6887)
+  hybrid mode control planes. This new feature can be configured in the `kong.conf` file. See
+  [`cluster_oscp`](/gateway-oss/2.4.x/configuration/#cluster_ocsp) in the Configuration Reference for
+  more information. [6887](https://github.com/Kong/kong/pull/6887)
 - Postgres `ssl_version` configuration now defaults to `any`. If `ssl_version` is not explicitly set,
   the `any` option ensures that `luasec` will negotiate the most secure protocol available.
 
 #### PDK
 - This release includes a new JavaScript Plugin Development Kit (PDK). This addition
-  allows users to write Kong plugins in JavaScript and TypeScript.
+  allows users to write Kong plugins in JavaScript and TypeScript. See
+  [Developing JavaScript plugins](/gateway-oss/2.4.x/external-plugins/#developing-javascript-plugins)
+  for more information.
 - This release includes support for the Protobuf plugin communication protocol, which can be used in
   place of MessagePack to communicate with non-Lua plugins. [6941](https://github.com/Kong/kong/pull/6941)
 - This release enables the `ssl_certificate` phase on plugins in the `stream` module.
@@ -64,14 +70,24 @@ no_version: true
     execute custom Lua code, opening up a new range of possibilities for generating logs to whichever specification
     administrators need the most. This feature uses the new PDK method `kong.log.set_serialize_value`,
     as well as the new sandbox capability, both introduced in Kong v2.3. [6944](https://github.com/Kong/kong/pull/6944)
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  - `kong-openid-connect` library updated to v2.1.0
+    - Treats JWE tokens as opaque, so that they can be introspected.
+    - Adds support for Ed448 curve in EdDSA signing and verification and JWKS key generation.
+
+### Dependencies
+- Bumped `opentracing-cpp` from v1.5.1 to v1.6.0
+- Bumped `datadog` from v1.1.2 to v1.3.0
+- Bumped `nginx-opentracing` from v0.9.0 to v0.14.0
+- Bumped `jaeger` from v0.5.0 to v0.7.0
+- Bumped `lua-resty-nettle` from v1.8.3 to v2.0.0 
+- Bumped `openresty` from v1.17.8.2 to v1.19.3.1
 
 ### Fixes
 
 #### Core
 - Topological sort now prioritizes core, avoiding problems when plugin entities use core entities but
   don't explicitly depend on them. [6880](https://github.com/Kong/kong/pull/6880)
-- If needed, `Host` header is now updated between balancer retries.
-  [6796](https://github.com/Kong/kong/pull/6796)
 - Schema validations now log more descriptive error messages when types are invalid.
   [6593](https://github.com/Kong/kong/pull/6593)
 - Kong now ignores tags in Cassandra when filtering by multiple entities, which is the
@@ -109,7 +125,6 @@ no_version: true
   and `dns server error: 3 name error`. The following updates correct the issue:
   - Kong does not cache empty upstream name dictionaries. [7002](https://github.com/Kong/kong/pull/7002)
   - Kong does not assume upstreams don't exist after init phases. [7010](https://github.com/Kong/kong/pull/7010)
-- Opentracing libraries (opentracing, jaegar, datadog) bumped to latest versions.
 - The Developer Portal is now disabled when running without a license.
 
 #### PDK
@@ -140,11 +155,6 @@ no_version: true
     [100](https://github.com/Kong/kong-plugin-zipkin/pull/100)
   - Fixed a bug which randomly caused requests to fail with a 400 error code during span timestamping if
     the access phase was skipped. [105](https://github.com/Kong/kong-plugin-zipkin/pull/105)
-- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  - `kong-openid-connect` library updated to v2.1.0
-    - Updates `lua-resty-nettle` dependency to v2.0.
-    - Treats JWE tokens as opaque, so that they can be introspected.
-    - Adds support for Ed448 curve in EdDSA signing and verification and JWKS key generation.
 - [Kong JWT Signer](/hub/kong-inc/jwt-signer) (`jwt-signer`)
   - Cache now uses upsert instead of insert/update with databases.
   - Key rotation is now more resilient on errors.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -113,7 +113,7 @@ no_version: true
 - The Developer Portal is now disabled when running without a license.
 
 #### PDK
-- Now Kong does not leave plugin servers alive after exiting and does not try to
+- Kong Gateway no longer leaves plugin servers alive after exiting and does not try to
   start them in the unsupported stream subsystem. [6849](https://github.com/Kong/kong/pull/6849)
 - Golang does not cache `kong.log` methods. The `kong` table has some special-case logic
   for the `.log` subtable, and avoiding cacheing preserves this logic. [6701](https://github.com/Kong/kong/pull/6701)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -132,7 +132,7 @@ no_version: true
   compatible with DB-less or hybrid modes. [6885](https://github.com/Kong/kong/pull/6885)
 - [OAuth 2.0](/hub/kong-inc/oauth2) (`oauth2`) 
   - To improve user experience and limit confusion, the plugin now handles cases of client invalid
-    token generation in a more predictable way. Before the resulting error codes were confusing and
+    token generation in a more predictable way. Before, the resulting error codes were confusing and
     unhelpful, often leading users to the wrong conclusions. [6594](https://github.com/Kong/kong/pull/6594)
 - [Zipkin](/hub/kong-inc/zipkin) (`zipkin`)
   - The W3C parsing function was returning a non-used extra value that has been removed, and the plugin


### PR DESCRIPTION
### Review
Combined both [CE 2.4.0.0 changelog](https://github.com/Kong/kong/blob/2.4.0-rc.1/CHANGELOG.md#240-rc1) and [EE - changelog](https://konghq.atlassian.net/wiki/spaces/FTT/pages/8356124/Kong+Enterprise+-+Changelog+Features+Release+Schedule#KongEnterprise-Changelog%2CFeatures%26ReleaseSchedule-KongEnterprise2.4.0.0Beta) for the 2.4.0 beta release.

[Google doc with original CE 2.4 beta changelog questions](https://docs.google.com/document/d/1wH08qMpYgzUWGyfn1Fyk1s9m_53sB423D1o79WqAQ0Q/edit)
### Summary
[DOCU-1401](https://konghq.atlassian.net/browse/DOCU-1401)
### Reason
Because we are releasing a 2.4.0.0 beta and want to inform users of the updates.
### Testing
[2.4.0.0-beta changelog](https://deploy-preview-2786--kongdocs.netlify.app/enterprise/changelog/#2400-beta)