### PR TITLE
Fixing missed dev portal link

### DIFF
--- a/app/getting-started-guide/2.4.x/dev-portal.md
+++ b/app/getting-started-guide/2.4.x/dev-portal.md
@@ -48,7 +48,7 @@ This will expose the Dev Portal at `http://<admin-hostname>:8003/SecureWorkspace
 
 After the Dev Portal is enabled for the Workspace, a few new links appear in the left navigation menu. It may take a few seconds for the Settings page to populate.
 
-You can learn more about personalization in the [the Dev Portal documentation](/enterprise/latest/developer-portal/overview/), including:
+You can learn more about personalization in the [the Dev Portal documentation](/enterprise/latest/developer-portal/), including:
 
 * [Customizing the look and feel of the site and editor](/enterprise/latest/developer-portal/theme-customization/easy-theme-editing/)
 * [Managing access](/enterprise/latest/developer-portal/administration/)


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
Updating a link.
### Reason
Link got missed in 2.4.x version of the getting started guide, as it was on a different branch when the links were updated as a whole.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
