### PR TITLE
Add missing nav file

### DIFF
--- a/app/_data/docs_nav_gsg_2.4.x.yml
+++ b/app/_data/docs_nav_gsg_2.4.x.yml
@@ -1,0 +1,21 @@
+- title: Getting Started Guide
+  icon: /assets/images/icons/documentation/icn-quickstart-color.svg
+  items:
+    - text: Overview
+      url: /overview
+    - text: Prepare to Administer
+      url: /prepare
+    - text: Expose your Services
+      url: /expose-services
+    - text: Protect your Services
+      url: /protect-services
+    - text: Improve Performance
+      url: /improve-performance
+    - text: Secure Services
+      url: /secure-services
+    - text: Set Up Intelligent Load Balancing
+      url: /load-balancing
+    - text: Manage Administrative Teams
+      url: /manage-teams
+    - text: Publish, Locate, and Consume Services
+      url: /dev-portal


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
Adding missing nav file for the 2.4.x version of the getting started guide.
### Reason
Nav is missing.
### Testing
https://deploy-preview-2789--kongdocs.netlify.app/getting-started-guide/2.4.x/overview/
