### PR TITLE
fix version variable for mesh

### DIFF
--- a/app/_includes/md/mesh/install-universal-run.md
+++ b/app/_includes/md/mesh/install-universal-run.md
@@ -1,11 +1,11 @@
 <!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
 ## 2. Run {{site.mesh_product_name}}
-Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_versions[0].version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
+Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{page.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
 
 Navigate to the `bin` folder:
 
 ```sh
-$ cd kong-mesh-{{page.kong_versions[0].version}}/bin
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
 ```
 
 <div class="alert alert-ee blue">

--- a/app/mesh/1.0.x/installation/amazonlinux.md
+++ b/app/mesh/1.0.x/installation/amazonlinux.md
@@ -36,13 +36,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/centos.md
+++ b/app/mesh/1.0.x/installation/centos.md
@@ -29,13 +29,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/debian.md
+++ b/app/mesh/1.0.x/installation/debian.md
@@ -27,13 +27,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -38,16 +38,16 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
-* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
-* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
-* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
-* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)
+* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 
 {% endnavtab %}
@@ -65,7 +65,7 @@ control plane process in the next step &mdash; which is served by the
 Navigate to the `bin` folder:
 
 ```sh
-$ cd kong-mesh-{{page.kong_versions[0].version}}/bin
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
 ```
 
 Then, run the control plane with:

--- a/app/mesh/1.0.x/installation/macos.md
+++ b/app/mesh/1.0.x/installation/macos.md
@@ -33,13 +33,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 
 {% endnavtab %}

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -38,16 +38,16 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
-* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
-* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
-* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
-* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)
+* [CentOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
+* [RedHat](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Debian](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
+* [Ubuntu](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
+* [macOS](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 
 {% endnavtab %}
@@ -66,7 +66,7 @@ control plane process in the next step &mdash; which is served by the
 Navigate to the `bin` folder:
 
 ```sh
-$ cd kong-mesh-{{page.kong_versions[0].version}}/bin
+$ cd kong-mesh-{{page.kong_latest.version}}/bin
 ```
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -27,12 +27,12 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/ubuntu.md
+++ b/app/mesh/1.0.x/installation/ubuntu.md
@@ -28,13 +28,13 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
+You can also [download](https://kong.bintray.com/kong-mesh/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:
 
 ```sh
-$ tar xvzf kong-mesh-{{page.kong_versions[0].version}}*.tar.gz
+$ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Review
@reviewer

### Summary
Call Mesh version consistently in Mesh install docs

### Reason
Stray odd call to version variable was creating inconsistent version numbers in Mesh install docs, leading to user confusion

### Testing
will post Netlify preview when it's ready
