### PR TITLE
mesh 1.2.3 release

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -447,7 +447,7 @@
   edition: "mesh"
 -
   release: "1.2.x"
-  version: "1.2.2"
+  version: "1.2.3"
   edition: "mesh"
 -
   release: "1.0.x"

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -4,6 +4,20 @@ no_search: true
 no_version: true
 ---
 
+## 1.2.3
+
+> Released on 2021/04/16
+
+### Changes
+
+Built on top of [Kuma 1.1.3]((https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#112)). Notably:
+
+- Built-in DNS provides support for specifying external services by original hostname and port
+
+### Upgrading
+
+Upgrades from `1.2.x` are seamless and no additional steps are needed. Note [specific configuration requirements](https://kuma.io/docs/1.1.3/networking/dns/#data-plane-proxy-built-in-dns) for taking advantage of built-in DNS. See also [new documentation for the external service policy](https://kuma.io/docs/1.1.3/policies/external-services/#usage)
+
 ## 1.2.2
 
 > Released on 2021/04/09

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -10,7 +10,7 @@ no_version: true
 
 ### Changes
 
-Built on top of [Kuma 1.1.3]((https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#112)). Notably:
+Built on top of [Kuma 1.1.3](https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#112). Notably:
 
 - Built-in DNS provides support for specifying external services by original hostname and port
 


### PR DESCRIPTION
### Review
@reviewer

### Summary
Mesh release 1.2.3 (all new features are in Kuma)

### Reason
Release

### Testing
https://6079ce9e640812000773fab4--kongdocs.netlify.app/mesh/changelog/
https://6079ce9e640812000773fab4--kongdocs.netlify.app/mesh/1.2.x/installation/openshift/ (check version number in commands for any arbitrary install platform)
