### PR TITLE
(no ticket) Change gateway version in konnect helm config

### DIFF
--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -84,7 +84,7 @@ you saved earlier:
     ```yaml
     image:
       repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-      tag: "{{site.data.kong_latest_ee.version}}-alpine"
+      tag: "2.3.2.0-alpine"
 
     secretVolumes:
     - kong-cluster-cert


### PR DESCRIPTION
### Summary
Change variable to hardcoded version, as the latest version doesn't work with Konnect.

### Reason
There's a breaking change with the OIDC plugin that breaks compatibility with 2.3.3.x

### Testing
https://deploy-preview-2797--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-kubernetes/#write-and-apply-configuration - see codeblock