### PR TITLE
fix old links

### DIFF
--- a/app/gateway-oss/2.4.x/index.md
+++ b/app/gateway-oss/2.4.x/index.md
@@ -28,7 +28,7 @@ quickstart, the complete {{site.base_gateway}} getting started guide provides
 in-depth examples, explanations, and step-by-step instructions, and explores
 Kong's many available tools for managing the gateway.
 
-[quickstart]: /{{page.kong_version}}/getting-started/quickstart
-[configuring-a-service]: /{{page.kong_version}}/getting-started/configuring-a-service
-[enabling-plugins]: /{{page.kong_version}}/getting-started/enabling-plugins
+[quickstart]: /gateway-oss/{{page.kong_version}}/getting-started/quickstart
+[configuring-a-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-service
+[enabling-plugins]: /gateway-oss/{{page.kong_version}}/getting-started/enabling-plugins
 [getting-started]: /getting-started-guide/latest/overview


### PR DESCRIPTION
See slack convos https://kongstrong.slack.com/archives/G012HLJ4GJJ/p1618919908088100

https://kongstrong.slack.com/archives/CDSTDSG9J/p1618913942118000

Direct review link:

https://deploy-preview-2802--kongdocs.netlify.app/gateway-oss/

Tested all links on this landing page and they now work, no more 404.