### PR TITLE
[DOCU-1415] Update SW license link on EE install pages

### DIFF
--- a/app/enterprise/2.3.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.3.x/deployment/installation/amazon-linux-2.md
@@ -14,7 +14,7 @@ the installation and configuration.
 steps to configure PostgreSQL. For assistance in setting up Cassandra, please contact your Sales or Support representative.
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.3.x/deployment/installation/amazon-linux.md
@@ -14,7 +14,7 @@ the installation and configuration.
 steps to configure PostgreSQL. For assistance in setting up Cassandra, please contact your Sales or Support representative.
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/centos.md
+++ b/app/enterprise/2.3.x/deployment/installation/centos.md
@@ -15,7 +15,7 @@ the installation and configuration.
 steps to configure PostgreSQL. For assistance in setting up Cassandra, please contact your Sales or Support representative.
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -14,7 +14,7 @@ the installation and configuration.
 steps to configure PostgreSQL.
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes.md
@@ -31,7 +31,7 @@ You can install Kong for Kubernetes Enterprise using YAML with `kubectl`, with
 OpenShift `oc`, or [with Helm](https://github.com/Kong/charts/tree/main/charts/kong).
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
@@ -21,7 +21,7 @@ for a feature breakdown and comparison between DB-less and database-backed deplo
 You can use `kubectl` or OpenShift `oc` to configure {{site.ee_product_name}} on Kubernetes, then deploy it [using Helm](https://github.com/Kong/charts/tree/main/charts/kong).
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.3.x/deployment/installation/rhel.md
@@ -14,7 +14,7 @@ the installation and configuration.
 steps to configure PostgreSQL. For assistance in setting up Cassandra, please contact your Sales or Support representative.
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 

--- a/app/enterprise/2.3.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.3.x/deployment/installation/ubuntu.md
@@ -14,7 +14,7 @@ Kong supports both PostgreSQL 9.5+ and Cassandra 3.11.* as its datastore. This g
 steps to configure PostgreSQL. For assistance in setting up Cassandra, please contact your Kong Sales or Support representative.
 
 This software is governed by the
-[Kong Software License Agreement](https://konghq.com/enterprisesoftwarelicense/).
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 
 ### Deployment options
 


### PR DESCRIPTION
Update software license agreement links on Kong Gateway Enterprise installation pages for version 2.3.x.

### Review
@eskibars 
@HCloward 

### Summary
Update links to the Kong Software License Agreement on all of the enterprise install instructions for 2.3.x. 

### Reason
Request by Shane Connelly and Tom/Legal as software license was updated in 2.3, and update needed for bintray migration. 

### Testing
Check new software license link on individual installation pages. 

Netlify links to:
- Ubuntu: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/ubuntu/
- CentOS: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/centos/
- Amazon-Linux: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/amazon-linux/
- Amazon-Linux-2: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/amazon-linux-2/
- Red Hat Enterprise Linux: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/rhel/
- Docker: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/docker/
- Kong for Kubernetes Enterprise: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes/
- Kong Gateway (Enterprise) on Kubernetes: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes/
- OpenShift with Kong for Kubernetes Enterprise: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes/
- OpenShift with Kong Gateway (Enterprise) on Kubernetes: https://deploy-preview-2804--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes/

Not updated in this PR, as a Marketplace:
- AWS (EKS)
- other Marketplaces

