### PR TITLE
[DOCU-1545] Enable Dev Portal fix install instructions

### DIFF
--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -145,7 +145,7 @@ This feature is only available with a
 2. In your container, set the Portal URL and set `KONG_PORTAL` to `on`:
 
     ```sh
-    $ echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=off kong reload exit" \
+    $ echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=on kong reload exit" \
       | docker exec -i kong-ee /bin/sh
     ```
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-1425 This fix is for 2.3.x. Will do another PR for 2.4.x on private repo where that upcoming version currently resides. 2.2.x does not have this issue. https://github.com/Kong/docs.konghq.com-private/blob/release/ee-2.4/app/enterprise/2.4.x/deployment/installation/docker.md

Checked all other applicable install topics and only Docker was off. https://docs.konghq.com/enterprise/2.3.x/deployment/installation/docker/#step-7-optional-enable-the-dev-portal

![image](https://user-images.githubusercontent.com/3756245/115891561-d2a47e80-a41b-11eb-9b09-da178bb9c03c.png)


Direct review link:

https://deploy-preview-2811--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/docker/

Thanks again @HCloward for your keen eye!