### PR TITLE
Bintray migration: Docker updates

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -365,7 +365,7 @@
   lua_doc: true
 -
   release: "1.5.x"
-  version: "1.5.0.9"
+  version: "1.5.0.11"
   edition: "enterprise"
   luarocks_version: "0.34.x"
   dependencies:
@@ -377,7 +377,7 @@
   lua_doc: true
 -
   release: "2.1.x"
-  version: "2.1.4.3"
+  version: "2.1.4.6"
   edition: "enterprise"
   luarocks_version: "0.34.x"
   dependencies:
@@ -389,7 +389,7 @@
   lua_doc: true
 -
   release: "2.2.x"
-  version: "2.2.1.0"
+  version: "2.2.1.3"
   edition: "enterprise"
   luarocks_version: "2.2.0.0"
   dependencies:
@@ -401,7 +401,7 @@
   lua_doc: true
 -
   release: "2.3.x"
-  version: "2.3.3.0"
+  version: "2.3.3.2"
   edition: "enterprise"
   luarocks_version: "2.2.0.0"
   dependencies:

--- a/app/enterprise/1.5.x/deployment/installation/docker.md
+++ b/app/enterprise/1.5.x/deployment/installation/docker.md
@@ -21,14 +21,15 @@ To complete this installation you will need:
 {% include /md/{{page.kong_version}}/bintray-and-license.md %}
 * A Docker-enabled system with proper Docker access.
 
-## Step 1. Add the Kong Docker Repository and Pull the Kong Enterprise Docker Image
+## Step 1. Pull the Kong Gateway Docker image {#pull-image}
+
+Pull the following Docker image:
 
 ```bash
-$ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kong-docker-kong-enterprise-edition-docker.bintray.io
-$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+$ docker pull kong/kong-gateway:{{page.kong_versions[7].version}}-alpine
 ```
 
-You should now have your Kong Enterprise image locally.
+You should now have your {{site.ee_product_name}} image locally.
 
 Verify that it worked, and find the image ID matching your repository:
 

--- a/app/enterprise/2.1.x/deployment/installation/docker.md
+++ b/app/enterprise/2.1.x/deployment/installation/docker.md
@@ -26,14 +26,15 @@ To complete this installation you will need:
 {% include /md/{{page.kong_version}}/bintray-and-license.md %}
 * A Docker-enabled system with proper Docker access.
 
-## Step 1. Add the Kong Docker Repository and Pull the Kong Enterprise Docker Image {#pull-image}
+## Step 1. Pull the Kong Gateway Docker image {#pull-image}
+
+Pull the following Docker image:
 
 ```bash
-$ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kong-docker-kong-enterprise-edition-docker.bintray.io
-$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[8].version}}-alpine
+$ docker pull kong/kong-gateway:{{page.kong_versions[8].version}}-alpine
 ```
 
-You should now have your Kong Enterprise image locally.
+You should now have your {{site.ee_product_name}} image locally.
 
 Verify that it worked, and find the image ID matching your repository:
 

--- a/app/enterprise/2.2.x/deployment/installation/docker.md
+++ b/app/enterprise/2.2.x/deployment/installation/docker.md
@@ -28,11 +28,10 @@ To complete this installation you will need:
 
 ## Step 1. Pull the Kong Gateway Docker image {#pull-image}
 
-Using Docker, log in to Bintray and pull the following Docker image:
+Pull the following Docker image:
 
 ```bash
-$ docker login -u <your_username_from_bintray> -p <your_apikey_from_bintray> kong-docker-kong-enterprise-edition-docker.bintray.io
-$ docker pull kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[9].version}}-alpine
+$ docker pull kong/kong-gateway:{{page.kong_versions[9].version}}-alpine
 ```
 
 You should now have your {{site.ee_product_name}} image locally.

--- a/app/enterprise/2.3.x/deployment/installation/docker.md
+++ b/app/enterprise/2.3.x/deployment/installation/docker.md
@@ -27,10 +27,10 @@ To complete this installation you will need a Docker-enabled system with proper
 
 ## Step 1. Pull the Kong Gateway Docker image {#pull-image}
 
-Using Docker, pull the following Docker image:
+Pull the following Docker image:
 
 ```bash
-$ docker pull kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition:{{page.kong_versions[10].version}}-alpine
+$ docker pull kong/kong-gateway:{{page.kong_versions[10].version}}-alpine
 ```
 
 You should now have your {{site.base_gateway}} image locally.


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
Updating `docker pull` commands to point to new location. Updating 2.3.x, 2.2.x, 2.1.x, and 1.5.x, as these are the available images on Docker Hub (https://hub.docker.com/r/kong/kong-gateway).
Companion PR to https://github.com/Kong/docs.konghq.com/pull/2814.

What this PR is not updating:
- Prerequisites. These are being updated in https://github.com/Kong/docs.konghq.com/pull/2814.
- Immunity images.
- Kubernetes instructions. 

### Reason
Migration from Bintray to https://hub.docker.com/r/kong/kong-gateway

### Testing
Docker pull commands tested, all worked for me. 

Previews:
[2.3.x](https://deploy-preview-2815--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/docker/)
[2.2.x](https://deploy-preview-2815--kongdocs.netlify.app/enterprise/2.2.x/deployment/installation/docker/)
[2.1.x](https://deploy-preview-2815--kongdocs.netlify.app/enterprise/2.1.x/deployment/installation/docker/)
[1.5.x](https://deploy-preview-2815--kongdocs.netlify.app/enterprise/1.5.x/deployment/installation/docker/)