### PR TITLE
[DOCU-1434] Fix declarative config example syntax

### DIFF
--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -48,7 +48,14 @@ endcapture %}
 %}{% endcapture %}
 
 <!-- Generate declarative yaml examples -->
-{% capture config_required_fields_yaml %}config: {% for field in page.params.config %}{% if field.value_in_examples != nil %}{% if field.value_in_examples.first %}{% if field.name contains "." %}{% assign names = field.name | split: "." %}{{ names[0] }}:{%
+{% capture config_required_fields_yaml
+  %}config: {%
+  for field in page.params.config %}{%
+  if field.value_in_examples != nil %}{%
+    if field.value_in_examples.first %}{%
+        if field.name contains "." %}{%
+          assign names = field.name | split: "." %}
+    {{ names[0] }}:{%
       for name in names offset:1 %}
       {{ name }}:{% endfor %}{%
       for value in field.value_in_examples %}


### PR DESCRIPTION
### Summary
Fix syntax. 

### Reason
Line breaks weren't showing up for some plugins.

Before:
![Screen Shot 2021-04-27 at 11 55 36 AM](https://user-images.githubusercontent.com/54370747/116312980-00fac480-a762-11eb-9146-ff7ce563bc2f.png)
(https://docs.konghq.com/hub/kong-inc/response-transformer/, declarative (YAML) tab)

### Testing
Check the declarative YAML tab in plugin docs, eg: https://deploy-preview-2818--kongdocs.netlify.app/hub/kong-inc/response-transformer/
