### PR TITLE
[DOCU-1429] Fix footer link to oss gateway

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -151,8 +151,8 @@
           <ul>
             <li>
               <a
-                href="https://konghq.com/get-started#install?itm_source=website&itm_medium=footer-nav"
-                >Install Kong Gateway</a
+                href="https://konghq.com/install/#kong-community"
+                >Install Kong Gateway </a
               >
             </li>
             <li>


### PR DESCRIPTION
### Summary
Interim fix for link. Will be a bigger site-wide change in the future.

Had to remove tracking query portion of URL, as it doesn't seem to work with anchors (`#`).

### Reason
Currently, the OSS doc is going to Konnect demo, which isn't a great user experience.

### Testing
TBA
