### PR TITLE
[DOC-1407] OPA plugin remove beta tag, version note for GA (merge for 2.4 EE GA)

### DIFF
--- a/app/_hub/kong-inc/opa/index.md
+++ b/app/_hub/kong-inc/opa/index.md
@@ -2,17 +2,12 @@
 name: OPA
 publisher: Kong Inc.
 version: 0.1.x
-beta: true
 # internal handler v 0.1.0
 
 desc: Authorize requests against Open Policy Agent
 description: |
     Forward request to Open Policy Agent and process the request only if the
     authorization policy allows for it.
-
-    <div class="alert alert-ee blue"><strong>Note:</strong> The OPA plugin is compatible with
-    the Kong Gateway (Enterprise) beta version 2.4.x.
-    </div>  
 
 enterprise: true
 type: plugin


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-1407

The compatible with version in the sidebar does not display the version until release time. That note and beta tag removed for GA.

Direct review link: 
https://deploy-preview-2823--kongdocs.netlify.app/hub/kong-inc/opa/