### PR TITLE
Fix documented priority of the ip-restriction plugin

### DIFF
--- a/app/gateway-oss/2.4.x/plugin-development/custom-logic.md
+++ b/app/gateway-oss/2.4.x/plugin-development/custom-logic.md
@@ -259,7 +259,6 @@ Plugin                      | Priority
 ----------------------------|----------
 pre-function                | `+inf`
 zipkin                      | 100000
-ip-restriction              | 3000
 bot-detection               | 2500
 cors                        | 2000
 session                     | 1900
@@ -270,6 +269,7 @@ key-auth                    | 1003
 ldap-auth                   | 1002
 basic-auth                  | 1001
 hmac-auth                   | 1000
+ip-restriction              | 990
 request-size-limiting       | 951
 acl                         | 950
 rate-limiting               | 901


### PR DESCRIPTION
### Summary
According to https://github.com/Kong/kong/blob/master/kong/plugins/ip-restriction/handler.lua#L10,
the value is 990 and not 3000 (because of this PR: Kong/kong#3526)

Therefore the documentation is misleading :-)