### PR TITLE
doc(kic) remove stderrthreshold flag

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/references/cli-arguments.md
+++ b/app/kubernetes-ingress-controller/1.0.x/references/cli-arguments.md
@@ -60,7 +60,6 @@ Following table describes all the flags that are available:
 | --process-classless-ingress-v1beta1  |`boolean`  | `false`                         | Toggles whether the controller processes `extensions/v1beta1` and `networking/v1beta1` Ingress resources that have no `kubernetes.io/ingress.class` annotation.|
 | --process-classless-ingress-v1       |`boolean`  | `false`                         | Toggles whether the controller processes  `networking/v1` Ingress resources that have no `kubernetes.io/ingress.class` annotation or class field.|
 | --process-classless-kong-consumer    |`boolean`  | `false`                         | Toggles whether the controller processes KongConsumer resources that have no `kubernetes.io/ingress.class` annotation.|
-| --stderrthreshold                    |`string`   | `2`                             | logs at or above this threshold go to stderr.|
 | --sync-period                        |`duration` | `10m`                           | Relist and confirm cloud resources this often.|
 | --sync-rate-limit                    |`float32`  | `0.3`                           | Define the sync frequency upper limit. |
 | --update-status                      |`boolean`  | `true`                          | Indicates if the ingress controller should update the Ingress status IP/hostname.|

--- a/app/kubernetes-ingress-controller/1.1.x/references/cli-arguments.md
+++ b/app/kubernetes-ingress-controller/1.1.x/references/cli-arguments.md
@@ -60,7 +60,6 @@ Following table describes all the flags that are available:
 | --process-classless-ingress-v1beta1  |`boolean`  | `false`                         | Toggles whether the controller processes `extensions/v1beta1` and `networking/v1beta1` Ingress resources that have no `kubernetes.io/ingress.class` annotation.|
 | --process-classless-ingress-v1       |`boolean`  | `false`                         | Toggles whether the controller processes  `networking/v1` Ingress resources that have no `kubernetes.io/ingress.class` annotation or class field.|
 | --process-classless-kong-consumer    |`boolean`  | `false`                         | Toggles whether the controller processes KongConsumer resources that have no `kubernetes.io/ingress.class` annotation.|
-| --stderrthreshold                    |`string`   | `2`                             | logs at or above this threshold go to stderr.|
 | --sync-period                        |`duration` | `10m`                           | Relist and confirm cloud resources this often.|
 | --sync-rate-limit                    |`float32`  | `0.3`                           | Define the sync frequency upper limit. |
 | --update-status                      |`boolean`  | `true`                          | Indicates if the ingress controller should update the Ingress status IP/hostname.|

--- a/app/kubernetes-ingress-controller/1.2.x/references/cli-arguments.md
+++ b/app/kubernetes-ingress-controller/1.2.x/references/cli-arguments.md
@@ -61,7 +61,6 @@ Following table describes all the flags that are available:
 | --process-classless-ingress-v1beta1  |`boolean`  | `false`                         | Toggles whether the controller processes `extensions/v1beta1` and `networking/v1beta1` Ingress resources that have no `kubernetes.io/ingress.class` annotation.|
 | --process-classless-ingress-v1       |`boolean`  | `false`                         | Toggles whether the controller processes  `networking/v1` Ingress resources that have no `kubernetes.io/ingress.class` annotation or class field.|
 | --process-classless-kong-consumer    |`boolean`  | `false`                         | Toggles whether the controller processes KongConsumer resources that have no `kubernetes.io/ingress.class` annotation.|
-| --stderrthreshold                    |`string`   | `2`                             | logs at or above this threshold go to stderr.|
 | --sync-period                        |`duration` | `10m`                           | Relist and confirm cloud resources this often.|
 | --sync-rate-limit                    |`float32`  | `0.3`                           | Define the sync frequency upper limit. |
 | --update-status                      |`boolean`  | `true`                          | Indicates if the ingress controller should update the Ingress status IP/hostname.|


### PR DESCRIPTION
### Summary
Remove the --stderrthreshold flag from KIC documentation. This is a leftover from an old logging library we used prior to 0.10.0. It hasn't actually been available since.

### Reason
Found when reviewing log flag updates for KIC 2.0: https://github.com/Kong/kubernetes-ingress-controller/pull/1294#pullrequestreview-655935956
