### PR TITLE
[DOCU-1476] HTTP log plugin custom header code block 

### DIFF
--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -152,7 +152,7 @@ The log server that receives these messages might require extra headers, such as
   - name: http-log
     config:
       headers:
-        Authorization: "Bearer <<token>>""
+        Authorization: "Bearer <<token>>"
 ...
 ```
 

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -145,14 +145,14 @@ params:
 
 ## Custom Headers
 
-The log server that receives these messages might require extra headers, e.g. for authorization purposes.
+The log server that receives these messages might require extra headers, such as for authorization purposes.
 
 ```yaml
 ...
   - name: http-log
     config:
       headers:
-        Authorization: Bearer <<token>>
+        Authorization: "Bearer <<token>>""
 ...
 ```
 

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -152,7 +152,7 @@ The log server that receives these messages might require extra headers, such as
   - name: http-log
     config:
       headers:
-        Authorization: "Bearer <<token>>"
+        Authorization: "Bearer <token>"
 ...
 ```
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-1476 correction as noted by Fel and others in slack

Direct review link:

https://deploy-preview-2839--kongdocs.netlify.app/hub/kong-inc/http-log/#custom-headers

Reviewers: also not sure why there are double angle brackets around the token placeholder? removed a set.