### PR TITLE
Konnect linux runtime setup typo

### DIFF
--- a/app/konnect/runtime-manager/gateway-runtime-conf.md
+++ b/app/konnect/runtime-manager/gateway-runtime-conf.md
@@ -60,7 +60,7 @@ to the file.
     cluster_telemetry_endpoint = <example.tp.konnect.foo>:443
     cluster_telemetry_server_name = <kong-telemetry-example.service>
     cluster_cert = /<path-to-file>/tls.crt
-    cluster_cert_key = /<path-to-file>/tls.crt
+    cluster_cert_key = /<path-to-file>/tls.key
     lua_ssl_trusted_certificate = system,/<path-to-file>/ca.crt
     ```
 


### PR DESCRIPTION
### Summary
Fixing a small typo that points to the wrong file. Other runtime setup topics refer to the correct files.

### Reason
Broken setup.
