### PR TITLE
update docs for release, include new docs for intermediate CA with Vault

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -449,7 +449,7 @@
   edition: "mesh"
 -
   release: "1.2.x"
-  version: "1.2.5"
+  version: "1.2.6"
   edition: "mesh"
 -
   release: "1.0.x"

--- a/app/mesh/1.2.x/features/vault.md
+++ b/app/mesh/1.2.x/features/vault.md
@@ -138,7 +138,7 @@ vault write kuma-pki-default/roles/dataplanes \
   require_cn=false \
   basic_constraints_valid_for_non_ca=true \
   max_ttl="720h" \
-  "ttl"="720h"
+  ttl="720h"
 ```
 
 #### Step 3. Create a policy to use the new role:

--- a/app/mesh/1.2.x/features/vault.md
+++ b/app/mesh/1.2.x/features/vault.md
@@ -12,46 +12,157 @@ Authority (CA) root certificate and key that will be used to generate the data
 plane certificates.
 * `provided`: the CA root certificate and key can be provided by the user.
 
-This feature adds one more mTLS backend mode:
+{{site.mesh_product_name}} adds:
 
-* `vault`: {{site.mesh_product_name}} will generate data plane certificates
-using a CA root certificate and key stored in a third-party HashiCorp Vault
+* `vault`: {{site.mesh_product_name}} generates data plane certificates
+using a CA root certificate and key stored in a HashiCorp Vault
 server.
 
-## Using Vault Mode
+## Vault Mode
 
-Unlike the `builtin` and `provided` backends, when using the `vault` mTLS mode,
-{{site.mesh_product_name}} communicates with a third-party HashiCorp Vault PKI,
+In `vault` mTLS mode, {{site.mesh_product_name}} communicates with the HashiCorp Vault PKI,
 which generates the data plane proxy certificates automatically.
+{{site.mesh_product_name}} does not retrieve private key of the CA to generate data plane proxy certificates,
+which means that private key of the CA is secured by Vault and not exposed to third parties.
 
-The `vault` mTLS backend expects a `kuma-pki-${MESH_NAME}` PKI already
-configured in Vault. For example, the PKI path for a mesh named `default` would
-be `kuma-pki-default`.
-
-To use this feature, you also need to point {{site.mesh_product_name}} to the
+In `vault` mode, you point {{site.mesh_product_name}} to the
 Vault server and provide the appropriate credentials. {{site.mesh_product_name}}
-will use these parameters to authenticate the control plane and generate the
+uses these parameters to authenticate the control plane and generate the
 data plane certificates.
 
-Once running, this backend is responsible for communicating with Vault and for
-using Vault's PKI to automatically issue and rotate data plane certificates for
+When {{site.mesh_product_name}} is running in `vault` mode, the backend communicates with Vault and ensures 
+that Vault's PKI automatically issues data plane certificates and rotates them for
 each proxy.
 
-## Enabling Vault Authentication
+### Configure Vault
 
-The communication to Vault happens directly from `kuma-cp`. To connect to
-Vault, you must provide the following values in the configuration for `kuma-cp`:
+The `vault` mTLS backend expects a `kuma-pki-${MESH_NAME}` PKI already
+configured in Vault. For example, the PKI path for a mesh named `default` is `kuma-pki-default`.
 
-* A `clientKey`.
-* A `clientCert`.
-* A `secret` token.
+The following steps show how to configure Vault for {{site.mesh_product_name}} with a mesh named 
+`default`. For your environment, replace `default` with the appropriate mesh name.
 
-These values can be inline (for testing purposes only), a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. See the official Kuma
-documentation to learn more about [Kuma Secrets](https://kuma.io/docs/latest/documentation/secrets/)
-and how to create one.
+#### Step 1. Configure the Certificate Authority
 
-Here's an example of a configuration using a `vault`-backed CA:
+    {{site.mesh_product_name}} works with a Root CA or an Intermediate CA.
+    
+    {% navtabs %}
+    {% navtab Root CA %}
+    
+    Create a new PKI for the `default` Mesh called `kuma-pki-default`:
+    
+    ```sh
+    vault secrets enable -path=kuma-pki-default pki
+    ```
+    
+    Generate a new Root Certificate Authority for the `default` Mesh:
+    
+    ```
+    vault secrets tune -max-lease-ttl=87600h kuma-pki-default
+    vault write -field=certificate kuma-pki-default/root/generate/internal \
+      common_name="Kuma Mesh Default" \
+      uri_sans="spiffe://default" \
+      ttl=87600h
+    ```
+    
+    {% endnavtab %}
+    {% navtab Intermediate CA %}
+    
+    Create a new Root Certificate Authority and save it to a file called `ca.pem`:
+    
+    ```sh
+    vault secrets enable pki
+    vault secrets tune -max-lease-ttl=87600h pki
+    vault write -field=certificate pki/root/generate/internal \
+      common_name="Organization CA" \
+      ttl=87600h > ca.pem
+    ```
+    
+    You can also use your current Root CA, retrieve the PEM-encoded certificate, and save it to `ca.pem`.
+    
+    Create a new PKI for the `default` Mesh:
+    
+    ```sh
+    vault secrets enable -path=kuma-pki-default pki
+    ```
+    
+    Generate the Intermediate CA for the `default` Mesh:
+    
+    ```sh
+    vault write -format=json kuma-pki-default/intermediate/generate/internal \
+        common_name="Kuma Mesh Default" \
+        uri_sans="spiffe://default" \
+        | jq -r '.data.csr' > pki_intermediate.csr
+    ```
+    
+    Sign the Intermediate CA with the Root CA. Make sure to pass the right path for the PKI that has the Root CA.
+    In this example, the path  value is `pki`:
+    
+    ```sh
+    vault write -format=json pki/root/sign-intermediate csr=@pki_intermediate.csr \
+      format=pem_bundle \
+      ttl="43800h" \
+      | jq -r '.data.certificate' > intermediate.cert.pem
+    ```
+    
+    Set the certificate of signed Intermediate CA to the `default` Mesh PKI. You must include the public certificate of the Root CA
+    so that data plane proxies can verify the certificates:
+    
+    ```sh
+    cat intermediate.cert.pem > bundle.pem
+    echo "" >> bundle.pem
+    cat ca.pem >> bundle.pem
+    vault write kuma-pki-default/intermediate/set-signed certificate=@bundle.pem
+    ```
+    
+    {% endnavtab %}
+    {% endnavtabs %}
+    
+#### Step 2. Create a role for generating data plane proxy certificates:
+
+    ```sh
+    vault write kuma-pki-default/roles/dataplanes \
+      allowed_uri_sans="spiffe://default/*,kuma://*" \
+      key_usage="KeyUsageKeyEncipherment,KeyUsageKeyAgreement,KeyUsageDigitalSignature" \
+      ext_key_usage="ExtKeyUsageServerAuth,ExtKeyUsageClientAuth" \
+      client_flag=true \
+      require_cn=false \
+      basic_constraints_valid_for_non_ca=true \
+      max_ttl="720h" \
+      "ttl"="720h"
+    ```
+
+#### Step 3. Create a policy to use the new role:
+
+    ```sh
+    cat > kuma-default-dataplanes.hcl <<- EOM
+    path "/kuma-pki-default/issue/dataplanes"
+    {
+      capabilities = ["create", "update"]
+    }
+    EOM
+    vault policy write kuma-default-dataplanes kuma-default-dataplanes.hcl
+    ```
+
+#### Step 4. Create a Vault token:
+
+    ```sh
+    vault token create -format=json -policy="kuma-default-dataplanes" | jq -r ".auth.client_token"
+    ```
+    
+    The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
+
+### Configure Mesh
+
+`kuma-cp` communicates directly with Vault. To connect to
+Vault, you must provide credentials in the configuration of the `Mesh` object of `kuma-cp`.
+
+You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
+
+You can provide these values inline for testing purposes only, as a path to a file on the
+same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/documentation/secrets/).
+
+Here's an example of a configuration with a `vault`-backed CA:
 
 {% navtabs %}
 {% navtab Kubernetes %}
@@ -82,12 +193,12 @@ spec:
               serverName: "" # verify sever name
             auth: # only one auth options is allowed so it's either "token" or "tls"
               token:
-                secret: token-1  # can be file, secret or inline
+                secret: token-1  # can be file, secret or inlineString
               tls:
                 clientKey:
                   secret: sec-2  # can be file, secret or inline
                 clientCert:
-                  file: /tmp/cert.pem # can be file, secret or inline
+                  file: /tmp/cert.pem # can be file, secret or inlineString
 ```
 
 Apply the configuration with `kubectl apply -f [..]`.
@@ -118,15 +229,15 @@ mtls:
           serverName: "" # verify sever name
         auth: # only one auth options is allowed so it's either "token" or "tls"
           token:
-            secret: token-1  # can be file, secret or inline
+            secret: token-1  # can be file, secret or inlineString
           tls:
             clientKey:
-              secret: sec-2  # can be file, secret or inline
+              secret: sec-2  # can be file, secret or inlineString
             clientCert:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or using the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.2.x/features/vault.md
+++ b/app/mesh/1.2.x/features/vault.md
@@ -57,8 +57,11 @@ vault secrets enable -path=kuma-pki-default pki
 
 Generate a new Root Certificate Authority for the `default` Mesh:
 
-```
+```sh
 vault secrets tune -max-lease-ttl=87600h kuma-pki-default
+```
+
+```sh
 vault write -field=certificate kuma-pki-default/root/generate/internal \
   common_name="Kuma Mesh Default" \
   uri_sans="spiffe://default" \
@@ -72,7 +75,13 @@ Create a new Root Certificate Authority and save it to a file called `ca.pem`:
 
 ```sh
 vault secrets enable pki
+```
+
+```sh
 vault secrets tune -max-lease-ttl=87600h pki
+```
+
+```sh
 vault write -field=certificate pki/root/generate/internal \
   common_name="Organization CA" \
   ttl=87600h > ca.pem
@@ -117,40 +126,40 @@ vault write kuma-pki-default/intermediate/set-signed certificate=@bundle.pem
 
 {% endnavtab %}
 {% endnavtabs %}
-    
+
 #### Step 2. Create a role for generating data plane proxy certificates:
 
-    ```sh
-    vault write kuma-pki-default/roles/dataplanes \
-      allowed_uri_sans="spiffe://default/*,kuma://*" \
-      key_usage="KeyUsageKeyEncipherment,KeyUsageKeyAgreement,KeyUsageDigitalSignature" \
-      ext_key_usage="ExtKeyUsageServerAuth,ExtKeyUsageClientAuth" \
-      client_flag=true \
-      require_cn=false \
-      basic_constraints_valid_for_non_ca=true \
-      max_ttl="720h" \
-      "ttl"="720h"
-    ```
+```sh
+vault write kuma-pki-default/roles/dataplanes \
+  allowed_uri_sans="spiffe://default/*,kuma://*" \
+  key_usage="KeyUsageKeyEncipherment,KeyUsageKeyAgreement,KeyUsageDigitalSignature" \
+  ext_key_usage="ExtKeyUsageServerAuth,ExtKeyUsageClientAuth" \
+  client_flag=true \
+  require_cn=false \
+  basic_constraints_valid_for_non_ca=true \
+  max_ttl="720h" \
+  "ttl"="720h"
+```
 
 #### Step 3. Create a policy to use the new role:
 
-    ```sh
-    cat > kuma-default-dataplanes.hcl <<- EOM
-    path "/kuma-pki-default/issue/dataplanes"
-    {
-      capabilities = ["create", "update"]
-    }
-    EOM
-    vault policy write kuma-default-dataplanes kuma-default-dataplanes.hcl
-    ```
+```sh
+cat > kuma-default-dataplanes.hcl <<- EOM
+path "/kuma-pki-default/issue/dataplanes"
+{
+  capabilities = ["create", "update"]
+}
+EOM
+vault policy write kuma-default-dataplanes kuma-default-dataplanes.hcl
+```
 
 #### Step 4. Create a Vault token:
 
-    ```sh
-    vault token create -format=json -policy="kuma-default-dataplanes" | jq -r ".auth.client_token"
-    ```
-    
-    The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
+```sh
+vault token create -format=json -policy="kuma-default-dataplanes" | jq -r ".auth.client_token"
+```
+
+The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 
 ### Configure Mesh
 

--- a/app/mesh/1.2.x/features/vault.md
+++ b/app/mesh/1.2.x/features/vault.md
@@ -18,7 +18,7 @@ plane certificates.
 using a CA root certificate and key stored in a HashiCorp Vault
 server.
 
-## Vault Mode
+## Vault mode
 
 In `vault` mTLS mode, {{site.mesh_product_name}} communicates with the HashiCorp Vault PKI,
 which generates the data plane proxy certificates automatically.
@@ -164,7 +164,7 @@ The output should print a Vault token that you then provide as the `conf.fromCp.
 ### Configure Mesh
 
 `kuma-cp` communicates directly with Vault. To connect to
-Vault, you must provide credentials in the configuration of the `Mesh` object of `kuma-cp`.
+Vault, you must provide credentials in the configuration of the `mesh` object of `kuma-cp`.
 
 You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
 

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -17,7 +17,7 @@ Built on top of [Kuma 1.1.6](https://github.com/kumahq/kuma/blob/master/CHANGELO
 - You can now specify TCP and HTTP health checks at the same time in the same policy. The health check policy also 
 now includes a `reuse_connection` option.
 - The `--gateway` flag is now available in the CLI.
-- You can now install Kong Ingress with the CLI.
+- You can now install an ingress controller with the CLI. Kong Gateway is the first supported ingress controller.
 - You can now install the Kuma demo application with the CLI.
 
 

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -4,6 +4,28 @@ no_search: true
 no_version: true
 ---
 
+## 1.2.6
+
+> Released on 2021/05/13
+
+### Changes
+
+Built on top of [Kuma 1.1.6](https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#116).
+
+- Intermediate Certificate Authorities (CAs) are now supported with Vault integration.
+- You can now specify any and all tags in a Traffic Permission policy for Vault integration.
+- You can now specify TCP and HTTP health checks at the same time in the same policy. The health check policy also 
+now includes a `reuse_connection` option.
+- The `--gateway` flag is now available in the CLI.
+- You can now install Kong Ingress with the CLI.
+- You can now install the Kuma demo application with the CLI.
+
+
+### Upgrading
+
+Upgrades from `1.2.x` are seamless and no additional steps are needed. Note [specific configuration requirements](https://kuma.io/docs/1.1.5/networking/dns/#data-plane-proxy-built-in-dns) for taking advantage of built-in DNS.
+
+
 ## 1.2.5
 
 > Released on 2021/05/05


### PR DESCRIPTION
### Review
@subnetmarco @lena-larionova 

### Summary
Add Mesh 1.2.6 release version, changelog. Include hopefully fixes to markdown for intermediate CA with Vault docs.

### Reason
Release day!

### Testing
https://deploy-preview-2845--kongdocs.netlify.app/mesh/1.2.x/features/vault/ and any mesh install page (for version number checking), e.g. https://deploy-preview-2845--kongdocs.netlify.app/mesh/1.2.x/installation/kubernetes/
