### PR TITLE
Fix relative links in gateway-oss-2.4.x Admin API docs

### DIFF
--- a/app/gateway-oss/2.4.x/admin-api.md
+++ b/app/gateway-oss/2.4.x/admin-api.md
@@ -584,7 +584,7 @@ target_data: |
   This page refers to the Admin API for running Kong configured with a
   database (Postgres or Cassandra). For using the Admin API for Kong
   in DB-less mode, please refer to the
-  <a href="/{{page.kong_version}}/db-less-admin-api">Admin API for DB-less Mode</a>
+  <a href="/gateway-oss/{{page.kong_version}}/db-less-admin-api">Admin API for DB-less Mode</a>
   page.
 </div>
 
@@ -3827,10 +3827,7 @@ HTTP 200 OK
 
 ---
 
-[clustering]: /{{page.kong_version}}/clustering
-[cli]: /{{page.kong_version}}/cli
-[active]: /{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
-[healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
-[secure-admin-api]: /{{page.kong_version}}/secure-admin-api
-[proxy-reference]: /{{page.kong_version}}/proxy
-[db-less-admin-api]: /{{page.kong_version}}/db-less-admin-api
+[active]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+[healthchecks]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers
+[secure-admin-api]: /gateway-oss/{{page.kong_version}}/secure-admin-api
+[proxy-reference]: /gateway-oss/{{page.kong_version}}/proxy


### PR DESCRIPTION
### Summary
The links on the [Admin API 2.4.x page](https://docs.konghq.com/gateway-oss/2.4.x/admin-api/) were broken. I checked [another page](https://github.com/Kong/docs.konghq.com/edit/main/app/gateway-oss/2.4.x/network.md) to see how the product URL was built and then copied the same format.

I also removed link references that are not used on this page (validated by searching for `[clustering]` etc in the source)

### Reason
Broken links need fixing

### Testing
Check in preview app
https://deploy-preview-2846--kongdocs.netlify.app/gateway-oss/2.4.x/admin-api/
