### PR TITLE
[DOCU-912] Kafka Log plugin remove install section

### DIFF
--- a/app/_hub/kong-inc/kafka-log/index.md
+++ b/app/_hub/kong-inc/kafka-log/index.md
@@ -177,9 +177,12 @@ This plugin makes use of the [lua-resty-kafka](https://github.com/doujiang24/lua
 
 ## Known issues and limitations
 
-1. There is no support for TLS.
-2. There is no support for authentication.
-3. There is no support for message compression.
+There is currently no support for:
+
+- TLS
+- authentication
+- message compression
+
 
 [badge-travis-url]: https://travis-ci.com/Kong/kong-plugin-kafka-log/branches
 [badge-travis-image]: https://travis-ci.com/Kong/kong-plugin-kafka-log.svg?token=BfzyBZDa3icGPsKGmBHb&branch=master

--- a/app/_hub/kong-inc/kafka-log/index.md
+++ b/app/_hub/kong-inc/kafka-log/index.md
@@ -39,7 +39,8 @@ params:
       default:
       datatype: set of record elements
       description: |
-        Set of bootstrap brokers in a `{host: host, port: port}` list format. For examples, see the Quickstart section.
+        Set of bootstrap brokers in a `{host: host, port: port}` list format. For examples, see the
+        [Quickstart](#quickstart).
     - name: topic
       required: true
       value_in_examples: TOPIC
@@ -66,8 +67,8 @@ params:
       datatype: integer
       description: |
          The number of acknowledgments the producer requires the leader to have received before
-         considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader;
-         and -1 for the full ISR (In-Sync Replica set).
+         considering a request complete. Allowed values: `0` for no acknowledgments; `1` for only the leader;
+         and `-1` for the full ISR (In-Sync Replica set).
     - name: producer_request_timeout
       required: false
       default: "`2000`"
@@ -124,82 +125,12 @@ params:
         API version of a Produce request. Allowed values: `0`, `1`, or `2`.
 ---
 
-## Installation
-
-Manually download and install:
-
-```
-$ git clone https://github.com/kong/kong-plugin-kafka-log.git /path/to/kong/plugins/kong-plugin-kafka-log
-$ cd /path/to/kong/plugins/kong-plugin-kafka-log
-$ luarocks make *.rockspec
-```
-
-In both cases, you need to change your Kong `plugins`
-[configuration option](https://docs.konghq.com/latest/configuration/#plugins)
-to include this plugin:
-
-```
-plugins = bundled,kong-plugin-kafka-log
-```
-
-Or, if you don't want to activate any of the bundled plugins:
-
-```
-plugins = kong-plugin-kafka-log
-```
-
-Then reload kong:
-
-```
-kong reload
-```
-
-## Configuration
-
-### Enabling globally
-
-```bash
-$ curl -X POST http://kong:8001/plugins \
-    --data "name=kafka-log" \
-    --data "config.bootstrap_servers[1].host=localhost" \
-    --data "config.bootstrap_servers[1].port=9092" \
-    --data "config.topic=kong-log" \
-    --data "config.timeout=10000" \
-    --data "config.keepalive=60000" \
-    --data "config.producer_request_acks=1" \
-    --data "config.producer_request_timeout=2000" \
-    --data "config.producer_request_limits_messages_per_request=200" \
-    --data "config.producer_request_limits_bytes_per_request=1048576" \
-    --data "config.producer_request_retries_max_attempts=10" \
-    --data "config.producer_request_retries_backoff_timeout=100" \
-    --data "config.producer_async=true" \
-    --data "config.producer_async_flush_timeout=1000" \
-    --data "config.producer_async_buffering_limits_messages_in_memory=50000"
-```
-
-## Log Format
-
-Similar to the [HTTP Log Plugin](https://docs.konghq.com/hub/kong-inc/http-log#log-format).
-
-## Implementation details
-
-This plugin makes use of the [lua-resty-kafka](https://github.com/doujiang24/lua-resty-kafka) client under the hood.
-
-## Known issues and limitations
-
-Known limitations:
-
-1. There is no support for TLS.
-2. There is no support for authentication.
-3. There is no support for message compression.
-
 ## Quickstart
 
-The following guidelines assume that both `Kong` and `Kafka` have been installed on your local machine:
+The following guidelines assume that both {{site.ee_product_name}} and `Kafka` have been
+installed on your local machine.
 
-1. Install `kong-plugin-kafka-log` as specified in the above Installation section.
-
-2. Create a `kong-log` topic in your Kafka cluster:
+1. Create a `kong-log` topic in your Kafka cluster:
 
     ```
     ${KAFKA_HOME}/bin/kafka-topics.sh --create \
@@ -209,25 +140,23 @@ The following guidelines assume that both `Kong` and `Kafka` have been installed
         --topic kong-log
     ```
 
-3. Add the `kafka-log` plugin globally:
+2. Add the `kafka-log` plugin globally:
 
     ```
     curl -X POST http://localhost:8001/plugins \
         --data "name=kafka-log" \
-        --data "config.bootstrap_servers[1].host=localhost \
-        --data "config.bootstrap_servers[1].port=9092 \
+        --data "config.bootstrap_servers[1].host=localhost" \
+        --data "config.bootstrap_servers[1].port=9092" \
         --data "config.topic=kong-log"
     ```
 
-    Alternatively to a global configuration, create a Service with a Route and attach the plugin to that Service.
-
-4. Make sample requests:
+3. Make sample requests:
 
     ```
     for i in {1..50} ; do curl http://localhost:8000/request/$i ; done
     ```
 
-5. Verify the contents of the Kafka `kong-log` topic:
+4. Verify the contents of the Kafka `kong-log` topic:
 
     ```
     ${KAFKA_HOME}/bin/kafka-console-consumer.sh \
@@ -237,6 +166,20 @@ The following guidelines assume that both `Kong` and `Kafka` have been installed
         --from-beginning \
         --timeout-ms 1000
     ```
+
+## Log format
+
+Similar to the [HTTP Log Plugin](https://docs.konghq.com/hub/kong-inc/http-log#log-format).
+
+## Implementation details
+
+This plugin makes use of the [lua-resty-kafka](https://github.com/doujiang24/lua-resty-kafka) client under the hood.
+
+## Known issues and limitations
+
+1. There is no support for TLS.
+2. There is no support for authentication.
+3. There is no support for message compression.
 
 [badge-travis-url]: https://travis-ci.com/Kong/kong-plugin-kafka-log/branches
 [badge-travis-image]: https://travis-ci.com/Kong/kong-plugin-kafka-log.svg?token=BfzyBZDa3icGPsKGmBHb&branch=master


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-912 Remove unnecessary install section (already removed from Kafka Upstream plugin). Also removed dupe global topic.

The more I look at this doc, the more room for improvements I see. Will log follow-up ticket. https://konghq.atlassian.net/browse/DOCU-1483

Direct review link:

https://deploy-preview-2848--kongdocs.netlify.app/hub/kong-inc/kafka-log/