### PR TITLE
[DOCU-1477] Runtime manager: Windows instructions for Docker

### DIFF
--- a/app/konnect/getting-started/configure-runtime.md
+++ b/app/konnect/getting-started/configure-runtime.md
@@ -28,9 +28,7 @@ organization admin permissions by default.
 * Tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **Windows:** The quick setup script does not currently work on Windows.
-  See the [Advanced](/konnect/runtime-manager/gateway-runtime-docker/#advanced-setup)
-  instructions instead, then move on to [configuring a service](/konnect/getting-started/configure-service).
+  * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/).
 
 ## Set up a New Runtime Instance
 

--- a/app/konnect/getting-started/configure-runtime.md
+++ b/app/konnect/getting-started/configure-runtime.md
@@ -22,12 +22,15 @@ runtime instances.
 
 ## Prerequisites
 
-* You have a {{site.konnect_product_name}} account. Contact your sales
-representative for access.
+* You have **Runtime Admin** or **Organization Admin** permissions in
+{{site.konnect_saas}}. If you created this account, the account has
+organization admin permissions by default.
 * Tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/)
+  * **Windows:** The quick setup script does not currently work on Windows.
+  See the [Advanced](/konnect/runtime-manager/gateway-runtime-docker/#advanced-setup)
+  instructions instead, then move on to [configuring a service](/konnect/getting-started/configure-service).
 
 ## Set up a New Runtime Instance
 

--- a/app/konnect/getting-started/configure-runtime.md
+++ b/app/konnect/getting-started/configure-runtime.md
@@ -25,7 +25,8 @@ runtime instances.
 * You have **Runtime Admin** or **Organization Admin** permissions in
 {{site.konnect_saas}}. If you created this account, the account has
 organization admin permissions by default.
-* Tools and permissions:
+* The quick setup script requires Docker and a Unix shell (for example, bash or
+  zshell). Platform-specific tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
   * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/).

--- a/app/konnect/runtime-manager/gateway-runtime-conf.md
+++ b/app/konnect/runtime-manager/gateway-runtime-conf.md
@@ -16,8 +16,8 @@ runtime instances.
 
 ## Prerequisites
 
-You have a {{site.konnect_product_name}} account. Contact your sales
-representative for access.
+* You have **Runtime Admin** or **Organization Admin** permissions in
+{{site.konnect_saas}}.
 
 ## Generate certificates
 

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -25,7 +25,8 @@ runtime instances.
 
 * You have **Runtime Admin** or **Organization Admin** permissions in
 {{site.konnect_saas}}.
-* Tools and permissions:
+* The quick setup script requires Docker and a Unix shell (for example, bash or
+  zshell). Platform-specific tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
   * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/). If you can't set up a WSL 2 backend, see the [advanced](#advanced-setup) instructions for

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -28,8 +28,8 @@ runtime instances.
 * Tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **Windows:** The quick setup script does not currently work on Windows.
-  See the [Advanced](#advanced-setup) instructions instead.
+  * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/). If you can't set up a WSL 2 backend, see the [advanced](#advanced-setup) instructions for
+  a custom Docker setup instead.
 
 ### Run the quick setup script
 

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -73,7 +73,7 @@ runtime instances.
 * Tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **Windows and MacOS:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows)
+  * **[Windows](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [MacOS](https://docs.docker.com/docker-for-mac/install/):** Docker Desktop installed
 
 ### Generate certificates
 {% include /md/konnect/runtime-certs.md %}

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -19,16 +19,19 @@ running on `localhost`.
 runtime instances.
 </div>
 
-## Prerequisites
+## Quick setup
 
-* You have a {{site.konnect_product_name}} account. Contact your sales
-representative for access.
-* (Quick Setup only) Tools and permissions:
+### Prerequisites
+
+* You have **Runtime Admin** or **Organization Admin** permissions in
+{{site.konnect_saas}}.
+* Tools and permissions:
   * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
   * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/)
+  * **Windows:** The quick setup script does not currently work on Windows.
+  See the [Advanced](#advanced-setup) instructions instead.
 
-## Quick setup
+### Run the quick setup script
 
 1. From the left navigation menu, open **Runtimes**.
 
@@ -62,10 +65,19 @@ representative for access.
 
 ## Advanced setup
 
+### Prerequisites
+
+* You have **Runtime Admin** or **Organization Admin** permissions in
+{{site.konnect_saas}}.
+* Tools and permissions:
+  * **All platforms:** [Docker](https://docs.docker.com/get-docker/) installed
+  * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
+  * **Windows and MacOS:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows)
+
 ### Generate certificates
 {% include /md/konnect/runtime-certs.md %}
 
-### Configure the runtime
+### Prepare the Docker image
 
 Next, pull the {{site.base_gateway}} Docker image, and configure a
 {{site.base_gateway}} runtime using the certificate, the private key, and the
@@ -77,7 +89,7 @@ remaining configuration details on the **Configure Runtime** page.
     ```bash
     $ docker pull kong/kong-gateway:2.3.2.0-alpine
     ```
-    
+
     You should now have your {{site.base_gateway}} image locally.
 
 2. Verify that it worked, and find the image ID matching your repository:
@@ -93,47 +105,77 @@ matching your repository:
     $ docker tag <IMAGE_ID> kong-ee
     ```
 
-4. Return to {{site.konnect_short_name}} and copy the
-codeblock in the **Step 2. Configuration Parameters** section.
+### Start Kong Gateway
+
+Use the following `docker run` command sample as a guide to compile your actual values:
+
+{% navtabs codeblock %}
+{% navtab Any Unix shell %}
+```sh
+$ docker run -d --name kong-gateway-dp1 \
+  -e "KONG_ROLE=data_plane" \
+  -e "KONG_DATABASE=off" \
+  -e "KONG_ANONYMOUS_REPORTS=off" \
+  -e "KONG_VITALS_TTL_DAYS=732" \
+  -e "KONG_CLUSTER_MTLS=pki" \
+  -e "KONG_CLUSTER_CONTROL_PLANE=<example.cp.konnect.foo>:443" \
+  -e "KONG_CLUSTER_SERVER_NAME=<kong-cpoutlet-example.service>" \
+  -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=<example.tp.konnect.foo>:443" \
+  -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" \
+  -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" \
+  -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" \
+  -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/<path-to-file>/ca.crt" \
+  --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly \
+  -p 8000:8000 \
+  kong-ee
+```
+{% endnavtab %}
+{% navtab Windows PowerShell %}
+```powershell
+docker run -d --name kong-gateway-dp1 `
+  -e "KONG_ROLE=data_plane" `
+  -e "KONG_DATABASE=off" `
+  -e "KONG_ANONYMOUS_REPORTS=off" `
+  -e "KONG_VITALS_TTL_DAYS=732" `
+  -e "KONG_CLUSTER_MTLS=pki" `
+  -e "KONG_CLUSTER_CONTROL_PLANE=<example.cp.konnect.foo>:443" `
+  -e "KONG_CLUSTER_SERVER_NAME=<kong-cpoutlet-example.service>" `
+  -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=<example.tp.konnect.foo>:443" `
+  -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" `
+  -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" `
+  -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" `
+  -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/<path-to-file>/ca.crt" `
+  --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly `
+  -p 8000:8000 `
+  kong-ee
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+1. Replace the values in `KONG_CLUSTER_CERT`, `KONG_CLUSTER_CERT_KEY`,
+        and `KONG_LUA_SSL_TRUSTED_CERTIFICATE` with the paths to your certificate files.
+
+2. Check the **Linux** or **Kubernetes** tabs in the Konnect UI to find the values for
+        `KONG_CLUSTER_CONTROL_PLANE`, `KONG_CLUSTER_SERVER_NAME`,
+        `KONG_CLUSTER_TELEMETRY_ENDPOINT`, and `KONG_CLUSTER_TELEMETRY_SERVER_NAME`,
+        then substitute them in the example below.
 
     ![Konnect Runtime Parameters](/assets/images/docs/konnect/konnect-runtime-manager.png)
-
-5. Replace the values in `KONG_CLUSTER_CERT`, `KONG_CLUSTER_CERT_KEY`,
-and `KONG_LUA_SSL_TRUSTED_CERTIFICATE` with the paths to your certificate files.
-
-6. Using the provided values, bring up a new container.
 
     See [Parameters](/konnect/runtime-manager/runtime-parameter-reference) for
     descriptions and the matching fields in {{site.konnect_short_name}}.
 
-    ```sh
-    $ docker run -d --name kong-gateway-dp1 \
-      -e "KONG_ROLE=data_plane" \
-      -e "KONG_DATABASE=off" \
-      -e "KONG_ANONYMOUS_REPORTS=off" \
-      -e "KONG_VITALS_TTL_DAYS=732" \
-      -e "KONG_CLUSTER_MTLS=pki" \
-      -e "KONG_CLUSTER_CONTROL_PLANE=<example.cp.konnect.foo>:443" \
-      -e "KONG_CLUSTER_SERVER_NAME=<kong-cpoutlet-example.service>" \
-      -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=<example.tp.konnect.foo>:443" \
-      -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" \
-      -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" \
-      -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" \
-      -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/<path-to-file>/ca.crt" \
-      --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly \
-      -p 8000:8000 \
-      kong-ee
-    ```
+3. `-p 8000:8000` sets the proxy URL to `http://localhost:8000`.
+        If you want to change this, bind the port to a different host. For example,
+        you can explicitly set an IP:
 
-    `-p 8000:8000` sets the proxy URL to `http://localhost:8000`.
-    To change this, bind the port to a different host. For example, you can
-    explicitly set an IP:
+      ```sh
+      -p 127.0.0.1:8000:8000
+      ```
 
-    ```sh
-    -p 127.0.0.1:8000:8000
-    ```
+4. Run the `docker run` command with your substituted values.
 
-7. On the **Configure New Runtime** page, click **Done** to go to the Runtime
+5. On the **Configure New Runtime** page, click **Done** to go to the Runtime
 Manager overview.
 
     The Runtime Manager will include a new entry for your instance.

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -16,8 +16,7 @@ runtime instances.
 
 ## Prerequisites
 
-* You have a {{site.konnect_product_name}} account. Contact your sales
-representative for access.
+* You have **Runtime Admin** or **Organization Admin** permissions in {{site.konnect_saas}}.
 * **Kubernetes cluster with load balancer:** {{site.konnect_short_name}} is
 compatible with all distributions of Kubernetes. You can use a Minikube, GKE,
 or OpenShift TLS.


### PR DESCRIPTION
### Review
@mikefero 

### Summary
* Add PowerShell option for Docker install
* Update and fix up runtime prerequisites
* Point to advanced setup for windows users from quickstart guide, since the script won't work for them

Reviewers: I don't love having to point the users from the docker setup instructions to one of the other UI tabs, but there's no good way to grab the info they need otherwise.

### Reason
https://konghq.atlassian.net/browse/DOCU-1477
Customer ran into issues with trying to run the Docker script on Windows, and there were no advanced instructions to back them up when it failed.

### Testing
Mainly here: https://deploy-preview-2854--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/

Minor changes made to:
https://deploy-preview-2854--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-kubernetes/
https://deploy-preview-2854--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-conf/
https://deploy-preview-2854--kongdocs.netlify.app/konnect/getting-started/configure-runtime/