### PR TITLE
[DOCU-1491] Remove unsupported plugins from Plus filter

### DIFF
--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -60,7 +60,7 @@ body_id: page-hub
             </li>
             <li class="nav-item">
               <a class="nav-link" data-filter="plus">
-                Plus (SaaS only)
+                Plus
               </a>
             </li>
             <li class="nav-item">

--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -43,11 +43,6 @@ body_id: page-hub
               </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" data-filter="open-source">
-                Open-source (Kong)
-              </a>
-            </li>
-            <li class="nav-item">
               <a class="nav-link" data-filter="pub-not-konghq">
                 Third-Party
               </a>

--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -12,7 +12,7 @@ description: |
   substitute those strings into transformed requests via flexible templates.
 
 enterprise: true
-plus: true
+saas: false
 type: plugin
 categories:
   - transformations

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -12,6 +12,7 @@ description: |
   those matched strings into variables, and substituting those strings into transformed requests using flexible templates.
 
 type: plugin
+saas: false
 categories:
   - transformations
 

--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -36,7 +36,7 @@ categories:
   - transformations
 
 enterprise: true
-plus: true
+saas: false
 kong_version_compatibility:
     enterprise_edition:
       compatible:


### PR DESCRIPTION
### Summary
* Removing response transformer advanced, request transformer, and request transformer advanced from Konnect Plus filter.
* Slight edit to filter text, as it was reported that users are assuming "Plus (SaaS only)" means that the plugins are available in SaaS only, not the other way around.
* Had to remove OSS filter as it was confusing people - had multiple people reach out to ask why we had both Free and OSS categories if they're the same.

### Reason
Plugins didn't make it into Konnect Plus.

### Testing
Check that response transformer advanced, request transformer, and request transformer advanced are greyed out when you click the "Plus" filter: https://deploy-preview-2855--kongdocs.netlify.app/hub
