### PR TITLE
Adds the certificate function to the stream module table

### DIFF
--- a/app/gateway-oss/2.4.x/plugin-development/custom-logic.md
+++ b/app/gateway-oss/2.4.x/plugin-development/custom-logic.md
@@ -59,6 +59,7 @@ To reduce unexpected behaviour changes, {{site.ce_product_name}} does not start 
 | `init_worker`   | [init_worker]                                                                | Executed upon every Nginx worker process's startup.
 | `preread`       | [preread]                                                                    | Executed once for every connection.
 | `log`           | [log](https://github.com/openresty/stream-lua-nginx-module#log_by_lua_block) | Executed once for each connection after it has been closed.
+| `certificate`   | [ssl_certificate] | Executed during the SSL certificate serving phase of the SSL handshake.
 
 All of those functions, except `init_worker`, take one parameter which is given
 by {{site.ce_product_name}} upon its invocation: the configuration of your Plugin. This parameter


### PR DESCRIPTION
Per @bungle with PR [#6873](https://github.com/Kong/kong/pull/6873) the `ssl_certificate` phase on plugins has been added to the Stream module - therefore it should be added to the table in this doc.

Will open a separate PR to add this update to the Enterprise docs.

### Testing
[Plugin development guide > Implementing custom logic > Available contexts > Stream module](https://deploy-preview-2856--kongdocs.netlify.app/gateway-oss/2.4.x/plugin-development/custom-logic/#available-contexts)