### PR TITLE
Document key-auth TTL parameter

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/index.md
+++ b/app/_hub/kong-inc/key-auth-enc/index.md
@@ -200,6 +200,7 @@ In both cases, the fields/parameters work as follows:
 field/parameter     | description
 ---                 | ---
 `{consumer}`        | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
+`ttl`<br>*optional* | The number of seconds the key is going to be valid. If missing, the `ttl` is unlimited.
 `key`<br>*optional* | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
 
 ### Make a Request with the Key

--- a/app/_hub/kong-inc/key-auth/index.md
+++ b/app/_hub/kong-inc/key-auth/index.md
@@ -226,6 +226,7 @@ In both cases, the fields/parameters work as follows:
 field/parameter     | description
 ---                 | ---
 `{consumer}`        | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
+`ttl`<br>*optional* | The number of seconds the key is going to be valid. If missing, the `ttl` is unlimited.
 `key`<br>*optional* | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
 
 ### Make a Request with the Key


### PR DESCRIPTION
### Summary
Document `ttl` parameter when creating a key with the key-auth plugin.

### Reason
This feature is not documented

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
