### PR TITLE
[DOCU-1510]Updates Immunity changelog URL to new location in 1.5.x, 2.1.x, 2.2.x…

### DIFF
--- a/app/enterprise/1.5.x/brain-immunity/changelog.md
+++ b/app/enterprise/1.5.x/brain-immunity/changelog.md
@@ -3,6 +3,6 @@ title: Kong Brain and Kong Immunity Changelog
 toc: false
 ---
 
-The Kong Brain and Kong Immunity changelog can be found under the Kong Collector documentation at   [https://github.com/Kong/kong-collector/releases](https://github.com/Kong/kong-collector/releases). 
+The Kong Brain and Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md](https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md). 
 
 See this changelog for the latest release information for Kong Brain, Kong Immunity, and Kong Collector. 

--- a/app/enterprise/2.1.x/brain-immunity/changelog.md
+++ b/app/enterprise/2.1.x/brain-immunity/changelog.md
@@ -8,6 +8,6 @@ toc: false
 <strong>Important:</strong> Kong Brain is deprecated and not available for use in Kong Enterprise version 2.1.4.2 and later.
 </div>
 
-The Kong Brain and Kong Immunity changelog can be found under the Kong Collector documentation at   [https://github.com/Kong/kong-collector/releases](https://github.com/Kong/kong-collector/releases). 
+The Kong Brain and Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md](https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md). 
 
 See this changelog for the latest release information for Kong Brain, Kong Immunity, and Kong Collector. 

--- a/app/enterprise/2.2.x/immunity/changelog.md
+++ b/app/enterprise/2.2.x/immunity/changelog.md
@@ -5,6 +5,6 @@ redirect_from:
   - /enterprise/2.2.x/brain-immunity/changelog
 ---
 
-The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector/releases](https://github.com/Kong/kong-collector/releases).
+The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md](https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md).
 
 See this changelog for the latest release information for Kong Immunity and Kong Collector.

--- a/app/enterprise/2.3.x/immunity/changelog.md
+++ b/app/enterprise/2.3.x/immunity/changelog.md
@@ -5,6 +5,6 @@ redirect_from:
   - /enterprise/2.2.x/brain-immunity/changelog
 ---
 
-The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector/releases](https://github.com/Kong/kong-collector/releases).
+The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md](https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md).
 
 See this changelog for the latest release information for Kong Immunity and Kong Collector.

--- a/app/enterprise/2.4.x/immunity/changelog.md
+++ b/app/enterprise/2.4.x/immunity/changelog.md
@@ -5,6 +5,6 @@ redirect_from:
   - /enterprise/2.2.x/brain-immunity/changelog
 ---
 
-The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector/releases](https://github.com/Kong/kong-collector/releases).
+The Kong Immunity changelog can be found under the Kong Collector documentation at [https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md](https://github.com/Kong/kong-collector-helm/blob/master/collector-changelog.md).
 
 See this changelog for the latest release information for Kong Immunity and Kong Collector.


### PR DESCRIPTION
Updates Immunity changelog URL to new location in 1.5.x, 2.1.x, 2.2.x, 2.3.x, and 2.4.x

### Reason
[DOCU-1510](https://konghq.atlassian.net/browse/DOCU-1510)
[AI-856](https://konghq.atlassian.net/browse/AI-856)
### Testing
[2.4.x](https://deploy-preview-2876--kongdocs.netlify.app/enterprise/2.4.x/immunity/changelog/)
[2.3.x](https://deploy-preview-2876--kongdocs.netlify.app/enterprise/2.3.x/immunity/changelog/)
[2.2.x](https://deploy-preview-2876--kongdocs.netlify.app/enterprise/2.2.x/immunity/changelog/)
[2.1.x](https://deploy-preview-2876--kongdocs.netlify.app/enterprise/2.1.x/brain-immunity/changelog/)
[1.5.x](https://deploy-preview-2876--kongdocs.netlify.app/enterprise/1.5.x/brain-immunity/changelog/)