### PR TITLE
[DOCU-1504]Removes centos 6 from available download options

### DIFF
--- a/app/_includes/md/enterprise/download/centos.md
+++ b/app/_includes/md/enterprise/download/centos.md
@@ -1,5 +1,49 @@
 There are two options to install {{site.base_gateway}} on CentOS.
 
+<!--2.4.x version --->
+
+{% if include.version == "2.4.x" %}
+
+{% navtabs %}
+{% navtab Download RPM file %}
+
+1. Choose your CentOS version:
+    * [CentOS 8]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/)
+    * [CentOS 7]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/)
+
+2. Click a {{site.base_gateway}} version from the list to download it.
+
+    Versions are listed in chronological order.
+
+    For example: `kong-enterprise-edition-{{page.kong_versions[11].version}}.el8.noarch.rpm`
+
+3. Copy the RPM file to your home directory on the CentOS system.
+
+    For example:
+
+    ```bash
+    $ scp kong-enterprise-edition-{{page.kong_versions[11].version}}.el8.noarch.rpm <centos user>@<server>:~
+    ```
+
+{% endnavtab %}
+{% navtab Download Kong repo file and add to Yum repo %}
+
+1. Download and save the {{site.base_gateway}} RPM repo file as `config.repo`:
+
+    * [CentOS 8]({{ site.links.download }}/gateway-2.x-centos-8/config.repo)
+    * [CentOS 7]({{ site.links.download }}/gateway-2.x-centos-7/config.repo)
+
+2. Securely copy the repo file to your home directory on the CentOS system:
+
+    ```bash
+    $ scp config.repo <centos user>@<server>:~
+    ```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+{% endif %}
+
 <!--2.x versions-->
 {% if include.version == "2.x" %}
 

--- a/app/_includes/md/enterprise/download/centos.md
+++ b/app/_includes/md/enterprise/download/centos.md
@@ -1,49 +1,5 @@
 There are two options to install {{site.base_gateway}} on CentOS.
 
-<!--2.4.x version --->
-
-{% if include.version == "2.4.x" %}
-
-{% navtabs %}
-{% navtab Download RPM file %}
-
-1. Choose your CentOS version:
-    * [CentOS 8]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/)
-    * [CentOS 7]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/)
-
-2. Click a {{site.base_gateway}} version from the list to download it.
-
-    Versions are listed in chronological order.
-
-    For example: `kong-enterprise-edition-{{page.kong_versions[11].version}}.el8.noarch.rpm`
-
-3. Copy the RPM file to your home directory on the CentOS system.
-
-    For example:
-
-    ```bash
-    $ scp kong-enterprise-edition-{{page.kong_versions[11].version}}.el8.noarch.rpm <centos user>@<server>:~
-    ```
-
-{% endnavtab %}
-{% navtab Download Kong repo file and add to Yum repo %}
-
-1. Download and save the {{site.base_gateway}} RPM repo file as `config.repo`:
-
-    * [CentOS 8]({{ site.links.download }}/gateway-2.x-centos-8/config.repo)
-    * [CentOS 7]({{ site.links.download }}/gateway-2.x-centos-7/config.repo)
-
-2. Securely copy the repo file to your home directory on the CentOS system:
-
-    ```bash
-    $ scp config.repo <centos user>@<server>:~
-    ```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-{% endif %}
-
 <!--2.x versions-->
 {% if include.version == "2.x" %}
 
@@ -53,7 +9,6 @@ There are two options to install {{site.base_gateway}} on CentOS.
 1. Choose your CentOS version:
     * [CentOS 8]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/)
     * [CentOS 7]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/)
-    * [CentOS 6]({{ site.links.download }}/gateway-2.x-centos-6/Packages/k/)
 
 2. Click a {{site.base_gateway}} version from the list to download it.
 
@@ -76,7 +31,6 @@ There are two options to install {{site.base_gateway}} on CentOS.
 
     * [CentOS 8]({{ site.links.download }}/gateway-2.x-centos-8/config.repo)
     * [CentOS 7]({{ site.links.download }}/gateway-2.x-centos-7/config.repo)
-    * [CentOS 6]({{ site.links.download }}/gateway-2.x-centos-6/config.repo)
 
 2. Securely copy the repo file to your home directory on the CentOS system:
 
@@ -98,7 +52,7 @@ There are two options to install {{site.base_gateway}} on CentOS.
 1. Choose your CentOS version:
     * [CentOS 8]({{ site.links.download }}/gateway-1.x-centos-8/Packages/k/)
     * [CentOS 7]({{ site.links.download }}/gateway-1.x-centos-7/Packages/k/)
-    * [CentOS 6]({{ site.links.download }}/gateway-1.x-centos-6/Packages/k/)
+    
 2. Select a {{site.base_gateway}} version from the list to download it.
 
     Versions are listed in chronological order.
@@ -120,7 +74,6 @@ There are two options to install {{site.base_gateway}} on CentOS.
 
     * [CentOS 8]({{ site.links.download }}/gateway-1.x-centos-8/config.repo)
     * [CentOS 7]({{ site.links.download }}/gateway-1.x-centos-7/config.repo)
-    * [CentOS 6]({{ site.links.download }}/gateway-1.x-centos-6/config.repo)
 
 2. Securely copy the repo file to your home directory on the CentOS system:
 

--- a/app/enterprise/2.4.x/deployment/installation/centos.md
+++ b/app/enterprise/2.4.x/deployment/installation/centos.md
@@ -28,7 +28,7 @@ root-equivalent access.
 
 ## Step 1. Prepare to install Kong Gateway {#step-1}
 
-{% include /md/enterprise/download/centos.md version='2.x' %}
+{% include /md/enterprise/download/centos.md version='2.4.x' %}
 
 <!-- ### (Optional) Verify the package integrity
 


### PR DESCRIPTION
### Reason
@eskibars discovered that the centos 6 OS was not available for download even though the docs say it is so it should be removed from docs as an option.

### Testing
* [Install Kong Gateway on Centos OS - 2.4.x](https://deploy-preview-2878--kongdocs.netlify.app/enterprise/2.4.x/deployment/installation/centos/)
* [Install Kong Gateway on Centos OS - 2.3.x](https://deploy-preview-2878--kongdocs.netlify.app/enterprise/2.3.x/deployment/installation/centos/)
* [Install Kong Gateway on Centos OS - 2.2.x](https://deploy-preview-2878--kongdocs.netlify.app/enterprise/2.2.x/deployment/installation/centos/)
* [Install Kong Gateway on Centos OS - 2.1.x](https://deploy-preview-2878--kongdocs.netlify.app/enterprise/2.1.x/deployment/installation/centos/)
* [Install Kong Gateway on Centos OS - 1.5.x](https://deploy-preview-2878--kongdocs.netlify.app/enterprise/1.5.x/deployment/installation/centos/)
