### PR TITLE
Rename X-Kong-Debug to Kong-Debug

### DIFF
--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -583,7 +583,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 


### PR DESCRIPTION
### Summary
It looks like there is a typo in the doc about this header.
I found the solution on this topic https://discuss.konghq.com/t/kong-1-4-0-using-x-kong-debug-1-doesnt-seem-to-work/4949.

I know the PR is not ok. That is a conversation start. I'll be happy to finish it as required.


