### PR TITLE
[DOCU-803] Refactor alert/callout design

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1011,12 +1011,6 @@
       color: @gray-dark;
   }
 
-  blockquote {
-    opacity: 0.8;
-    margin-left: 0;
-    font-style: italic;
-  }
-
   /*
 Generic Styling for Desktop
 */
@@ -1029,14 +1023,17 @@ Generic Styling for Desktop
     border: none;
     border-collapse: collapse;
     margin-top: 1.5em;
+    position: relative;
 
     i.fa-times {
       color: @red-500;
       opacity: 50%;
+      font-size: 20px;
     }
 
     i.fa-check {
       color: @green-400;
+      font-size: 18px;
     }
 
     code {
@@ -1057,6 +1054,10 @@ Generic Styling for Desktop
     font-weight: 600;
     color: @black-80;
     background-color: @grey-100;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    z-index: 2;
   }
 
   td,
@@ -1108,28 +1109,294 @@ Generic Styling for Desktop
   }
 
   .alert {
-    margin-bottom: 1.3em;
-    font-size: 16px;
+    margin-bottom: 0.8em;
+    margin-top: 0.8em;
+    font-size: 17px;
+    border-radius: 3px;
 
     &.alert-warning {
       color: hsl(45, 2%, 36%);
-      border-color: hsl(41, 83%, 89%);
-      background-color: hsl(51, 100%, 96%);
-    }
+        background-color: @yellow-100;
+        border-left: solid 3px @yellow-400;
+
+        &::before {
+          content: "\f071";
+          font-family: "Font Awesome", FontAwesome;
+          color: @yellow-400;
+          display: inline-block;
+          font-weight: 600;
+          font-size: 17px;
+          padding: 0 5px 0 0;
+        }
+      }
 
     &.alert-red {
-      color: red;
       border-color: red;
       background-color: #fdf3f2;
+
+      &::before {
+        content: "\f057";
+        font-family: "Font Awesome", FontAwesome;
+        color: @red-500;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
     }
 
-    ol {
-      list-style: none;
+    ol, li {
       margin-bottom: 0;
-      margin-top: 1em;
+      margin-top: 0.5em;
+    }
+  }
 
-      li {
-        margin-bottom: 0;
+  .alert-ee {
+    background-color: @blue-100;
+    border: none;
+    border-left: solid 3px @blue-400;
+    font-size: 17px;
+
+    &::before {
+      content: "\f05a";
+      font-family: "Font Awesome", FontAwesome;
+      color: @blue-400;
+      display: inline-block;
+      font-weight: 600;
+      font-size: 17px;
+      padding: 0 5px 0 0;
+    }
+
+    &.error {
+      background-color: @red-100;
+      border-left: solid 3px @red-500;
+
+      &::before {
+        content: "\f057";
+        font-family: "Font Awesome", FontAwesome;
+        color: @red-500;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    &.warning {
+      background-color: @yellow-100;
+      border-left: solid 3px @yellow-400;
+
+      &::before {
+        content: "\f071";
+        font-family: "Font Awesome", FontAwesome;
+        color: @yellow-400;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    &.info {
+      background-color: @blue-100;
+      border: none;
+      border-left: solid 3px @blue-400;
+
+      &::before {
+        content: "\f05a";
+        font-family: "Font Awesome", FontAwesome;
+        color: @blue-400;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    &.tip {
+      border-left: 3px solid @green-400;
+      background-color: @green-100;
+
+      &::before {
+        content: "\f058";
+        font-family: "Font Awesome", FontAwesome;
+        color: @green-400;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    .alert-body {
+      padding-top: 20px;
+    }
+
+    .left {
+      float: left;
+      padding-top: 5px;
+      margin: 0 20px 0;
+    }
+
+    .tag {
+      padding: 2px 8px;
+      margin-right: 12px;
+      border-radius: 11px;
+      font-family: Roboto, -apple-system, system-ui, BlinkMacSystemFont,
+        "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      font-size: 10px;
+      font-weight: bold;
+      background: @blue;
+      color: white;
+
+      &.green {
+        background: #35cb05;
+      }
+
+      &.red {
+        background: @red;
+      }
+    }
+
+    img {
+      width: 20px;
+      margin-right: 5px;
+      margin-top: 3px;
+      float: left;
+      display: inline-block;
+    }
+
+    code {
+      font-size: 13px;
+    }
+
+    p {
+      padding: 0 25px 0 75px;
+      font-size: 16px;
+    }
+
+    a {
+      text-decoration: none;
+      color: @blue-light;
+    }
+
+    &.condensed {
+      padding: 6px 8px;
+
+      .alert-body {
+        padding: 0;
+        margin: 0;
+        display: flex;
+        align-items: center;
+      }
+
+      p {
+        flex-grow: 1;
+        padding: 0;
+        margin: 0;
+      }
+    }
+
+    &.margin-bigger {
+      margin-bottom: 32px;
+    }
+  }
+
+  blockquote {
+    margin-bottom: 1.3em;
+    padding: 15px 18px;
+    background-color: @blue-100;
+    border: none;
+    border-left: solid 3px @blue-400;
+    border-radius: 3px;
+    display: block;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+
+    ol, ul {
+      margin-top: 0.5em;
+      margin-bottom: 0;
+    }
+
+    pre, code {
+      background-color: #fff;
+      border: none;
+      padding: 3px;
+    }
+
+    p, b, strong {
+      padding: 0;
+      margin: 0;
+      display: inline;
+    }
+
+    &::before {
+      content: "\f05a";
+      font-family: "Font Awesome", FontAwesome;
+      color: @blue-400;
+      display: inline-block;
+      font-weight: 600;
+      font-size: 17px;
+      padding: 0 5px ;
+    }
+    &.warning {
+      background-color: @red-100;
+      border-left: solid 3px @red-500;
+
+      &::before {
+        content: "\f057";
+        font-family: "Font Awesome", FontAwesome;
+        color: @red-500;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    &.important {
+      background-color: @yellow-100;
+      border-left: solid 3px @yellow-400;
+
+      &::before {
+        content: "\f071";
+        font-family: "Font Awesome", FontAwesome;
+        color: @yellow-400;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    &.info {
+      background-color: @blue-100;
+      border: none;
+      border-left: solid 3px @blue-400;
+
+      &::before {
+        content: "\f05a";
+        font-family: "Font Awesome", FontAwesome;
+        color: @blue-400;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
+      }
+    }
+
+    &.tip {
+      border-left: 3px solid @green-400;
+      background-color: @green-100;
+
+      &::before {
+        content: "\f058";
+        font-family: "Font Awesome", FontAwesome;
+        color: @green-400;
+        display: inline-block;
+        font-weight: 600;
+        font-size: 17px;
+        padding: 0 5px 0 0;
       }
     }
   }
@@ -1401,18 +1668,14 @@ Generic Styling for Desktop
 
 .alert {
   border: none;
-  border-left: 3px solid @gray;
-  color: #757575;
-  background-color: #f9f9f9;
   border-radius: 0;
   font-size: 16px;
-  padding: 8px 13px;
+  padding: 15px 18px;
 
   pre, code {
     background-color: #fff;
     border: none;
   }
-
 }
 
 .alert-info {
@@ -1424,121 +1687,6 @@ Generic Styling for Desktop
     color: #004a80;
     border-left: 3px solid #004b80;
     background-color: #edf7ff;
-  }
-}
-
-.alert-success {
-  color: #3dcc3d;
-  border-left: 3px solid #c0eac0;
-  background-color: #f4fff4;
-}
-
-.alert-warning {
-  color: #808060;
-  border-left: 3px solid #e0e0c9;
-  background-color: #fffff7;
-}
-
-.alert-danger {
-  color: #cc3d3d;
-  border-left: 3px solid #eac0c0;
-  background-color: #fff4f4;
-}
-
-.alert-ee {
-  background-color: #e5f4ff;
-  border: none;
-  border-left: solid 3px #b3dfff;
-  border-radius: 0;
-  font-size: 16px;
-
-  &.red {
-    background-color: #fdf3f2;
-    border-left: solid 3px @red;
-  }
-
-  &.warning {
-    background-color: #fffbea;
-    border-left: solid 3px #faebcb;
-  }
-
-  &.info {
-    border-left: 3px solid @gray;
-    color: #757575;
-    background-color: #f9f9f9;
-  }
-
-  .alert-body {
-    padding-top: 20px;
-  }
-
-  .left {
-    float: left;
-    padding-top: 5px;
-    margin: 0 20px 0;
-  }
-
-  .tag {
-    padding: 2px 8px;
-    margin-right: 12px;
-    border-radius: 11px;
-    font-family: Roboto, -apple-system, system-ui, BlinkMacSystemFont,
-      "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    font-size: 10px;
-    font-weight: bold;
-    background: @blue;
-    color: white;
-
-    &.green {
-      background: #35cb05;
-    }
-
-    &.red {
-      background: @red;
-    }
-  }
-
-  img {
-    width: 20px;
-    margin-right: 5px;
-    margin-top: 3px;
-    float: left;
-    display: inline-block;
-  }
-
-  code {
-    font-size: 13px;
-  }
-
-  p {
-    padding: 0 25px 0 75px;
-    font-size: 16px;
-  }
-
-  a {
-    text-decoration: none;
-    color: @blue-light;
-  }
-
-  &.condensed {
-    padding: 6px 8px;
-
-    .alert-body {
-      padding: 0;
-      margin: 0;
-      display: flex;
-      align-items: center;
-    }
-
-    p {
-      flex-grow: 1;
-      padding: 0;
-      margin: 0;
-    }
-  }
-
-  &.margin-bigger {
-    margin-bottom: 32px;
   }
 }
 

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1116,8 +1116,8 @@ Generic Styling for Desktop
 
     &.alert-warning {
       color: hsl(45, 2%, 36%);
-        background-color: @yellow-100;
-        border-left: solid 3px @yellow-400;
+      background-color: @yellow-100;
+      border-left: solid 3px @yellow-400;
 
         &::before {
           content: "\f071";
@@ -1131,8 +1131,8 @@ Generic Styling for Desktop
       }
 
     &.alert-red {
-      border-color: red;
-      background-color: #fdf3f2;
+      background-color: @red-100;
+      border-left: solid 3px @red-500;
 
       &::before {
         content: "\f057";

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -11,16 +11,13 @@ description: |
   checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
-  <div class="alert alert-ee blue"><strong>Tip:</strong> The LDAP Authentication Advanced plugin
-  provides additional features not available in the open source <a href="/hub/kong-inc/ldap-auth">LDAP Authentication plugin</a>,
+  {:.tip}
+  > **Tip:** The LDAP Authentication Advanced plugin
+  provides additional features not available in the open source [LDAP Authentication plugin](/hub/kong-inc/ldap-auth/),
   such as LDAP searches for group and consumer mapping:
-
-  <ul>
-  <li>Ability to authenticate based on username or custom ID.</li>
-  <li>The ability to bind to an enterprise LDAP directory with a password.</li>
-  <li>The ability to obtain LDAP groups and set them in a header to the request before proxying to the upstream. This is useful for Kong Manager role mapping.</li>
-  </ul>
-  </div>
+  * Ability to authenticate based on username or custom ID.
+  * The ability to bind to an enterprise LDAP directory with a password.
+  * The ability to obtain LDAP groups and set them in a header to the request before proxying to the upstream. This is useful for Kong Manager role mapping.
 
 enterprise: true
 plus: true

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -10,17 +10,14 @@ description: |
   checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
-  <div class="alert alert-ee blue"><strong>Tip:</strong> The
-  <a href="/hub/kong-inc/ldap-auth-advanced/">LDAP Authentication Advanced plugin</a> provides
+  {:.tip}
+  > **Tip:** The
+  [LDAP Authentication Advanced plugin](/hub/kong-inc/ldap-auth-advanced/) provides
   additional features not available in this open source LDAP plugin, such as LDAP searches
   for group and consumer mapping:
-
-  <ul>
-  <li>Ability to authenticate based on username or custom ID.</li>
-  <li>The ability to bind to an enterprise LDAP directory with a password.</li>
-  <li>The ability to authenticate/authorize using a group base DN and specific group member or group name attributes.</li>
-  </ul>
-  </div>
+  * Ability to authenticate based on username or custom ID.
+  * The ability to bind to an enterprise LDAP directory with a password.
+  * The ability to authenticate/authorize using a group base DN and specific group member or group name attributes.
 
 type: plugin
 categories:

--- a/app/_hub/kong-inc/mocking/index.md
+++ b/app/_hub/kong-inc/mocking/index.md
@@ -169,12 +169,12 @@ curl -X POST http://<admin-hostname>:8001/plugins/ \
 This example tutorial steps you through testing a mock response for
 a stock quote service API.
 
-<div class="alert alert-ee blue"><strong>Tip:</strong> Before following the steps in this
+{:.tip}
+> **Tip:** Before following the steps in this
 tutorial, you can view a video demonstration of the Mocking plugin
 used in conjunction with the Dev Portal. See the
-<a href="https://www.youtube.com/watch?v=l8uKbgkK6_I">Service Mocking video demo</a>
+[Service Mocking video demo](https://www.youtube.com/watch?v=l8uKbgkK6_I)
 available on YouTube.
-</div>
 
 Prerequisites:
 

--- a/app/_hub/kong-inc/oauth2/1.0.x.md
+++ b/app/_hub/kong-inc/oauth2/1.0.x.md
@@ -163,9 +163,7 @@ params:
 In order to use the plugin, you first need to create a consumer to associate one or more credentials to. The Consumer represents a developer using the upstream service.
 
 <div class="alert alert-warning">
-  <div class="text-center">
     <strong>Note</strong>: This plugin requires a database in order to work effectively. It *does not* work on DB-Less mode.
-  </div>
 </div>
 
 ### Endpoints

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -212,9 +212,7 @@ params:
 In order to use the plugin, you first need to create a consumer to associate one or more credentials to. The Consumer represents a developer using the upstream service.
 
 <div class="alert alert-warning">
-  <div class="text-center">
     <strong>Note</strong>: This plugin requires a database in order to work effectively. It *does not* work on DB-Less mode.
-  </div>
 </div>
 
 ### Endpoints
@@ -373,10 +371,8 @@ The authorization page is made of two parts:
 * The frontend page that the user will see, and that will allow him to authorize the client application to access his data
 * The backend that will process the HTML form displayed in the frontend, that will talk with the OAuth 2.0 plugin on Kong, and that will ultimately redirect the user to a third party URL.
 
-<div class="alert alert-warning">
-  <div class="container" style="text-align: center;">
+<div class="alert alert-info">
     <a href="{{ site.repos.oauth2_hello_world }}">You can see a sample implementation in node.js + express.js on GitHub</a>
-  </div>
 </div>
 
 A diagram representing this flow:

--- a/app/_hub/kong-inc/statsd-advanced/index.md
+++ b/app/_hub/kong-inc/statsd-advanced/index.md
@@ -12,17 +12,13 @@ description: |
   daemon by enabling its
   [StatsD plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
 
-  <div class="alert alert-ee blue"><strong>Tip:</strong> The StatsD Advanced plugin provides
-  additional features not available in the open source <a href="/hub/kong-inc/statsd/">StatsD</a> plugin,
+  {:.tip}
+  > **Tip:** The StatsD Advanced plugin provides
+  additional features not available in the open source [StatsD](/hub/kong-inc/statsd/) plugin,
   such as:
-
-  <ul>
-  <li>Ability to choose status codes to log to metrics.</li>
-  <li>More granular status codes per workspace.</li>
-  <li>Ability to use TCP instead of UDP.</li>
-  </ul>
-  </div>
-
+  * Ability to choose status codes to log to metrics.
+  * More granular status codes per workspace.
+  * Ability to use TCP instead of UDP.
 
 enterprise: true
 type: plugin

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -11,15 +11,12 @@ description: |
   daemon by enabling its [Statsd
   plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
 
-  <div class="alert alert-ee blue"><strong>Tip:</strong> The <a href="/hub/kong-inc/statsd-advanced/">StatsD Advanced plugin</a> provides
+  {:.tip}
+  > **Tip:** The [StatsD Advanced plugin](/hub/kong-inc/statsd-advanced/) provides
   additional features not available in this open source StatsD plugin, such as:
-
-  <ul>
-  <li>Ability to choose status codes to log to metrics.</li>
-  <li>More granular status codes per workspace.</li>
-  <li>Ability to use TCP instead of UDP.</li>
-  </ul>
-  </div>
+  * Ability to choose status codes to log to metrics.
+  * More granular status codes per workspace.
+  * Ability to use TCP instead of UDP.
 
 type: plugin
 categories:

--- a/app/_hub/tomkerkhove/microsoft_azure/index.md
+++ b/app/_hub/tomkerkhove/microsoft_azure/index.md
@@ -122,16 +122,12 @@ Here are the simple steps to provision one:
     ```
 
 <div class="alert alert-warning">
-  <div class="text-center">
     <strong>Note</strong>: Before connecting to your new database, make sure your IP address is allowed in "Connection Security"
-  </div>
 </div>
 
 ### Running Cassandra on Azure with Azure Cosmos DB
 Currently,  [Azure Cosmos DB](https://azure.microsoft.com/en-us/services/cosmos-db/)  is not supported as a Cassandra datastore.
 
 <div class="alert alert-info">
-  <div class="text-center">
     <strong>Note</strong>: See <a href="https://github.com/Kong/docker-kong/issues/188" target="blank">#188</a> for more information.
-  </div>
 </div>

--- a/app/_hub/tomkerkhove/microsoft_azure_container_instances/index.md
+++ b/app/_hub/tomkerkhove/microsoft_azure_container_instances/index.md
@@ -134,9 +134,7 @@ Running Kong on Azure Container Instances is super easy:
     The `8000`, `8001`, `8443`, and `8444` will be forwarded to the container.
 
     <div class="alert alert-warning">
-      <div class="text-center">
         <strong>Note</strong>: This will expose both the proxy and the Admin API on the default ports. This can have security implications.
-      </div>
     </div>
 
 1. **Use Kong**

--- a/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
+++ b/app/enterprise/1.5.x/kong-for-kubernetes/install-on-kubernetes.md
@@ -198,7 +198,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
     If you are running Postgres as a sub-chart and having problems with connecting to
     the database, delete Postgres' persistent volumes in your Kubernetes cluster, then
@@ -206,7 +206,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     </div>
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
     If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>.
     </div>
@@ -242,7 +242,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     ```
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.

--- a/app/enterprise/2.1.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.1.x/deployment/classic-deployment.md
@@ -12,7 +12,7 @@ in Hybrid mode, every node must connect to a database.
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.1.x/deployment/deployment-options.md
+++ b/app/enterprise/2.1.x/deployment/deployment-options.md
@@ -13,7 +13,7 @@ title: Deployment Options
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.

--- a/app/enterprise/2.1.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.1.x/deployment/installation/kong-on-kubernetes.md
@@ -232,7 +232,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
     If you are running Postgres as a sub-chart and having problems with connecting to
     the database, delete Postgres' persistent volumes in your Kubernetes cluster, then
@@ -240,7 +240,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     </div>
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
     If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>.
     </div>
@@ -274,7 +274,7 @@ The steps in this section show you how to install Kong Enterprise on Kubernetes 
     $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.

--- a/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
@@ -63,7 +63,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 * If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.1.x/kong-manager/authentication/sessions.md
+++ b/app/enterprise/2.1.x/kong-manager/authentication/sessions.md
@@ -71,7 +71,7 @@ directives.
 * If using different domains for the Admin API and Kong Manager: `"cookie_samesite": "off"`
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.2.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.2.x/deployment/classic-deployment.md
@@ -12,7 +12,7 @@ in Hybrid mode, every node must connect to a database.
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.2.x/deployment/deployment-options.md
+++ b/app/enterprise/2.2.x/deployment/deployment-options.md
@@ -13,7 +13,7 @@ title: Deployment Options
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.

--- a/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes.md
@@ -231,7 +231,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
     If you are running Postgres as a sub-chart and having problems with connecting to
     the database, delete Postgres' persistent volumes in your Kubernetes cluster, then
@@ -239,7 +239,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     </div>
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
     If you have already installed the CRDs, run the command above with the following flag: <code>--set ingressController.installCRDs=false</code>.
     </div>
@@ -273,7 +273,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     $ kubectl get svc -n kong my-kong-kong-admin --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.

--- a/app/enterprise/2.2.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.2.x/developer-portal/configuration/authentication/sessions.md
@@ -61,7 +61,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 * If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.2.x/kong-manager/authentication/sessions.md
+++ b/app/enterprise/2.2.x/kong-manager/authentication/sessions.md
@@ -71,7 +71,7 @@ directives.
 * If using different domains for the Admin API and Kong Manager: `"cookie_samesite": "off"`
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.3.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.3.x/deployment/classic-deployment.md
@@ -12,7 +12,7 @@ in Hybrid mode, every node must connect to a database.
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.3.x/deployment/deployment-options.md
+++ b/app/enterprise/2.3.x/deployment/deployment-options.md
@@ -13,7 +13,7 @@ title: Deployment Options
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.

--- a/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
@@ -307,7 +307,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
       <ul>
         <li>If you have already installed the CRDs, run the command above with
@@ -334,7 +334,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
       <ul>
         <li>If you have already installed the CRDs, run the command above with
@@ -366,7 +366,7 @@ After migrations are complete and the `my-kong-kong-<ID>` pod is running, contin
       --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.
@@ -414,7 +414,7 @@ After migrations are complete and the `my-kong-kong-<ID>` pod is running, contin
     ```
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.

--- a/app/enterprise/2.3.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.3.x/developer-portal/configuration/authentication/sessions.md
@@ -61,7 +61,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 * If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.3.x/kong-manager/authentication/sessions.md
+++ b/app/enterprise/2.3.x/kong-manager/authentication/sessions.md
@@ -71,7 +71,7 @@ directives.
 * If using different domains for the Admin API and Kong Manager: `"cookie_samesite": "off"`
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.4.x/deployment/classic-deployment.md
+++ b/app/enterprise/2.4.x/deployment/classic-deployment.md
@@ -12,7 +12,7 @@ in Hybrid mode, every node must connect to a database.
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.4.x/deployment/deployment-options.md
+++ b/app/enterprise/2.4.x/deployment/deployment-options.md
@@ -13,7 +13,7 @@ title: Deployment Options
 In this deployment mode, you install one instance of Kong, and all of its add-ons
 reside on the same node. This option is normally used for testing and development.
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <b>Warning:</b> The embedded mode is intended for evaluation and development
   environments and <b>should not</b> be used for a production environment.
 </div>

--- a/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.

--- a/app/enterprise/2.4.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.4.x/deployment/installation/kong-on-kubernetes.md
@@ -307,7 +307,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
       <ul>
         <li>If you have already installed the CRDs, run the command above with
@@ -334,7 +334,7 @@ The steps in this section show you how to install {{site.ee_product_name}} on Ku
     This may take some time.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong>
       <ul>
         <li>If you have already installed the CRDs, run the command above with
@@ -366,7 +366,7 @@ After migrations are complete and the `my-kong-kong-<ID>` pod is running, contin
       --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'
     ```
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.
@@ -414,7 +414,7 @@ After migrations are complete and the `my-kong-kong-<ID>` pod is running, contin
     ```
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Important:</strong> The command above requires the Kong Admin API. If you
     have not set <code>admin.enabled</code> to <code>true</code> in your
     <code>values.yaml</code>, then this command will not work.

--- a/app/enterprise/2.4.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.4.x/developer-portal/configuration/authentication/sessions.md
@@ -61,7 +61,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 * If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/enterprise/2.4.x/kong-manager/authentication/sessions.md
+++ b/app/enterprise/2.4.x/kong-manager/authentication/sessions.md
@@ -71,7 +71,7 @@ directives.
 * If using different domains for the Admin API and Kong Manager: `"cookie_samesite": "off"`
 
 <div class="alert alert-warning">
-   <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+  
    <strong>Important: </strong>Sessions are not invalidated when a user logs out if <code>"storage": "cookie"</code>
    (the default) is used. In that case, the cookie is deleted client-side. Only when session data is
    stored server-side with <code>"storage": "kong"</code> set is the session actively invalidated.

--- a/app/getting-started-guide/2.1.x/expose-services.md
+++ b/app/getting-started-guide/2.1.x/expose-services.md
@@ -216,7 +216,7 @@ The route is created and you are automatically redirected back to the
 is now using:
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.1.x/prepare.md
+++ b/app/getting-started-guide/2.1.x/prepare.md
@@ -69,7 +69,7 @@ command in a terminal window:
     to see the {{site.base_gateway}}'s most recent configuration.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.2.x/expose-services.md
+++ b/app/getting-started-guide/2.2.x/expose-services.md
@@ -239,7 +239,7 @@ The route is created and you are automatically redirected back to the
 is now using:
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.2.x/prepare.md
+++ b/app/getting-started-guide/2.2.x/prepare.md
@@ -75,7 +75,7 @@ command in a terminal window:
     to see the {{site.base_gateway}}'s most recent configuration.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.3.x/expose-services.md
+++ b/app/getting-started-guide/2.3.x/expose-services.md
@@ -236,7 +236,7 @@ A 201 message indicates the Route was created successfully.
 3. (Optional) You can update your local file with the new configuration:
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.3.x/prepare.md
+++ b/app/getting-started-guide/2.3.x/prepare.md
@@ -84,7 +84,7 @@ the following command in a terminal window:
     to see the {{site.base_gateway}}'s most recent configuration.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.4.x/expose-services.md
+++ b/app/getting-started-guide/2.4.x/expose-services.md
@@ -236,7 +236,7 @@ A 201 message indicates the Route was created successfully.
 3. (Optional) You can update your local file with the new configuration:
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/getting-started-guide/2.4.x/prepare.md
+++ b/app/getting-started-guide/2.4.x/prepare.md
@@ -84,7 +84,7 @@ the following command in a terminal window:
     to see the {{site.base_gateway}}'s most recent configuration.
 
     <div class="alert alert-warning">
-    <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+   
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/install/aws-cloudformation.md
+++ b/app/install/aws-cloudformation.md
@@ -75,7 +75,7 @@ on AWS RDS for you.
 
 ## Kong in DB-less mode
 
-Provisions Kong resources in a new VPC or existing VPC. 
+Provisions Kong resources in a new VPC or existing VPC.
 
 Note: User would need to provide an S3 bucket location where `kong.yml` is
 stored with the declarative configuration to bootstrap all the Kong instances.
@@ -155,9 +155,7 @@ stored with the declarative configuration to bootstrap all the Kong instances.
     **Note**: *To monitor the progress go to AWS CloudFormation console, select the stack in the list. In the stack details pane, click the "Events" tab to see the progress.*
 
     <div class="alert alert-warning">
-      <div class="text-center">
         <strong>Note</strong>: Check out the <a href="{{ site.repos.cloudformation }}">kong-dist-cloudformation</a> repository for further details.
-      </div>
     </div>
 
 7. **Use Kong**

--- a/app/install/vagrant.md
+++ b/app/install/vagrant.md
@@ -57,9 +57,7 @@ Here is a quick example showing how to build a (disposable) test setup:
     The host ports `8000`, `8001`, `8443`, and `8444` will be forwarded to the Vagrant box.
 
     <div class="alert alert-warning">
-      <div class="text-center">
         <strong>Note</strong>: Check out the <a href="{{ site.repos.vagrant }}">kong-vagrant</a> repository for further details on customizations and development.
-      </div>
     </div>
 
 3. **Use Kong**

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -61,7 +61,7 @@ The controller leaves `ImplementationSpecific` path rules entirely up to the Kon
 router. It creates a route with the exact same path string as the Ingress rule.
 
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   Both <code>Prefix</code> and <code>Exact</code> paths modify the paths you
   provide, and those modifications may interfere with user-provided regular
   expressions. If you are using your own regular expressions in paths, use

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-versions.md
@@ -61,7 +61,7 @@ The controller leaves `ImplementationSpecific` path rules entirely up to the Kon
 router. It creates a route with the exact same path string as the Ingress rule.
 
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   Both <code>Prefix</code> and <code>Exact</code> paths modify the paths you
   provide, and those modifications may interfere with user-provided regular
   expressions. If you are using your own regular expressions in paths, use

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-versions.md
@@ -61,7 +61,7 @@ The controller leaves `ImplementationSpecific` path rules entirely up to the Kon
 router. It creates a route with the exact same path string as the Ingress rule.
 
 <div class="alert alert-warning">
-  <i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
+ 
   Both <code>Prefix</code> and <code>Exact</code> paths modify the paths you
   provide, and those modifications may interfere with user-provided regular
   expressions. If you are using your own regular expressions in paths, use


### PR DESCRIPTION
### Summary
Reworking alerts/callouts in the docs.

As a team, we settled on the following categories for alerts:
* Note: general info you should probably know but doesn't necessarily fit the flow, plus needs to be called out; blue (default state, catch-all element)
* Warning: things that’ll break everything; red
* Important: something you really need to consider; yellow
* Tip: something that might help you improve; green

Adjusted styling for existing notes and reworked the `blockquote` element for easier note use. Now, instead of using HTML tags (`<div class="alert">`), you can simply use a markdown blockquote (>) and specify the note class right before or right after it:

```
{:.tip}
> Here's some useful info that might help you improve things.
```

The class options are `{:.tip}`, `{:.note}`, `{:.important}`, and `{:.warning}`. Each of these will generate a style with an icon, but does not have a label by default (eg "Note:"). This is to leave some flexibility for writers, as sometimes you might want to use a more descriptive label/title.

![Screen Shot 2021-05-25 at 10 29 37 AM](https://user-images.githubusercontent.com/54370747/119576568-d5bdc200-bd6d-11eb-9ca0-a78fe6bf525d.png)

#### Existing alerts
Existing alerts use the `<div class="alert">` tag and are too numerous in the doc to update entirely. I've updated their styling to match the blockquote element, and they will continue to work. We should phase them out going forward, though. 

To make sure that notes aren't breaking or creating redundant icons, I did some minor cleanup:
* Removed any centering styles
* Removed caution icons, otherwise there would be duplicates
* Updated the small number of existing "Tip" type notes to use the blockquote element.

### Reason
https://konghq.atlassian.net/browse/DOCU-803

### Testing
Examples of styling applied to docs:

Important and tip: https://deploy-preview-2883--kongdocs.netlify.app/hub/kong-inc/ldap-auth-advanced/
Generic note: https://deploy-preview-2883--kongdocs.netlify.app/mesh/
Warning: https://deploy-preview-2883--kongdocs.netlify.app/enterprise/2.4.x/deployment/upgrades/migrate-ce-to-ke/