### PR TITLE
Fix "Try Kong Gateway" section in docs intro

### DIFF
--- a/app/enterprise/1.3-x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.3-x/kong-for-kubernetes/install.md
@@ -18,7 +18,7 @@ Before installing Kong for Kubernetes Enterprise, be sure you have the following
 - A valid Kong Enterprise License
   * If you have a license, continue to [Step 1. Set Kong Enterprise License](#step-1-set-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
-  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
+  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/)
 - An Enterprise Docker image for {{page.kong_version}}.
 
   If you have lost access to your {{page.kong_version}} image, Kong recommends

--- a/app/enterprise/1.5.x/introduction.md
+++ b/app/enterprise/1.5.x/introduction.md
@@ -57,16 +57,16 @@ Kong Vitals provides useful metrics about the health and performance of your Kon
 
 Kong Studio enables spec-first development for all REST and GraphQL services. With Kong Studio, organizations can accelerate design and test workflows using automated testing, direct Git sync, and inspection of all response types. Teams of all sizes can use Kong Studio to increase development velocity, reduce deployment risk, and increase collaboration. For more information, see [_Kong Studio_](https://docs.konghq.com/studio/).
 
-## Try Kong Enterprise
+## Try Kong Gateway (Enterprise)
 
-Here are a few ways to try Kong Enterprise:
+{{site.ee_product_name}} is bundled with {{site.konnect_product_name}}.
+There are a few ways to test out the gateway's Plus or Enterprise features:
 
-* Sign up for the Kong Enterprise self-serve, cloud-based, 15 day
-[free trial](https://konghq.com/get-started/#free-trial/).
-* Try out Kong for Kubernetes Enterprise using a live tutorial at
-[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-* If you are interested in evaluating Kong Enterprise locally, the Kong sales
-team manages evaluation licenses as part of a formal sales process. The best
-way to get started with the sales process is to
+* Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
+* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
+[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* If you are interested in evaluating Enterprise features locally, the
+Kong sales team manages evaluation licenses as part of a formal sales process.
+The best way to get started with the sales process is to
 [request a demo](https://konghq.com/get-started/#request-demo) and indicate
 your interest.

--- a/app/enterprise/2.1.x/introduction.md
+++ b/app/enterprise/2.1.x/introduction.md
@@ -58,16 +58,16 @@ Kong Vitals provides useful metrics about the health and performance of your Kon
 Kong Studio enables spec-first development for all REST and GraphQL services. With Kong Studio, organizations can accelerate design and test workflows using automated testing, direct Git sync, and inspection of all response types. Teams of all sizes can use Kong Studio to increase development velocity, reduce deployment risk, and increase collaboration. For more information, see [_Kong Studio_](https://docs.konghq.com/studio/).
 
 
-## Try Kong Enterprise
+## Try Kong Gateway (Enterprise)
 
-Here are a few ways to try Kong Enterprise:
+{{site.ee_product_name}} is bundled with {{site.konnect_product_name}}.
+There are a few ways to test out the gateway's Plus or Enterprise features:
 
-* Sign up for the Kong Enterprise self-serve, cloud-based, 15 day
-[free trial](https://konghq.com/get-started/#free-trial/).
-* Try out Kong for Kubernetes Enterprise using a live tutorial at
-[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-* If you are interested in evaluating Kong Enterprise locally, the Kong sales
-team manages evaluation licenses as part of a formal sales process. The best
-way to get started with the sales process is to
+* Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
+* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
+[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* If you are interested in evaluating Enterprise features locally, the
+Kong sales team manages evaluation licenses as part of a formal sales process.
+The best way to get started with the sales process is to
 [request a demo](https://konghq.com/get-started/#request-demo) and indicate
 your interest.

--- a/app/enterprise/2.2.x/introduction/index.md
+++ b/app/enterprise/2.2.x/introduction/index.md
@@ -60,12 +60,13 @@ Kong Studio enables spec-first development for all REST and GraphQL services. Wi
 
 ## Try Kong Gateway (Enterprise)
 
-{{site.ee_product_name}} is bundled with {{site.konnect_short_name}}. Here are
-a couple of ways to try {{site.konnect_short_name}}, or just the gateway alone:
+{{site.ee_product_name}} is bundled with {{site.konnect_product_name}}.
+There are a few ways to test out the gateway's Plus or Enterprise features:
 
-* Try out Kong for Kubernetes Enterprise using a live tutorial at
-[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-* If you are interested in evaluating {{site.konnect_short_name}} locally, the
+* Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
+* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
+[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to
 [request a demo](https://konghq.com/get-started/#request-demo) and indicate

--- a/app/enterprise/2.3.x/index.md
+++ b/app/enterprise/2.3.x/index.md
@@ -59,12 +59,17 @@ Insomnia enables spec-first development for all REST and GraphQL services. With 
 
 ## Try Kong Gateway (Enterprise)
 
-{{site.ee_product_name}} is bundled with {{site.konnect_product_name}}. Here are
-a couple of ways to try {{site.konnect_short_name}}, or just the gateway alone:
+{{site.base_gateway}} is available in free mode.
+[Download it](/enterprise/{{page.kong_version}}/deployment/installation/overview)
+and start testing out Gateway's open source features with Kong Manager today.
 
-* Try out Kong for Kubernetes Enterprise using a live tutorial at
-[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-* If you are interested in evaluating {{site.konnect_short_name}} locally, the
+{{site.base_gateway}} is also bundled with {{site.konnect_product_name}}.
+There are a few ways to test out the gateway's Plus or Enterprise features:
+
+* Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
+* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
+[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to
 [request a demo](https://konghq.com/get-started/#request-demo) and indicate

--- a/app/enterprise/2.4.x/index.md
+++ b/app/enterprise/2.4.x/index.md
@@ -59,12 +59,17 @@ Insomnia enables spec-first development for all REST and GraphQL services. With 
 
 ## Try Kong Gateway (Enterprise)
 
-{{site.ee_product_name}} is bundled with {{site.konnect_product_name}}. Here are
-a couple of ways to try {{site.konnect_short_name}}, or just the gateway alone:
+{{site.base_gateway}} is available in free mode.
+[Download it](/enterprise/{{page.kong_version}}/deployment/installation/overview)
+and start testing out Gateway's open source features with Kong Manager today.
 
-* Try out Kong for Kubernetes Enterprise using a live tutorial at
-[https://kubecon.konglabs.io/](https://kubecon.konglabs.io/)
-* If you are interested in evaluating {{site.konnect_short_name}} locally, the
+{{site.base_gateway}} is also bundled with {{site.konnect_product_name}}.
+There are a few ways to test out the gateway's Plus or Enterprise features:
+
+* Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
+* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
+[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to
 [request a demo](https://konghq.com/get-started/#request-demo) and indicate


### PR DESCRIPTION
### Summary
* Fixing broken external links to kubernetes labs
* Adding links to Konnect registration
* Adding links to download Kong Gateway for free - only to 2.3.x and 2.4.x, since the feature was only introduced recently.

### Reason
Broken link reported by Aghi, and I noticed that we don't link to Konnect Plus as well. 

### Testing
https://deploy-preview-2888--kongdocs.netlify.app/enterprise/#try-kong-gateway-enterprise - 2.4 and 2.3 are the same
https://deploy-preview-2888--kongdocs.netlify.app/enterprise/2.2.x/introduction/#try-kong-gateway-enterprise - 2.2.x and earlier don't mention free mode, but still link to Konnect
