### PR TITLE
request-validator.config.allowed_content_types is an array

### DIFF
--- a/app/_hub/kong-inc/request-validator/index.md
+++ b/app/_hub/kong-inc/request-validator/index.md
@@ -43,7 +43,7 @@ params:
 
     - name: allowed_content_types
       required: true
-      default: "application/json"
+      default: ["application/json"]
       value_in_examples:
       datatype: Set of string elements
       description: |


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

https://docs.konghq.com/hub/kong-inc/request-validator/

The docs for the request validator plugin shows `allowed_content_types` to be a string, but it's actually an array of strings.


![Screenshot_20210527_085920](https://user-images.githubusercontent.com/15232461/119830008-d5d2d480-bec9-11eb-9b7e-ac98a2247632.png)


here's the source code https://github.com/Kong/kong-plugin-enterprise-request-validator/blob/master/kong/plugins/request-validator/schema.lua#L97-L103


### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
