### PR TITLE
Add image modal to plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -445,4 +445,6 @@ breadcrumbs:
   {% endif %}
 </div>
 
+{% include image-modal.html %}
+
 <!-- {% include intercom.html %} -->


### PR DESCRIPTION
### Review
@tlblessing 

### Summary
Enabling the image modal feature for the plugin docs.

### Reason
Request from @tlblessing. Need to be able to see detail in screenshots.

### Testing
Tested locally with Mocking plugin.
Netlify TBA