### PR TITLE
[DOCU-1538] Vault plugin is not available in GUIs due to custom DAO

### DIFF
--- a/app/_hub/kong-inc/vault-auth/index.md
+++ b/app/_hub/kong-inc/vault-auth/index.md
@@ -31,6 +31,8 @@ params:
   route_id: true
   consumer_id: false
   dbless_compatible: yes
+  manager_examples: false
+  konnect_examples: false
   config:
     - name: access_token_name
       required: true


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-1538 This PR turns off the autogenerated GUI examples in the plugin hub doc for Vault.

I'm not sure that we should add a note about why this plugin does not appear in any GUI. This is a current limitation in the code as noted in the slack convo pasted into the ticket. It requires some hardcoding on the part of eng. @eskibars what do you think?

Direct review link:
https://deploy-preview-2898--kongdocs.netlify.app/hub/kong-inc/vault-auth/

The GUI tabs should no longer be present in the autogen examples.

![image](https://user-images.githubusercontent.com/3756245/120016130-d6db3300-bfa9-11eb-8d5d-2d19d0811437.png)
