### PR TITLE
Fix links in KIC docs

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/concepts/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/custom-resources.md
@@ -124,8 +124,8 @@ release.
 Instead, please use secret-based credentials.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects

--- a/app/kubernetes-ingress-controller/1.0.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.0.x/references/custom-resources.md
@@ -412,8 +412,8 @@ Please refer to the
 guide for details on how to use this resource.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/custom-resources.md
@@ -124,8 +124,8 @@ release.
 Instead, please use secret-based credentials.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects

--- a/app/kubernetes-ingress-controller/1.1.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.1.x/references/custom-resources.md
@@ -412,8 +412,8 @@ Please refer to the
 guide for details on how to use this resource.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/custom-resources.md
@@ -124,8 +124,8 @@ release.
 Instead, please use secret-based credentials.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects

--- a/app/kubernetes-ingress-controller/1.2.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.2.x/references/custom-resources.md
@@ -412,8 +412,8 @@ Please refer to the
 guide for details on how to use this resource.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/custom-resources.md
@@ -124,8 +124,8 @@ release.
 Instead, please use secret-based credentials.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/design.md
@@ -60,5 +60,5 @@ configuration:
   kube-proxy but directly to the pod.
 
 For more information on how Kong works with Routes, Services, and Upstreams,
-please see the [Proxy](/../../latest/proxy/)
-and [Load balancing](/../../latest/loadbalancing/) references.
+please see the [Proxy](/gateway-oss/latest/proxy/)
+and [Load balancing](/gateway-oss/latest/loadbalancing/) references.

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-classes.md
@@ -28,7 +28,7 @@ categories:
 
 For example, an Ingress is translated directly into a Kong route, and a
 KongConsumer is translated directly into a
-[Kong consumer](/../../latest/admin-api/#consumer-object). A Secret containing
+[Kong consumer](/gateway-oss/latest/admin-api/#consumer-object). A Secret containing
 an authentication plugin credential is _not_ translated directly: it is only
 translated into Kong configuration if a KongConsumer resource references it.
 

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-versions.md
@@ -162,9 +162,9 @@ v1beta1 Ingresses.
 [uri-rfc-paths]: https://tools.ietf.org/html/rfc3986#section-3.3
 [posix-regex]: https://www.boost.org/doc/libs/1_38_0/libs/regex/doc/html/boost_regex/syntax/basic_extended.html
 [path-types]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-[kong-paths]: /latest/proxy/#request-path
+[kong-paths]: /gateway-oss/latest/proxy/#request-path
 [wildcard-hostnames]: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards
-[kong-wildcard-hostnames]: /latest/proxy/#using-wildcard-hostnames
+[kong-wildcard-hostnames]: /gateway-oss/latest/proxy/#using-wildcard-hostnames
 [resource-backends]: https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname

--- a/app/kubernetes-ingress-controller/1.3.x/guides/configuring-health-checks.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/configuring-health-checks.md
@@ -350,4 +350,4 @@ Scale the `httpbin` and `ingress-kong` deployments and observe how
 multiple pods change the outcome of the above demo.
 
 Read more about health-checks and ciruit breaker in Kong's
-[documentation](/../../latest/health-checks-circuit-breakers).
+[documentation](/gateway-oss/latest/health-checks-circuit-breakers).

--- a/app/kubernetes-ingress-controller/1.3.x/guides/preserve-client-ip.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/preserve-client-ip.md
@@ -39,9 +39,9 @@ Once you have configured the Load Balancer to use Proxy Protocol, you
 need to set the following environment variables in Kong for Kong to
 receive the Client IP from the Proxy Protocol header.
 
-- [`KONG_TRUSTED_IPS`](/../../latest/configuration/#trusted_ips)
-- [`KONG_PROXY_LISTEN`](/../../latest/configuration/#proxy_listen)
-- [`KONG_REAL_IP_HEADER`](/../../latest/configuration/#real_ip_header)
+- [`KONG_TRUSTED_IPS`](/gateway-oss/latest/configuration/#trusted_ips)
+- [`KONG_PROXY_LISTEN`](/gateway-oss/latest/configuration/#proxy_listen)
+- [`KONG_REAL_IP_HEADER`](/gateway-oss/latest/configuration/#real_ip_header)
 
 For example:
 
@@ -61,9 +61,9 @@ You should configure the Load Balancer to inject these headers, and then
 you need to set the following environment variables in Kong for Kong to pick up
 the Client IP address from HTTP headers:
 
-- [`KONG_TRUSTED_IPS`](/../../latest/configuration/#trusted_ips)
-- [`KONG_REAL_IP_HEADER`](/../../latest/configuration/#real_ip_header)
-- Optional [`KONG_REAL_IP_RECURSIVE`](/../../latest/configuration/#real_ip_recursive)
+- [`KONG_TRUSTED_IPS`](/gateway-oss/latest/configuration/#trusted_ips)
+- [`KONG_REAL_IP_HEADER`](/gateway-oss/latest/configuration/#real_ip_header)
+- Optional [`KONG_REAL_IP_RECURSIVE`](/gateway-oss/latest/configuration/#real_ip_recursive)
 
 Please note that if you are using an L7 Load Balancer with Kong,
 you cannot use the `certificates` feature in Kong as the TLS session is

--- a/app/kubernetes-ingress-controller/1.3.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/1.3.x/references/annotations.md
@@ -291,7 +291,7 @@ Please note the quotes (`"`) around the integer value.
 
 Sets the `regex_priority` setting to this value on the Kong route associated
 with the Ingress resource. This controls the [matching evaluation
-order](/../../latest/proxy/#evaluation-order) for regex-based
+order](/gateway-oss/latest/proxy/#evaluation-order) for regex-based
 routes. It accepts any integer value. Routes are evaluated in order of highest
 priority to lowest.
 
@@ -436,7 +436,7 @@ guide for details on how to use this annotation.
 This annotation can be set on a Kubernetes Service resource and indicates
 the protocol that should be used by Kong to communicate with the service.
 In other words, the protocol is used for communication between a
-[Kong Service](/../../latest/admin-api/#service-object) and
+[Kong Service](/gateway-oss/latest/admin-api/#service-object) and
 a Kubernetes Service, internally in the Kubernetes cluster.
 
 Accepted values are:
@@ -475,7 +475,7 @@ resource which contains the TLS cert and key pair.
 
 Under the hood, the controller creates a Certificate in Kong and then
 sets the
-[`service.client_certificate`](/../../latest/admin-api/#service-object)
+[`service.client_certificate`](/gateway-oss/latest/admin-api/#service-object)
 for the service.
 
 ### konghq.com/host-header

--- a/app/kubernetes-ingress-controller/1.3.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/1.3.x/references/custom-resources.md
@@ -412,8 +412,8 @@ Please refer to the
 guide for details on how to use this resource.
 
 [k8s-crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
-[kong-consumer]: https://getkong.org/docs/latest/admin-api/#consumer-object
-[kong-plugin]: https://getkong.org/docs/latest/admin-api/#plugin-object
-[kong-upstream]: https://getkong.org/docs/latest/admin-api/#upstream-objects
-[kong-service]: https://getkong.org/docs/latest/admin-api/#service-object
-[kong-route]: https://getkong.org/docs/latest/admin-api/#route-object
+[kong-consumer]: /gateway-oss/latest/admin-api/#consumer-object
+[kong-plugin]: /gateway-oss/latest/admin-api/#plugin-object
+[kong-upstream]: /gateway-oss/latest/admin-api/#upstream-objects
+[kong-service]: /gateway-oss/latest/admin-api/#service-object
+[kong-route]: /gateway-oss/latest/admin-api/#route-object

--- a/app/kubernetes-ingress-controller/1.3.x/references/plugin-compatibility.md
+++ b/app/kubernetes-ingress-controller/1.3.x/references/plugin-compatibility.md
@@ -9,7 +9,7 @@ database.
 
 Note that some DB-less compatible plugins have some limitations or require
 non-default configuration for
-[compatibility](/../../latest/db-less-and-declarative-config/#plugin-compatibility).
+[compatibility](/gateway-oss/latest/db-less-and-declarative-config/#plugin-compatibility).
 
 ## Kong
 


### PR DESCRIPTION
### Summary
Fixing links in KIC docs.

### Reason
KIC 1.3 didn't pick up changes made in 1.2, and I missed that while reviewing. Fixing links that were previously fixed in 1.2, plus a few more to avoid unnecessary redirects.

Caught by weekly GH action: https://github.com/Kong/docs.konghq.com/runs/2706638290?check_suite_focus=true

### Testing
Tested by running the link checker locally, no broken links.
