### PR TITLE
Add old version of KIC to robots.txt

### DIFF
--- a/app/robots.txt
+++ b/app/robots.txt
@@ -17,6 +17,7 @@ Disallow: /gateway-oss/2.2*
 Disallow: /gateway-oss/2.3*
 Disallow: /kubernetes-ingress-controller/1.0*
 Disallow: /kubernetes-ingress-controller/1.1*
+Disallow: /kubernetes-ingress-controller/1.2*
 Disallow: /getting-started-guide/CE*
 Disallow: /getting-started-guide/2.0*
 Disallow: /getting-started-guide/2.1*


### PR DESCRIPTION
### Summary
Adding KIC 1.2 doc to robots.txt to stop it from being indexed by search engines.

### Reason
KIC 1.3 was released, and we want to drive search traffic there.

### Testing
N/A
