### PR TITLE
Fix version display in page title metadata

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -1,6 +1,6 @@
 {% unless page.name and page.path contains '_hub' %} {% capture page_title %}{{
-page.title | escape }}{% if page.kong_version %} - v{{ page.kong_version |
-escape }}{% endif %}{% if page.title %} | {% endif %}{{ site.name }} - {{
+page.title | escape }}{% if page.kong_version and page.no_version != true %} -
+v{{ page.kong_version | escape }}{% endif %}{% if page.title %} | {% endif %}{{ site.name }} - {{
 site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
 {{ page.type }} | Kong{% endcapture %} {% endunless %}
 


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
Fixing page title to ignore pages marked "no_version".

### Reason
Currently, for pages with no version, the markdown file name gets filled in instead. You can see this issue with unversioned docs in any place that stores page metadata.

Browser tab label:
<img width="405" alt="Screen Shot 2021-06-03 at 3 20 20 PM" src="https://user-images.githubusercontent.com/54370747/120719622-72bfdf80-c47f-11eb-9245-f2040c2a75a6.png">

Google search results:
<img width="654" alt="Screen Shot 2021-06-03 at 3 20 43 PM" src="https://user-images.githubusercontent.com/54370747/120719628-7489a300-c47f-11eb-9b11-d6d25e4b99cd.png">

### Testing
Open any unversioned doc and mouse over the browser tab. Check that the title in the tab label doesn't contain the markdown filename. For example:
https://deploy-preview-2916--kongdocs.netlify.app/konnect/
