### PR TITLE
[DOCU-1543] Add redirect for gateway 2.4

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -36,6 +36,7 @@
 /latest/*                                   /gateway-oss/latest/:splat
 /latest                                     /
 /community                                  /https://konghq.com/community-resources/
+/2.4.x/*                                    /gateway-oss/2.4.x/:splat
 /2.3.x/*                                    /gateway-oss/2.3.x/:splat
 /2.2.x/*                                    /gateway-oss/2.2.x/:splat
 /2.1.x/*                                    /gateway-oss/2.1.x/:splat


### PR DESCRIPTION
### Summary
Adding a 2.4 redirect.

### Reason
There are still many links that lead to the old gateway OSS doc location. Cleaning them all up, especially with other gateway docs changes coming in the future, isn't feasible, so we handle them with redirects for now.

https://konghq.atlassian.net/browse/DOCU-1543

### Testing
Test the redirect by going to a 2.4 page and make sure it redirects to gateway-oss/2.4: 

https://deploy-preview-2920--kongdocs.netlify.app/2.4.x/proxy/