### PR TITLE
Site width and responsiveness

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -8,7 +8,7 @@
         width: 99%;
       }
 
-      @media screen and (max-width: 1100px) {
+      @media screen and (max-width: 1300px) {
         padding: 8px;
       }
     }
@@ -233,7 +233,7 @@
           min-height: 100px;
         }
 
-        @media screen and (max-width: 1080px) {
+        @media screen and (max-width: 1300px) {
           .title-version-search-container {
             padding-left: 316px;
             padding-right: 32px;
@@ -269,7 +269,7 @@
           }
         }
 
-        @media screen and (min-width: 801px) and (max-width: 1080px) {
+        @media screen and (min-width: 801px) and (max-width: 1300px) {
           padding-right: 0;
 
           &.no-sidebar {
@@ -455,7 +455,7 @@
     margin-top: 0px;
     min-width: 220px;
 
-    @media (max-width: 1080px) {
+    @media (max-width: 1300px) {
       position: static;
       margin-top: 20px;
       display: inline-block;
@@ -688,7 +688,7 @@
     height: auto;
   }
 
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 1300px) {
     .sidebar-toggle {
       visibility: visible;
     }

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -2,6 +2,7 @@
   &.v2 {
     .container {
       padding: 0;
+      width: 1600px;
 
       @media screen and (max-width: 1600px) {
         width: 99%;
@@ -136,11 +137,11 @@
       padding-left: 285px;
 
       &.no-sidebar {
-        padding-left: 75px;
+        padding-left: 50px;
       }
 
       .page-content {
-        padding-left: 75px;
+        padding-left: 50px;
 
         .welcome-text {
           margin-bottom: 32px;
@@ -258,8 +259,8 @@
         padding-right: 250px;
 
         .page-content {
-          padding-left: 75px;
-          padding-right: 75px;
+          padding-left: 50px;
+          padding-right: 50px;
         }
 
         @media screen and (min-width: 1081px) {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -8,7 +8,7 @@
         width: 99%;
       }
 
-      @media screen and (max-width: 1300px) {
+      @media screen and (max-width: 800px) {
         padding: 8px;
       }
     }
@@ -277,10 +277,10 @@
           }
 
           .page-content {
-            padding: 0 32px;
+            padding: 0 50px;
 
             .content {
-              padding-top: 32px;
+              padding-top: 50px;
             }
           }
         }

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -302,7 +302,7 @@
     color: @blue-light;
   }
 
-  @media (max-width: 1080px) {
+  @media (max-width: 800px) {
     float: initial;
     display: inline-block;
     margin-right: 5px;
@@ -713,7 +713,7 @@
     outline: 1px solid #b3dfff;
   }
 
-  @media screen and (min-width: 1081px) {
+  @media screen and (min-width: 1301px) {
     &.collapsed {
       width: 50px;
       overflow-y: hidden;
@@ -738,7 +738,7 @@
     }
   }
 
-  @media screen and (max-width: 1080px) {
+  @media screen and (max-width: 1300px) {
     position: fixed;
     right: 0;
     padding: 16px 24px;


### PR DESCRIPTION
### Summary
Adjusting site widths so that the page ToC collapses earlier and makes more room for the content. 

Setting an absolute width for the main container so that percentage widths have something to relate to and stop awkward jumpy transitions.

### Reason
Lots of issues with jumpy site window resizing, and awkward section widths at smaller sizes. 

Bad:
![Screen Shot 2021-06-04 at 3 32 53 PM](https://user-images.githubusercontent.com/54370747/120869004-35745400-c54a-11eb-864c-4cae137ac32b.png)

### Testing
Old/bad behavior: open [any docs page](https://docs.konghq.com/enterprise/) in full screen, then slowly resize the width of the window. Notice the sudden jump from whitespace on either side to no whitespace. Also notice how awkwardly narrow the middle column becomes before the page ToC collapses.

New/better behavior: test the same page in the netlify preview: https://deploy-preview-2921--kongdocs.netlify.app/enterprise/
