### PR TITLE
Update AWS AMI links in installation docs

### DIFF
--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -53,7 +53,7 @@
         - text: Marketplaces
           items:
             - text: AWS (AMI)
-              url: https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title
+              url: https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6
               absolute_url: true
             - text: AWS (EKS)
               url: https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title

--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -53,7 +53,7 @@
         - text: Marketplaces
           items:
             - text: AWS (AMI)
-              url: https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title
+              url: https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6
               absolute_url: true
               target_blank: true
             - text: AWS (EKS)

--- a/app/_data/docs_nav_ee_2.4.x.yml
+++ b/app/_data/docs_nav_ee_2.4.x.yml
@@ -52,7 +52,7 @@
         - text: Marketplaces
           items:
             - text: AWS (AMI)
-              url: https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title
+              url: https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6
               absolute_url: true
               target_blank: true
             - text: AWS (EKS)

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -70,7 +70,7 @@ disable_image_expand: true
 {% navtab Marketplaces %}
 <div class="docs-grid-install">
 
-  <a href="https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
+  <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
     <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>

--- a/app/enterprise/2.3.x/deployment/installation/overview.md
+++ b/app/enterprise/2.3.x/deployment/installation/overview.md
@@ -70,7 +70,7 @@ disable_image_expand: true
 {% navtab Marketplaces %}
 <div class="docs-grid-install">
 
-  <a href="https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
+  <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
     <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>

--- a/app/enterprise/2.4.x/deployment/installation/overview.md
+++ b/app/enterprise/2.4.x/deployment/installation/overview.md
@@ -70,7 +70,7 @@ disable_image_expand: true
 {% navtab Marketplaces %}
 <div class="docs-grid-install">
 
-  <a href="https://aws.amazon.com/marketplace/pp/B08P51PKC1?qid=1607026688511&sr=0-5&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
+  <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
     <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
The links currently being used are pointing to a removed marketplace entry.

### Reason
The current links are broken.

### Testing
Validate that the links work and point to active marketplace entry.
