### PR TITLE
[DOCU-1551]Updates autodoc for EE Prop reference with where to find the ee nginx custom template

### DIFF
--- a/app/enterprise/2.4.x/property-reference.md
+++ b/app/enterprise/2.4.x/property-reference.md
@@ -223,8 +223,10 @@ which must specify an Nginx configuration template. Such a template uses the
 the given Kong configuration, before being dumped in your Kong prefix
 directory, moments before starting Nginx.
 
-The default template can be found at:
-https://github.com/kong/kong/tree/master/kong/templates. It is split in two
+The default template for Kong Gateway OSS can be found at:
+https://github.com/kong/kong/tree/master/kong/templates. The default template for
+Kong Gateway Enterprise can be found by entering the following command on the system
+running your Kong instance: `find / -type d -name "templates" | grep kong`. It is split in two
 Nginx configuration files: `nginx.lua` and `nginx_kong.lua`. The former is
 minimalistic and includes the latter, which contains everything Kong requires
 to run. When `kong start` runs, right before starting Nginx, it copies these

--- a/app/enterprise/2.4.x/property-reference.md
+++ b/app/enterprise/2.4.x/property-reference.md
@@ -223,8 +223,7 @@ which must specify an Nginx configuration template. Such a template uses the
 the given Kong configuration, before being dumped in your Kong prefix
 directory, moments before starting Nginx.
 
-The default template for Kong Gateway OSS can be found at:
-https://github.com/kong/kong/tree/master/kong/templates. The default template for
+The default template for
 Kong Gateway Enterprise can be found by entering the following command on the system
 running your Kong instance: `find / -type d -name "templates" | grep kong`. It is split in two
 Nginx configuration files: `nginx.lua` and `nginx_kong.lua`. The former is

--- a/autodoc-conf-ee/data.lua
+++ b/autodoc-conf-ee/data.lua
@@ -226,8 +226,7 @@ which must specify an Nginx configuration template. Such a template uses the
 the given Kong configuration, before being dumped in your Kong prefix
 directory, moments before starting Nginx.
 
-The default template for Kong Gateway OSS can be found at:
-https://github.com/kong/kong/tree/master/kong/templates. The default template for
+The default template for
 Kong Gateway Enterprise can be found by entering the following command on the system
 running your Kong instance: `find / -type d -name "templates" | grep kong`. It is split in two
 Nginx configuration files: `nginx.lua` and `nginx_kong.lua`. The former is

--- a/autodoc-conf-ee/data.lua
+++ b/autodoc-conf-ee/data.lua
@@ -226,8 +226,10 @@ which must specify an Nginx configuration template. Such a template uses the
 the given Kong configuration, before being dumped in your Kong prefix
 directory, moments before starting Nginx.
 
-The default template can be found at:
-https://github.com/kong/kong/tree/master/kong/templates. It is split in two
+The default template for Kong Gateway OSS can be found at:
+https://github.com/kong/kong/tree/master/kong/templates. The default template for
+Kong Gateway Enterprise can be found by entering the following command on the system
+running your Kong instance: `find / -type d -name "templates" | grep kong`. It is split in two
 Nginx configuration files: `nginx.lua` and `nginx_kong.lua`. The former is
 minimalistic and includes the latter, which contains everything Kong requires
 to run. When `kong start` runs, right before starting Nginx, it copies these


### PR DESCRIPTION
### Review
I think this is the best way to update this file - not entirely sure . .. 

### Summary
Li Yang noticed that the file linked to in the prop ref is only useful for OSS gateway users. After talking with Mike Fero, the ee version of the file can be found with a specific command that I included.

### Reason
To make it easier for Gateway Enterprise users to find the nginx custom template.

### Testing
Will include sample build link when available.
