### PR TITLE
[DOCU-1552]Updates migrations doc by removing patch releases section

### DIFF
--- a/app/enterprise/2.1.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.1.x/deployment/upgrades/migrations.md
@@ -18,7 +18,7 @@ If you experience any issues when running migrations, contact
 ## Upgrade Path for Kong Enterprise Releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
-distinction between major, minor, and [patch](#patch) versions. The upgrade path
+distinction between major, minor, and patch versions. The upgrade path
 for major and minor versions differs depending on the previous version from which
 you are migrating.
 

--- a/app/enterprise/2.1.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.1.x/deployment/upgrades/migrations.md
@@ -120,39 +120,3 @@ the `-c` flag to indicate the path to your configuration file:
 $ kong migrations bootstrap [-c /path/to/kong.conf]
 $ kong start [-c /path/to/kong.conf]
 ```
-
-## Patch Releases {#patch}
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of {{site.ee_product_name}}
-(for example, 1.5.0.0 to 1.5.0.1; 2.1.1.0 to 2.1.1.1, and so forth). Therefore,
-the upgrade process is simpler for patch releases.
-
-### Prerequisites
-
-- Assuming that {{site.ee_product_name}} is already running on your system,
-  acquire the latest version from any of the available
-  [installation methods](https://docs.konghq.com/enterprise/{{page.kong_version}}/deployment/installation/overview/)
-  and install it, overriding your previous installation.
-
-- If you are planning to make modifications to your configuration, this is an
-  opportune time to do so.
-
-1. Run migrations to upgrade your database schema:
-
-   ```shell
-   $ kong migrations up [-c configuration_file]
-   ```
-
-2. If the command is successful, and no migration ran (no output),
-   then you only have to
-   [reload](https://docs.konghq.com/2.1.x/cli/#kong-reload) Kong:
-
-   ```shell
-   $ kong reload [-c configuration_file]
-   ```
-
-**Reminder:** The `kong reload` command leverages the Nginx `reload` signal that
-seamlessly starts new workers, which then take over from old workers before they
-are terminated. Kong serves new requests using the new
-configuration without dropping existing in-flight connections.

--- a/app/enterprise/2.2.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.2.x/deployment/upgrades/migrations.md
@@ -73,7 +73,7 @@ affect your current installation.
   `KONG_PLUGINS=oauth2`.
 
 
-### Migrating Databases for a Major or Minor Version Release {#migrate-db}
+### Migrating Databases for Upgrades {#migrate-db}
 
 {{site.ee_product_name}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two Kong clusters with different
@@ -154,39 +154,3 @@ the `-c` flag to indicate the path to your configuration file:
 $ kong migrations bootstrap [-c /path/to/kong.conf]
 $ kong start [-c /path/to/kong.conf]
 ```
-
-## Patch Releases {#patch}
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of {{site.ee_product_name}}
-(for example, patching 2.1.1.0 to 2.1.1.1 and so forth). Therefore, the upgrade
-process is typically simpler for both minor and patch releases.
-
-### Prerequisites
-
-- Assuming that {{site.ee_product_name}} is already running on your system,
-  acquire the latest version from any of the available
-  [installation methods](/enterprise/{{page.kong_version}}/deployment/installation/overview/)
-  and install it, overriding your previous installation.
-
-- If you are planning to make modifications to your configuration, this is an
-  opportune time to do so.
-
-1. Run migrations to upgrade your database schema:
-
-   ```shell
-   $ kong migrations up [-c configuration_file]
-   ```
-
-2. If the command is successful, and no migration ran (no output),
-   then you only have to
-   [reload](https://docs.konghq.com/2.1.x/cli/#kong-reload) Kong:
-
-   ```shell
-   $ kong reload [-c configuration_file]
-   ```
-
-**Reminder:** The `kong reload` command leverages the Nginx `reload` signal that
-seamlessly starts new workers, which then take over from old workers before they
-are terminated. Kong serves new requests using the new
-configuration without dropping existing in-flight connections.

--- a/app/enterprise/2.2.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.2.x/deployment/upgrades/migrations.md
@@ -18,7 +18,7 @@ If you experience any issues when running migrations, contact
 ## Upgrade Path for Kong Enterprise Releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
-distinction between major, minor, and [patch](#patch) versions. The upgrade path
+distinction between major, minor, and patch versions. The upgrade path
 for major and minor versions differs depending on the previous version from which
 you are migrating:
 

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -132,7 +132,7 @@ To handle clusters split across multiple releases, you should:
 
 This ensures that all instances are using the new Kong package before running kong migrations finish.
 
-### Migrating databases for a major or minor version release {#migrate-db}
+### Migrating databases for Upgrades {#migrate-db}
 
 {{site.ee_product_name}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two Kong clusters with different
@@ -215,40 +215,3 @@ the `-c` flag to indicate the path to your configuration file:
 $ kong migrations bootstrap [-c /path/to/kong.conf]
 $ kong start [-c /path/to/kong.conf]
 ```
-
-## Patch releases {#patch}
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of {{site.ee_product_name}}
-(for example, patching 2.1.1.0 to 2.1.1.1 and so forth). Therefore, the upgrade
-process is typically simpler for both minor and patch releases.
-
-### Prerequisites
-
-- Assuming that {{site.ee_product_name}} is already running on your system,
-  acquire the latest version from any of the available
-  [installation methods](/enterprise/{{page.kong_version}}/deployment/installation/overview/)
-  and install it, overriding your previous installation.
-
-- If you are planning to make modifications to your configuration, this is an
-  opportune time to do so.
-
-1. Run migrations to upgrade your database schema:
-
-   ```shell
-   $ kong migrations up [-c configuration_file]
-   ```
-
-2. If the command is successful, and no migration ran (no output),
-   then you only have to
-   [reload](https://docs.konghq.com/2.1.x/cli/#kong-reload) Kong:
-
-   ```shell
-   $ kong reload [-c configuration_file]
-   ```
-<div class="alert alert-ee blue">
-<strong>Reminder:</strong> The `kong reload` command leverages the Nginx `reload` signal that
-seamlessly starts new workers, which then take over from old workers before they
-are terminated. Kong serves new requests using the new
-configuration without dropping existing in-flight connections.
-</div>

--- a/app/enterprise/2.3.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.3.x/deployment/upgrades/migrations.md
@@ -18,7 +18,7 @@ If you experience any issues when running migrations, contact
 ## Upgrade path for Kong Gateway releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
-distinction between major, minor, and [patch](#patch) versions. The upgrade path
+distinction between major, minor, and patch versions. The upgrade path
 for major and minor versions differs depending on the previous version from which
 you are migrating:
 

--- a/app/enterprise/2.4.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.4.x/deployment/upgrades/migrations.md
@@ -134,7 +134,7 @@ To handle clusters split across multiple releases, you should:
 
 This ensures that all instances are using the new Kong package before running kong migrations finish.
 
-### Migrating databases for a major or minor version release {#migrate-db}
+### Migrating databases for Upgrades {#migrate-db}
 
 {{site.ee_product_name}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two Kong clusters with different
@@ -217,40 +217,3 @@ the `-c` flag to indicate the path to your configuration file:
 $ kong migrations bootstrap [-c /path/to/kong.conf]
 $ kong start [-c /path/to/kong.conf]
 ```
-
-## Patch releases {#patch}
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of {{site.ee_product_name}}
-(for example, patching 2.1.1.0 to 2.1.1.1 and so forth). Therefore, the upgrade
-process is typically simpler for both minor and patch releases.
-
-### Prerequisites
-
-- Assuming that {{site.ee_product_name}} is already running on your system,
-  acquire the latest version from any of the available
-  [installation methods](/enterprise/{{page.kong_version}}/deployment/installation/overview/)
-  and install it, overriding your previous installation.
-
-- If you are planning to make modifications to your configuration, this is an
-  opportune time to do so.
-
-1. Run migrations to upgrade your database schema:
-
-   ```shell
-   $ kong migrations up [-c configuration_file]
-   ```
-
-2. If the command is successful, and no migration ran (no output),
-   then you only have to
-   [reload](https://docs.konghq.com/2.1.x/cli/#kong-reload) Kong:
-
-   ```shell
-   $ kong reload [-c configuration_file]
-   ```
-<div class="alert alert-ee blue">
-<strong>Reminder:</strong> The `kong reload` command leverages the Nginx `reload` signal that
-seamlessly starts new workers, which then take over from old workers before they
-are terminated. Kong serves new requests using the new
-configuration without dropping existing in-flight connections.
-</div>

--- a/app/enterprise/2.4.x/deployment/upgrades/migrations.md
+++ b/app/enterprise/2.4.x/deployment/upgrades/migrations.md
@@ -18,7 +18,7 @@ If you experience any issues when running migrations, contact
 ## Upgrade path for Kong Gateway releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
-distinction between major, minor, and [patch](#patch) versions. The upgrade 
+distinction between major, minor, and patch versions. The upgrade 
 path for major and minor versions differs depending on the previous version 
 from which you are migrating:
 

--- a/app/gateway-oss/1.1.x/upgrading.md
+++ b/app/gateway-oss/1.1.x/upgrading.md
@@ -97,40 +97,6 @@ database in the final expected state for Kong 1.1).
 The process is the same as for upgrading from 1.0 listed above, but on step 1
 you should run `kong migrations up --force` instead.
 
-### Upgrade Path for Patch Releases
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of Kong
-(e.g. 1.0.0 to 1.0.1, 1.0.1 to 1.0.4, etc.). Therefore, the
-upgrade process is simpler.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://getkong.org/docs/latest/cli/#reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ### Installing 1.1 on a Fresh Datastore
 
 For installing on a fresh datastore, Kong 1.1 has the `kong migrations

--- a/app/gateway-oss/1.2.x/upgrading.md
+++ b/app/gateway-oss/1.2.x/upgrading.md
@@ -98,40 +98,6 @@ database in the final expected state for Kong 1.2).
 The process is the same as for upgrading from 1.0 listed above, but on step 1
 you should run `kong migrations up --force` instead.
 
-### Upgrade Path for Patch Releases
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of Kong
-(e.g. 1.0.0 to 1.0.1, 1.0.1 to 1.0.4, etc.). Therefore, the
-upgrade process is simpler.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://getkong.org/docs/latest/cli/#reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ### Installing 1.2 on a Fresh Datastore
 
 For installing on a fresh datastore, Kong 1.2 have the `kong migrations

--- a/app/gateway-oss/1.3.x/upgrading.md
+++ b/app/gateway-oss/1.3.x/upgrading.md
@@ -122,40 +122,6 @@ database in the final expected state for Kong 1.2).
    your migration was successful. From now on, you can safely make Admin API
    requests to your 1.3 nodes.
 
-### Upgrade Path for Patch Releases
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of Kong
-(e.g. 1.0.0 to 1.0.1, 1.0.1 to 1.0.4, etc.). Therefore, the
-upgrade process is simpler.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://getkong.org/docs/latest/cli/#reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ### Installing 1.3 on a Fresh Datastore
 
 The following commands should be used to prepare a new 1.3 cluster from a fresh

--- a/app/gateway-oss/1.4.x/upgrading.md
+++ b/app/gateway-oss/1.4.x/upgrading.md
@@ -122,40 +122,6 @@ database in the final expected state for Kong 1.2).
    your migration was successful. From now on, you can safely make Admin API
    requests to your 1.3 nodes.
 
-### Upgrade Path for Patch Releases
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of Kong
-(e.g. 1.0.0 to 1.0.1, 1.0.1 to 1.0.4, etc.). Therefore, the
-upgrade process is simpler.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://getkong.org/docs/latest/cli/#reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ### Installing 1.3 on a Fresh Datastore
 
 The following commands should be used to prepare a new 1.3 cluster from a fresh

--- a/app/gateway-oss/1.5.x/upgrading.md
+++ b/app/gateway-oss/1.5.x/upgrading.md
@@ -122,40 +122,6 @@ database in the final expected state for Kong 1.2).
    your migration was successful. From now on, you can safely make Admin API
    requests to your 1.3 nodes.
 
-### Upgrade Path for Patch Releases
-
-There are no migrations in upgrades between current or
-future patch releases of the same minor release of Kong
-(e.g. 1.0.0 to 1.0.1, 1.0.1 to 1.0.4, etc.). Therefore, the
-upgrade process is simpler.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://getkong.org/docs/latest/cli/#reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ### Installing 1.3 on a Fresh Datastore
 
 The following commands should be used to prepare a new 1.3 cluster from a fresh

--- a/app/gateway-oss/2.0.x/upgrading.md
+++ b/app/gateway-oss/2.0.x/upgrading.md
@@ -21,7 +21,6 @@ will be different on which previous version from which you are migrating.
 Upgrading into 2.0.x is a major version upgrade, so be aware of any
 breaking changes listed in the [CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md) document.
 
-
 #### 1. Dependencies
 
 If you are using the provided binary packages, all necessary dependencies
@@ -46,7 +45,6 @@ Kong if Go plugin support is enabled in Kong's configuration.
 Note that the Go version used to compile any Go plugins needs to match the Go
 version of the `go-pluginserver`. You can check the Go version used to
 build the `go-pluginserver` binary running `go-pluginserver -version`.
-
 
 #### 2. Breaking Changes
 

--- a/app/gateway-oss/2.1.x/upgrading.md
+++ b/app/gateway-oss/2.1.x/upgrading.md
@@ -8,39 +8,6 @@ you are planning to upgrade to. If such a section does not exist, the upgrade
 you want to perform does not have any particular instructions, and you can
 simply consult the [Suggested upgrade path](#suggested-upgrade-path).
 
-## Suggested upgrade path
-
-Unless indicated otherwise in one of the upgrade paths of this document, it is
-possible to upgrade Kong **without downtime**:
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://docs.konghq.com/1.0.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
-
 ## Upgrade to `2.1.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -193,7 +160,6 @@ $ kong migrations bootstrap [-c /path/to/your/kong.conf]
 $ kong start [-c /path/to/your/kong.conf]
 ```
 
-
 ## Upgrade to `2.0.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -201,7 +167,6 @@ distinction between "major", "minor", and "patch" versions. The upgrade path
 will be different on which previous version from which you are migrating.
 Upgrading into 2.0.x is a major version upgrade, so be aware of any
 breaking changes listed in the [CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md) document.
-
 
 #### 1. Dependencies
 
@@ -229,6 +194,7 @@ version of the `go-pluginserver`. You can check the Go version used to
 build the `go-pluginserver` binary running `go-pluginserver -version`.
 
 <a name="breaking-changes-2.0"></a>
+
 #### 2. Breaking Changes
 
 Kong 2.0.0 does include a few breaking changes over Kong 1.x, all of them
@@ -668,7 +634,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
 ## Upgrade to `1.5.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -755,7 +720,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
 ## Upgrade to `1.4.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -764,7 +728,6 @@ will be different on which previous version from which you are migrating.
 If you are upgrading from 0.x, this is a major upgrade. If you are
 upgrading from 1.0.x or 1.3.x, this is a minor upgrade. Both scenarios are
 explained below.
-
 
 #### 1. Dependencies
 
@@ -1096,8 +1059,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
-
 ## Upgrade to `1.2`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -1106,7 +1067,6 @@ will be different on which previous version from which you are migrating.
 If you are upgrading from 0.x, this is a major upgrade. If you are
 upgrading from 1.0.x or 1.1.x, this is a minor upgrade. Both scenarios are
 explained below.
-
 
 #### 1. Dependencies
 
@@ -1192,7 +1152,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
 ## Upgrade to `1.1`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -1201,7 +1160,6 @@ will be different on which previous version from which you are migrating.
 If you are upgrading from 0.x, this is a major upgrade. If you are
 upgrading from 1.0.x, this is a minor upgrade. Both scenarios are
 explained below.
-
 
 #### 1. Dependencies
 
@@ -1286,20 +1244,6 @@ The following commands should be used to prepare a new 1.1 cluster from a fresh 
 $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
-
-
-## Upgrading `1.0.x` patch releases
-
-If you are upgrading from another release in the 1.0.x series (e.g. from 1.0.0
-to 1.0.1), there are no migrations. Simply upgrade your Kong installation and
-[reload](https://docs.konghq.com/1.0.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-If you are upgrading from 0.x, then read the following section for
-detailed migration instructions.
 
 ## Upgrade from `0.x` to `1.0.x`
 
@@ -1483,6 +1427,7 @@ plugins is now removed.
 There are no deprecation notices in this release.
 
 <a name="kong-1-0-upgrade-path"></a>
+
 #### 3. Suggested Upgrade Path
 
 ##### Preliminary Checks
@@ -1560,7 +1505,6 @@ For installing on a fresh datastore, Kong 1.0 introduces the `kong migrations bo
 $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
-
 
 ## Upgrade to `0.15`
 
@@ -2074,7 +2018,8 @@ to **run migrations** and upgrade from a previous version of Kong.
 
 #### 1. Breaking Changes
 
-- **Note to Docker users**: The `latest` tag on Docker Hub now points to the
+{:.note}
+> **Note to Docker users**: The `latest` tag on Docker Hub now points to the
   **alpine** image instead of CentOS. This also applies to the `0.13.0` tag.
 
 ##### Dependencies

--- a/app/gateway-oss/2.2.x/upgrading.md
+++ b/app/gateway-oss/2.2.x/upgrading.md
@@ -8,38 +8,6 @@ you are planning to upgrade to. If such a section does not exist, the upgrade
 you want to perform does not have any particular instructions, and you can
 simply consult the [Suggested upgrade path](#suggested-upgrade-path).
 
-## Suggested upgrade path
-
-Unless indicated otherwise in one of the upgrade paths of this document, it is
-possible to upgrade Kong **without downtime**:
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://getkong.org/install/) and proceed to install it, overriding
-your previous installation.
-
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://docs.konghq.com/1.0.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ## Upgrade to `2.2.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -54,7 +22,6 @@ If you are migrating from 1.x, upgrading into 2.2.x is a major upgrade,
 so, in addition, be aware of any [breaking changes](#breaking-changes-2.0.0)
 between the 1.x and 2.x series below, further detailed in the
 [CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md) document.
-
 
 #### 1. Dependencies
 
@@ -346,7 +313,6 @@ indicate the path to your configuration file:
 $ kong migrations bootstrap [-c /path/to/your/kong.conf]
 $ kong start [-c /path/to/your/kong.conf]
 ```
-
 
 ## Upgrade to `2.0.0`
 
@@ -822,7 +788,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
 ## Upgrade to `1.5.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -909,7 +874,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
 ## Upgrade to `1.4.0`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -918,7 +882,6 @@ will be different on which previous version from which you are migrating.
 If you are upgrading from 0.x, this is a major upgrade. If you are
 upgrading from 1.0.x or 1.3.x, this is a minor upgrade. Both scenarios are
 explained below.
-
 
 #### 1. Dependencies
 
@@ -1016,7 +979,8 @@ be aware of the following changes:
   you are not affected by this change.
   [openresty-build-tools#26](https://github.com/Kong/openresty-build-tools/pull/26)
 
-**Note:** if you are not using one of our distribution packages and compiling
+{:.note}
+> **Note:** if you are not using one of our distribution packages and compiling
 OpenResty from source, you must still apply Kong's [OpenResty
 patches](https://github.com/kong/openresty-patches) (and, as highlighted above,
 compile OpenResty with the new lua-kong-nginx-module). Our new
@@ -1250,8 +1214,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
-
 ## Upgrade to `1.2`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -1260,7 +1222,6 @@ will be different on which previous version from which you are migrating.
 If you are upgrading from 0.x, this is a major upgrade. If you are
 upgrading from 1.0.x or 1.1.x, this is a minor upgrade. Both scenarios are
 explained below.
-
 
 #### 1. Dependencies
 
@@ -1346,7 +1307,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
 ## Upgrade to `1.1`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -1355,7 +1315,6 @@ will be different on which previous version from which you are migrating.
 If you are upgrading from 0.x, this is a major upgrade. If you are
 upgrading from 1.0.x, this is a minor upgrade. Both scenarios are
 explained below.
-
 
 #### 1. Dependencies
 
@@ -1441,20 +1400,6 @@ $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
 
-
-## Upgrading `1.0.x` patch releases
-
-If you are upgrading from another release in the 1.0.x series (e.g. from 1.0.0
-to 1.0.1), there are no migrations. Simply upgrade your Kong installation and
-[reload](https://docs.konghq.com/1.0.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-If you are upgrading from 0.x, then read the following section for
-detailed migration instructions.
-
 ## Upgrade from `0.x` to `1.0.x`
 
 Kong 1.0 is a major upgrade, and includes a number of new features
@@ -1474,6 +1419,7 @@ Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md) for a
 complete list of changes and new features.
 
 <a name="kong-1-0-breaking-changes"></a>
+
 #### 1. Breaking Changes
 
 ##### Dependencies
@@ -1637,6 +1583,7 @@ plugins is now removed.
 There are no deprecation notices in this release.
 
 <a name="kong-1-0-upgrade-path"></a>
+
 #### 3. Suggested Upgrade Path
 
 ##### Preliminary Checks
@@ -1714,7 +1661,6 @@ For installing on a fresh datastore, Kong 1.0 introduces the `kong migrations bo
 $ kong migrations bootstrap [-c config]
 $ kong start [-c config]
 ```
-
 
 ## Upgrade to `0.15`
 

--- a/app/gateway-oss/2.3.x/upgrading.md
+++ b/app/gateway-oss/2.3.x/upgrading.md
@@ -6,42 +6,6 @@ This document guides you through the process of upgrading {{site.ce_product_name
 To upgrade to prior versions, find the version number in the 
 [Upgrade doc in GitHub](https://github.com/Kong/kong/blob/master/UPGRADE.md).
 
-## Suggested upgrade path
-
-Unless indicated otherwise in one of the upgrade paths of this document, it is
-possible to upgrade Kong **without downtime**.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation methods](https://getkong.org/install/) 
-and proceed to install it, overriding your previous installation.
-
-<div class="alert alert-ee blue">
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
-</div>
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://docs.konghq.com/1.0.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-<div class="alert alert-ee blue">
-<strong>Reminder:</strong> <code>kong reload</code> leverages the Nginx
-<code>reload</code> signal that seamlessly starts new workers, which
-take over from old workers before those old workers are terminated.
-In this way, Kong will serve new requests using the new configuration,
-without dropping existing in-flight connections.
-</div>
-
 ## Upgrade to `2.3.x`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -56,7 +20,6 @@ If you are migrating from 1.x, upgrading into 2.3.x is a major upgrade,
 so, in addition, be aware of any [breaking changes](https://github.com/Kong/kong/blob/master/UPGRADE.md#breaking-changes-2.0)
 between the 1.x and 2.x series below, further detailed in the
 [CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md#200) document.
-
 
 ### Dependencies
 
@@ -94,20 +57,18 @@ git clone https://github.com/kong/kong
 cd kong
 git diff -w 2.0.0 2.3.0 kong/templates/nginx_kong*.lua
 ```
-<div class="alert alert-ee blue">
-<strong>Note:</strong> Adjust the starting version number 
+{:.note}
+> **Note:** Adjust the starting version number 
 (2.0.x, 2.1.x, or 2.2.x) to the version number you are currently using.
-</div>
-
 
 To produce a patch file, use the following command:
 
 ```
 git diff 2.0.0 2.3.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
 ```
-<strong>Note:</strong> Adjust the starting version number 
+{:.note}
+> **Note:** Adjust the starting version number 
 (2.0.x, 2.1.x, or 2.2.x) to the version number you are currently using.
-</div>
 
 ### Suggested upgrade path
 

--- a/app/gateway-oss/2.4.x/upgrading.md
+++ b/app/gateway-oss/2.4.x/upgrading.md
@@ -7,37 +7,6 @@ This document guides you through the process of upgrading {{site.ce_product_name
 To upgrade to prior versions, find the version number in the
 [Upgrade doc in GitHub](https://github.com/Kong/kong/blob/master/UPGRADE.md).
 
-## Suggested upgrade path
-
-Unless indicated otherwise in one of the upgrade paths of this document, it is
-possible to upgrade Kong **without downtime**.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation methods](https://getkong.org/install/)
-and proceed to install it, overriding your previous installation.
-
-**If you are planning to make modifications to your configuration, this is a
-good time to do so**.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://docs.konghq.com/gateway-oss/2.4.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.
-
 ## Upgrade to `2.4.x`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
@@ -52,7 +21,6 @@ If you are migrating from 1.x, upgrading into 2.4.x is a major upgrade,
 so, in addition, be aware of any [breaking changes](https://github.com/Kong/kong/blob/master/UPGRADE.md#breaking-changes-2.0)
 between the 1.x and 2.x series below, further detailed in the
 [CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md#200) document.
-
 
 ### Dependencies
 
@@ -91,7 +59,8 @@ cd kong
 git diff -w 2.0.0 2.4.0 kong/templates/nginx_kong*.lua
 ```
 
-**Note:** Adjust the starting version number
+{:.note}
+> **Note:** Adjust the starting version number
 (2.0.x, 2.1.x, 2.2.x or 2.3.x) to the version number you are currently using.
 
 To produce a patch file, use the following command:
@@ -100,9 +69,9 @@ To produce a patch file, use the following command:
 git diff 2.0.0 2.4.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
 ```
 
-**Note:** Adjust the starting version number
+{:.note}
+> **Note:** Adjust the starting version number
 (2.0.x, 2.1.x, 2.2.x or 2.3.x) to the version number you are currently using.
-
 
 ### Suggested upgrade path
 
@@ -195,31 +164,3 @@ indicate the path to your configuration file:
 $ kong migrations bootstrap [-c /path/to/your/kong.conf]
 $ kong start [-c /path/to/your/kong.conf]
 ```
-Unless indicated otherwise in one of the upgrade paths of this document, it is
-possible to upgrade Kong **without downtime**.
-
-Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation methods](https://getkong.org/install/)
-and proceed to install it, overriding your previous installation.
-
-**If you are planning to make modifications to your configuration, this is a
-good time to do so**.
-
-Then, run migration to upgrade your database schema:
-
-```shell
-$ kong migrations up [-c configuration_file]
-```
-
-If the command is successful, and no migration ran
-(no output), then you only have to
-[reload](https://docs.konghq.com/gateway-oss/2.4.x/cli/#kong-reload) Kong:
-
-```shell
-$ kong reload [-c configuration_file]
-```
-
-**Reminder**: `kong reload` leverages the Nginx `reload` signal that seamlessly
-starts new workers, which take over from old workers before those old workers
-are terminated. In this way, Kong will serve new requests via the new
-configuration, without dropping existing in-flight connections.


### PR DESCRIPTION
### Review
Check that Patch releases section has been removed from upgrade guide for EE versions 2.1.x and higher and Migrating Databases for a Major or Minor Version Release header has been updated to Migrating Databases for Upgrades.
### Summary
Yi Lang noticed some discrepancies in our migration doc that I confirmed with the Fast Track Team.
### Reason
Fast Track Team say there is no reason for the Patch releases section to exist as it is inaccurate and to update the header suggesting steps are diff depending on type of update. 
[Slack Convo](https://kongstrong.slack.com/archives/CDSTDSG9J/p1623295650075700)
[DOCU-1552](https://konghq.atlassian.net/browse/DOCU-1552)
### Testing
- [Migrating Kong Gateway from 2.3.x to 2.4.x](https://deploy-preview-2935--kongdocs.netlify.app/enterprise/2.4.x/deployment/upgrades/migrations/)
- [Migrating Kong Gateway from 2.2.x to 2.3.x](https://deploy-preview-2935--kongdocs.netlify.app/enterprise/2.3.x/deployment/upgrades/migrations/)
- [Migrating Kong Gateway from 2.1.x to 2.2.x](https://deploy-preview-2935--kongdocs.netlify.app/enterprise/2.2.x/deployment/upgrades/migrations/)
- [Migrating Kong Gateway from 1.5.x to 2.1.x](https://deploy-preview-2935--kongdocs.netlify.app/enterprise/2.1.x/deployment/upgrades/migrations/)