### PR TITLE
Updated getting-started-istio documentation

### DIFF
--- a/app/kubernetes-ingress-controller/1.3.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/getting-started-istio.md
@@ -109,7 +109,7 @@ namespace/my-istio-app created
 ```console
 $ kubectl label namespace my-istio-app istio-injection=enabled
 namespace/my-istio-app labeled
-kubectl apply -n my-istio-app -f istio-1.6.7/samples/bookinfo/platform/kube/bookinfo.yaml
+$ kubectl apply -n my-istio-app -f istio-1.6.7/samples/bookinfo/platform/kube/bookinfo.yaml
 ```
 Wait until the application is up:
 ```console
@@ -143,6 +143,7 @@ metadata:
   namespace: my-istio-app
   annotations:
     konghq.com/plugins: rate-limit
+    kubernetes.io/ingress.class: kong 
 spec:
   rules:
   - http:
@@ -151,6 +152,7 @@ spec:
         backend:
           serviceName: productpage
           servicePort: 9080
+EOF
 ```
 
 ### Make some requests to the sample application


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
This PR is to update the documentation for the Getting Started using Istio guide to ensure that it functions correctly.
The following detailed changes were made:
- Updated to show second command for applying the Kubernetes manifest for `Deploy bookinfo in an Istio-enabled namespace` 

- Updated `productpage` ingress so that it would work correctly by adding:
  -  `kubernetes.io/ingress.class: kong` so that kong detects service and routing works correctly
  -  `EOF` at end of manifest

### Reason
Documentation under [Getting Started using Istio](https://docs.konghq.com/kubernetes-ingress-controller/1.3.x/guides/getting-started-istio/) was incorrect around sample commands to be used

### Testing
Run through guide and test steps as required

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
https://deploy-preview-2936--kongdocs.netlify.app
