### PR TITLE
[DOCU-1553]Adds note about Immunity being incompatible with Kong Enterprise v2.4.x

### DIFF
--- a/app/_includes/md/enterprise/download/immunity.md
+++ b/app/_includes/md/enterprise/download/immunity.md
@@ -44,7 +44,10 @@ $ docker tag <IMAGE_ID> kong-bi
 {% if include.version == ">2.1" %}
 ## Version Compatibility
 Immunity follows a different versioning scheme from Kong Enterprise. The Immunity version reflects the `kong/immunity` package available on Docker Hub.
-For Kong Enterprise 2.1.x and above, use Immunity 4.x.x.          |
+For Kong Enterprise 2.1.x and above, use Immunity 4.x.x.
+
+{:.warning}
+> **Warning:** Kong Immunity is not compatible with Kong Enterprise v2.4.x.
 
 ## Install Immunity on Kubernetes
 Set up the Collector App via Helm. Use the public helm chart for setting up the Collector App and all its dependencies on Kubernetes. Setup instructions can be found on the public repo at: [https://github.com/Kong/kong-collector-helm/blob/master/README.md](https://github.com/Kong/kong-collector-helm/blob/master/README.md).


### PR DESCRIPTION
### Review
Check to be sure Immunity install docs for EE v2.1+ include a note that states v2.4.x is not compatible with Immunity.
### Summary
Immunity is incompatible with EE v2.4.1.0 and v2.4.1.1 - the install docs need to indicate that it will not work with those versions until the fix is released with v2.4.1.2.
### Reason
[DOCU-1553](https://konghq.atlassian.net/browse/DOCU-1553)
### Testing
Will include sample build link when available.
