### PR TITLE
fix typo in the OIDC setup section

### DIFF
--- a/app/kubernetes-ingress-controller/1.3.x/guides/using-oidc-plugin.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/using-oidc-plugin.md
@@ -123,7 +123,7 @@ config:
   - http://192.0.2.8.xip.io
 plugin: openid-connect
 " | kubectl apply -f -
-kongplugin.configuration.konghq.com/global-rate-limit created
+kongplugin.configuration.konghq.com/oidc-auth created
 ```
 
 The `redirect_uri` parameter must be a URI that matches the Ingress rule we


### PR DESCRIPTION
updated a copy-paste(?) error to show the right name of the plugin

### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
fixed a copy-paste error. The output of kubectl apply was showing the wrong plugin name

### Reason


### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
