### PR TITLE
[DOCU-1556][DOCU-1558] Konnect Cloud updates for deploy on June 15

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -109,10 +109,25 @@ params:
     - name: strategy
       required:
       default: cluster
-      value_in_examples:
+      value_in_examples: local
       datatype: string
       description: |
-        The sync strategy to use; `cluster` and `redis` are supported.
+        The rate-limiting strategy to use for retrieving and incrementing the
+        limits. Available values are:
+        - `local`: Counters are stored locally in-memory on the node.
+        - `cluster`: Counters are stored in the Kong datastore and shared across
+        the nodes.
+        - `redis`: Counters are stored on a Redis server and shared
+        across the nodes.
+
+        In DB-less and hybrid modes, the `cluster` config strategy is not supported.
+        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
+        `redis`, or `local` for data planes only.
+
+        In Konnect Cloud, the default strategy is `redis`.
+
+        For details on which strategy should be used, refer to the
+        [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).
     - name: redis.host
       required: semi
       default:

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -97,11 +97,25 @@ params:
     - name: strategy
       required: true
       default: cluster
-      value_in_examples:
+      value_in_examples: local
       datatype: string
       description: |
-        The sync strategy to use; `cluster` and `redis` are supported. Hybrid mode does
-        not support the `cluster` strategy.
+        The rate-limiting strategy to use for retrieving and incrementing the
+        limits. Available values are:
+        - `local`: Counters are stored locally in-memory on the node.
+        - `cluster`: Counters are stored in the Kong datastore and shared across
+         the nodes.
+        - `redis`: Counters are stored on a Redis server and shared
+        across the nodes.
+
+        In DB-less and hybrid modes, the `cluster` config strategy is not supported.
+        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
+        `redis`, or `local` for data planes only.
+
+        In Konnect Cloud, the default strategy is `redis`.
+
+        For details on which strategy should be used, refer to the
+        [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).
     - name: hide_client_headers
       required: false
       default: false

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -123,15 +123,19 @@ params:
         The rate-limiting policies to use for retrieving and incrementing the
         limits. Available values are:
         - `local`: Counters are stored locally in-memory on the node.
-        - `cluster`: Counters are stored in the datastore and shared across the
-        nodes.
+        - `cluster`: Counters are stored in the Kong datastore and shared across
+        the nodes.
         - `redis`: Counters are stored on a Redis server and shared
         across the nodes.
 
-        In the case of DB-less mode, at least one of `local` or `redis` must be
-        specified. For hybrid mode, only `redis` is supported.
+        In DB-less and hybrid modes, the `cluster` config policy is not supported.
+        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
+        `redis`, or `local` for data planes only.
+
+        In Konnect Cloud, the default policy is `redis`.
+
         For details on which policy should be used, refer to the
-        <a href="https://docs.konghq.com/hub/kong-inc/rate-limiting/#implementation-considerations">Implementation Considerations</a>.
+        [implementation considerations](#implementation-considerations).
     - name: fault_tolerant
       required: false
       default: '`true`'

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -118,8 +118,26 @@ params:
     - name: policy
       required: false
       default: "`cluster`"
+      value_in_examples: local
       datatype: string
-      description: The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node), `cluster` (counters are stored in the datastore and shared across the nodes), and `redis` (counters are stored on a Redis server and will be shared across the nodes).
+      description: |
+        The rate-limiting policies to use for retrieving and incrementing the
+        limits. Available values are:
+        - `local`: Counters are stored locally in-memory on the node.
+        - `cluster`: Counters are stored in the Kong datastore and shared across
+        the nodes.
+        - `redis`: Counters are stored on a Redis server and shared
+        across the nodes.
+
+        In DB-less and hybrid modes, the `cluster` config policy is not supported.
+        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
+        `redis`, or `local` for data planes only.
+
+        In Konnect Cloud, the default policy is `redis`.
+
+        For details on which policy should be used, refer to the
+        [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).
+
     - name: fault_tolerant
       required: true
       default: "`true`"

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -8,6 +8,32 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
+## June 2021
+
+### 2021.06.15
+**Default strategy/policy for rate limiting plugins**
+: The rate limiting plugins now default to `redis` as the rate limiting
+strategy or policy. This setting allows cluster-wide rate limiting using a
+Redis server. To store counters in-memory on each node, change this setting
+to `local`.
+
+: The `cluster` config strategy/policy is not supported in
+{{site.konnect_saas}}, and does not appear as an option in the plugin
+configuration anymore.
+
+: To find the setting based on the rate limiting plugin, see:
+* `config.policy`:
+    * [Rate Limiting](/hub/kong-inc/rate-limiting)
+    * [Response Rate Limiting](/hub/kong-inc/response-ratelimiting)
+* `config.strategy`:
+    * [GraphQL Rate Limiting Advanced](/hub/kong-inc/graphql-rate-limiting-advanced/)
+    * [Rate Limiting Advanced ](/hub/kong-inc/rate-limiting-advanced)
+
+**Sorting the runtime status table**
+: You can now sort the runtime status table in
+[Runtime Manager](https://konnect.konghq.com/runtime-manager) by the
+**Last Seen** or **Sync Status** columns.
+
 ## May 2021
 
 ### 2021.05.12


### PR DESCRIPTION
### Review
@skibum 

### Summary
Release notes for Konnect Cloud deploy on 06/15/21. 

* Resolving some confusion around rate limiting plugins by removing a setting that doesn't work in Konnect Cloud
* Adjusting property descriptions in plugin docs to explain what each strategy/policy is.
  * "strategy" and "policy" are two different config setting names for the same thing. Two plugins use the parameter "policy", and two use "strategy", but both settings accomplish the same goal.
  * These descriptions were already known, just not used in every plugin. Used part of the description from the Rate Limiting plugin and from the plugin compatibility table. 
  * Set the value in examples to `local`, as that's the only setting that can work in all modes without extra configuration.
 
### Reason
Deploy went out today.

https://konghq.atlassian.net/browse/DOCU-1556
https://konghq.atlassian.net/browse/DOCU-1558

### Testing
https://deploy-preview-2943--kongdocs.netlify.app/konnect/updates/

Plugins (mostly the same changes with minor link and param name differences):
https://deploy-preview-2943--kongdocs.netlify.app/hub/kong-inc/rate-limiting/
https://deploy-preview-2943--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/
https://deploy-preview-2943--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/
https://deploy-preview-2943--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/