### PR TITLE
Fixing issues with decK links and versions

### DIFF
--- a/algolia/config-full-docs.json
+++ b/algolia/config-full-docs.json
@@ -5,7 +5,7 @@
       "url": "https://docs.konghq.com/konnect/"
     },
     {
-      "url": "https://docs.konghq.com/deck/"
+      "url": "https://docs.konghq.com/deck/1.7.x/"
     },
     {
       "url": "https://docs.konghq.com/kubernetes-ingress-controller/1.3.x/"

--- a/app/_redirects
+++ b/app/_redirects
@@ -6,6 +6,13 @@
 /hub/kong-inc/deck/                   /deck/
 /hub/hbagdi/deck/                     /deck/
 /deck/commands/                       /deck/latest/reference/deck/
+/deck/commands/                       /deck/latest/reference/deck/
+/deck/guides/*                        /deck/latest/guides/:splat
+/deck/compatibility-promise/          /deck/latest/compatibility-promise/
+/deck/design-architecture/            /deck/latest/design-architecture/
+/deck/faqs/                           /deck/latest/faqs/
+/deck/installation/                   /deck/latest/installation/
+/deck/terminology/                    /deck/latest/terminology/
 
 # kubernetes ingress controller
 /kubernetes-ingress-controller/latest/introduction /kubernetes-ingress-controller/

--- a/app/_redirects
+++ b/app/_redirects
@@ -6,7 +6,6 @@
 /hub/kong-inc/deck/                   /deck/
 /hub/hbagdi/deck/                     /deck/
 /deck/commands/                       /deck/latest/reference/deck/
-/deck/commands/                       /deck/latest/reference/deck/
 /deck/guides/*                        /deck/latest/guides/:splat
 /deck/compatibility-promise/          /deck/latest/compatibility-promise/
 /deck/design-architecture/            /deck/latest/design-architecture/

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -23,5 +23,6 @@ Disallow: /getting-started-guide/2.0*
 Disallow: /getting-started-guide/2.1*
 Disallow: /getting-started-guide/2.2*
 Disallow: /getting-started-guide/2.3*
+Disallow: /deck/pre-1.7*
 
 Sitemap: {{site.links.web}}/sitemap.xml


### PR DESCRIPTION
### Summary
* Redirecting unversioned decK links to /latest/
* Setting algolia config to only index the latest deck version
* Stopping pre-1.7 decK docs from being indexed by search engines

### Reason
Links were all updated in the docs but unversioned links exist out in the world. Issue was reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1623879076092400

### Testing
Test any of the redirects in the file to make sure they work. For example: https://deploy-preview-2945--kongdocs.netlify.app/deck/installation/