### PR TITLE
update urls on grpc plugins

### DIFF
--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -87,20 +87,20 @@ Sample configuration via the Admin API:
 
 ```bash
 $ # add the gRPC service
-$ curl -XPOST localhost:8001/services \
+$ curl -X POST localhost:8001/services \
   --data name=grpc \
   --data protocol=grpc \
   --data host=localhost \
   --data port=9000
 
 $ # add an http route
-$ curl -XPOST localhost:8001/services/grpc/routes \
+$ curl -X POST localhost:8001/services/grpc/routes \
   --data protocols=http \
   --data name=web-service \
   --data paths[]=/
 
 $ # add the plugin to the route
-$ curl -XPOST localhost:8001/routes/web-service/plugins \
+$ curl -X POST localhost:8001/routes/web-service/plugins \
   --data name=grpc-gateway
 ```
 
@@ -164,4 +164,4 @@ Currently only unary requests are supported; streaming requests are not supporte
 
 ## See also
 
-[Introduction to Kong gRPC plugins](/enterprise/2.1.x/plugins/grpc)
+[Introduction to Kong gRPC plugins](/enterprise/latest/plugins/grpc)

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -97,20 +97,20 @@ Same thing via the Admin API:
 
 ```bash
 $ # add the gRPC service
-$ curl -XPOST localhost:8001/services \
+$ curl -X POST localhost:8001/services \
   --data name=grpc \
   --data protocol=grpc \
   --data host=localhost \
   --data port=9000
 
 $ # add an http route
-$ curl -XPOST localhost:8001/services/grpc/routes \
+$ curl -X POST localhost:8001/services/grpc/routes \
   --data protocols=http \
   --data name=web-service \
   --data paths=/
 
 $ # add the plugin to the route
-$ curl -XPOST localhost:8001/routes/web-service/plugins \
+$ curl -X POST localhost:8001/routes/web-service/plugins \
   --data name=grpc-web
 ```
 
@@ -168,7 +168,7 @@ or via the Admin API:
 
 ```bash
 $ # add the plugin to the route
-$ curl -XPOST localhost:8001/routes/web-service/plugins \
+$ curl -X POST localhost:8001/routes/web-service/plugins \
   --data name=grpc-web \
   --data proto=path/to/hello.proto
 ```
@@ -199,4 +199,4 @@ separate records if it has to support multiple response messages.
 
 ## See also
 
-[Introduction to Kong gRPC plugins](/enterprise/2.1.x/plugins/grpc)
+[Introduction to Kong gRPC plugins](/enterprise/latest/plugins/grpc)


### PR DESCRIPTION
@lena-larionova 

### Summary

Update gRPC-gateway and gRPC-Web plug-in page URLs to include `/latest/` instead of hard-coded version. 

### Reason

Hard-coded versions require manual updating. 

### Testing

Local testing to ensure links go to latest docs. 
