### PR TITLE
Fix link to Kong/kong README [skip ci]

### DIFF
--- a/app/contributing/index.md
+++ b/app/contributing/index.md
@@ -25,8 +25,7 @@ this kind of content, though, join the community on [Kong's forum](https://discu
 
 The community is the place to ask support questions, too. We can't help you with the product in this repository.
 
-For bugs against Kong Gateway functionality, see the [code repository]
-(https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-report-bugs).
+For bugs against Kong Gateway functionality, see the [code repository](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-report-bugs).
 
 ## How to contribute
 


### PR DESCRIPTION
### Summary
Fixing a link


### Reason
Link wasn't displaying because of an extra newline.

### Testing
reviewers: I skipped the Netlify preview initially because I was thinking I updated the README itself, but that's not at all true. You can still test the link directly on the branch though: https://github.com/Kong/docs.konghq.com/blob/docs/readme-link/app/contributing/index.md