### PR TITLE
Makes updates discussed in style guide team meeting

### DIFF
--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -294,19 +294,20 @@ With this order, the first H3 gets skipped.
 ## Badges
 
 Use badges when you need to label a heading, a page, or some other element as
-a specific Konnect tier.
+a specific Konnect tier or DB-less compatible.
 
 Badge | HTML tag | Markdown tag
 ------|----------|-------------
-<span class="badge free"></span> | `<span class="badge free"></span>` | `{:.badge free}`
-<span class="badge plus"></span> | `<span class="badge plus"></span>` | `{:.badge plus}`
-<span class="badge enterprise"></span> | `<span class="badge enterprise"></span>` | `{:.badge enterprise}`
+<span class="badge free"></span> | `<span class="badge free"></span>` | `{:.badge .free}`
+<span class="badge plus"></span> | `<span class="badge plus"></span>` | `{:.badge .plus}`
+<span class="badge enterprise"></span> | `<span class="badge enterprise"></span>` | `{:.badge .enterprise}`
+<span class="badge dbless"></span> | `<span class="badge dbless"></span>` | `{:.badge .dbless}`
 
 For example, you can use the Markdown tag on headers:
 
 ```markdown
 ### Set up the Dev Portal
-{:.badge enterprise}
+{:.badge .enterprise}
 ```
 
 The HTML span tag is useful for including a badge inline:

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -19,7 +19,7 @@ no_version: true
 |                                   |That is, ...                                   |i.e., ...                                          |
 |---                                |---                                            |---                                                |
 |Avoid generic prounouns            |Once you have added **the inputs section**, ...|Once you have added **this**, ...                  |
-|Don't use displays or appears      |In the blank that **appears**, do the thing.   |Do the thing.      |
+|Don't use _displays_ or _appears_      |In the blank that **appears**, do the thing.   |Do the thing.      |
 |---                                |---                                            |---                                                |
 |Use descriptive headings           |Overview                                       |Improve Vitals performance with InfluxDB           |
 |                                   |Query behavior                                 |Query frequency and precision                      |

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -19,7 +19,7 @@ no_version: true
 |                                   |That is, ...                                   |i.e., ...                                          |
 |---                                |---                                            |---                                                |
 |Avoid generic prounouns            |Once you have added **the inputs section**, ...|Once you have added **this**, ...                  |
-|Don't use displays                 |In the blank that **appears**, do the thing.   |In the blank that **displays**, do the thing.      |
+|Don't use displays or appears      |In the blank that **appears**, do the thing.   |Do the thing.      |
 |---                                |---                                            |---                                                |
 |Use descriptive headings           |Overview                                       |Improve Vitals performance with InfluxDB           |
 |                                   |Query behavior                                 |Query frequency and precision                      |
@@ -27,11 +27,9 @@ no_version: true
 |Use sentence case for headings     |Understanding traffic flow in Kong Gateway     |Understanding Traffic Flow in Kong Gateway         |
 |---                                |---                                            |---                                                |
 
-
 ## Formatting standards
 
 ### Admonitions
-
 - Do not stack admonitions, in other words, list several admonitions one after the other.<br/>
   Admonitions should be carefully selected, called-out text.
 - Admonition types:
@@ -41,19 +39,22 @@ no_version: true
 For more information about formatting admonitions see [markdown-rules](/contributing/markdown-rules/#admonitions).
 
 ## Punctuation rules
+- Commas and periods always go inside quotation marks, and colons and semicolons (dashes as well) go outside.
+  - For example: “There was a storm last night,” Paul said.
 
 ### Placeholder values
+- Use single curly braces, all caps text, and underscores between words.
+  - For example: {EXAMPLE_VALUE}
 
 ## Capitalization guidelines
-
 Follow the user interface(UI). If a term is capitalized in the UI, it should be capitalized in the documentation.
 
 ### Kong-specific terms
-
 Capitalize the following Kong-specific terms:
 
 #### Product names
 - Kong Konnect (Kong Konnect for first mention, Konnect after)
+- Kong Gateway (Enterprise)
 - Kong Gateway
 - Kong Mesh (Kong Mesh for first mention, Mesh after)
 - Insomnia
@@ -65,7 +66,6 @@ Capitalize the following Kong-specific terms:
 - Immunity
 
 ### Generic terms
-
 Do not capitalize the following generic terms:
 - plugins
 - control plane
@@ -76,30 +76,27 @@ Do not capitalize the following generic terms:
 - consumer
 
 ## Code formatting
-
 - Separate commands from output.
 - Include properly formatted code comments.
 - For long commands, split the code block into separate lines to avoid horizontal scrolling.
 - Never have more than one command in a block/example.
 - Always set a language for codeblocks, for example, bash.<br/>
   [List of supported languages](https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers)
+- Do **NOT** use the command prompt marker ($) in code snippets.
 
 ### Inline code formatting
+- Enclose sample code with single backticks.
+  - For example: `sudo yum install /path/to/package.rpm`
 
 ## Images
-
+- Add files to the corresponding product folder by navigating in the repo from **app > assets > images > docs**.
+- When naming/titling image files, use lowercase letters and dashes only.
 - Use SVGs whenever possible, otherwise use PNGs.
 - Limit image file size to ~2MB.
 - Do not use shadows.
-
-### Screenshots
-
-### Diagrams
-
-## User Interface text
+- Borders can be added to screenshots only - 1px black.
 
 ## Reference style guides
-
 - [Valero Style Guide](https://velero.io/docs/v1.5/style-guide/#inline-code-formatting)
 - [Splunk Style Guide](https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Howtouse)
 - [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/)

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -43,8 +43,8 @@ For more information about formatting admonitions see [markdown-rules](/contribu
   - For example: “There was a storm last night,” Paul said.
 
 ### Placeholder values
-- Use single curly braces, all caps text, and underscores between words.
-  - For example: {EXAMPLE_VALUE}
+- Use single curly braces, all caps text, and underscores between words.<br/>
+  For example: {EXAMPLE_VALUE}
 
 ## Capitalization guidelines
 Follow the user interface(UI). If a term is capitalized in the UI, it should be capitalized in the documentation.
@@ -85,8 +85,8 @@ Do not capitalize the following generic terms:
 - Do **NOT** use the command prompt marker ($) in code snippets.
 
 ### Inline code formatting
-- Enclose sample code with single backticks.
-  - For example: `sudo yum install /path/to/package.rpm`
+- Enclose sample code with single backticks.<br/>
+  For example: \`sudo yum install /path/to/package.rpm`
 
 ## Images
 - Add files to the corresponding product folder by navigating in the repo from **app > assets > images > docs**.


### PR DESCRIPTION
### Summary
Made some edits to the style guide per our doc team discussions. Also, added the new badge to the markdown rules doc and updated the examples with a dot before the class.
### Reason
The style guide needed update as part of our continuous improvement efforts and after creating the db-less compatible badge, I realized the dot was missing from the examples and needed to be added.
### Testing
[Badges update](https://deploy-preview-2961--kongdocs.netlify.app/contributing/markdown-rules/#badges)
[Style guide update](https://deploy-preview-2961--kongdocs.netlify.app/contributing/style-guide/)