### PR TITLE
Design: fix plugin search bar and remove underlines

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -17,8 +17,6 @@ a:active,a:hover {
 
 abbr[title] {
     border-bottom: none;
-    text-decoration: underline;
-    text-decoration: underline dotted
 }
 
 b,strong {
@@ -231,7 +229,7 @@ summary {
     }
 
     a,a:visited {
-        text-decoration: underline
+        text-decoration: none;
     }
 
     abbr[title]::after {
@@ -290,7 +288,6 @@ label,output {
 
 body {
     margin: 0;
-    font-size: 1rem;
     font-weight: 400;
     line-height: 1.5;
     background-color: #fff
@@ -352,7 +349,7 @@ a {
 
 a:focus,a:hover {
     color: #000406;
-    text-decoration: underline
+    text-decoration: none;
 }
 
 .navbar-nav a:hover,.navbar-nav a:focus {
@@ -3162,7 +3159,7 @@ a.btn.disabled,a.disabled.nav-next,a.disabled.nav-previous,a.disabled.textbody_c
 
 .btn-link:focus,.btn-link:hover {
     color: #000406;
-    text-decoration: underline;
+    text-decoration: none;
     background-color: transparent
 }
 
@@ -3824,7 +3821,7 @@ tbody.collapse.show {
 }
 
 .card-link:hover .card-title {
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 .card-link:hover .card-description {
@@ -11363,7 +11360,7 @@ a.text-gray-dark:focus,a.text-gray-dark:hover {
 }
 
 .hljs-link {
-    text-decoration: underline
+    text-decoration: none;
 }
 
 .plugin-card a:hover,.bg-summit a:hover,.kong-post a:hover,.kong-sidebar .featured-post a,.nav-next a,.nav-previous a,.post-type-archive-plugins .kong-main .plugin-card a:active,.post-type-archive-plugins .kong-main .plugin-card a:hover,a.btn-gh,a.no-decoration {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -861,8 +861,8 @@
     text-decoration: none;
     color: @blue;
 
-    &:hover {
-      text-decoration: underline;
+    &:hover, &:focus {
+      text-decoration: none;
       opacity: 0.7;
     }
   }

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -234,8 +234,9 @@ header.navbar {
       color: @color-blue;
       font-weight: bold;
 
-      &:hover {
-        text-decoration: underline;
+      &:hover, &:focus {
+        text-decoration: none;
+        opacity: 0.7;
       }
     }
 
@@ -536,8 +537,9 @@ header.navbar {
         .link-text {
           margin: 8px 0;
 
-          &:hover {
-            text-decoration: underline;
+          &:hover, &:focus {
+            text-decoration: none;
+            opacity: 0.7;
           }
         }
       }


### PR DESCRIPTION
### Review
@falondarville 

### Summary
Removing underlines from link hover states for accuracy.
Fixing font size in plugin search bar

### Reason
Modernizing and making the styles consistent.

For plugins, there was an unnecessary global font size set on the page that was shrinking it:
![Screen Shot 2021-06-23 at 5 06 36 PM](https://user-images.githubusercontent.com/54370747/123182975-6529c400-d445-11eb-9133-18607a22e51e.png)

### Testing
Test search bar at the top of https://deploy-preview-2964--kongdocs.netlify.app/hub/, font size should be normal

Spot-check that any links you see have no underlines, for example:
https://deploy-preview-2964--kongdocs.netlify.app/hub/kong-inc/application-registration/
https://deploy-preview-2964--kongdocs.netlify.app/enterprise/changelog/