### PR TITLE
[DOCU-1544] Doc feature: Editable placeholders

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -663,7 +663,7 @@ $(function () {
       copyInput.text(
         snippet.data("copy-code") ||
           snippet
-            .find(".rouge-code")
+            .find("code")
             .text()
             .replace(/^\s*\$\s*/gi, "")
       );
@@ -877,4 +877,16 @@ setInterval(function () {
 $(".closebanner").click(function () {
   $(".navbar-v2").addClass("closed");
   localStorage.setItem("closebanner-konnect", "closebanner");
+});
+
+
+$('[contenteditable]').on('paste', function(e) {
+    //strips elements added to the editable tag when pasting
+    var $self = $(this);
+    setTimeout(function() {$self.html($self.text());}, 0);
+}).on('keypress', function(e) {
+    if (event.keyCode === 13) {
+     // unfocus when hitting enter key
+     $('[contenteditable]').blur();
+   }
 });

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -886,7 +886,7 @@ $('[contenteditable]').on('paste', function(e) {
     setTimeout(function() {$self.html($self.text());}, 0);
 }).on('keypress', function(e) {
     if (event.keyCode === 13) {
-     // unfocus when hitting enter key
-     $('[contenteditable]').blur();
-   }
+      // unfocus when hitting enter key
+      $('[contenteditable]').blur();
+    }
 });

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -159,7 +159,6 @@ code {
     line-height: 16px;
     border-radius: 2px;
     -webkit-user-modify: read-write-plaintext-only;
-    text-transform: uppercase;
 
     &::after {
       content: "\f040";

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -149,6 +149,53 @@ code {
   font-family: @family-code;
 }
 
+[contenteditable='true'] {
+    color: @green-400;
+    font-weight: bold;
+    margin: 1px;
+    padding: 0 0 0 5px;
+    font-size: 14px;
+    display: inline-block;
+    line-height: 16px;
+    border-radius: 2px;
+    -webkit-user-modify: read-write-plaintext-only;
+    text-transform: uppercase;
+
+    &::after {
+      content: "\f040";
+      font-family: "Font Awesome", FontAwesome;
+      font-weight: 100;
+      color: @green-400;
+      display: inline-block;
+      font-weight: 600;
+      font-size: 15px;
+      padding: 5px;
+      position: relative;
+    }
+
+    br {
+    display: none;
+    visibility: hidden;
+    }
+
+    &:hover {
+      opacity: 0.8;
+      text-decoration: underline;
+    }
+
+    &:active {
+      border: none;
+      outline: none;
+    }
+
+    &:focus {
+    border: 1px solid @green-300;
+    background: #fff;
+    outline: 0;
+    margin: 0;
+    }
+}
+
 a {
   color: @blue;
   text-decoration: none;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -934,51 +934,6 @@
     }
   }
 
-  /* Rouge syntax and line numbers */
-
-  pre.highlight {
-      padding: 1rem 1.5rem;
-      overflow: auto;
-      line-height: 1.4rem;
-      position: relative;
-  }
-
-  table.rouge-table,
-  table.rouge-table tr,
-  table.rouge-table td,
-  table.rouge-table pre {
-      border: 0;
-      padding: 0;
-      margin: 0;
-      overflow: visible;
-      display: inline-block;
-      font-family: @family-code;
-  }
-
-  table.rouge-table td.rouge-gutter {
-      padding-right: 0.8rem;
-      border-right: 1px solid @gray;
-
-      @media (max-width: 1100px) {
-        margin-left: -1.2rem;
-      }
-  }
-
-  table.rouge-table td.rouge-code {
-      padding-left: 0.8em;
-  }
-
-  figure pre {
-      margin-bottom: 0;
-  }
-
-  .lineno {
-      text-align: center;
-      height: 100%;
-      min-width: 1.8rem;
-      color: @gray-dark;
-  }
-
   /*
 Generic Styling for Desktop
 */
@@ -1346,7 +1301,7 @@ Generic Styling for Desktop
         font-family: "Font Awesome", FontAwesome;
         color: @blue-400;
         display: inline-block;
-        font-weight: 600;
+        font-weight: bold;
         font-size: 17px;
         padding: 0 5px 0 0;
       }

--- a/app/_includes/md/2.4.x/docker-install-steps.md
+++ b/app/_includes/md/2.4.x/docker-install-steps.md
@@ -7,7 +7,7 @@ and in the vitals on influxdb docs. -->
 Pull the following Docker image:
 
 ```bash
-$ docker pull kong/kong-gateway:{{page.kong_versions[11].version}}-alpine
+docker pull kong/kong-gateway:{{page.kong_versions[11].version}}-alpine
 ```
 {:.important}
 > Some [older {{site.base_gateway}} images](https://support.konghq.com/support/s/article/Downloading-older-Kong-versions)
@@ -21,24 +21,22 @@ You should now have your {{site.base_gateway}} image locally.
 Verify that it worked, and find the image ID matching your repository:
 
 ```bash
-$ docker images
+docker images
 ```
 
 Tag the image ID for easier use:
 
-```bash
-$ docker tag <IMAGE_ID> kong-ee
-```
+<pre><code>docker tag <div contenteditable="true">{IMAGE_ID}</div> kong-ee</code></pre>
 
 {:.note}
-> **Note:** Replace `<IMAGE_ID>` with the one matching your repository.
+> **Note:** Replace `{IMAGE_ID}` with the one matching your repository.
 
 {{ include.heading1 }}Create a Docker network {#create-network}
 
 Create a custom network to allow the containers to discover and communicate with each other.
 
 ```bash
-$ docker network create kong-ee-net
+docker network create kong-ee-net
 ```
 
 {{ include.heading2 }}Start a database
@@ -46,7 +44,7 @@ $ docker network create kong-ee-net
 Start a PostgreSQL container:
 
 ```bash
-$ docker run -d --name kong-ee-database \
+docker run -d --name kong-ee-database \
   --network=kong-ee-net \
   -p 5432:5432 \
   -e "POSTGRES_USER=kong" \
@@ -57,15 +55,13 @@ $ docker run -d --name kong-ee-database \
 
 {{ include.heading3 }}Prepare the Kong database
 
-```bash
-$ docker run --rm --network=kong-ee-net \
+<pre><code>docker run --rm --network=kong-ee-net \
   -e "KONG_DATABASE=postgres" \
   -e "KONG_PG_HOST=kong-ee-database" \
   -e "KONG_PG_PASSWORD=kong" \
-  -e "KONG_PASSWORD=<SOMETHING-YOU-KNOW>" \
-  kong-ee kong migrations bootstrap
-```
+  -e "KONG_PASSWORD=<div contenteditable="true">{PASSWORD}</div>" \
+  kong-ee kong migrations bootstrap </code></pre>
 
 {:.note}
-> **Note:** For `KONG_PASSWORD`, replace `<SOMETHING-YOU-KNOW>`
+> **Note:** For `KONG_PASSWORD`, replace `{PASSWORD}`
 with a valid password that only you know.

--- a/app/enterprise/2.4.x/deployment/installation/docker.md
+++ b/app/enterprise/2.4.x/deployment/installation/docker.md
@@ -29,8 +29,7 @@ To complete this installation you will need a Docker-enabled system with proper
 
 ## Step 5. Start the gateway with Kong Manager {#start-gateway}
 
-```bash
-$ docker run -d --name kong-ee --network=kong-ee-net \
+<pre><code>docker run -d --name kong-ee --network=kong-ee-net \
   -e "KONG_DATABASE=postgres" \
   -e "KONG_PG_HOST=kong-ee-database" \
   -e "KONG_PG_PASSWORD=kong" \
@@ -39,7 +38,7 @@ $ docker run -d --name kong-ee --network=kong-ee-net \
   -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
   -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
   -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
-  -e "KONG_ADMIN_GUI_URL=http://<DNSorIP>:8002" \
+  -e "KONG_ADMIN_GUI_URL=http://<div contenteditable="true">{DNS_or_IP}</div>:8002" \
   -p 8000:8000 \
   -p 8443:8443 \
   -p 8001:8001 \
@@ -48,8 +47,7 @@ $ docker run -d --name kong-ee --network=kong-ee-net \
   -p 8445:8445 \
   -p 8003:8003 \
   -p 8004:8004 \
-  kong-ee
-```
+  kong-ee </code></pre>
 
 <div class="alert alert-ee">
 <b>Note:</b> For <code>KONG_ADMIN_GUI_URL</code>, replace <code>&lt;DNSorIP&gt;</code>
@@ -61,18 +59,14 @@ with with the DNS name or IP of the Docker host. <code>KONG_ADMIN_GUI_URL</code>
 
 1. Access the `/services` endpoint using the Admin API:
 
-    ```bash
-    $ curl -i -X GET --url http://<DNSorIP>:8001/services
-    ```
+    <pre><code>curl -i -X GET --url http://<div contenteditable="true">{HOSTNAME}</div>:8001/services</code></pre>
 
     You should receive an `HTTP/1.1 200 OK` message.
 
 2. Verify that Kong Manager is running by accessing it using the URL specified
 in `KONG_ADMIN_GUI_URL` in [Step 5](#start-gateway):
 
-    ```
-    http://<DNSorIP>:8002
-    ```
+    <pre><code>http://<div contenteditable="true">{HOSTNAME}</div>:8002 </code></pre>
 
 ## Step 7. (Optional) Enable the Dev Portal
 
@@ -87,8 +81,8 @@ This feature is only available with a
 
 2. In your container, set the Portal URL and set `KONG_PORTAL` to `on`:
 
-    ```sh
-    $ echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=on kong reload exit" \
+    ```bash
+    echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=on kong reload exit" \
       | docker exec -i kong-ee /bin/sh
     ```
 
@@ -99,20 +93,16 @@ This feature is only available with a
     be preceded by a protocol, for example, <code>http://</code>.
     </div>
 
-3. Execute the following command. Change `<DNSorIP>` to the IP or valid DNS of
+3. Execute the following command. Change `{HOSTNAME}` to the IP or valid DNS of
 your Docker host:
 
-    ```bash
-    $ curl -X PATCH http://<DNSorIP>:8001/workspaces/default \
-      --data "config.portal=true"
-    ```
+    <pre><code> curl -X PATCH http://<div contenteditable="true">{HOSTNAME}</div>:8001/workspaces/default \
+      --data "config.portal=true" </code></pre>
 
 4. Access the Dev Portal for the default workspace using the URL specified
 in the `KONG_PORTAL_GUI_HOST` variable:
 
-    ```
-    http://<DNSorIP>:8003/default
-    ```
+    <pre><code>http://<div contenteditable="true">{HOSTNAME}</div>:8003/default </code></pre>
 
 ## Troubleshooting
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -5,13 +5,10 @@ permalink: pretty
 timezone: America/San_Francisco
 markdown: kramdown
 kramdown:
+  syntax_highlighter: rouge
   syntax_highlighter_opts:
     css_class: 'highlight'
-    span:
-      line_numbers: false
-    block:
-      line_numbers: true
-      start_line: 1
+    guess_lang: true
 incremental: true
 
 keep_files:

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -5,13 +5,10 @@ permalink: pretty
 timezone: America/San_Francisco
 markdown: kramdown
 kramdown:
+  syntax_highlighter: rouge
   syntax_highlighter_opts:
     css_class: 'highlight'
-    span:
-      line_numbers: false
-    block:
-      line_numbers: true
-      start_line: 1
+    guess_lang: true
 incremental: true
 
 keep_files:


### PR DESCRIPTION
### Review
@HCloward @falondarville 

### Summary
* Adding support for editable placeholders in the documentation, inspired by [Google's implementation](https://developers.google.com/style/placeholders?hl=en).

* Removing line numbers from codeblocks: we've tested them out and found they weren't adding much value and were instead making codeblocks look busy.

* Enabling language guessing for syntax highlighting: instead of leaving codeblocks unformatted, if there is a codeblock without a language explicitly set on it, the syntax highlighter will attempt to guess the language. If it can't figure it out, it defaults to plaintext. 

#### Using editable codeblocks

Since you can't insert HTML into fenced codeblocks, you must set `pre` and `code` tags instead. To include a placeholder, use a `<div contenteditable="true">` tag. For example:

```
<pre><code>http://<div contenteditable="true">{HOSTNAME}</div>:8002 </code></pre>
```
Whatever content you enter will be converted to uppercase visually. 

Note that you have to include the pre and code tags inline with a line of code, otherwise they'll generate an extra empty line. For multiline codeblocks, do this:

```
<pre><code> curl -X PATCH http://<div contenteditable="true">{HOSTNAME}</div>:8001/workspaces/default \
      --data "config.portal=true" </code></pre>
```

Unfortunately, Rouge (our syntax highlighter) can only highlight fenced codeblocks, that is, codeblocks enclosed with three backticks. I've tested all the possible combinations of classes and tags to get stuff picked up by the highlighter, but I'm out of ideas. Reviewers, I welcome suggestions.

There is also a tiny bit of javascript that strips formatting from pasted content, and that registers the enter key as a submission/escape instead of a newline. @falondarville can you look at that and let me know if it needs any tweaking?

### Reason
Many confused users not noticing that they have to edit a variable in a codeblock, copying code as is, and running it with the placeholders.

### Testing
https://deploy-preview-2968--kongdocs.netlify.app/enterprise/2.4.x/deployment/installation/docker/

Reviewers: please test the functionality and look for anything that stands out as odd/awkward/needs work.
* Enter a value and press enter to save, then click the copy code icon to make sure it copies the new text
* Color choice
* Any other ideas for better UX
* Comment on using a mix of highlighted and non-highlighted codeblocks in a topic - does it look strange? Should we stick with all non-highlighted or all highlighted?