### PR TITLE
Responsive tabs

### DIFF
--- a/app/_assets/stylesheets/cookie-policy.less
+++ b/app/_assets/stylesheets/cookie-policy.less
@@ -35,4 +35,10 @@
     bottom: 2rem;
     right: 2rem;
   }
+
+  @media (max-width: 575px) {
+    width: auto;
+    bottom: 0;
+    right: 0;
+  }
 }

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -23,6 +23,7 @@
         background-color: @grey-200;
         color: rgba(black, 0.6);
         opacity: 1;
+        displaY: flex;
 
         .navtab-title {
           font-size: 14px;
@@ -89,6 +90,10 @@
         }
       }
     }
+
+    @media (max-width: 575px) {
+      display: inline;
+      }
   }
 
   .navtab-contents {


### PR DESCRIPTION
### Summary
Adjusting tab display on mobile.

### Reason
Tabs extend plugin pages on mobile.

### Testing
https://deploy-preview-2970--kongdocs.netlify.app/getting-started-guide/2.4.x/improve-performance/ - resize the width of the page until it's below 575px to test the tabs. 