### PR TITLE
Add getting started guide redirect

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -28,6 +28,7 @@
 /gateway-oss/2.3.x/getting-started/introduction  /gateway-oss/2.3.x/
 /gateway-oss/2.4.x/getting-started/introduction  /gateway-oss/2.4.x/
 /gateway-oss/latest/getting-started/introduction /gateway-oss/
+/getting-started-guide/                          /getting-started-guide/latest/overview/
 
 # plugins
 /hub/api-fortress/api-fortress-http-log/    /hub/


### PR DESCRIPTION
### Summary
Adding a redirect for logical top-level Getting Started guide page (docs.konghq.com/getting-started-guide). 

### Reason
Currently it leads to a 404.

### Testing
Test that https://deploy-preview-2981--kongdocs.netlify.app/getting-started-guide redirects to the getting started guide overview.