### PR TITLE
Remove is_homepage from getting started guide metadata

### DIFF
--- a/app/getting-started-guide/2.4.x/overview.md
+++ b/app/getting-started-guide/2.4.x/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Getting Started Guide
 subtitle: A single guide for both {{site.ce_product_name}} and {{site.ee_product_name}}
-is_homepage: true
 redirect_from:
   - /enterprise/latest/getting-started/
 ---


### PR DESCRIPTION
### Summary
Setting the Getting Started Guide to use the regular layout and not hide the right-hand page nav.

### Reason
Missing page nav for no good reason.

### Testing
https://deploy-preview-2983--kongdocs.netlify.app/getting-started-guide/2.4.x/overview/ - the right-hand page nav should be visible.