### PR TITLE
Remove references to rouge css classes [skip ci]

### DIFF
--- a/pdf-generation/create-pdf.js
+++ b/pdf-generation/create-pdf.js
@@ -52,8 +52,7 @@ async function createPDF (name, urls) {
       content: `
         @page { size: A4 portrait; margin: 24px; }
         pre { max-height: 100% !important; white-space: pre-wrap; }
-        .rouge-gutter.gl {display:none !important;}
-        .rouge-code { padding-left: 0 !important; }
+        .code { padding-left: 0 !important; }
 
         .navtab-content { display: block !important } /* Expand tabbed content */
         .navtab-contents { padding: 0 !important; }


### PR DESCRIPTION
### Summary
Removing references to classes that no longer exist.

### Reason
Line numbers, and therefore all the extra rouge classes that went with them, were removed in https://github.com/Kong/docs.konghq.com/pull/2968.

### Testing
N/A