### PR TITLE
Label OPA and Mocking plugins as Plus tier

### DIFF
--- a/app/_hub/kong-inc/mocking/index.md
+++ b/app/_hub/kong-inc/mocking/index.md
@@ -26,6 +26,7 @@ description: |
   v2.4.1.1.
 
 enterprise: true
+plus: true
 type:
   plugin
 categories:
@@ -45,9 +46,6 @@ params:
   dbless_explanation: |
     Use the `api_specification` config for DB-less or hybrid mode. Attach the spec contents directly
     instead of uploading to the Dev Portal. The API spec is configured directly in the plugin.
-  yaml_examples: false
-  k8s_examples: false
-  konnect_examples: false
   examples: false
 
   config:

--- a/app/_hub/kong-inc/opa/index.md
+++ b/app/_hub/kong-inc/opa/index.md
@@ -15,6 +15,7 @@ description: |
     v2.4.1.1.
 
 enterprise: true
+plus: true
 type: plugin
 categories:
   - security
@@ -31,7 +32,6 @@ params:
   consumer_id: false
   protocols: ["http", "https"]
   dbless_compatible: yes
-  konnect_examples: false
   config:
     - name: opa_protocol
       required: false


### PR DESCRIPTION
### Summary
Plugins are missing their labels.

### Reason
These two plugins are available in Konnect Plus, not just Enterprise.

### Testing
https://deploy-preview-2991--kongdocs.netlify.app/hub/ - make sure that OPA and Mocking both have the PLUS badge