### PR TITLE
[DOCU-1592] Instructions for using editable placeholders

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -152,7 +152,7 @@ code {
 [contenteditable='true'] {
     color: @green-400;
     font-weight: bold;
-    margin: 1px;
+    margin: 0 1px 0 -3px;
     padding: 0 0 0 5px;
     font-size: 14px;
     display: inline-block;
@@ -191,8 +191,9 @@ code {
     border: 1px solid @green-300;
     background: #fff;
     outline: 0;
-    margin: 0;
-    }
+    margin: -1px 0 -1px -4px;
+    padding: 0 0 0 5px;
+  }
 }
 
 a {

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -114,19 +114,80 @@ Include a language whenever possible (in the example above, that language is
 You can also create tabbed codeblocks, so that users can easily switch to
 their preferred format. See [tabs for codeblocks](#tabs-for-codeblocks).
 
-### Line numbers
-By default, every codeblock is generated with line numbers, which is useful for
-calling out specific sections of code. If you need to disable the line numbers,
-use the `highlight` tag with an optional language class instead of
-backticks. For example:
+If you're including placeholders in codeblocks, use HTML tags instead of
+backticks. See [editable placeholders](#editable-placeholders-in-codeblocks).
 
-{% raw %}
+## Placeholders
+
+Use placeholders in both inline text and in codeblocks to
+denote a value that the user should edit. Always enclose placeholders in code
+formatting.
+
+### Inline placeholders
+If you're adding a placeholder inline, such as in a sentence, enclose them single
+backticks: \`{EXAMPLE_TEXT}`
+
+### Editable placeholders in codeblocks
+If you have text in your codeblock that you want the user to edit before running
+the code, you can use editable placeholders.
+
+Editable placeholders are only supported in HTML, and are not supported with
+fenced codeblocks.
+
+* Use the `<pre>` and `<code>` tags to create a codeblock
+* Enclose your placeholder in `<div contenteditable="true"></div>` tags
+* Do not add any newlines around the `pre` and `code` tags. These tags read
+their contents very literally, so all newlines will output as newlines.
+* HTML codeblocks can't pick up syntax highlighting. For consistency, if you're
+using fenced codeblocks elsewhere on the same page, set the language to
+`plaintext`:
+    ````
+    ```plaintext
+    some code here
+    ```
+    ````
+
+**Do:**
+{% navtabs %}
+{% navtab Input %}
 ```
-{% highlight bash %}
-some code here
-{% endhighlight %}
+<pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+port: 80 </code></pre>
 ```
-{% endraw %}
+{% endnavtab %}
+{% navtab Output %}
+
+<pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+port: 80 </code></pre>
+
+{% endnavtab %}
+{% endnavtabs %}
+
+**Don't do:**
+{% navtabs %}
+{% navtab Input %}
+```
+<pre>
+  <code>
+  host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+  port: 80
+  </code>
+</pre>
+```
+{% endnavtab %}
+{% navtab Output %}
+
+<pre>
+  <code>
+  host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+  port: 80
+  </code>
+</pre>
+
+{% endnavtab %}
+{% endnavtabs %}
+
+
 
 ## Tabs
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -140,15 +140,10 @@ fenced codeblocks.
 their contents very literally, so all newlines will output as newlines.
 * HTML codeblocks can't pick up syntax highlighting. For consistency, if you're
 using fenced codeblocks elsewhere on the same page, set the language to
-`plaintext`:
-    ````
-    ```plaintext
-    some code here
-    ```
-    ````
+`plaintext`.
 
 **Do:**
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Input %}
 ```
 <pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
@@ -156,15 +151,13 @@ port: 80 </code></pre>
 ```
 {% endnavtab %}
 {% navtab Output %}
-
 <pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
 port: 80 </code></pre>
-
 {% endnavtab %}
 {% endnavtabs %}
 
 **Don't do:**
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Input %}
 ```
 <pre>
@@ -176,18 +169,14 @@ port: 80 </code></pre>
 ```
 {% endnavtab %}
 {% navtab Output %}
-
 <pre>
   <code>
   host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
   port: 80
   </code>
 </pre>
-
 {% endnavtab %}
 {% endnavtabs %}
-
-
 
 ## Tabs
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -124,7 +124,7 @@ denote a value that the user should edit. Always enclose placeholders in code
 formatting.
 
 ### Inline placeholders
-If you're adding a placeholder inline, such as in a sentence, enclose them single
+If you're adding a placeholder inline, such as in a sentence, enclose it in single
 backticks: \`{EXAMPLE_TEXT}`
 
 ### Editable placeholders in codeblocks
@@ -156,7 +156,7 @@ port: 80 </code></pre>
 {% endnavtab %}
 {% endnavtabs %}
 
-**Don't do:**
+**Don't:**
 {% navtabs codeblock %}
 {% navtab Input %}
 ```
@@ -333,7 +333,7 @@ and will only pick up H2 and H3 level headings.
 Here, the headings are nested correctly, with the smaller heading H3 contained
 within H2.
 
-**Don't do:**
+**Don't:**
 ```markdown
 ### Sub-sub-heading Level 3
 ## Sub-heading Level 2

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -43,11 +43,16 @@ For more information about formatting admonitions see [markdown-rules](/contribu
   - For example: “There was a storm last night,” Paul said.
 
 ### Placeholder values
-- Use single curly braces, all caps text, and underscores between words.<br/>
-  For example: {EXAMPLE_VALUE}
+- Use single curly braces, all caps text, and underscores between words.
+
+    For example: `{EXAMPLE_VALUE}`
+
+    In codeblocks, use [editable placeholders](/contributing/markdown-rules/#placeholders)
+    where you want a user to enter their own value.
 
 ## Capitalization guidelines
-Follow the user interface(UI). If a term is capitalized in the UI, it should be capitalized in the documentation.
+Follow the user interface (UI). If a term is capitalized in the UI, it should be
+capitalized in the documentation.
 
 ### Kong-specific terms
 Capitalize the following Kong-specific terms:
@@ -78,10 +83,13 @@ Do not capitalize the following generic terms:
 ## Code formatting
 - Separate commands from output.
 - Include properly formatted code comments.
-- For long commands, split the code block into separate lines to avoid horizontal scrolling.
+- For long commands, split the code block into separate lines with `\`
+to avoid horizontal scrolling.
 - Never have more than one command in a block/example.
-- Always set a language for codeblocks, for example, bash.<br/>
-  [List of supported languages](https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers)
+- Set a language for codeblocks, for example, bash, to enable syntax highlighting.
+    - [List of supported languages](https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers)
+    - If using HTML tags to create a codeblock for editable placeholders,
+    see [guidelines for editable placeholders](/contributing/markdown-rules/#editable-placeholders-in-codeblocks)
 - Do **NOT** use the command prompt marker ($) in code snippets.
 
 ### Inline code formatting


### PR DESCRIPTION
### Summary
Adding guidelines for using editable placeholders to contributing guide and removing info about line numbers.

Also adjusting padding and margins for placeholders because it became clear, while writing up guidelines, that they were way too big.

### Reason
https://konghq.atlassian.net/browse/DOCU-1592

### Testing
https://deploy-preview-2995--kongdocs.netlify.app/contributing/markdown-rules/#placeholders
