### PR TITLE
Delete duplicate sitemap file

### DIFF
--- a/app/sitemap.txt
+++ b/app/sitemap.txt
@@ -1,7 +1,0 @@
----
-layout: null
-sitemap: false
----
-{% for page in site.pages %}{% if page.sitemap != false %}
-{{ site.url }}{{ page.url }}
-{% endif %}{% endfor %}


### PR DESCRIPTION
### Summary
We are using sitemap.txt and sitemap.xml.
* Sitemap.xml gets submitted to search providers and is the current sitemap logged in Google Search Console. It’s also specified in our robots.txt. 
* Sitemap.txt hasn't been touched in six years and isn't actually in use.

### Reason
Sitemap.txt doesn’t appear to have a use, and is listing all outdated version pages. It adds a not-insignificant amount of time to our build.

### Testing
N/A
