### PR TITLE
Fix duplicate alias generation

### DIFF
--- a/app/_plugins/alias_generator.rb
+++ b/app/_plugins/alias_generator.rb
@@ -33,6 +33,7 @@ module Jekyll
 
     def generate(site)
       @site = site
+      @generated = {}
 
       process_posts
       process_pages
@@ -59,20 +60,52 @@ module Jekyll
       alias_paths.flatten.each do |alias_path|
         alias_path = alias_path.to_s
 
-        alias_dir  = File.extname(alias_path).empty? ? alias_path : File.dirname(alias_path)
+        alias_dir = File.extname(alias_path).empty? ? alias_path : File.dirname(alias_path)
         alias_file = File.extname(alias_path).empty? ? "index.html" : File.basename(alias_path)
 
-        fs_path_to_dir   = File.join(@site.dest, alias_dir)
+        fs_path_to_dir = File.join(@site.dest, alias_dir)
         alias_index_path = File.join(alias_dir, alias_file)
 
         FileUtils.mkdir_p(fs_path_to_dir)
 
-        File.open(File.join(fs_path_to_dir, alias_file), 'w') do |file|
+        File.open(File.join(fs_path_to_dir, alias_file), "w") do |file|
           file.write(alias_template(page, destination_path))
         end
 
-        (alias_index_path.split('/').size).times do |sections|
-          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_index_path.split('/')[1, sections + 1].join('/'), '')
+        (alias_index_path.split("/").size).times do |sections|
+          target = alias_index_path.split("/")[1, sections + 1].join("/")
+          target_version = page.data["kong_versions"].last["release"]
+
+          # We only want to generate each alias once
+
+          # This code snippet works by generating a redirect for every segment of a URL
+          # e.g. enterprise/2.4.x/developer-portal/using-the-editor/ will generate:
+          # enterprise/latest => enterprise/2.4.x
+          # enterprise/latest/developer-portal => enterprise/2.4.x/developer-portal
+          # enterprise/latest/developer-portal/using-the-editor => enterprise/2.4.x/developer-portal/using-the-editor
+
+          # This works until you have two pages with a common base URL such as:
+          # enterprise/2.4.x/developer-portal/working-with-templates/index.html
+          # enterprise/2.4.x/developer-portal/using-the-editor/
+
+          # In this instance, enterprise/2.4.x/developer-portal will be generated twice
+          # and jekyll will complain with the following error:
+          # Conflict: The following destination is shared by multiple files
+
+          # To resolve this, we keep track of all URLs we generate a redirect for and skip
+          # the generation if the version they're pointing to are the same
+
+          # If two redirects point to different versions, we raise an error as this
+          # should never happen
+
+          # If the versions match, skip generation
+          next if @generated[target] && target_version == @generated[target]
+
+          # Otherwise error if the two versions are different
+          raise "Two pages point to different versions: #{target} (#{target_version} and #{@generated[target]})" if @generated[target]
+
+          @generated[target] = target_version
+          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, target, "")
         end
       end
     end


### PR DESCRIPTION
### Review
@lena-larionova 

### Summary
We only want to generate each alias once

This code snippet works by generating a redirect for every segment of a URL
e.g. enterprise/2.4.x/developer-portal/using-the-editor/ will generate:

* enterprise/latest => enterprise/2.4.x
* enterprise/latest/developer-portal => enterprise/2.4.x/developer-portal
* enterprise/latest/developer-portal/using-the-editor => enterprise/2.4.x/developer-portal/using-the-editor

This works until you have two pages with a common base URL such as:

* enterprise/2.4.x/developer-portal/working-with-templates/index.html
* enterprise/2.4.x/developer-portal/using-the-editor/

In this instance, enterprise/2.4.x/developer-portal will be generated twice
and jekyll will complain with the following error:

> Conflict: The following destination is shared by multiple files

To resolve this, we keep track of all URLs we generate a redirect for and skip
the generation if the version they're pointing to are the same

If two redirects point to different versions, we raise an error as this
should never happen

### Reason
Fix the build

### Testing
Only two duplicate entries should be listed when running the build (which are valid)
