### PR TITLE
Add jekyll-cache to makefile clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean:
 	-docker-compose stop
 	-docker-compose rm -f
 	-rm -rf dist
+	-rm -rf app/.jekyll-cache
 	-rm yarn.lock
 	-rm -rf node_modules
 	-rm install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+# Installs gulp.
 install-prerequisites:
 	npm install -g gulp
 
+# Installs npm packages and gems.
 install:
 	-mkdir -p node_modules
 	chmod 777 node_modules
@@ -8,13 +10,20 @@ install:
 	yarn --ignore-engines
 	touch install
 
+# Using local dependencies, starts a doc site instance on http://localhost:3000.
 run: install
 	-chmod -R 777 dist
 	gulp
 
+# Brings up a docker container and starts a doc site instance on
+# http://localhost:3000.
 develop:
 	docker-compose up
 
+# Cleans up all docker-compose containers and all temp files in the build.
+# Run `make clean` locally whenever you're updating dependencies, or to help
+# troubleshoot build issues.
+# Used in build-test and check-links workflows.
 clean:
 	-docker-compose stop
 	-docker-compose rm -f
@@ -24,19 +33,24 @@ clean:
 	-rm -rf node_modules
 	-rm install
 
+# Runs tests using the npm standard and echint linters.
 test: install
 	npm test
 
+# Starts a docker container in the background.
 background-docker-up:
 	docker-compose up -d
 	-while [ `curl -s -o /dev/null -w ''%{http_code}'' localhost:3000` != 200 ]; do echo "waiting"; docker-compose logs --tail=10 jekyll; sleep 45; done
 
+# Starts a docker container in the background, then runs tests.
 docker-test: background-docker-up
 	docker-compose exec -T jekyll npm test
 
+# Brings up a docker container, runs jekyll build, and checks all internal links.
 check-links: background-docker-up
 	docker-compose exec -T jekyll yarn blc http://localhost:3000 -efr --exclude careers --exclude hub --exclude kong-cloud --exclude community --exclude localhost:3000\/2\.4\.x --exclude localhost:3000\/2\.3\.x --exclude localhost:3000\/2\.2\.x --exclude localhost:3000\/2\.1\.x --exclude localhost:3000\/2\.0\.x --exclude localhost:3000\/1\.5\.x --exclude localhost:3000\/1\.4\.x --exclude localhost:3000\/1\.3\.x --exclude localhost:3000\/1\.2\.x --exclude localhost:3000\/1\.1\.x --exclude localhost:3000\/1\.0\.x --exclude localhost:3000\/0\.15\.x --exclude localhost:3000\/0\.14\.x --exclude localhost:3000\/0\.13\.x --exclude localhost:3000\/0\.12\.x --exclude localhost:3000\/0\.11\.x --exclude localhost:3000\/0\.10\.x --exclude localhost:3000\/0\.9\.x --exclude localhost:3000\/0\.8\.x --exclude localhost:3000\/0\.7\.x --exclude localhost:3000\/0\.6\.x --exclude localhost:3000\/0\.5\.x --exclude localhost:3000\/0\.4\.x --exclude localhost:3000\/0\.3\.x --exclude localhost:3000\/0\.2\.x
 
-# make run first, then use this link check for non-Docker development
+# Checks all internal links in a running http://localhost:3000 instance. To use
+# this command, `make run` first, then `make check-links-local`.
 check-links-local:
 	yarn blc http://localhost:3000 -efr --exclude careers --exclude hub --exclude kong-cloud --exclude community --exclude localhost:3000\/2\.4\.x --exclude localhost:3000\/2\.3\.x --exclude localhost:3000\/2\.2\.x --exclude localhost:3000\/2\.1\.x --exclude localhost:3000\/2\.0\.x --exclude localhost:3000\/1\.5\.x --exclude localhost:3000\/1\.4\.x --exclude localhost:3000\/1\.3\.x --exclude localhost:3000\/1\.2\.x --exclude localhost:3000\/1\.1\.x --exclude localhost:3000\/1\.0\.x --exclude localhost:3000\/0\.15\.x --exclude localhost:3000\/0\.14\.x --exclude localhost:3000\/0\.13\.x --exclude localhost:3000\/0\.12\.x --exclude localhost:3000\/0\.11\.x --exclude localhost:3000\/0\.10\.x --exclude localhost:3000\/0\.9\.x --exclude localhost:3000\/0\.8\.x --exclude localhost:3000\/0\.7\.x --exclude localhost:3000\/0\.6\.x --exclude localhost:3000\/0\.5\.x --exclude localhost:3000\/0\.4\.x --exclude localhost:3000\/0\.3\.x --exclude localhost:3000\/0\.2\.x


### PR DESCRIPTION
### Summary
Adding `rm -rf app/.jekyll-cache` to `clean`. 
Also adding comments to explain what each command does so that anyone can understand what's going on, and which one they might want to run.

### Reason
Jekyll-cache should be cleaned out so that tests are more accurate, and will help with troubleshooting.
For the comments, taking a cue from Michael's [recent PR](https://github.com/Kong/docs.konghq.com/pull/3002). We should try to add code comments as much as possible, so that anyone on the team can understand what's going on.

### Testing
To test, pull down the branch and run `make clean && make install`. It should remove dist and jekyll-cache, which will get recreated next time you `make run`. 