### PR TITLE
Konnect docs: shared config and app reg cleanup

### DIFF
--- a/app/konnect/dev-portal/administrators/app-registration/disable-app-reg.md
+++ b/app/konnect/dev-portal/administrators/app-registration/disable-app-reg.md
@@ -25,20 +25,14 @@ again any time at your discretion.
 
 1. From the {{site.konnect_short_name}} menu, click **Services**.
 
-   The Services page is displayed.
-
    ![Konnect Services Page](/assets/images/docs/konnect/konnect-services-page.png)
 
 2. Depending on your view, click the tile for the Service in cards view or the row
    for the Service in table view.
 
-   The Overview page for the service is displayed.
-
    ![Konnect Disable App Registration](/assets/images/docs/konnect/konnect-disable-app-reg.png)
 
 3. From the **Actions** menu, click **Disable app registration**.
-
-   You are prompted to confirm the disable action.
 
    ![Konnect Confirm Disable App Registration](/assets/images/docs/konnect/konnect-confirm-disable-app-reg.png)
 

--- a/app/konnect/dev-portal/administrators/app-registration/enable-app-reg.md
+++ b/app/konnect/dev-portal/administrators/app-registration/enable-app-reg.md
@@ -22,10 +22,12 @@ conjunction with the `key-auth` or `OIDC` plugins. After app registration is ena
 the `key-auth` or `OIDC` and `ACL` plugins are no longer available on the Plugins page because
 they have already been enabled.
 
-<div class="alert alert-ee warning"><strong>WARNING:</strong>
-It is possible to view the Consumers in the Shared Config. Do not delete the ACLs associated
-with a Consumer managed by application registration.
-</div>
+{:.important}
+> **Important:** Developers registered through app registration appear as
+consumers on the
+![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}
+Shared Config page. Do not delete the ACLs associated with a consumer managed
+by app registration.
 
 Plugins enabled by app registration cannot be disabled using the toggle in the **Plugins** pane
 on the Services Version page. The only way to disable or delete them is to disable app registration,
@@ -39,17 +41,8 @@ any time at your discretion.
 
 ## Prerequisites
 
-- Proper role permissions.
-
-  You must be a {{site.konnect_short_name}} admin with the
-  [correct roles and permissions](/konnect/reference/org-management/#role-definitions)
-  to manage application connections to a Service.
-
-  The following roles allow you to
-  enable app registration for a Service:
-
-  - Organization Admin
-  - Service Admin
+- [**Organization Admin** or **Service Admin**](/konnect/reference/org-management/#role-definitions)
+permissions.
 
 - The Services have been created, versioned, and published to the
   {{site.konnect_short_name}} Dev Portal so that they appear in the Catalog.
@@ -67,20 +60,14 @@ any time at your discretion.
 
 1. From the {{site.konnect_short_name}} menu, click **Services**.
 
-   The Services page is displayed.
-
    ![Konnect Services Page](/assets/images/docs/konnect/konnect-services-page.png)
 
 2. Depending on your view, click the tile for the Service in cards view or the row
    for the Service in table view.
 
-   The Overview page for the Service is displayed.
-
    ![Konnect Enable App Registration](/assets/images/docs/konnect/konnect-enable-app-reg-service-menu.png)
 
 3. From the **Actions** menu, click **Enable app registration**.
-
-   The Enable App Registration dialog is displayed.
 
    ![Konnect Enable App Registration with Key Authentication](/assets/images/docs/konnect/konnect-enable-app-reg-key-auth.png)
 
@@ -99,9 +86,8 @@ any time at your discretion.
 
 6. Click **Enable**.
 
-   The status for application registration changes to **Enabled**.
-
-   The Version information page for the service shows the `acl` and `key-auth` plugins were automatically enabled.
+    With app registration enabled, all versions of this service now include
+    read-only entries for the `acl` and `key-auth` plugins.
 
    ![Konnect App Registration Key Auth Plugins](/assets/images/docs/konnect/key-auth-acl-plugins.png)
 
@@ -145,9 +131,8 @@ any time at your discretion.
 
 6. Click **Enable**.
 
-   The status for application registration changes to **Enabled**.
-
-   The Version information page for the service shows the `acl` and `oidc` plugins were automatically enabled.
+    With app registration enabled, all versions of this service now include
+    read-only entries for the `acl` and `oidc` plugins.
 
 ###  OpenID Connect Configuration Parameters {#openid-config-params}
 

--- a/app/konnect/dev-portal/administrators/app-registration/manage-app-connections.md
+++ b/app/konnect/dev-portal/administrators/app-registration/manage-app-connections.md
@@ -14,15 +14,8 @@ them about the change in status.--->
 
 ## Prerequisite
 
-You must be a {{site.konnect_short_name}} admin with the
-[correct roles and permissions](/konnect/reference/org-management/#role-definitions)
-to manage application connections to a Service.
-
-The following roles allow you to
-manage application connections to a Service:
-
-- Organization Admin
-- Service Admin
+[**Organization Admin** or **Service Admin**](/konnect/reference/org-management/#role-definitions)
+permissions.
 
 ## Application Connection to a Service Status
 
@@ -94,16 +87,10 @@ that was revoked for a Service can be approved again any time at your discretion
 
 1. Click **Connections > Applications**.
 
-   The Applications page is displayed.
-
 2. Click on an application row.
 
-   The Connections details for an application are displayed.
-
-3. In the row for Service whose connection status you want to change, click the icon and choose **Approve** from the
-   context menu.
-
-   The status is updated to **Approved**.
+3. In the row for Service whose connection status you want to change, click the
+icon and choose **Approve** from the context menu.
 
 ### Delete an Application's Connection to a Service {#delete-app-connection}
 
@@ -113,13 +100,7 @@ to the Service can be made again by a developer.
 
 1. Click **Connections > Applications**.
 
-   The Applications page is displayed.
-
 2. Click on an application row.
-
-   The Connections details for an application are displayed.
 
 3. In the row for application connection you want to delete, click the icon and choose **Delete** from the
    context menu.
-
-   The application connection to the Service is deleted and removed from the **Connections** pane.

--- a/app/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests.md
+++ b/app/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests.md
@@ -12,15 +12,8 @@ developers must register their applications with a Service.
 
 ## Prerequisite
 
-You must be a {{site.konnect_short_name}} admin with the
-[correct roles and permissions](/konnect/reference/org-management/#role-definitions)
-to manage application registration requests for a Service.
-
-The following roles allow you to
-manage application registration requests:
-
-- Organization Admin
-- Service Admin
+[**Organization Admin** or **Service Admin**](/konnect/reference/org-management/#role-definitions)
+permissions.
 
 ## Application Registration Status
 

--- a/app/konnect/dev-portal/administrators/auto-approve-devs-apps.md
+++ b/app/konnect/dev-portal/administrators/auto-approve-devs-apps.md
@@ -21,22 +21,14 @@ If Auto Approve is enabled portal-wide, it overrides the per Service setting.
 
 ![Konnect Portal Settings for Auto Approve Developers and Applications](/assets/images/docs/konnect/konnect-portal-auto-approve.png)
 
-## Enable Auto Approve for Developer or Application Registrations
+## Enable or disable auto approve
 
-1. From the {{site.konnect_short_name}} menu, click the settings icon.
+1. From the {{site.konnect_short_name}} menu, click the
+![settings icon](/assets/images/icons/konnect/konnect-settings.svg){:.inline .no-image-expand}
+settings icon.
 
-2. Enable Auto Approve for one or both options:
-   * In the **Auto Approve Developers** pane, click the toggle to **Enabled**.
-   * In the **Auto Approve Applications** pane, click the toggle to **Enabled**.
-
-3. Click **Save**.
-
-## Disable Auto Approve for Developer or Application Registrations
-
-1. From the {{site.konnect_short_name}} menu, click the settings icon.
-
-2. Disable Auto Approve for one or both options:
-   * In the **Auto Approve Developers** pane, click the toggle to **Disabled**.
-   * In the **Auto Approve Applications** pane, click the toggle to **Disabled**.
+2. Click the toggle to enable or disable Auto Approve for one or both options:
+   * **Auto Approve Developers**
+   * **Auto Approve Applications**
 
 3. Click **Save**.

--- a/app/konnect/dev-portal/administrators/customization/themes.md
+++ b/app/konnect/dev-portal/administrators/customization/themes.md
@@ -3,8 +3,6 @@ title: Customizing the Dev Portal Appearance
 no_version: true
 ---
 
-## Customize the appearance of your Konnect Developer Portal
-
 Customize the appearance of your {{site.konnect_short_name}} Dev Portal to match
 your own unique branding. Upload your own logo and a favicon for browser tabs.
 

--- a/app/konnect/dev-portal/administrators/manage-devs.md
+++ b/app/konnect/dev-portal/administrators/manage-devs.md
@@ -9,13 +9,8 @@ enable [auto approve](/konnect/dev-portal/administrators/auto-approve-devs-apps)
 
 ## Prerequisite
 
-You must be a {{site.konnect_short_name}} admin with the
-[correct roles and permissions](/konnect/reference/org-management/#role-definitions)
-to manage developers and their access to your {{site.konnect_short_name}} Dev Portal.
-The following roles allow you to manage developers:
-
-- Organization Admin
-- Portal Admin
+[**Organization Admin** or **Portal Admin**](/konnect/reference/org-management/#role-definitions)
+permissions.
 
 ## Developer Status
 

--- a/app/konnect/dev-portal/administrators/public-portal.md
+++ b/app/konnect/dev-portal/administrators/public-portal.md
@@ -11,21 +11,15 @@ The Register options are not available in a public-facing portal.
 
 ![Konnect Settings for a Public Portal](/assets/images/docs/konnect/konnect-portal-auto-approve.png)
 
-You can enable and disable public access to a portal 
+You can enable and disable public access to a portal
 any time at your discretion.
 
-## Enable Public Access for a Dev Portal
+## Enable or disable public access for a Dev Portal
 
-1. From the {{site.konnect_short_name}} menu, click the settings icon.
+1. From the {{site.konnect_short_name}} menu, click the
+![settings icon](/assets/images/icons/konnect/konnect-settings.svg){:.inline .no-image-expand}
+settings icon.
 
-2. In the **Public Portal** pane, click the toggle to **Enabled**.
-
-3. Click **Save**.
-
-## Disable Public Access for a Dev Portal
-
-1. From the {{site.konnect_short_name}} menu, click the settings icon.
-
-2. In the **Public Portal** pane, click the toggle to **Disabled**.
+2. In the **Public Portal** pane, click the toggle to **Enabled** or **Disabled**.
 
 3. Click **Save**.

--- a/app/konnect/dev-portal/developers/dev-apps.md
+++ b/app/konnect/dev-portal/developers/dev-apps.md
@@ -76,8 +76,6 @@ Edit basic details like the name, reference ID, and description of your applicat
 
 1. From the [application details page](#app-details-page), click **Edit**.
 
-   The Update Application dialog is displayed.
-
    ![Update App Details Dialog](/assets/images/docs/konnect/konnect-edit-app.png)
 
 2. Make your changes and click **Update**.
@@ -91,6 +89,5 @@ from the following locations:
 
   ![Konnect Dev Portal Delete an App](/assets/images/docs/konnect/konnect-portal-delete-app.png)
 
-- In the [Update Application](#edit-my-app) dialog, click **Delete**.
-
-You are prompted to confirm the deletion.
+- In the [Update Application](#edit-my-app) dialog, click **Delete**, then
+confirm deletion.

--- a/app/konnect/dev-portal/developers/dev-gen-creds.md
+++ b/app/konnect/dev-portal/developers/dev-gen-creds.md
@@ -19,18 +19,13 @@ You can generate multiple credentials and delete as needed.
 
 1. From the Dev Portal, click the **Dashboard** menu under your login name.
 
-   The My Apps page is displayed.
+   This opens the **My Apps** page.
 
 2. Click the application for which you want to generate a credential.
 
-   The [application details](/konnect/dev-portal/developers/dev-apps#app-details-page) page is displayed.
-
 3. In the **Authentication** pane, click **Generate Credential**.
 
-   The credential is generated and displayed in
-   the Authentication pane of the application details page.
-
-4. Test the credential by making a call to the service the
+4. Test the generated credential by making a call to the service the
    [application is registered with](/konnect/dev-portal/developers/dev-reg-app-service)
    using your `key-auth` credential (API key).
 
@@ -46,5 +41,3 @@ You can generate multiple credentials and delete as needed.
    and click **Delete** from the context menu.
 
    ![Konnect Application Delete API Keys](/assets/images/docs/konnect/konnect-dev-gen-app-cred-api-key.png)
-
-   The credential is deleted from the **Authentication** pane.

--- a/app/konnect/dev-portal/developers/dev-reg-app-service.md
+++ b/app/konnect/dev-portal/developers/dev-reg-app-service.md
@@ -20,9 +20,8 @@ This procedure assumes that there are no
 existing Services configured for an application yet. You can register an application with multiple
 applicable Services.
 
-1. Log in to the {{site.konnect_short_name}} Dev Portal.
-
-   The Service Catalog is displayed.
+1. Log in to the {{site.konnect_short_name}} Dev Portal to access the Service
+Catalog.
 
 2. Click on a Service tile.
 
@@ -30,8 +29,6 @@ applicable Services.
    if you need it enabled on a Service.
 
 3. Click **Register**.
-
-   The Register for Service dialog is displayed.
 
    ![Konnect Register App with Service](/assets/images/docs/konnect/konnect-register-app-service-request.png)
 
@@ -60,11 +57,7 @@ the **Services** pane.
 
 1. Click **Dashboard**.
 
-   The My Apps dashboard page is displayed.
-
 2. Click the application you want to unregister.
-
-   The application details page is displayed.
 
    ![Konnect Unregister App from Service](/assets/images/docs/konnect/konnect-unregister-app-service.png)
 

--- a/app/konnect/dev-portal/developers/dev-reg.md
+++ b/app/konnect/dev-portal/developers/dev-reg.md
@@ -46,6 +46,6 @@ displayed on the **Dev Portal** page. The format looks something like this:
       if [auto approve](/konnect/dev-portal/administrators/auto-approve-devs-apps) is not enabled.
 
 6. After your request has been [approved by an admin](/konnect/dev-portal/administrators/manage-devs) or automatically approved,
-   click **Login**. The Login dialog is displayed.
+   click **Login**.
 
 7. Enter your credentials and log in. If you experience any access issues, contact your {{site.konnect_short_name}} admin.

--- a/app/konnect/getting-started/declarative-config.md
+++ b/app/konnect/getting-started/declarative-config.md
@@ -12,8 +12,7 @@ In {{site.konnect_saas}}, decK can manage:
 * **All parts of a service:** Service versions, implementations, routes, and
 plugins.
 * **Dev Portal documents:** Specs and markdown files.
-* **Shared configuration:** Manage consumers, upstreams, and global plugins with
-declarative config.
+* Consumers, upstreams, and global plugins.
 
 To do this, you need [decK v1.7.0 or later](/deck/).
 
@@ -169,12 +168,10 @@ new service named `MyService` in the
     ![ServiceHub tiles](/assets/images/docs/konnect/konnect-myservice.png)
 
 
-## Manage shared configuration
+## Manage consumers and global plugins
 
-Shared configuration defines objects that are not tied to a specific service or
- route.
-
-For this example, create a consumer and a global proxy caching plugin:
+You can also use decK to manage objects not tied to a specific service or
+route. For this example, create a consumer and a global proxy caching plugin:
 
 * Consumers represent users of a service, and are most often used for
 authentication. They provide a way to divide access to your services, and
@@ -227,7 +224,7 @@ to see your changes:
     ![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}
     **[Shared Config](https://konnect.konghq.com/configuration)** menu option.
 
-    ![Shared config overview](/assets/images/docs/konnect/konnect-shared-config.png)
+    ![Shared Config overview page](/assets/images/docs/konnect/konnect-shared-config.png)
 
     {:.note}
     > **Note:** If you add consumers to the `konnect.yaml` file and sync your

--- a/app/konnect/manage-plugins/index.md
+++ b/app/konnect/manage-plugins/index.md
@@ -4,7 +4,7 @@ no_version: true
 ---
 
 Any {{site.ee_gateway_names}} plugins supported in a self-managed hybrid mode
-deployment are also accessible through ServiceHub or Shared Config.
+deployment are also accessible through ServiceHub or the Shared Config page.
 
 ## Kong plugins in Konnect Cloud
 
@@ -17,11 +17,11 @@ or applying it globally.
 or consumer. You can configure plugins on
 [services](/konnect/manage-plugins/enable-service-plugin) and
 [routes](/konnect/manage-plugins/enable-route-plugin) through ServiceHub, and on
-[consumers](/konnect/manage-plugins/shared-config) through Shared Config.
+[consumers](/konnect/manage-plugins/shared-config) through the Shared Config page.
 
 * If you want to apply a plugin **globally** &ndash; that is, to all services,
-routes, and consumers in a cluster &ndash; set it up through
-[shared config](/konnect/manage-plugins/shared-config/).
+routes, and consumers in a cluster &ndash; set it up through the
+[Shared Config page](/konnect/manage-plugins/shared-config/).
 
 ### Functionality differences from self-managed Kong Gateway
 

--- a/app/konnect/manage-plugins/shared-config.md
+++ b/app/konnect/manage-plugins/shared-config.md
@@ -3,14 +3,14 @@ title: Manage Plugins through Shared Config
 no_version: true
 ---
 
-Through shared config, you can manage global and consumer-scoped plugins.
+You can manage global and consumer-scoped plugins from the Shared Config page.
 
 **Global plugins** are plugins that apply to all services, routes, and consumers
 in the cluster, as applicable.
 
-The shared config overview shows all plugins in the cluster. However, you can
+The Shared Config page shows all plugins in the cluster. However, you can
 only edit **global** or **consumer-scoped** plugins here.
-[Service](/konnect/manage-plugins/enable-service-plugin) and 
+[Service](/konnect/manage-plugins/enable-service-plugin) and
 [route](/konnect/manage-plugins/enable-route-plugin) plugins must be managed
 through the ServiceHub.
 
@@ -43,7 +43,7 @@ plugin at any time.
 
 1. Open the
 ![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}
-Shared Config overview, then select **View All** for the plugins
+Shared Config page, then select **View All** for the plugins
 list, or open **Plugins** from the menu.
 
 2. Find your plugin in the plugins list and click **Edit**.
@@ -58,7 +58,7 @@ Deleting a plugin completely removes it and its configuration from
 
 1. Open the
 ![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}
-Shared Config overview, then select **View All** for the plugins
+Shared Config page, then select **View All** for the plugins
 list, or open **Plugins** from the menu.
 
 2. Find your plugin in the plugins list and click **Edit**.

--- a/app/konnect/shared-config/index.md
+++ b/app/konnect/shared-config/index.md
@@ -4,15 +4,12 @@ no_version: true
 toc: false
 ---
 
-[Shared configuration](https://konnect.konghq.com/configuration/)
-defines {{site.konnect_short_name}} objects that are not tied to a specific
-service, route, or Dev Portal.
-
-![Shared configuration overview](/assets/images/docs/konnect/konnect-shared-conf-overview.png)
-
 Use the ![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}
-**Shared Config** page in {{site.konnect_saas}} to manage consumers,
+[**Shared Config** page](https://konnect.konghq.com/configuration/) in
+{{site.konnect_saas}} to manage consumers,
 upstreams, certificates, SNIs, and global and consumer-scoped plugins.
+
+![Shared config overview](/assets/images/docs/konnect/konnect-shared-conf-overview.png)
 
 **Consumers**
 : Consumer objects represent users of a service, and are most often used for
@@ -25,7 +22,7 @@ make it easy to revoke that access without disturbing a service's function.
 : Plugins let you extend proxy functionality by adding rules, policies,
 transformations, and more on requests and responses.
 
-: You can manage global and consumer-scoped plugins from Shared Config, and
+: You can manage global and consumer-scoped plugins from the Shared Config page, and
 view all plugins in the cluster, including service and route plugins.
 
 : Global plugins are plugins that apply to all services, routes, and consumers

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -12,7 +12,7 @@ services.
 ### 2021.06.24
 **Global plugin support**
 : You can now configure global plugins through {{site.konnect_saas}}. Visit the
-new plugin configuration page through [shared configuration](https://konnect.konghq.com/configuration/)
+[Shared Config page](https://konnect.konghq.com/configuration/)
 and select the **Plugin** menu option to get started.
 
 ### 2021.06.21


### PR DESCRIPTION
### Summary
Cleaning up references to the Shared Config page. Should always say "Shared Config page", as shared config is not a real concept and only exists as a bucket for misc configurations.

Also cleaning up all the unnecessary "this item displays" text, and shortening prereqs for permissions to just list the permission. 

### Reason

Terminology and UI woes and a small step towards simplifying GUI documentation.

### Testing
https://deploy-preview-3008--kongdocs.netlify.app/konnect/shared-config/

Most topics under app reg and dev portal, eg: 
https://deploy-preview-3008--kongdocs.netlify.app/konnect/dev-portal/administrators/app-registration/enable-app-reg/

Shortening the following topics:
https://deploy-preview-3008--kongdocs.netlify.app/konnect/dev-portal/administrators/auto-approve-devs-apps/
https://deploy-preview-3008--kongdocs.netlify.app/konnect/dev-portal/administrators/public-portal/


