### PR TITLE
[DOCU-1603] Add title attrs and more desc link titles

### DIFF
--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -19,7 +19,7 @@
               if extn.enterprise %}enterprise {%
                 else %}open-source {% endif %}{%
                   else %}pub-not-konghq pub-{{extn_publisher}}{% endif %}">
-      <a href="{{ extn.url | remove: '/index' }}">
+      <a href="{{ extn.url | remove: '/index' }}" title="{{ extn.name }}: {{ extn.desc }}">
         <div>
           <div class="name-desc {% if extn.plus and extn_publisher == 'kong-inc' %}plus{% endif %}">
             <img class="card-img-top" src="{{ header_icon }}" />

--- a/app/deck/1.7.x/index.md
+++ b/app/deck/1.7.x/index.md
@@ -68,7 +68,7 @@ commands.
 
 [Access our FAQs page](/deck/{{page.kong_version}}/faqs).
 
-## Kong Summit motivation behind decK video
+## Video: Kong Summit motivation behind decK
 
 [Harry Bagdi gave a talk on the motivation behind decK](https://www.youtube.com/watch?v=fzpNC5vWE3g) and demonstrated a few key
 features of decK at Kong Summit 2019.

--- a/app/deck/1.7.x/index.md
+++ b/app/deck/1.7.x/index.md
@@ -16,10 +16,7 @@ Features include:
 * Manage Kong’s configuration in a distributed way using tags, helping you split
 the configuration across various teams
 
-Here is an introductory screencast explaining decK:
-<a href="https://asciinema.org/a/238318">
-  <img class="no-image-expand" src="https://asciinema.org/a/238318.svg" alt="deck screencast" />
-</a>
+[View our introductory screencast explaining decK](https://asciinema.org/a/238318).
 
 ## Features
 * **Export**: Export Kong configuration to a YAML configuration file.
@@ -65,26 +62,21 @@ The command line `--help` flag on the main command or a subcommand (like diff,
 sync, reset, etc.) shows the help text along with supported flags for those
 commands.
 
-A list of all commands that are available in decK can be found
-[here](/deck/{{page.kong_version}}/reference/deck).
+[See a list of all commands available with decK](/deck/{{page.kong_version}}/reference/deck).
 
 ## Frequently Asked Questions (FAQs)
 
-You can find answers to FAQs [here](/deck/{{page.kong_version}}/faqs).
+[Access our FAQs page](/deck/{{page.kong_version}}/faqs).
 
-## Explainer video
+## Kong Summit motivation behind decK video
 
-Harry Bagdi gave a talk on motivation behind decK and demonstrated a few key
-features of decK at Kong Summit 2019. The following is a recording of that session:
-
-<a href="https://www.youtube.com/watch?v=fzpNC5vWE3g">
-  <img class="no-image-expand" src="https://img.youtube.com/vi/fzpNC5vWE3g/0.jpg" alt="decK talk by Harry Bagdi" />
-</a>
+[Harry Bagdi gave a talk on the motivation behind decK](https://www.youtube.com/watch?v=fzpNC5vWE3g) and demonstrated a few key
+features of decK at Kong Summit 2019.
 
 ## Changelog
 
 The changelog can be found in the
-[CHANGELOG.md](https://github.com/kong/deck/blob/main/CHANGELOG.md) file.
+[CHANGELOG](https://github.com/kong/deck/blob/main/CHANGELOG.md) file.
 
 ## Licensing
 
@@ -95,34 +87,31 @@ Please read the
 ## Security
 
 decK does not offer to secure your Kong deployment but only configures it.
-It encourages you to protect your Kong's Admin API with authentication but
+It encourages you to protect your Kong Admin API implementation with authentication but
 doesn't offer such a service itself.
 
 decK's state file can contain sensitive data such as private keys of
-certificates, credentials, etc. It is left up to the user to manage
+certificates, credentials, etc. It is up to the user to manage
 and store the state file in a secure fashion.
 
 If you believe that you have found a security vulnerability in decK,
 submit a detailed report, along with reproducible steps
 to [security@konghq.com](mailto:security@konghq.com).
 
-## Getting help
+## Get help
 
-One of the design goals of decK is deliver a good developer experience to you.
-Part of it is getting the required help when you need it.
-To seek help, use the following resources:
+One of the design goals of decK is to deliver a good developer experience.
+To get help, use the following resources:
 - `--help` flag gives you the necessary help in the terminal itself and should
   solve most of your problems.
-- If you still need help, please open a
-  [Github issue](https://github.com/kong/deck/issues/new) to ask your
+- If you still need help, [open a Github issue](https://github.com/kong/deck/issues/new) to ask your
   question.
 - decK has very wide adoption by Kong's community and you can seek help
   from the larger community at [Kong Nation](https://discuss.konghq.com).
 
-## Reporting a bug
+## Report a bug
 
-If you believe you have run into a bug with decK, please open
-a [Github issue](https://github.com/kong/deck/issues/new).
+If you believe you have run into a bug with decK, [open a Github issue](https://github.com/kong/deck/issues/new).
 
-If you think you've found a security issue with decK, please read the
+If you think you've found a security issue with decK, read the
 [Security](#security) section.

--- a/app/kubernetes-ingress-controller/1.3.x/index.md
+++ b/app/kubernetes-ingress-controller/1.3.x/index.md
@@ -7,7 +7,7 @@ subtitle: An ingress controller for the Kong Gateway
 
 ### Architecture
 
-The [design][design] document explains how the {{site.kic_product_name}} works
+The [design document][design] explains how the {{site.kic_product_name}} works
 inside a Kubernetes cluster and configures Kong to proxy traffic as per
 rules defined in the Ingress resources.
 
@@ -22,12 +22,12 @@ A few custom resources are bundled with the {{site.kic_product_name}} to
 configure settings that are specific to Kong and provide fine-grained control
 over the proxying behavior.
 
-Please refer to [custom resources][crd] concept document for more details.
+Please refer to [custom resources concept document][crd] for more details.
 
 ### Deployment Methods
 
 The {{site.kic_product_name}} can be deployed in a variety of deployment patterns.
-Please refer to the [deployment](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/deployment) documentation,
+Please refer to the [deployment documentation](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/deployment),
 which explains all the components
 involved and different ways of deploying them based on the use-case.
 
@@ -35,7 +35,7 @@ involved and different ways of deploying them based on the use-case.
 
 The {{site.kic_product_name}} is designed to scale with your traffic
 and infrastructure.
-Please refer to [this document](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/ha-and-scaling) to understand
+Please refer to the [High-availability and Scaling guide](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/ha-and-scaling) to understand
 failures scenarios, recovery methods, as well as scaling considerations.
 
 ### Ingress classes
@@ -46,12 +46,12 @@ load configuration intended for other instances or other ingress controllers.
 
 ### Security
 
-Please refer to [this document](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/security) to understand the
+Please refer to the [Security concepts guide](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/security) to understand the
 default security settings and how to further secure the Ingress Controller.
 
 ## Guides and Tutorials
 
-Please browse through [guides][guides] to get started or understand how to configure
+Browse through [guides][guides] to get started or understand how to configure
 a specific setting with the {{site.kic_product_name}}.
 
 ## Configuration Reference
@@ -78,7 +78,7 @@ understanding of how Ingress Controller is designed and deployed
 along alongside Kong.
 
 - [FAQs][faqs] might help as well.
-- [Troubleshooting][troubleshooting] guide can help
+- [Troubleshooting guide][troubleshooting] can help
   resolve some issues.  
   Please contribute back if you feel your experience can help
   the larger community.

--- a/app/kubernetes-ingress-controller/1.3.x/index.md
+++ b/app/kubernetes-ingress-controller/1.3.x/index.md
@@ -22,12 +22,12 @@ A few custom resources are bundled with the {{site.kic_product_name}} to
 configure settings that are specific to Kong and provide fine-grained control
 over the proxying behavior.
 
-Please refer to [custom resources concept document][crd] for more details.
+Refer to the [custom resources concept document][crd] for more details.
 
 ### Deployment Methods
 
 The {{site.kic_product_name}} can be deployed in a variety of deployment patterns.
-Please refer to the [deployment documentation](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/deployment),
+Refer to the [deployment documentation](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/deployment),
 which explains all the components
 involved and different ways of deploying them based on the use-case.
 
@@ -35,7 +35,7 @@ involved and different ways of deploying them based on the use-case.
 
 The {{site.kic_product_name}} is designed to scale with your traffic
 and infrastructure.
-Please refer to the [High-availability and Scaling guide](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/ha-and-scaling) to understand
+Refer to the [High-availability and Scaling guide](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/ha-and-scaling) to understand
 failures scenarios, recovery methods, as well as scaling considerations.
 
 ### Ingress classes
@@ -46,12 +46,12 @@ load configuration intended for other instances or other ingress controllers.
 
 ### Security
 
-Please refer to the [Security concepts guide](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/security) to understand the
+Refer to the [Security concepts guide](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/security) to understand the
 default security settings and how to further secure the Ingress Controller.
 
 ## Guides and Tutorials
 
-Browse through [guides][guides] to get started or understand how to configure
+Browse through the [how-to guides][guides] to get started or understand how to configure
 a specific setting with the {{site.kic_product_name}}.
 
 ## Configuration Reference


### PR DESCRIPTION
### Review

@Kong/team-docs 

### Summary

/hub:
* add `title` attributes to links with `extn.name` and `extn.desc`

/deck:
* change clickable video stills to easy-to-read links
* update links to be more readable and descriptive

/kubernetes-ingress-controller:
* update links to be more readable and descriptive

### Reason

Accessibility efforts. 

Note that for /decK, clickable images appear misleading (as hosted or imbedded media) for users not using a screen reader. For screen-reader users, there was no description of the image. I opted to add descriptive links instead. 

### Testing

Tested locally. 

https://deploy-preview-3017--kongdocs.netlify.app/hub/ 
https://deploy-preview-3017--kongdocs.netlify.app/deck/
https://deploy-preview-3017--kongdocs.netlify.app/kubernetes-ingress-controller/

### Next Steps

I recommend creating an accessible links section in our Contributing Guide so that we can update as we go. 
* links should be descriptive of the content linked to. Instead of "click here", write "specific name of the resource".
* if the link contains added content (like the hub panels, which has an img), add a descriptive `title` attribute to the `a` tag. 
* refrain from using video stills, as they can be misleading

Resource accessed to learn more about link accessibility: https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML