### PR TITLE
Include cache fixes

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -879,9 +879,11 @@ jQuery(document).ready(function () {
 
   // Active link
   var url = $(".page.v2").data("url");
-  var urlNoSlash = url.slice(0, -1);
-  var activeNav = $(".docs-sidebar li a[href='"+url+"'], .docs-sidebar li a[href='"+urlNoSlash+"'] ").addClass("active");
-  activeNav.parents(".accordion-item").addClass("active");
+  if (url){
+    var urlNoSlash = url.slice(0, -1);
+    var activeNav = $(".docs-sidebar li a[href='"+url+"'], .docs-sidebar li a[href='"+urlNoSlash+"'] ").addClass("active");
+    activeNav.parents(".accordion-item").addClass("active");
+  }
 
 
   // open docs sidebar items

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -5,7 +5,7 @@
   {% assign is_plugin_hub = true %}
   {% endif %}
 
-  {% include_cached head.html is_plugin_hub=is_plugin_hub%}
+  {% include_cached head.html is_plugin_hub=is_plugin_hub name=page.name title=page.title url=page.url %}
 
   <body
     id="{{ page.id }}"

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -27,7 +27,7 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    {% include_cached nav-v2.html %}
+    {% include_cached nav-v2.html layout=page.layout %}
 
     {{ content | replace: '<a href="http', '<a rel="nofollow noopener noreferrer" href="http' }}
 


### PR DESCRIPTION
### Review

@falondarville 

### Summary
After merging the build improvement PR @falondarville noticed that the blue bar wasn't showing on the homepage. This is due to the sidebar not existing and has been fixed in this PR.

Additionally, the page title generation was being cached and the Algolia search was missing code on the landing page. Both of these are resolved in this PR.

### Reason
Fixes for production and PR #3003 

### Testing
* Blue bar should show up on the landing page
* Page titles should be correct

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
