### PR TITLE
Fix include_cache issue on plugin pages

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -233,7 +233,7 @@ breadcrumbs:
         {% endif %}
 
         {% if page.params.examples != false %}
-          {% include_cached hub-examples.html %}
+          {% include_cached hub-examples.html params=page.params %}
         {% endif %}
 
         <h3 id="parameters">Parameters</h3>


### PR DESCRIPTION
### Summary

All plugins are showing `google-auth` as the name due to the recent update to use `include_cached`. This PR passes in the parameters directly to fix this issue

<img width="871" alt="Screenshot 2021-07-13 at 11 09 43" src="https://user-images.githubusercontent.com/59130/125434231-d023a0f9-bb59-4136-a481-205167df1da3.png">

### Testing
Visit `/hub/kong-inc/basic-auth/` - you should see 

```
curl -X POST http://{HOST}:8001/services/{SERVICE}/plugins \
    --data "name=basic-auth"  \
```

rather than

```
curl -X POST http://{HOST}:8001/plugins/ \
    --data "name=google-logging" 
```
