### PR TITLE
Refactor gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,466 +1,540 @@
-'use strict'
+"use strict";
 
-var browserSync = require('browser-sync').create()
-var childProcess = require('child_process')
-var log = require('fancy-log')
-var del = require('del')
-var ghPages = require('gh-pages')
-var gulp = require('gulp')
-var path = require('path')
-var fs = require('fs')
-var sequence = require('run-sequence')
-var dev = false
+var browserSync = require("browser-sync").create();
+var childProcess = require("child_process");
+var log = require("fancy-log");
+var del = require("del");
+var ghPages = require("gh-pages");
+var gulp = require("gulp");
+var path = require("path");
+var fs = require("fs");
+var sequence = require("run-sequence");
+var dev = false;
 
 // load gulp plugins
-var $ = require('gulp-load-plugins')()
+var $ = require("gulp-load-plugins")();
 
 var paths = {
-  assets: './app/_assets/',
-  modules: './node_modules/',
-  dist: './dist/'
-}
+  assets: "./app/_assets/",
+  modules: "./node_modules/",
+  dist: "./dist/",
+};
 
 // Sources
 var sources = {
-  content: 'app/**/*.{markdown,md,html,txt,yml,yaml}',
-  styles: paths.assets + 'stylesheets/**/*',
+  content: "app/**/*.{markdown,md,html,txt,yml,yaml}",
+  styles: paths.assets + "stylesheets/**/*",
   js: [
-    paths.assets + 'javascripts/jquery-3.6.0.min.js',
-    paths.assets + 'javascripts/app.js',
-    paths.assets + 'javascripts/subscribe.js',
-    paths.assets + 'javascripts/editable-code-snippet.js',
-    paths.assets + 'javascripts/navbar.js',
-    paths.assets + 'javascripts/promo-banner.js',
-    paths.assets + 'javascripts/copy-code-snippet-support.js'
+    paths.assets + "javascripts/jquery-3.6.0.min.js",
+    paths.assets + "javascripts/app.js",
+    paths.assets + "javascripts/subscribe.js",
+    paths.assets + "javascripts/editable-code-snippet.js",
+    paths.assets + "javascripts/navbar.js",
+    paths.assets + "javascripts/promo-banner.js",
+    paths.assets + "javascripts/copy-code-snippet-support.js",
   ],
-  images: paths.assets + 'images/**/*',
+  images: paths.assets + "images/**/*",
   fonts: [
-    paths.modules + 'font-awesome/fonts/**/*.*',
-    paths.assets + 'fonts/*.*'
-  ]
-}
+    paths.modules + "font-awesome/fonts/**/*.*",
+    paths.assets + "fonts/*.*",
+  ],
+};
 
 // Destinations
 var dest = {
-  html: paths.dist + '**/*.html',
-  js: paths.dist + 'assets/app.js'
-}
+  html: paths.dist + "**/*.html",
+  js: paths.dist + "assets/app.js",
+};
 
-var reload = done => {
-  browserSync.reload()
-  done()
-}
+var reload = (done) => {
+  browserSync.reload();
+  done();
+};
 
 /* Functions
 --------------------------------------- */
 
 // Basic Tasks
 function css() {
-  return gulp.src(paths.assets + 'css/*.css')
-    .pipe(gulp.dest(paths.dist + 'assets'))
+  return gulp
+    .src(paths.assets + "css/*.css")
+    .pipe(gulp.dest(paths.dist + "assets"));
 }
 
 function styles() {
-  return gulp.src(paths.assets + 'stylesheets/index.less')
-    .pipe($.plumber())
-    .pipe($.if(dev, $.sourcemaps.init()))
-    .pipe($.less())
-    .pipe($.autoprefixer())
-    // .pipe($.purifycss([dest.html], {
-    //   whitelist: [
-    //     '.affix',
-    //     '.alert',
-    //     '.close',
-    //     '.collaps',
-    //     '.fade',
-    //     '.has',
-    //     '.help',
-    //     '.in',
-    //     '.modal',
-    //     '.open',
-    //     '.popover',
-    //     '.tooltip'
-    //   ]
-    // }))
-    .pipe($.cleanCss({ compatibility: 'ie8' }))
-    .pipe($.rename('styles.css'))
-    .pipe($.if(dev, $.sourcemaps.write()))
-    .pipe(gulp.dest(paths.dist + 'assets'))
-    .pipe($.size())
-    .pipe(browserSync.stream())
+  return (
+    gulp
+      .src(paths.assets + "stylesheets/index.less")
+      .pipe($.plumber())
+      .pipe($.if(dev, $.sourcemaps.init()))
+      .pipe($.less())
+      .pipe($.autoprefixer())
+      // .pipe($.purifycss([dest.html], {
+      //   whitelist: [
+      //     '.affix',
+      //     '.alert',
+      //     '.close',
+      //     '.collaps',
+      //     '.fade',
+      //     '.has',
+      //     '.help',
+      //     '.in',
+      //     '.modal',
+      //     '.open',
+      //     '.popover',
+      //     '.tooltip'
+      //   ]
+      // }))
+      .pipe($.cleanCss({ compatibility: "ie8" }))
+      .pipe($.rename("styles.css"))
+      .pipe($.if(dev, $.sourcemaps.write()))
+      .pipe(gulp.dest(paths.dist + "assets"))
+      .pipe($.size())
+      .pipe(browserSync.stream())
+  );
 }
 
 function js() {
-  return gulp.src(sources.js)
+  return gulp
+    .src(sources.js)
     .pipe($.plumber())
     .pipe($.if(dev, $.sourcemaps.init()))
-    .pipe($.concat('app.js'))
+    .pipe($.concat("app.js"))
     .pipe($.if(dev, $.sourcemaps.write()))
-    .pipe(gulp.dest('dist/assets'))
-    .pipe(browserSync.stream())
+    .pipe(gulp.dest("dist/assets"))
+    .pipe(browserSync.stream());
 }
 
 function js_min() {
-  return gulp.src(sources.js)
-  .pipe($.plumber())
-  .pipe($.if(dev, $.sourcemaps.init()))
-  .pipe($.minify({
-    noSource: true,
-    ext: {
-      min: '.js'
-    }
-  }))
-  .pipe($.concat('app.js'))
-  .pipe($.if(dev, $.sourcemaps.write()))
-  .pipe(gulp.dest('dist/assets'))
-  .pipe($.size())
-  .pipe(browserSync.stream())
+  return gulp
+    .src(sources.js)
+    .pipe($.plumber())
+    .pipe($.if(dev, $.sourcemaps.init()))
+    .pipe(
+      $.minify({
+        noSource: true,
+        ext: {
+          min: ".js",
+        },
+      })
+    )
+    .pipe($.concat("app.js"))
+    .pipe($.if(dev, $.sourcemaps.write()))
+    .pipe(gulp.dest("dist/assets"))
+    .pipe($.size())
+    .pipe(browserSync.stream());
 }
 
 function images() {
-  return gulp.src(sources.images)
+  return gulp
+    .src(sources.images)
     .pipe($.plumber())
-    .pipe(gulp.dest(paths.dist + 'assets/images'))
+    .pipe(gulp.dest(paths.dist + "assets/images"));
 }
 
 function images_min() {
-  return gulp.src(sources.images)
-  .pipe($.plumber())
-  .pipe($.imagemin())
-  .pipe(gulp.dest(paths.dist + 'assets/images'))
-  .pipe($.size())
+  return gulp
+    .src(sources.images)
+    .pipe($.plumber())
+    .pipe($.imagemin())
+    .pipe(gulp.dest(paths.dist + "assets/images"))
+    .pipe($.size());
 }
 
 function fonts() {
-  return gulp.src(sources.fonts)
+  return gulp
+    .src(sources.fonts)
     .pipe($.plumber())
-    .pipe(gulp.dest(paths.dist + 'assets/fonts'))
+    .pipe(gulp.dest(paths.dist + "assets/fonts"))
     .pipe($.size())
-    .pipe(browserSync.stream())
+    .pipe(browserSync.stream());
 }
 
 function jekyll(cb) {
-  var command = 'bundle exec jekyll build --config jekyll.yml --profile --destination ' + paths.dist
+  var command =
+    "bundle exec jekyll build --config jekyll.yml --profile --destination " +
+    paths.dist;
 
   childProcess.exec(command, function (err, stdout, stderr) {
-    log(stdout)
-    log(stderr)
-    cb(err)
-  })
+    log(stdout);
+    log(stderr);
+    cb(err);
+  });
 }
 
 function jekyll_dev(cb) {
-  var command = 'bundle exec jekyll build --config jekyll-dev.yml --profile --destination ' + paths.dist
+  var command =
+    "bundle exec jekyll build --config jekyll-dev.yml --profile --destination " +
+    paths.dist;
 
   childProcess.exec(command, function (err, stdout, stderr) {
-    log(stdout)
-    log(stderr)
-    cb(err)
-  })
+    log(stdout);
+    log(stderr);
+    cb(err);
+  });
 }
 
 function html() {
-  return gulp.src(paths.dist + '/**/*.html')
+  return gulp
+    .src(paths.dist + "/**/*.html")
     .pipe($.plumber())
     .pipe(gulp.dest(paths.dist))
-    .pipe($.size())
+    .pipe($.size());
 }
-
 
 // Lua Tasks
 function pdk_docs(cb) {
-  var KONG_PATH, KONG_VERSION,
-    navFilepath, doc, pdkRegex, newNav, newDoc,
-    cmd, obj, errLog,
-    refDir, modules,
-    gitSha1, confFilepath
+  var KONG_PATH,
+    KONG_VERSION,
+    navFilepath,
+    doc,
+    pdkRegex,
+    newNav,
+    newDoc,
+    cmd,
+    obj,
+    errLog,
+    refDir,
+    modules,
+    gitSha1,
+    confFilepath;
 
   // 0 Obtain "env-var params"
-  KONG_PATH = process.env.KONG_PATH
+  KONG_PATH = process.env.KONG_PATH;
   if (KONG_PATH === undefined) {
-    return cb('No KONG_PATH environment variable set')
+    return cb("No KONG_PATH environment variable set");
   }
 
-  KONG_VERSION = process.env.KONG_VERSION
+  KONG_VERSION = process.env.KONG_VERSION;
   if (KONG_VERSION === undefined) {
-    return cb('No KONG_VERSION environment variable set. Example: 0.14.x')
+    return cb("No KONG_VERSION environment variable set. Example: 0.14.x");
   }
 
   // 1. Update nav file
   // 1.1 Check that nav file exists
-  navFilepath = './app/_data/docs_nav_' + KONG_VERSION + '.yml'
+  navFilepath = "./app/_data/docs_nav_" + KONG_VERSION + ".yml";
   try {
-    doc = fs.readFileSync(navFilepath, 'utf8')
+    doc = fs.readFileSync(navFilepath, "utf8");
   } catch (err) {
-    return cb('Could not find the file ' + navFilepath + '. Err: ' + err)
+    return cb("Could not find the file " + navFilepath + ". Err: " + err);
   }
 
   // 1.2 Check that nav file has the correct yaml entry
-  pdkRegex = /[ ]+- text: Plugin Development Kit[\s\S]+\n-/gm
+  pdkRegex = /[ ]+- text: Plugin Development Kit[\s\S]+\n-/gm;
   if (!doc.match(pdkRegex)) {
-    return cb('Could not find the appropriate section in ' + navFilepath)
+    return cb("Could not find the appropriate section in " + navFilepath);
   }
 
   // 1.3 Generate new yaml using ldoc
-  cmd = 'LUA_PATH="$LUA_PATH;./?.lua" ' +
-        'ldoc -q -i --filter ldoc/filters.nav ' +
-        KONG_PATH + '/kong/pdk'
-  obj = childProcess.spawnSync(cmd, { shell: true })
+  cmd =
+    'LUA_PATH="$LUA_PATH;./?.lua" ' +
+    "ldoc -q -i --filter ldoc/filters.nav " +
+    KONG_PATH +
+    "/kong/pdk";
+  obj = childProcess.spawnSync(cmd, { shell: true });
   // ignore "unkwnown tag" errors
-  errLog = obj.stderr.toString().replace(/.*unknown tag.*\n/g, '')
+  errLog = obj.stderr.toString().replace(/.*unknown tag.*\n/g, "");
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
 
   // 1.4 Replace existing yaml with generated one
-  newNav = obj.stdout.toString()
-  newDoc = doc.replace(pdkRegex, newNav + '\n-')
-  fs.writeFileSync(navFilepath, newDoc)
-  log('Updated contents of ' + navFilepath + ' with new navigation items')
+  newNav = obj.stdout.toString();
+  newDoc = doc.replace(pdkRegex, newNav + "\n-");
+  fs.writeFileSync(navFilepath, newDoc);
+  log("Updated contents of " + navFilepath + " with new navigation items");
 
   // 2. Generate markdown docs using custom ldoc templates
   // 2.1 Prepare ref folder
-  refDir = 'app/' + KONG_VERSION + '/pdk'
-  cmd = 'rm -rf ' + refDir + ' && mkdir ' + refDir
-  obj = childProcess.spawnSync(cmd, { shell: true })
-  errLog = obj.stderr.toString()
+  refDir = "app/" + KONG_VERSION + "/pdk";
+  cmd = "rm -rf " + refDir + " && mkdir " + refDir;
+  obj = childProcess.spawnSync(cmd, { shell: true });
+  errLog = obj.stderr.toString();
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
 
   // 2.2 Obtain the list of modules in json form & parse it
-  cmd = 'LUA_PATH="$LUA_PATH;./?.lua" ' +
-        'ldoc -q -i --filter ldoc/filters.json ' +
-        KONG_PATH + '/kong/pdk'
-  obj = childProcess.spawnSync(cmd, { shell: true })
+  cmd =
+    'LUA_PATH="$LUA_PATH;./?.lua" ' +
+    "ldoc -q -i --filter ldoc/filters.json " +
+    KONG_PATH +
+    "/kong/pdk";
+  obj = childProcess.spawnSync(cmd, { shell: true });
   // ignore "unkwnown tag" errors
-  errLog = obj.stderr.toString().replace(/.*unknown tag.*\n/g, '')
+  errLog = obj.stderr.toString().replace(/.*unknown tag.*\n/g, "");
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
-  modules = JSON.parse(obj.stdout.toString())
+  modules = JSON.parse(obj.stdout.toString());
 
   // 2.3 For each module, generate its docs in markdown
   for (let module of modules) {
-    cmd = 'LUA_PATH="$LUA_PATH;./?.lua" ' +
-          'ldoc -q -c ldoc/config.ld ' +
-          module.file + ' && ' +
-          'mv ./' + module.generated_name + '.md ' + refDir + '/' +
-          module.name + '.md'
-    obj = childProcess.spawnSync(cmd, { shell: true })
-    errLog = obj.stderr.toString()
+    cmd =
+      'LUA_PATH="$LUA_PATH;./?.lua" ' +
+      "ldoc -q -c ldoc/config.ld " +
+      module.file +
+      " && " +
+      "mv ./" +
+      module.generated_name +
+      ".md " +
+      refDir +
+      "/" +
+      module.name +
+      ".md";
+    obj = childProcess.spawnSync(cmd, { shell: true });
+    errLog = obj.stderr.toString();
     if (errLog.length > 0) {
-      return cb(errLog)
+      return cb(errLog);
     }
   }
-  log('Re-generated PDK docs in ' + refDir)
+  log("Re-generated PDK docs in " + refDir);
 
   // 3 Write pdk_info yaml file
   // 3.1 Obtain git sha-1 hash of the current git log
-  cmd = 'pushd ' + KONG_PATH + ' > /dev/null; git rev-parse HEAD; popd > /dev/null'
-  obj = childProcess.spawnSync(cmd, { shell: true })
-  errLog = obj.stderr.toString()
+  cmd =
+    "pushd " + KONG_PATH + " > /dev/null; git rev-parse HEAD; popd > /dev/null";
+  obj = childProcess.spawnSync(cmd, { shell: true });
+  errLog = obj.stderr.toString();
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
-  gitSha1 = obj.stdout.toString().trim()
+  gitSha1 = obj.stdout.toString().trim();
 
   // 3.2 Write it into file
-  confFilepath = 'app/_data/pdk_info.yml'
-  fs.writeFileSync(confFilepath, 'sha1: ' + gitSha1 + '\n')
-  log('git SHA-1 (' + gitSha1 + ') written to ' + confFilepath)
+  confFilepath = "app/_data/pdk_info.yml";
+  fs.writeFileSync(confFilepath, "sha1: " + gitSha1 + "\n");
+  log("git SHA-1 (" + gitSha1 + ") written to " + confFilepath);
 }
 
 function admin_api_docs(cb) {
-  var KONG_PATH, KONG_VERSION, cmd, obj, errLog
+  var KONG_PATH, KONG_VERSION, cmd, obj, errLog;
 
   // 0 Obtain "env-var params"
-  KONG_PATH = process.env.KONG_PATH
+  KONG_PATH = process.env.KONG_PATH;
   if (KONG_PATH === undefined) {
-    return cb('No KONG_PATH environment variable set')
+    return cb("No KONG_PATH environment variable set");
   }
 
-  KONG_VERSION = process.env.KONG_VERSION
+  KONG_VERSION = process.env.KONG_VERSION;
   if (KONG_VERSION === undefined) {
-    return cb('No KONG_VERSION environment variable set. Example: 0.14.x')
+    return cb("No KONG_VERSION environment variable set. Example: 0.14.x");
   }
 
   // 1 Generate admin-api.md
-  cmd = 'resty autodoc-admin-api/run.lua'
-  obj = childProcess.spawnSync(cmd, { shell: true })
-  errLog = obj.stderr.toString()
+  cmd = "resty autodoc-admin-api/run.lua";
+  obj = childProcess.spawnSync(cmd, { shell: true });
+  errLog = obj.stderr.toString();
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
 
-  log('Re-generated Admin API docs for ' + KONG_VERSION)
+  log("Re-generated Admin API docs for " + KONG_VERSION);
 }
 
 function cli_docs(cb) {
-  var KONG_PATH, KONG_VERSION, cmd, obj, errLog
+  var KONG_PATH, KONG_VERSION, cmd, obj, errLog;
 
   // 0 Obtain "env-var params"
-  KONG_PATH = process.env.KONG_PATH
+  KONG_PATH = process.env.KONG_PATH;
   if (KONG_PATH === undefined) {
-    return cb('No KONG_PATH environment variable set')
+    return cb("No KONG_PATH environment variable set");
   }
 
-  KONG_VERSION = process.env.KONG_VERSION
+  KONG_VERSION = process.env.KONG_VERSION;
   if (KONG_VERSION === undefined) {
-    return cb('No KONG_VERSION environment variable set. Example: 1.0.x')
+    return cb("No KONG_VERSION environment variable set. Example: 1.0.x");
   }
 
   // 1 Generate cli.md
-  cmd = 'luajit autodoc-cli/run.lua'
-  obj = childProcess.spawnSync(cmd, { shell: true })
-  errLog = obj.stderr.toString()
+  cmd = "luajit autodoc-cli/run.lua";
+  obj = childProcess.spawnSync(cmd, { shell: true });
+  errLog = obj.stderr.toString();
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
 
-  log('Re-generated CLI docs for ' + KONG_VERSION)
+  log("Re-generated CLI docs for " + KONG_VERSION);
 }
 
 function conf_docs(cb) {
-  var KONG_PATH, KONG_VERSION, cmd, obj, errLog
+  var KONG_PATH, KONG_VERSION, cmd, obj, errLog;
 
   // 0 Obtain "env-var params"
-  KONG_PATH = process.env.KONG_PATH
+  KONG_PATH = process.env.KONG_PATH;
   if (KONG_PATH === undefined) {
-    return cb('No KONG_PATH environment variable set')
+    return cb("No KONG_PATH environment variable set");
   }
 
-  KONG_VERSION = process.env.KONG_VERSION
+  KONG_VERSION = process.env.KONG_VERSION;
   if (KONG_VERSION === undefined) {
-    return cb('No KONG_VERSION environment variable set. Example: 1.0.x')
+    return cb("No KONG_VERSION environment variable set. Example: 1.0.x");
   }
 
   // Generate configuration.md
-  cmd = 'luajit autodoc-conf/run.lua'
-  obj = childProcess.spawnSync(cmd, { shell: true })
-  errLog = obj.stderr.toString()
+  cmd = "luajit autodoc-conf/run.lua";
+  obj = childProcess.spawnSync(cmd, { shell: true });
+  errLog = obj.stderr.toString();
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
 
-  log('Re-generated Conf docs for ' + KONG_VERSION)
+  log("Re-generated Conf docs for " + KONG_VERSION);
 }
 
 function nav_docs(cb) {
-  var KONG_VERSION, cmd, obj, errLog
+  var KONG_VERSION, cmd, obj, errLog;
 
   // 0 Obtain "env-var params"
-  KONG_VERSION = process.env.KONG_VERSION
+  KONG_VERSION = process.env.KONG_VERSION;
   if (KONG_VERSION === undefined) {
-    return cb('No KONG_VERSION environment variable set. Example: 1.0.x')
+    return cb("No KONG_VERSION environment variable set. Example: 1.0.x");
   }
 
   // 1 Generate docs_nav_X.Y.x.yml
-  cmd = 'luajit autodoc-nav/run.lua'
-  obj = childProcess.spawnSync(cmd, { shell: true })
-  errLog = obj.stderr.toString()
+  cmd = "luajit autodoc-nav/run.lua";
+  obj = childProcess.spawnSync(cmd, { shell: true });
+  errLog = obj.stderr.toString();
   if (errLog.length > 0) {
-    return cb(errLog)
+    return cb(errLog);
   }
 
-  log('Re-generated navigation file for ' + KONG_VERSION)
+  log("Re-generated navigation file for " + KONG_VERSION);
 }
 
 // Custom Tasks
 function browser_sync(done) {
   browserSync.init({
-    logPrefix: ' ▶ ',
+    logPrefix: " ▶ ",
     minify: false,
     notify: false,
-    server: 'dist',
-    open: false
-  })
-  done()
+    server: "dist",
+    open: false,
+  });
+  done();
 }
 
 function gh_pages(cb) {
-  var cmd = 'git rev-parse --short HEAD'
+  var cmd = "git rev-parse --short HEAD";
 
   childProcess.exec(cmd, function (err, stdout, stderr) {
     if (err) {
-      cb(err)
+      cb(err);
     }
 
-    ghPages.publish(path.join(__dirname, paths.dist), {
-      message: 'Deploying ' + stdout + '(' + new Date().toISOString() + ')'
-    }, cb)
-  })
+    ghPages.publish(
+      path.join(__dirname, paths.dist),
+      {
+        message: "Deploying " + stdout + "(" + new Date().toISOString() + ")",
+      },
+      cb
+    );
+  });
 }
 
 function cloudflare(cb) {
   // configure cloudflare
-  var cloudflare = require('cloudflare').createClient({
+  var cloudflare = require("cloudflare").createClient({
     email: process.env.MASHAPE_CLOUDFLARE_EMAIL,
-    token: process.env.MASHAPE_CLOUDFLARE_TOKEN
-  })
+    token: process.env.MASHAPE_CLOUDFLARE_TOKEN,
+  });
 
-  cloudflare.clearCache('docs.getkong.com', function (err) {
+  cloudflare.clearCache("docs.getkong.com", function (err) {
     if (err) {
-      log(err.message)
+      log(err.message);
     }
 
-    cb()
-  })
+    cb();
+  });
 }
 
 function clean() {
-  ghPages.clean()
-  return del(['dist', '.gh-pages'])
+  ghPages.clean();
+  return del(["dist", ".gh-pages"]);
 }
 
 function watch_files() {
-  gulp.watch(sources.content, gulp.series(jekyll, html, reload))
-  gulp.watch(sources.styles, styles)
-  gulp.watch(sources.images, gulp.series(images, reload))
-  gulp.watch(sources.js, gulp.series(js, reload))
-  gulp.watch(paths.assets + 'css/hub.css', css)
+  gulp.watch(sources.content, gulp.series(jekyll, html, reload));
+  gulp.watch(sources.styles, styles);
+  gulp.watch(sources.images, gulp.series(images, reload));
+  gulp.watch(sources.js, gulp.series(js, reload));
+  gulp.watch(paths.assets + "css/hub.css", css);
 }
 
 function set_dev(cb) {
-  dev = true
-  cb()
+  dev = true;
+  cb();
 }
 
 /*----------------------------------------*/
 
 // Basic Tasks
-gulp.task("js", js)
-gulp.task("js_min", js_min)
-gulp.task("css", css)
-gulp.task("styles", styles)
-gulp.task("images", images)
-gulp.task("images_min", images_min)
-gulp.task("fonts", fonts)
-gulp.task("jekyll", jekyll)
-gulp.task("jekyll_dev", jekyll_dev)
-gulp.task("html", html)
+gulp.task("js", js);
+gulp.task("js_min", js_min);
+gulp.task("css", css);
+gulp.task("styles", styles);
+gulp.task("images", images);
+gulp.task("images_min", images_min);
+gulp.task("fonts", fonts);
+gulp.task("jekyll", jekyll);
+gulp.task("jekyll_dev", jekyll_dev);
+gulp.task("html", html);
 
 // Lua Tasks
-gulp.task("pdk_docs", pdk_docs)
-gulp.task("admin_api_docs", admin_api_docs)
-gulp.task("cli_docs", cli_docs)
-gulp.task("conf_docs", conf_docs)
-gulp.task("nav_docs", nav_docs)
+gulp.task("pdk_docs", pdk_docs);
+gulp.task("admin_api_docs", admin_api_docs);
+gulp.task("cli_docs", cli_docs);
+gulp.task("conf_docs", conf_docs);
+gulp.task("nav_docs", nav_docs);
 
 // Custom Tasks
-gulp.task("browser_sync", browser_sync)
-gulp.task("gh_pages", gh_pages)
-gulp.task("cloudflare", cloudflare)
-gulp.task("set_dev", set_dev)
-
+gulp.task("browser_sync", browser_sync);
+gulp.task("gh_pages", gh_pages);
+gulp.task("cloudflare", cloudflare);
+gulp.task("set_dev", set_dev);
 
 // Gulp Commands
-gulp.task("build", gulp.series(gulp.parallel(js, images, fonts, css), jekyll, html, styles))
+gulp.task(
+  "build",
+  gulp.series(gulp.parallel(js, images, fonts, css), jekyll, html, styles)
+);
 
-gulp.task("watch", gulp.series(browser_sync, watch_files))
+gulp.task("watch", gulp.series(browser_sync, watch_files));
 
-gulp.task("dev", gulp.series(set_dev, clean, gulp.parallel(js, images, fonts, css), jekyll, html, styles, browser_sync, watch_files))
+gulp.task(
+  "dev",
+  gulp.series(
+    set_dev,
+    clean,
+    gulp.parallel(js, images, fonts, css),
+    jekyll,
+    html,
+    styles,
+    browser_sync,
+    watch_files
+  )
+);
 
-gulp.task('default', gulp.series(clean, gulp.parallel(js, images, fonts, css), jekyll_dev, html, styles, browser_sync, watch_files))
+gulp.task(
+  "default",
+  gulp.series(
+    clean,
+    gulp.parallel(js, images, fonts, css),
+    jekyll_dev,
+    html,
+    styles,
+    browser_sync,
+    watch_files
+  )
+);
 
-gulp.task("deploy", gulp.series(gulp.parallel(js_min, images_min, fonts, css), jekyll, html, styles, gh_pages))
+gulp.task(
+  "deploy",
+  gulp.series(
+    gulp.parallel(js_min, images_min, fonts, css),
+    jekyll,
+    html,
+    styles,
+    gh_pages
+  )
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,6 @@ var ghPages = require("gh-pages");
 var gulp = require("gulp");
 var path = require("path");
 var fs = require("fs");
-var sequence = require("run-sequence");
 var dev = false;
 
 // load gulp plugins
@@ -62,36 +61,18 @@ function css() {
 }
 
 function styles() {
-  return (
-    gulp
-      .src(paths.assets + "stylesheets/index.less")
-      .pipe($.plumber())
-      .pipe($.if(dev, $.sourcemaps.init()))
-      .pipe($.less())
-      .pipe($.autoprefixer())
-      // .pipe($.purifycss([dest.html], {
-      //   whitelist: [
-      //     '.affix',
-      //     '.alert',
-      //     '.close',
-      //     '.collaps',
-      //     '.fade',
-      //     '.has',
-      //     '.help',
-      //     '.in',
-      //     '.modal',
-      //     '.open',
-      //     '.popover',
-      //     '.tooltip'
-      //   ]
-      // }))
-      .pipe($.cleanCss({ compatibility: "ie8" }))
-      .pipe($.rename("styles.css"))
-      .pipe($.if(dev, $.sourcemaps.write()))
-      .pipe(gulp.dest(paths.dist + "assets"))
-      .pipe($.size())
-      .pipe(browserSync.stream())
-  );
+  return gulp
+    .src(paths.assets + "stylesheets/index.less")
+    .pipe($.plumber())
+    .pipe($.if(dev, $.sourcemaps.init()))
+    .pipe($.less())
+    .pipe($.autoprefixer())
+    .pipe($.cleanCss({ compatibility: "ie8" }))
+    .pipe($.rename("styles.css"))
+    .pipe($.if(dev, $.sourcemaps.write()))
+    .pipe(gulp.dest(paths.dist + "assets"))
+    .pipe($.size())
+    .pipe(browserSync.stream());
 }
 
 function js() {


### PR DESCRIPTION
### Review
@lena-larionova @falondarville 

### Summary
Refactor the `gulpfile` to reduce duplication and provide predictable builds

### Reason
Whilst running `make run` without any arguments I noticed that the first time the build ran `jekyll_dev`, but when I changed a file it ran `jekyll` without the dev profile. This is due to `watch_files` being hardcoded to run `jekyll`.

I started to add a `watch_files_dev` method but noticed a lot of duplication within the methods and decided to take another route and dynamically decide what to run based on the value of the `dev` variable that is used elsewhere.

Whilst refactoring I noticed that other methods were almost exact copies (e.g. `js` and `js_min`, `images` and `images_min`). By using the `dev` variable I could combine these methods and only run the minification tasks when `dev` was not `true`.

Finally, I noticed that the tasks used to run various builds were almost identical:

```javascript
gulp.task("build", gulp.series(gulp.parallel(js, images, fonts, css), jekyll, html, styles))
gulp.task("watch", gulp.series(browser_sync, watch_files))
gulp.task("dev", gulp.series(set_dev, clean, gulp.parallel(js, images, fonts, css), jekyll, html, styles, browser_sync, watch_files))
gulp.task('default', gulp.series(clean, gulp.parallel(js, images, fonts, css), jekyll_dev, html, styles, browser_sync, watch_files))
gulp.task("deploy", gulp.series(gulp.parallel(js_min, images_min, fonts, css), jekyll, html, styles, gh_pages))
```

It would be easy for any of these to get out of sync as new tasks were added. In order to resolve this I added a function that runs all of the standard tasks, and optionally runs any method before the standard tasks (e.g. `set_dev`) and after (e.g. `browser_sync`, `watch_files`). This method can also be used for deployments:

```javascript
// The first parameter is a list of tasks to run before the build
// The second is a list of tasks to run after the build
// To opt out of adding any tasks pre/post, you can pass in null

gulp.task("default", build_site([set_dev], [browser_sync, watch_files]));
gulp.task("dev", build_site([set_dev], [browser_sync, watch_files]));
gulp.task("prod", build_site(null, [browser_sync, watch_files]));
gulp.task("build", build_site());
gulp.task("deploy", build_site(null, [gh_pages]));
```

### Testing
Run `make run` and ensure that your existing workflow is not broken. You may optionally run any of the additional tasks such as `gulp images` or `gulp images_min` that you need.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
