### PR TITLE
Add testing framework

### DIFF
--- a/.github/workflows/run-smoke-tests.yml
+++ b/.github/workflows/run-smoke-tests.yml
@@ -1,0 +1,52 @@
+name: Run Smoke Tests
+on:
+  pull_request:
+    types: [synchronize, ready_for_review, opened]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+
+      # Configure Ruby to build Jekyll site
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+      - name: Ruby gem cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle Setup
+        run: bundle config path ${{ github.workspace }}/vendor/bundle
+      - name: Bundle Install
+        run: bundle install --jobs 4 --retry 3
+
+      # Configure Node to build assets
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      # Build the Docs
+      - name: Build Docs
+        run: |
+          npm ci
+          ./node_modules/.bin/gulp build
+
+      - name: Run tests
+        run: |
+          make rspec

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,12 @@ gem "jekyll-redirect-from"
 gem "rouge", "3.26.0"
 gem "liquid-c"
 gem "jekyll-include-cache"
+
+group :development do
+  gem "rspec"
+  gem "capybara"
+  gem "rack-jekyll"
+  gem "puma"
+  gem "pry"
+  gem "apparition"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,21 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    apparition (0.6.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
+    capybara (3.35.3)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    coderay (1.1.3)
     colorator (1.1.0)
     concurrent-ruby (1.1.9)
+    diff-lcs (1.4.4)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -44,35 +57,80 @@ GEM
     liquid (4.0.3)
     liquid-c (4.0.0)
       liquid (>= 3.0.0)
-    listen (3.5.1)
+    listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    method_source (1.0.0)
+    mini_mime (1.1.0)
+    mini_portile2 (2.6.1)
+    nio4r (2.5.8)
+    nokogiri (1.12.2)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
+    puma (5.4.0)
+      nio4r (~> 2.0)
+    racc (1.5.2)
+    rack (1.6.13)
+    rack-jekyll (0.5.0)
+      jekyll (>= 1.3)
+      listen (>= 1.3)
+      rack (~> 1.5)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.1.1)
     rexml (3.2.5)
     rouge (3.26.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  apparition
+  capybara
   jekyll (= 4.2.0)
   jekyll-include-cache
   jekyll-redirect-from
   kramdown-parser-gfm
   liquid-c
+  pry
+  puma
+  rack-jekyll
   rouge (= 3.26.0)
+  rspec
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ run: install
 	-chmod -R 777 dist
 	gulp
 
+build: install
+	-chmod -R 777 dist
+	./node_modules/.bin/gulp build
+
 # Brings up a docker container and starts a doc site instance on
 # http://localhost:3000.
 develop:
@@ -36,6 +40,9 @@ clean:
 # Runs tests using the npm standard and echint linters.
 test: install
 	npm test
+
+rspec: install
+	bundle exec rspec
 
 # Starts a docker container in the background.
 background-docker-up:

--- a/README.md
+++ b/README.md
@@ -150,3 +150,24 @@ git push
 ```
 
 Then open a pull request against `release/2.4`.
+
+## Testing
+
+Tests for this site are written using `rspec` and `capybara` with the `apparition` driver.
+
+> You'll need Google Chrome installed to run these tests
+
+To run the tests, you must first build the site by running `make build` before running `make rspec`
+
+Many of the tests are smoke tests to check issues that occurred whilst adding caching to the site, such as ensuring that the side navigation isn't cached.
+
+To add your own tests, look in the `spec` directory and use `home_spec.rb` as a sample. You specify which URL to visit and then a CSS selector to search for, before asserting that the contents match what you expect.
+
+```ruby
+it "has the 'Welcome to Kong' header" do
+  visit "/"
+  expect(find(".landing-page h1").text).to eq("Welcome to Kong Docs")
+end
+```
+
+This test framework can also be used to test behaviour added with JavaScript, but we do not have any examples at this time

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   publish = "dist"
   command = "gulp build"
-  environment = { NODE_OPTIONS = "--max_old_space_size=8192" }
+  environment = { BUNDLE_WITHOUT = "development", NODE_OPTIONS = "--max_old_space_size=8192" }

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -1,0 +1,32 @@
+describe "breadcrumbs", type: :feature, js: true do
+  describe "Gateway OSS", type: :feature, js: true do
+    it "renders the index page breadcrumbs correctly" do
+      visit "/gateway-oss/"
+      expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("OPEN SOURCE")
+      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway (OSS)")
+    end
+
+    it "renders nested breadcrumbs correctly" do
+      visit "/gateway-oss/2.5.x/plugin-development/custom-entities/"
+      expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("OPEN SOURCE")
+      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway (OSS)")
+      expect(find(".breadcrumb-item:nth-of-type(3)").text).to eq("Plugin development")
+    end
+  end
+
+  describe "decK", type: :feature, js: true do
+    it "renders the index page breadcrumbs correctly" do
+      visit "/deck/"
+      expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("OPEN SOURCE")
+      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("decK")
+    end
+  end
+
+  describe "Gateway Enterprise", type: :feature, js: true do
+    it "renders the index page breadcrumbs correctly" do
+      visit "/enterprise/"
+      expect(find(".breadcrumb-item:nth-of-type(1)").text).to eq("KONG KONNECT PLATFORM")
+      expect(find(".breadcrumb-item:nth-of-type(2)").text).to eq("Kong Gateway (Enterprise)")
+    end
+  end
+end

--- a/spec/home_spec.rb
+++ b/spec/home_spec.rb
@@ -1,0 +1,11 @@
+describe "homepage", type: :feature, js: true do
+  it "has the 'Welcome to Kong' header" do
+    visit "/"
+    expect(find(".landing-page h1").text).to eq("Welcome to Kong Docs")
+  end
+
+  it "shows the blue promo banner", js: true do
+    visit "/"
+    expect(page).to have_selector("#promo-banner", visible: true)
+  end
+end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,31 @@
+describe "plugins", type: :feature, js: true do
+  it "renders the plugin card CSS correctly" do
+    # This means that hub.css has been included
+    visit "/hub/"
+    expect(first(".plugin-card")).to match_style("display" => "flex")
+  end
+
+  # These tests ensure that the generated samples are correct
+  # We had a caching issue previously where they all showed the same information
+  describe "shows the correct sample", type: :feature, js: true do
+
+    # Set a baseline on a common plugin (basic-auth)
+    it "basic-auth (kong inc)" do
+      visit "/hub/kong-inc/basic-auth/"
+      expect(first(".navtab-content").text).to include('--data "name=basic-auth"')
+    end
+
+    # Make sure that a different plugin shows the correct name too
+    # In case we cached basic-auth by coincidence
+    it "cors (kong inc)" do
+      visit "/hub/kong-inc/cors/"
+      expect(first(".navtab-content").text).to include('--data "name=cors"')
+    end
+
+    # Show a community contributed plugin too
+    it "salt (community)" do
+      visit "/hub/salt/salt/"
+      expect(first(".content").text).to include('--data "name=salt-agent" \\')
+    end
+  end
+end

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -1,0 +1,59 @@
+describe "sidebar", type: :feature, js: true do
+  describe "Version Switcher", type: :feature, js: true do
+    it "links to the same page if it exists in previous versions" do
+      visit "/enterprise/2.5.x/deployment/installation/docker/"
+      # Open up the navigation
+      first("#version-dropdown").click
+      expect(first('a[data-version-id="2.1.x"]')[:href]).to end_with('/enterprise/2.1.x/deployment/installation/docker/')
+    end
+
+    it "links to the root page if the page does not exist in previous versions" do
+      visit "/enterprise/2.5.x/deployment/installation/docker/"
+      # Open up the navigation
+      first("#version-dropdown").click
+      expect(first('a[data-version-id="0.34-x"]')[:href]).to end_with('/enterprise/0.34-x')
+    end
+  end
+
+  describe "Outdated version documentation", type: :feature, js: true do
+
+    # If the test is failing, make sure this is the latest version
+    latest_version = "2.5.x"
+
+    it "does not show on the latest version" do
+      visit "/enterprise/#{latest_version}/deployment/installation/docker/"
+      expect(page).not_to have_selector(".alert.alert-warning a", visible: true)
+    end
+
+    it "links to the same page" do
+      visit "/enterprise/2.1.x/deployment/installation/docker/"
+      expect(first('.alert.alert-warning a')[:href]).to end_with("/enterprise/#{latest_version}/deployment/installation/docker/")
+    end
+
+    it "links to the root when the page no longer exists" do
+      visit "/enterprise/0.31-x/postgresql-redhat/"
+      expect(first('.alert.alert-warning a')[:href]).to end_with("/enterprise/")
+    end
+  end
+
+  describe "Gateway OSS", type: :feature, js: true do
+    it "has the correct number of sidebar sections" do
+      visit "/gateway-oss/"
+      expect(page).to have_selector('.accordion-container > .accordion-item', count: 6)
+    end
+  end
+
+  describe "decK", type: :feature, js: true do
+    it "has the correct number of sidebar sections" do
+      visit "/deck/"
+      expect(page).to have_selector('.accordion-container > .accordion-item', count: 6)
+    end
+  end
+
+  describe "Gateway Enterprise", type: :feature, js: true do
+    it "has the correct number of sidebar sections" do
+      visit "/enterprise/"
+      expect(page).to have_selector('.accordion-container > .accordion-item', count: 11)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+# Require all of the necessary gems
+require "rspec"
+require "capybara/rspec"
+require "rack/jekyll"
+require "rack/test"
+require "pry"
+require "capybara/apparition"
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  # Configure Capybara to load the website through rack-jekyll.
+  # (force_build: true) builds the site before the tests are run,
+  # so our tests are always running against the latest version
+  # of our jekyll site.
+
+  Capybara.server = :puma, { Silent: true }
+
+  Capybara.register_driver :apparition do |app|
+    Capybara::Apparition::Driver.new(app, { :headless => true, :window_size => [1366, 768] })
+  end
+  Capybara.javascript_driver = :apparition
+  Capybara.app = Rack::Jekyll.new(force_build: false, config: "jekyll.yml")
+end


### PR DESCRIPTION
### Review
@lena-larionova 

### Summary
Add an automated test framework to ensure that we're not breaking any key functionality whilst refactoring.

### Reason
I broke the site multiple times whilst adding the `include_cached` gem.

* During the initial PR (#3003)
  * Sidebar was cached unintentionally
  * Breadcrumbs were cached unintentionally
  * The plugin hub CSS file wasn't loaded due to `head.html` being cached
  * Active state was being cached (this was solved with Javascript)
* Promo banner wasn't showing on the homepage (#3027)
* Plugin configuration instructions were all showing the same plugin instructions (#3030)

Tests have been added to cover all of these cases

### Testing
Run the tests locally. See the `Testing` section in the README.
The tests are automatically run on GitHub Actions too

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
