### PR TITLE
Fix broken link in Shared Config doc

### DIFF
--- a/app/konnect/shared-config/index.md
+++ b/app/konnect/shared-config/index.md
@@ -29,7 +29,7 @@ view all plugins in the cluster, including service and route plugins.
 in the cluster, as applicable, and consumer-scoped plugins only apply to a
 specific consumer.
 
-: [Configure global and consumer-scoped plugins &gt;](/konnect/shared-config/plugins)
+: [Configure global and consumer-scoped plugins &gt;](/konnect/manage-plugins/shared-config/)
 : [Plugin object reference &gt;](/enterprise/latest/admin-api/#plugin-object)
 : [Plugin Hub &gt;](/hub/)
 


### PR DESCRIPTION
### Summary
Fixing a link that the link checker flagged as broken.

### Reason
Broken link.

### Testing
https://deploy-preview-3046--kongdocs.netlify.app/konnect/shared-config/