### PR TITLE
Styling changes to links, tables, and code syntax

### DIFF
--- a/app/_assets/stylesheets/accordion.less
+++ b/app/_assets/stylesheets/accordion.less
@@ -37,7 +37,7 @@
       color: @color-text;
 
       &:hover {
-        color: @blue;
+        color: @blue-500;
       }
     }
 

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -197,16 +197,15 @@ code {
 }
 
 a {
-  color: @blue;
+  color: @blue-500;
   text-decoration: none;
 
   &:hover {
-    color: @blue - 30%;
+    color: @blue-500 - 30%;
   }
 
   code {
-    color: @blue;
-    background-color: #ebf7ff;
+    color: @blue-500;
   }
 }
 
@@ -306,7 +305,7 @@ nav {
 
     &:active,
     &.active {
-      color: @blue;
+      color: @blue-500;
     }
   }
 }

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -3,10 +3,8 @@
   margin-bottom: 1.5rem;
 
     &.codeblock {
-      background-color: @grey-100;
-      border-bottom: 1px solid @grey-200;
-      border-left: 1px solid @grey-200;
-      border-right: 1px solid @grey-200;
+      background-color: @grey-200;
+      border: 1px solid @grey-200;
       border-radius: 3px;
       line-height: 24px;
 
@@ -75,14 +73,14 @@
         width: 100%;
         left: 0;
         top: 100%;
-        background: @blue;
+        background: @blue-500;
         height: 2px;
         transition: opacity 0.2s;
       }
 
       &.active {
         opacity: 1;
-        color: @blue;
+        color: @blue-500;
         cursor: text;
 
         &::after {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -547,7 +547,7 @@
 
         a {
           font-size: 14px;
-          color: @blue;
+          color: @blue-500;
 
             img, i {
               float: left;
@@ -637,7 +637,7 @@
 
   a {
     font-size: 14px;
-    color: @blue;
+    color: @blue-500;
 
     &:hover {
     opacity: 0.5;
@@ -650,7 +650,7 @@
 
   table {
     a {
-      color: @blue;
+      color: @blue-500;
     }
   }
 }
@@ -773,7 +773,7 @@
   h5,
   h6 {
     .font-source-sans();
-    color: #505659;
+    color: @font-color;
   }
 
   h1,
@@ -859,10 +859,10 @@
 
   a {
     text-decoration: none;
-    color: @blue;
+    color: @blue-500;
 
     &:hover, &:focus {
-      text-decoration: none;
+      text-decoration: underline;
       opacity: 0.7;
     }
   }
@@ -941,10 +941,11 @@ Generic Styling for Desktop
   table {
     display: block;
     max-width: 100%;
-    font-size: 14px;
+    font-size: 16px;
     overflow-x: auto;
     border: none;
     border-collapse: collapse;
+    border-radius: 3px;
     margin-top: 1.5em;
     position: relative;
 
@@ -962,6 +963,13 @@ Generic Styling for Desktop
     code {
       white-space: normal;
       font-size: 13px;
+      background-color: #fff;
+      border: 1px solid @steel-200;
+    }
+
+    a {
+      text-decoration: none;
+      color: @blue-500;
     }
   }
 
@@ -975,20 +983,35 @@ Generic Styling for Desktop
 
   th {
     font-weight: 600;
+    font-size: 15px;
     color: @black-80;
-    background-color: @grey-100;
+    background-color: #fff;
+    padding: 8px 16px 8px;
+    border-bottom: 2px solid @steel-200;
+    border-top: none;
     position: -webkit-sticky;
     position: sticky;
+    vertical-align: bottom;
     top: 0;
     z-index: 2;
+    text-transform: uppercase;
   }
 
-  td,
-  th {
+  td {
     padding: 8px 16px 8px;
-    border-bottom: 1px solid @grey-300;
-    border-top: 1px solid @grey-300;
   }
+
+  tr:nth-child(even) {
+    background-color: @steel-080;
+    border: 1px solid @steel-100;
+  }
+
+  tr:nth-child(odd) {
+    background-color: @steel-100;
+    border: 1px solid @steel-100;
+  }
+
+
 
   @media only screen and (max-width: 1099px) {
     table,
@@ -1009,14 +1032,14 @@ Generic Styling for Desktop
       }
 
       tr {
-        border-top: 1px solid @grey-300;
-        border-bottom: 1px solid @grey-300;
+        border-top: 1px solid @steel-200;
+        border-bottom: 1px solid @steel-200;
       }
 
       td {
         /* Behave  like a "row" */
         border: none;
-        border-bottom: 1px solid @grey-300;
+        border-bottom: 1px solid @steel-200;
         position: relative;
       }
 
@@ -1199,7 +1222,7 @@ Generic Styling for Desktop
 
     a {
       text-decoration: none;
-      color: @blue-light;
+      color: @blue-500;
     }
 
     &.condensed {
@@ -1463,7 +1486,6 @@ Generic Styling for Desktop
     font-size: 14px;
     border-radius: 3px;
     display: block;
-    background-color: @gray-light;
     border: 1px solid @gray;
 
     &:before {
@@ -1681,9 +1703,9 @@ Generic Styling for Desktop
       color: @navy-text;
 
       &:hover {
-        color: #1155cb;
+        color: @blue-500;
         opacity: 1;
-        text-decoration: none;
+        text-decoration: underline;
       }
     }
   }

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -430,8 +430,8 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: #b3dfff;
-    outline: 1px solid #b3dfff;
+    background-color: @blue-200;
+    outline: 1px solid @blue-200;
   }
 
   ul.items {
@@ -646,7 +646,8 @@
             }
 
             &:hover {
-            color: #1155cb;
+            color: @blue-500;
+            text-decoration: underline;
             }
           }
         }
@@ -709,8 +710,8 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: #b3dfff;
-    outline: 1px solid #b3dfff;
+    background-color: @blue-200;
+    outline: 1px solid @blue-200;
   }
 
   @media screen and (min-width: 1301px) {

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -126,15 +126,6 @@
         margin-top: 2em;
         margin-bottom: 2em;
     }
-
-    table {
-      p {
-        font-size: 14px;
-      }
-      code {
-        font-size: 13px;
-      }
-    }
   }
 
   .alert-info {

--- a/app/_assets/stylesheets/syntax.less
+++ b/app/_assets/stylesheets/syntax.less
@@ -1,17 +1,17 @@
 //.highlight { background-color: #ffffcc }
 .c { color: #999988; font-style: italic } /* Comment */
-.err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.err { color: #a61717; } /* Error */
 .k { color: #000000; font-weight: bold } /* Keyword */
 .o { color: #000000; font-weight: bold } /* Operator */
 .cm { color: #999988; font-style: italic } /* Comment.Multiline */
 .cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
 .c1 { color: #999988; font-style: italic } /* Comment.Single */
 .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-.gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.gd { color: #000000; } /* Generic.Deleted */
 .ge { color: #000000; font-style: italic } /* Generic.Emph */
 .gr { color: #aa0000 } /* Generic.Error */
 .gh { color: #999999 } /* Generic.Heading */
-.gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.gi { color: #000000;} /* Generic.Inserted */
 .go { color: #888888 } /* Generic.Output */
 .gp { color: #555555 } /* Generic.Prompt */
 .gs { font-weight: bold } /* Generic.Strong */
@@ -24,16 +24,16 @@
 .kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
 .kt { color: #445588; font-weight: bold } /* Keyword.Type */
 .m { color: #009999 } /* Literal.Number */
-.s { color: #d01040 } /* Literal.String */
+.s { color: #6e30bf } /* Literal.String */
 .na { color: #008080 } /* Name.Attribute */
 .nb { color: #0086B3 } /* Name.Builtin */
 .nc { color: #445588; font-weight: bold } /* Name.Class */
 .no { color: #008080 } /* Name.Constant */
 .nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
 .ni { color: #800080 } /* Name.Entity */
-.ne { color: #990000; font-weight: bold } /* Name.Exception */
-.nf { color: #990000; font-weight: bold } /* Name.Function */
-.nl { color: #990000; font-weight: bold } /* Name.Label */
+.ne { color: #450498; font-weight: bold } /* Name.Exception */
+.nf { color: #450498; font-weight: bold } /* Name.Function */
+.nl { color: #450498; font-weight: bold } /* Name.Label */
 .nn { color: #555555 } /* Name.Namespace */
 .nt { color: #000080 } /* Name.Tag */
 .nv { color: #008080 } /* Name.Variable */
@@ -43,16 +43,16 @@
 .mh { color: #009999 } /* Literal.Number.Hex */
 .mi { color: #009999 } /* Literal.Number.Integer */
 .mo { color: #009999 } /* Literal.Number.Oct */
-.sb { color: #d01040 } /* Literal.String.Backtick */
-.sc { color: #d01040 } /* Literal.String.Char */
-.sd { color: #d01040 } /* Literal.String.Doc */
-.s2 { color: @red } /* Literal.String.Double */
-.se { color: #d01040 } /* Literal.String.Escape */
-.sh { color: #d01040 } /* Literal.String.Heredoc */
-.si { color: #d01040 } /* Literal.String.Interpol */
-.sx { color: #d01040 } /* Literal.String.Other */
+.sb { color: #6e30bf } /* Literal.String.Backtick */
+.sc { color: #6e30bf } /* Literal.String.Char */
+.sd { color: #6e30bf } /* Literal.String.Doc */
+.s2 { color: #6e30bf } /* Literal.String.Double */
+.se { color: #6e30bf } /* Literal.String.Escape */
+.sh { color: #6e30bf } /* Literal.String.Heredoc */
+.si { color: #6e30bf } /* Literal.String.Interpol */
+.sx { color: #6e30bf } /* Literal.String.Other */
 .sr { color: #009926 } /* Literal.String.Regex */
-.s1 { color: #d01040 } /* Literal.String.Single */
+.s1 { color: #6e30bf } /* Literal.String.Single */
 .ss { color: #990073 } /* Literal.String.Symbol */
 .bp { color: #999999 } /* Name.Builtin.Pseudo */
 .vc { color: #008080 } /* Name.Variable.Class */

--- a/app/_assets/stylesheets/syntax.less
+++ b/app/_assets/stylesheets/syntax.less
@@ -23,12 +23,12 @@
 .kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
 .kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
 .kt { color: #445588; font-weight: bold } /* Keyword.Type */
-.m { color: #009999 } /* Literal.Number */
+.m { color: #024aca } /* Literal.Number */
 .s { color: #6e30bf } /* Literal.String */
-.na { color: #008080 } /* Name.Attribute */
-.nb { color: #0086B3 } /* Name.Builtin */
+.na { color: #015c80 } /* Name.Attribute */
+.nb { color: #005c7c } /* Name.Builtin */
 .nc { color: #445588; font-weight: bold } /* Name.Class */
-.no { color: #008080 } /* Name.Constant */
+.no { color: #015c80 } /* Name.Constant */
 .nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
 .ni { color: #800080 } /* Name.Entity */
 .ne { color: #450498; font-weight: bold } /* Name.Exception */
@@ -36,13 +36,13 @@
 .nl { color: #450498; font-weight: bold } /* Name.Label */
 .nn { color: #555555 } /* Name.Namespace */
 .nt { color: #000080 } /* Name.Tag */
-.nv { color: #008080 } /* Name.Variable */
+.nv { color: #015c80 } /* Name.Variable */
 .ow { color: #000000; font-weight: bold } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #009999 } /* Literal.Number.Float */
-.mh { color: #009999 } /* Literal.Number.Hex */
-.mi { color: #009999 } /* Literal.Number.Integer */
-.mo { color: #009999 } /* Literal.Number.Oct */
+.mf { color: #024aca } /* Literal.Number.Float */
+.mh { color: #024aca } /* Literal.Number.Hex */
+.mi { color: #024aca } /* Literal.Number.Integer */
+.mo { color: #024aca } /* Literal.Number.Oct */
 .sb { color: #6e30bf } /* Literal.String.Backtick */
 .sc { color: #6e30bf } /* Literal.String.Char */
 .sd { color: #6e30bf } /* Literal.String.Doc */
@@ -55,10 +55,10 @@
 .s1 { color: #6e30bf } /* Literal.String.Single */
 .ss { color: #990073 } /* Literal.String.Symbol */
 .bp { color: #999999 } /* Name.Builtin.Pseudo */
-.vc { color: #008080 } /* Name.Variable.Class */
-.vg { color: #008080 } /* Name.Variable.Global */
-.vi { color: #008080 } /* Name.Variable.Instance */
-.il { color: #009999 } /* Literal.Number.Integer.Long */
+.vc { color: #015c80 } /* Name.Variable.Class */
+.vg { color: #015c80 } /* Name.Variable.Global */
+.vi { color: #015c80 } /* Name.Variable.Instance */
+.il { color: #024aca } /* Literal.Number.Integer.Long */
 
 /* Disable selecting $ prompt, e.g. shell curl call docs */
 .gp {

--- a/app/_assets/stylesheets/variables.less
+++ b/app/_assets/stylesheets/variables.less
@@ -43,7 +43,7 @@
 // Colors
 // -------------------------
 
-@font-color: #505659;
+@font-color: #494E50;
 @light-gray: #5c6266;
 @middle-gray: #45494d;
 @dark-gray: #323638;
@@ -132,7 +132,9 @@
 @blue-600: #083c99;
 @blue-700: #0a2b66;
 
-@steel-100: #f0f4fa;
+@steel-080: #fafbfd;
+@steel-090: #f3f6fb;
+@steel-100: #eff2f8;
 @steel-200: #dae3f2;
 @steel-300: #a3b6d9;
 @steel-400: #7d91b3;


### PR DESCRIPTION
### Review
@falondarville 

### Summary
* Add underlines to links (ADA guidelines) in body text. This does not include the navigation.
* Consistent link colors - matching the landing page
* Syntax highlighting uses purple instead of red
* Add even/odd rules to tables to separate rows more clearly
* Change scrollbar color for consistency - was a light blue tone that doesn't go with anything else
* Slightly raise contrast on font color

### Reason
Various tickets and accessibility guidelines.
https://konghq.atlassian.net/browse/DOCU-204

### Testing
Tested with ADA contrast checker and with chrome dev tools.

Lots of tables: https://deploy-preview-3049--kongdocs.netlify.app/konnect-platform/compatibility/plugins/
* Resize the screen to mobile size to see how the tables react - previously, they were fully white and nearly unreadable on mobile.
* Hover over any links in the text to see the link underlines + a bolder blue
* Content font color is very slightly darker, just enough to provide adequate contrast for ADA guidelines when it appears in tables

Lots of syntax highlighting: https://deploy-preview-3049--kongdocs.netlify.app/enterprise/2.4.x/admin-api/


