### PR TITLE
Update vitals reports time limit

### DIFF
--- a/app/enterprise/2.4.x/vitals/vitals-reports.md
+++ b/app/enterprise/2.4.x/vitals/vitals-reports.md
@@ -28,7 +28,7 @@ To create a time-series report containing Vitals data, complete the steps in thi
 
 1. On the Vitals view, click the **Reports** button.
 
-2. On the Reports page select the **Timeframe**, up to 12 hours, for which you want to create the report.
+2. On the Reports page select the **Timeframe**, up to 3 years, for which you want to create the report.
 
 3. Select the report criteria for the report:
 

--- a/app/enterprise/2.4.x/vitals/vitals-reports.md
+++ b/app/enterprise/2.4.x/vitals/vitals-reports.md
@@ -28,7 +28,7 @@ To create a time-series report containing Vitals data, complete the steps in thi
 
 1. On the Vitals view, click the **Reports** button.
 
-2. On the Reports page select the **Timeframe**, up to 3 years, for which you want to create the report.
+2. On the Reports page select the **Timeframe** for which you want to create the report.
 
 3. Select the report criteria for the report:
 


### PR DESCRIPTION
### Summary
The time limit for Vitals Reports was up to 12 hours but has been updated to up to 3 years.
### Reason
@rezaloo75 requested update in [Slack](https://kongstrong.slack.com/archives/C029PLEEKTK/p1627400698004100)
### Testing
Will include Netlify preview build when available.
