### PR TITLE
[DOCU-1628] add skip to content

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -14952,10 +14952,14 @@ header.page-header {
 .page-hub {
   h2 {
     margin-top: 130px;
-  }
+  },
   h3 {
     margin-bottom: 68px;
   }
+}
+
+#main {
+    scroll-margin-top: 100px;
 }
 
 #free-trial-form-container .hide {

--- a/app/_assets/stylesheets/header-v2.less
+++ b/app/_assets/stylesheets/header-v2.less
@@ -6,8 +6,35 @@ header.navbar-v2 {
   height: 60px;
   background: white;
   box-shadow: 0 8px 24px rgba(4, 53, 88, 0.1);
-  z-index: 100;
+  z-index: 10;
   padding: 0 24px;
+
+  a.skip-main {
+    left:-999px;
+    position:absolute;
+    top:auto;
+    width:1px;
+    height:1px;
+    overflow:hidden;
+    z-index:-999;
+  }
+
+  a.skip-main:focus, a.skip-main:active {
+      color: black;
+      background-color:white;
+      left: auto;
+      top: auto;
+      width: 30%;
+      height: auto;
+      overflow:auto;
+      margin: 10px 35%;
+      padding: 5px;
+      border-radius: 10px;
+      border: 2px solid black;
+      text-align: center;
+      font-size: 1em;
+      z-index: 999;
+  }
 
   @media screen and (max-width: 800px) {
     box-shadow: none;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -406,15 +406,7 @@
       margin-bottom: 0.1em;
       margin-top: 0.1em;
       font: lighter 38px/40px Roboto;
-
-      // should adjust the anchor link, not working
-      // :target::before {
-      //   content: "";
-      //   top:-120px;
-      //   display: block;
-      //   position: relative;
-      //   visibility: hidden;
-      // }
+      scroll-margin-top: 100px;
     }
 
     @media screen and (max-width: 1080px) {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -406,6 +406,15 @@
       margin-bottom: 0.1em;
       margin-top: 0.1em;
       font: lighter 38px/40px Roboto;
+
+      // should adjust the anchor link, not working
+      // :target::before {
+      //   content: "";
+      //   top:-120px;
+      //   display: block;
+      //   position: relative;
+      //   visibility: hidden;
+      // }
     }
 
     @media screen and (max-width: 1080px) {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -203,6 +203,10 @@
         margin-bottom: 0.4em;
         font: lighter 34px/40px Roboto;
         scroll-margin-top: 100px;
+
+        &::before {
+          display: none;
+        }
       }
 
       .page-content-subtitle {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -203,8 +203,12 @@
         margin-bottom: 0.4em;
         font: lighter 34px/40px Roboto;
 
+        // shifts anchor link to display properly
         &::before {
-          display: none;
+          top:-120px;
+          display: block;
+          position: relative;
+          visibility: hidden;
         }
       }
 

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -202,14 +202,7 @@
         color: #062e4d;
         margin-bottom: 0.4em;
         font: lighter 34px/40px Roboto;
-
-        // shifts anchor link to display properly
-        &::before {
-          top:-120px;
-          display: block;
-          position: relative;
-          visibility: hidden;
-        }
+        scroll-margin-top: 100px;
       }
 
       .page-content-subtitle {

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -25,15 +25,7 @@ header.navbar {
     font-size: 48px;
     line-height: 67px;
     color: @color-text;
-
-    //  should alter the anchor link -- not working
-    // &::before {
-    //   content: "";
-    //   top: -500px;
-    //   display: none;
-    //   position: relative;
-    //   visibility: hidden;
-    // }
+    scroll-margin-top: 100px;
 
     > span {
       white-space: nowrap;

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -26,6 +26,15 @@ header.navbar {
     line-height: 67px;
     color: @color-text;
 
+    //  should alter the anchor link -- not working
+    // &::before {
+    //   content: "";
+    //   top: -500px;
+    //   display: none;
+    //   position: relative;
+    //   visibility: hidden;
+    // }
+
     > span {
       white-space: nowrap;
     }

--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -15,7 +15,7 @@ body_id: page-hub
 
 <div class="page page-hub">
   <header class="page-header">
-    <h2 class="text-center">Kong Plugin Hub</h2>
+    <h2 class="text-center" id="main" tabindex="-1">Kong Plugin Hub</h2>
     <h3 class="text-center">Extend {{site.konnect_product_name}} with powerful plugins and easy integrations</h3>
   </header>
   <div class="container kong-plugins">

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -32,7 +32,7 @@
           </ul>
         {% endif %}
 
-        <h1>{{ header_title }}</h1>
+        <h1 id="main" tabindex="-1">{{ header_title }}</h1>
 
         {% if page.header_caption or include.header_caption%}
           <p>{{ page.header_caption }}{{ include.header_caption }}</p>

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -1,5 +1,5 @@
 <header class="navbar-v2">
-  <a class="skip-main" href="#main">Skip to content</a>  
+  <a class="skip-main" href="#main">Skip to content</a>
   <div id="promo-banner">
     <div class="container">
       <div class="closebanner"></div> <strong><label>New</label> Konnect Plus: Pay-as-you-go from startup friendly to enterprise scale. <a target="_blank" href="https://konghq.com/pricing/">See Pricing &rarr;</a></strong></div>

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -1,6 +1,8 @@
 <header class="navbar-v2">
+  <a class="skip-main" href="#main">Skip to content</a>  
   <div id="promo-banner">
-    <div class="container"><div class="closebanner"></div> <strong><label>New</label> Konnect Plus: Pay-as-you-go from startup friendly to enterprise scale. <a target="_blank" href="https://konghq.com/pricing/">See Pricing &rarr;</a></strong></div>
+    <div class="container">
+      <div class="closebanner"></div> <strong><label>New</label> Konnect Plus: Pay-as-you-go from startup friendly to enterprise scale. <a target="_blank" href="https://konghq.com/pricing/">See Pricing &rarr;</a></strong></div>
   </div>
   <div class="navbar-content">
     <a href="https://konghq.com/" class="navbar-brand col col-xl-auto">
@@ -13,7 +15,7 @@
     <div class="separator mobile"></div>
     <div class="search-input-wrapper">
       <img src="/assets/images/landing-page/search.svg" alt="search" onclick="handleSearchClicked()">
-      <input id="getkong-algolia-search-input" type="text" placeholder="Search the docs...">
+      <input id="getkong-algolia-search-input" type="text" role="search" placeholder="Search the docs...">
     </div>
 
     <div class="search-results-wrapper"></div>

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -92,12 +92,12 @@ page.kong_latest.release %}
               </div>
             {% endif %}
 
-            <h1 class="page-content-title{%
+            <h1 tabindex="-1" id="main" class="page-content-title{%
             if page.badge %} badge{%
             if page.badge == 'plus' %} plus{% endif %}{%
             if page.badge == 'enterprise' %} enterprise{% endif %}
             {% endif %}"
-            >{{page.title | flatify }}</h1>
+            >{{page.title | flatify }} </h1>
             {% if page.enterprise %}{% endif %}
             {% if page.subtitle %}
               <h2 class="page-content-subtitle">{{page.subtitle | flatify }}</h2>

--- a/app/_layouts/landing-page.html
+++ b/app/_layouts/landing-page.html
@@ -12,7 +12,7 @@ id: landing-page
     <div class="top-gradient"></div>
   </div>
 
-  <h1>Welcome <span>to Kong Docs</span></h1>
+  <h1 id="main" tabindex="-1">Welcome <span>to Kong Docs</span></h1>
   <h4>Find all the information you need to use the {{site.konnect_product_name}} platform and Kong’s projects</h4>
 
   <section class="search">

--- a/app/_layouts/page.html
+++ b/app/_layouts/page.html
@@ -6,7 +6,7 @@ layout: default
   {% include header.html %}
 
   <div class="container">
-    <div class="content">
+    <div class="content" id="main" tabindex="-1">
       {{ content }}
     </div>
   </div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ var sources = {
     paths.assets + "javascripts/editable-code-snippet.js",
     paths.assets + "javascripts/navbar.js",
     paths.assets + "javascripts/promo-banner.js",
-    paths.assets + "javascripts/copy-code-snippet-support.js",
+    paths.assets + "javascripts/copy-code-snippet-support.js"
   ],
   images: paths.assets + "images/**/*",
   fonts: [


### PR DESCRIPTION
### Review

@lena-larionova 

### Summary

Add "skip to content" feature. 

@adamjkuhn I am working on site accessibility, and my current feature is a "skip to content" button (reached through tabbing) that skips tabbing through the menu and goes to the first element on that page (header). I'm having issues with the anchor linking from the "skip to content" to the #main ids. They are going too far down the page. 

To replicate: 
* pull down my work locally and navigate to the docs homepage
* tab to see "skip to content"
* use Enter
* you will see that the anchor goes to below the header

It's working on main product pages correctly, for example, /konnect/ (styling at docs.less). But it's not working on the homepage, the hub page, and the hub detail pages. 

Note that base.less (lines 221-230) could be interfering with the homepage anchor linkings from "skip the content". 

Not working as anticipated: 
* Homepage: https://deploy-preview-3059--kongdocs.netlify.app/?utm_source=github&utm_campaign=bot_dp
* Hub: https://deploy-preview-3059--kongdocs.netlify.app/hub/
* Hub (plugin) detail page: https://deploy-preview-3059--kongdocs.netlify.app/hub/kong-inc/application-registration/
* Install: https://deploy-preview-3059--kongdocs.netlify.app/install/centos/

Working as anticipated:
* Platform: https://deploy-preview-3059--kongdocs.netlify.app/enterprise/

### Reason

Improve accessibility. 

### Testing

Tab through and see the "skip to content". 