### PR TITLE
add underline on hover to main nav and footer

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -209,6 +209,12 @@ a {
   }
 }
 
+a.navbar-item {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 h1, h2, h3, h4, h5, h6, .page-header-section-title {
   margin-top: 0;
   margin-bottom: 2rem;

--- a/app/_assets/stylesheets/footer.less
+++ b/app/_assets/stylesheets/footer.less
@@ -606,6 +606,10 @@
     padding-top: 0 !important;
   }
 
+  a:hover {
+    text-decoration: underline;
+  }
+
   nav {
     h4 {
       color: @color-dark-blend-strong;

--- a/app/_assets/stylesheets/header-v2.less
+++ b/app/_assets/stylesheets/header-v2.less
@@ -149,14 +149,6 @@ header.navbar-v2 {
           color: #043558;
         }
 
-        &.active {
-          font-weight: bold;
-
-          > a {
-            color: rgba(17, 85, 203, 1);
-          }
-        }
-
         .navbar-item-submenu {
           position: absolute;
           left: -16px;


### PR DESCRIPTION
### Review

@lena-larionova 

### Summary

* when fixing underline on hover for the submenu non-clickable headers, the styling stripped from the remaining nav items. I added underlining to non-Docs items
* added underline on hover to footer items
* remove bold when active for Docs menu item

### Reason

Increase accessibility by adding more visible indicator that user is hovering on a link. 

### Testing

Hover over main nav and footer link items. 
