### PR TITLE
[DOCU-1622][DOCU-1397] Add missing hybrid mode sections to enterprise doc

### DIFF
--- a/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
- 
+
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.
@@ -337,6 +337,9 @@ similar to declarative config, therefore <code>database</code> has to be set to
 <code>off</code> for Kong to start up properly.
 </div>
 
+See the [DP node start sequence](#dp-node-start-sequence) for more information 
+on how data plane nodes process configuration.
+
 {% navtabs %}
 {% navtab Using Docker %}
 1. Using the [Docker installation documentation](/enterprise/{{page.kong_version}}/deployment/installation/docker),
@@ -537,6 +540,22 @@ The output shows all of the connected Data Plane instances in the cluster:
     "next": null
 }
 ```
+
+## DP Node Start Sequence
+
+When set as a DP node, {{site.base_gateway}} processes configuration in the
+following order:
+
+1. **Config cache**: If the file `config.json.gz` exists in the `kong_prefix`
+path (`/usr/local/kong` by default), the DP node loads it as configuration.
+2. **`declarative_config` exists**: If there is no config cache and the
+`declarative_config` parameter is set, the DP node loads the specified file.
+3. **Empty config**: If there is no config cache or declarative
+configuration file available, the node starts with empty configuration. In this
+state, it returns 404 to all requests.
+4. **Contact CP Node**: In all cases, the DP node contacts the CP node to retrieve
+the latest configuration. If successful, it gets stored in the local config
+cache (`config.json.gz`).
 
 ## Configuration Reference
 

--- a/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
@@ -321,6 +321,29 @@ backend database.
 
 >**Note:** Control Plane nodes cannot be used for proxying.
 
+### (Optional) Revocation checks of Data Plane certificates
+
+When Kong is running Hybrid mode with PKI mode, the Control Plane can be configured to
+optionally check for revocation status of the connecting Data Plane certificate.
+
+The supported method is through Online Certificate Status Protocol (OCSP) responders.
+Issued data plane certificates must contain the Certificate Authority Information Access extension
+that references the URI of OCSP responder that can be reached from the Control Plane.
+
+To enable OCSP checks, set the `cluster_ocsp` config on the Control Plane to one of the following values:
+
+* `on`: OCSP revocation check is enabled and the Data Plane must pass the revocation check
+to establish connection with the Control Plane. This implies that certificates without the
+OCSP extension or unreachable OCSP responder also prevents a connection from being established.
+* `off`: OCSP revocation check is disabled (default).
+* `optional`: OCSP revocation check will be attempted, however, if the OCSP responder URI is not
+found inside the Data Plane-provided certificate or communication with the OCSP responder failed,
+then Data Plane is still allowed through.
+
+Note that OCSP checks are only performed on the Control Plane against certificates provided by incoming Data Plane
+nodes. The `cluster_ocsp` config has no effect on Data Plane nodes.
+`cluster_oscp` affects all Hybrid mode connections established from a Data Plane to its Control Plane.
+
 ## Step 3: Install and Start Data Planes
 Now that the Control Plane is running, you can attach Data Plane nodes to it to
 start serving traffic.
@@ -337,7 +360,7 @@ similar to declarative config, therefore <code>database</code> has to be set to
 <code>off</code> for Kong to start up properly.
 </div>
 
-See the [DP node start sequence](#dp-node-start-sequence) for more information 
+See the [DP node start sequence](#dp-node-start-sequence) for more information
 on how data plane nodes process configuration.
 
 {% navtabs %}
@@ -541,7 +564,8 @@ The output shows all of the connected Data Plane instances in the cluster:
 }
 ```
 
-## DP Node Start Sequence
+## References
+### DP Node Start Sequence
 
 When set as a DP node, {{site.base_gateway}} processes configuration in the
 following order:
@@ -557,7 +581,7 @@ state, it returns 404 to all requests.
 the latest configuration. If successful, it gets stored in the local config
 cache (`config.json.gz`).
 
-## Configuration Reference
+### Configuration Reference
 
 Use the following configuration properties to configure {{site.ee_product_name}}
 in Hybrid mode.

--- a/app/gateway-oss/2.4.x/hybrid-mode.md
+++ b/app/gateway-oss/2.4.x/hybrid-mode.md
@@ -347,16 +347,21 @@ cluster_cert_key = cluster.key
 lua_ssl_trusted_certificate = cluster.crt
 ```
 
-### DP Node Stat Sequence
+### DP Node Start Sequence
 
-When set as a DP node, Kong will follow the following steps regarding its configuration: 
+When set as a DP node, {{site.base_gateway}} processes configuration in the
+following order:
 
-step | description
----|---
-config cache | If a file `config.json.gz` exists in the `kong_prefix` path (`/usr/local/kong` by default), the DP Node loads it as configuration.
-declarative_config | If there wasn't a config cache and the `declarative_config` parameter is set, it's loaded as usual.
-empty config | If neither the config cache or a declarative configuration is available, the Node starts with an empty configuration. In this state, it returns 404 to all requests.
-contact CP Node | In all cases, the DP Node contacts the CP Node to retrieve the latest configuration. If successful, it will be stored in the local config cache (`config.json.gz`)
+1. **Config cache**: If the file `config.json.gz` exists in the `kong_prefix`
+path (`/usr/local/kong` by default), the DP node loads it as configuration.
+2. **`declarative_config` exists**: If there is no config cache and the
+`declarative_config` parameter is set, the DP node loads the specified file.
+3. **Empty config**: If there is no config cache or declarative
+configuration file available, the node starts with empty configuration. In this
+state, it returns 404 to all requests.
+4. **Contact CP Node**: In all cases, the DP node contacts the CP node to retrieve
+the latest configuration. If successful, it gets stored in the local config
+cache (`config.json.gz`).
 
 
 ## Checking the status of the cluster

--- a/app/gateway-oss/2.5.x/hybrid-mode.md
+++ b/app/gateway-oss/2.5.x/hybrid-mode.md
@@ -345,16 +345,21 @@ cluster_cert = cluster.crt
 cluster_cert_key = cluster.key
 ```
 
-### DP Node Stat Sequence
+### DP Node Start Sequence
 
-When set as a DP node, Kong will follow the following steps regarding its configuration: 
+When set as a DP node, {{site.base_gateway}} processes configuration in the
+following order:
 
-step | description
----|---
-config cache | If a file `config.json.gz` exists in the `kong_prefix` path (`/usr/local/kong` by default), the DP Node loads it as configuration.
-declarative_config | If there wasn't a config cache and the `declarative_config` parameter is set, it's loaded as usual.
-empty config | If neither the config cache or a declarative configuration is available, the Node starts with an empty configuration. In this state, it returns 404 to all requests.
-contact CP Node | In all cases, the DP Node contacts the CP Node to retrieve the latest configuration. If successful, it will be stored in the local config cache (`config.json.gz`)
+1. **Config cache**: If the file `config.json.gz` exists in the `kong_prefix`
+path (`/usr/local/kong` by default), the DP node loads it as configuration.
+2. **`declarative_config` exists**: If there is no config cache and the
+`declarative_config` parameter is set, the DP node loads the specified file.
+3. **Empty config**: If there is no config cache or declarative
+configuration file available, the node starts with empty configuration. In this
+state, it returns 404 to all requests.
+4. **Contact CP Node**: In all cases, the DP node contacts the CP node to retrieve
+the latest configuration. If successful, it gets stored in the local config
+cache (`config.json.gz`).
 
 
 ## Checking the status of the cluster
@@ -433,7 +438,7 @@ plugins installed and loaded. The major version of those configured plugins must
 be the same on both the control planes and data planes. Also, the minor versions of the plugins on the data planes
 could not be newer than versions installed on the control planes. Note that similar to
 {{site.ce_product_name}} version checks, plugin patch versions are also ignored
-when determining the compatibility. 
+when determining the compatibility.
 
 {:.important}
 > Configured plugins means any plugin that is either enabled globally or configured by Services, Routes, or Consumers.


### PR DESCRIPTION
### Review
@HCloward 

### Summary
* Adding missing sections from OSS gateway docs to enterprise gateway docs:
  * Fault tolerance and disconnected mode added to hybrid mode info page
  * Revocation checks added to hybrid mode setup page
* Fixing typo in "DP node stat sequence" (should be "start sequence") and adding this missing section to enterprise gateway docs
  * Reformatted the start sequence table into a list, as it is a list of steps that the DP node takes, in order, and cleaned up the text of that section.

### Reason
Issue noted on Slack.
https://konghq.atlassian.net/browse/DOCU-1622

### Testing
https://deploy-preview-3064--kongdocs.netlify.app/enterprise/2.4.x/deployment/hybrid-mode/#fault-tolerance

https://deploy-preview-3064--kongdocs.netlify.app/enterprise/2.4.x/deployment/hybrid-mode-setup/ - see sections on DP node start sequence and revocation checks

https://deploy-preview-3064--kongdocs.netlify.app/gateway-oss/2.5.x/hybrid-mode/ - reformatted DP node start sequence section

