### PR TITLE
[DOCU-1635] make features cards stack on mobile

### DIFF
--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -360,7 +360,6 @@ header.navbar {
 
   section.docs {
     display: flex;
-    // margin-top: 40px;
 
     section.title-cards {
       display: flex;
@@ -644,6 +643,10 @@ header.navbar {
 
           .card {
             margin-right: 0;
+
+            &:first-child {
+              margin-bottom:24px;
+            }
           }
         }
       }

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -89,6 +89,15 @@ header.navbar {
     }
   }
 
+
+  #feature-title {
+    padding-top: 40px;
+
+    @media (max-width:767px) {
+      text-align: center;
+    }
+  }
+
   .cards-container {
     display: flex;
     align-items: flex-start;
@@ -467,7 +476,7 @@ header.navbar {
   }
 
   section.features {
-    margin-top: 72px;
+    margin-top: 40px;
 
     .cards-container {
       display: grid;
@@ -629,7 +638,7 @@ header.navbar {
     }
 
     section.docs {
-      flex-direction: column;
+      flex-direction: row;
       margin-top: 32px;
 
       section.title-cards {
@@ -638,6 +647,8 @@ header.navbar {
 
         .cards-container {
           flex-direction: column;
+          margin-right: 24px;
+          justify-content: center;
 
           .card {
             margin-right: 0;
@@ -651,10 +662,9 @@ header.navbar {
       margin-top: 32px;
 
       .cards-container {
-        overflow-x: auto;
         padding: 8px 16px 8px 16px;
         grid-template-columns: none;
-        grid-auto-flow: column;
+        grid-auto-flow: row;
         grid-gap: 16px;
         box-sizing: border-box;
         margin-left: -16px;
@@ -670,6 +680,11 @@ header.navbar {
           width: 1px;
           height: 10px;
         }
+      }
+
+      @media (max-width:767px) {
+        justify-content: center;
+        display: flex;
       }
     }
 

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -44,7 +44,6 @@ header.navbar {
     font-size: 20px;
     line-height: 28px;
     color: @color-text;
-
   }
 
   h4 {
@@ -92,10 +91,6 @@ header.navbar {
 
   #feature-title {
     padding-top: 40px;
-
-    @media (max-width:767px) {
-      text-align: center;
-    }
   }
 
   .cards-container {
@@ -476,8 +471,6 @@ header.navbar {
   }
 
   section.features {
-    margin-top: 40px;
-
     .cards-container {
       display: grid;
       grid-gap: 24px;
@@ -562,7 +555,7 @@ header.navbar {
 
     section.docs {
       section.title-cards {
-        margin-right: 24px;
+        margin-right: 48px;
 
         .cards-container {
           .card {
@@ -647,7 +640,7 @@ header.navbar {
 
         .cards-container {
           flex-direction: column;
-          margin-right: 24px;
+          margin-right: 48px;
           justify-content: center;
 
           .card {
@@ -659,7 +652,6 @@ header.navbar {
     }
 
     section.features {
-      margin-top: 32px;
 
       .cards-container {
         padding: 8px 16px 8px 16px;
@@ -671,7 +663,6 @@ header.navbar {
         margin-right: -16px;
 
         .card {
-          width: 288px;
           flex-shrink: 0;
         }
 

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -40,6 +40,7 @@ header.navbar {
   }
 
   h3 {
+    padding-top: 45px;
     font-weight: normal;
     font-size: 20px;
     line-height: 28px;
@@ -90,7 +91,7 @@ header.navbar {
 
 
   #feature-title {
-    padding-top: 40px;
+    padding-top: 45px;
   }
 
   .cards-container {
@@ -235,7 +236,6 @@ header.navbar {
 
     section.konnect-docs {
       .shadowed-card;
-      margin-bottom: 45px;
 
       .platform-links {
         padding: 5px 0 20px;
@@ -360,7 +360,7 @@ header.navbar {
 
   section.docs {
     display: flex;
-    margin-top: 40px;
+    // margin-top: 40px;
 
     section.title-cards {
       display: flex;
@@ -632,7 +632,6 @@ header.navbar {
 
     section.docs {
       flex-direction: row;
-      margin-top: 32px;
 
       section.title-cards {
         margin-top: 8px;
@@ -645,7 +644,6 @@ header.navbar {
 
           .card {
             margin-right: 0;
-            margin-bottom: 24px;
           }
         }
       }
@@ -664,12 +662,6 @@ header.navbar {
 
         .card {
           flex-shrink: 0;
-        }
-
-        &:after {
-          content: "";
-          width: 1px;
-          height: 10px;
         }
       }
 

--- a/app/_layouts/landing-page.html
+++ b/app/_layouts/landing-page.html
@@ -176,8 +176,8 @@ id: landing-page
   </section>
 
   {% for feature in site.data.landing_page.features %}
+  <h3 id="feature-title">{{ feature.title }}</h3>
   <section class="features">
-    <h3>{{ feature.title }}</h3>
     <div class="cards-container">
       {% for item in feature.items %}
       <div class="card default">


### PR DESCRIPTION
### Review

@Kong/team-docs 

### Summary

Previously, the "Key features" and "Ecosystem integrations" cards on the landing pages (on mobile) can only be accessed if the user scrolls right. This makes it difficult for users to understand how to use the page to see the content "hidden". 

The "Key features" and "Ecosystem integrations" cards now stack on smaller screen so that you don't have to scroll right. 

### Reason

* users can see all content without having to guess how to use the scrolling feature
* provides more accessible elements
* makes more sense visually

### Testing

Check out the landing page "Key features" and "Ecosystem integrations" cards on smaller screens and mobile. They will stack now. 
