### PR TITLE
[DOCU-1636] Rate limiting advanced plugin: local strategy workaround

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -31,7 +31,10 @@ params:
   name: graphql-rate-limiting-advanced
   service_id: true
   route_id: true
-  dbless_compatible: yes
+  dbless_compatible: partially
+  dbless_explanation: |
+   The cluster strategy is not supported in DB-less and hybrid modes. For Kong
+   Gateway in DB-less or hybrid mode, use the `redis` strategy.
   config:
     - name: cost_strategy
       required: true
@@ -109,22 +112,28 @@ params:
     - name: strategy
       required:
       default: cluster
-      value_in_examples: local
+      value_in_examples: cluster
       datatype: string
       description: |
         The rate-limiting strategy to use for retrieving and incrementing the
         limits. Available values are:
-        - `local`: Counters are stored locally in-memory on the node.
         - `cluster`: Counters are stored in the Kong datastore and shared across
         the nodes.
         - `redis`: Counters are stored on a Redis server and shared
         across the nodes.
 
-        In DB-less and hybrid modes, the `cluster` config strategy is not supported.
-        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
-        `redis`, or `local` for data planes only.
+        In DB-less and hybrid modes, the `cluster` config strategy is not
+        supported.
 
         In Konnect Cloud, the default strategy is `redis`.
+
+        {:.important}
+        > There is no local storage strategy. However, you can achieve local
+        rate limiting by using a dummy `strategy` value (either `cluster` or `redis`)
+        and a `sync_rate` of `-1`. This setting stores counters in-memory on the
+        node.
+        <br><br>If using `redis` as the dummy value, you must fill in all
+        additional `redis` configuration parameters with dummy values.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -129,11 +129,11 @@ params:
 
         {:.important}
         > There is no local storage strategy. However, you can achieve local
-        rate limiting by using a dummy `strategy` value (either `cluster` or `redis`)
+        rate limiting by using a placeholder `strategy` value (either `cluster` or `redis`)
         and a `sync_rate` of `-1`. This setting stores counters in-memory on the
         node.
-        <br><br>If using `redis` as the dummy value, you must fill in all
-        additional `redis` configuration parameters with dummy values.
+        <br><br>If using `redis` as the placeholder value, you must fill in all
+        additional `redis` configuration parameters with placeholder values.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -42,7 +42,8 @@ params:
   protocols: ["http", "https", "grpc", "grpcs"]
   dbless_compatible: partially
   dbless_explanation: |
-   The cluster policy is not supported in DB-less and hybrid modes. For Kong Gateway on Kubernetes in DB-less mode, use one of `redis` or `local`; for hybrid mode, use `redis`.
+   The cluster strategy is not supported in DB-less and hybrid modes. For Kong
+   Gateway in DB-less or hybrid mode, use the `redis` strategy.
   config:
     - name: limit
       required: true
@@ -100,22 +101,28 @@ params:
     - name: strategy
       required: true
       default: cluster
-      value_in_examples: local
+      value_in_examples: cluster
       datatype: string
       description: |
         The rate-limiting strategy to use for retrieving and incrementing the
         limits. Available values are:
-        - `local`: Counters are stored locally in-memory on the node.
         - `cluster`: Counters are stored in the Kong datastore and shared across
          the nodes.
         - `redis`: Counters are stored on a Redis server and shared
         across the nodes.
 
-        In DB-less and hybrid modes, the `cluster` config strategy is not supported.
-        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
-        `redis`, or `local` for data planes only.
+        In DB-less and hybrid modes, the `cluster` config strategy is not
+        supported.
 
         In Konnect Cloud, the default strategy is `redis`.
+
+        {:.important}
+        > There is no local storage strategy. However, you can achieve local
+        rate limiting by using a dummy `strategy` value (either `cluster` or `redis`)
+        and a `sync_rate` of `-1`. This setting stores counters in-memory on the
+        node.
+        <br><br>If using `redis` as the dummy value, you must fill in all
+        additional `redis` configuration parameters with dummy values.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -118,11 +118,11 @@ params:
 
         {:.important}
         > There is no local storage strategy. However, you can achieve local
-        rate limiting by using a dummy `strategy` value (either `cluster` or `redis`)
+        rate limiting by using a placeholder `strategy` value (either `cluster` or `redis`)
         and a `sync_rate` of `-1`. This setting stores counters in-memory on the
         node.
-        <br><br>If using `redis` as the dummy value, you must fill in all
-        additional `redis` configuration parameters with dummy values.
+        <br><br>If using `redis` as the placeholder value, you must fill in all
+        additional `redis` configuration parameters with placeholder values.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).


### PR DESCRIPTION
### Review
@murillopaula , @HCloward 

### Summary
Removing the option to select `local` as a rate limiting strategy for the Rate Limiting Advanced and GraphQL Rate Limiting Advanced plugins. Instead, documenting the workaround defined here: https://konghq.atlassian.net/browse/DOCU-1636

### Reason
A direct `local` strategy does not exist, but you can rate limit locally using `sync_rate`.
See https://konghq.atlassian.net/browse/DOCU-1636 for more detail.

### Testing
https://deploy-preview-3071--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/
https://deploy-preview-3071--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/
