### PR TITLE
[DOCU-1644] rm changelog link for route transformer advanced plugin

### DIFF
--- a/app/_hub/kong-inc/route-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/index.md
@@ -53,19 +53,15 @@ params:
 ---
 
 _NOTE_: The advanced label is only attached because this is an Enterprise-only
-plugin. There is not a corresponding community plugin version available.
+plugin. There is no corresponding community plugin version available.
 
 ## Synopsis
 
 This plugin transforms the routing on the fly in Kong, changing the upstream server/port/path to hit. The substitutions can be configured via flexible templates.
 
-## History
+## Template as value
 
-See the [hangelog](https://github.com/Kong/kong-plugin-route-transformer-advanced/blob/master/CHANGELOG.md).
-
-## Template as Value
-
-The templates that can be used as values are the same as the [request-transformer](https://docs.konghq.com/hub/kong-inc/request-transformer-advanced/).
+The templates that can be used as values are the same as the [request-transformer](x/hub/kong-inc/request-transformer-advanced/).
 
 [badge-travis-url]: https://travis-ci.com/Kong/kong-plugin-route-transformer-advanced/branches
 [badge-travis-image]: https://travis-ci.com/Kong/kong-plugin-route-transformer-advanced.svg?token=BfzyBZDa3icGPsKGmBHb&branch=master

--- a/app/_hub/kong-inc/route-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/index.md
@@ -61,7 +61,7 @@ This plugin transforms the routing on the fly in Kong, changing the upstream ser
 
 ## Template as value
 
-The templates that can be used as values are the same as the [request-transformer](x/hub/kong-inc/request-transformer-advanced/).
+The templates that can be used as values are the same as the [request-transformer](/hub/kong-inc/request-transformer-advanced/).
 
 [badge-travis-url]: https://travis-ci.com/Kong/kong-plugin-route-transformer-advanced/branches
 [badge-travis-image]: https://travis-ci.com/Kong/kong-plugin-route-transformer-advanced.svg?token=BfzyBZDa3icGPsKGmBHb&branch=master


### PR DESCRIPTION
### Review

@Kong/team-docs 

### Summary

Remove link to changelog on route transformer advanced plugin docs. 

### Reason

We don't actively maintain this changelog. 

### Testing

Tested locally. 
