### PR TITLE
Update networking urls (issue 3068)

### DIFF
--- a/app/_data/docs_nav_ee_1.3-x.yml
+++ b/app/_data/docs_nav_ee_1.3-x.yml
@@ -283,7 +283,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /property-reference/#developer-portal-section
+      url: /property-reference/#dev-portal
     - text: Configuration
       url: /developer-portal/configuration
       items:

--- a/app/_data/docs_nav_ee_1.3-x.yml
+++ b/app/_data/docs_nav_ee_1.3-x.yml
@@ -283,7 +283,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /developer-portal/networking
+      url: /property-reference/#developer-portal-section
     - text: Configuration
       url: /developer-portal/configuration
       items:

--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -328,7 +328,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /developer-portal/networking
+      url: /property-reference/#developer-portal-section
     - text: Configuration
       url: /developer-portal/configuration
       items:

--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -328,7 +328,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /property-reference/#developer-portal-section
+      url: /property-reference/#dev-portal
     - text: Configuration
       url: /developer-portal/configuration
       items:

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -367,7 +367,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /developer-portal/networking
+      url: /property-reference/#developer-portal-section
     - text: Configuration
       items:
         - text: Authentication

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -358,7 +358,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /developer-portal/networking
+      url: /property-reference/#developer-portal-section
     - text: Configuration
       items:
         - text: Authentication

--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -385,7 +385,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /developer-portal/networking
+      url: /property-reference/#developer-portal-section
     - text: Configuration
       items:
         - text: Authentication

--- a/app/_data/docs_nav_ee_2.4.x.yml
+++ b/app/_data/docs_nav_ee_2.4.x.yml
@@ -392,7 +392,7 @@
     - text: Using the Editor
       url: /developer-portal/using-the-editor
     - text: Networking
-      url: /developer-portal/networking
+      url: /property-reference/#developer-portal-section
     - text: Configuration
       items:
         - text: Authentication

--- a/app/enterprise/1.3-x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.3-x/developer-portal/configuration/authentication/sessions.md
@@ -8,7 +8,7 @@ title: Sessions in the Dev Portal
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal
 
@@ -56,7 +56,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host): `"cookie_samesite": "off"`
+* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host): `"cookie_samesite": "off"`
 
 ## Example Configurations
 

--- a/app/enterprise/1.3-x/developer-portal/networking.md
+++ b/app/enterprise/1.3-x/developer-portal/networking.md
@@ -1,3 +1,0 @@
----
-redirect_to: /enterprise/1.3-x/property-reference/#dev-portal
----

--- a/app/enterprise/1.3-x/developer-portal/overview.md
+++ b/app/enterprise/1.3-x/developer-portal/overview.md
@@ -102,10 +102,10 @@ Read the full Kong Enterprise 1.3 Changelog [here](/enterprise/changelog).
   <div class="docs-grid-block">
     <h3>
         <img src="/assets/images/icons/documentation/icn-doc-reference.svg" />
-        <a href="/enterprise/1.3-x/developer-portal/networking">Networking</a>
+        <a href="/enterprise/1.3-x/property-reference/#developer-portal-section">Networking</a>
     </h3>
     <p></p>
-    <a href="/enterprise/1.3-x/developer-portal/networking">
+    <a href="/enterprise/1.3-x/property-reference/#developer-portal-section">
       View the Developer Portal Networking Property Reference &rarr;
     </a>
   </div>

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -8,7 +8,7 @@ title: Sessions in the Dev Portal
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal
 
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host): `"cookie_samesite": "off"`
+* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference//#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host): `"cookie_samesite": "off"`
 
 ## Example Configurations
 

--- a/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/1.5.x/developer-portal/configuration/authentication/sessions.md
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference//#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host): `"cookie_samesite": "off"`
+* If using different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host): `"cookie_samesite": "off"`
 
 ## Example Configurations
 

--- a/app/enterprise/1.5.x/developer-portal/networking.md
+++ b/app/enterprise/1.5.x/developer-portal/networking.md
@@ -1,3 +1,0 @@
----
-redirect_to: /enterprise/1.5.x/property-reference/#dev-portal
----

--- a/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.1.x/developer-portal/configuration/authentication/sessions.md
@@ -10,7 +10,7 @@ configured with `portal_auth` other than `openid-connect`; for example, `key-aut
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal {#portal-session-conf}
 
@@ -60,7 +60,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
+* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
   

--- a/app/enterprise/2.1.x/developer-portal/networking.md
+++ b/app/enterprise/2.1.x/developer-portal/networking.md
@@ -1,3 +1,0 @@
----
-redirect_to: /enterprise/1.5.x/property-reference/#dev-portal
----

--- a/app/enterprise/2.2.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.2.x/developer-portal/configuration/authentication/sessions.md
@@ -8,7 +8,7 @@ title: Sessions in the Dev Portal
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal
 
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
+* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
   

--- a/app/enterprise/2.2.x/developer-portal/networking.md
+++ b/app/enterprise/2.2.x/developer-portal/networking.md
@@ -1,3 +1,0 @@
----
-redirect_to: /enterprise/1.5.x/property-reference/#dev-portal
----

--- a/app/enterprise/2.3.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.3.x/developer-portal/configuration/authentication/sessions.md
@@ -8,7 +8,7 @@ title: Sessions in the Dev Portal
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal
 
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
+* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
   

--- a/app/enterprise/2.3.x/developer-portal/networking.md
+++ b/app/enterprise/2.3.x/developer-portal/networking.md
@@ -1,3 +1,0 @@
----
-redirect_to: /enterprise/1.5.x/property-reference/#dev-portal
----

--- a/app/enterprise/2.4.x/developer-portal/configuration/authentication/sessions.md
+++ b/app/enterprise/2.4.x/developer-portal/configuration/authentication/sessions.md
@@ -8,7 +8,7 @@ title: Sessions in the Dev Portal
 
 When a user logs in to the Dev Portal with their credentials, the Sessions Plugin will create a session cookie. The cookie is used for all subsequent requests and is valid to authenticate the user. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
-The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
+The Session configuration is secure by default, which may [require alteration](#session-security) if using HTTP or different domains for [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host). Even if an attacker were to obtain a stale cookie, it would not benefit them since the cookie is encrypted. The encrypted session data may be stored either in Kong or the cookie itself.
 
 ## Configuration to Use the Sessions Plugin with the Dev Portal
 
@@ -58,7 +58,7 @@ The Session configuration is secure by default, so the cookie uses the [Secure, 
 
 ⚠️**Important:** The following properties must be altered depending on the protocol and domains in use:
 * If using HTTP instead of HTTPS: `"cookie_secure": false`
-* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/developer-portal/networking/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
+* If using different subdomains for the [portal_api_url](/enterprise/{{page.kong_version}}/property-reference/#portal_api_url) and [portal_gui_host](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_host), see the example below for [Domains](https://docs.konghq.com/enterprise/2.1.x/developer-portal/configuration/authentication/sessions/#domains).
 
 <div class="alert alert-warning">
   


### PR DESCRIPTION
### Review

@lena-larionova 

### Summary

* Update URLs to networking content for versions 1.3.x +. 
* Delete `networking.md` for versions 1.3.x +.

### Reason

Link currently goes to older documentation. Addresses https://github.com/Kong/docs.konghq.com/issues/3068

### Testing

Local testing. Go through EE docs versions 1.3.x + and click on "Networking" to ensure that it is linking to "Property Reference" section. 
