### PR TITLE
[DOCU-1630] Remove echint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "browser-sync": "2.27.4",
         "cloudflare": "2.7.0",
         "del": "6.0.0",
-        "echint": "4.0.2",
         "fancy-log": "1.3.3",
         "font-awesome": "4.7.0",
         "gh-pages": "3.2.3",
@@ -3503,15 +3502,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3966,15 +3956,6 @@
         "domelementtype": "1"
       }
     },
-    "node_modules/dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/download": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
@@ -4117,72 +4098,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/echint": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/echint/-/echint-4.0.2.tgz",
-      "integrity": "sha512-iUEHrTxUqpZ0V6ayTmjyf9/f3Iz/Pp3EGKhmfFpnZQ4tjTk3ZyO9bO2qGwgr3coSknzXdieYrcCe3JDsiI/Uvw==",
-      "deprecated": "no longer maintained",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "commander": "^2.19.0",
-        "dotenv": "^7.0.0",
-        "glob": "^7.1.3",
-        "lintspaces": "0.6.3",
-        "minimatch": "^3.0.4",
-        "pkg-config": "^1.1.1"
-      },
-      "bin": {
-        "echint": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/echint/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/echint/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/echint/node_modules/commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
-    },
-    "node_modules/echint/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ee-first": {
@@ -6530,7 +6445,71 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "bundleDependencies": [
-        "node-pre-gyp"
+        "node-pre-gyp",
+        "abbrev",
+        "ansi-regex",
+        "aproba",
+        "are-we-there-yet",
+        "balanced-match",
+        "brace-expansion",
+        "chownr",
+        "code-point-at",
+        "concat-map",
+        "console-control-strings",
+        "core-util-is",
+        "debug",
+        "deep-extend",
+        "delegates",
+        "detect-libc",
+        "fs-minipass",
+        "fs.realpath",
+        "gauge",
+        "glob",
+        "has-unicode",
+        "iconv-lite",
+        "ignore-walk",
+        "inflight",
+        "inherits",
+        "ini",
+        "is-fullwidth-code-point",
+        "isarray",
+        "minimatch",
+        "minimist",
+        "minipass",
+        "minizlib",
+        "mkdirp",
+        "ms",
+        "needle",
+        "nopt",
+        "npm-bundled",
+        "npm-packlist",
+        "npmlog",
+        "number-is-nan",
+        "object-assign",
+        "once",
+        "os-homedir",
+        "os-tmpdir",
+        "osenv",
+        "path-is-absolute",
+        "process-nextick-args",
+        "rc",
+        "readable-stream",
+        "rimraf",
+        "safe-buffer",
+        "safer-buffer",
+        "sax",
+        "semver",
+        "set-blocking",
+        "signal-exit",
+        "string_decoder",
+        "string-width",
+        "strip-ansi",
+        "strip-json-comments",
+        "tar",
+        "util-deprecate",
+        "wide-align",
+        "wrappy",
+        "yallist"
       ],
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
@@ -6755,6 +6734,8 @@
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7136,6 +7117,8 @@
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10512,60 +10495,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/lintspaces": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/lintspaces/-/lintspaces-0.6.3.tgz",
-      "integrity": "sha512-nUwq/jK+gUhpILtV9Ms2cuF16LB9a8nnecowSQD5LRNX3+h1Bl1zIvPZNQgJYeK9xxuoR+HuWnjagQsvyJbS4w==",
-      "dev": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "editorconfig": "^0.15.0",
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=5"
-      }
-    },
-    "node_modules/lintspaces/node_modules/commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
-    },
-    "node_modules/lintspaces/node_modules/editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
-      },
-      "bin": {
-        "editorconfig": "bin/editorconfig"
-      }
-    },
-    "node_modules/lintspaces/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/lintspaces/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/list-assets": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/list-assets/-/list-assets-0.0.2.tgz",
@@ -13217,30 +13146,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14262,12 +14167,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.2",
@@ -19892,12 +19791,6 @@
         }
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -20253,12 +20146,6 @@
         "domelementtype": "1"
       }
     },
-    "dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
-      "dev": true
-    },
     "download": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
@@ -20381,58 +20268,6 @@
       "dev": true,
       "requires": {
         "tfunk": "^4.0.0"
-      }
-    },
-    "echint": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/echint/-/echint-4.0.2.tgz",
-      "integrity": "sha512-iUEHrTxUqpZ0V6ayTmjyf9/f3Iz/Pp3EGKhmfFpnZQ4tjTk3ZyO9bO2qGwgr3coSknzXdieYrcCe3JDsiI/Uvw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.2",
-        "commander": "^2.19.0",
-        "dotenv": "^7.0.0",
-        "glob": "^7.1.3",
-        "lintspaces": "0.6.3",
-        "minimatch": "^3.0.4",
-        "pkg-config": "^1.1.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "ee-first": {
@@ -22403,6 +22238,8 @@
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -22705,6 +22542,8 @@
         },
         "sax": {
           "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -25349,53 +25188,6 @@
       "integrity": "sha1-r2XlnbUucMH/sYrEw8sFa/55aDA=",
       "dev": true
     },
-    "lintspaces": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/lintspaces/-/lintspaces-0.6.3.tgz",
-      "integrity": "sha512-nUwq/jK+gUhpILtV9Ms2cuF16LB9a8nnecowSQD5LRNX3+h1Bl1zIvPZNQgJYeK9xxuoR+HuWnjagQsvyJbS4w==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "editorconfig": "^0.15.0",
-        "rc": "^1.2.8"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "dev": true
-        },
-        "editorconfig": {
-          "version": "0.15.3",
-          "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-          "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.19.0",
-            "lru-cache": "^4.1.5",
-            "semver": "^5.6.0",
-            "sigmund": "^1.0.1"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        }
-      }
-    },
     "list-assets": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/list-assets/-/list-assets-0.0.2.tgz",
@@ -27431,26 +27223,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -28247,12 +28019,6 @@
           }
         }
       }
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "gulp",
     "dev": "gulp dev",
     "pdk-docs": "KONG_PATH=${KONG_PATH:=} KONG_VERSION=${KONG_VERSION:=} gulp pdk-docs",
-    "test": "standard && echint --verbose"
+    "test": "standard --verbose"
   },
   "standard": {
     "ignore": [
@@ -25,33 +25,11 @@
       "app/_redirects"
     ]
   },
-  "echint": {
-    "ignore": [
-      "Makefile",
-      "dist/**",
-      "app/*.x/**",
-      "app/enterprise/**/*",
-      "app/gateway-oss/**/*",
-      "app/_assets/images/**",
-      "app/_assets/fonts/**",
-      "app/license/index.md",
-      "ldoc/*",
-      "Gemfile.lock",
-      "autodoc-admin-api/*.lua",
-      "autodoc-conf/*.lua",
-      "autodoc-conf-ee/*.lua",
-      "vendor/**",
-      "node_modules/**",
-      "Docker",
-      "app/_redirects"
-    ]
-  },
   "devDependencies": {
     "broken-link-checker": "0.7.8",
     "browser-sync": "2.27.4",
     "cloudflare": "2.7.0",
     "del": "6.0.0",
-    "echint": "4.0.2",
     "fancy-log": "1.3.3",
     "font-awesome": "4.7.0",
     "gh-pages": "3.2.3",


### PR DESCRIPTION
### Review
@falondarville 

### Summary
Removing echint.

### Reason
Echint is deprecated and not maintained: https://www.npmjs.com/package/echint
This code linter flags very odd warnings as errors (mostly about having an extra newline at the end of a file, or an indent in the wrong place) and causes builds to fail.

### Testing
Run the build locally and make sure it doesn't break.
Wait for checks to pass on this PR.