### PR TITLE
[DOCU-1641] Remove non-existent JWT version

### DIFF
--- a/app/_data/extensions/kong-inc/jwt/versions.yml
+++ b/app/_data/extensions/kong-inc/jwt/versions.yml
@@ -1,4 +1,3 @@
 - release: 2.2-x
 - release: 2.1-x
-- release: 1.0-x
 - release: 0.1-x

--- a/app/_hub/kong-inc/jwt/2.1-x.md
+++ b/app/_hub/kong-inc/jwt/2.1-x.md
@@ -1,6 +1,7 @@
 ---
 name: JWT
 publisher: Kong Inc.
+version: 2.1-x
 
 desc: Verify and authenticate JSON Web Tokens
 description: |


### PR DESCRIPTION
### Summary
Removing version 1.0-x from the JWT version dropdown.

### Reason
This version doc doesn't exist: https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/kong-inc/jwt
The dropdown entry causes a 404.

### Testing
Check by testing the version dropdown and making sure all versions work: https://deploy-preview-3076--kongdocs.netlify.app/hub/kong-inc/jwt/