### PR TITLE
Cleafy plugin doc: remove legacy metadata

### DIFF
--- a/app/_hub/cleafy/cleafy/index.md
+++ b/app/_hub/cleafy/cleafy/index.md
@@ -46,8 +46,6 @@ kong_version_compatibility:
       - 0.35-x
       - 0.36-x
 
-kong_legacy_api: false
-
 params:
   name: cleafy-plugin-for-kong
   api_id: false


### PR DESCRIPTION
### Summary
Removing legacy value `kong_legacy_api`. It's not used anywhere in our templates.

### Reason
https://github.com/Kong/docs.konghq.com-private/issues/87

### Testing
Just check that the page didn't break: https://deploy-preview-3079--kongdocs.netlify.app/hub/cleafy/cleafy/