### PR TITLE
[DOCU-1655]Updates datadog plugin doc with correct default value

### DIFF
--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -79,6 +79,8 @@ params:
       datatype: array of record elements
       description: |
         List of Metrics to be logged. Available values are described at [Metrics](#metrics).
+        By default, the plugin logs all available metrics. If you specify an array of metrics,
+        only the listed metrics are logged.
     - name: prefix
       required: true
       default: "`kong`"

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -75,7 +75,7 @@ params:
       description: The port to send data to on the upstream server
     - name: metrics
       required: true
-      default: All metrics are logged
+      default: DEFAULT_METRICS
       datatype: array of record elements
       description: |
         List of Metrics to be logged. Available values are described at [Metrics](#metrics).
@@ -115,8 +115,12 @@ Field           | Description                                           | Dataty
 
 ### Metric requirements
 
-1.  All metrics get logged by default.
-2.  Metrics with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
+- All metrics get logged by default.
+- Metrics with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
+
+## Setting specific metrics
+
+
 
 ## Migrating Datadog queries
 The plugin updates replace the api, status, and consumer-specific metrics with a generic metric name.

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -75,7 +75,7 @@ params:
       description: The port to send data to on the upstream server
     - name: metrics
       required: true
-      default: DEFAULT_METRICS
+      default: 'DEFAULT_METRICS'
       datatype: array of record elements
       description: |
         List of Metrics to be logged. Available values are described at [Metrics](#metrics).

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -75,7 +75,7 @@ params:
       description: The port to send data to on the upstream server
     - name: metrics
       required: true
-      default: 'DEFAULT_METRICS'
+      default: 
       datatype: array of record elements
       description: |
         List of Metrics to be logged. Available values are described at [Metrics](#metrics).
@@ -117,10 +117,6 @@ Field           | Description                                           | Dataty
 
 - All metrics get logged by default.
 - Metrics with `stat_type` as `counter` or `gauge` must have `sample_rate` defined as well.
-
-## Setting specific metrics
-
-
 
 ## Migrating Datadog queries
 The plugin updates replace the api, status, and consumer-specific metrics with a generic metric name.


### PR DESCRIPTION
### Review
@svenwal - I removed the original string and replaced it with 
### Summary
This is to remove the current default value for config.metrics as it is wrong. 
### Reason
[DOCU-1655](https://konghq.atlassian.net/browse/DOCU-1655)
### Testing
[Datadog plugin](https://deploy-preview-3084--kongdocs.netlify.app/hub/kong-inc/datadog/)