### PR TITLE
Version switcher cache

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -11,7 +11,7 @@ page.kong_latest.release %}
 <div class="page v2 {{ page.class }}" data-url={{ page.url }}>
 
   <div class="container">
-    {% include_cached docs-sidebar.html kong_version=page.kong_version edition=page.edition %}
+    {% include_cached docs-sidebar.html url=page.url kong_version=page.kong_version edition=page.edition %}
 
     {% if page.toc == true or page.toc != false and filename != "index.md" and page.is_homepage != true %}
       <aside class="docs-toc">

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -6,8 +6,7 @@ id: documentation
 
 {% assign latest_page_url = page.url | replace: page.kong_version,
 page.kong_latest.release %}
-{% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}
-{% endcapture %}
+{% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
 
 <div class="page v2 {{ page.class }}" data-url={{ page.url }}>
 


### PR DESCRIPTION
### Review
@lena-larionova 

### Summary
Desired behavior (was previously working): when you're on a doc page (eg https://docs.konghq.com/enterprise/2.1.x/deployment/installation/docker/) and switch to another version of this page using the dropdown in the top left, the same page should load up but with the new URL ( eg https://docs.konghq.com/enterprise/2.4.x/deployment/installation/docker/). Caching breaks this.

Caching is also breaking the link to latest documentation from older versions. Again, see https://docs.konghq.com/enterprise/2.1.x/deployment/installation/docker/ - the note at the top of the page should link to the latest version of this Docker installation, but instead it simply goes to https://docs.konghq.com/enterprise/

### Reason
DOCU-1633

### Testing
Switch versions on the left hand side switcher and it should take you to the same page. Use the link at the top of the main content block to get back to the latest version. It should keep you on the same page