### PR TITLE
docs(kafka-upstream): update plugin docs to reflect latest changes

### DIFF
--- a/app/_hub/kong-inc/kafka-upstream/0.1.0.md
+++ b/app/_hub/kong-inc/kafka-upstream/0.1.0.md
@@ -52,60 +52,6 @@ params:
       datatype: string
       description: |
          The Kafka topic to publish to.
-    - name: authentication.strategy
-      required: false
-      value_in_examples: sasl
-      urlencode_in_examples: true
-      default:
-      datatype: string
-      description: |
-         Authentication strategy one of: sasl
-    - name: authentication.mechanism
-      required: false
-      value_in_examples: PLAIN
-      urlencode_in_examples: true
-      default:
-      datatype: string
-      description: |
-        SASL mechanism one of: PLAIN,SCRAM-SHA-256
-    - name: authentication.user
-      required: false
-      value_in_examples: admin
-      urlencode_in_examples: true
-      default:
-      datatype: string
-      description: |
-        Username for SASL authentication. 
-    - name: authentication.password
-      required: false
-      value_in_examples: admin-secret
-      urlencode_in_examples: true
-      default:
-      datatype: string
-      description: |
-        Password for SASL authentication. 
-    - name: authentication.tokenauth
-      required: false
-      value_in_examples: false
-      default: false
-      datatype: boolean
-      description: |
-        Enable this to indicate DelegationToken authentication
-    - name: security.ssl
-      required: false
-      value_in_examples: false
-      default: false
-      datatype: boolean
-      description: |
-        Enables TLS
-    - name: security.certificate_id
-      required: false
-      urlencode_in_examples: true
-      value_in_examples: nil
-      default:
-      datatype: string
-      description: |
-        UUID of certificate entity for mTLS authentication
     - name: timeout
       required: false
       default: "`10000`"
@@ -240,7 +186,7 @@ $ curl -X POST http://kong:8001/routes/my-route/plugins \
 
 ## Implementation details
 
-This plugin makes use of [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client under the hood.
+This plugin makes use of [lua-resty-kafka](https://github.com/doujiang24/lua-resty-kafka) client under the hood.
 
 When encoding request bodies, several things happen:
 
@@ -252,53 +198,14 @@ When encoding request bodies, several things happen:
   then the body will be base64-encoded to ensure that the message can be sent as JSON. In such a case,
   the message has an extra attribute called `body_base64` set to `true`.
 
-
-## TLS
-
-Enable TLS by setting `config.security.ssl` to `true`
-
-## mTLS
-
-Enable mTLS by setting a valid UUID of a certificate in `config.security.certificate_id`. Note that this option needs `config.security.ssl` set to true.
-[Refer this this section on how to set up Certificates](https://docs.konghq.com/enterprise/2.5.x/admin-api/#certificate-object)
-
-## SASL Authentication
-
-To use SASL auth set the config option `config.authentication.strategy` to `sasl`.
-
-Make sure that these mechanism are enabled on the Kafka side as well.
-
-This plugin supports multiple mechanisms:
-
-- PLAIN:
-
-Enable this mechanism with set `config.authentication.mechanism` to `PLAIN`.
-
-Provide a username and password with the config options `config.authentication.user` and `config.authentication.password` respectively.
-
-- SCRAM-SHA-256:
-
-> In cryptography, the Salted Challenge Response Authentication Mechanism (SCRAM) is a family of modern, password-based challenge–response authentication mechanisms providing authentication of a user to a server.
-
-Enable this mechanism with set `config.authentication.mechanism` to `SCRAM-SHA-256`.
-
-Provide a username and password with the config options `config.authentication.user` and `config.authentication.password` respectively.
-
-
-- Delegation Tokens:
-
-Delegation Tokens can be generated in Kafka and then used to authenticate this plugin. [Read more on how to create, renew and revoke them.](https://docs.confluent.io/platform/current/kafka/authentication_sasl/authentication_sasl_delegation.html#authentication-using-delegation-tokens)
-
-
-`Delegation Tokens` leverage the `SCRAM-SHA-256` authentication mechanism. The `tokenID` is provided via the `config.authentication.user` field and the `token-hmac` is provided via the `config.authentication.password` field. To indicate that a token is used you have to set the `config.authentication.tokenauth` setting to `true`.
-
-
 ## Known issues and limitations
 
 Known limitations:
 
-1. There is no support for message compression.
-2. The message format is not customizable.
+1. There is no support for TLS.
+2. There is no support for authentication.
+3. There is no support for message compression.
+4. The message format is not customizable.
 
 ## Quickstart
 

--- a/app/_hub/kong-inc/kafka-upstream/index.md
+++ b/app/_hub/kong-inc/kafka-upstream/index.md
@@ -28,8 +28,6 @@ kong_version_compatibility:
         - 2.3.x
         - 2.2.x
         - 2.1.x
-        - 1.5.x
-        - 1.3-x
 
 params:
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jaiks@posteo.de>

### Review
@HCloward 

Note that the plugin version wasn't bumped as I need to merge some last changes [see here](https://github.com/Kong/kong-plugin-kafka-upstream/pull/10) 


### Summary
Adding features for [this plugin](https://github.com/Kong/kong-plugin-kafka-upstream)

Notable changes:

* TLS
* mTLS
* SASL auth
  * PLAIN
  * SCRAM-SHA-256
  * Delegation Tokens

### Reason

https://konghq.atlassian.net/browse/FT-1781
https://konghq.atlassian.net/browse/FT-1860

### Testing

Testing can be done by following the proposed docs. In addition we have [tests for the `compatible kong versions`](https://github.com/Kong/kong-plugin-kafka-upstream/actions/runs/1097543520)

