### PR TITLE
Docs/update contributor guide

### DIFF
--- a/app/_includes/md/enterprise/turn-on-rbac.md
+++ b/app/_includes/md/enterprise/turn-on-rbac.md
@@ -5,32 +5,19 @@ To enable RBAC, you will need the initial KONG_PASSWORD that was used when you f
 {% navtabs %}
 {% navtab UNIX-based system or Windows %}
 1. Modify configuration settings below in your `kong.conf` file. Navigate to the file at `/etc/kong/kong.conf`:
-    ```sh
-    $ cd /etc/kong/
-    ```
+    <pre><code>cd /etc/kong/</code></pre>
 2. Copy the `kong.conf.default` file so you know you have a working copy to fall back to.
-
-    ```sh
-    $ cp kong.conf.default kong.conf
-    ```
-
+    <pre><code>cp kong.conf.default kong.conf</code></pre>
 3. Now, edit the following settings in `kong.conf`:
 
-    ```sh
-    $ echo >> “enforce_rbac = on” >> /etc/kong/kong.conf
-    $ echo >> “admin_gui_auth = basic-auth” >> /etc/kong.conf
-    $ echo >> “admin_gui_session_conf = {"secret":"secret","storage":"kong","cookie_secure":false}”
-    ```
+    <pre><code>echo >> “enforce_rbac = on” >> /etc/kong/kong.conf<br>echo >> “admin_gui_auth = basic-auth” >> /etc/kong.conf<br>echo >> “admin_gui_session_conf = {"secret":"secret","storage":"kong","cookie_secure":false}”</code></pre>
 
     This will turn on RBAC, tell {{site.base_gateway}} to use basic authentication (username/password), and tell the Sessions Plugin how to create a session cookie.
 
     The cookie is used for all subsequent requests to authenticate the user until it expires. The session has a limited duration and renews at a configurable interval, which helps prevent an attacker from obtaining and using a stale cookie after the session has ended.
 
 4. Restart {{site.base_gateway}} and point to the new config file:
-
-    ```sh
-    $ kong restart -c /etc/kong/kong.conf
-    ```
+    <pre><code>kong restart -c /etc/kong/kong.conf</code></pre>
 {% endnavtab %}
 {% navtab Docker %}
 
@@ -38,12 +25,7 @@ If you have a Docker installation, run the following command to set the needed e
 
 **Note:** make sure to replace `<kong-container-id>` with the ID of your container.
 
-```sh
-$ echo "KONG_ENFORCE_RBAC=on \
-  KONG_ADMIN_GUI_AUTH=basic-auth \
-  KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' \
-  kong reload exit" | docker exec -i <kong-container-id> /bin/sh
-```
+<pre><code>echo "KONG_ENFORCE_RBAC=on \<br>KONG_ADMIN_GUI_AUTH=basic-auth \<br>KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' \<br>kong reload exit" | docker exec -i <div contenteditable="true">{KONG_CONTAINER_ID}</div> /bin/sh</code></pre>
 
 This will turn on RBAC, tell {{site.base_gateway}} to use basic authentication (username/password), and tell the Sessions Plugin how to create a session cookie.
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -287,12 +287,12 @@ ways to complete the task, like with the Admin API as well as the Kong Manager U
 want to include tabs. Tabs do not indent well though and often reset the numbering of
 ordered lists.
 
-To indent your tabs, including codeblock tabs, you can use the indent filter on a capture
-of your tabs.
+To indent your tabs so you can maintain your numbering, including codeblock tabs,
+you can use the indent filter on a capture of your tabs.
 
 {% raw %}
 {% capture the_code %}
-{%%}
+{%  %}
 {% endraw %}
 
 ## Admonitions

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -291,9 +291,92 @@ To indent your tabs so you can maintain your numbering, including codeblock tabs
 you can use the indent filter on a capture of your tabs.
 
 {% raw %}
+```
 {% capture the_code %}
-{%  %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
+-d source=crud \
+-d event=consumers \
+-d handler=webhook \
+-d config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+{% endnavtab %}
+{% navtab HTTPie %}
+<div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
+source=crud \
+event=consumers \
+handler=webhook \
+config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+```
 {% endraw %}
+
+And here's what it looks like:
+
+To make a technical writer smile, **always** do the following:
+
+1. Use the Oxford comma. It matters. (With indent filter)
+
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
+-d source=crud \
+-d event=consumers \
+-d handler=webhook \
+-d config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+{% endnavtab %}
+{% navtab HTTPie %}
+<div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
+source=crud \
+event=consumers \
+handler=webhook \
+config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+2. Laugh at all of their awesome puns. Using puns used to be considered a sign of great intelligence afterall. (Without the indent filter)
+
+  {% navtabs codeblock %}
+  {% navtab cURL %}
+  <div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
+  -d source=crud \
+  -d event=consumers \
+  -d handler=webhook \
+  -d config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+  {% endnavtab %}
+  {% navtab HTTPie %}
+  <div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
+  source=crud \
+  event=consumers \
+  handler=webhook \
+  config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+  {% endnavtab %}
+  {% endnavtabs %}
+
+3. Bring chocolate. There's nothing wrong with bribery. (Without the indent filter)
+
+  {% navtabs codeblock %}
+  {% navtab cURL %}
+  <div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
+  -d source=crud \
+  -d event=consumers \
+  -d handler=webhook \
+  -d config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+  {% endnavtab %}
+  {% navtab HTTPie %}
+  <div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
+  source=crud \
+  event=consumers \
+  handler=webhook \
+  config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+  {% endnavtab %}
+  {% endnavtabs %}
 
 ## Admonitions
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -115,7 +115,7 @@ You can also create tabbed codeblocks, so that users can easily switch to
 their preferred format. See [tabs for codeblocks](#tabs-for-codeblocks).
 
 If you're including placeholders in codeblocks, use HTML tags instead of
-backticks. See [editable placeholders](#editable-placeholders-in-codeblocks).
+backticks. See [editable placeholders](#editable-placeholders-in-codeblocks). 
 
 ## Placeholders
 
@@ -143,6 +143,7 @@ information includes:
 
 #### Create an editable placeholder
 
+* Enclose the entire codeblock in a `<div>` tag with a "copy-code-snippet" class: `<div class="copy-code-snippet"></div>`
 * Use the `<pre>` and `<code>` tags to create a codeblock
 * Enclose your placeholder in `<div contenteditable="true"></div>` tags
 * Do not add any newlines around the `pre` and `code` tags. These tags read
@@ -155,13 +156,13 @@ using fenced codeblocks elsewhere on the same page, set the language to
 {% navtabs codeblock %}
 {% navtab Input %}
 ```
-<pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
-port: 80 </code></pre>
+<div class="copy-code-snippet"><pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+port: 80 </code></pre></div>
 ```
 {% endnavtab %}
 {% navtab Output %}
-<pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
-port: 80 </code></pre>
+<div class="copy-code-snippet"><pre><code>host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+port: 80 </code></pre></div>
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -169,21 +170,25 @@ port: 80 </code></pre>
 {% navtabs codeblock %}
 {% navtab Input %}
 ```
-<pre>
-  <code>
-  host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
-  port: 80
-  </code>
-</pre>
+<div class="copy-code-snippet">
+  <pre>
+    <code>
+    host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+    port: 80
+    </code>
+  </pre>
+</div>
 ```
 {% endnavtab %}
 {% navtab Output %}
-<pre>
-  <code>
-  host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
-  port: 80
-  </code>
-</pre>
+<div class="copy-code-snippet">
+  <pre>
+      <code>
+      host: <div contenteditable="true">{EXAMPLE_VALUE}</div>
+      port: 80
+      </code>
+  </pre>
+</div>
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -275,6 +280,20 @@ $ httpie some request
 {% endnavtab %}
 {% endnavtabs %}
 
+### Indenting tabs in an ordered list
+
+Sometimes you are writing an ordered list of steps and may need to include multiple
+ways to complete the task, like with the Admin API as well as the Kong Manager UI, and
+want to include tabs. Tabs do not indent well though and often reset the numbering of
+ordered lists.
+
+To indent your tabs, including codeblock tabs, you can use the indent filter on a capture
+of your tabs.
+
+{% raw %}
+{% capture the_code %}
+{%%}
+{% endraw %}
 
 ## Admonitions
 


### PR DESCRIPTION
### Review
Check out the event-hooks code samples, they shoudn't have any extra spaces as they do in the current site. Also, I have added a note to the editablecontent section of the codeblocks in markdown-rules in the contributor's guide about making the copy-code-snippet icon and functionality show up and a section on indenting tabs in ordered lists.
### Summary
Noticed some extra spaces in event-hooks that were driving me crazy so fixed them and needed to explain how to use the new filter I added to the site for indenting tabs in ordered lists.
### Testing
[Indenting tabs with ordered lists](https://deploy-preview-3091--kongdocs.netlify.app/contributing/markdown-rules/)
[Editable placeholders in codeblocks note ](https://deploy-preview-3091--kongdocs.netlify.app/contributing/markdown-rules/)- see first bullet under create an editable placeholder