### PR TITLE
[DOCU-1661]Updates support policy table by adding the 2.5.x.x release

### DIFF
--- a/app/enterprise/2.5.x/support-policy.md
+++ b/app/enterprise/2.5.x/support-policy.md
@@ -46,6 +46,7 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |
 |  2.4.x.x |  2021-05-18   |     2022-08-24      |      2023-08-24       |  
 |  2.3.x.x |  2021-02-11   |     2022-08-24      |      2023-08-24       |
 |  2.2.x.x |  2020-11-17   |     2022-08-24      |      2023-08-24       |


### PR DESCRIPTION
### Summary
As far as I understand the support policy, the only thing that needs updating on this table is adding the new release number.
### Reason
[DOCU-1661](https://konghq.atlassian.net/browse/DOCU-1661)
### Testing
[Version Support for Kong Gateway (Enterprise)](https://deploy-preview-3094--kongdocs.netlify.app/enterprise/2.5.x/support-policy/#version-support-for-kong-gateway-enterprise)