### PR TITLE
[DOCU-1671]Eradicates RedHat from site 

### DIFF
--- a/app/_data/docs_nav_ee_0.31-x.yml
+++ b/app/_data/docs_nav_ee_0.31-x.yml
@@ -85,7 +85,7 @@
       url: /edition-versioning
     - text: Multiple Authentication Methods
       url: /allowing-multiple-authentication-methods
-    - text: PostgreSQL on RedHat
+    - text: PostgreSQL on Red Hat
       url: /postgresql-redhat
     - text: OpenID Connect with Google
       url: /oidc-google

--- a/app/_data/docs_nav_ee_0.32-x.yml
+++ b/app/_data/docs_nav_ee_0.32-x.yml
@@ -94,7 +94,7 @@
       url: /edition-versioning
     - text: Multiple Authentication Methods
       url: /allowing-multiple-authentication-methods
-    - text: PostgreSQL on RedHat
+    - text: PostgreSQL on Red Hat
       url: /postgresql-redhat
     - text: OpenID Connect with Google
       url: /oidc-google

--- a/app/_data/docs_nav_ee_0.33-x.yml
+++ b/app/_data/docs_nav_ee_0.33-x.yml
@@ -130,7 +130,7 @@
       url: /edition-versioning
     - text: Multiple Authentication Methods
       url: /allowing-multiple-authentication-methods
-    - text: PostgreSQL on RedHat
+    - text: PostgreSQL on Red Hat
       url: /postgresql-redhat
     - text: OpenID Connect with Google
       url: /oidc-google

--- a/app/_data/docs_nav_ee_0.34-x.yml
+++ b/app/_data/docs_nav_ee_0.34-x.yml
@@ -183,7 +183,7 @@
       url: /edition-versioning
     - text: Multiple Authentication Methods
       url: /allowing-multiple-authentication-methods
-    - text: PostgreSQL on RedHat
+    - text: PostgreSQL on Red Hat
       url: /postgresql-redhat
     - text: OpenID Connect with Google
       url: /oidc-google

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -66,7 +66,7 @@
             - text: Google Cloud
               url: https://console.cloud.google.com/marketplace/details/konghq-public/kongenterprise21
               absolute_url: true
-            - text: RedHat
+            - text: Red Hat
               url: https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm
               absolute_url: true
     - text: Deployment Options

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -64,7 +64,7 @@
             - text: Google Cloud
               url: https://console.cloud.google.com/marketplace/details/konghq-public/kongenterprise21
               absolute_url: true
-            - text: RedHat
+            - text: Red Hat
               url: https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm
               absolute_url: true
     - text: Deployment Options

--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -68,7 +68,7 @@
               url: https://console.cloud.google.com/marketplace/details/konghq-public/kongenterprise21
               absolute_url: true
               target_blank: true
-            - text: RedHat
+            - text: Red Hat
               url: https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm
               absolute_url: true
               target_blank: true

--- a/app/_data/docs_nav_ee_2.4.x.yml
+++ b/app/_data/docs_nav_ee_2.4.x.yml
@@ -67,7 +67,7 @@
               url: https://console.cloud.google.com/marketplace/details/konghq-public/kongenterprise21
               absolute_url: true
               target_blank: true
-            - text: RedHat
+            - text: Red Hat
               url: https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm
               absolute_url: true
               target_blank: true

--- a/app/_data/docs_nav_ee_2.5.x.yml
+++ b/app/_data/docs_nav_ee_2.5.x.yml
@@ -67,7 +67,7 @@
               url: https://console.cloud.google.com/marketplace/details/konghq-public/kongenterprise21
               absolute_url: true
               target_blank: true
-            - text: RedHat
+            - text: Red Hat
               url: https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm
               absolute_url: true
               target_blank: true

--- a/app/_data/docs_nav_mesh_1.0.x.yml
+++ b/app/_data/docs_nav_mesh_1.0.x.yml
@@ -25,7 +25,7 @@
       url: /installation/docker
     - text: CentOS
       url: /installation/centos
-    - text: RedHat
+    - text: Red Hat
       url: /installation/redhat
     - text: Amazon Linux
       url: /installation/amazonlinux

--- a/app/_data/docs_nav_mesh_1.1.x.yml
+++ b/app/_data/docs_nav_mesh_1.1.x.yml
@@ -25,7 +25,7 @@
       url: /installation/docker
     - text: CentOS
       url: /installation/centos
-    - text: RedHat
+    - text: Red Hat
       url: /installation/redhat
     - text: Amazon Linux
       url: /installation/amazonlinux

--- a/app/_data/docs_nav_mesh_1.2.x.yml
+++ b/app/_data/docs_nav_mesh_1.2.x.yml
@@ -26,7 +26,7 @@
       url: /installation/docker
     - text: CentOS
       url: /installation/centos
-    - text: RedHat
+    - text: Red Hat
       url: /installation/redhat
     - text: Amazon Linux
       url: /installation/amazonlinux

--- a/app/_data/docs_nav_mesh_1.3.x.yml
+++ b/app/_data/docs_nav_mesh_1.3.x.yml
@@ -26,7 +26,7 @@
       url: /installation/docker
     - text: CentOS
       url: /installation/centos
-    - text: RedHat
+    - text: Red Hat
       url: /installation/redhat
     - text: Amazon Linux
       url: /installation/amazonlinux

--- a/app/_includes/md/rpm.md
+++ b/app/_includes/md/rpm.md
@@ -35,8 +35,8 @@ $ sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
     
     {% if include.distribution == "rhel" %}
     
-- [Redhat 7]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel7.noarch.rpm)
-- [Redhat 8]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel8.noarch.rpm)
+- [Red Hat 7]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel7.amd64.rpm)
+- [Red Hat 8]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel8.amd64.rpm)
 
 To install from the command line
 
@@ -81,8 +81,8 @@ $ sudo yum install -y kong
     
     {% if include.distribution == "rhel" %}
     
-- [Redhat 7]({{ site.links.download }}/gateway-2.x-rhel-7/)
-- [Redhat 8]({{ site.links.download }}/gateway-2.x-rhel-8/)
+- [Red Hat 7]({{ site.links.download }}/gateway-2.x-rhel-7/)
+- [Red Hat 8]({{ site.links.download }}/gateway-2.x-rhel-8/)
 
 ```bash
 $ curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{rhel}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo

--- a/app/enterprise/0.31-x/postgresql-redhat.md
+++ b/app/enterprise/0.31-x/postgresql-redhat.md
@@ -1,10 +1,10 @@
 ---
-title: Installing PostgreSQL on RedHat
+title: Installing PostgreSQL on Red Hat
 ---
 
 ## Introduction
 
-The Kong [installation instructions for RedHat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of RedHat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
+The Kong [installation instructions for Red Hat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of Red Hat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
 
 As the ec2 default user run the following:
 

--- a/app/enterprise/0.32-x/postgresql-redhat.md
+++ b/app/enterprise/0.32-x/postgresql-redhat.md
@@ -1,10 +1,10 @@
 ---
-title: Installing PostgreSQL on RedHat
+title: Installing PostgreSQL on Red Hat
 ---
 
 ## Introduction
 
-The Kong [installation instructions for RedHat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of RedHat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
+The Kong [installation instructions for Red Hat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of Red Hat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
 
 As the ec2 default user run the following:
 

--- a/app/enterprise/0.33-x/postgresql-redhat.md
+++ b/app/enterprise/0.33-x/postgresql-redhat.md
@@ -1,9 +1,9 @@
 ---
-title: Installing PostgreSQL on RedHat
+title: Installing PostgreSQL on Red Hat
 toc: false
 ---
 
-The Kong [installation instructions for RedHat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of RedHat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
+The Kong [installation instructions for Red Hat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of Red Hat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
 
 As the ec2 default user run the following:
 

--- a/app/enterprise/0.34-x/postgresql-redhat.md
+++ b/app/enterprise/0.34-x/postgresql-redhat.md
@@ -1,9 +1,9 @@
 ---
-title: Installing PostgreSQL on RedHat
+title: Installing PostgreSQL on Red Hat
 toc: false
 ---
 
-The Kong [installation instructions for RedHat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of RedHat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
+The Kong [installation instructions for Red Hat](/install/redhat/) focus on Kong. These instructions add some additional steps to get PostgreSQL setup. These exact installation steps come from an EC2 instance of Red Hat Enterprise Linux 7, but can be generally applied to most Linux releases as well.
 
 As the ec2 default user run the following:
 

--- a/app/enterprise/2.1.x/deployment/installation/overview.md
+++ b/app/enterprise/2.1.x/deployment/installation/overview.md
@@ -91,8 +91,8 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="RedHat Marketplace" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <div class="install-text">Red Hat</div>
   </a>
 
 </div>

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -91,8 +91,8 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="RedHat Marketplace" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <div class="install-text">Red Hat</div>
   </a>
 
 </div>

--- a/app/enterprise/2.3.x/deployment/installation/overview.md
+++ b/app/enterprise/2.3.x/deployment/installation/overview.md
@@ -91,8 +91,8 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="RedHat Marketplace" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <div class="install-text">Red Hat</div>
   </a>
 
 </div>

--- a/app/enterprise/2.4.x/deployment/installation/overview.md
+++ b/app/enterprise/2.4.x/deployment/installation/overview.md
@@ -91,8 +91,8 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="RedHat Marketplace" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <div class="install-text">Red Hat</div>
   </a>
 
 </div>

--- a/app/enterprise/2.5.x/deployment/installation/overview.md
+++ b/app/enterprise/2.5.x/deployment/installation/overview.md
@@ -91,8 +91,8 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="RedHat Marketplace" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <div class="install-text">Red Hat</div>
   </a>
 
 </div>

--- a/app/gateway-oss/2.2.x/kong-user.md
+++ b/app/gateway-oss/2.2.x/kong-user.md
@@ -28,7 +28,7 @@ configuration property. It is also possible to run Kong as a custom non-root use
 * [Amazon Linux](/install/aws-linux)
 * [CentOS](/install/centos)
 * [Debian](/install/debian)
-* [RedHat](/install/redhat)
+* [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
 ## Run {{site.ce_product_name}} as the built-in kong user

--- a/app/gateway-oss/2.3.x/kong-user.md
+++ b/app/gateway-oss/2.3.x/kong-user.md
@@ -29,7 +29,7 @@ configuration property.
 * [Amazon Linux](/install/aws-linux)
 * [CentOS](/install/centos)
 * [Debian](/install/debian)
-* [RedHat](/install/redhat)
+* [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
 ## Run Kong Gateway as a non-root user

--- a/app/gateway-oss/2.4.x/kong-user.md
+++ b/app/gateway-oss/2.4.x/kong-user.md
@@ -29,7 +29,7 @@ configuration property.
 * [Amazon Linux](/install/aws-linux)
 * [CentOS](/install/centos)
 * [Debian](/install/debian)
-* [RedHat](/install/redhat)
+* [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
 ## Run Kong Gateway as a non-root user

--- a/app/gateway-oss/2.5.x/kong-user.md
+++ b/app/gateway-oss/2.5.x/kong-user.md
@@ -29,7 +29,7 @@ configuration property.
 * [Amazon Linux](/install/aws-linux)
 * [CentOS](/install/centos)
 * [Debian](/install/debian)
-* [RedHat](/install/redhat)
+* [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
 ## Run Kong Gateway as a non-root user

--- a/app/mesh/1.0.x/install.md
+++ b/app/mesh/1.0.x/install.md
@@ -19,7 +19,7 @@ distributions that provide a drop-in replacement to Kuma's native binaries.
 * [OpenShift](/mesh/{{page.kong_version}}/installation/openshift)
 * [Docker](/mesh/{{page.kong_version}}/installation/docker)
 * [CentOS](/mesh/{{page.kong_version}}/installation/centos)
-* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Red Hat](/mesh/{{page.kong_version}}/installation/redhat)
 * [Amazon Linux](/mesh/{{page.kong_version}}/installation/amazonlinux)
 * [Debian](/mesh/{{page.kong_version}}/installation/debian)
 * [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -133,7 +133,7 @@ will be executing the commands.
 See the individual installation pages for your OS to download and extract
 `kumactl` to your machine:
 * [CentOS](/mesh/{{page.kong_version}}/installation/centos)
-* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Red Hat](/mesh/{{page.kong_version}}/installation/redhat)
 * [Debian](/mesh/{{page.kong_version}}/installation/debian)
 * [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
 * [macOS](/mesh/{{page.kong_version}}/installation/macos)

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -39,7 +39,7 @@ the **client host** from where you will be executing the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -39,7 +39,7 @@ the **client host** from where you will be executing the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_versions[0].version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.0.x/installation/redhat.md
+++ b/app/mesh/1.0.x/installation/redhat.md
@@ -1,8 +1,8 @@
 ---
-title: Kong Mesh with RedHat
+title: Kong Mesh with Red Hat
 ---
 
-To install and run {{site.mesh_product_name}} on RedHat (**x86_64**), execute
+To install and run {{site.mesh_product_name}} on Red Hat (**x86_64**), execute
 the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)

--- a/app/mesh/1.1.x/install.md
+++ b/app/mesh/1.1.x/install.md
@@ -54,8 +54,8 @@ links to cloud marketplace integrations.
   </a>
 
   <a href="/mesh/{{page.kong_version}}/installation/redhat" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq" alt="RedHat" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq" alt="Red Hat" />
+    <div class="install-text">Red Hat</div>
   </a>
 
   <a href="/mesh/{{page.kong_version}}/installation/amazonlinux" class="docs-grid-install-block no-description">

--- a/app/mesh/1.1.x/installation/docker.md
+++ b/app/mesh/1.1.x/installation/docker.md
@@ -133,7 +133,7 @@ will be executing the commands.
 See the individual installation pages for your OS to download and extract
 `kumactl` to your machine:
 * [CentOS](/mesh/{{page.kong_version}}/installation/centos)
-* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Red Hat](/mesh/{{page.kong_version}}/installation/redhat)
 * [Debian](/mesh/{{page.kong_version}}/installation/debian)
 * [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
 * [macOS](/mesh/{{page.kong_version}}/installation/macos)

--- a/app/mesh/1.1.x/installation/kubernetes.md
+++ b/app/mesh/1.1.x/installation/kubernetes.md
@@ -39,7 +39,7 @@ the **client host** from where you will be executing the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.1.x/installation/openshift.md
+++ b/app/mesh/1.1.x/installation/openshift.md
@@ -39,7 +39,7 @@ the **client host** from where you will be executing the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.1.x/installation/redhat.md
+++ b/app/mesh/1.1.x/installation/redhat.md
@@ -1,8 +1,8 @@
 ---
-title: Kong Mesh with RedHat
+title: Kong Mesh with Red Hat
 ---
 
-To install and run {{site.mesh_product_name}} on RedHat (**x86_64**), execute
+To install and run {{site.mesh_product_name}} on Red Hat (**x86_64**), execute
 the following steps:
 
 * [1. Download {{site.mesh_product_name}}](#1-download-kong-mesh)

--- a/app/mesh/1.2.x/install.md
+++ b/app/mesh/1.2.x/install.md
@@ -54,8 +54,8 @@ links to cloud marketplace integrations.
   </a>
 
   <a href="/mesh/{{page.kong_version}}/installation/redhat" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq" alt="RedHat" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq" alt="Red Hat" />
+    <div class="install-text">Red Hat</div>
   </a>
 
   <a href="/mesh/{{page.kong_version}}/installation/amazonlinux" class="docs-grid-install-block no-description">

--- a/app/mesh/1.2.x/installation/docker.md
+++ b/app/mesh/1.2.x/installation/docker.md
@@ -118,7 +118,7 @@ will be executing the commands.
 See the individual installation pages for your OS to download and extract
 `kumactl` to your machine:
 * [CentOS](/mesh/{{page.kong_version}}/installation/centos)
-* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Red Hat](/mesh/{{page.kong_version}}/installation/redhat)
 * [Debian](/mesh/{{page.kong_version}}/installation/debian)
 * [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
 * [macOS](/mesh/{{page.kong_version}}/installation/macos)

--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -36,7 +36,7 @@ the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.2.x/installation/openshift.md
+++ b/app/mesh/1.2.x/installation/openshift.md
@@ -39,7 +39,7 @@ the **client host** from where you will be executing the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.2.x/installation/redhat.md
+++ b/app/mesh/1.2.x/installation/redhat.md
@@ -1,8 +1,8 @@
 ---
-title: Kong Mesh with RedHat
+title: Kong Mesh with Red Hat
 ---
 
-To install and run {{site.mesh_product_name}} on RedHat (**x86_64**):
+To install and run {{site.mesh_product_name}} on Red Hat (**x86_64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
 1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)

--- a/app/mesh/1.3.x/install.md
+++ b/app/mesh/1.3.x/install.md
@@ -54,8 +54,8 @@ links to cloud marketplace integrations.
   </a>
 
   <a href="/mesh/{{page.kong_version}}/installation/redhat" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq" alt="RedHat" />
-    <div class="install-text">RedHat</div>
+    <img class="install-icon" src="https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq" alt="Red Hat" />
+    <div class="install-text">Red Hat</div>
   </a>
 
   <a href="/mesh/{{page.kong_version}}/installation/amazonlinux" class="docs-grid-install-block no-description">

--- a/app/mesh/1.3.x/installation/docker.md
+++ b/app/mesh/1.3.x/installation/docker.md
@@ -118,7 +118,7 @@ will be executing the commands.
 See the individual installation pages for your OS to download and extract
 `kumactl` to your machine:
 * [CentOS](/mesh/{{page.kong_version}}/installation/centos)
-* [RedHat](/mesh/{{page.kong_version}}/installation/redhat)
+* [Red Hat](/mesh/{{page.kong_version}}/installation/redhat)
 * [Debian](/mesh/{{page.kong_version}}/installation/debian)
 * [Ubuntu](/mesh/{{page.kong_version}}/installation/ubuntu)
 * [macOS](/mesh/{{page.kong_version}}/installation/macos)

--- a/app/mesh/1.3.x/installation/kubernetes.md
+++ b/app/mesh/1.3.x/installation/kubernetes.md
@@ -36,7 +36,7 @@ the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.3.x/installation/openshift.md
+++ b/app/mesh/1.3.x/installation/openshift.md
@@ -39,7 +39,7 @@ the **client host** from where you will be executing the commands to access
 Kubernetes:
 
 * [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-centos-amd64.tar.gz)
-* [RedHat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
+* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-rhel-amd64.tar.gz)
 * [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-debian-amd64.tar.gz)
 * [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-ubuntu-amd64.tar.gz)
 * [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)

--- a/app/mesh/1.3.x/installation/redhat.md
+++ b/app/mesh/1.3.x/installation/redhat.md
@@ -1,8 +1,8 @@
 ---
-title: Kong Mesh with RedHat
+title: Kong Mesh with Red Hat
 ---
 
-To install and run {{site.mesh_product_name}} on RedHat (**x86_64**):
+To install and run {{site.mesh_product_name}} on Red Hat (**x86_64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
 1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
@@ -16,7 +16,7 @@ You have a license for {{site.mesh_product_name}}.
 
 {:.note}
 > **Note:** {{site.mesh_product_name}} ships with a FIPS 140-2 compliant
-build of Envoy. This build is only available on RedHat 8 and later. For any previous
+build of Envoy. This build is only available on Red Hat 8 and later. For any previous
 versions, use [Docker](/mesh/{{page.kong_version}}/installation/docker/). 
 
 ## 1. Download {{site.mesh_product_name}}


### PR DESCRIPTION
### Review
Check for any instances of RedHat. They should all now be Red Hat. 
### Summary
RedHat apparently updated its name to Red Hat and so now every instance in our documentation needs to be updated to reflect the new name. Particularly since we will be partnering with them soon. Also, fixed a couple of links for rhel install packages on the OSS pages - was pointing to a broken link. Should be fixed.
### Reason
[DOCU-1671](https://konghq.atlassian.net/browse/DOCU-1671)
### Testing
Will include Netlify link when available.
