### PR TITLE
[DOCU-1692] Update site title, name, and description

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -1,6 +1,6 @@
 {% unless page.name and page.path contains '_hub' %} {% capture page_title %}{{
 page.title | escape }}{% if page.kong_version and page.no_version != true %} -
-v{{ page.kong_version | escape }}{% endif %}{% if page.title %} | {% endif %}{{ site.name }} - {{
+v{{ page.kong_version | escape }}{% endif %}{% if page.title %} | {% endif %}{{
 site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
 {{ page.type }} | Kong{% endcapture %} {% endunless %}
 
@@ -19,7 +19,7 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ page.name }}
   <title>{{ page_title }}</title>
   <meta name="description" content="{{ site.description }}" />
   <meta name="author" content="KongHQ" />
-  <meta property="og:title" content="{{ site.title }}" />
+  <meta property="og:title" content="{{ site.title }} | {{ page.title }}" />
   <meta property="og:site_name" content="{{ site.name }}" />
   <!-- use share link for facebook -->
   <meta property="og:url" content="{{ site.links.share }}" />

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -15,9 +15,9 @@ keep_files:
   - assets
 
 # Site settings
-name: Kong
-title: Open-Source API Management and Microservice Management
-description: "Secure, Manage &amp; Extend your APIs or Microservices with plugins for authentication, logging, rate-limiting, transformations and more."
+name: Kong Docs
+title: Kong Docs
+description: "Documentation for Kong, the Cloud Connectivity Company for APIs and Microservices."
 links:
   web: https://docs.konghq.com
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -15,9 +15,9 @@ keep_files:
   - assets
 
 # Site settings
-name: Kong
-title: Open-Source API Management and Microservice Management
-description: "Secure, Manage &amp; Extend your APIs or Microservices with plugins for authentication, logging, rate-limiting, transformations and more."
+name: Kong Docs
+title: Kong Docs
+description: "Documentation for Kong, the Cloud Connectivity Company for APIs and Microservices."
 links:
   web: https://docs.konghq.com
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters


### PR DESCRIPTION
### Review
@falondarville and also @Kong/team-docs 

### Summary
This change will give us better link previews and a more up-to-date website summary for search engines.

**Reviewers:** I did some research on the difference between site name and site title, and came up blank. Site name isn't even a default jekyll variable, it's a custom one that someone added. I'm still not sure why we had a different site name vs site title, so I made them the same and removed the redundancy in link titles. However, if someone knows more about this and could answer _why_ we might have this and whether we might need to come up with a unique site name, I'd be glad to hear about it.

### Reason
Site metadata was very out of date, and our link previews would only ever generate a site description as the link title. 

### Testing
TBA
