### PR TITLE
Add media query to widen plugin cards on mobile

### DIFF
--- a/app/_assets/css/hub.css
+++ b/app/_assets/css/hub.css
@@ -7992,6 +7992,10 @@ a.text-gray-dark:focus,a.text-gray-dark:hover {
     .hidden-xs-down {
         display:none!important
     }
+
+    .plugin-card {
+        width: 300px;
+    }
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
### Review

@lena-larionova 

### Summary

Added a media query to widen the plugin cards on mobile (max-width 575px). 

### Reason

The plugin cards were very narrow. 

### Testing

Check on mobile to see that the plugin cards are wider now. 

https://deploy-preview-3105--kongdocs.netlify.app/hub/