### PR TITLE
[DOCU-1705] Updates ee changelog with 5 new minor releases

### DIFF
--- a/app/enterprise/2.4.x/deployment/hybrid-mode.md
+++ b/app/enterprise/2.4.x/deployment/hybrid-mode.md
@@ -61,30 +61,43 @@ For the full Kubernetes Hybrid mode documentation, see
 in the `kong/charts` repository.
 
 ## Version Compatibility
-{{site.ee_gateway_name}} control planes only connect to data planes with the
-same major version and at most two minor versions earlier (edge included).
-Control planes won't connect to data planes with newer versions.
+{{site.ee_gateway_name}} control planes only allow connections from data planes with the
+same major version.
+Control planes won't allow connections from data planes with newer minor versions.
 
-For example, a {{site.ee_product_name}} v2.4.2 control plane:
+For example, a {{site.ee_product_name}} v2.5.2 control plane:
 
-- Accepts a {{site.ee_product_name}} 2.4.0, 2.4.1 and 2.4.2 data plane
-- Accepts a {{site.ee_product_name}} 2.3.8, 2.2.1 and 2.2.0 data plane
-- Rejects a {{site.ee_product_name}} 2.4.3 data plane
-- Rejects a {{site.ee_product_name}} 2.1.9 data plane
-- Rejects a {{site.ee_product_name}} 1.0.0 data plane
+- Accepts a {{site.ee_product_name}} 2.5.0, 2.5.1 and 2.5.2 data plane.
+- Accepts a {{site.ee_product_name}} 2.3.8, 2.2.1 and 2.2.0 data plane.
+- Accepts a {{site.ee_product_name}} 2.5.3 data plane (newer patch version on the data plane is accepted).
+- Rejects a {{site.ee_product_name}} 1.0.0 data plane (major version differs).
+- Rejects a {{site.ee_product_name}} 2.6.0 data plane (minor version on data plane is newer).
 
-Plugins installed on both control planes and data planes must have the same
-major and minor versions.
+Furthermore, for every plugin that is configured on the {{site.ee_product_name}}
+control plane, new configs are only pushed to data planes that have those configured
+plugins installed and loaded. The major version of those configured plugins must
+be the same on both the control planes and data planes. Also, the minor versions
+of the plugins on the data planes can not be newer than versions installed on the
+control planes. Similar to {{site.ee_product_name}} version checks,
+plugin patch versions are also ignored when determining compatibility.
+
+{:.important}
+> Configured plugins means any plugin that is either enabled globally or
+configured by services, routes, or consumers.
 
 For example, if a {{site.ee_product_name}} control plane has `plugin1` v1.1.1
-and `plugin2` v2.1.0 installed:
+and `plugin2` v2.1.0 installed, and `plugin1` is configured by a `Route` object:
 
 - It accepts {{site.ee_product_name}} data planes with `plugin1` v1.1.2,
-`plugin2` v2.1.0 installed
+`plugin2` not installed.
 - It accepts {{site.ee_product_name}} data planes with `plugin1` v1.1.2,
-`plugin2` v2.1.0 and  `plugin3` v9.8.1 installed
+`plugin2` v2.1.0, and  `plugin3` v9.8.1 installed.
+- It accepts {{site.ee_product_name}} data planes with `plugin1` v1.1.1
+and `plugin3` v9.8.1 installed.
 - It rejects {{site.ee_product_name}} data planes with `plugin1` v1.2.0,
-`plugin2` v2.1.0 installed
+`plugin2` v2.1.0 installed (minor version of plugin on data plane is newer).
+- It rejects {{site.ee_product_name}} data planes with `plugin1` not installed
+(plugin configured on control plane but not installed on data plane).
 
 Version compatibility checks between the control plane and data plane
 occur at configuration read time. As each data plane proxy receives

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -13,7 +13,8 @@ no_version: true
 - Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
 - Now, bootstrap migrations for multi-node Apache Cassandra clusters work as expected.
   With this fix, inserts are performed after schema agreement.
-- Updated Nettle version from `3.7.2` to `3.7.3` which fixes bugs that could make RSA decription crash on invalid inputs.
+- Updates Nettle dependency version from `3.7.2` to `3.7.3`, fixing bugs that could cause
+  RSA decryption functions to crash with invalid inputs.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
@@ -510,9 +511,10 @@ no_version: true
   the counts, allowing an empty workspace to be deleted.
 - Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
 - Users with the `kong_admin` role can now log in to Kong Manager when `enforce_rbac=both` is set. 
-- Renamed the property identifying control planes in hybrid mode when using Kong Vitals with anonymous
+- Renames the property identifying control planes in hybrid mode when using Kong Vitals with anonymous
   reports enabled. Before, users received the error, `Cannot use this function in data plane`, on their control planes.
-- Updated Nettle version from `3.7.2` to `3.7.3` which fixes bugs that could make RSA decription crash on invalid inputs.
+- Updates Nettle dependency version from `3.7.2` to `3.7.3`, fixing bugs that could cause
+  RSA decryption functions to crash with invalid inputs.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -521,7 +521,7 @@ no_version: true
 
 #### Hybrid Mode
 - Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
-  [Version compatibility](/gateway-oss/2.4.x/hybrid-mode/#version_compatibility)
+  [Version compatibility](/gateway-oss/2.4.x/deployment/hybrid-mode/#version_compatibility)
   section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ## 2.4.1.1

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -13,6 +13,7 @@ no_version: true
 - Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
 - Now, bootstrap migrations for multi-node Apache Cassandra clusters work as expected.
   With this fix, inserts are performed after schema agreement.
+- Updated Nettle version from `3.7.2` to `3.7.3` which fixes bugs that could make RSA decription crash on invalid inputs.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
@@ -511,6 +512,7 @@ no_version: true
 - Users with the `kong_admin` role can now log in to Kong Manager when `enforce_rbac=both` is set. 
 - Renamed the property identifying control planes in hybrid mode when using Kong Vitals with anonymous
   reports enabled. Before, users received the error, `Cannot use this function in data plane`, on their control planes.
+- Updated Nettle version from `3.7.2` to `3.7.3` which fixes bugs that could make RSA decription crash on invalid inputs.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -11,7 +11,7 @@ no_version: true
 
 #### Enterprise
 - Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
-- Now, bootstrap migrations for multi-node Apache Cassandra 4.0.0 clusters work as expected.
+- Now, bootstrap migrations for multi-node Apache Cassandra clusters work as expected.
   With this fix, inserts are performed after schema agreement.
 
 #### Plugins
@@ -521,7 +521,7 @@ no_version: true
 
 #### Hybrid Mode
 - Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
-  [Version compatibility](/gateway-oss/2.5.x/hybrid-mode/#version_compatibility)
+  [Version compatibility](/gateway-oss/2.4.x/hybrid-mode/#version_compatibility)
   section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ## 2.4.1.1
@@ -960,7 +960,7 @@ keep-alive connections. [7102](https://github.com/Kong/kong/pull/7102)
 
 #### Hybrid Mode
 - Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
-  [Version compatibility](/enterprise/2.5.x/deployment/hybrid-mode/#version-compatibility)
+  [Version compatibility](/enterprise/2.3.x/deployment/hybrid-mode/#version-compatibility)
   section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ## 2.3.3.2

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -4,6 +4,20 @@ no_search: true
 no_version: true
 ---
 
+## 2.5.0.1
+**Release Date** 2021/08/12
+
+### Fixes
+
+#### Enterprise
+- Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  With this fix, when the OpenID Connect plugin is configured with a `config.anonymous` consumer and
+  `config.scopes_required` is set, a token missing the required scopes will have the anonymous consumer
+  headers set when sent to the upstream.
+
 ## 2.5.0.0
 **Release Date** 2021/08/03
 
@@ -479,6 +493,31 @@ no_version: true
   with command not found". [#7523](https://github.com/Kong/kong/pull/7523)
 
 
+## 2.4.1.2
+**Release Date** 2021/08/12
+
+### Fixes
+
+#### Enterprise
+- Users can now successfully delete workspaces after deleting all entities associated with that workspace.
+  Previously, Kong Gateway was not correctly cleaning up parent-child relationships. For example, creating
+  an Admin also creates a Consumer and RBAC user. When deleting the Admin, the Consumer and RBAC user are
+  also deleted, but accessing the `/workspaces/workspace_name/meta` endpoint would show counts for Consumers
+  and RBAC users, which prevented the workspace from being deleted. Now deleting entities correctly updates
+  the counts, allowing an empty workspace to be deleted.
+- Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
+- Users with the `kong_admin` role can now log in to Kong Manager when `enforce_rbac=both` is set. 
+- Renamed the property identifying control planes in hybrid mode when using Kong Vitals with anonymous
+  reports enabled. Before, users received the error, `Cannot use this function in data plane`, on their control planes.
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  With this fix, when the OpenID Connect plugin is configured with a `config.anonymous` consumer and
+  `config.scopes_required` is set, a token missing the required scopes will have the anonymous consumer
+  headers set when sent to the upstream.
+- Fixes a regression in the Kong Collector plugin that caused HARs to be kept in its queue indefinitely.
+
+
 ## 2.4.1.1
 **Release Date** 2021/05/27
 
@@ -886,6 +925,32 @@ keep-alive connections. [7102](https://github.com/Kong/kong/pull/7102)
 - [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
   - The plugin was not allowing access to any Kong modules within the sandbox except `kong.request`,
     which prevented access to other necessary modules such as `kong.log`.
+
+
+## 2.3.3.3
+**Release Date** 2021/08/12
+
+### Fixes
+
+#### Enterprise
+- Users can now successfully delete workspaces after deleting all entities associated with that workspace.
+  Previously, Kong Gateway was not correctly cleaning up parent-child relationships. For example, creating
+  an Admin also creates a Consumer and RBAC user. When deleting the Admin, the Consumer and RBAC user are
+  also deleted, but accessing the `/workspaces/workspace_name/meta` endpoint would show counts for Consumers
+  and RBAC users, which prevented the workspace from being deleted. Now deleting entities correctly updates
+  the counts, allowing an empty workspace to be deleted.
+- Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
+- Users can now include special characters ".", "-", "_", "~" in workspace names. Before when users created
+  workspaces using the UI, the workspace name was validated; however, when using the Admin API to add users,
+  the workspace name was not validated. Because the name was not validated in the Admin Api, users could create workspace names with special characters that would then break the environment.
+- Kong Gateway now escapes "-" and "." special characters in workspace names when building the compiled pattern
+  for collision detection. 
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  With this fix, when the OpenID Connect plugin is configured with a `config.anonymous` consumer and
+  `config.scopes_required` is set, a token missing the required scopes will have the anonymous consumer
+  headers set when sent to the upstream.
 
 ## 2.3.3.2
 **Release Date** 2021/04/21
@@ -1296,6 +1361,26 @@ fixed causing a 500 auth error when falling back to an anonymous user.
 ### Deprecated
 #### Distributions
 - Support for CentOS-6 is removed and entered end-of-life on Nov 30, 2020.
+
+## 2.2.1.4
+**Release Date** 2021/08/12
+
+### Fixes
+
+#### Enterprise
+- Users can now successfully delete workspaces after deleting all entities associated with that workspace.
+  Previously, Kong Gateway was not correctly cleaning up parent-child relationships. For example, creating
+  an Admin also creates a Consumer and RBAC user. When deleting the Admin, the Consumer and RBAC user are
+  also deleted, but accessing the `/workspaces/workspace_name/meta` endpoint would show counts for Consumers
+  and RBAC users, which prevented the workspace from being deleted. Now deleting entities correctly updates
+  the counts, allowing an empty workspace to be deleted.
+- Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  With this fix, when the OpenID Connect plugin is configured with a `config.anonymous` consumer and
+  `config.scopes_required` is set, a token missing the required scopes will have the anonymous consumer
+  headers set when sent to the upstream.
 
 ## 2.2.1.3
 **Release Date** 2021/04/22
@@ -1712,6 +1797,26 @@ open-source **Kong Gateway 2.2.0.0**:
 - The `shorthands` attribute in schema definitions is deprecated in favor of
   the new `shorthand_fields` top-level attribute.
 
+## 2.1.4.7
+**Release Date** 2021/08/12
+
+### Fixes
+
+#### Enterprise
+- Users can now successfully delete workspaces after deleting all entities associated with that workspace.
+  Previously, Kong Gateway was not correctly cleaning up parent-child relationships. For example, creating
+  an Admin also creates a Consumer and RBAC user. When deleting the Admin, the Consumer and RBAC user are
+  also deleted, but accessing the `/workspaces/workspace_name/meta` endpoint would show counts for Consumers
+  and RBAC users, which prevented the workspace from being deleted. Now deleting entities correctly updates
+  the counts, allowing an empty workspace to be deleted.
+- Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  With this fix, when the OpenID Connect plugin is configured with a `config.anonymous` consumer and
+  `config.scopes_required` is set, a token missing the required scopes will have the anonymous consumer
+  headers set when sent to the upstream.
+
 ## 2.1.4.6
 **Release Date** 2021/04/21
 
@@ -1722,12 +1827,12 @@ This release includes internal updates that do not affect product functionality.
 #### Enterprise
 - Fixed an issue encountered when users were deleting a Kong Dev Portal collection and
   the collection was not defined in `portal.conf.yaml` or `portal.conf.yaml`
-  did not exist. Instead of deleting the content, users recieved an error.
+  did not exist. Instead of deleting the content, users received an error.
   This issue also occurred when users were using the Kong Dev Portal CLI to wipe or deploy
   templates. With this fix, deleting content from the Kong Dev Portal works as
   expected.
-- In Kong Manager, users could recieve an emtpy set of roles from an API request,
-  even when valid RBAC roles existed in the databse because of a filtering issue
+- In Kong Manager, users could receive an empty set of roles from an API request,
+  even when valid RBAC roles existed in the database because of a filtering issue
   with portal and default roles on a paginated set. With this fix, if valid RBAC
   roles exist in the database, an API request returns with those valid roles.
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -11,6 +11,8 @@ no_version: true
 
 #### Enterprise
 - Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
+- Now, bootstrap migrations for multi-node Apache Cassandra 4.0.0 clusters work as expected.
+  With this fix, inserts are performed after schema agreement.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
@@ -44,7 +46,7 @@ no_version: true
   See [Starting Data Plane Nodes](/gateway-oss/2.5.x/hybrid-mode/#starting-data-plane-nodes)
   in the Hybrid Mode guide for more information. [#7044](https://github.com/kong/kong/pull/7044)
 - New `declarative_config_string` option allows loading declarative configurations directly from a string. See the
-  [Loading The Declarative Configuration File](/gateway-oss/2.5.x/db-less-and-declarative-config/#loading-the-declarative-configuration-file)
+  [Loading The Declarative Configuration File](/enterprise/2.5.x/db-less-and-declarative-config/#loading-the-declarative-configuration-file)
   section of the DB-less and Declarative Configuration guide for more information.
   [#7379](https://github.com/kong/kong/pull/7379)
 
@@ -95,10 +97,10 @@ no_version: true
 
 #### Hybrid Mode
 - Kong Gateway now exposes an upstream health checks endpoint (using the status API) on the data plane for better
-  observability. See [Readonly Status API endpoints on Data Plane](/gateway-oss/2.5.x/hybrid-mode/#readonly-status-api-endpoints-on-data-plane)
+  observability. See [Readonly Status API endpoints on Data Plane](/enterprise/2.5.x/deployment/hybrid-mode/#readonly-status-api-endpoints-on-data-plane)
   in the Hybrid Mode guide for more information. [#7429](https://github.com/Kong/kong/pull/7429)
 - Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
-  [Version compatibility](/gateway-oss/2.5.x/hybrid-mode/#version_compatibility)
+  [Version compatibility](/enterprise/2.5.x/deployment/hybrid-mode/#version-compatibility)
   section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ### Dependencies
@@ -208,8 +210,8 @@ no_version: true
 - The stream access log configuration options are now properly separated from the HTTP access log. Before when users
   used Kong Gateway with TCP, they couldn’t use a custom log format. With this fix, `proxy_stream_access_log` and `proxy_stream_error_log`
   have been added to differentiate the Stream access log from the HTTP subsystem. See
-  [`proxy_stream_access_log`](/enterprise/2.4.x/property-reference/#proxy_stream_access_log)
-  and [`proxy_stream_error_log`](/enterprise/2.4.x/property-reference/#proxy_stream_error_log) in the Configuration
+  [`proxy_stream_access_log`](/enterprise/2.5.x/property-reference/#proxy_stream_access_log)
+  and [`proxy_stream_error_log`](/enterprise/2.5.x/property-reference/#proxy_stream_error_log) in the Configuration
   Property Reference for more information. [#7046](https://github.com/kong/kong/pull/7046)
 
 #### Migrations
@@ -260,7 +262,7 @@ no_version: true
   - The plugin no longer shares context between several Zipkin plugins. Before the plugin was using `ngx.ctx` exclusively,
     even in a global context, which meant more than one instance of the Zipkin plugin would override each other. Now the plugin
     uses `kong.ctx.plugin` to hold the `zipkin` table, instead of `ngx.ctx`.
-- [External plugins](/enterprise/2.4.x/external-plugins)
+- [External plugins](/enterprise/2.5.x/external-plugins)
   This release includes better error messages when external plugins fail to start. With this fix, Kong Gateway detects the return code
   127 (command not found), allowing it to display an appropriate error message, "external plugin server start command exited
   with command not found". [#7523](https://github.com/Kong/kong/pull/7523)
@@ -517,6 +519,10 @@ no_version: true
   headers set when sent to the upstream.
 - Fixes a regression in the Kong Collector plugin that caused HARs to be kept in its queue indefinitely.
 
+#### Hybrid Mode
+- Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
+  [Version compatibility](/gateway-oss/2.5.x/hybrid-mode/#version_compatibility)
+  section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ## 2.4.1.1
 **Release Date** 2021/05/27
@@ -951,6 +957,11 @@ keep-alive connections. [7102](https://github.com/Kong/kong/pull/7102)
   With this fix, when the OpenID Connect plugin is configured with a `config.anonymous` consumer and
   `config.scopes_required` is set, a token missing the required scopes will have the anonymous consumer
   headers set when sent to the upstream.
+
+#### Hybrid Mode
+- Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
+  [Version compatibility](/enterprise/2.5.x/deployment/hybrid-mode/#version-compatibility)
+  section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ## 2.3.3.2
 **Release Date** 2021/04/21


### PR DESCRIPTION
### Summary
The Enterprise Gateway is releasing 5 minor releases with a handful of bug fixes and the changelog needs to be updated with these new versions and what updates are included in them.
Internal changelog:

- [2.1.4.7](https://konghq.atlassian.net/wiki/spaces/FTT/pages/2594734310/Kong+Enterprise+2.1.4.7)
- [2.2.1.4](https://konghq.atlassian.net/wiki/spaces/FTT/pages/2594865355/Kong+Enterprise+2.2.1.4)
- [2.3.3.3](https://konghq.atlassian.net/wiki/spaces/FTT/pages/2590736896/Kong+Enterprise+2.3.3.3)
- [2.4.1.2](https://konghq.atlassian.net/wiki/spaces/FTT/pages/2594734458/Kong+Enterprise+2.4.1.2)
- [2.5.0.1](https://konghq.atlassian.net/wiki/spaces/FTT/pages/2596307228/Kong+Enterprise+2.5.0.1)
### Reason
[DOCU-1705](https://konghq.atlassian.net/browse/DOCU-1705)
### Testing
- [2.1.4.7](https://deploy-preview-3106--kongdocs.netlify.app/enterprise/changelog/#2147)
- [2.2.1.4](https://deploy-preview-3106--kongdocs.netlify.app/enterprise/changelog/#2214)
- [2.3.3.3](https://deploy-preview-3106--kongdocs.netlify.app/enterprise/changelog/#2333)
- [2.4.1.2](https://deploy-preview-3106--kongdocs.netlify.app/enterprise/changelog/#2412)
- [2.5.0.1](https://deploy-preview-3106--kongdocs.netlify.app/enterprise/changelog/#2501)