### PR TITLE
Deleted the duplicated order for ip-restriction

### DIFF
--- a/app/enterprise/2.5.x/plugin-development/custom-logic.md
+++ b/app/enterprise/2.5.x/plugin-development/custom-logic.md
@@ -268,7 +268,6 @@ pre-function                | `+inf`
 correlation-id              | 100001
 zipkin                      | 100000
 exit-transformer            | 9999
-ip-restriction              | 3000
 bot-detection               | 2500
 cors                        | 2000
 session                     | 1900


### PR DESCRIPTION

### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@Kong/team-docs 

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
 I checked the order by the below commands:

```
cd /usr/local/share/lua/5.1/kong/plugins/
find . | xargs grep  \.PRIORITY |  sort -k 3 -t " " -n -r | grep ip-
```

Then you can find below:
`./ip-restriction/handler.lua:  PRIORITY = 990,`

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
