### PR TITLE
Basic auth plugin: remove non-existent version

### DIFF
--- a/app/_data/extensions/kong-inc/basic-auth/versions.yml
+++ b/app/_data/extensions/kong-inc/basic-auth/versions.yml
@@ -1,4 +1,3 @@
 - release: 2.2-x
 - release: 2.1-x
-- release: 1.0-x
 - release: 0.1-x


### PR DESCRIPTION
### Summary
Removing nav entry for a plugin version that doesn't have docs.

### Reason
Broken link in the [basic auth dropdown to 1.0-x,](https://docs.konghq.com/hub/kong-inc/basic-auth/) and the version doesn't exist: https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/kong-inc/basic-auth

### Testing
Check nav on basic auth: https://deploy-preview-3113--kongdocs.netlify.app/hub/kong-inc/basic-auth/
