### PR TITLE
[DOCU-1164] clean up Dev Portal Overview

### DIFF
--- a/app/konnect/dev-portal/administrators/public-portal.md
+++ b/app/konnect/dev-portal/administrators/public-portal.md
@@ -1,10 +1,10 @@
 ---
-title: Public Developer Portal
+title: Enable Public Dev Portal
 no_version: true
 ---
 
 When Public Portal is enabled, anyone can access your Dev Portal without a 
-login. Developers will not need to register and new application registrations will not be possible.
+login. Developers will not need to register and new Application registrations will not be possible.
 
 Note that the Register options are not available in a public-facing portal.
 

--- a/app/konnect/dev-portal/developers/dev-reg.md
+++ b/app/konnect/dev-portal/developers/dev-reg.md
@@ -20,6 +20,10 @@ Admins can find the Dev Portal URL in [konnect.konghq.com](https://konnect.kongh
 
 3. Under the title heading **Published Services**, see the **Portal URL** link.
 
+{:.note}
+> **Note**: Admins cannot currently set up a custom Dev Portal URL through
+{{site.konnect_short_name}}. If needed, contact [Kong Support](https://support.konghq.com/), and we will manually set up a custom Dev Portal URL for your {{site.konnect_short_name}} account.
+
 ## Register as a Developer
 
 All Developers must register through the {{site.konnect_short_name}} Dev Portal. As each Dev Portal has a unique URL, reach out to your {{site.konnect_short_name}} admin for the URL you should access.

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -9,5 +9,5 @@ document and manage Application registration for your Services. Admin roles publ
 
 The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](konnect/dev-portal/developers/dev-reg/). 
 
-Also see:
+See also:
 * [Application Overview](/konnect/dev-portal/application-overview)

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -1,25 +1,13 @@
 ---
-title: Developer Portal Overview
+title: Dev Portal Overview
 no_version: true
 toc: false
 ---
 
-The Dev Portal in {{site.konnect_product_name}} provides an API Catalog, which allows you to
-document and manage application registration for all of your Services and their versions.
+The Dev Portal is an API Catalog that allows Admin roles to
+document and manage Application registration for your Services. Admin roles publish Services through Konnect, and Developers use those Services. 
 
-You can access the Dev Portal for any published Service through the URL
-found on the **Dev Portal** page. From the {{site.konnect_short_name}} menu,
-click **Dev Portal**. The **Published Services** page displays the **Portal URL**.
+The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](konnect/dev-portal/developers/dev-reg/). 
 
-![Konnect Portal URL](/assets/images/docs/konnect/konnect-portal-url.png)
-
-The format looks something like this:
-
-```
-<org-name>.portal.konnect.konghq.com
-```
-
-Setting up custom Dev Portal URLs is not currently supported through
-{{site.konnect_saas}}. If needed,
-contact [Kong Support](https://support.konghq.com/), and we will manually set up
-a custom Dev Portal URL for your {{site.konnect_saas}} account.
+Also see:
+* [Application Overview](/konnect/dev-portal/application-overview)


### PR DESCRIPTION
### Review

@lena-larionova 

### Summary

* rm screenshot and info about where to find Portal URL (this appears in Developer Registration - may move later, this is iterative)
* clean up product description
* add "see also" to give users a place to go next (will add to this as we continue to iterate)

### Reason

Current overview contains extraneous information.

### Testing

https://deploy-preview-3117--kongdocs.netlify.app/konnect/dev-portal/
