### PR TITLE
doc(kic) update Ingress documentation for 1.22

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -241,7 +241,7 @@ Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
   Generation:          1
   Owner References:
-    API Version:           extensions/v1beta1
+    API Version:           networking.k8s.io/v1
     Block Owner Deletion:  true
     Controller:            true
     Kind:                  Ingress

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -122,13 +122,12 @@ Setup an Ingress rule to expose the application:
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-example-com
-  annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - host: demo.example.com
     http:
@@ -188,15 +187,15 @@ Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-example-com
   annotations:
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   tls:
   - secretName: demo-example-com
     hosts:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configure-acl-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configure-acl-plugin.md
@@ -50,14 +50,14 @@ Create two Ingress rules to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-get
   annotations:
     konghq.com/strip-path: "false"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -68,14 +68,14 @@ spec:
 ' | kubectl apply -f -
 
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-post
   annotations:
     konghq.com/strip-path: "false"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -158,15 +158,15 @@ Now let's associate the plugin to the Ingress rules we created earlier.
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-get
   annotations:
     konghq.com/plugins: app-jwt
     konghq.com/strip-path: "false"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -177,15 +177,15 @@ spec:
 ' | kubectl apply -f -
 
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-post
   annotations:
     konghq.com/plugins: app-jwt
     konghq.com/strip-path: "false"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -578,15 +578,15 @@ evaluated.
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-get
   annotations:
     konghq.com/plugins: app-jwt,plain-user-acl
     konghq.com/strip-path: "false"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -597,15 +597,15 @@ spec:
 ' | kubectl apply -f -
 
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-post
   annotations:
     konghq.com/plugins: app-jwt,admin-acl
     konghq.com/strip-path: "false"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-fallback-service.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-fallback-service.md
@@ -96,14 +96,14 @@ Create an Ingress rule to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -147,13 +147,13 @@ to send all requests to it that don't match any of our Ingress rules:
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: fallback
   annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   backend:
     serviceName: fallback-svc
     servicePort: 80

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-health-checks.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-health-checks.md
@@ -54,14 +54,14 @@ Create an Ingress rule to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-https-redirect.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-https-redirect.md
@@ -50,14 +50,14 @@ Create an Ingress rule to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -136,15 +136,15 @@ EOF
 
 ```console
 $ kubectl apply -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: productpage
   namespace: my-istio-app
   annotations:
     konghq.com/plugins: rate-limit
-    kubernetes.io/ingress.class: kong 
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
@@ -51,13 +51,12 @@ Create an Ingress rule to proxy the echo-server created previously:
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
-  annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -120,14 +119,14 @@ Create a new Ingress resource which uses this plugin:
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-example-com
   annotations:
     konghq.com/plugins: request-id
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - host: example.com
     http:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
@@ -204,14 +204,14 @@ Execute the following:
 
 ```bash
 echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: sample-ingresses
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
      paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/redis-rate-limiting.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/redis-rate-limiting.md
@@ -58,14 +58,14 @@ Create an Ingress rule to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-consumer-credential-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-consumer-credential-resource.md
@@ -50,14 +50,14 @@ Create an Ingress rule to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -109,15 +109,15 @@ using the `konghq.com/plugins` annotation:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
     konghq.com/plugins: httpbin-auth
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-external-service.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-external-service.md
@@ -56,14 +56,14 @@ spec:
 
 ```bash
 echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: proxy-from-k8s-to-httpbin
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
@@ -64,15 +64,15 @@ by defining Ingress rules.
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: httpbin-app
   namespace: httpbin
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -84,14 +84,13 @@ spec:
 ingress.extensions/demo created
 
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echo-app
   namespace: echo
-  annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
@@ -51,13 +51,12 @@ by defining an Ingress.
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
-  annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
@@ -60,14 +60,14 @@ by defining Ingress rules.
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:
@@ -127,14 +127,14 @@ service:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-2
   annotations:
     konghq.com/strip-path: "true"
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-mtls-auth-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-mtls-auth-plugin.md
@@ -148,14 +148,14 @@ by defining an Ingress.
 
 ```bash
 $ echo "
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
     konghq.com/plugins: mtls-auth
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-oidc-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-oidc-plugin.md
@@ -52,13 +52,12 @@ Create an Ingress rule to proxy the httpbin service we just created:
 
 ```bash
 $ echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
-  annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - host: 192.0.2.8.xip.io
     http:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-rewrites.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-rewrites.md
@@ -81,14 +81,13 @@ request paths starting at `/`.
 
 ```bash
 echo '
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-app
   namespace: echo
-  annotations:
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - host: myapp.example.com
     http:

--- a/app/kubernetes-ingress-controller/2.0.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/annotations.md
@@ -65,14 +65,13 @@ KongConsumer resources by default.
 
 ### kubernetes.io/ingress.class
 
-<div class="alert alert-ee blue">
-<a href="https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation">Kubernetes versions after 1.18</a>
-introduced the new <code>ingressClassName</code> field to the Ingress spec
-and deprecated the <code>kubernetes.io/ingress.class</code> annotation.
-Ingress resources should now use the <code>ingressClassName</code> field.
-Kong resources (KongConsumer, TCPIngress, etc.) still use the
-<code>kubernetes.io/ingress.class</code> annotation.
-</div>
+{:.note}
+> Kubernetes versions after 1.18 introduced the new `ingressClassName` 
+field to the Ingress spec and 
+[deprecated the `kubernetes.io/ingress.class` annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation). 
+Ingress resources should now use the `ingressClassName` field. 
+Kong resources (KongConsumer, TCPIngress, etc.) 
+still use the `kubernetes.io/ingress.class` annotation.
 
 If you have multiple Ingress controllers in a single cluster,
 you can pick one by specifying the `ingress.class` annotation.

--- a/app/kubernetes-ingress-controller/2.0.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/custom-resources.md
@@ -115,14 +115,14 @@ spec:
 The KongPlugin above can be applied to a specific ingress (route or routes):
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-example-com
   annotations:
     konghq.com/plugins: request-id
-    kubernetes.io/ingress.class: kong
 spec:
+  ingressClassName: kong
   rules:
   - host: example.com
     http:


### PR DESCRIPTION
### Summary
Update Ingress examples in documentation to use resources compatible
with Kubernetes 1.22, which removes support for Ingress versions other
than networking.k8s.io/v1:

https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes

Replace ingress.class annotations on Ingress objects with
ingressClassName fields. Although still supported, the ingress.class
annotaion is deprecated. Note that KIC still lacks proper support for
the associated IngressClass resource and treats ingressClassName
effectively the same as the ingress.class annotation.

Remove documentation for classless resources. These are no longer
supported in KIC 2.x.

### Reason
Changes in Kubernetes and our controller mandate this change.

### Testing
Waiting for Netlify. The annotations page contains new raw HTML, need to check that.
