### PR TITLE
[DOCU-1716] Basic auth plugin: Remove optional label from password

### DIFF
--- a/app/_hub/kong-inc/basic-auth/0.1-x.md
+++ b/app/_hub/kong-inc/basic-auth/0.1-x.md
@@ -104,10 +104,10 @@ $ curl -X POST http://kong:8001/consumers/{consumer}/basic-auth \
 
 `consumer`: The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
 
-form parameter             | default | description
----                        | ---     | ---
-`username`                 |         | The username to use in the Basic Authentication
-`password`<br>*optional*   |         | The password to use in the Basic Authentication
+form parameter   | default | description
+---              | ---     | ---
+`username`       |         | The username to use in the Basic Authentication
+`password`       |         | The password to use in the Basic Authentication
 
 ### Using the Credential
 
@@ -218,4 +218,3 @@ Consumer.
 [configuration]: /gateway-oss/latest/configuration
 [consumer-object]: /gateway-oss/latest/admin-api/#consumer-object
 [acl-associating]: /plugins/acl/#associating-consumers
-

--- a/app/_hub/kong-inc/basic-auth/2.1-x.md
+++ b/app/_hub/kong-inc/basic-auth/2.1-x.md
@@ -152,11 +152,11 @@ basicauth_credentials:
 
 In both cases, the fields / parameters work as described below:
 
-field/parameter            | description
----                        | ---
-`{consumer}`               | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
-`username`                 | The username to use in the Basic Authentication
-`password`<br>*optional*   | The password to use in the Basic Authentication
+field/parameter | description
+---             | ---
+`{consumer}`    | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
+`username`      | The username to use in the Basic Authentication
+`password`      | The password to use in the Basic Authentication
 
 
 ### Using the Credential
@@ -278,4 +278,3 @@ Consumer.
 [configuration]: /gateway-oss/latest/configuration
 [consumer-object]: /gateway-oss/latest/admin-api/#consumer-object
 [acl-associating]: /plugins/acl/#associating-consumers
-


### PR DESCRIPTION
### Summary
Basic auth plugin:
* Removing "optional" label from the password property in the consumer credential.
* In latest version of the doc, minor cleanup (phrasing, grammar, format); turned request/response codeblocks into two tabs for easier copying; placeholder formatting.

### Reason
Bug reported on Slack. Ticket: https://konghq.atlassian.net/browse/DOCU-1716

### Testing
https://deploy-preview-3119--kongdocs.netlify.app/hub/kong-inc/basic-auth/