### PR TITLE
[DOCU-1719] Add Community Tab to Contributing

### DIFF
--- a/app/_data/docs_nav_contributing.yml
+++ b/app/_data/docs_nav_contributing.yml
@@ -14,10 +14,19 @@
     - text: Variables
       url: /variables
 
-- title: Plugin docs
+- title: Community
   icon: /assets/images/icons/documentation/icn-references-color.svg
-  url: /plugin-docs
+  url: /community
+  items:
+    - text: Community Expectations
+      url: /community-expectations
+    - text: Hackathons
+      url: /hackathons
 
-- title: Terms
-  icon: /assets/images/icons/documentation/icn-references-color.svg
-  url: /terms
+# - title: Plugin docs
+#   icon: /assets/images/icons/documentation/icn-references-color.svg
+#   url: /plugin-docs
+
+# - title: Terms
+#   icon: /assets/images/icons/documentation/icn-references-color.svg
+#   url: /terms

--- a/app/contributing/community-expectations.md
+++ b/app/contributing/community-expectations.md
@@ -3,11 +3,11 @@ title: Community expectations
 no_version: true
 ---
 
-This section outlines our primary community expectations. 
+This section outlines our community expectations around inclusive language and accessibility. 
 
 ## Inclusive language
 
-Use inclusive language that does not exclude groups. Be aware of how impactful language is, and use it with care. We will not except contributions that 
+Use inclusive language that does not exclude groups. Be aware of how impactful language is, and use it with care. 
 
 See: [Microsoft's Bias-free communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication). 
 
@@ -25,7 +25,7 @@ For code-based contributions, check the following:
 
 * All clickable elements can be tabbed through in a predictable sequence. 
 * HTML is written:
-    * without skipping header level (`h1` to `h2`, instead of `h1` to `h3`)
-    * using the proper elements (`li` for lists instead of `div`)
-* No accessibility should be "hacked" by using JavaScript or other means. For example, don't force tabbing. Instead, write HTML that tabs properly. 
+    * without skipping header level (`h1` to `h2`, instead of `h1` to `h3`).
+    * using the proper elements (`li` for lists instead of `div`).
+* No accessibility should be "hacked" by using JavaScript or other means. For example, don't force tabbing (`.on('keyup')`). Instead, write HTML that tabs properly. 
 * Color contrast is compatible with WCAG standards. Use a [color contrast checker](https://color.a11y.com/) or Dev Tools. 

--- a/app/contributing/community-expectations.md
+++ b/app/contributing/community-expectations.md
@@ -23,7 +23,7 @@ We are currently working on making our Docs site accessible in compliance with [
 
 For code-based contributions, check the following:
 
-* All clickable elements can be tabbed through in a predictable sequence. 
+* All clickable elements can be tabbed through in a [predictable sequence](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html). 
 * HTML is written:
     * without skipping header level (`h1` to `h2`, instead of `h1` to `h3`).
     * using the proper elements (`li` for lists instead of `div`).

--- a/app/contributing/community-expectations.md
+++ b/app/contributing/community-expectations.md
@@ -1,0 +1,31 @@
+---
+title: Community expectations
+no_version: true
+---
+
+This section outlines our primary community expectations. 
+
+## Inclusive language
+
+Use inclusive language that does not exclude groups. Be aware of how impactful language is, and use it with care. We will not except contributions that 
+
+See: [Microsoft's Bias-free communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication). 
+
+## Accessibility
+
+We are currently working on making our Docs site accessible in compliance with [WCAG 2.1](https://www.w3.org/WAI/standards-guidelines/wcag/glance/). Please ensure that all contributions do not derail from our goal. Overall, take into account the following for text-based contributions:
+
+* All non-decorative images have useful and descriptive text alternatives. 
+* Avoid screenshots and use descriptive text instead. 
+* Use clear, concise, and easy-to-understand language. 
+* Organize content intentionally and make things easy to find. 
+* Don't get too experimental - stick to content and organization that's predictable. 
+
+For code-based contributions, check the following:
+
+* All clickable elements can be tabbed through in a predictable sequence. 
+* HTML is written:
+    * without skipping header level (`h1` to `h2`, instead of `h1` to `h3`)
+    * using the proper elements (`li` for lists instead of `div`)
+* No accessibility should be "hacked" by using JavaScript or other means. For example, don't force tabbing. Instead, write HTML that tabs properly. 
+* Color contrast is compatible with WCAG standards. Use a [color contrast checker](https://color.a11y.com/) or Dev Tools. 

--- a/app/contributing/community.md
+++ b/app/contributing/community.md
@@ -1,0 +1,69 @@
+---
+title: Community
+no_version: true
+---
+
+This section contains information on how to be part of our community, including docs-as-code process and productive hackathon participation. 
+
+## How to contribute to docs-as-code as a beginner
+
+Welcome to our introduction on how to contribute to Kong Docs. We’ll introduce you to our docs-as-code approach. This tutorial is designed for first-time contributors who want to get started with simple tasks to boost their confidence in tooling, add to their portfolio, and join our international community. 
+
+We house all our docs code on GitHub, a code versioning platform that allows people all over the world to collaborate on projects. You'll need a [GitHub](https://github.com/) account, so if you don't already have one, now's the time to sign up. 
+
+Once you have a GitHub account, head over to our [docs.konghq.com](https://github.com/Kong/docs.konghq.com) project. 
+
+The first thing we’re going to do is look over the README. This will give us the information we need to get started with this project. As you can see, we have a lot of information here including a link to our contributing guide and information about how to set up the project locally. 
+
+### Basic setup
+
+When it comes to working in the docs-as-code approach, you'll need:
+
+* A code editor like [VScode](https://code.visualstudio.com/) or [Atom](https://atom.io/).
+* Basic Git knowledge, see [Git/GitHub Resources](/contributing/#gitgithub-resources)
+* A local copy of our repository. On [our main repository page](https://github.com/Kong/docs.konghq.com), click the `Code` dropdown button and copy the `ssh` URL. In your terminal, run `git clone {SSH_URL}`, replacing `{SSH_URL}` with the URL you copied from the `Code` dropdown button. 
+* To know the difference between a PR and an Issue. PR stands for Pull Request or Please Review. And it’s different from an Issue in that an Issue is a statement of something that needs attention, while a PR attempts to resolve something. So, an Issue is an idea and a PR is an action. 
+
+From here, determine which applies to you:
+
+* [I know what I want to contribute](#i-know-what-i-want-to-contribute)
+* [I need ideas on what to contribute](#i-need-ideas-on-what-to-contribute)
+
+### I know what I want to contribute
+
+Great! Let's first check to see if someone had the same idea as you. Go to [Issues](https://github.com/Kong/docs.konghq.com/issues) and read through the titles to see if something sounds similar to what you want to contribute or fix. 
+
+If you find an Issue that aligns with what you want to contribute, go ahead and assign it to yourself in the right-side column and add a comment stating that you're going to be working on this task. 
+
+### I need ideas on what to contribute
+
+Go to [Issues](https://github.com/Kong/docs.konghq.com/issues) and read through the titles to see if something catches your eye. If you don't find anything of your interest there, explore the following:
+
+* Find a product or area of interest in our current docs
+* Audit a page and determine if it aligns with our [Style Guide](/contributing/style-guide/)
+
+### Make your contribution
+
+Once you've identified what you want to work on, let's get to writing! 
+
+1. Create a branch off `main` in your cloned project. 
+
+    `git checkout -b {CONCISE_AND_RELEVANT_BRANCH_NAME}`
+
+2. Locate the file(s) you want to modify and make your edits.
+
+3. Add, commit, and push your work to your remote (`{CONCISE_AND_RELEVANT_BRANCH_NAME}`) branch. 
+
+    a. `git add .` to add all work, or `git add {FILE_NAME}` to add a single file
+
+    b. `git commit -m "{DETAILED_COMMIT_MESSAGE}"`
+
+    c. `git push origin {CONCISE_AND_RELEVANT_BRANCH_NAME}`
+
+4. Navigate to GitHub and you should see a message that prompts you to open a PR (Pull Request). If you cannot locate this message, read the terminal output after you have pushed your code, and you should see a link in there to open a PR. 
+
+5. Fill out the PR with a title (initially populated by your commit message), and all form details. The more thorough and clear you are, the easier it is for us to understand the change and why it's been made. 
+
+6. Submit your PR!
+
+We encourage you to explore the [README](/Kong/docs.konghq.com) more, read through our [contributing guidelines](/contributing/), and also try out setting up your project locally (via instructions in our README). We appreciate your interest and involvement and are looking forward to seeing your future contributions!

--- a/app/contributing/community.md
+++ b/app/contributing/community.md
@@ -3,50 +3,50 @@ title: Community
 no_version: true
 ---
 
-This section contains information on how to be part of our community, including docs-as-code process and productive hackathon participation. 
+This section contains information on how to contribute using our docs-as-code approach. You may also be interested in [Community Expectations](/contributing/community-expectations/) and [Hackathons](/contributing/hackathons/). 
 
 ## How to contribute to docs-as-code as a beginner
 
-Welcome to our introduction on how to contribute to Kong Docs. We’ll introduce you to our docs-as-code approach. This tutorial is designed for first-time contributors who want to get started with simple tasks to boost their confidence in tooling, add to their portfolio, and join our international community. 
+Welcome to our introduction on how to contribute to Kong Docs using our docs-as-code approach. This tutorial is designed for first-time contributors who want to get started with simple tasks to boost their confidence in tooling, add to their portfolio, and join our international community. 
 
 We house all our docs code on GitHub, a code versioning platform that allows people all over the world to collaborate on projects. You'll need a [GitHub](https://github.com/) account, so if you don't already have one, now's the time to sign up. 
 
 Once you have a GitHub account, head over to our [docs.konghq.com](https://github.com/Kong/docs.konghq.com) project. 
 
-The first thing we’re going to do is look over the README. This will give us the information we need to get started with this project. As you can see, we have a lot of information here including a link to our contributing guide and information about how to set up the project locally. 
+The first thing we’re going to do is look over the README. Read through the intro section for some basic information about our project. 
 
 ### Basic setup
 
-When it comes to working in the docs-as-code approach, you'll need:
+To contribute using our docs-as-code approach, you'll need:
 
 * A code editor like [VScode](https://code.visualstudio.com/) or [Atom](https://atom.io/).
-* Basic Git knowledge, see [Git/GitHub Resources](/contributing/#gitgithub-resources)
+* Basic Git knowledge, see [Git/GitHub Resources](/contributing/#gitgithub-resources).
 * A local copy of our repository. On [our main repository page](https://github.com/Kong/docs.konghq.com), click the `Code` dropdown button and copy the `ssh` URL. In your terminal, run `git clone {SSH_URL}`, replacing `{SSH_URL}` with the URL you copied from the `Code` dropdown button. 
-* To know the difference between a PR and an Issue. PR stands for Pull Request or Please Review. And it’s different from an Issue in that an Issue is a statement of something that needs attention, while a PR attempts to resolve something. So, an Issue is an idea and a PR is an action. 
+* To know the difference between a PR and an Issue. PR stands for Pull Request or Please Review. It’s different from an Issue in that an Issue is a statement of something that needs attention, while a PR attempts to resolve something. So, an Issue is an idea and a PR is an action. 
 
 From here, determine which applies to you:
 
-* [I know what I want to contribute](#i-know-what-i-want-to-contribute)
-* [I need ideas on what to contribute](#i-need-ideas-on-what-to-contribute)
+* [I know what I want to contribute](#i-know-what-i-want-to-contribute).
+* [I need ideas on what to contribute](#i-need-ideas-on-what-to-contribute).
 
 ### I know what I want to contribute
 
 Great! Let's first check to see if someone had the same idea as you. Go to [Issues](https://github.com/Kong/docs.konghq.com/issues) and read through the titles to see if something sounds similar to what you want to contribute or fix. 
 
-If you find an Issue that aligns with what you want to contribute, go ahead and assign it to yourself in the right-side column and add a comment stating that you're going to be working on this task. 
+If you find an Issue that aligns with what you want to contribute, go ahead and assign it to yourself in the right-side column and add a comment stating that you're going to be working on this task. Then, head to [Make your contribution](#make-your-contribution). 
 
 ### I need ideas on what to contribute
 
 Go to [Issues](https://github.com/Kong/docs.konghq.com/issues) and read through the titles to see if something catches your eye. If you don't find anything of your interest there, explore the following:
 
-* Find a product or area of interest in our current docs
-* Audit a page and determine if it aligns with our [Style Guide](/contributing/style-guide/)
+* Find a product or area of interest in our current docs.
+* Audit a page and determine if it aligns with our [Style Guide](/contributing/style-guide/).
 
 ### Make your contribution
 
 Once you've identified what you want to work on, let's get to writing! 
 
-1. Create a branch off `main` in your cloned project. 
+1. Create a branch off `main` in your cloned local project. 
 
     `git checkout -b {CONCISE_AND_RELEVANT_BRANCH_NAME}`
 

--- a/app/contributing/community.md
+++ b/app/contributing/community.md
@@ -35,6 +35,8 @@ Great! Let's first check to see if someone had the same idea as you. Go to [Issu
 
 If you find an Issue that aligns with what you want to contribute, go ahead and assign it to yourself in the right-side column and add a comment stating that you're going to be working on this task. Then, head to [Make your contribution](#make-your-contribution). 
 
+If you don't find an Issue that aligns with what you want to contribute, there's no need to open one up. Instead, go to [Make your contribution](#make-your-contribution). 
+
 ### I need ideas on what to contribute
 
 Go to [Issues](https://github.com/Kong/docs.konghq.com/issues) and read through the titles to see if something catches your eye. If you don't find anything of your interest there, explore the following:
@@ -66,4 +68,4 @@ Once you've identified what you want to work on, let's get to writing!
 
 6. Submit your PR!
 
-We encourage you to explore the [README](/Kong/docs.konghq.com) more, read through our [contributing guidelines](/contributing/), and also try out setting up your project locally (via instructions in our README). We appreciate your interest and involvement and are looking forward to seeing your future contributions!
+We encourage you to explore the [README](https://github.com/Kong/docs.konghq.com/blob/main/README.md) more, read through our [contributing guidelines](/contributing/), and also try out setting up your project locally (via instructions in our README). We appreciate your interest and involvement and are looking forward to seeing your future contributions!

--- a/app/contributing/hackathons.md
+++ b/app/contributing/hackathons.md
@@ -3,13 +3,14 @@ title: Hackathons
 no_version: true
 ---
 
-Here, you'll find all the information you need to contribute effectively to our Hackathons. 
+Here, you'll find all the information you need to contribute effectively to our hackathons. 
 
 ## Prep
 
-* Make sure you have a GitHub account set up! That's where you'll find all [our code](https://github.com/Kong/docs.konghq.com). 
+* Make sure you have a [GitHub](https://github.com/) account set up! That's where you'll find all [our code](https://github.com/Kong/docs.konghq.com). 
 * Head over to [Community](/contributing/community) to learn docs-as-code if you don't already know the process. 
-* Be aware of resources available to you throughout the Hackathon. Is there a Slack channel or other outlet that'll keep you connected? We'll keep you posted about specific Hackathon details. 
+* Read through our [Community Expectations](/contributing/community-expectations/) to learn about our inclusive language and accessibility efforts. 
+* Be aware of resources available to you throughout the hackathon. Is there a Slack channel or other outlet that'll keep you connected? We'll keep you posted about specific hackathon details. 
 
 ## Participation expectations
 
@@ -17,10 +18,10 @@ We're so thankful for contributions, and we also have some participation expecta
 
 Here are some of our expectations:
 
-* **Your contribution is meaningful**. We put effort into planning and prepping for our Hackathons, and we really appreciate contributions that align with meaningfully improving our Docs and clearly addressing pain points. 
+* **Your contribution is meaningful**. We put effort into planning and prepping for our hackathons, and we really appreciate contributions that align with meaningfully improving our Docs and clearly addressing pain points. 
     
-    It's helpful to think about your personal motivations for involvement in Hackathons - are you here to learn? Gain confidence in docs-as-code? Get green boxes on your GitHub profile? Have something to show potential employers? All of these motivations can help you remain intentional about your contributions. 
+    It's helpful to think about your personal motivations for involvement in hackathons - are you here to learn? Gain confidence in docs-as-code? Get green boxes on your GitHub profile? Have something to show potential employers? All of these motivations can help you remain intentional about your contributions. 
 
 * **You take pride in your contribution**. Is this something you're proud of contributing? Each contribution you make has ripple effect on our community, and we love to see thoughtful PRs. Before submitting a PR, read it through and ask yourself if it's clear, concise, and represents your intentions of being a mindful contributor. 
 
-* **Follow our Community Expectations**. See [Community Expectations](/contributing/community-expectations) for more information. 
+* **Follow our Community Expectations**. See [Community Expectations](/contributing/community-expectations) for information about our inclusive language and accessibility efforts. 

--- a/app/contributing/hackathons.md
+++ b/app/contributing/hackathons.md
@@ -1,0 +1,26 @@
+---
+title: Hackathons
+no_version: true
+---
+
+Here, you'll find all the information you need to contribute effectively to our Hackathons. 
+
+## Prep
+
+* Make sure you have a GitHub account set up! That's where you'll find all [our code](https://github.com/Kong/docs.konghq.com). 
+* Head over to [Community](/contributing/community) to learn docs-as-code if you don't already know the process. 
+* Be aware of resources available to you throughout the Hackathon. Is there a Slack channel or other outlet that'll keep you connected? We'll keep you posted about specific Hackathon details. 
+
+## Participation expectations
+
+We're so thankful for contributions, and we also have some participation expectations! These help us to manage incoming PRs and encourage strong community. 
+
+Here are some of our expectations:
+
+* **Your contribution is meaningful**. We put effort into planning and prepping for our Hackathons, and we really appreciate contributions that align with meaningfully improving our Docs and clearly addressing pain points. 
+    
+    It's helpful to think about your personal motivations for involvement in Hackathons - are you here to learn? Gain confidence in docs-as-code? Get green boxes on your GitHub profile? Have something to show potential employers? All of these motivations can help you remain intentional about your contributions. 
+
+* **You take pride in your contribution**. Is this something you're proud of contributing? Each contribution you make has ripple effect on our community, and we love to see thoughtful PRs. Before submitting a PR, read it through and ask yourself if it's clear, concise, and represents your intentions of being a mindful contributor. 
+
+* **Follow our Community Expectations**. See [Community Expectations](/contributing/community-expectations) for more information. 


### PR DESCRIPTION
### Review

@Kong/team-docs 

### Summary

In order to prep for our upcoming hackathon, we needed some resources:

* Community: provides contributors with information on our docs-as-code process
* Community Expectations: provides contributors with information on our inclusive language and accessibility efforts. Note that I plan on adding more content to the inclusive language section later on but this is a good starting place. 
* Hackathons: provides contributors with general information about effective hackathon participation

In addition to adding three pages, I hid "Terms" and "Plugin docs" from our sidebar nav as they were incomplete and can be confusing to contributors. 

### Reason

We didn't have in-depth information for contributors to be able to join our community. 

### Testing

Community: https://deploy-preview-3124--kongdocs.netlify.app/contributing/community/
Community Expectations: https://deploy-preview-3124--kongdocs.netlify.app/contributing/community-expectations/
Hackathons: https://deploy-preview-3124--kongdocs.netlify.app/contributing/hackathons/