### PR TITLE
[WIP] Splitting commands and responses in KIC guides

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -25,8 +25,14 @@ This tutorial was written using Google Kubernetes Engine.
 
 Execute the following to install the Ingress Controller:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+kubectl create -f https://bit.ly/k4k8s
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created
@@ -40,6 +46,8 @@ service/kong-proxy created
 service/kong-validation-webhook created
 deployment.extensions/kong created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Set up cert-manager
 
@@ -48,8 +56,14 @@ on how to install cert-manager onto your cluster.
 
 Once installed, verify all the components are running using:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
 kubectl get all -n cert-manager
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 NAME                                           READY   STATUS    RESTARTS   AGE
 pod/cert-manager-86478c5ff-mkhb9               1/1     Running   0          23m
 pod/cert-manager-cainjector-65dbccb8b6-6dnjl   1/1     Running   0          23m
@@ -68,60 +82,105 @@ replicaset.apps/cert-manager-86478c5ff               1         1         1      
 replicaset.apps/cert-manager-cainjector-65dbccb8b6   1         1         1       23m
 replicaset.apps/cert-manager-webhook-78f9d55fdf      1         1         1       23m
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Set up your application
 
 Any HTTP-based application can be used, for the purpose of the demo, install
 the following echo server:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ kubectl apply -f https://bit.ly/echo-service
+kubectl apply -f https://bit.ly/echo-service
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 service/echo created
 deployment.apps/echo created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Set up DNS
 
 Get the IP address of the load balancer for Kong:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ kubectl get service -n kong kong-proxy
+kubectl get service -n kong kong-proxy
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
 kong-proxy   LoadBalancer   10.63.250.199   35.233.170.67   80:31929/TCP,443:31408/TCP   58d
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 To get only the IP address:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy
+kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 35.233.170.67
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Please note that the IP address in your case will be different.
 
 Next, setup a DNS records to resolve `proxy.example.com` to the
 above IP address:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ dig +short proxy.example.com
+dig +short proxy.example.com
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 35.233.170.67
 ```
+{% endnavtab %}
+{% endnavtabs %}
+
 
 Next, setup a CNAME DNS record to resolve `demo.example.com` to
 `proxy.example.com`.
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ dig +short demo.yolo2.com
+dig +short demo.example.com
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 proxy.example.com.
 35.233.170.67
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Expose your application to the Internet
 
 Setup an Ingress rule to expose the application:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ echo "
+echo "
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -137,13 +196,25 @@ spec:
           serviceName: echo
           servicePort: 80
 " | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ingress.extensions/demo-example-com created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Access your application:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ curl -I demo.example.com
+curl -I demo.example.com
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
@@ -153,11 +224,15 @@ X-Kong-Upstream-Latency: 1
 X-Kong-Proxy-Latency: 1
 Via: kong/1.1.2
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Request TLS Certificate from Let's Encrypt
 
 First, setup a ClusterIssuer for cert-manager
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
 $ echo "apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -174,8 +249,14 @@ spec:
     - http01:
         ingress:
           class: kong" | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 *Note*: If you run into issues configuring this,
 be sure that the group (`cert-manager.io`) and
@@ -185,6 +266,8 @@ This directs cert-manager which CA authority to use to issue the certificate.
 
 Next, update your Ingress resource to provision a certificate and then use it:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
 $ echo '
 apiVersion: networking.k8s.io/v1
@@ -209,8 +292,14 @@ spec:
           serviceName: echo
           servicePort: 80
 ' | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ingress.extensions/demo-example-com configured
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Things to note here:
 
@@ -229,8 +318,14 @@ the certificate and in sometime the certificate will be available for use.
 
 You can track the progress of certificate issuance:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ kubectl describe certificate demo-example-com
+kubectl describe certificate demo-example-com
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
@@ -279,13 +374,21 @@ Events:
   Normal  OrderComplete       53m   cert-manager  Order "demo-example-com-3811625818" completed successfully
   Normal  CertIssued          53m   cert-manager  Certificate issued successfully
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Test HTTPS
 
 Once all is in place, you can use HTTPS:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ curl -v https://demo.example.com
+curl -v https://demo.example.com
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 * Rebuilt URL to: https://demo.example.com/
 *   Trying 35.233.170.67...
 * TCP_NODELAY set
@@ -366,6 +469,8 @@ Request Headers:
 Request Body:
   -no body in request-
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Et voilà ! You've secured your API with HTTPS
 with the {{site.kic_product_name}} and cert-manager.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -22,50 +22,93 @@ For this guide, you will need:
 
 Download the Istio bundle at version 1.6.7:
 
-```console
-$ curl -L https://istio.io/downloadIstio | env ISTIO_VERSION=1.6.7 sh -
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -L https://istio.io/downloadIstio | env ISTIO_VERSION=1.6.7 sh -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ...
 ...
 Istio 1.6.7 Download Complete!                                                                                                 
 
-Istio has been successfully downloaded into the istio-1.6.7 folder on your system.                                                                                                                                                                            
+Istio has been successfully downloaded into the istio-1.6.7 folder on your system.
 ...
 ...
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ### Install Istio Operator
 
 Invoke `istioctl` to deploy the Istio Operator to the Kubernetes cluster:
 
-```console
-$ ./istio-1.6.7/bin/istioctl operator init
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+./istio-1.6.7/bin/istioctl operator init
+```
+{% endnavtab %}
+{% navtab Response %}
+```
 Using operator Deployment image: docker.io/istio/operator:1.6.7
 ✔ Istio operator installed                                                                                                                                                                                                                                    
 ✔ Installation complete
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ### Deploy Istio using Operator
 
-Deploy Istio using Istio Operator:
+Deploy Istio using Istio Operator.
 
-```console
-$ kubectl create namespace istio-system
+Create a namespace:
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl create namespace istio-system
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 namespace/istio-system created
 ```
-```console
-$ kubectl apply -f - <<EOF
-  apiVersion: install.istio.io/v1alpha1
-  kind: IstioOperator
-  metadata:
-    namespace: istio-system
-    name: example-istiocontrolplane
-  spec:
-    profile: demo
+{% endnavtab %}
+{% endnavtabs %}
+
+Deploy Istio:
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl apply -f - <<EOF
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane
+spec:
+  profile: demo
 EOF
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 istiooperator.install.istio.io/example-istiocontrolplane created
 ```
-```console
-$ kubectl describe istiooperator -n istio-system
+{% endnavtab %}
+{% endnavtabs %}
+
+Check the status:
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl describe istiooperator -n istio-system
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ...
 ...
 Status:
@@ -73,21 +116,53 @@ Status:
 ...
 ...
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Wait until the `kubectl describe istiooperator` command returns `Status: HEALTHY`.
 
 ### Deploy the {{site.kic_product_name}} in an Istio-enabled namespace {#deploy-kic-istio-namespace}
 
-```console
-$ kubectl create namespace kong-istio
+Create a namespace:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl create namespace kong-istio
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 namespace/kong-istio created
 ```
-```console
-$ kubectl label namespace kong-istio istio-injection=enabled
+{% endnavtab %}
+{% endnavtabs %}
+
+Label the namespace:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl label namespace kong-istio istio-injection=enabled
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 namespace/kong-istio labeled
 ```
-```console
-$ helm install -n kong-istio example-kong kong/kong --set ingressController.installCRDs=false
+{% endnavtab %}
+{% endnavtabs %}
+
+Deploy the Kong Ingress Controller in the new namespace:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+helm install -n kong-istio example-kong kong/kong --set ingressController.installCRDs=false
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ...
 NAME: example-kong
 LAST DEPLOYED: Mon Aug 10 15:14:44 2020
@@ -95,33 +170,58 @@ NAMESPACE: kong-istio
 STATUS: deployed
 ...
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 _Optional:_ Run `kubectl describe pod -n kong-istio -l app.kubernetes.io/instance=example-kong` to see that the Istio sidecar (`istio-proxy`) is running alongside the {{site.kic_product_name}}.
 
 ### Deploy bookinfo in an Istio-enabled namespace
 
-Deploy the sample _bookinfo_ app from the Istio bundle:
+Deploy the sample _bookinfo_ app from the Istio bundle.
 
-```console
-$ kubectl create namespace my-istio-app
+Create a namespace:
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl create namespace my-istio-app
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 namespace/my-istio-app created
 ```
-```console
-$ kubectl label namespace my-istio-app istio-injection=enabled
-namespace/my-istio-app labeled
-$ kubectl apply -n my-istio-app -f istio-1.6.7/samples/bookinfo/platform/kube/bookinfo.yaml
+{% endnavtab %}
+{% endnavtabs %}
+
+Label the namespace:
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl label namespace my-istio-app istio-injection=enabled
 ```
+{% endnavtab %}
+{% navtab Response %}
+```bash
+namespace/my-istio-app labeled
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Apply the configuration:
+```bash
+kubectl apply -n my-istio-app -f istio-1.6.7/samples/bookinfo/platform/kube/bookinfo.yaml
+```
+
 Wait until the application is up:
-```console
-$ kubectl wait --for=condition=Available deployment productpage -n my-istio-app --timeout=240s
+```bash
+kubectl wait --for=condition=Available deployment productpage -n my-istio-app --timeout=240s
 ```
 ### Deploy ingress
 
-Define a `KongPlugin` rate-limiting access to 100 requests per minute. Define an `Ingress` telling Kong to proxy traffic
-to a service belonging to the sample application:
+Define a `KongPlugin` rate-limiting access to 100 requests per minute:
 
-```console
-$ kubectl apply -f - <<EOF
+```bash
+kubectl apply -f - <<EOF
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
@@ -134,8 +234,11 @@ config:
 EOF
 ```
 
-```console
-$ kubectl apply -f - <<EOF
+Define an `Ingress` telling Kong to proxy traffic to a service belonging to the
+sample application:
+
+```bash
+kubectl apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -162,13 +265,21 @@ Connect to the sample application served via Kong and Istio.
 Note that `8080:80` means that `kubectl` will open the `tcp/8080` port on the local system and forward all requests to
 Kong's port `80`.
 
-```console
-$ # Keep the command below running in the background
-$ kubectl port-forward service/example-kong-kong-proxy 8080:80 -n kong-istio
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+# Keep the command below running in the background
+kubectl port-forward service/example-kong-kong-proxy 8080:80 -n kong-istio
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 Forwarding from 127.0.0.1:8080 -> 8000
 Forwarding from [::1]:8080 -> 8000
 ...
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Navigate your web browser to `http://localhost:8080/` You should be able to see a bookstore web application. Click
 through any available links several times. As you hit 30 requests per minute (for example, by holding down the "Refresh"
@@ -178,13 +289,21 @@ key combination, e.g. `<Ctrl-R>` or `<Command-R>`), you should obtain a `Kong Er
 
 Connect to Kiali (the Istio dashboard):
 
-```console
-$ # Keep the command below running in the background
-$ kubectl port-forward service/kiali 20001:20001 -n istio-system
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+# Keep the command below running in the background
+kubectl port-forward service/kiali 20001:20001 -n istio-system
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 Forwarding from 127.0.0.1:20001 -> 20001
 Forwarding from [::1]:20001 -> 20001
 ...
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 * Navigate your web browser to `http://localhost:20001/`.
 * Log in using the default credentials (`admin`/`admin`).
@@ -200,13 +319,21 @@ application services such as `ratings-v1` and `details-v1`.
 
 Connect to Grafana (a dashboard frontend for Prometheus which has been deployed with Istio):
 
-```console
-$ # Keep the command below running in the background
-$ kubectl port-forward service/grafana 3000:3000 -n istio-system
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+# Keep the command below running in the background
+kubectl port-forward service/grafana 3000:3000 -n istio-system
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 Forwarding from 127.0.0.1:3000 -> 3000
 Forwarding from [::1]:3000 -> 3000
 ...
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 * Navigate your web browser to `http://localhost:3000/`.
 * Expand the dashboard selection drop-down menu from the top of the screen. Expand the `istio` directory and choose the

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
@@ -17,8 +17,14 @@ If you've not done so, please follow one of the
 If everything is setup correctly, making a request to Kong should return back
 a HTTP 404 Not Found.
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ curl -i $PROXY_IP
+curl -i $PROXY_IP
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 404 Not Found
 Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
@@ -28,6 +34,8 @@ Server: kong/1.1.2
 
 {"message":"no Route matched with those values"}
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 This is expected since Kong doesn't know how to proxy the request yet.
 
@@ -36,11 +44,19 @@ This is expected since Kong doesn't know how to proxy the request yet.
 Setup an echo-server application to demonstrate how
 to use the {{site.kic_product_name}}:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ kubectl apply -f https://bit.ly/echo-service
+kubectl apply -f https://bit.ly/echo-service
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 service/echo created
 deployment.apps/echo created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 This application just returns information about the
 pod and details from the HTTP request.
@@ -49,8 +65,10 @@ pod and details from the HTTP request.
 
 Create an Ingress rule to proxy the echo-server created previously:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ echo "
+echo "
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -65,13 +83,25 @@ spec:
           serviceName: echo
           servicePort: 80
 " | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ingress.extensions/demo created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Test the Ingress rule:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ curl -i $PROXY_IP/foo
+curl -i $PROXY_IP/foo
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Transfer-Encoding: chunked
@@ -82,8 +112,6 @@ X-Kong-Upstream-Latency: 0
 X-Kong-Proxy-Latency: 1
 Via: kong/1.1.2
 
-
-
 Hostname: echo-758859bbfb-txt52
 
 Pod Information:
@@ -93,6 +121,9 @@ Pod Information:
         pod IP: 172.17.0.14
 <-- clipped -->
 ```
+{% endnavtab %}
+{% endnavtabs %}
+
 
 If everything is deployed correctly, you should see the above response.
 This verifies that Kong can correctly route traffic to an application running
@@ -102,8 +133,10 @@ inside Kubernetes.
 
 Setup a KongPlugin resource:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ echo "
+echo "
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
@@ -112,13 +145,21 @@ config:
   header_name: my-request-id
 plugin: correlation-id
 " | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 kongplugin.configuration.konghq.com/request-id created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Create a new Ingress resource which uses this plugin:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ echo "
+echo "
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -136,16 +177,28 @@ spec:
           serviceName: echo
           servicePort: 80
 " | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 ingress.extensions/demo-example-com created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 The above resource directs Kong to execute the request-id plugin whenever
 a request is proxied matching any rule defined in the resource.
 
 Send a request to Kong:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ curl -i -H "Host: example.com" $PROXY_IP/bar/sample
+curl -i -H "Host: example.com" $PROXY_IP/bar/sample
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Transfer-Encoding: chunked
@@ -155,8 +208,6 @@ Server: echoserver
 X-Kong-Upstream-Latency: 1
 X-Kong-Proxy-Latency: 1
 Via: kong/1.1.2
-
-
 
 Hostname: echo-758859bbfb-cnfmx
 
@@ -193,6 +244,8 @@ Request Headers:
 Request Body:
         -no body in request-
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 The `my-request-id` can be seen in the request received by echo-server.
 It is injected by Kong as the request matches one
@@ -206,8 +259,10 @@ no matter which Ingress path it came from.
 
 Create a KongPlugin resource:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ echo "
+echo "
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
@@ -218,8 +273,14 @@ config:
   policy: local
 plugin: rate-limiting
 " | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 kongplugin.configuration.konghq.com/rl-by-ip created
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 Next, apply the `konghq.com/plugins` annotation on the Kubernetes Service
 that needs rate-limiting:
@@ -232,8 +293,14 @@ kubectl patch svc echo \
 Now, any request sent to this service will be protected by a rate-limit
 enforced by Kong:
 
+{% navtabs codeblock %}
+{% navtab Command %}
 ```bash
-$ curl -I $PROXY_IP/foo
+curl -I $PROXY_IP/foo
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
@@ -244,8 +311,20 @@ X-RateLimit-Remaining-minute: 2
 X-Kong-Upstream-Latency: 0
 X-Kong-Proxy-Latency: 4
 Via: kong/1.1.2
+```
+{% endnavtab %}
+{% endnavtabs %}
 
-$ curl -I -H "Host: example.com" $PROXY_IP/bar/sample
+Try another one:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -I -H "Host: example.com" $PROXY_IP/bar/sample
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
@@ -257,6 +336,8 @@ X-Kong-Upstream-Latency: 1
 X-Kong-Proxy-Latency: 2
 Via: kong/1.1.2
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Result
 


### PR DESCRIPTION
### Summary
Splitting out commands from responses in three KIC guides: Getting started, Getting started with Istio, and Cert manager.

### Reason
https://konghq.atlassian.net/browse/DOCU-1658 and many other complaints in the past. 
Users get confused as they try to copy a command and run it without looking at every line:
* Often, the examples in the KIC docs have many lines of command (e.g. `kubectl apply` examples) and one line of response, and it's hard to see that. 
* Conversely, sometimes the command is one line and the response/example is many lines, but it looks daunting and complicated at first glance because all are in the same codeblock.

### Testing
TBA
