### PR TITLE
Stop wrong banner from appearing in KIC beta version

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -91,11 +91,13 @@ page.kong_latest.release %}
               </div>
             {% endif %}
             {% if page.url contains "/kubernetes-ingress-controller/" %}
+            {% unless page.kong_version == "2.0.x" %}
             <blockquote class="note">
               <p>Kong's Kubernetes Ingress Controller v2.0.0 is currently in beta. Check out the
               <a href="/kubernetes-ingress-controller-beta/">beta documentation</a> and try out
               <a href="https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v2.0.0-beta.1">v2.0.0</a> for yourself.</p>
             </blockquote>
+            {% endunless %}
             {% endif %}
 
 


### PR DESCRIPTION
### Summary
Setting KIC beta notification banner to not appear on 2.0.x.

### Reason
Since the beta KIC doc is based on main, it's pulling in the beta notification banner into all pages. Because of that, the beta docs end up with two banners on every page: https://kic-v2-beta--kongdocs.netlify.app/kubernetes-ingress-controller/

### Testing
N/A, but tested locally. Will need to merge into beta branch.