### PR TITLE
Docs/mesh helm install improvement

### DIFF
--- a/app/mesh/1.3.x/installation/helm.md
+++ b/app/mesh/1.3.x/installation/helm.md
@@ -54,7 +54,21 @@ suggest `kong-mesh-system`.
    By default the license option is disabled and so you need to enable it in order for the license to take effect.
    This can be done in two ways:
    
-   a. Using `values.yaml` file
+   a. Overriding the values using the `--set` switch on the helm command
+      
+      The easiest option is to override each field on the CLI, the only 
+      downside with this is every time you run a helm upgrade you need to supply these values otherwise they will be 
+      reverted back to what the charts default values are for those fields
+   
+      ```sh
+      $ helm repo update
+      $ helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh \
+        --set kuma.controlPlane.secrets[0].Env="KMESH_LICENSE_INLINE" \
+        --set kuma.controlPlane.secrets[0].Secret="kong-mesh-license" \
+        --set kuma.controlPlane.secrets[0].Key="license.json"
+      ```
+   
+   b. Using `values.yaml` file
    
       To get the default values file run the following command and write it to a `values.yaml` file
       
@@ -122,19 +136,6 @@ suggest `kong-mesh-system`.
       $ helm repo update
       $ helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh --values values.yaml
       ```
-   
-   b. Overriding the values using the `--set` switch on the helm command
-   
-      You can do the same thing without downloading the values file by overriding each field on the CLI, the only 
-      downside with this is every time you run a helm upgrade you need to supply these values otherwise they will be 
-      reverted back to what the charts default values are for those fields
-    ```sh
-    $ helm repo update
-    $ helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh \
-       --set kuma.controlPlane.secrets[0].Env="KMESH_LICENSE_INLINE" \
-       --set kuma.controlPlane.secrets[0].Secret="kong-mesh-license" \
-       --set kuma.controlPlane.secrets[0].Key="license.json"
-    ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
     deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)

--- a/app/mesh/1.3.x/installation/helm.md
+++ b/app/mesh/1.3.x/installation/helm.md
@@ -52,13 +52,9 @@ suggest `kong-mesh-system`.
 3. Deploy the {{site.mesh_product_name}} Helm chart:
 
    By default the license option is disabled and so you need to enable it in order for the license to take effect.
-   This can be done in two ways:
-   
-   a. Overriding the values using the `--set` switch on the helm command
-      
-      The easiest option is to override each field on the CLI, the only 
-      downside with this is every time you run a helm upgrade you need to supply these values otherwise they will be 
-      reverted back to what the charts default values are for those fields
+   The easiest option is to override each field on the CLI, the only 
+   downside with this is every time you run a helm upgrade you need to supply these values otherwise they will be 
+   reverted back to what the charts default values are for those fields, i.e. disabled
    
       ```sh
       $ helm repo update
@@ -68,75 +64,6 @@ suggest `kong-mesh-system`.
         --set kuma.controlPlane.secrets[0].Key="license.json"
       ```
    
-   b. Using `values.yaml` file
-   
-      To get the default values file run the following command and write it to a `values.yaml` file
-      
-      ```sh
-      helm show values kong-mesh/kong-mesh > values.yaml
-      ```
-      This is the what the default values file looks like
-      ```sh
-      kuma:
-        nameOverride: kong-mesh
-        # The default registry and tag to use for all Kuma images
-        global:
-          image:
-            registry: "docker.io/kong"
-            tag: "1.3.3"
-    
-        controlPlane:
-          image:
-            repository: "kuma-cp"
-      #   secrets:
-      #   - Env: "KMESH_LICENSE_INLINE"
-      #     Secret: "kong-mesh-license"
-      #     Key: "license.json"
-          webhooks:
-            validator:
-              additionalRules: |
-                - apiGroups:
-                    - kuma.io
-                  apiVersions:
-                    - v1alpha1
-                  operations:
-                    - CREATE
-                    - UPDATE
-                    - DELETE
-                  resources:
-                    - opapolicies
-            ownerReference:
-              additionalRules: |
-                - apiGroups:
-                    - kuma.io
-                  apiVersions:
-                    - v1alpha1
-                  operations:
-                    - CREATE
-                  resources:
-                    - opapolicies
-        # Configuration for the kuma dataplane sidecar
-        dataPlane:
-          image:
-            repository: "kuma-dp"
-        
-          # Configuration for the kuma init phase in the sidecar
-          initImage:
-            repository: "kuma-init"
-     ```  
-      All you need to do is uncomment the following section and then run the helm upgrade command passing 
-      the values files in
-      ```sh
-      #    secrets:
-      #      - Env: "KMESH_LICENSE_INLINE"
-      #        Secret: "kong-mesh-license"
-      #        Key: "license.json"
-      ```
-      ```
-      $ helm repo update
-      $ helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh --values values.yaml
-      ```
-
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
     deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
     like _multi-zone_.


### PR DESCRIPTION
### Review
<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
@reviewer

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
This change is updating the docs for installing mesh using helm. By default the license config is commented out and so is not applied to mesh on install, this needs to be overwritten for it to work, so added docs on how to do that.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Reason I am making this change is because there are no docs about how to apply the license for mesh and by default it does not apply the license even though the docs say create a secret with the license in. The config needs to be adjusted in order for this to work.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Testing the change is very easy, install mesh without the switch and then with the switch and you will see it not apply and then apply.

Not apply license:

helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh

Apply license:

helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh \
        --set kuma.controlPlane.secrets[0].Env="KMESH_LICENSE_INLINE" \
        --set kuma.controlPlane.secrets[0].Secret="kong-mesh-license" \
        --set kuma.controlPlane.secrets[0].Key="license.json"


<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
