### PR TITLE
[DOCU-1744] Open-source badge

### DIFF
--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -55,6 +55,15 @@
       background-color: @red-700;
       text-align: center;
     }
+
+  &.oss::after {
+      content: "OPEN-SOURCE ONLY";
+      opacity: 0.7;
+      color: white;
+      border-color: #6e30bf;
+      background-color: #6e30bf;
+      text-align: center;
+    }
 }
 
 span.badge {

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -102,7 +102,8 @@ page.kong_latest.release %}
             <h1 tabindex="-1" id="main" class="page-content-title{%
             if page.badge %} badge{%
             if page.badge == 'plus' %} plus{% endif %}{%
-            if page.badge == 'enterprise' %} enterprise{% endif %}
+            if page.badge == 'enterprise' %} enterprise{% endif %}{%
+            if page.badge == 'oss' %} oss{% endif %}
             {% endif %}"
             >{{page.title | flatify }} </h1>
             {% if page.enterprise %}{% endif %}

--- a/app/gateway-oss/2.5.x/performance-testing-framework.md
+++ b/app/gateway-oss/2.5.x/performance-testing-framework.md
@@ -1,11 +1,12 @@
 ---
 title: Performance Testing Framework
+badge: oss
 ---
 
 ## Introduction
 
 The Kong codebase includes a performance testing framework (hereinafter referred to as the “framework").
-It allows Kong developers and users to evaluate the performance of Kong itself as well as 
+It allows Kong developers and users to evaluate the performance of Kong itself as well as
 bundled or custom plugins, and plot framegraphs to debug performance bottlenecks.
 The framework collects RPS (request per second) and latencies of Kong processing the request
 to represent performance metrics under different workloads.
@@ -290,8 +291,8 @@ Starts to send load to Kong using `wrk`. Throws error if any. Options is a Lua t
 - **path** String request path; defaults to `/ `.
 - **uri** Base URI exception path; defaults to `http://kong-ip:kong-port/`.
 - **connections** Connection count; defaults to 1000.
-- **threads** Request thread count; defaults to 5. 
-- **duration** Number of performance tests duration in seconds; defaults to 10. 
+- **threads** Request thread count; defaults to 5.
+- **duration** Number of performance tests duration in seconds; defaults to 10.
 - **script** Content of `wrk` script as string; defaults to nil.
 
 [Back to top](#introduction)


### PR DESCRIPTION
### Review
@falondarville 

### Summary
* Adding a new badge for "open-source only"
* Labelling Performance Testing Framework as OSS
* Adding to layout

### Reason
https://konghq.atlassian.net/browse/DOCU-1744

### Testing
TBA