### PR TITLE
chore: Fix links flagged by weekly link checker

### DIFF
--- a/app/enterprise/2.5.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.5.x/deployment/installation/amazon-linux-2.md
@@ -155,7 +155,7 @@ Linux 2 system. For example:
 
 ## Step 5. Seed the Super Admin password and bootstrap Kong Gateway
 
-{% include /md/{{page.kong_version}}/ee-kong-user.md %}
+{% include /md/{{page.kong_version}}/ee-kong-user.md kong_version=page.kong_version %}
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 

--- a/app/enterprise/2.5.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.5.x/deployment/installation/amazon-linux.md
@@ -154,7 +154,7 @@ Linux 1 system. For example:
 
 ## Step 5. Seed the Super Admin password and bootstrap Kong Gateway
 
-{% include /md/{{page.kong_version}}/ee-kong-user.md %}
+{% include /md/{{page.kong_version}}/ee-kong-user.md kong_version=page.kong_version %}
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 

--- a/app/enterprise/2.5.x/deployment/installation/centos.md
+++ b/app/enterprise/2.5.x/deployment/installation/centos.md
@@ -150,7 +150,7 @@ root-equivalent access.
 
 ## Step 5. Seed the Super Admin password and bootstrap Kong Gateway
 
-{% include /md/{{page.kong_version}}/ee-kong-user.md %}
+{% include /md/{{page.kong_version}}/ee-kong-user.md kong_version=page.kong_version %}
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 

--- a/app/enterprise/2.5.x/deployment/installation/docker.md
+++ b/app/enterprise/2.5.x/deployment/installation/docker.md
@@ -25,7 +25,7 @@ This software is governed by the
 To complete this installation you will need a Docker-enabled system with proper
  Docker access.
 
-{% include /md/{{page.kong_version}}/docker-install-steps.md heading="## Step 1. " heading1="## Step 2. " heading2="## Step 3. " heading3="## Step 4. " kong_versions=page.kong_versions %}
+{% include /md/{{page.kong_version}}/docker-install-steps.md heading="## Step 1. " heading1="## Step 2. " heading2="## Step 3. " heading3="## Step 4. " kong_version=page.kong_version %}
 
 ## Step 5. Start the gateway with Kong Manager {#start-gateway}
 
@@ -82,7 +82,7 @@ in `KONG_ADMIN_GUI_URL` in [Step 5](#start-gateway):
     {:.note}
     > The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should not be preceded by a protocol, for example, `http://`.
 
-3. Execute the following command. 
+3. Execute the following command.
 
     <pre><code>curl -X PATCH --url http://<div contenteditable="true">{HOSTNAME}</div>:8001/workspaces/default \
         --data "config.portal=true"</code></pre>
@@ -106,4 +106,3 @@ out of {{site.base_gateway}}.
 
 If you have an Enterprise subscription, add the license using the
 [`/licenses` Admin API endpoint](/enterprise/{{page.kong_version}}/deployment/licenses/deploy-license).
-

--- a/app/enterprise/2.5.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.5.x/deployment/installation/rhel.md
@@ -56,7 +56,7 @@ root-equivalent access.
 
     * [RHEL 8]({{ site.links.download }}/gateway-2.x-rhel-8/config.repo)
     * [RHEL 7]({{ site.links.download }}/gateway-2.x-rhel-7/config.repo)
-    
+
 2. Securely copy the repo file to your home directory on the RHEL system:
 
     ```bash
@@ -169,7 +169,7 @@ root-equivalent access.
 
 ## Step 5. Seed the Super Admin password and bootstrap Kong Gateway
 
-{% include /md/{{page.kong_version}}/ee-kong-user.md %}
+{% include /md/{{page.kong_version}}/ee-kong-user.md kong_version=page.kong_version %}
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 

--- a/app/enterprise/2.5.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.5.x/deployment/installation/ubuntu.md
@@ -120,7 +120,7 @@ information about PostgreSQL on Ubuntu, see [https://www.postgresql.org/download
 
 ## Step 5. Seed the Super Admin's password and bootstrap Kong Gateway
 
-{% include /md/{{page.kong_version}}/ee-kong-user.md %}
+{% include /md/{{page.kong_version}}/ee-kong-user.md kong_version=page.kong_version %}
 
 Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
 

--- a/app/enterprise/2.5.x/deployment/licenses/deploy-license.md
+++ b/app/enterprise/2.5.x/deployment/licenses/deploy-license.md
@@ -5,4 +5,4 @@ title: Deploy an Enterprise License
 Deploy an enterprise license to a {{site.base_gateway}} installation to gain access
 to [Enterprise-specific features](/enterprise/{{page.kong_version}}/deployment/licensing).
 
-{% include /md/enterprise/deploy-license.md heading="##" %}
+{% include /md/enterprise/deploy-license.md heading="##" kong_version=page.kong_version %}

--- a/app/enterprise/2.5.x/immunity/install-configure.md
+++ b/app/enterprise/2.5.x/immunity/install-configure.md
@@ -8,7 +8,7 @@ redirect_from:
 ## Introduction
 Kong Immunity (Immunity) is installed on Kong Enterprise, either on Kubernetes or Docker, as defined below. Immunity uses the Collector App and Collector Plugin to communicate with Kong Enterprise.
 
-{% include /md/enterprise/download/immunity.md version='>2.1' %}
+{% include /md/enterprise/download/immunity.md version='>2.1' kong_version=page.kong_version %}
 
 ### Step 2. Confirm the Kong EE Docker Network is available
 Confirm the Kong Enterprise network is available, which is the network you set up when installing Kong Enterprise on Docker named `kong-ee-net`.

--- a/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
@@ -1,6 +1,6 @@
 ---
 title: Vitals with InfluxDB
-redirect_from: 
+redirect_from:
   - /enterprise/2.2.x/admin-api/vitals/vitals-influx-strategy
   - /enterprise/latest/admin-api/vitals/vitals-influx-strategy
 ---
@@ -24,9 +24,9 @@ PostgreSQL, Cassandra), refer to
 If you already have a {{site.base_gateway}} instance, skip to [Step 2](#step-2-deploy-a-kong-gateway-enterprise-license).
 
 If you have not installed {{site.base_gateway}}, a Docker installation
-will work for the purposes of this guide. 
+will work for the purposes of this guide.
 
-{% include /md/2.5.x/docker-install-steps.md heading="#### " heading1="#### " heading2="#### " heading3="#### " kong_versions=page.kong_versions %}
+{% include /md/2.5.x/docker-install-steps.md heading="#### " heading1="#### " heading2="#### " heading3="#### " kong_version=page.kong_version %}
 
 #### Start the gateway with Kong Manager
 
@@ -67,7 +67,7 @@ instance, skip to [Step 3](#step-3-start-an-influxdb-database).
 You will not be able to access the Kong Vitals functionality without a valid
 {{site.ee_product_name}} license attached to your {{site.base_gateway}} instance.
 
-{% include /md/enterprise/deploy-license.md heading="####" %}
+{% include /md/enterprise/deploy-license.md heading="####" kong_version=page.kong_version %}
 
 ### Step 3. Start an InfluxDB database
 
@@ -87,13 +87,13 @@ $ docker run -p 8086:8086 \
 > You **must** use InfluxDB 1.8.4-alpine because
 InfluxDB 2.0 will **not** work.  
 
-Writing Vitals data to InfluxDB requires that the `kong` database is created, 
+Writing Vitals data to InfluxDB requires that the `kong` database is created,
 this is done using the `INFLUXDB_DB` variable.
 
 ### Step 4. Configure Kong Gateway
 
 {:.note}
-> **Note:** If you used the configuration in 
+> **Note:** If you used the configuration in
 [Step 1. Installing {{site.base_gateway}} on Docker](#step-1-install-kong-gateway),
 then you do not need to complete this step.
 
@@ -107,13 +107,13 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 
 ## Understanding Vitals data using InfluxDB measurements
 
-Kong Vitals records metrics in two InfluxDB measurements: 
+Kong Vitals records metrics in two InfluxDB measurements:
 
 1. `kong_request`: Contains field values for request latencies and HTTP,
   and tags for various Kong entities associated with the requests (for
   example, the Route and Service in question).
 2. `kong_datastore_cache`: Contains points about cache hits and
-  misses. 
+  misses.
 
 To display the measurement schemas on your InfluxDB instance running
 in Docker:
@@ -190,13 +190,13 @@ duplicate metrics shipped at the same point in time.
 As demonstrated above, the series cardinality of the `kong_request` measurement
 varies based on the cardinality of the Kong cluster configuration - a greater
 number of Service/Route/Consumer/Workspace combinations handled by Kong results
-in a greater series cardinality as written by Vitals. 
+in a greater series cardinality as written by Vitals.
 
 ## Sizing an InfluxDB node/cluster for Vitals
 
 Consult the
 [InfluxDB sizing guidelines](https://docs.influxdata.com/influxdb/v1.8/guides/hardware_sizing/)
-for reference on appropriately sizing an InfluxDB node/cluster. 
+for reference on appropriately sizing an InfluxDB node/cluster.
 
 {:.note}
 > **Note:** The query behavior when reading Vitals data falls under the "moderate" load
@@ -214,7 +214,7 @@ whichever comes first.
 
 Metrics points are written with microsecond (`u`) precision. To comply with
 the [Vitals API](/enterprise/{{page.kong_version}}/admin-api/vitals/#vitals-api), measurement
-values are read back grouped by second. 
+values are read back grouped by second.
 
 {:.note}
 > **Note:** Because of limitations in the OpenResty API, writing values with

--- a/app/enterprise/2.5.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-prometheus-strategy.md
@@ -53,7 +53,7 @@ using default config that listens on port `9090`.
 
 ### Download and configure StatsD exporter
 
-{% include /md/enterprise/download/statsd.md version='>=1.3' %}
+{% include /md/enterprise/download/statsd.md version='>=1.3' kong_version=page.kong_version %}
 
 ### Configure Prometheus to scrape StatsD exporter
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -510,7 +510,7 @@ no_version: true
   and RBAC users, which prevented the workspace from being deleted. Now deleting entities correctly updates
   the counts, allowing an empty workspace to be deleted.
 - Updates Kong Dev Portal templates' JQuery dependency to v3.6.0, improving security.
-- Users with the `kong_admin` role can now log in to Kong Manager when `enforce_rbac=both` is set. 
+- Users with the `kong_admin` role can now log in to Kong Manager when `enforce_rbac=both` is set.
 - Renames the property identifying control planes in hybrid mode when using Kong Vitals with anonymous
   reports enabled. Before, users received the error, `Cannot use this function in data plane`, on their control planes.
 - Updates Nettle dependency version from `3.7.2` to `3.7.3`, fixing bugs that could cause
@@ -525,7 +525,7 @@ no_version: true
 
 #### Hybrid Mode
 - Control planes are now more lenient when checking data planes' compatibility in hybrid mode. See the
-  [Version compatibility](/gateway-oss/2.4.x/deployment/hybrid-mode/#version_compatibility)
+  [Version compatibility](/gateway-oss/2.4.x/hybrid-mode/#version-compatibility)
   section of the Hybrid Mode guide for more information. [#7488](https://github.com/Kong/kong/pull/7488)
 
 ## 2.4.1.1
@@ -954,7 +954,7 @@ keep-alive connections. [7102](https://github.com/Kong/kong/pull/7102)
   workspaces using the UI, the workspace name was validated; however, when using the Admin API to add users,
   the workspace name was not validated. Because the name was not validated in the Admin Api, users could create workspace names with special characters that would then break the environment.
 - Kong Gateway now escapes "-" and "." special characters in workspace names when building the compiled pattern
-  for collision detection. 
+  for collision detection.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -5,9 +5,9 @@ toc: false
 ---
 
 The Dev Portal is an API Catalog that allows Admin roles to
-document and manage Application registration for your Services. Admin roles publish Services through Konnect, and Developers use those Services. 
+document and manage Application registration for your Services. Admin roles publish Services through Konnect, and Developers use those Services.
 
-The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](konnect/dev-portal/developers/dev-reg/). 
+The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](/konnect/dev-portal/developers/dev-reg/).
 
 See also:
 * [Application Overview](/konnect/dev-portal/application-overview)


### PR DESCRIPTION
### Summary
Fixing links, mostly by passing missing page variables to includes.

### Reason
Weekly github action flagged a few broken links: https://github.com/Kong/docs.konghq.com/runs/3395596702?check_suite_focus=true (or see the [raw log](https://pipelines.actions.githubusercontent.com/lbO7jOdCYHXFUs2lFNDY4GerqWoPFrJcA3BOwQPwbFETa74unU/_apis/pipelines/1/runs/5493/signedlogcontent/3?urlExpires=2021-08-23T18%3A41%3A12.1744904Z&urlSigningMethod=HMACV1&urlSignature=jBW0wMP4B%2Fcx6QC47ohL%2F%2F0P5yRt7cn%2BSz5d4B7CTTc%3D) for easier searching).
Most of them happened because includes weren't properly updated to accept page variables.

### Testing
TBA