### PR TITLE
Updated old URL for KongPlugin to new URL

### DIFF
--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -134,7 +134,7 @@ configuration will target.
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-First, create a [KongPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
+First, create a [KongPlugin](/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource:
 
 ```yaml

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -269,7 +269,7 @@ $ curl -X POST http://{HOST}:8001/routes/{ROUTE}/plugins \
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-First, create a [KongPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
+First, create a [KongPlugin](/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource:
 
 ```yaml

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -516,7 +516,7 @@ $ curl -X POST http://{HOST}:8001/plugins/ \
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-Create a [KongClusterPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongclusterplugin)
+Create a [KongClusterPlugin](/kubernetes-ingress-controller/latest/references/custom-resources/#kongclusterplugin)
 resource and label it as global:
 
 ```yaml

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -516,7 +516,7 @@ $ curl -X POST http://{HOST}:8001/plugins/ \
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-Create a [KongClusterPlugin](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/custom-resources.md#kongclusterplugin)
+Create a [KongClusterPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource and label it as global:
 
 ```yaml

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -134,7 +134,7 @@ configuration will target.
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-First, create a [KongPlugin](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/custom-resources.md#kongplugin)
+First, create a [KongPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource:
 
 ```yaml
@@ -269,7 +269,7 @@ $ curl -X POST http://{HOST}:8001/routes/{ROUTE}/plugins \
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-First, create a [KongPlugin](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/custom-resources.md#kongplugin)
+First, create a [KongPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource:
 
 ```yaml
@@ -408,7 +408,7 @@ You can combine `consumer.id`, `service.id`, or `route.id`
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-First, create a [KongPlugin](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/custom-resources.md#kongplugin)
+First, create a [KongPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource:
 
 ```yaml
@@ -516,7 +516,7 @@ $ curl -X POST http://{HOST}:8001/plugins/ \
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-Create a [KongClusterPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
+Create a [KongClusterPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongclusterplugin)
 resource and label it as global:
 
 ```yaml

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -408,7 +408,7 @@ You can combine `consumer.id`, `service.id`, or `route.id`
 {% unless include.params.k8s_examples == false %}
 {% navtab Kubernetes %}
 
-First, create a [KongPlugin](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
+First, create a [KongPlugin](/kubernetes-ingress-controller/latest/references/custom-resources/#kongplugin)
 resource:
 
 ```yaml


### PR DESCRIPTION
The URL https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/custom-resources.md#kongplugin is an old URL which is written as a 301 since December 2020, and now includes a link to https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/ instead. Updating accordingly for improved CX, including anchor to KongPlugin section in Custom Resources doc page.

### Review
@lena-larionova 

### Summary
Updated the URL to avoid the 301 redirect from GitHub (which is not a real automatic 301, thus why this change is needed).

### Reason
The old URL was modified to display a 301 Permanent Redirect and included a link to the new destination. Saving this step for improved customer experience.

### Testing
Just click the new URL and it should direct to the latest version automatically for the Kong Plugin reference link. 👍 
