### PR TITLE
Adds an 's' onto a variable in an include for Docker install docs

### DIFF
--- a/app/enterprise/2.5.x/deployment/installation/docker.md
+++ b/app/enterprise/2.5.x/deployment/installation/docker.md
@@ -25,7 +25,7 @@ This software is governed by the
 To complete this installation you will need a Docker-enabled system with proper
  Docker access.
 
-{% include /md/{{page.kong_version}}/docker-install-steps.md heading="## Step 1. " heading1="## Step 2. " heading2="## Step 3. " heading3="## Step 4. " kong_version=page.kong_versions %}
+{% include /md/{{page.kong_version}}/docker-install-steps.md heading="## Step 1. " heading1="## Step 2. " heading2="## Step 3. " heading3="## Step 4. " kong_versions=page.kong_versions %}
 
 ## Step 5. Start the gateway with Kong Manager {#start-gateway}
 


### PR DESCRIPTION
@lena-larionova - it was a missing "s" 