### PR TITLE
doc(kic) fix v1 Ingress specs

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/2.0.x/concepts/ingress-classes.md
@@ -107,9 +107,12 @@ spec:
   - http:
       paths:
       - path: /vsemznakom
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 
 ---
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -133,9 +133,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo-example-com created
 ```
@@ -205,9 +208,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo-example-com configured
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configure-acl-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configure-acl-plugin.md
@@ -62,9 +62,12 @@ spec:
   - http:
       paths:
       - path: /get
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 
 $ echo '
@@ -80,9 +83,12 @@ spec:
   - http:
       paths:
       - path: /post
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ```
 
@@ -171,9 +177,12 @@ spec:
   - http:
       paths:
       - path: /get
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 
 $ echo '
@@ -190,9 +199,12 @@ spec:
   - http:
       paths:
       - path: /post
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ```
 
@@ -591,9 +603,12 @@ spec:
   - http:
       paths:
       - path: /get
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 
 $ echo '
@@ -610,9 +625,12 @@ spec:
   - http:
       paths:
       - path: /post
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-fallback-service.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-fallback-service.md
@@ -108,9 +108,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```
@@ -155,8 +158,10 @@ metadata:
 spec:
   ingressClassName: kong
   backend:
-    serviceName: fallback-svc
-    servicePort: 80
+    service:
+      name: fallback-svc
+      port:
+        number: 80
 " | kubectl apply -f -
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-health-checks.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-health-checks.md
@@ -66,9 +66,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-https-redirect.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-https-redirect.md
@@ -62,9 +62,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -149,9 +149,12 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: productpage
-          servicePort: 9080
+          service:
+            name: productpage
+            port:
+              number: 9080
 EOF
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
@@ -61,9 +61,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo created
 ```
@@ -132,6 +135,7 @@ spec:
     http:
       paths:
       - path: /bar
+        pathType: ImplementationSpecific
         backend:
           serviceName: echo
           servicePort: 80

--- a/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
@@ -216,17 +216,26 @@ spec:
   - http:
      paths:
      - path: /billing
+       pathType: ImplementationSpecific
        backend:
-         serviceName: billing
-         servicePort: 80
+         service:
+           name: billing
+           port:
+             number: 80
      - path: /comments
+       pathType: ImplementationSpecific
        backend:
-         serviceName: comments
-         servicePort: 80
+         service:
+           name: comments
+           port:
+             number: 80
      - path: /invoice
+       pathType: ImplementationSpecific
        backend:
-         serviceName: invoice
-         servicePort: 80
+         service:
+           name: invoice
+           port:
+             number: 80
 ' | kubectl apply -f -
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/redis-rate-limiting.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/redis-rate-limiting.md
@@ -70,9 +70,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-consumer-credential-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-consumer-credential-resource.md
@@ -62,9 +62,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```
@@ -122,9 +125,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-external-service.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-external-service.md
@@ -68,9 +68,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: proxy-to-httpbin
-          servicePort: 80
+          service:
+            name: proxy-to-httpbin
+            port:
+              number: 80
 ' | kubectl create -f -
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
@@ -77,9 +77,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: proxy-to-httpbin
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo created
 
@@ -95,9 +98,12 @@ spec:
   - http:
       paths:
       - path: /bar
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
@@ -61,9 +61,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
@@ -72,13 +72,19 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
       - path: /bar
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```
@@ -139,9 +145,12 @@ spec:
   - http:
       paths:
       - path: /baz
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo-2 created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-mtls-auth-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-mtls-auth-plugin.md
@@ -160,9 +160,12 @@ spec:
   - http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-oidc-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-oidc-plugin.md
@@ -63,9 +63,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: httpbin
-          servicePort: 80
+          service:
+            name: httpbin
+            port:
+              number: 80
 ' | kubectl apply -f -
 ingress.extensions/demo created
 ```

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-rewrites.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-rewrites.md
@@ -93,9 +93,12 @@ spec:
     http:
       paths:
       - path: /myapp
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 ' | kubectl create -f -
 ```
 

--- a/app/kubernetes-ingress-controller/2.0.x/references/custom-resources.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/custom-resources.md
@@ -128,9 +128,12 @@ spec:
     http:
       paths:
       - path: /bar
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 ```
 
 A plugin can also be applied to a specific KongConsumer by adding


### PR DESCRIPTION
### Review
@mflendrich 

### Summary
My initial attempt in https://github.com/Kong/docs.konghq.com/pull/3118 was incomplete because I didn't update the backends and didn't include pathTypes.

### Reason
The v1 Ingresses are invalid otherwise. Using `implementationSpecific` as the default for everything since that was the de facto behavior in v1beta1.

### Testing
Spot check against your own K8S 1.22 instances. I did:

```
16:47:33-0700 yagody $ echo "    
apiVersion: networking.k8s.io/v1
kind: Ingress                   
metadata:    
  name: demo-example-com
spec:                   
  ingressClassName: kong
  rules:                
  - host: demo.example.com
    http:                 
      paths:
      - path: /
        pathType: ImplementationSpecific
        backend:                        
          service:
            name: echo                                                                                                                             
            port:                                                                                                                                
              number: 80                                                                                                                       
" | kubectl apply -f -                                                                                                                                     

ingress.networking.k8s.io/demo-example-com created
16:50:02-0700 yagody $ kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.1", GitCommit:"5e58841cce77d4bc13713ad2b91fa0d961e69192", GitTreeState:"clean", BuildDate:"2021-05-12T14:18:45Z", GoVersion:"go1.16.4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1", GitCommit:"632ed300f2c34f6d6d15ca4cef3d3c7073412212", GitTreeState:"clean", BuildDate:"2021-08-25T19:54:13Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```
from `app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md` as an arbitrary spot check, since most of the changes are similar.