### PR TITLE
[DOCU-1650][DOCU-1653] Konnect deploy Aug31

### DIFF
--- a/app/konnect/deployment/index.md
+++ b/app/konnect/deployment/index.md
@@ -50,5 +50,5 @@ data plane.
 | {{site.ee_product_name}} 2.3.x    | <i class="fa fa-check"></i>      |
 | {{site.ee_product_name}} 2.2.x or earlier | <i class="fa fa-times"></i> |
 
-¹⁾ Supports 2.4.1.1 onward.
+¹⁾ Supports 2.4.1.1 onward.<br>
 ²⁾ Supports 2.5.0.1 onward.

--- a/app/konnect/deployment/index.md
+++ b/app/konnect/deployment/index.md
@@ -45,8 +45,10 @@ data plane.
 
 |                                   | {{site.konnect_saas}} |
 |-----------------------------------|:--------------------------------:|
-| {{site.ee_product_name}} 2.4.x    | <i class="fa fa-check"></i> ¹    |
+| {{site.ee_product_name}} 2.5.x    | <i class="fa fa-check"></i> ¹    |
+| {{site.ee_product_name}} 2.4.x    | <i class="fa fa-check"></i> ²    |
 | {{site.ee_product_name}} 2.3.x    | <i class="fa fa-check"></i>      |
 | {{site.ee_product_name}} 2.2.x or earlier | <i class="fa fa-times"></i> |
 
 ¹⁾ Supports 2.4.1.1 onward.
+²⁾ Supports 2.5.0.1 onward.

--- a/app/konnect/runtime-manager/gateway-runtime-conf.md
+++ b/app/konnect/runtime-manager/gateway-runtime-conf.md
@@ -61,15 +61,13 @@ to the file.
     cluster_telemetry_server_name = <kong-telemetry-example.service>
     cluster_cert = /<path-to-file>/tls.crt
     cluster_cert_key = /<path-to-file>/tls.key
-    lua_ssl_trusted_certificate = system,/<path-to-file>/ca.crt
     ```
 
     See [Parameters](/konnect/runtime-manager/runtime-parameter-reference) for
     descriptions and the matching fields in {{site.konnect_short_name}}.
 
-4. Replace the values in `cluster_cert`, `cluster_cert_key`,
-and `lua_ssl_trusted_certificate` with the paths to your certificate and key
-files.
+4. Replace the values in `cluster_cert` and `cluster_cert_key` with the paths
+to your certificate and key files.
 
 5. Restart {{site.base_gateway}} for the settings to take effect:
 

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -88,7 +88,7 @@ remaining configuration details on the **Configure Runtime** page.
 
 
     ```bash
-    $ docker pull kong/kong-gateway:2.4.1.1-alpine
+    $ docker pull kong/kong-gateway:2.5.0.1-alpine
     ```
 
     You should now have your {{site.base_gateway}} image locally.
@@ -125,7 +125,6 @@ $ docker run -d --name kong-gateway-dp1 \
   -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" \
   -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" \
   -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" \
-  -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/<path-to-file>/ca.crt" \
   --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly \
   -p 8000:8000 \
   kong-ee
@@ -145,7 +144,6 @@ docker run -d --name kong-gateway-dp1 `
   -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" `
   -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" `
   -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" `
-  -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/<path-to-file>/ca.crt" `
   --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly `
   -p 8000:8000 `
   kong-ee
@@ -153,8 +151,8 @@ docker run -d --name kong-gateway-dp1 `
 {% endnavtab %}
 {% endnavtabs %}
 
-1. Replace the values in `KONG_CLUSTER_CERT`, `KONG_CLUSTER_CERT_KEY`,
-        and `KONG_LUA_SSL_TRUSTED_CERTIFICATE` with the paths to your certificate files.
+1. Replace the values in `KONG_CLUSTER_CERT` and `KONG_CLUSTER_CERT_KEY` with
+the paths to your certificate and key files.
 
 2. Check the **Linux** or **Kubernetes** tabs in the Konnect UI to find the values for
         `KONG_CLUSTER_CONTROL_PLANE`, `KONG_CLUSTER_SERVER_NAME`,

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -90,7 +90,7 @@ like this:
     ```yaml
     image:
       repository: kong/kong-gateway
-      tag: "2.4.1.1-alpine"
+      tag: "2.5.0.1-alpine"
 
     secretVolumes:
     - kong-cluster-cert
@@ -112,7 +112,6 @@ like this:
       cluster_ca_cert: /etc/secrets/kong-cluster-ca/ca.crt
       cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
       cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
-      lua_ssl_trusted_certificate: /etc/secrets/kong-cluster-ca/ca.crt
 
     ingressController:
       enabled: false
@@ -123,8 +122,8 @@ like this:
 with your specific values from {{site.konnect_short_name}}.
 
     If your cluster cert locations differ from the paths in the template, update
-    the values in `cluster_cert`, `cluster_cert_key`, `cluster_ca_cert`, and
-    `lua_ssl_trusted_certificate` with references to the secrets you created earlier.
+    the values in `cluster_cert`, `cluster_cert_key` and `cluster_ca_cert`
+    with references to the secrets you created earlier.
 
     See [Parameters](/konnect/runtime-manager/runtime-parameter-reference) for
     descriptions and matching values in {{site.konnect_short_name}}.

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -122,7 +122,7 @@ like this:
 with your specific values from {{site.konnect_short_name}}.
 
     If your cluster cert locations differ from the paths in the template, update
-    the values in `cluster_cert`, `cluster_cert_key` and `cluster_ca_cert`
+    the values in `cluster_cert`, `cluster_cert_key`, and `cluster_ca_cert`
     with references to the secrets you created earlier.
 
     See [Parameters](/konnect/runtime-manager/runtime-parameter-reference) for

--- a/app/konnect/runtime-manager/runtime-parameter-reference.md
+++ b/app/konnect/runtime-manager/runtime-parameter-reference.md
@@ -20,4 +20,3 @@ Refer to these parameters when using the **Advanced** runtime setup option.
  [`cluster_ca_cert`](/enterprise/latest/property-reference/#cluster_ca_cert) | **Certificate** | The trusted CA certificate file, in PEM format, used to verify the `cluster_cert`.
  [`cluster_cert`](/enterprise/latest/property-reference/#cluster_cert) | **Certificate** | The certificate used for mTLS between CP/DP nodes.
  [`cluster_cert_key`](/enterprise/latest/property-reference/#cluster_cert_key) | **Private Key** | The private key used for mTLS between CP/DP nodes.
- [`lua_ssl_trusted_certificate`](/enterprise/latest/property-reference/#lua_ssl_trusted_certificate) | **Root CA Certificate** | Lists files as trusted by OpenResty. Accepts a comma-separated list of paths. If you have already specified a different `lua_ssl_trusted_certificate`, adding the content of `cluster.crt` into that file achieves the same result.

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -8,6 +8,16 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
+## August 2021
+### 2021.08.31
+**{{site.base_gateway}} 2.5.0.1 support**
+: {{site.konnect_saas}} now supports {{site.base_gateway}} 2.5.0.1.
+runtimes. You can keep using existing 2.4.x runtimes, or you can upgrade to
+2.5.0.1 to take advantage of any new features, updates, and bug fixes.
+: This release includes [event hook support](/enterprise/latest/admin-api/event-hooks/reference),
+improvements to CP-DP communication, new configuration options in plugins, and more.
+: For all the changes and new features in {{site.base_gateway}} 2.5.x, see the [changelog](/enterprise/changelog).
+
 ## June 2021
 ### 2021.06.24
 **Global plugin support**


### PR DESCRIPTION
### Summary
* Entry in changelog to introduce support for 2.5
* Update version in sample codeblocks for runtime setup
* Remove `lua_ssl_trusted_certificate` from the doc due to changes made in https://github.com/kong/kong/pull/7044.
 
### Reason
Konnect CP has been updated to run on Gateway 2.5.0.1.
https://konghq.atlassian.net/browse/DOCU-1650
https://konghq.atlassian.net/browse/DOCU-1653

### Testing
Changelog entry: 
https://deploy-preview-3163--kongdocs.netlify.app/konnect/updates

Versions and `lua_ssl_trusted_certificate` updated in:
https://deploy-preview-3163--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/
https://deploy-preview-3163--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-conf/
https://deploy-preview-3163--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-kubernetes/
