### PR TITLE
Update search to index latest versions [skip ci]

### DIFF
--- a/algolia/config-full-docs.json
+++ b/algolia/config-full-docs.json
@@ -18,13 +18,13 @@
       "selectors_key": "changelog"
     },
     {
-      "url": "https://docs.konghq.com/gateway-oss/2.4.x/"
+      "url": "https://docs.konghq.com/gateway-oss/2.5.x/"
     },
     {
-      "url": "https://docs.konghq.com/getting-started-guide/2.4.x/"
+      "url": "https://docs.konghq.com/getting-started-guide/2.5.x/"
     },
     {
-      "url": "https://docs.konghq.com/mesh/1.3.x/"
+      "url": "https://docs.konghq.com/mesh/1.4.x/"
     },
     {
       "url": "https://docs.konghq.com/mesh/changelog/",


### PR DESCRIPTION
### Summary
Updating latest Kong Gateway, Mesh, and Getting started guide versions.

### Reason
Search results are pulling up the previous version.

### Testing
N/A
