### PR TITLE
KIC 2.0: fix an incorrect external link

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/references/prometheus.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/prometheus.md
@@ -18,7 +18,7 @@ This document is a reference for the former type.
 In addition to the above, {{site.kic_product_name}} exposes more low-level performance metrics - these may however change from version to version, as they are provided by underlying frameworks of {{site.kic_product_name}}.
 
 A non-exhaustive list of these low-level metrics is present in the following places:
-* [controller-runtime metrics definition](https://github.com/Kong/kubernetes-ingress-controller/blob/main/internal/metrics/prometheus.go)
+* [controller-runtime metrics definition](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/internal/controller/metrics/metrics.go)
 * [workqueue metrics definition](https://github.com/kubernetes/component-base/blob/release-1.20/metrics/prometheus/workqueue/metrics.go#L29)
 
 [kongplugin-guide]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kongplugin-resource/


### PR DESCRIPTION
### Review
n/a

### Summary
Fixes the link to the controller-runtime metrics definition

### Reason
A link to the wrong place has been there

### Testing
n/a

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
