### PR TITLE
[DOCU-1798]Adds changelog entries for the 2.2.1.5, 2.3.3.4, 2.4.1.3, and 2.5.0.2 hot fix releases

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -11,7 +11,7 @@ no_version: true
 
 #### Enterprise
 - This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
-from portals created in Kong Gateway v2.2.1.4.
+from portals created in Kong Gateway v2.5.0.1.
 
 #### Plugins
 - [Mocking](/hub/kong-inc/mocking) (`mocking`)
@@ -518,7 +518,7 @@ from portals created in Kong Gateway v2.2.1.4.
 
 #### Enterprise
 - This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
-from portals created in Kong Gateway v2.2.1.4.
+from portals created in Kong Gateway v2.4.1.2.
 
 ## 2.4.1.2
 **Release Date** 2021/08/18
@@ -967,7 +967,7 @@ keep-alive connections. [7102](https://github.com/Kong/kong/pull/7102)
 
 #### Enterprise
 - This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
-from portals created in Kong Gateway v2.2.1.4.
+from portals created in Kong Gateway v2.3.3.3.
 
 ## 2.3.3.3
 **Release Date** 2021/08/18

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -4,6 +4,20 @@ no_search: true
 no_version: true
 ---
 
+## 2.5.0.2
+**Release Date** 2021/09/02
+
+### Fixes
+
+#### Enterprise
+- This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
+from portals created in Kong Gateway v2.2.1.4.
+
+#### Plugins
+- [Mocking](/hub/kong-inc/mocking) (`mocking`)
+  This release fixes special character handling in path matching for the plugin. Before, if a path contained a hyphen
+  the plugin failed to match the path.
+
 ## 2.5.0.1
 **Release Date** 2021/08/18
 
@@ -497,6 +511,15 @@ no_version: true
   with command not found". [#7523](https://github.com/Kong/kong/pull/7523)
 
 
+## 2.4.1.3
+**Release Date** 2021/09/02
+
+### Fixes
+
+#### Enterprise
+- This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
+from portals created in Kong Gateway v2.2.1.4.
+
 ## 2.4.1.2
 **Release Date** 2021/08/18
 
@@ -937,6 +960,15 @@ keep-alive connections. [7102](https://github.com/Kong/kong/pull/7102)
     which prevented access to other necessary modules such as `kong.log`.
 
 
+## 2.3.3.4
+**Release Date** 2021/09/02
+
+### Fixes
+
+#### Enterprise
+- This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
+from portals created in Kong Gateway v2.2.1.4.
+
 ## 2.3.3.3
 **Release Date** 2021/08/18
 
@@ -1376,6 +1408,15 @@ fixed causing a 500 auth error when falling back to an anonymous user.
 ### Deprecated
 #### Distributions
 - Support for CentOS-6 is removed and entered end-of-life on Nov 30, 2020.
+
+## 2.2.1.5
+**Release Date** 2021/09/02
+
+### Fixes
+
+#### Enterprise
+- This release fixes a regression in the Kong Dev Portal templates that removed dynamic menu navigation and other improvements
+from portals created in Kong Gateway v2.2.1.4.
 
 ## 2.2.1.4
 **Release Date** 2021/08/18


### PR DESCRIPTION
### Summary
Main update is to inform users about the Dev Portal template issue being fixed by the hot fixes - [FTI-2828](https://konghq.atlassian.net/browse/FTI-2828), and for 2.5.0.2 a fix for the Mocking plugin was also included - [FTI-2582](https://konghq.atlassian.net/browse/FTI-2582)
### Reason
[DOCU-1798](https://konghq.atlassian.net/browse/DOCU-1798)
### Testing
2.2.1.5
2.3.3.4
2.4.1.2
2.5.0.2

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
