### PR TITLE
docs: add prom metrics to kic 2.x toc

### DIFF
--- a/app/_data/docs_nav_kic_2.0.x.yml
+++ b/app/_data/docs_nav_kic_2.0.x.yml
@@ -120,3 +120,5 @@
       url: /references/version-compatibility
     - text: Troubleshooting
       url: /troubleshooting
+    - text: Prometheus Metrics
+      url: /references/prometheus


### PR DESCRIPTION
### Review
@lena-larionova 

### Summary
Adds prometheus to the references TOC.

### Reason
The entry in the TOC is currently missing.

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1803