### PR TITLE
[DOCU-1801] Developer Portal to Dev Portal

### DIFF
--- a/app/enterprise/2.5.x/developer-portal/administration/application-registration/3rd-party-oauth.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/application-registration/3rd-party-oauth.md
@@ -127,7 +127,7 @@ the OIDC and Application Registration plugins. Click on the image to expand its
 
 | Step | Explanation                                                          |
 |:------|:--------------------------------------------------------------------|
-| a | A developer copies the target Service's `issuer_id`, which can be exposed in the Developer Portal application view Service Details page. Developers can configure their application to make a request to this endpoint to authenticate the user and retrieve an access token. |
+| a | A developer copies the target Service's `issuer_id`, which can be exposed in the Dev Portal application view Service Details page. Developers can configure their application to make a request to this endpoint to authenticate the user and retrieve an access token. |
 | b | Okta redirects the user to a login page. |
 | c | The user inputs their Single Sign-On (SSO) information. |
 | d | The user submits the SSO form that contains their Okta username and password. |

--- a/app/enterprise/2.5.x/developer-portal/administration/application-registration/auth-provider-strategy.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/application-registration/auth-provider-strategy.md
@@ -45,7 +45,7 @@ applications across all Workspaces (Dev Portals) in a {{site.base_gateway}} clus
 ### Authorization provider strategy configuration for Application Registration {#portal-app-auth}
 
 The `portal_app_auth` configuration option must be set in `kong.conf` to enable
-the Developer Portal Application Registration plugin with your chosen
+the Dev Portal Application Registration plugin with your chosen
 authorization strategy. The default setting (`kong-oauth2`) accommodates the
 OAuth2 or Key Authentication plugins.
 
@@ -74,7 +74,7 @@ If you are using an external IdP, follow these steps.
 
    ```
    portal_app_auth = external-oauth2
-            # Developer Portal application registration
+            # Dev Portal application registration
             # auth provider and strategy. Must be set to configure
             # authentication in conjunction with the application_registration plugin.
             # Currently accepts kong-oauth2 or external-oauth2.

--- a/app/enterprise/2.5.x/developer-portal/administration/application-registration/azure-oidc-config.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/application-registration/azure-oidc-config.md
@@ -189,7 +189,7 @@ next procedure.
 
 ## Create an Application in Kong
 
-1. Log in to your Developer Portal and create a new application:
+1. Log in to your Dev Portal and create a new application:
    1. Select the **My Apps** menu -> **New Application**.
    2. Enter the **Name** of your Azure application.
    3. Paste the `aud` value generated in JWT in the **Reference ID** field.

--- a/app/enterprise/2.5.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -3,16 +3,16 @@ title: Enable Application Registration
 ---
 
 ## Introduction
-Application Registration allows registered developers on the Kong Developer Portal to
+Application Registration allows registered developers on the Kong Dev Portal to
 authenticate with supported Authentication plugins against a Service on Kong. Either {{site.base_gateway}} or
 external identity provider admins can selectively admit access to Services using Kong Manager.
 
 ## Prerequisites
 * {{site.ee_product_name}} is installed, version 2.1.0.0 or later. If you plan to use
 key authentication, version 2.2.1.0 or later.
-* Developer Portal is enabled on the same Workspace as the Service.
+* Dev Portal is enabled on the same Workspace as the Service.
 * The Service is created and enabled with HTTPS.
-* Authentication is enabled on the Developer Portal.
+* Authentication is enabled on the Dev Portal.
 * Logged in as an admin with read and write roles on applications, services, and
   developers.
 * The `portal_app_auth` configuration option is configured for your OAuth provider
@@ -62,8 +62,8 @@ In Kong Manager, access the Service for which you want to enable Application Reg
 | `Service` | The Service that this plugin configuration will target. Required. |
 | `Tags` | A set of strings for grouping and filtering, separated by commas. Optional. |
 | `Auto Approve` | If enabled, all new Service contract requests are automatically approved. Otherwise, Dev Portal admins must manually approve requests. Default: `false`. |
-| `Description` | Description displayed in the information about a Service in the Developer Portal. Optional. |
-| `Display Name` | Unique name displayed in the information about a Service in the Developer Portal. Required. |
+| `Description` | Description displayed in the information about a Service in the Dev Portal. Optional. |
+| `Display Name` | Unique name displayed in the information about a Service in the Dev Portal. Required. |
 | `Show Issuer` | Displays the Issuer URL in the Service Details page. Default: `false`. **Important:** Exposing the **Issuer URL** is essential for the [Authorization Code Flow](/enterprise/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow) workflow configured for third-party identity providers. |
 
 ## Next steps

--- a/app/enterprise/2.5.x/developer-portal/administration/application-registration/managing-applications.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/application-registration/managing-applications.md
@@ -3,11 +3,11 @@ title: Manage Applications
 ---
 
 ## Manage Developer Applications from Kong Manager
-Developers can create applications from the Kong Developer Portal. An application can apply to any number of Services. This is called a Service Contract. To use an application with a Service, the Service Contract must have an Approved status. To enable automatic approval for all new Service Contracts, enable Auto-approve for the Portal Application Registration plugin.
+Developers can create applications from the Kong Dev Portal. An application can apply to any number of Services. This is called a Service Contract. To use an application with a Service, the Service Contract must have an Approved status. To enable automatic approval for all new Service Contracts, enable Auto-approve for the Portal Application Registration plugin.
 
 ### Create an Application
 
-1. Log in to the Kong Developer Portal.
+1. Log in to the Kong Dev Portal.
 2. Click **My Apps** in the top navigation bar.
 3. Click **New Application**.
 4. Complete the **Create Application** dialog:

--- a/app/enterprise/2.5.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/application-registration/okta-config.md
@@ -74,7 +74,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 ## Register an application in Okta
 
 Follow these steps to register an application in Okta and associate the Okta
-application with an application in the Kong Developer Portal.
+application with an application in the Kong Dev Portal.
 
 1. Sign in to the [Developer Okta site](https://developer.okta.com/).
 2. Click **Applications** > **+ Add Application**.
@@ -99,7 +99,7 @@ your Okta application will vary:
 ## Associate the identity provider application with your Kong application
 
 Now that the application has been configured in Okta, you need to associate the
-Okta application with the corresponding application in Kong's Developer Portal.
+Okta application with the corresponding application in Kong's Dev Portal.
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Each developer should have their own application in both Okta and Kong.  

--- a/app/enterprise/2.5.x/developer-portal/administration/developer-permissions.md
+++ b/app/enterprise/2.5.x/developer-portal/administration/developer-permissions.md
@@ -4,7 +4,7 @@ title: Developer Roles and Content Permissions
 
 ## Introduction
 
-Access to the Developer Portal can be fine-tuned with the use of Developer
+Access to the Dev Portal can be fine-tuned with the use of Developer
 Roles and Content Permissions, managed through the Dev Portal Permissions page
 of Kong Manager. This page can be found by clicking the **Permissions** link
 under **Dev Portal** in the Kong Manager navigation bar.

--- a/app/enterprise/2.5.x/developer-portal/configuration/authentication/basic-auth.md
+++ b/app/enterprise/2.5.x/developer-portal/configuration/authentication/basic-auth.md
@@ -4,7 +4,7 @@ title: Enable Basic Auth in the Dev Portal
 
 ## Introduction
 
-The Kong Developer Portal can be fully or partially authenticated using HTTP protocol's Basic Authentication scheme. Requests are sent with an Authorization header that
+The Kong Dev Portal can be fully or partially authenticated using HTTP protocol's Basic Authentication scheme. Requests are sent with an Authorization header that
 contains the word `Basic` followed by the base64-encoded `username:password` string.
 
 Basic Authentication for the Dev Portal can be enabled using any of the following ways:

--- a/app/enterprise/2.5.x/developer-portal/configuration/authentication/key-auth.md
+++ b/app/enterprise/2.5.x/developer-portal/configuration/authentication/key-auth.md
@@ -4,7 +4,7 @@ title: Enable Key Auth in the Dev Portal
 
 ### Introduction
 
-The Kong Developer Portal can be fully or partially authenticated using API keys or **Key
+The Kong Dev Portal can be fully or partially authenticated using API keys or **Key
 Authentication**. Users provide a unique key upon registering and use this key
 to log into the Dev Portal.
 

--- a/app/enterprise/2.5.x/developer-portal/configuration/authentication/oidc.md
+++ b/app/enterprise/2.5.x/developer-portal/configuration/authentication/oidc.md
@@ -5,7 +5,7 @@ title: Enable OpenID Connect in the Dev Portal
 ### Introduction
 
 The [OpenID Connect Plugin](/hub/kong-inc/openid-connect/) (OIDC)
-allows the Kong Developer Portal to hook into existing authentication setups using third-party
+allows the Kong Dev Portal to hook into existing authentication setups using third-party
 *Identity Providers* (IdP) such as Google, Okta, Microsoft Azure AD,
 [Curity](/enterprise/latest/plugins/oidc-curity/#kong-dev-portal-authentication), etc.
 

--- a/app/enterprise/2.5.x/developer-portal/configuration/smtp.md
+++ b/app/enterprise/2.5.x/developer-portal/configuration/smtp.md
@@ -15,7 +15,7 @@ curl http://localhost:8001/workspaces/<WORKSPACE_NAME> \
 
 If they are not modified manually, the Dev Portal will use the default value defined in the Kong Configuration file.
 
-In 1.3.0.1 or greater, [Developer Portal email content and styling can be customized via template files](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/emails/)
+In 1.3.0.1 or greater, [Dev Portal email content and styling can be customized via template files](/enterprise/{{page.kong_version}}/developer-portal/theme-customization/emails/)
 
 
 ### portal_invite_email
@@ -27,11 +27,11 @@ When enabled, Kong admins will be able to invite developers to a Dev Portal by u
 
 **Email:**
 ```
-Subject: Invite to access Developer Portal <WORKSPACE_NAME>
+Subject: Invite to access Dev Portal <WORKSPACE_NAME>
 
 Hello Developer!
 
-You have been invited to create a Developer Portal account at %s.
+You have been invited to create a Dev Portal account at %s.
 Please visit `<DEV_PORTAL_URL/register>` to create your account.
 ```
 
@@ -52,11 +52,11 @@ When enabled, developers will receive an email upon registration to verify their
 When enabled, Kong Admins specified by `smtp_admin_emails` will receive an email when a Developer requests access to a Dev Portal.
 
 ```
-Subject: Request to access Developer Portal <WORKSPACE NAME>
+Subject: Request to access Dev Portal <WORKSPACE NAME>
 
 Hello Admin!
 
-<DEVELOPER NAME> has requested Developer Portal access for <WORKSPACE_NAME>.
+<DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>.
 Please visit <KONG_MANAGER_URL/developers/requested> to review this request.
 ```
 
@@ -69,7 +69,7 @@ Please visit <KONG_MANAGER_URL/developers/requested> to review this request.
 When enabled, developers will receive an email when access to a Dev Portal has been approved.
 
 ```
-Subject: Developer Portal access approved
+Subject: Dev Portal access approved
 
 Hello Developer!
 You have been approved to access <WORKSPACE_NAME>.
@@ -87,11 +87,11 @@ When enabled, developers will be able to use the Reset Password flow on a Dev Po
 When disabled, developers will *not* be able to reset their account passwords.
 
 ```
-Subject: Password Reset Instructions for Developer Portal <WORKSPACE_NAME>.
+Subject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.
 
 Hello Developer,
 
-Please click the link below to reset your Developer Portal password.
+Please click the link below to reset your Dev Portal password.
 
 <DEV_PORTAL_URL/reset?token=12345>
 
@@ -111,10 +111,10 @@ When enabled, developers will receive an email after successfully reseting their
 When disabled, developers will still be able to reset their account passwords, but will not receive a confirmation email.
 
 ```
-Subject: Developer Portal password change success
+Subject: Dev Portal password change success
 
 Hello Developer,
-We are emailing you to let you know that your Developer Portal password at <DEV_PORTAL_URL> has been changed.
+We are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.
 
 Click the link below to sign in with your new credentials.
 


### PR DESCRIPTION
### Review

@lena-larionova 

### Summary

In Gateway Enterprise, I changed instances of "Developer Portal" to "Dev Portal". 

Note: We are not currently updating the folder name (and hence, URL) as we will defer this for our single-sourcing efforts. 

### Reason

Growth team initiated a name change. 

### Testing

Local
