### PR TITLE
[DOCU-1708] Accessibility: Icon and image modal alt text

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -463,6 +463,7 @@ jQuery(function () {
         $(document.body).addClass("image-modal-no-scroll");
         imageModal.addClass("visible");
         imageModal.find("img").attr("src", $img.attr("src"));
+        imageModal.find("img").attr("alt", $img.attr("alt"));
 
         document.addEventListener("keydown", imageModalKeyDown);
       });

--- a/app/_includes/accordion-item.html
+++ b/app/_includes/accordion-item.html
@@ -5,7 +5,7 @@
   {% endif %}
   <label for="accordion-{{ include.id }}">
     {% if include.icon %}
-    <img src="{{ include.icon }}" alt="icon">
+    <img src="{{ include.icon }}" alt="">
     {% endif %}
     {% if include.url %}
     <a href="{{ include.url }}">{{ include.label }}</a>

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -22,7 +22,7 @@
       <a href="{{ extn.url | remove: '/index' }}" title="{{ extn.name }}: {{ extn.desc }}">
         <div>
           <div class="name-desc {% if extn.plus and extn_publisher == 'kong-inc' %}plus{% endif %}">
-            <img class="card-img-top" src="{{ header_icon }}" />
+            <img class="card-img-top" src="{{ header_icon }}" alt="" />
             <p class="lg mt-1x fw-500">{{ extn.name }}</p>
             <p class="sm">{{ extn.desc }}</p>
           </div>

--- a/app/_includes/image-modal.html
+++ b/app/_includes/image-modal.html
@@ -1,7 +1,7 @@
 <div id="image-modal" data-image-expand-disabled="{{ include.disable_image_expand }}">
   <div class="image-modal-backdrop"></div>
   <div class="image-container">
-    <img src="" alt="expanded-image">
+    <img src="" alt="">
     <i class="fa fa-times"></i>
   </div>
 </div>

--- a/app/_includes/image-modal.html
+++ b/app/_includes/image-modal.html
@@ -1,7 +1,7 @@
 <div id="image-modal" data-image-expand-disabled="{{ include.disable_image_expand }}">
   <div class="image-modal-backdrop"></div>
   <div class="image-container">
-    <img src="" alt="image">
+    <img src="" alt="expanded-image">
     <i class="fa fa-times"></i>
   </div>
 </div>

--- a/app/_layouts/landing-page.html
+++ b/app/_layouts/landing-page.html
@@ -33,7 +33,7 @@ id: landing-page
         <a href="/konnect-platform/" class="name-link">
           <div class="name-label">
                 <div class="link-text">
-                  <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="doc">
+                  <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="">
                   Konnect Platform Overview
                 </div>
               </div>
@@ -41,7 +41,7 @@ id: landing-page
           <a href="/konnect/" class="name-link">
             <div class="name-label">
               <div class="link-text">
-                <img class="icon" src="/assets/images/icons/icn-cloud-blue.svg" alt="cloud">
+                <img class="icon" src="/assets/images/icons/icn-cloud-blue.svg" alt="">
                 Cloud
               </div>
             </div>
@@ -49,7 +49,7 @@ id: landing-page
           <a href="/enterprise/" class="name-link">
             <div class="name-label">
               <div class="link-text">
-                <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="server">
+                <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="">
                 Self-hosted
               </div>
             </div>
@@ -62,39 +62,39 @@ id: landing-page
       </h3>
     <div class="cards-container">
       <div class="card">
-        <img class="icon" src="/assets/images/landing-page/connection.svg" alt="connection"/>
+        <img class="icon" src="/assets/images/landing-page/connection.svg" alt=""/>
         <div class="title">1. Runtime connection</div>
         <div class="description">Set up your first runtime connection</div>
         <a href="/konnect/getting-started/configure-runtime/" class="link-text">
           Set up
-          <img src="/assets/images/icons/icn-arrow-right.svg" alt="right">
+          <img src="/assets/images/icons/icn-arrow-right.svg" alt="">
         </a>
       </div>
       <div class="arrow-card">
         <div class="arrow">
-          <img src="/assets/images/landing-page/arrow-right.svg" alt="arrow">
+          <img src="/assets/images/landing-page/arrow-right.svg" alt="">
         </div>
         <div class="card">
-          <img class="icon" src="/assets/images/landing-page/catalog.svg" alt="connection"/>
+          <img class="icon" src="/assets/images/landing-page/catalog.svg" alt=""/>
           <div class="title">2. Catalog services</div>
           <div class="description">Catalog your services using the {{site.konnect_short_name}} ServiceHub</div>
           <a href="/konnect/getting-started/configure-service" class="link-text">
             Catalog
-            <img src="/assets/images/icons/icn-arrow-right.svg" alt="right">
+            <img src="/assets/images/icons/icn-arrow-right.svg" alt="">
           </a>
         </div>
       </div>
       <div class="arrow-card">
         <div class="arrow">
-          <img src="/assets/images/landing-page/arrow-right.svg" alt="arrow">
+          <img src="/assets/images/landing-page/arrow-right.svg" alt="">
         </div>
         <div class="card">
-          <img class="icon" src="/assets/images/landing-page/services.svg" alt="connection"/>
+          <img class="icon" src="/assets/images/landing-page/services.svg" alt=""/>
           <div class="title">3. Manage services</div>
           <div class="description">Manage your services using the {{site.konnect_short_name}} ServiceHub</div>
           <a href="/konnect/getting-started/implement-service/" class="link-text">
             Manage
-            <img src="/assets/images/icons/icn-arrow-right.svg" alt="right">
+            <img src="/assets/images/icons/icn-arrow-right.svg" alt="">
           </a>
         </div>
       </div>
@@ -106,7 +106,7 @@ id: landing-page
       <h3>Connectivity runtimes</h3>
       <div class="cards-container">
         <div class="card">
-          <img class="banner-image" src="/assets/images/landing-page/gateway.png" alt="mesh">
+          <img class="banner-image" src="/assets/images/landing-page/gateway.png" alt="">
           <div class="title">{{site.base_gateway}}</div>
           <div class="description">A lightweight API Gateway that lets you secure, manage, and extend APIs and microservices.</div>
           <hr>
@@ -117,11 +117,11 @@ id: landing-page
                   Enterprise
                 </div>
                 <div class="icon-label">
-                  <img src="/assets/images/icons/icn-server.svg" alt="server">
+                  <img src="/assets/images/icons/icn-server.svg" alt="">
                   Self-hosted version
                 </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="doc">
+              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
             <a href="/gateway-oss/" class="name-link">
               <div class="name-label">
@@ -129,16 +129,16 @@ id: landing-page
                   Open source
                 </div>
                 <div class="icon-label">
-                  <img src="/assets/images/icons/icn-server.svg" alt="server">
+                  <img src="/assets/images/icons/icn-server.svg" alt="">
                   Self-hosted version
                 </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="doc">
+              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
           </div>
         </div>
         <div class="card">
-          <img class="banner-image" src="/assets/images/landing-page/mesh.png" alt="mesh">
+          <img class="banner-image" src="/assets/images/landing-page/mesh.png" alt="">
           <div class="title">{{site.mesh_product_name}}</div>
           <div class="description">
             Universal service mesh for enterprise organizations focused on simplicity, security, and scalability with Kuma and Envoy.
@@ -151,11 +151,11 @@ id: landing-page
                   {{site.mesh_product_name}}
                 </div>
                 <div class="icon-label">
-                  <img src="/assets/images/icons/icn-server.svg" alt="server">
+                  <img src="/assets/images/icons/icn-server.svg" alt="">
                   Self-hosted version
                 </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="doc">
+              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
             <a href="https://kuma.io/docs/" class="name-link">
               <div class="name-label">
@@ -163,11 +163,11 @@ id: landing-page
                   Kuma (open-source)
                 </div>
                 <div class="icon-label">
-                  <img src="/assets/images/icons/icn-server.svg" alt="server">
+                  <img src="/assets/images/icons/icn-server.svg" alt="">
                   Self-hosted version
                 </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="doc">
+              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
           </div>
         </div>
@@ -181,14 +181,14 @@ id: landing-page
     <div class="cards-container">
       {% for item in feature.items %}
       <div class="card default">
-        <img src="{{ item.icon }}" alt="service" class="icon">
+        <img src="{{ item.icon }}" alt="" class="icon">
         <div class="title">{{ item.name }}</div>
         <div class="description">{{ item.description }}</div>
         <hr>
         <div class="links-container">
           {% for link in item.links %}
           <a href="{{ link.url }}" class="link-text">
-            <img class="icon" src="{{ link.icon }}" alt="link icon">
+            <img class="icon" src="{{ link.icon }}" alt="">
             {{ link.text }}
           </a>
           {% endfor %}
@@ -206,7 +206,7 @@ id: landing-page
       <div class="links-container">
         {% for link in site.data.landing_page.contribute_links %}
         <a href="{{ link.url }}" class="link-text">
-          <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="doc">
+          <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="">
           {{ link.text }}
         </a>
         {% endfor %}
@@ -218,7 +218,7 @@ id: landing-page
       <div class="links-container">
         {% for link in site.data.landing_page.popular_topics %}
         <a href="{{ link.url }}" class="link-text">
-          <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="doc">
+          <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="">
           {{ link.text }}
         </a>
         {% endfor %}
@@ -228,7 +228,7 @@ id: landing-page
 
     {% include feedback-widget.html %}
 
-  <img class="kong-image" src="/assets/images/landing-page/kong.svg" alt="kong">
+  <img class="kong-image" src="/assets/images/landing-page/kong.svg" alt="">
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
### Review
@falondarville 

### Summary
* Removing alt text from left nav, landing page, and plugin hub icons. 
* Also removing alt text from decorative images on the landing page (arrows, background banners)
* Adjusting image modals to pull alt text from the images that they're expanding, instead of affixing a useless "image" label.

### Reason
https://konghq.atlassian.net/browse/DOCU-1708

Currently, we have alt text on decorative icons throughout the site. If the icons are decorative, they should have empty alt text. See: homepage, product pages left-side menu, and hub

Reference: https://www.w3.org/WAI/tutorials/images/decorative/

### Testing
https://deploy-preview-3178--kongdocs.netlify.app/ - text with Chrome WAVE extension
