### PR TITLE
Fixed the URL

### DIFF
--- a/app/konnect/dev-portal/developers/dev-gen-creds.md
+++ b/app/konnect/dev-portal/developers/dev-gen-creds.md
@@ -23,7 +23,7 @@ A credential, or API key, generated in the {{site.konnect_short_name}} Dev Porta
    using your `key-auth` credential:
 
    ```
-   <proxy-url or proxy-ip>/<route>?apikey=<apikey>
+   {PROXY_URL_OR_PROXY_IP}/{ROUTE}?apikey={APIKEY}
    ```
 
 ## Delete a credential

--- a/app/konnect/dev-portal/developers/dev-gen-creds.md
+++ b/app/konnect/dev-portal/developers/dev-gen-creds.md
@@ -23,7 +23,7 @@ A credential, or API key, generated in the {{site.konnect_short_name}} Dev Porta
    using your `key-auth` credential:
 
    ```
-   <proxy-url>/<service>/?apikey=<apikey>
+   <proxy-url or proxy-ip>/<route>?apikey=<apikey>
    ```
 
 ## Delete a credential


### PR DESCRIPTION
1. The proxy is either available at a URL [Linux](https://docs.konghq.com/konnect/runtime-manager/gateway-runtime-conf/) or an IP address [Kubernetes](https://docs.konghq.com/konnect/runtime-manager/gateway-runtime-kubernetes/)
2. The next segment of the URL must be the route and not the name of the service
