### PR TITLE
[DOCU-1808]Updates kong version in download code sample

### DIFF
--- a/app/deck/1.7.x/installation.md
+++ b/app/deck/1.7.x/installation.md
@@ -28,7 +28,7 @@ the Github [release page](https://github.com/kong/deck/releases)
 or install by downloading a compressed archive, which contains the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v{{page.kong_versions[0].version}}/deck_{{page.kong_versions[0].version}}_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v{{page.kong_versions[1].version}}/deck_{{page.kong_versions[1].version}}_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```


### PR DESCRIPTION
### Summary
@liyangau noted in docs channel on Slack that this download code sample was pointing to the prior version and not the latest version, 1.7. I have updated the variable to point to the 1 index instead of 0.
### Reason
Want to be sure users are being directed to download the version that matches the version of the doc they are reading.
[DOCU-1808](https://konghq.atlassian.net/browse/DOCU-1808)
### Testing
Will include Netlify link when available.
