### PR TITLE
Adjust the metadata for page titles

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -1,8 +1,9 @@
-{% unless include.name and include.path contains '_hub' %} {% capture page_title %}{{
-include.title | escape }}{% if include.kong_version and include.no_version != true %} -
-v{{ include.kong_version | escape }}{% endif %}{% if include.title %} | {% endif %}{{
+{% unless include.name and include.path contains '_hub' %}
+{% capture page_title %}{{
+include.title | escape }}{% if include.kong_version and include.no_version != true %} - v{{ include.kong_version | escape }}{% endif %}{% if include.title %} | {% endif %}{{
 site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ include.name }}
-{{ include.type }} | Kong{% endcapture %} {% endunless %}
+{{ include.type }} | {{site.title}}{% endcapture %}
+{% endunless %}
 
 <head>
   <!-- Google Tag Manager -->
@@ -19,7 +20,7 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ include.name
   <title>{{ page_title }}</title>
   <meta name="description" content="{{ site.description }}" />
   <meta name="author" content="KongHQ" />
-  <meta property="og:title" content="{{ site.title }} | {{ page.title }}" />
+  <meta property="og:title" content="{{ page_title }}" />
   <meta property="og:site_name" content="{{ site.name }}" />
   <!-- use share link for facebook -->
   <meta property="og:url" content="{{ site.links.share }}" />


### PR DESCRIPTION
### Review
@falondarville
 
### Summary
Currently the landing page preview is `Kong Docs |`, including that extra `|` character.
Adjusting page title to display in a more useful and cleaner way. 

### Reason
Accidentally used `page.title` instead of `page_title` originally.

### Testing
TBA
When netlify preview is ready, right click on a page in the preview and click "Inspect". Look through the `<head>` tag to find the title metadata.
