### PR TITLE
[DOCU-1812]Adds changelog for 2.5.1.0 EE kong gateway release

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -4,8 +4,46 @@ no_search: true
 no_version: true
 ---
 
+## 2.5.1.0 
+**Release Date** 2021/09/08
+
+### Dependencies
+- Bumped `grpcurl` from 1.8.1 to 1.8.2 [#7659](https://github.com/Kong/kong/pull/7659)
+- Bumped `lua-resty-openssl` from 0.7.3 to 0.7.4 [#7657](https://github.com/Kong/kong/pull/7657)
+- Bumped `penlight` from 1.10.0 to 1.11.0 [#7736](https://github.com/Kong/kong/pull/7736)
+- Bumped `luasec` from 1.0.1 to 1.0.2 [#7750](https://github.com/Kong/kong/pull/7750)
+- Bumped `OpenSSL` from 1.1.1k to 1.1.1l [#7767](https://github.com/Kong/kong/pull/7767)
+
+### Fixes
+
+#### Core
+- You can now successfully delete workspaces after deleting all entities associated with that workspace.
+  Previously, Kong Gateway was not correctly cleaning up parent-child relationships. For example, creating
+  an Admin also creates a Consumer and RBAC user. When deleting the Admin, the Consumer and RBAC user are
+  also deleted, but accessing the `/workspaces/workspace_name/meta` endpoint would show counts for Consumers
+  and RBAC users, which prevented the workspace from being deleted. Now deleting entities correctly updates
+  the counts, allowing an empty workspace to be deleted. [#7560](https://github.com/Kong/kong/pull/7560)
+- When an upstream event is received from the DAO, `handler.lua` now gets the workspace ID from the request
+  and adds it to the upstream entity that will be used in the worker and cluster events. Before this change,
+  when posting balancer CRUD events, the workspace ID was lost and the balancer used the default
+  workspace ID as a fallback. [#7778](https://github.com/Kong/kong/pull/7778)
+
+#### CLI
+- Fixes regression that included an issue where Go plugins prevented CLI commands like `kong config parse`
+  or `kong config db_import` from working as expected. [#7589](https://github.com/Kong/kong/pull/7589)
+
+#### Admin API
+- Kong Gateway now validates workspace names, preventing the use of reserved names on workspaces.
+  [#7380](https://github.com/Kong/kong/pull/7380)
+
+#### Plugins
+- [Azure Functions](/hub/kong-inc/azure-functions) (`azure-functions`)
+  This relese updates the `lua-resty-http` dependency to v0.16.1, which means the plugin no longer
+  uses the deprecated functions.
+
+
 ## 2.5.0.2
-**Release Date** 2021/09/02
+**Release Date** 2021/09/02cf
 
 ### Fixes
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -43,7 +43,7 @@ no_version: true
 
 
 ## 2.5.0.2
-**Release Date** 2021/09/02cf
+**Release Date** 2021/09/02
 
 ### Fixes
 


### PR DESCRIPTION
### Summary
UpdateS changelog with EE Kong Gateway v2.5.1.0 patch release
### Reason
[DOCU-1812](https://konghq.atlassian.net/browse/DOCU-1812)
### Testing
Will include sample build link when available.