### PR TITLE
[DOCU-1814] Fix link and other issues in KIC 2.0 prometheus guide

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
@@ -4,7 +4,7 @@ title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
 
 The {{site.kic_product_name}} can give you visibility into how {{site.base_gateway}} is performing and how the services in your Kubernetes cluster are responding to the inbound traffic.
 
-This guide below walks you through setting up monitoring for
+This guide walks you through setting up monitoring for
 {{site.base_gateway}} with Prometheus.
 
 {:.important}

--- a/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
@@ -2,21 +2,18 @@
 title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
 ---
 
-The {{site.kic_product_name}} can give you visibility not only into how Kong is
-performing but also gives visibilty into
-how the services in your Kubernetes cluster are responding to the
-inbound traffic.
+The {{site.kic_product_name}} can give you visibility into how {{site.base_gateway}} is performing and how the services in your Kubernetes cluster are responding to the inbound traffic.
 
-This how-to guide walks through the steps of how to configure Kong and
-Prometheus to collect metrics from Kong Gateway.
+This guide below walks you through setting up monitoring for
+{{site.base_gateway}} with Prometheus.
 
-<div class="alert alert-red no-icon">
-The guide below walks you through setting up monitoring for Kong Gateway.<br />
-As of {{site.kic_product_name}} 2.0, there are additional performance metrics associated with the configuration process (as opposed to the runtime performance of the Gateway), described in detail in the [Prometheus metrics reference](/kubernetes-ingress-controller/{{page.kong_version}}/references/prometheus).
-</div>
+{:.important}
+> As of {{site.kic_product_name}} 2.0, there are additional
+> performance metrics associated with the configuration process
+> (as opposed to the runtime performance of the Gateway), described in detail
+> in the [Prometheus metrics reference](/kubernetes-ingress-controller/{{page.kong_version}}/references/prometheus).
 
-> Note: This guide was originally posted on Kong Inc's blog:
-[https://konghq.com/blog/observability-kubernetes-kong/](https://konghq.com/blog/observability-kubernetes-kong/)
+This guide was originally posted on [Kong Inc's blog](https://konghq.com/blog/observability-kubernetes-kong/).
 
 ## Prerequisites
 


### PR DESCRIPTION
### Review
@Bradamant3

### Summary
* Fixing link
* Changing note to full Markdown formatting
* Rephrasing intro for clarity and removing repetition

### Reason
Someone pointed out the broken link on Slack. See https://konghq.atlassian.net/browse/DOCU-1814.

### Testing
https://deploy-preview-3197--kongdocs.netlify.app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana/
