### PR TITLE
Update navigation to include Kong Academy link, remove outdated links

### DIFF
--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -85,10 +85,7 @@
           <a href="https://konghq.com/community/" class="navbar-item">Community</a>
         </li>
         <li role="menuitem" class="main-menu-item">
-          <a href="https://learn.konghq.com/account/login/" class="navbar-item">Kong U</a>
-        </li>
-        <li role="menuitem" class="main-menu-item">
-          <a href="https://portal.konglabs.io/workshops" class="navbar-item">Demos & Labs</a>
+          <a href="https://education.konghq.com/" class="navbar-item">Kong Academy</a>
         </li>
       </ul>
       <a href="https://konghq.com/get-started/?itm_source=website&amp;itm_medium=nav" class="navbar-button">


### PR DESCRIPTION
### Summary
Kong Academy now supplants both Kong U and the old workshops/labs environment.

### Reason
The Kong U and old Portal links are now outdated and should no longer be publicized.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

