### PR TITLE
 docs: cleaning up KIC 2.0 docs "CRD" guides

### DIFF
--- a/app/_data/docs_nav_kic_2.0.x.yml
+++ b/app/_data/docs_nav_kic_2.0.x.yml
@@ -69,6 +69,10 @@
           url: /guides/using-consumer-credential-resource
         - text: Using the KongClusterPlugin Resource
           url: /guides/using-kongclusterplugin-resource
+        - text: Using the TCPIngress Resource
+          url: /guides/using-tcpingress
+        - text: Using the UDPIngress Resource
+          url: /guides/using-udpingress
     - text: Using the ACL and JWT Plugins
       url: /guides/configure-acl-plugin
     - text: Using cert-manager with Kong

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-consumer-credential-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-consumer-credential-resource.md
@@ -24,7 +24,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -81,7 +80,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 0
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 19:25:32 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 2
@@ -140,7 +138,6 @@ now require a valid API key:
 ```bash
 $ curl -i $PROXY_IP/foo/status/200
 HTTP/1.1 401 Unauthorized
-Date: Wed, 17 Jul 2019 19:30:33 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 WWW-Authenticate: Key realm="kong"
@@ -216,7 +213,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 0
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 19:34:44 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 3

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-external-service.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-external-service.md
@@ -22,7 +22,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-ingress-with-grpc.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-ingress-with-grpc.md
@@ -27,7 +27,6 @@ If everything is set up correctly, Kong returns
 ```bash
 curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kong-with-knative.md
@@ -100,7 +100,6 @@ Send a request to the above domain that we have configured:
 ```bash
 curl -i http://35.247.39.83.xip.io/
 HTTP/1.1 404 Not Found
-Date: Wed, 11 Mar 2020 00:18:49 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -145,7 +144,6 @@ HTTP/1.1 200 OK
 Content-Type: text/plain; charset=utf-8
 Content-Length: 20
 Connection: keep-alive
-Date: Tue, 10 Mar 2020 23:45:14 GMT
 X-Kong-Upstream-Latency: 2723
 X-Kong-Proxy-Latency: 0
 Via: kong/1.4.3
@@ -221,7 +219,6 @@ HTTP/1.1 200 OK
 Content-Type: text/plain; charset=utf-8
 Content-Length: 20
 Connection: keep-alive
-Date: Wed, 11 Mar 2020 00:35:07 GMT
 demo:  injected-by-kong
 X-Kong-Upstream-Latency: 2455
 X-Kong-Proxy-Latency: 1

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
@@ -25,7 +25,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -118,7 +117,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 0
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 21:38:00 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 2
@@ -131,7 +129,6 @@ HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 21:38:17 GMT
 Server: echoserver
 X-Kong-Upstream-Latency: 2
 X-Kong-Proxy-Latency: 1
@@ -205,7 +202,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 21:54:31 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 demo:  injected-by-kong
@@ -217,7 +213,6 @@ $ curl -I $PROXY_IP/bar
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 21:54:39 GMT
 Server: echoserver
 demo:  injected-by-kong
 X-Kong-Upstream-Latency: 2

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongclusterplugin-resource.md
@@ -2,7 +2,7 @@
 title: Using KongClusterPlugin resource
 ---
 
-In this guide, we will learn how to use KongClusterPlugin resource to configure
+In this guide we will learn how to use KongClusterPlugin resource to configure
 plugins in Kong.
 The guide will cover configuring a plugin for services across different
 namespaces.
@@ -69,7 +69,7 @@ metadata:
   name: httpbin-app
   namespace: httpbin
   annotations:
-    konghq.com/strip-path: "true"
+    konghq.com/strip-path: 'true'
 spec:
   ingressClassName: kong
   rules:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
@@ -247,5 +247,5 @@ $ curl -s $PROXY_IP/foo | grep "pod IP"
 ```
 
 
-You can experiement with various load balancing and healthchecking settings
+You can experiment with various load balancing and health-checking settings
 that KongIngress resource exposes to suit your specific use case.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongingress-resource.md
@@ -23,7 +23,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -79,7 +78,6 @@ HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 21:38:17 GMT
 Server: echoserver
 X-Kong-Upstream-Latency: 2
 X-Kong-Proxy-Latency: 1

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
@@ -284,8 +284,8 @@ Server: kong/1.2.1
 ```
 
 You can also see how the `demo` header was injected only for `/foo`,
-as the request also matched one of the rules defined in the `demo` `Ingress`
-resource but `/baz` does not match.
+as the request matched one of the rules defined in the `Ingress`
+resource, but not for `/baz` because that request does not match.
 
 ## Configure consumer and credential
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kongplugin-resource.md
@@ -25,7 +25,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -98,7 +97,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 0
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 21:38:00 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 2
@@ -110,7 +108,6 @@ HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 21:38:17 GMT
 Server: echoserver
 X-Kong-Upstream-Latency: 2
 X-Kong-Proxy-Latency: 1
@@ -197,7 +194,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 21:54:31 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 demo:  injected-by-kong
@@ -209,7 +205,6 @@ $ curl -I $PROXY_IP/bar
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 21:54:39 GMT
 Server: echoserver
 demo:  injected-by-kong
 X-Kong-Upstream-Latency: 2
@@ -230,7 +225,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 21:56:20 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 3
@@ -273,7 +267,6 @@ no matter which `Ingress` rule it matched:
 ```bash
 $ curl -I $PROXY_IP/baz
 HTTP/1.1 401 Unauthorized
-Date: Wed, 17 Jul 2019 22:09:04 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 WWW-Authenticate: Key realm="kong"
@@ -282,7 +275,6 @@ Server: kong/1.2.1
 
 $ curl -I $PROXY_IP/foo
 HTTP/1.1 401 Unauthorized
-Date: Wed, 17 Jul 2019 22:12:13 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 WWW-Authenticate: Key realm="kong"
@@ -291,14 +283,14 @@ demo:  injected-by-kong
 Server: kong/1.2.1
 ```
 
-You can also see how the `demo` header was injected as the request also
-matched one of the rules defined in the `demo` `Ingress` resource.
+You can also see how the `demo` header was injected only for `/foo`,
+as the request also matched one of the rules defined in the `demo` `Ingress`
+resource but `/baz` does not match.
 
 ## Configure consumer and credential
 
 Follow the [Using Consumers and Credentials](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-consumer-credential-resource)
-guide to provision a user and an apikey.
-Once you have it, please continue:
+guide to provision a user and an `apikey`.
 
 Use the API key to pass authentication:
 
@@ -309,7 +301,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 22:16:35 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 2
@@ -322,7 +313,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 22:15:34 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 demo:  injected-by-kong
@@ -372,7 +362,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 22:34:10 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-RateLimit-Limit-minute: 5
@@ -386,7 +375,6 @@ $ curl -I $PROXY_IP/bar
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 22:34:14 GMT
 Server: echoserver
 X-RateLimit-Limit-minute: 5
 X-RateLimit-Remaining-minute: 4
@@ -448,7 +436,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 9593
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 22:34:10 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-RateLimit-Limit-minute: 10
@@ -463,7 +450,6 @@ $ curl -I $PROXY_IP/bar
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Connection: keep-alive
-Date: Wed, 17 Jul 2019 22:34:14 GMT
 Server: echoserver
 X-RateLimit-Limit-minute: 5
 X-RateLimit-Remaining-minute: 4

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-mtls-auth-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-mtls-auth-plugin.md
@@ -28,7 +28,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -178,7 +177,6 @@ or not when we make the request:
 ```
 $ curl -k https://$PROXY_IP
 HTTP/2 401
-date: Mon, 11 May 2020 18:15:05 GMT
 content-type: application/json; charset=utf-8
 content-length: 50
 x-kong-response-latency: 0
@@ -296,7 +294,6 @@ service:
 $ curl --key client.key --cert client.crt  https://$PROXY_IP/foo -k -I
 HTTP/2 200
 content-type: text/plain; charset=UTF-8
-date: Mon, 11 May 2020 18:27:22 GMT
 server: echoserver
 x-kong-upstream-latency: 1
 x-kong-proxy-latency: 1

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-oidc-plugin.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-oidc-plugin.md
@@ -26,7 +26,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
@@ -87,7 +86,6 @@ Content-Type: text/html; charset=utf-8
 Content-Length: 0
 Connection: keep-alive
 Server: gunicorn/19.9.0
-Date: Wed, 17 Jul 2019 19:25:32 GMT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: true
 X-Kong-Upstream-Latency: 2

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-rewrites.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-rewrites.md
@@ -21,7 +21,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
@@ -42,7 +42,6 @@ HTTP 404 Not Found.
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found
-Date: Fri, 21 Jun 2019 17:01:07 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
@@ -2,9 +2,8 @@
 title: TCPIngress with Kong
 ---
 
-This guide walks through using TCPIngress Custom Resource
-resource to expose TCP-based services running in Kubernetes to the out
-side world.
+This guide walks through using TCPIngress Custom Resource to expose TCP-based
+services running in Kubernetes to the outside world.
 
 ## Overview
 
@@ -12,7 +11,7 @@ TCP-based Ingress means that Kong simply forwards the TCP stream to a Pod
 of a Service that's running inside Kubernetes. Kong will not perform any
 sort of transformations.
 
-There are two modes avaialble:
+There are two modes available:
 - **Port based routing**: In this mode, Kong simply proxies all traffic it
   receives on a specific port to the Kubernetes Service. TCP connections are
   load balanced across all the available pods of the Service.
@@ -116,13 +115,9 @@ $ kubectl patch service -n kong kong-proxy --patch '{
 service/kong-proxy patched
 ```
 
-You are free to choose other ports as well.
-
 ## Install TCP echo service
 
-Next, we will install a dummy TCP service.
-If you already have a TCP-based service running in your cluster,
-you can use that as well.
+Next, we will install an example TCP service.
 
 ```shell
 $ kubectl apply -f https://bit.ly/tcp-echo

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
@@ -2,7 +2,7 @@
 title: TCPIngress with Kong
 ---
 
-This guide walks through using TCPIngress Custom Resource to expose TCP-based
+This guide walks through using the TCPIngress Custom Resource to expose TCP-based
 services running in Kubernetes to the outside world.
 
 ## Overview


### PR DESCRIPTION
### Review
@lena-larionova 

### Summary
Some minor cleanup of our CRD related guides.

### Reason
Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1792

### Testing
I created a cluster and walked through all the example code, which was functional except for one YAML configuration which I fixed as a part of this PR.