### PR TITLE
Introduce a "no-icon" option for admonitions and remove "tip"

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1276,7 +1276,7 @@ Generic Styling for Desktop
       display: inline;
     }
 
-    &::before {
+    &:not(.no-icon)::before {
       content: "\f05a";
       font-family: "Font Awesome", FontAwesome;
       color: @blue-400;
@@ -1285,11 +1285,12 @@ Generic Styling for Desktop
       font-size: 17px;
       padding: 0 5px ;
     }
+
     &.warning {
       background-color: @red-100;
       border-left: solid 3px @red-500;
 
-      &::before {
+      &:not(.no-icon)::before {
         content: "\f057";
         font-family: "Font Awesome", FontAwesome;
         color: @red-500;
@@ -1304,7 +1305,7 @@ Generic Styling for Desktop
       background-color: @yellow-100;
       border-left: solid 3px @yellow-400;
 
-      &::before {
+      &:not(.no-icon)::before {
         content: "\f071";
         font-family: "Font Awesome", FontAwesome;
         color: @yellow-400;
@@ -1315,32 +1316,17 @@ Generic Styling for Desktop
       }
     }
 
-    &.info {
+    &.note {
       background-color: @blue-100;
       border: none;
       border-left: solid 3px @blue-400;
 
-      &::before {
+      &:not(.no-icon)::before {
         content: "\f05a";
         font-family: "Font Awesome", FontAwesome;
         color: @blue-400;
         display: inline-block;
         font-weight: bold;
-        font-size: 17px;
-        padding: 0 5px 0 0;
-      }
-    }
-
-    &.tip {
-      border-left: 3px solid @green-400;
-      background-color: @green-100;
-
-      &::before {
-        content: "\f058";
-        font-family: "Font Awesome", FontAwesome;
-        color: @green-400;
-        display: inline-block;
-        font-weight: 600;
         font-size: 17px;
         padding: 0 5px 0 0;
       }

--- a/app/_hub/kong-inc/ldap-auth-advanced/index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/index.md
@@ -11,9 +11,8 @@ description: |
   checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
-  {:.tip}
-  > **Tip:** The LDAP Authentication Advanced plugin
-  provides additional features not available in the open source [LDAP Authentication plugin](/hub/kong-inc/ldap-auth/),
+  The LDAP Authentication Advanced plugin
+  provides features not available in the open-source [LDAP Authentication plugin](/hub/kong-inc/ldap-auth/),
   such as LDAP searches for group and consumer mapping:
   * Ability to authenticate based on username or custom ID.
   * The ability to bind to an enterprise LDAP directory with a password.

--- a/app/_hub/kong-inc/ldap-auth/index.md
+++ b/app/_hub/kong-inc/ldap-auth/index.md
@@ -10,11 +10,8 @@ description: |
   checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers
   (in that order).
 
-  {:.tip}
-  > **Tip:** The
-  [LDAP Authentication Advanced plugin](/hub/kong-inc/ldap-auth-advanced/) provides
-  additional features not available in this open source LDAP plugin, such as LDAP searches
-  for group and consumer mapping:
+  This plugin is the open-source version of the [LDAP Authentication Advanced plugin](/hub/kong-inc/ldap-auth-advanced/), which provides
+  additional features such as LDAP searches for group and consumer mapping:
   * Ability to authenticate based on username or custom ID.
   * The ability to bind to an enterprise LDAP directory with a password.
   * The ability to authenticate/authorize using a group base DN and specific group member or group name attributes.

--- a/app/_hub/kong-inc/mocking/index.md
+++ b/app/_hub/kong-inc/mocking/index.md
@@ -172,8 +172,8 @@ curl -X POST http://<admin-hostname>:8001/plugins/ \
 This example tutorial steps you through testing a mock response for
 a stock quote service API.
 
-{:.tip}
-> **Tip:** Before following the steps in this
+{:.note}
+> **Note:** Before following the steps in this
 tutorial, you can view a video demonstration of the Mocking plugin
 used in conjunction with the Dev Portal. See the
 [Service Mocking video demo](https://www.youtube.com/watch?v=l8uKbgkK6_I)

--- a/app/_hub/kong-inc/statsd-advanced/index.md
+++ b/app/_hub/kong-inc/statsd-advanced/index.md
@@ -12,10 +12,8 @@ description: |
   daemon by enabling its
   [StatsD plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
 
-  {:.tip}
-  > **Tip:** The StatsD Advanced plugin provides
-  additional features not available in the open source [StatsD](/hub/kong-inc/statsd/) plugin,
-  such as:
+  The StatsD Advanced plugin provides
+  features not available in the open-source [StatsD](/hub/kong-inc/statsd/) plugin, such as:
   * Ability to choose status codes to log to metrics.
   * More granular status codes per workspace.
   * Ability to use TCP instead of UDP.

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -11,9 +11,7 @@ description: |
   daemon by enabling its [Statsd
   plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
 
-  {:.tip}
-  > **Tip:** The [StatsD Advanced plugin](/hub/kong-inc/statsd-advanced/) provides
-  additional features not available in this open source StatsD plugin, such as:
+  This plugin is the open-source version of the [StatsD Advanced plugin](/hub/kong-inc/statsd-advanced/), which provides additional features such as:
   * Ability to choose status codes to log to metrics.
   * More granular status codes per workspace.
   * Ability to use TCP instead of UDP.

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -423,6 +423,14 @@ Set a class on the admonition to display a specific style:
     {:.warning}
     > **Warning:** Everything will break forever if you do this.
 
+* **No icon:** {% raw %}`{:.no-icon}`{% endraw %}
+
+    If you have a situation where you need to use a specific admonition type but
+    the icon doesn't belong, you can hide the icon by setting `no-icon` along
+    with any other admonition class. For example, here's the result of using `{:.warning .no-icon}`:
+
+    {:.warning .no-icon}
+    > This is something that's vital in a special way and the icon doesn't apply.
 
 ## Page-level navigation
 


### PR DESCRIPTION
### Review
@Kong/team-docs 

### Summary
* Add a `no-icon` option for admonitions
* Removing the `tip` class, as we decided sometime back, as a team, to narrow down the options to only three
* Cleaning up any use of the `tip` style (there weren't many)
* Adding usage info to contributing guide

### Reason
Need an iconless option for some situations. For example, when labelling a product "beta" or "tech preview", we don't want the X icon around as it looks like the feature is broken (this just came up for Okta IdP docs). 

### Testing
https://deploy-preview-3216--kongdocs.netlify.app/contributing/markdown-rules/#admonitions