### PR TITLE
[DOCU-1665][DOCU-1842] deck CLI updates for 1.8

### DIFF
--- a/app/_data/docs_nav_deck_1.8.x.yml
+++ b/app/_data/docs_nav_deck_1.8.x.yml
@@ -43,6 +43,8 @@
   icon: /assets/images/icons/documentation/icn-references-color.svg
   url: /reference/deck
   items:
+    - text: deck completion
+      url: /reference/deck_completion
     - text: deck convert
       url: /reference/deck_convert
     - text: deck diff

--- a/app/deck/1.7.x/reference/deck.md
+++ b/app/deck/1.7.x/reference/deck.md
@@ -26,7 +26,6 @@ It can be used to export, import, or sync entities to Kong.
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_convert.md
+++ b/app/deck/1.7.x/reference/deck_convert.md
@@ -38,7 +38,6 @@ deck convert [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_diff.md
+++ b/app/deck/1.7.x/reference/deck_diff.md
@@ -24,7 +24,6 @@ deck diff [flags]
       --rbac-resources-only   sync only the RBAC resources (Kong Enterprise only).
       --select-tag strings    only entities matching tags specified via this flag are diffed.
                               When this setting has multiple tag values, entities must match each of them.
-      --silence-events        disable printing events to stdout
       --skip-consumers        do not diff consumers or any plugins associated with consumers
   -s, --state strings         file(s) containing Kong's configuration.
                               This flag can be specified multiple times for multiple files.
@@ -51,7 +50,6 @@ deck diff [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_dump.md
+++ b/app/deck/1.7.x/reference/deck_dump.md
@@ -46,7 +46,6 @@ deck dump [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_konnect.md
+++ b/app/deck/1.7.x/reference/deck_konnect.md
@@ -32,7 +32,6 @@ might have breaking changes in future releases.
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_konnect_diff.md
+++ b/app/deck/1.7.x/reference/deck_konnect_diff.md
@@ -24,7 +24,6 @@ deck konnect diff [flags]
                              exit code 0 if no diff is found,
                              and exit code 1 if an error occurs.
       --parallelism int      Maximum number of concurrent operations. (default 100)
-      --silence-events       disable printing events to stdout
   -s, --state strings        file(s) containing Konnect's configuration.
                              This flag can be specified multiple times for multiple files. (default [konnect.yaml])
 ```
@@ -47,7 +46,6 @@ deck konnect diff [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_konnect_dump.md
+++ b/app/deck/1.7.x/reference/deck_konnect_dump.md
@@ -44,7 +44,6 @@ deck konnect dump [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_konnect_ping.md
+++ b/app/deck/1.7.x/reference/deck_konnect_ping.md
@@ -37,7 +37,6 @@ deck konnect ping [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_konnect_sync.md
+++ b/app/deck/1.7.x/reference/deck_konnect_sync.md
@@ -18,7 +18,6 @@ deck konnect sync [flags]
   -h, --help                help for sync
       --include-consumers   export consumers, associated credentials and any plugins associated with consumers.
       --parallelism int     Maximum number of concurrent operations. (default 100)
-      --silence-events      disable printing events to stdout
   -s, --state strings       file(s) containing Konnect's configuration.
                             This flag can be specified multiple times for multiple files. (default [konnect.yaml])
 ```
@@ -41,7 +40,6 @@ deck konnect sync [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_ping.md
+++ b/app/deck/1.7.x/reference/deck_ping.md
@@ -35,7 +35,6 @@ deck ping [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_reset.md
+++ b/app/deck/1.7.x/reference/deck_reset.md
@@ -44,7 +44,6 @@ deck reset [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_sync.md
+++ b/app/deck/1.7.x/reference/deck_sync.md
@@ -12,7 +12,7 @@ deck sync [flags]
 ### Options
 
 ```
-      --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations 
+      --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations
                                           for related entities (usually for Cassandra deployments).
                                           See 'db_update_propagation' in kong.conf.
   -h, --help                              help for sync
@@ -20,7 +20,6 @@ deck sync [flags]
       --rbac-resources-only               diff only the RBAC resources (Kong Enterprise only).
       --select-tag strings                only entities matching tags specified via this flag are synced.
                                           When this setting has multiple tag values, entities must match every tag.
-      --silence-events                    disable printing events to stdout
       --skip-consumers                    do not diff consumers or any plugins associated with consumers.
   -s, --state strings                     file(s) containing Kong's configuration.
                                           This flag can be specified multiple times for multiple files.
@@ -47,7 +46,6 @@ deck sync [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_validate.md
+++ b/app/deck/1.7.x/reference/deck_validate.md
@@ -43,7 +43,6 @@ deck validate [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.7.x/reference/deck_version.md
+++ b/app/deck/1.7.x/reference/deck_version.md
@@ -33,7 +33,6 @@ deck version [flags]
       --konnect-password-file string   File containing the password to your Konnect account.
       --no-color                       Disable colorized output
       --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
       --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
                                        This value can also be set using DECK_TLS_SERVER_NAME environment variable.
       --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.

--- a/app/deck/1.8.x/reference/deck.md
+++ b/app/deck/1.8.x/reference/deck.md
@@ -7,7 +7,7 @@ configuration file.
 
 It can be used to export, import, or sync entities to Kong.
 
-### Options
+## Options
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -36,8 +36,8 @@ It can be used to export, import, or sync entities to Kong.
                                        between decK and Kong.
 ```
 
-### See also
-
+## See also
+* [deck completion](/deck/{{page.kong_version}}/reference/deck_completion)	 - Generate completion script
 * [deck convert](/deck/{{page.kong_version}}/reference/deck_convert)	 - Convert files from one format into another format
 * [deck diff](/deck/{{page.kong_version}}/reference/deck_diff)	 - Diff the current entities in Kong with the one on disks
 * [deck dump](/deck/{{page.kong_version}}/reference/deck_dump)	 - Export Kong configuration to a file

--- a/app/deck/1.8.x/reference/deck_completion.md
+++ b/app/deck/1.8.x/reference/deck_completion.md
@@ -1,23 +1,77 @@
 ---
-title: deck convert
+title: deck completion
 ---
 
-The convert command changes configuration files from one format
-into another compatible format. For example, a configuration for 'kong-gateway'
-can be converted into a 'konnect' configuration file.
+Generate completion script.
 
+```sh
+deck completion [bash|zsh|fish|powershell]
 ```
-deck convert [flags]
+
+## Usage
+To load completions, follow the instructions for your shell below.
+
+### Bash
+
+```sh
+source <(deck completion bash)
 ```
+
+To load completions for each session, execute once:
+
+**Linux:**
+```sh
+deck completion bash > /etc/bash_completion.d/deck
+```
+
+**macOS:**
+```sh
+deck completion bash > /usr/local/etc/bash_completion.d/deck
+```
+
+### Zsh
+
+If shell completion is not already enabled in your environment,
+you will need to enable it. You can execute the following once:
+```sh
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+
+To load completions for each session, execute once:
+```sh
+deck completion zsh > "${fpath[1]}/_yourprogram"
+```
+
+You will need to start a new shell for this setup to take effect.
+
+### fish
+
+```sh
+deck completion fish | source
+```
+
+To load completions for each session, execute once:
+```sh
+deck completion fish > ~/.config/fish/completions/deck.fish
+```
+
+### PowerShell
+
+```powershell
+PS> deck completion powershell | Out-String | Invoke-Expression
+```
+
+To load completions for every new session, run:
+```powershell
+PS> deck completion powershell > deck.ps1
+```
+
+Then source this file from your PowerShell profile.
 
 ## Options
 
 ```
-      --from string          format of the source file, allowed formats: [kong-gateway]
-  -h, --help                 help for convert
-      --input-file string    configuration file to be converted. Use '-' to read from stdin.
-      --output-file string   file to write configuration to after conversion. Use '-' to write to stdout.
-      --to string            desired format of the output, allowed formats: [konnect]
+  -h, --help   help for completion
 ```
 
 ## Options inherited from parent commands
@@ -50,4 +104,4 @@ deck convert [flags]
 
 ## See also
 
-* [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+* [deck](/deck/{{page.kong_version}}/reference/deck) - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_diff.md
+++ b/app/deck/1.8.x/reference/deck_diff.md
@@ -13,7 +13,7 @@ that will be created, updated, or deleted.
 deck diff [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help                  help for diff
@@ -33,7 +33,7 @@ deck diff [flags]
                               This takes precedence over _workspace fields in state files.
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -61,6 +61,6 @@ deck diff [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_dump.md
+++ b/app/deck/1.8.x/reference/deck_dump.md
@@ -12,7 +12,7 @@ configure Kong.
 deck dump [flags]
 ```
 
-### Options
+## Options
 
 ```
       --all-workspaces        dump configuration of all Workspaces (Kong Enterprise only).
@@ -28,7 +28,7 @@ deck dump [flags]
       --yes                   assume 'yes' to prompts and run non-interactively.
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -56,6 +56,6 @@ deck dump [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_konnect.md
+++ b/app/deck/1.8.x/reference/deck_konnect.md
@@ -8,13 +8,13 @@ configure Konnect.
 WARNING: This command is currently in alpha state. This command
 might have breaking changes in future releases.
 
-### Options
+## Options
 
 ```
   -h, --help   help for konnect
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -42,7 +42,7 @@ might have breaking changes in future releases.
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
 * [deck konnect diff](/deck/{{page.kong_version}}/reference/deck_konnect_diff)	 - Diff the current entities in Konnect with the one on disks (in alpha)

--- a/app/deck/1.8.x/reference/deck_konnect_diff.md
+++ b/app/deck/1.8.x/reference/deck_konnect_diff.md
@@ -15,7 +15,7 @@ might have breaking changes in future releases.
 deck konnect diff [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help                 help for diff
@@ -29,7 +29,7 @@ deck konnect diff [flags]
                              This flag can be specified multiple times for multiple files. (default [konnect.yaml])
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -57,6 +57,6 @@ deck konnect diff [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck konnect](/deck/{{page.kong_version}}/reference/deck_konnect)	 - Configuration tool for Konnect (in alpha)

--- a/app/deck/1.8.x/reference/deck_konnect_dump.md
+++ b/app/deck/1.8.x/reference/deck_konnect_dump.md
@@ -4,7 +4,7 @@ title: deck konnect dump
 
 The konnect dump command reads all entities present in Konnect
 	and writes them to a local file.
-	
+
 	The file can then be read using the 'deck konnect sync' command or 'deck konnect diff' command to
 	configure Konnect.
 
@@ -15,7 +15,7 @@ might have breaking changes in future releases.
 deck konnect dump [flags]
 ```
 
-### Options
+## Options
 
 ```
       --format string        output file format: json or yaml. (default "yaml")
@@ -26,7 +26,7 @@ deck konnect dump [flags]
       --yes                  Assume 'yes' to prompts and run non-interactively.
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -54,6 +54,6 @@ deck konnect dump [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck konnect](/deck/{{page.kong_version}}/reference/deck_konnect)	 - Configuration tool for Konnect (in alpha)

--- a/app/deck/1.8.x/reference/deck_konnect_ping.md
+++ b/app/deck/1.8.x/reference/deck_konnect_ping.md
@@ -13,13 +13,13 @@ might have breaking changes in future releases.
 deck konnect ping [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for ping
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -47,6 +47,6 @@ deck konnect ping [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck konnect](/deck/{{page.kong_version}}/reference/deck_konnect)	 - Configuration tool for Konnect (in alpha)

--- a/app/deck/1.8.x/reference/deck_konnect_sync.md
+++ b/app/deck/1.8.x/reference/deck_konnect_sync.md
@@ -12,7 +12,7 @@ might have breaking changes in future releases.
 deck konnect sync [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help                help for sync
@@ -23,7 +23,7 @@ deck konnect sync [flags]
                             This flag can be specified multiple times for multiple files. (default [konnect.yaml])
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -51,6 +51,6 @@ deck konnect sync [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck konnect](/deck/{{page.kong_version}}/reference/deck_konnect)	 - Configuration tool for Konnect (in alpha)

--- a/app/deck/1.8.x/reference/deck_ping.md
+++ b/app/deck/1.8.x/reference/deck_ping.md
@@ -9,7 +9,7 @@ can connect to Kong's Admin API.
 deck ping [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help               help for ping
@@ -17,7 +17,7 @@ deck ping [flags]
                            Useful when RBAC permissions are scoped to a Workspace.
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -45,6 +45,6 @@ deck ping [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_reset.md
+++ b/app/deck/1.8.x/reference/deck_reset.md
@@ -13,7 +13,7 @@ By default, this command will ask for confirmation.
 deck reset [flags]
 ```
 
-### Options
+## Options
 
 ```
       --all-workspaces        reset configuration of all workspaces (Kong Enterprise only).
@@ -26,7 +26,7 @@ deck reset [flags]
   -w, --workspace string      reset configuration of a specific workspace(Kong Enterprise only).
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -54,6 +54,6 @@ deck reset [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_sync.md
+++ b/app/deck/1.8.x/reference/deck_sync.md
@@ -9,10 +9,10 @@ to get Kong's state in sync with the input state.
 deck sync [flags]
 ```
 
-### Options
+## Options
 
 ```
-      --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations 
+      --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations
                                           for related entities (usually for Cassandra deployments).
                                           See 'db_update_propagation' in kong.conf.
   -h, --help                              help for sync
@@ -29,7 +29,7 @@ deck sync [flags]
                                           This takes precedence over _workspace fields in state files.
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -57,6 +57,6 @@ deck sync [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_validate.md
+++ b/app/deck/1.8.x/reference/deck_validate.md
@@ -15,7 +15,7 @@ this command.
 deck validate [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help                  help for validate
@@ -25,7 +25,7 @@ deck validate [flags]
                               Use '-' to read from stdin. (default [kong.yaml])
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -53,6 +53,6 @@ deck validate [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively

--- a/app/deck/1.8.x/reference/deck_version.md
+++ b/app/deck/1.8.x/reference/deck_version.md
@@ -9,13 +9,13 @@ commit hash of the source tree.
 deck version [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for version
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --analytics                      Share anonymized data to help improve decK. (default true)
@@ -43,6 +43,6 @@ deck version [flags]
                                        between decK and Kong.
 ```
 
-### See also
+## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively


### PR DESCRIPTION
### Review
@hbagdi , @Kong/team-docs 
### Summary
* Generate new CLI doc for deck 1.8
* Set up formatting for `deck completion`; did not do anything with grammar, as we will need to clean up the text on the deck repo side to generate cleaner instructions
* Remove `--timeout` and `--silence-event` flags from 1.7. Since the doc was generated halfway between releases, it accidentally picked up flags that are not available in 1.7.

### Reason
deck 1.8 release.

Flag removal from 1.7 is based on changelog entry: https://github.com/Kong/deck/blob/main/CHANGELOG.md#v180---20210913

### Testing
https://deploy-preview-3218--kongdocs.netlify.app/deck/
https://deploy-preview-3218--kongdocs.netlify.app/deck/1.8.x/reference/deck_completion/