### PR TITLE
GH template: Remove redundant reviewer section [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-### Review
-<!-- (Optional) Assign this PR, or add [wip] if not ready for review. -->
-@reviewer
-
 ### Summary
 <!-- Description of PR, with any special instructions for your reviewers. -->
 


### PR DESCRIPTION
### Summary
Removing "Review" section from the github template.

### Reason
The reviewer section is redundant with the "Reviewers" section of the PR.

### Testing
N/A
