### PR TITLE
docs: major updates of istio guide

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -656,9 +656,9 @@ Now you've got an Istio mesh enable service with Kong features available to it!
 For more examples of features you can take advantage of with Kong see our
 [available guides][kic-guides] and experiment further with this environment.
 
-[kongplugin]:/guides/using-kongplugin-resource/
+[kongplugin]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kongplugin-resource/
 [anns]:https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-[kic-guides]:/guides/overview/
+[kic-guides]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/overview/
 
 ### Mesh Network Observability with Kiali
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -199,8 +199,8 @@ application with which to utilize the stack.
 
 In order to utilize Istio's mesh functionality for any given Kubernetes
 [Pod][k8s-pods] a [namespace][k8s-namespaces] must be [labeled][k8s-labels]
-with the `istio-injection=enabled` label to instruct [IstioD][istiod] to manage
-them and add them to the mesh network.
+with the `istio-injection=enabled` label to instruct [IstioD][istiod] (the main
+control program for Istio) to manage them and add them to the mesh network.
 
 For this guide we'll create a distinct Istio-enabled namespace for our Kong
 pods so that they will automatically be joined to the mesh network:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -800,7 +800,7 @@ deployed at the edge of our cluster down to the backend `BookInfo` application
 and with this you should have a sense of some of the fundamental capabilities
 of Istio. The Kiali console for Istio provides a wide range of features. To
 explore beyond this guide and learn Kiali further, see the
-[Kiali Documentation][kialidocs].
+[Kiali Documentation][kiali-docs].
 
 If after this you're interested in exploring Istio further in terms of more
 general features and operations (e.g. no just Kiali) check out the [Istio Task
@@ -814,6 +814,6 @@ of other Istio features.
 [kiali-features]:https://kiali.io/documentation/latest/features/
 [prometheus]:https://prometheus.io
 [graphana]:https://grafana.com/
-[kiali-docs]:https://kiali.io/documentation/latest/
 [k8s-port-forwarding]:https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/
+[kiali-docs]:https://kiali.io/documentation/latest/
 [istio-tasks]:https://istio.io/latest/docs/tasks/

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -784,12 +784,10 @@ http://localhost:20001/kiali
 This command should have automatically opened the http://localhost:20001/kiali
 link in your web browser, but if not then navigate to that page manually.
 
-Now we've got some requests processed for our `BookInfo` app and we're ready
-to use our Kiali console to observe. Perform the following tasks to access
-and familiarize yourself with Kiali and graphically view the topology for your
-`BookInfo` application's web requests:
+You're not connected to Kiali and have a window into the traffic moving across
+your mesh network. Familiarize yourself with Kiali and graphically view the
+topology for your `BookInfo` application's web requests:
 
-- Navigate your web browser to `http://localhost:20001/`.
 - Choose _Workloads_ from the menu on the left.
 - Select `bookinfo` in the _Namespace_ drop-down menu.
 - Click the _productpage-v1_ service name.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -16,7 +16,7 @@ features for [Kubernetes][k8s] clusters.
 
 When using Kong as the gateway for Istio it's possible to leverage both the
 mesh features of Istio intra-cluster while enabling Kong's rich featureset
-for ingress traffic.
+for ingress traffic coming in from outside the cluster.
 
 In this guide, you will:
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -145,11 +145,13 @@ $ istioctl x precheck
 
 Now you're ready to move on to Istio deployment.
 
-> **NOTE** If you're interested in other installation methods see the [Istio
-FAQ][install-method-faq] for more details on the differences between methods.
+> **NOTE** If you're interested in other installation methods see the
+  [Istio FAQ][install-method-faq] for more details on the differences
+  between methods.
+
 > **NOTE** If you use one of the other installation mechanisms note that the
-examples in this guide may not work without experiementation and manual
-intervention.
+  examples in this guide may not work without experiementation and manual
+  intervention.
 
 [istio-install]:https://istio.io/latest/docs/setup/install/
 [istio-quickstart]:https://istio.io/latest/docs/setup/getting-started/

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -749,13 +749,20 @@ deployment.apps/kiali created
 {% endnavtab %}
 {% endnavtabs %}
 
+With Kiali now running we'll need to generate some traffic for our `BookInfo`
+app to populate metrics:
+
+```console
+$ COUNT=25 ; until [ $COUNT -le 0 ]; do curl -s -o /dev/null http://$PROXY_IP ; ((COUNT--)); done
+```
+
 Since this sample version of Kiali isn't tuned for security and is meant to be
 cluster internal only, we wont expose this via Kong but instead we'll use the
 [port-forwarding][k8s-port-forwarding] functionality available in `istioctl` to
 tunnel our connection to the Kiali service.
 
-Run the following command in a new terminal as it will run continually in the
-background:
+Run the following command in a new terminal which will run a `port-forward` to
+Kiali for you in the background and open it up in your web browser:
 
 {% navtabs %}
 {% navtab Command %}
@@ -774,13 +781,8 @@ http://localhost:20001/kiali
 {% endnavtab %}
 {% endnavtabs %}
 
-With that running in the background you can now access Kiala via your systems
-`localhost` network, but first you'll want to populate some sample traffic to
-the `BookInfo` app for metrics collection:
-
-```console
-$ COUNT=25 ; until [ $COUNT -le 0 ]; do curl -s -o /dev/null http://$PROXY_IP ; ((COUNT--)); done
-```
+This command should have automatically opened the http://localhost:20001/kiali
+link in your web browser, but if not then navigate to that page manually.
 
 Now we've got some requests processed for our `BookInfo` app and we're ready
 to use our Kiali console to observe. Perform the following tasks to access

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -38,7 +38,7 @@ In this guide, you will:
 * A Kubernetes `v1.19` (or newer) cluster
 * [kubectl][kubectl] `v1.19` (or newer)
 * [Helm][helm] `v3.5` (or newer)
-* [CURL][curl] `v7` (or newer)
+* [cURL][curl] `v7` (or newer)
 
 You can use a managed cluster from a cloud provider such as [AWS (EKS)][eks],
 [Google Cloud (GKE)][gke] or [Azure (AKS)][aks], or you can work locally with 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -11,8 +11,8 @@ functionality simoltaneously.
 ## Overview
 
 [Istio][istio] is a popular [service mesh][mesh] which enables [Traffic
-Management][mgmt], [Security][sec] and [Observability][obs] features for
-for [Kubernetes][k8s] clusters.
+Management][traffic-management], [Security][security] and [Observability][obs]
+features for [Kubernetes][k8s] clusters.
 
 When using Kong as the gateway for Istio it's possible to leverage both the
 mesh features of Istio intra-cluster while enabling Kong's rich featureset
@@ -28,6 +28,8 @@ In this guide, you will:
 
 [istio]:https://istio.io
 [mesh]:https://istio.io/latest/docs/concepts/
+[traffic-management]:https://istio.io/latest/docs/concepts/traffic-management/
+[security]:https://istio.io/latest/docs/concepts/security/
 [obs]:https://istio.io/latest/docs/concepts/observability/
 [k8s]:https://kubernetes.io
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -670,7 +670,7 @@ some of the [observability][obs] features of Istio inside the mesh network.
 For observability Istio includes a web console called [Kiali][kiali] which is
 capable of providing [topology][kiali-topology], [health][kiali-health] and a
 [wide variety of other features][kiali-features] which give you deep insights
-into your Istio mesh network.
+into your application traffic.
 
 To support several metrics related features of Kiali we'll need to deploy
 Istio's [Prometheus][prometheus] metrics server:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -2,147 +2,456 @@
 title: Running the Kubernetes Ingress Controller with Istio
 ---
 
+This guide walks you through deploying Kong as the Gateway for [Istio][istio] to
+utilize the features of both Kong for ingress traffic and Istio's mesh
+functionality simoltaneously.
+
+[istio]:https://istio.io
+
+## Overview
+
+[Istio][istio] is a popular [service mesh][mesh] which enables [Traffic
+Management][mgmt], [Security][sec] and [Observability][obs] features for
+for [Kubernetes][k8s] clusters.
+
+When using Kong as the gateway for Istio it's possible to leverage both the
+mesh features of Istio intra-cluster while enabling Kong's rich featureset
+for ingress traffic.
+
 In this guide, you will:
-* Install Istio v1.6.7 and Kong in your cluster.
-* Deploy an example Istio-enabled application (_bookinfo_).
-* Deploy an `Ingress` customized with a `KongPlugin` for the example application.
-* Make several requests to the sample application via Kong and Istio.
-* See the performance metrics of the sample application, provided by Istio.
+
+* Install Istio `v1.11` and Kong in your cluster
+* Deploy an example Istio-enabled application
+* Deploy an `Ingress` customized with a `KongPlugin` for the example application
+* Make several requests to the sample application via Kong and Istio
+* Use some of the observability features of Istio to visualize cluster traffic
+
+[istio]:https://istio.io
+[mesh]:https://istio.io/latest/docs/concepts/
+[obs]:https://istio.io/latest/docs/concepts/observability/
+[k8s]:https://kubernetes.io
 
 ### Prerequisites
+
 For this guide, you will need:
 
-* A Kubernetes v1.15 (or newer) cluster which can pull container images from public registries. For example, you can use:
-    * A managed Kubernetes cluster (AWS EKS, Google Cloud GKE, Azure AKS).
-    * Minikube.
-    * `microk8s` with the `dns` addon enabled.
-* `kubectl` with admin access to the cluster.
+* A Kubernetes `v1.19` (or newer) cluster
+* [kubectl][kubectl] `v1.19` (or newer)
+* [Helm][helm] `v3.5` (or newer)
+* [CURL][curl] `v7` (or newer)
 
-### Download Istio
+You can use a managed cluster from a cloud provider such as [AWS (EKS)][eks],
+[Google Cloud (GKE)][gke] or [Azure (AKS)][aks], or you can use a local cluster
+provide such as [Minikube][minikube] or [Microk8s][microk8s].
 
-Download the Istio bundle at version 1.6.7:
+> **NOTE** Your Kubernetes cluster needs to be capable of provisioning
+  `LoadBalancer` type [Services][svc] (if you're not certain what this means,
+  see the [relevant documentation][svc-lb]). Cloud providers will generally
+  automate `LoadBalancer` type `Service` provisioning with their default
+  settings, but for other cluster types you may need to check your Kubernetes
+  distribution's documentation for options to enable this.
+
+> **NOTE** Several examples using `kubectl` in this guide assume that the test
+  cluster you want to use is the current default cluster context. If you're
+  uncertain what this means or you need to reconfigure `kubectl` to accommodate
+  for this then make sure to review the
+  [configuring access to multiple clusters][contexts] documentation and make
+  any changes needed before continuing.
+
+[kubectl]:https://kubernetes.io/docs/tasks/tools/#kubectl
+[helm]:https://helm.sh/
+[curl]:https://github.com/curl/curl
+[eks]:https://aws.amazon.com/eks/
+[gke]:https://cloud.google.com/kubernetes-engine/
+[aks]:https://azure.microsoft.com/services/kubernetes-service/
+[minikube]:https://github.com/kubernetes/minikube
+[microk8s]:https://microk8s.io/
+[svc]:https://kubernetes.io/docs/concepts/services-networking/service/
+[svc-lb]:https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#external-load-balancer-providers
+[contexts]:https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+
+### Downloading & Verifying Istio
+
+If you review the [Istio Installation Guides][istio-install] you may note that
+there are currently several alternative deployment mechanisms available. For the
+purposes of this example the [istioctl installation method][istioctl] will be
+used as it is the community recommended method.
+
+Download the `istioctl` command-line utility for your platform:
+
+{% navtabs %}
+{% navtab Command %}
 
 ```console
-$ curl -L https://istio.io/downloadIstio | env ISTIO_VERSION=1.6.7 sh -
-...
-...
-Istio 1.6.7 Download Complete!                                                                                                 
-
-Istio has been successfully downloaded into the istio-1.6.7 folder on your system.                                                                                                                                                                            
-...
-...
+$ curl -s -L https://istio.io/downloadIstio | ISTIO_VERSION=1.11.2 sh -
 ```
 
-### Install Istio Operator
-
-Invoke `istioctl` to deploy the Istio Operator to the Kubernetes cluster:
+{% endnavtab %}
+{% navtab Response %}
 
 ```console
-$ ./istio-1.6.7/bin/istioctl operator init
-Using operator Deployment image: docker.io/istio/operator:1.6.7
-✔ Istio operator installed                                                                                                                                                                                                                                    
+Downloading istio-1.11.2 from https://github.com/istio/istio/releases/download/1.11.2/istio-1.11.2-linux-amd64.tar.gz ...
+
+Istio 1.11.2 Download Complete!
+
+Istio has been successfully downloaded into the istio-1.11.2 folder on your system.
+
+Next Steps:
+See https://istio.io/latest/docs/setup/install/ to add Istio to your Kubernetes cluster.
+
+To configure the istioctl client tool for your workstation,
+add the /home/kong/Downloads/istio/istio-1.11.2/bin directory to your environment path variable with:
+    export PATH="$PATH:/home/kong/Downloads/istio/istio-1.11.2/bin"
+
+Begin the Istio pre-installation check by running:
+    istioctl x precheck
+
+Need more information? Visit https://istio.io/latest/docs/setup/install/
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+In the above you'll notice that some instructions were provided for how to
+further set up the `istioctl` program locally and do pre-check validation of
+the Istio installation. Make sure to add `istioctl` to your shell's path:
+
+```console
+$ export PATH="$PATH:$PWD/istio-1.11.2/bin"
+```
+
+Verify that `istioctl` is working, and run some validation checks on your
+Kubernetes cluster to ensure Istio will deploy to it properly:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ istioctl x precheck
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+✔ No issues found when checking the cluster. Istio is safe to install or upgrade!
+  To get started, check out https://istio.io/latest/docs/setup/getting-started/
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Now you're ready to move on to Istio deployment.
+
+> **NOTE** If you're interested in other installation methods see the [Istio
+FAQ][install-method-faq] for more details on the differences between methods.
+> **NOTE** If you use one of the other installation mechanisms note that the
+examples in this guide may not work without experiementation and manual
+intervention.
+
+[istio-install]:https://istio.io/latest/docs/setup/install/
+[istio-quickstart]:https://istio.io/latest/docs/setup/getting-started/
+[istioctl]:https://istio.io/latest/docs/setup/install/istioctl/
+[install-method-faq]:https://istio.io/latest/about/faq/#install-method-selection
+
+### Deploying Istio
+
+The `istioctl` command-line program incorporates the concept of
+[profiles][istio-profiles] which provide high level customization of the Istio
+deployment for specialized purposes. For the purposes of this guide we'll use
+the `demo` profile which is meant for testing and evaluation.
+
+Deploy Istio with the `demo` profile:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ istioctl install --set profile=demo -y
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+✔ Istio core installed
+✔ Istiod installed
+✔ Egress gateways installed
+✔ Ingress gateways installed
 ✔ Installation complete
 ```
 
-### Deploy Istio using Operator
+{% endnavtab %}
+{% endnavtabs %}
 
-Deploy Istio using Istio Operator:
+The Istio components are now deployed to your cluster in the `istio-system`
+[namespace][k8s-namespaces] and you're ready to deploy Kong and a sample
+application with which to utilize the stack.
 
-```console
-$ kubectl create namespace istio-system
-namespace/istio-system created
-```
-```console
-$ kubectl apply -f - <<EOF
-  apiVersion: install.istio.io/v1alpha1
-  kind: IstioOperator
-  metadata:
-    namespace: istio-system
-    name: example-istiocontrolplane
-  spec:
-    profile: demo
-EOF
-istiooperator.install.istio.io/example-istiocontrolplane created
-```
-```console
-$ kubectl describe istiooperator -n istio-system
-...
-...
-Status:
-  Status:  RECONCILING
-...
-...
-```
+[istio-profiles]:https://istio.io/latest/docs/setup/additional-setup/config-profiles/
+[k8s-namespaces]:https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 
-Wait until the `kubectl describe istiooperator` command returns `Status: HEALTHY`.
+### Creating an Istio-enabled Namespace for {{site.kic_product_name}}
 
-### Deploy the {{site.kic_product_name}} in an Istio-enabled namespace {#deploy-kic-istio-namespace}
+In order to utilize Istio's mesh functionality for any given Kubernetes
+[Pod][k8s-pods] a [namespace][k8s-namespaces] must be [labeled][k8s-labels]
+with the `istio-injection=enabled` label to instruct [IstioD][istiod] to manage
+them and add them to the mesh network.
+
+For this guide we'll create a distinct Istio-enabled namespace for our Kong
+pods so that they will automatically be joined to the mesh network:
+
+{% navtabs %}
+{% navtab Command %}
 
 ```console
 $ kubectl create namespace kong-istio
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
 namespace/kong-istio created
 ```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+The `kong-istio` namespace must then be enabled for Istio mesh:
+
+{% navtabs %}
+{% navtab Command %}
+
 ```console
 $ kubectl label namespace kong-istio istio-injection=enabled
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
 namespace/kong-istio labeled
 ```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+The `kong-istio` namespace is now ready for us to deploy Kong and our sample
+applications.
+
+[k8s-pods]:https://kubernetes.io/docs/concepts/workloads/pods/
+[k8s-namespaces]:https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+[k8s-labels]:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[istiod]:https://istio.io/latest/docs/ops/deployment/architecture/#istiod
+
+### Deploy {{site.kic_product_name}}
+
+We'll use the [Kong Helm Chart][chart] to deploy the {{site.kic_product_name}}
+to our Istio-enabled `kong-istio` namespace so that we can start proxying
+traffic from outside the cluster into our mesh-enabled services.
+
+Ensure that you have the Kong Helm repository configured locally:
+
+{% navtabs %}
+{% navtab Command %}
+
 ```console
-$ helm install -n kong-istio example-kong kong/kong --set ingressController.installCRDs=false
-...
-NAME: example-kong
-LAST DEPLOYED: Mon Aug 10 15:14:44 2020
+$ helm repo add kong https://charts.konghq.com && helm repo update
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+"kong" has been added to your repositories
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "kong" chart repository
+Update Complete. ⎈Happy Helming!⎈
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Deploy the chart:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ helm install -n kong-istio kong-istio kong/kong
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+NAME: kong-istio
 NAMESPACE: kong-istio
 STATUS: deployed
-...
 ```
 
-_Optional:_ Run `kubectl describe pod -n kong-istio -l app.kubernetes.io/instance=example-kong` to see that the Istio sidecar (`istio-proxy`) is running alongside the {{site.kic_product_name}}.
+{% endnavtab %}
+{% endnavtabs %}
 
-### Deploy bookinfo in an Istio-enabled namespace
+You can verify that Kong deployed and the Istio sidecar container was injected
+properly into Kong by running `kubectl describe` to [review the
+events][k8s-describe-pod] for the `Pod`:
 
-Deploy the sample _bookinfo_ app from the Istio bundle:
-
-```console
-$ kubectl create namespace my-istio-app
-namespace/my-istio-app created
-```
-```console
-$ kubectl label namespace my-istio-app istio-injection=enabled
-namespace/my-istio-app labeled
-$ kubectl apply -n my-istio-app -f istio-1.6.7/samples/bookinfo/platform/kube/bookinfo.yaml
-```
-Wait until the application is up:
-```console
-$ kubectl wait --for=condition=Available deployment productpage -n my-istio-app --timeout=240s
-```
-### Deploy ingress
-
-Define a `KongPlugin` rate-limiting access to 100 requests per minute. Define an `Ingress` telling Kong to proxy traffic
-to a service belonging to the sample application:
+{% navtabs %}
+{% navtab Command %}
 
 ```console
-$ kubectl apply -f - <<EOF
-apiVersion: configuration.konghq.com/v1
-kind: KongPlugin
-metadata:
-  name: rate-limit
-  namespace: my-istio-app
-plugin: rate-limiting
-config:
-  minute: 30
-  policy: local
-EOF
+$ kubectl describe pod -n kong-istio -l app.kubernetes.io/instance=kong-istio
 ```
 
+{% endnavtab %}
+{% navtab Response %}
+
 ```console
-$ kubectl apply -f - <<EOF
+Events:
+  Type     Reason     From               Message
+  ----     ------     ----               -------
+  Normal   Scheduled  default-scheduler  Successfully assigned kong-istio/kong-istio-kong-8f875f9fd-qsv4p to gke-istio-testing-default-pool-403b2219-l5ns
+  Normal   Pulled     kubelet            Container image "docker.io/istio/proxyv2:1.11.2" already present on machine
+  Normal   Created    kubelet            Created container istio-init
+  Normal   Started    kubelet            Started container istio-init
+  Normal   Pulling    kubelet            Pulling image "kong/kubernetes-ingress-controller:1.3"
+  Normal   Pulled     kubelet            Successfully pulled image "kong/kubernetes-ingress-controller:1.3" in 2.645390171s
+  Normal   Created    kubelet            Created container ingress-controller
+  Normal   Started    kubelet            Started container ingress-controller
+  Normal   Pulling    kubelet            Pulling image "kong:2.5"
+  Normal   Pulled     kubelet            Successfully pulled image "kong:2.5" in 3.982679281s
+  Normal   Created    kubelet            Created container proxy
+  Normal   Started    kubelet            Started container proxy
+  Normal   Pulled     kubelet            Container image "docker.io/istio/proxyv2:1.11.2" already present on machine
+  Normal   Created    kubelet            Created container istio-proxy
+  Normal   Started    kubelet            Started container istio-proxy
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+[chart]:https://github.com/Kong/charts
+[k8s-describe-pod]:https://kubernetes.io/docs/tasks/debug-application-cluster/debug-application-introspection/#using-kubectl-describe-pod-to-fetch-details-about-pods
+
+### Deploy "BookInfo" Example Application
+
+For this step we'll deploy Istio's [BookInfo][bookinfo] application, which is
+a basic example application commonly used to exercise and evaluate Istio's
+mesh features.
+
+Similar to what we did in previous steps for the Kong pods we'll need to create
+and label a namespace where the `BookInfo` app will be deployed so that it will
+be automatically joined to the mesh network.
+
+Create the namespace:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl create namespace bookinfo
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+namespace/bookinfo created
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Label the namespace for Istio injection:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl label namespace bookinfo istio-injection=enabled
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+namespace/bookinfo labeled
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+
+Deploy the `BookInfo` app from the Istio bundle:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl -n bookinfo apply -f istio-1.11.2/samples/bookinfo/platform/kube/bookinfo.yaml
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+service/details created
+serviceaccount/bookinfo-details created
+deployment.apps/details-v1 created
+service/ratings created
+serviceaccount/bookinfo-ratings created
+deployment.apps/ratings-v1 created
+service/reviews created
+serviceaccount/bookinfo-reviews created
+deployment.apps/reviews-v1 created
+deployment.apps/reviews-v2 created
+deployment.apps/reviews-v3 created
+service/productpage created
+serviceaccount/bookinfo-productpage created
+deployment.apps/productpage-v1 created
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Wait until the application is up by waiting for the relevant deployment to be
+available before proceeding to the next steps:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl -n bookinfo wait --for=condition=Available deployment productpage-v1
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+deployment.apps/productpage-v1 condition met
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+[bookinfo]:https://istio.io/latest/docs/examples/bookinfo/
+
+### Access BookInfo Externally with Kong Gateway
+
+So far we've deployed our `BookInfo` application in an entirely internal way,
+but with everything up and running we're ready to expose the service for
+access from outside the cluster using [Ingress][ingress].
+
+Save the following file as `bookinfo-ingress.yaml`:
+
+```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: productpage
-  namespace: my-istio-app
-  annotations:
-    konghq.com/plugins: rate-limit
+  namespace: bookinfo
 spec:
   ingressClassName: kong
   rules:
@@ -155,68 +464,352 @@ spec:
             name: productpage
             port:
               number: 9080
-EOF
 ```
 
-### Make some requests to the sample application
+Apply the `bookinfo-ingress.yaml` manifests:
 
-Connect to the sample application served via Kong and Istio.
-
-Note that `8080:80` means that `kubectl` will open the `tcp/8080` port on the local system and forward all requests to
-Kong's port `80`.
+{% navtabs %}
+{% navtab Command %}
 
 ```console
-$ # Keep the command below running in the background
-$ kubectl port-forward service/example-kong-kong-proxy 8080:80 -n kong-istio
-Forwarding from 127.0.0.1:8080 -> 8000
-Forwarding from [::1]:8080 -> 8000
-...
+$ kubectl apply -f bookinfo-ingress.yaml
 ```
 
-Navigate your web browser to `http://localhost:8080/` You should be able to see a bookstore web application. Click
-through any available links several times. As you hit 30 requests per minute (for example, by holding down the "Refresh"
-key combination, e.g. `<Ctrl-R>` or `<Command-R>`), you should obtain a `Kong Error - API rate limit exceeded` response.
-
-### See the connection graph in Kiali
-
-Connect to Kiali (the Istio dashboard):
+{% endnavtab %}
+{% navtab Command %}
 
 ```console
-$ # Keep the command below running in the background
-$ kubectl port-forward service/kiali 20001:20001 -n istio-system
-Forwarding from 127.0.0.1:20001 -> 20001
-Forwarding from [::1]:20001 -> 20001
-...
+ingress.networking.k8s.io/productpage created
 ```
 
-* Navigate your web browser to `http://localhost:20001/`.
-* Log in using the default credentials (`admin`/`admin`).
-* Choose _Workloads_ from the menu on the left.
-* Select `my-istio-app` in the _Namespace_ drop-down menu.
-* Click the _productpage-v1_ service name.
-* Click the three dots button in the top-right corner of _Graph Overview_ and click _Show full graph_.
-* Select `kong-istio` alongside `my-istio-app` in the _Namespace_ diagram.
-* Observe a connection graph spanning from `example-kong-kong-proxy` through `productpage-v1` to the other sample
-application services such as `ratings-v1` and `details-v1`.
+{% endnavtab %}
+{% endnavtabs %}
 
-### See the metrics in Grafana
+We're ready to start making connections to the `BookInfo` product page, but
+we'll need to gather the `LoadBalancer` IP address of the Kong Gateway in
+order to make our HTTP requests.
 
-Connect to Grafana (a dashboard frontend for Prometheus which has been deployed with Istio):
+Gather the `LoadBalancer` address and store it in the local `PROXY_IP`
+environment variable:
 
 ```console
-$ # Keep the command below running in the background
-$ kubectl port-forward service/grafana 3000:3000 -n istio-system
-Forwarding from 127.0.0.1:3000 -> 3000
-Forwarding from [::1]:3000 -> 3000
-...
+$ export PROXY_IP=$(kubectl -n kong-istio get svc kong-istio-kong-proxy -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
 
-* Navigate your web browser to `http://localhost:3000/`.
-* Expand the dashboard selection drop-down menu from the top of the screen. Expand the `istio` directory and choose the
-_Istio Workload Dashboard_ from the list.
-* Choose _Namespace: my-istio-app_ and _Workload: productpage-v1_ from the drop-downs.
-* Choose a timespan in the top-right of the page to include the time when you made requests to the sample application (e.g. _Last 1 hour_).
-* Observe the incoming and outgoing request graphs reflecting actual requests from Kong to `productpage-v1`, and from `productpage-v1` to its backends.
+> **NOTE** for some cluster types (such as with AWS) the `.ip` in the above
+command wont work as the `LoadBalancer` provisioner does not provide an IP
+address but instead only provides a DNS name. For these situations either
+replace `.ip` with `.hostname` in the above command or instead you can just
+manually locate the external host yourself by finding it in the output of
+`kubectl get svc kong-istio-kong-proxy`. In any case make sure the contents
+of your local `PROXY_IP` environment variable end up as that value.
 
-Note that the requests from the web browser to Kong are not reflected in inbound stats of `example-kong-kong-proxy`
-because we've issued these requests by `kubectl port-forward`, thus bypassing the Istio proxy sidecar in Kong.
+Once you've checked the contents of `$PROXY_IP` you can make a connection to
+the `BookInfo` application via Kong:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ curl -s -v http://$PROXY_IP | head -4
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+$ curl -s -v http://$PROXY_IP | head -4
+*   Trying 127.0.0.1:80...
+* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1
+> User-Agent: curl/7.76.1
+> Accept: */*
+>
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 200 OK
+< content-type: text/html; charset=utf-8
+< content-length: 1683
+< server: istio-envoy
+< x-envoy-upstream-service-time: 6
+< x-kong-upstream-latency: 4
+< x-kong-proxy-latency: 1
+< via: kong/2.5.0
+< x-envoy-decorator-operation: kong-istio-kong-proxy.kong-istio.svc.cluster.local:80/*
+<
+{ [1079 bytes data]
+* Connection #0 to host 127.0.0.1 left intact
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Simple Bookstore App</title>
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Note the following in the above response:
+
+- `<title>Simple Bookstore App</title>` - this indicates that we're connected
+  properly to the `BookInfo` app as expected.
+- `server: istio-envoy` - shows that the Istio mesh network is in use for
+  the `BookInfo` product page.
+- `via: kong/2.5.0` - indicates that we've pass through the Kong Gateway to our
+  backend `BookInfo` service.
+
+[ingress]:https://kubernetes.io/docs/concepts/services-networking/ingress/
+
+### Configure Ratelimits with Kong
+
+The `BookInfo` app is now accessible outside of the cluster but we've yet to
+take advantage of Kong featuresets when accessing it. To demonstrate using Kong
+features for Istio enabled services we'll create a [KongPlugin][kongplugin]
+which will enforce Kong rate-limiting on ingress requests to the `BookInfo`
+service.
+
+Save the following `KongPlugin` as `bookinfo-ratelimiter.yaml`:
+
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: rate-limit
+  namespace: bookinfo
+plugin: rate-limiting
+config:
+  minute: 30
+  policy: local
+```
+
+This plugin will add rate limiting to the `BookInfo` application and limit
+outside access to `30` requests per minute.
+
+Apply the `bookinfo-ratelimiter.yaml` manifest:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl apply -f bookinfo-ratelimiter.yaml
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+kongplugin.configuration.konghq.com/rate-limit created
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Now let's [annotate][anns] our previously created `Ingress` resource for the
+`BookInfo` app to attach our ratelimiter to it:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl -n bookinfo patch ingress productpage -p '{"metadata":{"annotations":{"konghq.com/plugins":"rate-limit"}}}'
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+ingress.networking.k8s.io/productpage patched
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+After the above is complete we should see the ratelimiter reflected in the
+headers in responses from the product page:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ curl -s -v http://$PROXY_IP 2>&1 | grep ratelimit
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+< x-ratelimit-remaining-minute: 26
+< x-ratelimit-limit-minute: 30
+< ratelimit-remaining: 26
+< ratelimit-limit: 30
+< ratelimit-reset: 2
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Now you've got an Istio mesh enable service with Kong features available to it!
+
+For more examples of features you can take advantage of with Kong see our
+[available guides][kic-guides] and experiment further with this environment.
+
+[kongplugin]:/guides/using-kongplugin-resource/
+[anns]:https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+[kic-guides]:/guides/overview/
+
+### Mesh Network Observability with Kiali
+
+We now have an Istio enabled `BookInfo` app running now which we can access
+externally via Kong and we've seen the ingress features Kong can provide us at
+the edge of the mesh network. In the following example we'll focus on exploring
+some of the [observability][obs] features of Istio inside the mesh network.
+
+For observability Istio includes a web console called [Kiali][kiali] which is
+capable of providing [topology][kiali-topology], [health][kiali-health] and a
+[wide variety of other features][kiali-features] which give you deep insights
+into your Istio mesh network.
+
+To support several metrics related features of Kiali we'll need to deploy
+Istio's [Prometheus][prometheus] metrics server:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/addons/prometheus.yaml
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+serviceaccount/prometheus created
+configmap/prometheus created
+clusterrole.rbac.authorization.k8s.io/prometheus created
+clusterrolebinding.rbac.authorization.k8s.io/prometheus created
+service/prometheus created
+deployment.apps/prometheus created
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Additionally we'll install [Graphana][graphana] which includes visualization
+dashboards for Istio:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/addons/grafana.yaml
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+serviceaccount/grafana created
+configmap/grafana created
+service/grafana created
+deployment.apps/grafana created
+configmap/istio-grafana-dashboards created
+configmap/istio-services-grafana-dashboards created
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+With these components deployed we can now move on to deploying Kiali itself:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/addons/kiali.yaml
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+serviceaccount/kiali created
+configmap/kiali created
+clusterrole.rbac.authorization.k8s.io/kiali-viewer created
+clusterrole.rbac.authorization.k8s.io/kiali created
+clusterrolebinding.rbac.authorization.k8s.io/kiali created
+role.rbac.authorization.k8s.io/kiali-controlplane created
+rolebinding.rbac.authorization.k8s.io/kiali-controlplane created
+service/kiali created
+deployment.apps/kiali created
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Since this sample version of Kiali isn't tuned for security and is meant to be
+cluster internal only, we wont expose this via Kong but instead we'll use the
+[port-forwarding][k8s-port-forwarding] functionality available in `istioctl` to
+tunnel our connection to the Kiali service.
+
+Run the following command in a new terminal as it will run continually in the
+background:
+
+{% navtabs %}
+{% navtab Command %}
+
+```console
+$ istioctl dashboard kiali
+```
+
+{% endnavtab %}
+{% navtab Response %}
+
+```console
+http://localhost:20001/kiali
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+With that running in the background you can now access Kiala via your systems
+`localhost` network, but first you'll want to populate some sample traffic to
+the `BookInfo` app for metrics collection:
+
+```console
+$ COUNT=25 ; until [ $COUNT -le 0 ]; do curl -s -o /dev/null http://$PROXY_IP ; ((COUNT--)); done
+```
+
+Now we've got some requests processed for our `BookInfo` app and we're ready
+to use our Kiali console to observe. Perform the following tasks to access
+and familiarize yourself with Kiali and graphically view the topology for your
+`BookInfo` application's web requests:
+
+- Navigate your web browser to `http://localhost:20001/`.
+- Choose _Workloads_ from the menu on the left.
+- Select `bookinfo` in the _Namespace_ drop-down menu.
+- Click the _productpage-v1_ service name.
+- In the top-right corner change the `Last <time>` dropdown to `Last 1h`.
+- Click the three dots button in the top-right corner of _Graph Overview_ and click _Show full graph_.
+- Select `kong-istio` alongside `bookinfo` in the _Namespace_ diagram.
+
+What you're seeing now is a connection graph spanning from the Kong Gateway we
+deployed at the edge of our cluster down to the backend `BookInfo` application
+and with this you should have a sense of some of the fundamental capabilities
+of Istio. The Kiali console for Istio provides a wide range of features. To
+explore beyond this guide and learn Kiali further, see the
+[Kiali Documentation][kialidocs].
+
+If after this you're interested in exploring Istio further in terms of more
+general features and operations (e.g. no just Kiali) check out the [Istio Task
+Documentation][istio-tasks] which includes several walkthroughs for a variety
+of other Istio features.
+
+[obs]:https://istio.io/latest/docs/concepts/observability/
+[kiali]:https://kiali.io/
+[kiali-topology]:https://kiali.io/documentation/latest/features/topology/
+[kiali-health]:https://kiali.io/documentation/latest/features/health/
+[kiali-features]:https://kiali.io/documentation/latest/features/
+[prometheus]:https://prometheus.io
+[graphana]:https://grafana.com/
+[kiali-docs]:https://kiali.io/documentation/latest/
+[k8s-port-forwarding]:https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/
+[istio-tasks]:https://istio.io/latest/docs/tasks/

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -480,7 +480,7 @@ $ kubectl apply -f bookinfo-ingress.yaml
 ```
 
 {% endnavtab %}
-{% navtab Command %}
+{% navtab Response %}
 
 ```console
 ingress.networking.k8s.io/productpage created

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -20,7 +20,7 @@ for ingress traffic from outside the cluster.
 
 In this guide, you will:
 
-* Install Istio `v1.11` and Kong in your cluster.
+* Install Istio `v1.11` and Kong Gateway in your cluster.
 * Deploy an example Istio-enabled application.
 * Deploy an `Ingress` customized with a `KongPlugin` for the example application.
 * Make requests to the sample application via Kong and Istio.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -427,7 +427,7 @@ available before proceeding to the next steps:
 {% navtab Command %}
 
 ```console
-$ kubectl -n bookinfo wait --for=condition=Available deployment productpage-v1
+$ kubectl -n bookinfo wait --timeout 120s --for=condition=Available deployment productpage-v1
 ```
 
 {% endnavtab %}


### PR DESCRIPTION
### Summary

This PR updates the Istio guide for the Kong Kubernetes Ingress controller to a modern Istio version and fixes problems with the documentation.

This patch also expands beyond the original guide in the following ways:

- extended explanations about components designed to help improve understanding
- significantly more links, allowing readers to explore further outside of the guide's boundaries afterwards
- more concise command and output examples

### Reason

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1791

### Testing

I've tested these examples successfully against a `v1.19` Kubernetes cluster on GKE.