### PR TITLE
Added 2.5.x compatibility

### DIFF
--- a/app/_hub/kong-inc/route-by-header/index.md
+++ b/app/_hub/kong-inc/route-by-header/index.md
@@ -19,6 +19,7 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
+        - 2.5.x
         - 2.4.x
         - 2.3.x
         - 2.2.x


### PR DESCRIPTION
### Summary
Added 2.5.x compatibility in list.

### Reason
This plugin works correctly on 2.5.0 but is missing from the documentations as a supported version. I believe this is due to confusion earlier on deprecation of this plugin which was a decision that was later reversed as I understand it. Ref: https://konghq.atlassian.net/browse/FT-1695