### PR TITLE
Plugin page title adjustment

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -1,7 +1,7 @@
 {% unless include.name and include.path contains '_hub' %}
 {% capture page_title %}{{
 include.title | escape }}{% if include.kong_version and include.no_version != true %} - v{{ include.kong_version | escape }}{% endif %}{% if include.title %} | {% endif %}{{
-site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ include.name }}
+site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if page.path contains "/hub/" %}{{ include.title }}{% else %}{{ include.name }}{% endif %}
 {{ include.type }} | {{site.title}}{% endcapture %}
 {% endunless %}
 

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" itemscope itemtype="http://schema.org/Article">
 
-  {% include_cached head.html name=page.name title=page.title url=page.url kong_version=page.kong_version no_version=page.no_version type=page.type kong_latest=page.kong_latest %}
+  {% include_cached head.html path=page.path name=page.name title=page.title url=page.url kong_version=page.kong_version no_version=page.no_version type=page.type kong_latest=page.kong_latest %}
 
   <body
     id="{{ page.id }}"


### PR DESCRIPTION
### Summary
Adjusting the way a plugin page title displays in link previews, browser tab titles, and anywhere else that uses the metadata.

### Reason
No ticket; this is a fix for an issue accidentally introduced in https://github.com/Kong/docs.konghq.com/pull/3210.
Currently, plugin pages all display "Index" as the page title; for example, see https://docs.konghq.com/hub/kong-inc/basic-auth/ (look at the browser tab label).

### Testing
Compare browser tab label on https://deploy-preview-3234--kongdocs.netlify.app/hub/kong-inc/basic-auth/ with  https://docs.konghq.com/hub/kong-inc/basic-auth/. The Netlify preview version should have the plugin name. 
Tested locally.
