### PR TITLE
decK for DB-less mode in the getting-started-guide

### DIFF
--- a/app/getting-started-guide/2.5.x/expose-services.md
+++ b/app/getting-started-guide/2.5.x/expose-services.md
@@ -9,7 +9,8 @@ If you are following the Getting Started workflow, make sure you have completed
 before moving on.
 
 If you are not following the Getting Started workflow, make sure you have
-{{site.base_gateway}} installed and started.
+{{site.base_gateway}} installed and started. For [DB-less mode](https://docs.konghq.com/gateway-oss/2.5.x/db-less-and-declarative-config/),
+make sure you use [decK](https://docs.konghq.com/deck/) below.
 
 ## What are Services and Routes?
 


### PR DESCRIPTION
### Reason
When using DB-less mode, the admin API (and I'm assuming Kong Manager, but I don't know that to be true) doesn't support creating services to avoid config drift. This should clarify that for other folks going through the guide.

