### PR TITLE
Chore/KIC v2 beta metadata

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -77,16 +77,18 @@ page.kong_latest.release %}
           </div>
           {% endif %}
             {% if page.kong_version != page.kong_latest.release and page.no_version != true %}
+              {% unless page.url contains "/kubernetes-ingress-controller/" and page.kong_version == "1.3.x" %}
               <div class="alert alert-warning">
               You are browsing documentation for an outdated version. See the
               <a href="{% if latest_page_exists == 'true' %}{{latest_page_url}}{% elsif page.edition == 'gateway-oss'%}/gateway-oss/{% elsif page.edition == 'enterprise'%}/enterprise/{% elsif page.edition == 'mesh'%}/mesh/{% elsif page.edition == 'kubernetes-ingress-controller/'%}/kubernetes-ingress-controller/{% else %}/{% endif %}">
                 latest documentation here</a>.
-            </div>
+              </div>
+              {% endunless %}
             {% endif %}
             {% if page.edition == "kubernetes-ingress-controller" and page.kong_version == "2.0.x" %}
             <div class="alert alert-red no-icon">
-              This version is released as <span class="badge beta"></span> and should not be deployed in a production environment.
-              <br> For the latest stable version, see the documentation for <a href ="https://docs.konghq.com/kubernetes-ingress-controller/1.3.x">Kubernetes Ingress Controller v1.3.x</a>.
+              <p>Kong's Kubernetes Ingress Controller v2.0 is available in <b>beta</b> with limited support. It should not be deployed in a production environment.</p>
+              For the latest stable version, see the documentation for <a href ="https://docs.konghq.com/kubernetes-ingress-controller/1.3.x">Kubernetes Ingress Controller v1.3.x</a>.
             </div>
             {% endif %}
             {% if page.url contains "/kubernetes-ingress-controller/" %}

--- a/app/_redirects
+++ b/app/_redirects
@@ -21,8 +21,8 @@
 /enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes/  /enterprise/2.1.x/deployment/installation/kong-for-kubernetes/
 
 # kic beta
-/kubernetes-ingress-controller-beta/   https://kic-v2-beta--kongdocs.netlify.app/kubernetes-ingress-controller/
-/kubernetes-ingress-controller-beta/*  https://kic-v2-beta--kongdocs.netlify.app/kubernetes-ingress-controller/:splat
+/kubernetes-ingress-controller-beta/   /kubernetes-ingress-controller/
+/kubernetes-ingress-controller-beta/*  /kubernetes-ingress-controller/:splat
 
 # enterprise gateway
 /enterprise/latest/introduction       /enterprise/


### PR DESCRIPTION
### Summary
* Updating the redirect from `/kubernetes-ingress-controller-beta` to point to live site instead of netlify
* For 1.3, removing the banner that says "this is an older version" since it's KIC's latest stable version.
* For 2.0, adjusting the beta banner to replace "beta" badge with text (badge is not accessible; will redesign badges in the future to fix that) and adjust language to mention limited support

### Reason
Prep for publishing live docs.

### Testing
Tested locally.
Banners:
https://deploy-preview-3238--kongdocs.netlify.app/kubernetes-ingress-controller/
https://deploy-preview-3238--kongdocs.netlify.app/kubernetes-ingress-controller/1.3.x/

Redirect:
https://deploy-preview-3238--kongdocs.netlify.app/kubernetes-ingress-controller-beta - goes to 2.0
