### PR TITLE
Fixes header levels in OAuth2 doc

### DIFF
--- a/app/_hub/kong-inc/oauth2/0.1.x.md
+++ b/app/_hub/kong-inc/oauth2/0.1.x.md
@@ -238,7 +238,7 @@ You can use this information on your side to implement additional logic. You can
 
 ## OAuth 2.0 Flows
 
-## Client Credentials
+### Client Credentials
 
 The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow will work out of the box, without building any authorization page. The clients will need to use the `/oauth2/token` endpoint to request an access token.
 

--- a/app/_hub/kong-inc/oauth2/1.0.x.md
+++ b/app/_hub/kong-inc/oauth2/1.0.x.md
@@ -299,7 +299,7 @@ You can use this information on your side to implement additional logic. You can
 
 ## OAuth 2.0 Flows
 
-## Client Credentials
+### Client Credentials
 
 The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow will work out of the box, without building any authorization page. The clients will need to use the `/oauth2/token` endpoint to request an access token.
 

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -350,7 +350,7 @@ You can use this information on your side to implement additional logic. You can
 
 ## OAuth 2.0 Flows
 
-## Client Credentials
+### Client Credentials
 
 The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow will work out of the box, without building any authorization page. The clients will need to use the `/oauth2/token` endpoint to request an access token.
 


### PR DESCRIPTION
### Summary
Fixes heading levels for the OAuth2 Authentication section in https://docs.konghq.com/hub/kong-inc/oauth2/#oauth-20-flows

### Reason
Fix to the issue: https://github.com/Kong/docs.konghq.com/issues/3214

### Testing
Locally ran an instance of the docs platform and confirmed the heading levels are updated correctly

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
