### PR TITLE
404 page layout adjustments

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -7,6 +7,7 @@ toc: false
 feedback: false
 no_version: true
 no_search: true
+layout: default
 ---
 
 <div class="page-404">
@@ -22,7 +23,7 @@ no_search: true
             <li><i class="fas fa-arrow-right"></i>  Go back to our <a class="anchor-text" href="/">homepage</a> and try again</li> <br/>
             <li><i class="fas fa-arrow-right"></i>  Get started using our <a class="anchor-text" href="https://konghq.com/install/">installation instructions</a>.</li> <br/>
             <li><i class="fas fa-arrow-right"></i>  Check out our <a class="anchor-text" href="https://konghq.com/community/">community</a> page for support or to report an issue</li> <br/>
-              
+
         </div>
     </div>
 </div>

--- a/app/_assets/stylesheets/pages/404.less
+++ b/app/_assets/stylesheets/pages/404.less
@@ -33,7 +33,7 @@
     color: @blue-500;
     font-weight: 600;
 
-    &:hover {
+    &:hover, &:focus {
       text-decoration: underline;
       opacity: 0.7;
     }

--- a/app/_assets/stylesheets/pages/404.less
+++ b/app/_assets/stylesheets/pages/404.less
@@ -1,12 +1,14 @@
 .page-404 {
   * {
     box-sizing: border-box;
-    margin: 0;
     padding: 0;
   }
   .container {
+    margin-top: 100px;
+    margin-bottom: 10px;
     text-align: center;
     user-select: none;
+    width: 80%;
   }
   .container h1 {
     font-size: 10rem;
@@ -21,14 +23,20 @@
     margin-top: 20px;
     word-spacing: 5px;
   }
-  
+
   li{
     list-style-type: none;
-    font-weight: bold;
+    font-weight: normal;
   }
-  
+
   .anchor-text {
-    color: black;
+    color: @blue-500;
+    font-weight: 600;
+
+    &:hover {
+      text-decoration: underline;
+      opacity: 0.7;
+    }
   }
   /* animation */
 


### PR DESCRIPTION
### Summary
* Using `default` layout to prevent sidebar and extra content from showing up
* Adjusting the CSS to fit default layout (mainly margins) and bring in some branding colours

### Reason
Expanding on the work done in https://github.com/Kong/docs.konghq.com/pull/3248. 

### Testing
https://deploy-preview-3260--kongdocs.netlify.app/404