### PR TITLE
chore: deck 1.8.2 release

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -485,7 +485,7 @@
   edition: "deck"
 -
   release: "1.8.x"
-  version: "1.8.0"
+  version: "1.8.2"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Summary
Updating decK version.

### Reason
Merge when https://github.com/Kong/deck/pull/496 is merged.

### Testing
https://deploy-preview-3262--kongdocs.netlify.app/deck/1.8.x/installation/ - version used in installation codeblock
