### PR TITLE
[DOCU-1731]Docs/2.6 beta changelog ee

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -42,39 +42,41 @@ Additionally, the following changes were specifically included to improve perfor
   [#7818](https://github.com/Kong/kong/pull/7818)
 
 #### Configuration
-
 - Enable IPV6 on `dns_order` as unsupported experimental feature.
   [#7819](https://github.com/Kong/kong/pull/7819).
 - The template renderer can now use `os.getenv`.
   [#6872](https://github.com/Kong/kong/pull/6872).
 
 #### Hybrid Mode
-
 - Data plane is able to eliminate some unknown fields when Control Plane is using a more modern version.
   [#7827](https://github.com/Kong/kong/pull/7827).
 
 #### Admin API
-
 - Add support for HEAD requests.
   [#7796](https://github.com/Kong/kong/pull/7796)
 - Improve support for OPTIONS requests.
   [#7830](https://github.com/Kong/kong/pull/7830)
 
 #### Plugins
-
-- [jq](/hub/kong-inc/jq) (`jq`)
-  New jq plugin added. 
-- [Rate Limiting](/hub/kong-inc/rate-limiting) (`rate-limiting`)
-  - A new identifier type  was added: `path`, allowing rate limiting by matching request paths.
-  - Add a “local” strategy in the schema (it automatically sets `config.sync_rate` to -1).
+- **New plugin:** [jq](/hub/kong-inc/jq) (`jq`)
+  The jq plugin enables arbitrary jq transformations on JSON objects included in API requests or responses.
+- [Kafka Log](/hub/kong-inc/kafka-log) (`kafka-log`)
+  The Kafka Log plugin now supports TLS, mTLS, and SASL auth.
+- [Kafka Upstream](/hub/kong-inc/kafka-upstream) (`kafka-upstream`)
+  The Kafka Upstream plugin now supports TLS, mTLS, and SASL auth.
+- [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
+  - The Rate Limiting plugin now has a new identifier type: `path`, which allows rate limiting by matching request paths.
+  - The plugin now has a “local” strategy in the schema. The local strategy automatically sets `config.sync_rate` to -1.
 - [OPA](/hub/kong-inc/opa) (`opa`)
-  Add request path, allowing administrators to set policies on a path basis more easily. 
+  The OPA plugin now has a request path, which makes setting policies on a path easier for administrators.
+- [Canary](/hub/kong-inc/canary) (`canary`)
+  The Canary plugin now has the option to hash on the header (falls back on IP, and then random).
 - [AWS-Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) 
   The plugin will now try to detect the AWS region by using `AWS_REGION` and
   `AWS_DEFAULT_REGION` environment variables (when not specified with the plugin configuration).
   [#7765](https://github.com/Kong/kong/pull/7765)
 - [Datadog](/hub/kong-inc/datadog) (`datadog`)
-  `host` and `port` config options can be configured from `ENV` variables.
+  The Datadog plugin now allows `host` and `port` config options be configured from `ENV` variables.
   [#7463](https://github.com/Kong/kong/pull/7463)
 - [Prometheus](/hub/kong-inc/prometheus) (`prometheus`) 
   The new `data_plane_cluster_cert_expiry_timestamp` exposes DP cert expiry timestamp.
@@ -137,8 +139,8 @@ release:
 ### Fixes
 
 #### Enterprise
-- Fixed the Vitals InfluxDB timestamp generation when inserting metrics.
-- Do not export consumer_reset_secrets.
+- This release includes a fix for an issue with the Vitals InfluxDB timestamp generation when inserting metrics. 
+- Kong Gateway (Enterprise) no longer exports `consumer_reset_secrets`.
 
 #### Core
 - Balancer retries now correctly set the `:authority` pseudo-header on balancer retries.
@@ -178,9 +180,9 @@ release:
 - [Vault Auth](/hub/kong-inc/vault-auth) (`vault-auth)
   This plugin is now available for selection in the Kong Manager UI, previously it was hidden.
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  Upgrade to v2.0.x keeping version compatibility with older data planes.
-  - Allow the OpenID Connect plugin to handle jwt responses from a userinfo endpoint.
-  - Support for JWE Introspection.
+  Upgrade to v2.0.x to maintain version compatibility with older data planes.
+  - The OpenID Connect plugin can now handle JWT responses from a `userinfo` endpoint.
+  - The plugin now supports JWE Introspection.
 - [ACME](/hub/kong-inc/acme) (`acme`)
   Dots in wildcard domains are escaped.
   [#7839](https://github.com/Kong/kong/pull/7839).
@@ -192,7 +194,7 @@ release:
   [#7775](https://github.com/Kong/kong/pull/7775)
 
 #### Deprecations
-- InfluxDB reports UI and /vitals/reports/:entity_type endpoint.
+- InfluxDB reports UI and `/vitals/reports/:entity_type` endpoint.
 
 ## 2.5.1.0
 **Release Date** 2021/09/08

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -28,9 +28,12 @@ only one or neither of the fields be configured.
   [#7827](https://github.com/Kong/kong/pull/7827).
 
 #### Admin API
-- Add support for HEAD requests.
+- Added support for the HTTP HEAD method for all Admin API endpoints.
   [#7796](https://github.com/Kong/kong/pull/7796)
-- Improve support for OPTIONS requests.
+- Added better support for OPTIONS requests. Previously, the Admin API replied the same on all OPTIONS requests,
+  where as now OPTIONS request will only reply to routes that our Admin API has. Non-existing routes will have a
+  404 returned. Additionally, the Allow header was added to responses. Both Allow and Access-Control-Allow-Methods
+  now contain only the methods that the specific API supports.
   [#7830](https://github.com/Kong/kong/pull/7830)
 
 #### Plugins
@@ -54,25 +57,34 @@ only one or neither of the fields be configured.
 - [AWS-Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) 
   The plugin will now try to detect the AWS region by using `AWS_REGION` and
   `AWS_DEFAULT_REGION` environment variables (when not specified with the plugin configuration).
+  This allows users to specify a 'region' on a per Kong node basis, adding the ability to invoke the
+  Lambda function in the same region where Kong is located.
   [#7765](https://github.com/Kong/kong/pull/7765)
 - [Datadog](/hub/kong-inc/datadog) (`datadog`)
-  The Datadog plugin now allows `host` and `port` config options be configured from `ENV` variables.
+  The Datadog plugin now allows `host` and `port` config options be configured from environment variables,
+  `KONG_DATADOG_AGENT_HOST` and `KONG_DATADOG_AGENT_PORT`. This update enables users to set 
+   different destinations on a per Kong node basis, which makes multi-DC setups easier and in Kubernetes helps 
+   with the ability to run the Datadog agents as a daemon-set.
   [#7463](https://github.com/Kong/kong/pull/7463)
 - [Prometheus](/hub/kong-inc/prometheus) (`prometheus`) 
-  The new `data_plane_cluster_cert_expiry_timestamp` exposes DP cert expiry timestamp.
+  The Prometheus plugin now includes a new metric, `data_plane_cluster_cert_expiry_timestamp`, to expose the Data Plane's `cluster_cert` 
+   expiry timestamp for improved monitoring in Hybrid Mode.
   [#7800](https://github.com/Kong/kong/pull/7800).
 - [GRPC-Gateway](/hub/kong-inc/grpc-gateway) (grpc-gateway)
-  - The plugin can decode entities of type `.google.protobuf.Timestamp`
+  - Fields of type `.google.protobuf.Timestamp` on the gRPC side are now
+    transcoded to and from ISO8601 strings in the REST side.
     [#7538](https://github.com/Kong/kong/pull/7538)
-  - Added support for structured URI arguments
+  - URI arguments like `..?foo.bar=x&foo.baz=y` are interpreted as structured
+    fields, equivalent to `{"foo": {"bar": "x", "baz": "y"}}`.
     [#7564](https://github.com/Kong/kong/pull/7564)
 - [Request Termination](/hub/kong-inc/request-termination) (`request-termination`)
-  - New `trigger` config option, which makes the plugin activate for any requests with a header or query parameter
-    named like the trigger
+  - The Request Termination plugin now includes a new `trigger` config option, which makes the plugin
+    only activate for any requests with a header or query parameter named like the trigger. This config option
+    can be a great debugging aid, without impacting actual traffic being processed.
     [#6744](https://github.com/Kong/kong/pull/6744).
-  - The `request-echo` config option. If not set, the plugin activates on all requests.
-    If set, then the plugin only activates for any requests with a header or query parameter
-    named like the trigger
+  - The `request-echo` config option was added. If set, the plugin responds with a copy of the incoming request.
+    This config option eases troubleshooting when Kong Gateway is behind one or more other proxies or LB's,
+    especially when combined with the new `trigger` option.
     [#6744](https://github.com/Kong/kong/pull/6744).
 
 ### Dependencies

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -4,7 +4,7 @@ no_search: true
 no_version: true
 ---
 
-## 2.6.0.0
+## 2.6.0.0 (beta1)
 **Release date:** 2021/09/28
 
 ### Features
@@ -16,30 +16,6 @@ This release includes the addition of a new schema entity validator: `mutually_e
 `only_one_of` validator required at least one of the fields included be configured. This new entity validator allows
 only one or neither of the fields be configured.
 [#7765](https://github.com/Kong/kong/pull/7765)
-
-#### Performance
-
-For this release we've focused on performance improvement.
-
-There's a new performance workflow which periodically checks new code additions against some
-typical scenarios. [#7030](https://github.com/Kong/kong/pull/7030) [#7547](https://github.com/Kong/kong/pull/7547)
-
-Additionally, the following changes were specifically included to improve performance:
-
-- Reduced unnecessary reads of `ngx.var`.
-  [#7840](https://github.com/Kong/kong/pull/7840)
-- Loaded more indexed variables.
-  [#7849](https://github.com/Kong/kong/pull/7849)
-- Optimized table creation in Balancer.
-  [#7852](https://github.com/Kong/kong/pull/7852)
-- Reduced calls to `ngx.update_time`.
-  [#7853](https://github.com/Kong/kong/pull/7853)
-- Use read-only replica for PostgreSQL meta-schema reading.
-  [#7454](https://github.com/Kong/kong/pull/7454)
-- URL escaping detects cases when it's not needed and early-exists.
-  [#7742](https://github.com/Kong/kong/pull/7742)
-- Accelerated variable loading via indexes.
-  [#7818](https://github.com/Kong/kong/pull/7818)
 
 #### Configuration
 - Enable IPV6 on `dns_order` as unsupported experimental feature.
@@ -65,12 +41,16 @@ Additionally, the following changes were specifically included to improve perfor
 - [Kafka Upstream](/hub/kong-inc/kafka-upstream) (`kafka-upstream`)
   The Kafka Upstream plugin now supports TLS, mTLS, and SASL auth.
 - [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
-  - The Rate Limiting plugin now has a new identifier type: `path`, which allows rate limiting by matching request paths.
-  - The plugin now has a “local” strategy in the schema. The local strategy automatically sets `config.sync_rate` to -1.
+  - The Rate Limiting Advanced plugin now has a new identifier type: `path`, which allows rate limiting by matching request paths.
+  - The plugin now has a `local` strategy in the schema. The local strategy automatically sets `config.sync_rate` to -1.
 - [OPA](/hub/kong-inc/opa) (`opa`)
-  The OPA plugin now has a request path, which makes setting policies on a path easier for administrators.
+  The OPA plugin now has a request path parameter, which makes setting policies on a path easier for administrators.
 - [Canary](/hub/kong-inc/canary) (`canary`)
   The Canary plugin now has the option to hash on the header (falls back on IP, and then random).
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  Upgrade to v2.0.x to maintain version compatibility with older data planes.
+  - The OpenID Connect plugin can now handle JWT responses from a `userinfo` endpoint.
+  - The plugin now supports JWE Introspection.
 - [AWS-Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) 
   The plugin will now try to detect the AWS region by using `AWS_REGION` and
   `AWS_DEFAULT_REGION` environment variables (when not specified with the plugin configuration).
@@ -119,23 +99,6 @@ Additionally, the following changes were specifically included to improve perfor
 - Bumped `lua-resty-ipmatcher` to 0.6.1
   [#7703](https://github.com/Kong/kong/pull/7703)
 
-All Kong Gateway OSS plugins will be moved from individual repositories and centralized
-into the main Kong Gateway (OSS) repository. We are making a gradual transition. On this
-release:
-
-- Moved AWS-Lambda inside the Kong repo
-  [#7464](https://github.com/Kong/kong/pull/7464).
-- Moved ACME inside the Kong repo
-  [#7464](https://github.com/Kong/kong/pull/7464).
-- Moved Prometheus inside the Kong repo
-  [#7666](https://github.com/Kong/kong/pull/7666).
-- Moved Session inside the Kong repo
-  [#7738](https://github.com/Kong/kong/pull/7738).
-- Moved GRPC-web inside the Kong repo
-  [#7782](https://github.com/Kong/kong/pull/7782).
-- Moved Serverless functions inside the Kong repo
-  [#7792](https://github.com/Kong/kong/pull/7792).
-
 ### Fixes
 
 #### Enterprise
@@ -163,7 +126,7 @@ release:
   [#7589](https://github.com/Kong/kong/pull/7589).
 
 ##### Configuration
-- Declarative Configuration parser now prints more correct errors when pointing unknown foreign references.
+- Declarative Configuration parser now prints more correct errors when printing unknown foreign references.
   [#7756](https://github.com/Kong/kong/pull/7756).
 - YAML anchors in Declarative Configuration are properly processed.
   [#7748](https://github.com/Kong/kong/pull/7748).
@@ -179,10 +142,6 @@ release:
 ##### Plugins
 - [Vault Auth](/hub/kong-inc/vault-auth) (`vault-auth)
   This plugin is now available for selection in the Kong Manager UI, previously it was hidden.
-- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  Upgrade to v2.0.x to maintain version compatibility with older data planes.
-  - The OpenID Connect plugin can now handle JWT responses from a `userinfo` endpoint.
-  - The plugin now supports JWE Introspection.
 - [ACME](/hub/kong-inc/acme) (`acme`)
   Dots in wildcard domains are escaped.
   [#7839](https://github.com/Kong/kong/pull/7839).

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -5,7 +5,7 @@ no_version: true
 ---
 
 ## 2.6.0.0 (beta1)
-**Release date:** 2021/09/30
+**Release date:** 2021/10/04
 
 ### Features
 

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -5,7 +5,7 @@ no_version: true
 ---
 
 ## 2.6.0.0 (beta1)
-**Release date:** 2021/09/28
+**Release date:** 2021/09/30
 
 ### Features
 
@@ -40,20 +40,31 @@ only one or neither of the fields be configured.
 - **New plugin:** [jq](/hub/kong-inc/jq) (`jq`)
   The jq plugin enables arbitrary jq transformations on JSON objects included in API requests or responses.
 - [Kafka Log](/hub/kong-inc/kafka-log) (`kafka-log`)
-  The Kafka Log plugin now supports TLS, mTLS, and SASL auth.
+  The Kafka Log plugin now supports TLS, mTLS, and SASL auth. SASL auth includes support for PLAIN, SCRAM-SHA-256,
+  and delegation tokens.
 - [Kafka Upstream](/hub/kong-inc/kafka-upstream) (`kafka-upstream`)
-  The Kafka Upstream plugin now supports TLS, mTLS, and SASL auth.
+  The Kafka Upstream plugin now supports TLS, mTLS, and SASL auth. SASL auth includes support for PLAIN, SCRAM-SHA-256,
+  and delegation tokens.
 - [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
-  - The Rate Limiting Advanced plugin now has a new identifier type: `path`, which allows rate limiting by matching request paths.
+  - The Rate Limiting Advanced plugin now has a new identifier type, `path`, which allows rate limiting by
+    matching request paths.
   - The plugin now has a `local` strategy in the schema. The local strategy automatically sets `config.sync_rate` to -1.
+  - The highest sync-rate configurable was a 1 second interval. This sync-rate has been increased by reducing
+    the minimum allowed interval from 1 to 0.020 second (20ms).
+  - The plugin now supports rate limit consumer groups, which allow different rate limit configurations
+    to be applied for consumers in consumer groups.
 - [OPA](/hub/kong-inc/opa) (`opa`)
   The OPA plugin now has a request path parameter, which makes setting policies on a path easier for administrators.
 - [Canary](/hub/kong-inc/canary) (`canary`)
   The Canary plugin now has the option to hash on the header (falls back on IP, and then random).
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  Upgrade to v2.0.x to maintain version compatibility with older data planes.
-  - The OpenID Connect plugin can now handle JWT responses from a `userinfo` endpoint.
-  - The plugin now supports JWE Introspection.
+  Upgrade to v2.1.0 to maintain version compatibility with older data planes.
+  - Features from v2.0.x include the following:
+    - The OpenID Connect plugin can now handle JWT responses from a `userinfo` endpoint.
+    - The plugin now supports JWE Introspection.
+  - Feature from to v2.1.x includes the following:
+    - The plugin now has a new param, `by_username_ignore_case`, which allows `consumer_by` username values to be
+      matched case-insensitive with Identity Provider claims.
 - [AWS-Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) 
   The plugin will now try to detect the AWS region by using `AWS_REGION` and
   `AWS_DEFAULT_REGION` environment variables (when not specified with the plugin configuration).
@@ -116,6 +127,13 @@ only one or neither of the fields be configured.
 #### Enterprise
 - This release includes a fix for an issue with the Vitals InfluxDB timestamp generation when inserting metrics. 
 - Kong Gateway (Enterprise) no longer exports `consumer_reset_secrets`.
+- Fixes an issue where keyring data was not being properly generated and activated
+  on a Kong process start (for example, kong start).
+- Kong Gateway now returns keyring-encrypted fields early when a decrypt attempt is made, giving you time
+  to import the keys so Kong Gateway can recognize the decrypted fields. Before if there were data fields
+  keyring-encrypted in the database, Kong Gateway attempted to decrypt them on the `init*` phases (`init` or `init_worker`
+  phases - when the Kong process is started), and you would get errors like "no request found". **Keys must still be imported after the Kong process is started.**
+- The [Keyring Encryption](/enterprise/2.6.x/db-encryption/) feature is no longer in an alpha quality state.
 
 #### Core
 - Balancer retries now correctly set the `:authority` pseudo-header on balancer retries.

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -152,8 +152,6 @@ only one or neither of the fields be configured.
   [#7828](https://github.com/Kong/kong/pull/7828).
 
 ##### Plugins
-- [Vault Auth](/hub/kong-inc/vault-auth) (`vault-auth)
-  This plugin is now available for selection in the Kong Manager UI, previously it was hidden.
 - [ACME](/hub/kong-inc/acme) (`acme`)
   Dots in wildcard domains are escaped.
   [#7839](https://github.com/Kong/kong/pull/7839).

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -51,8 +51,6 @@ only one or neither of the fields be configured.
   - The plugin now has a `local` strategy in the schema. The local strategy automatically sets `config.sync_rate` to -1.
   - The highest sync-rate configurable was a 1 second interval. This sync-rate has been increased by reducing
     the minimum allowed interval from 1 to 0.020 second (20ms).
-  - The plugin now supports rate limit consumer groups, which allow different rate limit configurations
-    to be applied for consumers in consumer groups.
 - [OPA](/hub/kong-inc/opa) (`opa`)
   The OPA plugin now has a request path parameter, which makes setting policies on a path easier for administrators.
 - [Canary](/hub/kong-inc/canary) (`canary`)

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -12,10 +12,10 @@ no_version: true
 #### Enterprise
 
 #### Core
-- This release includes the addition of a new schema entity validator: `mutually_exclusive`. Before, the
-  `only_one_of` validator required at least one of the fields included be configured. This new entity validator allows
-  only one or neither of the fields be configured.
-  [#7765](https://github.com/Kong/kong/pull/7765)
+This release includes the addition of a new schema entity validator: `mutually_exclusive`. Before, the
+`only_one_of` validator required at least one of the fields included be configured. This new entity validator allows
+only one or neither of the fields be configured.
+[#7765](https://github.com/Kong/kong/pull/7765)
 
 #### Performance
 
@@ -192,9 +192,6 @@ release:
 - [Proxy-Cache](/hub/kong-inc/proxy-cache) (`proxy-cache`) 
   Fixed an issue where the plugin would sometimes fetch data from the cache but not return it.
   [#7775](https://github.com/Kong/kong/pull/7775)
-
-#### Deprecations
-- InfluxDB reports UI and `/vitals/reports/:entity_type` endpoint.
 
 ## 2.5.1.0
 **Release Date** 2021/09/08

--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -4,6 +4,196 @@ no_search: true
 no_version: true
 ---
 
+## 2.6.0.0
+**Release date:** 2021/09/28
+
+### Features
+
+#### Enterprise
+
+#### Core
+- This release includes the addition of a new schema entity validator: `mutually_exclusive`. Before, the
+  `only_one_of` validator required at least one of the fields included be configured. This new entity validator allows
+  only one or neither of the fields be configured.
+  [#7765](https://github.com/Kong/kong/pull/7765)
+
+#### Performance
+
+For this release we've focused on performance improvement.
+
+There's a new performance workflow which periodically checks new code additions against some
+typical scenarios. [#7030](https://github.com/Kong/kong/pull/7030) [#7547](https://github.com/Kong/kong/pull/7547)
+
+Additionally, the following changes were specifically included to improve performance:
+
+- Reduced unnecessary reads of `ngx.var`.
+  [#7840](https://github.com/Kong/kong/pull/7840)
+- Loaded more indexed variables.
+  [#7849](https://github.com/Kong/kong/pull/7849)
+- Optimized table creation in Balancer.
+  [#7852](https://github.com/Kong/kong/pull/7852)
+- Reduced calls to `ngx.update_time`.
+  [#7853](https://github.com/Kong/kong/pull/7853)
+- Use read-only replica for PostgreSQL meta-schema reading.
+  [#7454](https://github.com/Kong/kong/pull/7454)
+- URL escaping detects cases when it's not needed and early-exists.
+  [#7742](https://github.com/Kong/kong/pull/7742)
+- Accelerated variable loading via indexes.
+  [#7818](https://github.com/Kong/kong/pull/7818)
+
+#### Configuration
+
+- Enable IPV6 on `dns_order` as unsupported experimental feature.
+  [#7819](https://github.com/Kong/kong/pull/7819).
+- The template renderer can now use `os.getenv`.
+  [#6872](https://github.com/Kong/kong/pull/6872).
+
+#### Hybrid Mode
+
+- Data plane is able to eliminate some unknown fields when Control Plane is using a more modern version.
+  [#7827](https://github.com/Kong/kong/pull/7827).
+
+#### Admin API
+
+- Add support for HEAD requests.
+  [#7796](https://github.com/Kong/kong/pull/7796)
+- Improve support for OPTIONS requests.
+  [#7830](https://github.com/Kong/kong/pull/7830)
+
+#### Plugins
+
+- [jq](/hub/kong-inc/jq) (`jq`)
+  New jq plugin added. 
+- [Rate Limiting](/hub/kong-inc/rate-limiting) (`rate-limiting`)
+  - A new identifier type  was added: `path`, allowing rate limiting by matching request paths.
+  - Add a “local” strategy in the schema (it automatically sets `config.sync_rate` to -1).
+- [OPA](/hub/kong-inc/opa) (`opa`)
+  Add request path, allowing administrators to set policies on a path basis more easily. 
+- [AWS-Lambda](/hub/kong-inc/aws-lambda) (`aws-lambda`) 
+  The plugin will now try to detect the AWS region by using `AWS_REGION` and
+  `AWS_DEFAULT_REGION` environment variables (when not specified with the plugin configuration).
+  [#7765](https://github.com/Kong/kong/pull/7765)
+- [Datadog](/hub/kong-inc/datadog) (`datadog`)
+  `host` and `port` config options can be configured from `ENV` variables.
+  [#7463](https://github.com/Kong/kong/pull/7463)
+- [Prometheus](/hub/kong-inc/prometheus) (`prometheus`) 
+  The new `data_plane_cluster_cert_expiry_timestamp` exposes DP cert expiry timestamp.
+  [#7800](https://github.com/Kong/kong/pull/7800).
+- [GRPC-Gateway](/hub/kong-inc/grpc-gateway) (grpc-gateway)
+  - The plugin can decode entities of type `.google.protobuf.Timestamp`
+    [#7538](https://github.com/Kong/kong/pull/7538)
+  - Added support for structured URI arguments
+    [#7564](https://github.com/Kong/kong/pull/7564)
+- [Request Termination](/hub/kong-inc/request-termination) (`request-termination`)
+  - New `trigger` config option, which makes the plugin activate for any requests with a header or query parameter
+    named like the trigger
+    [#6744](https://github.com/Kong/kong/pull/6744).
+  - The `request-echo` config option. If not set, the plugin activates on all requests.
+    If set, then the plugin only activates for any requests with a header or query parameter
+    named like the trigger
+    [#6744](https://github.com/Kong/kong/pull/6744).
+
+### Dependencies
+- Bumped `openresty` from 1.19.3.2 to [1.19.9.1](https://openresty.org/en/changelog-1019009.html)
+  [#7430](https://github.com/Kong/kong/pull/7727)
+- Bumped `openssl` from `1.1.1k` to `1.1.1l`
+  [7767](https://github.com/Kong/kong/pull/7767)
+- Bumped `lua-resty-http` from 0.15 to 0.16.1
+  [#7797](https://github.com/kong/kong/pull/7797)
+- Bumped `Penlight` to 1.11.0
+  [#7736](https://github.com/Kong/kong/pull/7736)
+- Bumped `lua-resty-http` from 0.15 to 0.16.1
+  [#7797](https://github.com/kong/kong/pull/7797)
+- Bumped `lua-protobuf` from 0.3.2 to 0.3.3
+  [#7656](https://github.com/Kong/kong/pull/7656)
+- Bumped `lua-resty-openssl` from 0.7.3 to 0.7.4
+  [#7657](https://github.com/Kong/kong/pull/7657)
+- Bumped `lua-resty-acme` from 0.6 to 0.7.1
+  [#7658](https://github.com/Kong/kong/pull/7658)
+- Bumped `grpcurl` from 1.8.1 to 1.8.2
+  [#7659](https://github.com/Kong/kong/pull/7659)
+- Bumped `luasec` from 1.0.1 to 1.0.2
+  [#7750](https://github.com/Kong/kong/pull/7750)
+- Bumped `lua-resty-ipmatcher` to 0.6.1
+  [#7703](https://github.com/Kong/kong/pull/7703)
+
+All Kong Gateway OSS plugins will be moved from individual repositories and centralized
+into the main Kong Gateway (OSS) repository. We are making a gradual transition. On this
+release:
+
+- Moved AWS-Lambda inside the Kong repo
+  [#7464](https://github.com/Kong/kong/pull/7464).
+- Moved ACME inside the Kong repo
+  [#7464](https://github.com/Kong/kong/pull/7464).
+- Moved Prometheus inside the Kong repo
+  [#7666](https://github.com/Kong/kong/pull/7666).
+- Moved Session inside the Kong repo
+  [#7738](https://github.com/Kong/kong/pull/7738).
+- Moved GRPC-web inside the Kong repo
+  [#7782](https://github.com/Kong/kong/pull/7782).
+- Moved Serverless functions inside the Kong repo
+  [#7792](https://github.com/Kong/kong/pull/7792).
+
+### Fixes
+
+#### Enterprise
+- Fixed the Vitals InfluxDB timestamp generation when inserting metrics.
+- Do not export consumer_reset_secrets.
+
+#### Core
+- Balancer retries now correctly set the `:authority` pseudo-header on balancer retries.
+  [#7725](https://github.com/Kong/kong/pull/7725).
+- Healthchecks are now stopped while the Balancer is being recreated.
+  [#7549](https://github.com/Kong/kong/pull/7549).
+- Fixed an issue in which a malformed `Accept` header could cause unexpected HTTP 500.
+  [#7757](https://github.com/Kong/kong/pull/7757).
+- Kong no longer removes `Proxy-Authentication` request header and `Proxy-Authenticate` response header.
+  [#7724](https://github.com/Kong/kong/pull/7724).
+- Fixed an issue where Kong would not sort correctly Routes with both regex and prefix paths.
+  [#7695](https://github.com/Kong/kong/pull/7695)
+
+#### Hybrid Mode
+- Ensure data plane config thread is terminated gracefully, preventing a semi-deadlocked state.
+  [#7568](https://github.com/Kong/kong/pull/7568)
+
+##### CLI
+- `kong config parse` no longer crashes when there's a Go plugin server enabled.
+  [#7589](https://github.com/Kong/kong/pull/7589).
+
+##### Configuration
+- Declarative Configuration parser now prints more correct errors when pointing unknown foreign references.
+  [#7756](https://github.com/Kong/kong/pull/7756).
+- YAML anchors in Declarative Configuration are properly processed.
+  [#7748](https://github.com/Kong/kong/pull/7748).
+
+##### Admin API
+- `GET /upstreams/:upstreams/targets/:target` no longer returns 404 when target weight is 0.
+  [#7758](https://github.com/Kong/kong/pull/7758).
+
+##### PDK
+- `kong.response.exit` now uses customized "Content-Length" header when found.
+  [#7828](https://github.com/Kong/kong/pull/7828).
+
+##### Plugins
+- [Vault Auth](/hub/kong-inc/vault-auth) (`vault-auth)
+  This plugin is now available for selection in the Kong Manager UI, previously it was hidden.
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  Upgrade to v2.0.x keeping version compatibility with older data planes.
+  - Allow the OpenID Connect plugin to handle jwt responses from a userinfo endpoint.
+  - Support for JWE Introspection.
+- [ACME](/hub/kong-inc/acme) (`acme`)
+  Dots in wildcard domains are escaped.
+  [#7839](https://github.com/Kong/kong/pull/7839).
+- [Prometheus](/hub/kong-inc/prometheus) (`prometheus`)
+  Upstream's health info now includes previously missing `subsystem` field.
+  [#7802](https://github.com/Kong/kong/pull/7802).
+- [Proxy-Cache](/hub/kong-inc/proxy-cache) (`proxy-cache`) 
+  Fixed an issue where the plugin would sometimes fetch data from the cache but not return it.
+  [#7775](https://github.com/Kong/kong/pull/7775)
+
+#### Deprecations
+- InfluxDB reports UI and /vitals/reports/:entity_type endpoint.
+
 ## 2.5.1.0
 **Release Date** 2021/09/08
 


### PR DESCRIPTION
### Summary
v2.6.0.0 beta changelog - includes [OSS v2.6.0 changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md#260) as well as Enterprise additions included on the [Internal changelong on Confluence](https://konghq.atlassian.net/wiki/spaces/FTT/pages/2587787325/Kong+Enterprise+2.6.0.0).
### Reason
v2.6.0.0 Beta is scheduled for release Tuesday, 9/28/
### Testing
Will include sample build link when available.