### PR TITLE
Update using-tcpingress.md

### DIFF
--- a/app/kubernetes-ingress-controller/1.3.x/guides/using-tcpingress.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/using-tcpingress.md
@@ -91,7 +91,7 @@ $ kubectl patch deploy -n kong ingress-kong --patch '{
     }
   }
 }'
-deployment.extensions/ingress-kong patched
+deployment.apps/ingress-kong patched
 ```
 
 ```shell


### PR DESCRIPTION
The Deployment API is part of the `apps` API group now:

- https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
- https://docs.openshift.com/container-platform/4.8/rest_api/workloads_apis/deployment-apps-v1.html#deployment-apps-v1

This just modifies command output.