### PR TITLE
docs(configuration) mention Lua functions available in templating

### DIFF
--- a/app/gateway-oss/2.0.x/configuration.md
+++ b/app/gateway-oss/2.0.x/configuration.md
@@ -221,7 +221,11 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two

--- a/app/gateway-oss/2.1.x/configuration.md
+++ b/app/gateway-oss/2.1.x/configuration.md
@@ -221,7 +221,11 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two

--- a/app/gateway-oss/2.2.x/configuration.md
+++ b/app/gateway-oss/2.2.x/configuration.md
@@ -221,7 +221,11 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two

--- a/app/gateway-oss/2.3.x/configuration.md
+++ b/app/gateway-oss/2.3.x/configuration.md
@@ -221,7 +221,11 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two

--- a/app/gateway-oss/2.4.x/configuration.md
+++ b/app/gateway-oss/2.4.x/configuration.md
@@ -221,7 +221,11 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two

--- a/app/gateway-oss/2.5.x/configuration.md
+++ b/app/gateway-oss/2.5.x/configuration.md
@@ -221,7 +221,11 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two

--- a/app/gateway-oss/2.6.x/configuration.md
+++ b/app/gateway-oss/2.6.x/configuration.md
@@ -221,7 +221,12 @@ Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
 which must specify an Nginx configuration template. Such a template uses the
 [Penlight][Penlight] [templating engine][pl.template], which is compiled using
 the given Kong configuration, before being dumped in your Kong prefix
-directory, moments before starting Nginx.
+directory, moments before starting Nginx. The following Lua functions are
+available in the [templating engine][pl.template]:
+
+- `pairs`, `ipairs`
+- `tostring`
+- `os.getenv`
 
 The default template can be found at:
 https://github.com/kong/kong/tree/master/kong/templates. It is split in two


### PR DESCRIPTION
### Summary
Mention Lua functions available in templating. 

### Reason
https://github.com/Kong/kong/pull/6872
`os.getenv` is added in 2.6, also adding the description for other existing functions user can use in templating.

The feature is originally from a community issue https://github.com/Kong/kong/issues/6546.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
