### PR TITLE
docs: add istio version compat table

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -6,7 +6,12 @@ This guide walks you through deploying Kong as the gateway for [Istio][istio] to
 combine the features of Kong for ingress traffic with Istio's mesh
 functionality.
 
+A [version compatibility reference][compat] is available for this guide which
+shows the versions of {{site.kic_product_name}} and Istio which are tested for
+compatibility.
+
 [istio]:https://istio.io
+[compat]:/kubernetes-ingress-controller/{{page.kong_version}}/references/version-compatibility/#istio
 
 ## Overview
 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -6,9 +6,8 @@ This guide walks you through deploying Kong as the gateway for [Istio][istio] to
 combine the features of Kong for ingress traffic with Istio's mesh
 functionality.
 
-A [version compatibility reference][compat] is available for this guide which
-shows the versions of {{site.kic_product_name}} and Istio which are tested for
-compatibility.
+See the [version compatibility reference][compat] for the
+tested compatible versions of {{site.kic_product_name}} and Istio.
 
 [istio]:https://istio.io
 [compat]:/kubernetes-ingress-controller/{{page.kong_version}}/references/version-compatibility/#istio

--- a/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
@@ -55,9 +55,9 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 
 ## Istio
 
-The {{site.kic_product_name}} can be integrated with an [Istio Service Mesh][istio] in order to use Kong Gateway as an ingress gateway for application traffic into the mesh network, an example of this is provided in our [Istio Guide][istio-guide].
+The {{site.kic_product_name}} can be integrated with an [Istio Service Mesh][istio] to use Kong Gateway as an ingress gateway for application traffic into the mesh network. See an example of this in the [Istio Guide][istio-guide].
 
-For each {{site.kic_product_name}} release tests are run to verify this documentation with upcoming versions of KIC and Istio: The result is the following table which highlights the combinations which have been tested:
+For each {{site.kic_product_name}} release, tests are run to verify this documentation with upcoming versions of KIC and Istio. The following table lists the tested combinations:
 
 | {{site.kic_product_name}} |            1.0.x            |            1.1.x            |            1.2.x            |            1.3.x            |            2.0.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|

--- a/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
@@ -52,3 +52,16 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.22           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
+
+## Istio
+
+The {{site.kic_product_name}} can be integrated with an [Istio Service Mesh][istio] in order to use Kong Gateway as an ingress gateway for application traffic into the mesh network, an example of this is provided in our [Istio Guide][istio-guide].
+
+For each {{site.kic_product_name}} release tests are run to verify this documentation with upcoming versions of KIC and Istio: The result is the following table which highlights the combinations which have been tested:
+
+| {{site.kic_product_name}} |            1.0.x            |            1.1.x            |            1.2.x            |            1.3.x            |            2.0.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Istio 1.11                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+
+[istio]:https://istio.io
+[istio-guide]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/getting-started-istio/


### PR DESCRIPTION
### Summary
This adds a version compatibility reference which is relevant to our existing Istio guide and shows which versions of the KIC have been tested with Istio in order to use Kong as an Ingress Gateway into applications in the mesh network.

### Reason
Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1859

### Testing
The [KIC](https://github.com/kong/kubernetes-ingress-controller) now includes testing facilities to automatically test this:

- [x] https://github.com/Kong/kubernetes-testing-framework/pull/122
- [x] https://github.com/Kong/kubernetes-ingress-controller/pull/1868