### PR TITLE
docs(datadog) env vars docs, version bump

### DIFF
--- a/app/_hub/kong-inc/datadog/3.0.x.md
+++ b/app/_hub/kong-inc/datadog/3.0.x.md
@@ -1,8 +1,8 @@
 ---
 name: Datadog
 publisher: Kong Inc.
-version: 3.1.x
-# internal handler version 3.1.0
+version: 3.0.x
+# internal handler version 3.0.1
 
 desc: Visualize metrics on Datadog
 description: |
@@ -24,8 +24,6 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
-        - 2.6.x
-        - 2.5.x
         - 2.4.x
         - 2.3.x      
         - 2.2.x
@@ -135,15 +133,6 @@ would need to change to:
 ```
 avg:kong.latency.avg{name:sample-service}
 ```
-
-## Setting host and port per Kong node basis
-
-When installing a multi-data center setup, you might want to set Datadog's agent host and port on a per Kong node basis. This configuration is possible by setting the host and port properties using environment variables.
-
-Field           | Description                                           | Datatypes
----             | ---                                                   | ---
-`KONG_DATADOG_AGENT_HOST` | The IP address or host name to send data to. | string
-`KONG_DATADOG_AGENT_PORT` | The port to send data to on the upstream server | integer
 
 ## Kong Process Errors
 

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -1,8 +1,8 @@
 ---
 name: Datadog
 publisher: Kong Inc.
-version: 3.0.x
-# internal handler version 3.0.1
+version: 3.1.x
+# internal handler version 3.1.0
 
 desc: Visualize metrics on Datadog
 description: |
@@ -24,6 +24,8 @@ categories:
 kong_version_compatibility:
     community_edition:
       compatible:
+        - 2.6.x
+        - 2.5.x
         - 2.4.x
         - 2.3.x      
         - 2.2.x
@@ -133,6 +135,15 @@ would need to change to:
 ```
 avg:kong.latency.avg{name:sample-service}
 ```
+
+## Setting host and port per Kong node basis
+
+When installing a multi-datacenter setup, one might want to set Datadog's agent host and port on a per Kong node basis. This is possible by setting the host and port properties using environment variables.
+
+Field           | Description                                           | Datatypes
+---             | ---                                                   | ---
+`KONG_DATADOG_AGENT_HOST` | The IP address or host name to send data to. | string
+`KONG_DATADOG_AGENT_PORT` | The port to send data to on the upstream server | integer
 
 ## Kong Process Errors
 

--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -140,6 +140,9 @@ avg:kong.latency.avg{name:sample-service}
 
 When installing a multi-data center setup, you might want to set Datadog's agent host and port on a per Kong node basis. This configuration is possible by setting the host and port properties using environment variables.
 
+{:.note}
+> **Note:** `host` and `port` fields in the plugin config take precedence over environment variables.
+
 Field           | Description                                           | Datatypes
 ---             | ---                                                   | ---
 `KONG_DATADOG_AGENT_HOST` | The IP address or host name to send data to. | string


### PR DESCRIPTION
### Summary
New environemnt variables for the datadog plugin. Also, plugin version was bumped.

### Reason
The new datadog plugin version is being release alongside Kong 2.6.0.

### Testing
I didn't test, just documented a community contribution (https://github.com/Kong/kong/pull/7463)