### PR TITLE
Issue 3205 : Test and edit Kong Gateway (OSS) Quickstart guide

### DIFF
--- a/app/gateway-oss/2.5.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.5.x/getting-started/adding-consumers.md
@@ -11,8 +11,8 @@ title: Adding Consumers
   </ol>
 </div>
 
-In the last section, we learned how to add plugins to Kong, in this section
-we're going to learn how to add consumers to your Kong instances. Consumers are
+In the last section, we learnt how to add plugins to Kong, in this section
+you're going to learn how to add consumers to your Kong instances. Consumers are
 associated to individuals using your Service, and can be used for tracking, access
 management, and more.
 
@@ -30,7 +30,7 @@ $ curl -i -X POST \
   --data "username=Jason"
 ```
 
-You should see a response similar to the one below:
+You can see a response similar to the one below:
 
 ```http
 HTTP/1.1 201 Created
@@ -63,8 +63,8 @@ $ curl -i -X POST \
 
 ## 3. Verify that your Consumer credentials are valid
 
-We can now issue the following request to verify that the credentials of
-our `Jason` Consumer is valid:
+You can now issue the following request to verify that the credentials of
+your `Jason` Consumer is valid:
 
 ```bash
 $ curl -i -X GET \
@@ -75,7 +75,7 @@ $ curl -i -X GET \
 
 ## Next Steps
 
-Now that we've covered the basics of adding Services, Routes, Consumers and enabling
+Now that you've covered the basics of adding Services, Routes, Consumers and enabling
 Plugins, feel free to read more on Kong in one of the following documents:
 
 - [Configuration file Reference][configuration]

--- a/app/gateway-oss/2.5.x/getting-started/adding-consumers.md
+++ b/app/gateway-oss/2.5.x/getting-started/adding-consumers.md
@@ -11,7 +11,7 @@ title: Adding Consumers
   </ol>
 </div>
 
-In the last section, we learnt how to add plugins to Kong, in this section
+In the last section, you learned how to add plugins to Kong, in this section
 you're going to learn how to add consumers to your Kong instances. Consumers are
 associated to individuals using your Service, and can be used for tracking, access
 management, and more.
@@ -30,7 +30,7 @@ $ curl -i -X POST \
   --data "username=Jason"
 ```
 
-You can see a response similar to the one below:
+You should see a response similar to the one below:
 
 ```http
 HTTP/1.1 201 Created
@@ -67,7 +67,7 @@ You can now issue the following request to verify that the credentials of
 your `Jason` Consumer is valid:
 
 ```bash
-$ curl -i -X GET \
+curl -i -X GET \
   --url http://localhost:8000 \
   --header "Host: example.com" \
   --header "apikey: ENTER_KEY_HERE"
@@ -75,8 +75,7 @@ $ curl -i -X GET \
 
 ## Next Steps
 
-Now that you've covered the basics of adding Services, Routes, Consumers and enabling
-Plugins, feel free to read more on Kong in one of the following documents:
+Read more about the following related topics:
 
 - [Configuration file Reference][configuration]
 - [CLI Reference][CLI]

--- a/app/gateway-oss/2.5.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.5.x/getting-started/configuring-a-grpc-service.md
@@ -14,18 +14,18 @@ Note: this guide assumes familiarity with gRPC; for learning how to set up
 Kong with an upstream REST API, check out the [Configuring a Service guide][conf-service].
 
 Starting with version 1.3, gRPC proxying is natively supported in Kong. In this
-section, you'll learn how to configure Kong to manage your gRPC services. For the
-purpose of this guide, we'll use [grpcurl][grpcurl] and [grpcbin][grpcbin] - they
+section, you're going to learn how to configure Kong to manage your gRPC services. For the
+purpose of this guide, you can use [grpcurl][grpcurl] and [grpcbin][grpcbin] - they
 provide a gRPC client and gRPC services, respectively.
 
-We will describe two setups: Single gRPC Service and Route and single gRPC Service
+You have to describe two setups: Single gRPC Service and Route and single gRPC Service
 with multiple Routes. In the former, a single catch-all Route is configured, which
-proxies all matching gRPC traffic to an upstream gRPC service; the latter demonstrates
+proxies all matching gRPC traffic to an upstream gRPC service. The latter demonstrates
 how to use a Route per gRPC method.
 
 In Kong 1.3, gRPC support assumes gRPC over HTTP/2 framing. As such, make sure
 you have at least one HTTP/2 proxy listener (check out the [Configuration Reference][configuration-reference]
-for how to). In this guide, we will assume Kong is listening for HTTP/2 proxy
+for how to). In this guide, you have to assume Kong is listening for HTTP/2 proxy
 requests on port 9080.
 
 ## 1. Single gRPC Service and Route
@@ -58,7 +58,7 @@ $ grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
   -plaintext localhost:9080 hello.HelloService.SayHello
 ```
 
-The response should resemble the following:
+The response shall resemble the following:
 
 ```
 Resolved method descriptor:
@@ -85,8 +85,7 @@ Response trailers received:
 Sent 1 request and received 1 response
 ```
 
-Notice that Kong response headers, such as `via` and `x-kong-proxy-latency`, were
-inserted in the response.
+Notice that the response inserts the Kong response headers, such as `via` and `x-kong-proxy-latency`.
 
 ## 2. Single gRPC Service with Multiple Routes
 
@@ -94,8 +93,7 @@ Building on top of the previous example, let's create a few more routes, for
 individual gRPC methods.
 
 The gRPC "HelloService" service being used in this example exposes a few different
-methods, as can be seen in [its protobuf file][protobuf]. We will create individual
-routes for its "SayHello" and LotsOfReplies methods.
+methods which can be seen in [its protobuf file][protobuf]. You're going to create individual routes for its "SayHello" and LotsOfReplies methods.
 
 Create a Route for "SayHello":
 
@@ -115,8 +113,8 @@ $ curl -XPOST localhost:8001/services/grpc/routes \
   --data name=lots-of-replies
 ```
 
-With this setup, gRPC requests to the "SayHello" method will match the first
-Route, while requests to "LotsOfReplies" will be routed to the latter.
+With this setup, gRPC requests to the "SayHello" method are going to match the first
+Route, while requests to "LotsOfReplies" are routed to the latter.
 
 Issue a gRPC request to the "SayHello" method:
 
@@ -126,10 +124,10 @@ $ grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
   localhost:9080 hello.HelloService.SayHello
 ```
 
-(Notice we are sending a header `kong-debug`, which causes Kong to insert
+(Notice that we are sending a header `kong-debug`, which causes Kong to insert
 debugging information in response headers.)
 
-The response should look like:
+The response shall look like:
 
 ```
 Resolved method descriptor:
@@ -159,7 +157,7 @@ Response trailers received:
 Sent 1 request and received 1 response
 ```
 
-Notice the Route ID should refer to the first route we created.
+Notice that the Route ID refers to the first route we created.
 
 Similarly, let's issue a request to the "LotsOfReplies" gRPC method:
 
@@ -169,7 +167,7 @@ $ grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
   localhost:9080 hello.HelloService.LotsOfReplies
 ```
 
-The response should look like the following:
+The response shall look like the following:
 
 ```
 Resolved method descriptor:
@@ -250,11 +248,11 @@ and refers to the second Route created in this page.
 **Note:**
 Some gRPC clients (typically CLI clients) issue ["gRPC Reflection Requests"][grpc-reflection]
 as a means of determining what methods a server exports and how those methods are called.
-Said requests have a particular path; for example, `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo`
-is a valid reflection path. As with any proxy request, Kong needs to know how to
-route these; in the current example, they would be routed to the catch-all route
+Those requests have a particular path; for example, `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo`, 
+which is a valid reflection path. As with any proxy request, Kong needs to know how to
+route these; in the current example, they have to be routed to the catch-all route
 (whose path is `/`, matching any path). If no route matches the gRPC reflection
-request, Kong will respond, as expected, with a `404 Not Found` response.
+request, Kong responds, as expected, with a `404 Not Found` response.
 
 ## 3. Enabling Plugins
 

--- a/app/gateway-oss/2.5.x/getting-started/configuring-a-grpc-service.md
+++ b/app/gateway-oss/2.5.x/getting-started/configuring-a-grpc-service.md
@@ -14,7 +14,7 @@ Note: this guide assumes familiarity with gRPC; for learning how to set up
 Kong with an upstream REST API, check out the [Configuring a Service guide][conf-service].
 
 Starting with version 1.3, gRPC proxying is natively supported in Kong. In this
-section, you're going to learn how to configure Kong to manage your gRPC services. For the
+section, you'll learn how to configure Kong to manage your gRPC services. For the
 purpose of this guide, you can use [grpcurl][grpcurl] and [grpcbin][grpcbin] - they
 provide a gRPC client and gRPC services, respectively.
 
@@ -25,7 +25,7 @@ how to use a Route per gRPC method.
 
 In Kong 1.3, gRPC support assumes gRPC over HTTP/2 framing. As such, make sure
 you have at least one HTTP/2 proxy listener (check out the [Configuration Reference][configuration-reference]
-for how to). In this guide, you have to assume Kong is listening for HTTP/2 proxy
+for how to). In this guide, we'll assume Kong is listening for HTTP/2 proxy
 requests on port 9080.
 
 ## 1. Single gRPC Service and Route
@@ -58,7 +58,7 @@ $ grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
   -plaintext localhost:9080 hello.HelloService.SayHello
 ```
 
-The response shall resemble the following:
+The response should resemble the following:
 
 ```
 Resolved method descriptor:
@@ -93,7 +93,7 @@ Building on top of the previous example, let's create a few more routes, for
 individual gRPC methods.
 
 The gRPC "HelloService" service being used in this example exposes a few different
-methods which can be seen in [its protobuf file][protobuf]. You're going to create individual routes for its "SayHello" and LotsOfReplies methods.
+methods which can be seen in [its protobuf file][protobuf]. You'll create individual routes for its "SayHello" and LotsOfReplies methods.
 
 Create a Route for "SayHello":
 
@@ -113,7 +113,7 @@ $ curl -XPOST localhost:8001/services/grpc/routes \
   --data name=lots-of-replies
 ```
 
-With this setup, gRPC requests to the "SayHello" method are going to match the first
+With this setup, gRPC requests to the "SayHello" method will match the first
 Route, while requests to "LotsOfReplies" are routed to the latter.
 
 Issue a gRPC request to the "SayHello" method:
@@ -127,7 +127,7 @@ $ grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
 (Notice that we are sending a header `kong-debug`, which causes Kong to insert
 debugging information in response headers.)
 
-The response shall look like:
+The response should look like:
 
 ```
 Resolved method descriptor:
@@ -167,7 +167,7 @@ $ grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
   localhost:9080 hello.HelloService.LotsOfReplies
 ```
 
-The response shall look like the following:
+The response should look like the following:
 
 ```
 Resolved method descriptor:
@@ -250,9 +250,9 @@ Some gRPC clients (typically CLI clients) issue ["gRPC Reflection Requests"][grp
 as a means of determining what methods a server exports and how those methods are called.
 Those requests have a particular path; for example, `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo`, 
 which is a valid reflection path. As with any proxy request, Kong needs to know how to
-route these; in the current example, they have to be routed to the catch-all route
+route these. In the current example, they would be routed to the catch-all route
 (whose path is `/`, matching any path). If no route matches the gRPC reflection
-request, Kong responds, as expected, with a `404 Not Found` response.
+request, Kong responds with a `404 Not Found` response.
 
 ## 3. Enabling Plugins
 

--- a/app/gateway-oss/2.5.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.5.x/getting-started/configuring-a-service.md
@@ -10,15 +10,15 @@ title: Configuring a Service
   </ol>
 </div>
 
-In this section, you're going to add an API to Kong. In order to do this, you must add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
+In this section, you'll add an API to Kong. In order to do this, you must add a _Service_.  A Service in Kong refers to the upstream APIs and microservices
 it manages.
 
-For the purpose of this guide, you have to create a Service pointing to the [Mockbin API][mockbin]. Mockbin is an "echo" type public website which returns the requests it gets back to the requester, as responses. This makes it helpful for learning how Kong proxies your API requests.
+For the purpose of this guide, you'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is an "echo" type public website that returns the requests it gets back to the requester as responses. This is helpful in learning how Kong proxies your API requests.
 
-Before you can start making requests against the Service, you have to add a _Route_ to it.
+Before you can start making requests against the Service, you have to add a _Route_ to the Service.
 Routes specify how (and _if_) requests are sent to their Services after they reach Kong. A single Service can have many Routes.
 
-After configuring the Service and the Route, you can make requests through Kong using them.
+After configuring the Service and the Route, you'll be able to make requests through Kong using them.
 
 Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, including adding Services and Routes, is made via requests on that API.
 
@@ -34,7 +34,7 @@ $ curl -i -X POST \
   --data 'url=http://mockbin.org'
 ```
 
-You shall receive a response similar to:
+You should receive a response similar to:
 
 ```http
 HTTP/1.1 201 Created
@@ -66,7 +66,7 @@ $ curl -i -X POST \
   --data 'hosts[]=example.com'
 ```
 
-The answer shall be similar to:
+The answer should be similar to:
 
 ```http
 HTTP/1.1 201 Created
@@ -111,7 +111,7 @@ $ curl -i -X GET \
 
 A successful response means Kong is now forwarding requests made to
 `http://localhost:8000` to the `url` you configured in step #1,
-and is forwarding the response back to you. Kong knows how to do this through
+and is forwarding the response back to you. Kong knows to do this through
 the header defined in the above cURL request:
 
 <ul>

--- a/app/gateway-oss/2.5.x/getting-started/configuring-a-service.md
+++ b/app/gateway-oss/2.5.x/getting-started/configuring-a-service.md
@@ -10,22 +10,17 @@ title: Configuring a Service
   </ol>
 </div>
 
-In this section, you'll be adding an API to Kong. In order to do this, you'll
-first need to add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
+In this section, you're going to add an API to Kong. In order to do this, you must add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
 it manages.
 
-For the purpose of this guide, we'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is
-an "echo" type public website which returns the requests it gets back to the requester, as responses. This
-makes it helpful for learning how Kong proxies your API requests.
+For the purpose of this guide, you have to create a Service pointing to the [Mockbin API][mockbin]. Mockbin is an "echo" type public website which returns the requests it gets back to the requester, as responses. This makes it helpful for learning how Kong proxies your API requests.
 
-Before you can start making requests against the Service, you will need to add a _Route_ to it.
-Routes specify how (and _if_) requests are sent to their Services after they reach Kong. A single
-Service can have many Routes.
+Before you can start making requests against the Service, you have to add a _Route_ to it.
+Routes specify how (and _if_) requests are sent to their Services after they reach Kong. A single Service can have many Routes.
 
-After configuring the Service and the Route, you'll be able to make requests through Kong using them.
+After configuring the Service and the Route, you can make requests through Kong using them.
 
-Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, including adding Services and
-Routes, is made via requests on that API.
+Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong's configuration, including adding Services and Routes, is made via requests on that API.
 
 ## 1. Add your Service using the Admin API
 
@@ -39,7 +34,7 @@ $ curl -i -X POST \
   --data 'url=http://mockbin.org'
 ```
 
-You should receive a response similar to:
+You shall receive a response similar to:
 
 ```http
 HTTP/1.1 201 Created
@@ -71,7 +66,7 @@ $ curl -i -X POST \
   --data 'hosts[]=example.com'
 ```
 
-The answer should be similar to:
+The answer shall be similar to:
 
 ```http
 HTTP/1.1 201 Created
@@ -115,8 +110,8 @@ $ curl -i -X GET \
 ```
 
 A successful response means Kong is now forwarding requests made to
-`http://localhost:8000` to the `url` we configured in step #1,
-and is forwarding the response back to us. Kong knows to do this through
+`http://localhost:8000` to the `url` you configured in step #1,
+and is forwarding the response back to you. Kong knows how to do this through
 the header defined in the above cURL request:
 
 <ul>

--- a/app/gateway-oss/2.5.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.5.x/getting-started/enabling-plugins.md
@@ -11,16 +11,16 @@ title: Enabling Plugins
   </ol>
 </div>
 
-In this section, you'll learn how to configure Kong plugins. One of the core
+In this section, you're going to learn how to configure Kong plugins. One of the core
 principles of Kong is its extensibility through [plugins][plugins]. Plugins
-allow you to easily add new features to your Service or make it easier to
+allow you to easily add new features to your Service and make it easier to
 manage.
 
-In the steps below, you will configure the [key-auth][key-auth] plugin to add
+In the steps below, you have to configure the [key-auth][key-auth] plugin to add
 authentication to your Service. Prior to the addition of this plugin, **all**
-requests to your Service would be proxied upstream. Once you add and configure this
-plugin, **only** requests with the correct key(s) will be proxied - all
-other requests will be rejected by Kong, thus protecting your upstream service
+requests to your Service is going to be proxied upstream. Once you add and configure this
+plugin, **only** requests with the correct key(s) are proxied. All
+other requests are rejected by Kong to protect your upstream service
 from unauthorized use.
 
 
@@ -42,7 +42,7 @@ are supported) that are supposed to contain the apikey during a request.
 ## 2. Verify that the plugin is properly configured
 
 Issue the following cURL request to verify that the [key-auth][key-auth]
-plugin was properly configured on the Service:
+plugin is properly configured on the Service:
 
 ```bash
 $ curl -i -X GET \
@@ -51,7 +51,7 @@ $ curl -i -X GET \
 ```
 
 Since you did not specify the required `apikey` header or parameter, the
-response should be `401 Unauthorized`:
+response shall be `401 Unauthorized`:
 
 ```http
 HTTP/1.1 401 Unauthorized
@@ -65,7 +65,7 @@ HTTP/1.1 401 Unauthorized
 ## Next Steps
 
 Now that you've configured the **key-auth** plugin lets learn how to add
-consumers to your Service so we can continue proxying requests through Kong.
+consumers to your Service so that you can continue proxying requests through Kong.
 
 Go to [Adding Consumers &rsaquo;][adding-consumers]
 

--- a/app/gateway-oss/2.5.x/getting-started/enabling-plugins.md
+++ b/app/gateway-oss/2.5.x/getting-started/enabling-plugins.md
@@ -11,7 +11,7 @@ title: Enabling Plugins
   </ol>
 </div>
 
-In this section, you're going to learn how to configure Kong plugins. One of the core
+In this section, you'll learn how to configure Kong plugins. One of the core
 principles of Kong is its extensibility through [plugins][plugins]. Plugins
 allow you to easily add new features to your Service and make it easier to
 manage.
@@ -45,13 +45,13 @@ Issue the following cURL request to verify that the [key-auth][key-auth]
 plugin is properly configured on the Service:
 
 ```bash
-$ curl -i -X GET \
+curl -i -X GET \
   --url http://localhost:8000/ \
   --header 'Host: example.com'
 ```
 
 Since you did not specify the required `apikey` header or parameter, the
-response shall be `401 Unauthorized`:
+response should be `401 Unauthorized`:
 
 ```http
 HTTP/1.1 401 Unauthorized

--- a/app/gateway-oss/2.5.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.5.x/getting-started/quickstart.md
@@ -7,7 +7,7 @@ title: Start Kong Gateway (OSS)
   <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
-In this section, you're going to learn how to manage your Kong instance. First, you
+In this section, you'll learn how to manage your Kong instance. First, you
 have to start Kong in order to give yourself access to the RESTful Admin
 interface, through which you manage your Services, Routes, Consumers, and more. Data that you send through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
 supports PostgreSQL and Cassandra).
@@ -21,7 +21,7 @@ migrations:
 $ kong migrations bootstrap [-c /path/to/kong.conf]
 ```
 
-You can see a message that tells you Kong has successfully migrated your
+You should see a message that tells you Kong has successfully migrated your
 database. If not, you probably incorrectly configured your database
 connection settings in your configuration file.
 
@@ -36,7 +36,7 @@ allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
-If everything goes well, you can see a message (`Kong started`)
+If everything goes well, you should see a message (`Kong started`)
 informing you that Kong is running.
 
 By default, Kong listens on the following ports:

--- a/app/gateway-oss/2.5.x/getting-started/quickstart.md
+++ b/app/gateway-oss/2.5.x/getting-started/quickstart.md
@@ -7,10 +7,9 @@ title: Start Kong Gateway (OSS)
   <a href="https://konghq.com/install/#kong-community">installed Kong</a> &mdash; It should only take a minute!
 </div>
 
-In this section, you'll learn how to manage your Kong instance. First, we'll
-have you start Kong in order to give you access to the RESTful Admin
-interface, through which you manage your Services, Routes, Consumers, and more. Data sent
-through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
+In this section, you're going to learn how to manage your Kong instance. First, you
+have to start Kong in order to give yourself access to the RESTful Admin
+interface, through which you manage your Services, Routes, Consumers, and more. Data that you send through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
 supports PostgreSQL and Cassandra).
 
 ## 1. Start Kong Gateway
@@ -22,7 +21,7 @@ migrations:
 $ kong migrations bootstrap [-c /path/to/kong.conf]
 ```
 
-You should see a message that tells you Kong has successfully migrated your
+You can see a message that tells you Kong has successfully migrated your
 database. If not, you probably incorrectly configured your database
 connection settings in your configuration file.
 
@@ -37,7 +36,7 @@ allowing you to point to [your own configuration][configuration-loading].
 
 ## 2. Verify that Kong has started successfully
 
-If everything went well, you should see a message (`Kong started`)
+If everything goes well, you can see a message (`Kong started`)
 informing you that Kong is running.
 
 By default, Kong listens on the following ports:


### PR DESCRIPTION
### Summary
This PR tries to incline the Kong Gateway QuickStart guide as per the latest Kong Style document.

### Reason
To resolve the issue - https://github.com/Kong/docs.konghq.com/issues/3205

### Testing
The page previews look good

### Preview
https://deploy-preview-3270--kongdocs.netlify.app/gateway-oss/2.5.x/getting-started/quickstart/
https://deploy-preview-3270--kongdocs.netlify.app/gateway-oss/2.5.x/getting-started/configuring-a-service/
https://deploy-preview-3270--kongdocs.netlify.app/gateway-oss/2.5.x/getting-started/configuring-a-grpc-service/
https://deploy-preview-3270--kongdocs.netlify.app/gateway-oss/2.5.x/getting-started/enabling-plugins/
https://deploy-preview-3270--kongdocs.netlify.app/gateway-oss/2.5.x/getting-started/adding-consumers/