### PR TITLE
chore(*) styles and auto generated for 2.6

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1546,6 +1546,24 @@ Generic Styling for Desktop
         background-color: #e23b3b;
       }
     }
+
+    &.head {
+      border-color: #f28bc7;
+
+      &:before {
+        content: "HEAD";
+        background-color: #e32391;
+      }
+    }
+
+    &.options {
+      border-color: #9fe0d6;
+
+      &:before {
+        content: "OPTIONS";
+        background-color: #3fb4a2;
+      }
+    }
   }
 
   @media (max-width: 1200px) {

--- a/app/_data/docs_nav_ce_2.6.x.yml
+++ b/app/_data/docs_nav_ce_2.6.x.yml
@@ -220,6 +220,12 @@
         - text: Retrieve Node Information
           url: /admin-api/#retrieve-node-information
 
+        - text: Check Endpoint Or Entity Existence
+          url: /admin-api/#check-endpoint-or-entity-existence
+
+        - text: List Http Methods by Endpoint
+          url: /admin-api/#list-http-methods-by-endpoint
+
         - text: List Available Endpoints
           url: /admin-api/#list-available-endpoints
 

--- a/app/gateway-oss/2.6.x/admin-api.md
+++ b/app/gateway-oss/2.6.x/admin-api.md
@@ -816,6 +816,52 @@ HTTP 200 OK
 
 ---
 
+### Check Endpoint Or Entity Existence
+{:.badge .dbless}
+
+Similar to `HTTP GET`, but does not return the body. Returns `HTTP 200` when the endpoint exits or `HTTP 404` when it does not. Other status codes are possible.
+
+<div class="endpoint head">/&lt;any-endpoint&gt;</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```http
+Access-Control-Allow-Origin: *
+Content-Length: 11389
+Content-Type: application/json; charset=utf-8
+X-Kong-Admin-Latency: 1
+```
+
+
+---
+
+### List Http Methods by Endpoint
+{:.badge .dbless}
+
+List all the supported `HTTP` methods by an endpoint. This can also be used with a `CORS` preflight request.
+
+<div class="endpoint options">/&lt;any-endpoint&gt;</div>
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+```http
+Access-Control-Allow-Headers: Content-Type
+Access-Control-Allow-Methods: GET, HEAD, OPTIONS
+Access-Control-Allow-Origin: *
+Allow: GET, HEAD, OPTIONS
+```
+
+
+---
+
 ### List Available Endpoints
 {:.badge .dbless}
 


### PR DESCRIPTION
### Summary

This is related to:
https://github.com/Kong/kong/pull/7895

This PR adds latest auto-generated docs including the change PR above made proposes. It also updates `page.less` to include `HTTP OPTIONS` and `HTTP HEAD` methods, and adds styles for them.