### PR TITLE
Cont Guidelines - Hackathon: rm Issue assignment

### DIFF
--- a/app/contributing/community.md
+++ b/app/contributing/community.md
@@ -33,7 +33,7 @@ From here, determine which applies to you:
 
 Great! Let's first check to see if someone had the same idea as you. Go to [Issues](https://github.com/Kong/docs.konghq.com/issues) and read through the titles to see if something sounds similar to what you want to contribute or fix. 
 
-If you find an Issue that aligns with what you want to contribute, go ahead and assign it to yourself in the right-side column and add a comment stating that you're going to be working on this task. Then, head to [Make your contribution](#make-your-contribution). 
+If you find an Issue that aligns with what you want to contribute, go ahead and add a comment stating that you're going to be working on this task. We don't assign Issues. Then, head to [Make your contribution](#make-your-contribution). 
 
 If you don't find an Issue that aligns with what you want to contribute, there's no need to open one up. Instead, go to [Make your contribution](#make-your-contribution). 
 


### PR DESCRIPTION
Given discussion with the Insomnia team regarding their Issue process, it would be in our (and the community's) best interest to stop assigning Issues to individual contributors (outside of the Kong org). 

### Reasons
* It puts pressure on a single individual to commit to that Issue even if they find it too complex after they start working on it
* It creates potential conflict between contributors vying to work on the same task
* It increases overhead for repo maintainers, who have to keep an eye on whether or not a PR is raised by a specific contributor for that specific Issue originally assigned to them
* Individuals outside of the Kong org also do not have the ability to assign Issues to themselves, so it puts onus on us to go through each Issue and assign it as comments appear