### PR TITLE
[DOCU-1699] List styling improvements

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -840,7 +840,7 @@
       padding: 7px 0 15px 35px;
 
       &:last-child {
-        padding-bottom: 15px;
+        padding-bottom: 5px;
       }
 
       &:before {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -97,7 +97,8 @@
 #documentation {
   .content {
     ol {
-      padding-left: 2rem;
+      padding-left: 1rem;
+      padding-top: 1rem;
       counter-reset: base;
 
       li {
@@ -113,28 +114,29 @@
       font-size: 13px;
     }
 
-    ul {
+    ol, ul {
       // avoid nested lists and lists elements to have smaller and smaller
       // font sizes
       font-size: inherit;
-      margin-left: 0.5rem;
+      margin-left: 0.7rem;
       list-style: none;
 
       li {
         // avoid ridiculously big spaces between lists elements
-        margin-bottom: 0.2rem;
+        margin-bottom: 0.1rem;
         list-style-type: disc;
 
         p {
-          font-size: inherit;
+          // font-size: inherit;
+          margin-bottom: 1.2rem;
         }
       }
 
-      ul {
+      ol, ul {
         // avoid nested lists to have too much margin
         margin-left: 1.3rem;
-        margin-top: 0.3rem;
-        margin-bottom: 0.3rem;
+        margin-top: 0.7rem;
+        margin-bottom: 0.7rem;
       }
     }
 


### PR DESCRIPTION
### Summary
* Nested ordered lists no longer get smaller and smaller
* Adjusted margins on list items and shrunk the massive margins at the ends of lists

### Reason
Really awkward list styling, for example:
![Screen Shot 2021-08-11 at 11 20 28 AM](https://user-images.githubusercontent.com/54370747/135172951-2696308d-a412-494f-8d89-e77d3e609014.png)

### Testing
Compare the [old nested list styling](https://docs.konghq.com/konnect/org-management/okta-idp/) with [adjusted styling](https://deploy-preview-3280--kongdocs.netlify.app/konnect/org-management/okta-idp/).
