### PR TITLE
[DOCU-1714] Guidelines for using includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@
 
 # KONG's Documentation Website
 
-This repository contains the source content and code for [Kong](https://github.com/Kong/kong)'s documentation website. It's built using [Jekyll](https://jekyllrb.com/) and deployed with [Netlify](https://www.netlify.com/). 
+This repository contains the source content and code for [Kong](https://github.com/Kong/kong)'s documentation website. It's built using [Jekyll](https://jekyllrb.com/) and deployed with [Netlify](https://www.netlify.com/).
 
 Here are some things to know before you get started:
 
 * **We're beginner-friendly**. Whether you're a Technical Writer learning about docs-as-code or an engineer practicing your documentation skills, we welcome your involvement. If you'd like to contribute and don't have something in mind already, head on over to [Issues](https://github.com/Kong/docs.konghq.com/issues). We've added `good first issue` labels on beginner-friendly issues.
 
-* **We need more help in some areas**. We'd especially love some help with [plugin](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub) documentation. 
+* **We need more help in some areas**. We'd especially love some help with [plugin](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub) documentation.
 
-* **Some of our docs are generated**. 
+* **Some of our docs are generated**.
     * [Admin API](https://docs.konghq.com/gateway-oss/)
     * [Configuration reference](https://docs.konghq.com/gateway-oss/latest/configuration/)
     * [CLI reference](https://docs.konghq.com/gateway-oss/latest/cli/)
-    * [Upgrade guide](https://docs.konghq.com/gateway-oss/latest/upgrading/) 
+    * [Upgrade guide](https://docs.konghq.com/gateway-oss/latest/upgrading/)
 
 All pull requests for these docs should be opened on the [Kong/kong](https://github.com/Kong/kong) repository.
 
-For [Gateway Enterprise configuration reference](https://docs.konghq.com/enterprise/latest/property-reference/) and [PDK reference](https://docs.konghq.com/gateway-oss/latest/pdk/) documentation, open an issue on this repo and we'll update the docs. 
+For [Gateway Enterprise configuration reference](https://docs.konghq.com/enterprise/latest/property-reference/) and [PDK reference](https://docs.konghq.com/gateway-oss/latest/pdk/) documentation, open an issue on this repo and we'll update the docs.
 
 * **Community is a priority for us**. Before submitting an issue or pull request, make sure to review our [Contributing Guide](https://docs.konghq.com/contributing/).
 
@@ -29,7 +29,7 @@ For [Gateway Enterprise configuration reference](https://docs.konghq.com/enterpr
 ## Run local project
 ***
 
-For anything other than minor changes, clone the repository onto your local machine and build locally. 
+For anything other than minor changes, clone the repository onto your local machine and build locally.
 
 ## Run locally with gulp
 ***
@@ -72,7 +72,7 @@ gem install bundler
 npm install
 ```
 
-Run the project: 
+Run the project:
 ```
 npm start
 ```
@@ -82,7 +82,7 @@ npm start
 
 If you have contributed a plugin, you can add a Kong badge to your plugin README.
 
-Use the following, where you replace `test` with your plugin name and `link-to-docs` with a link to the Kong docs for your plugin. 
+Use the following, where you replace `test` with your plugin name and `link-to-docs` with a link to the Kong docs for your plugin.
 
 ```
 [![](https://img.shields.io/badge/Kong-test-blue.svg?colorA=042943&colorB=00C4BB&style=flat&longCache=true&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4xOdTWsmQAAAIcSURBVDhPY2DRdCYb0Vgzh46btlcCmiAEEdDMb+w9a+Xmr99/FHdM49R1R5PFp5nPyHvfifP/weDvv39LNu4SMfdHVoBPs2VY9q4jpx8+ewnRDwRHz13h1veAK8CpmdfQq6xrRt2EeS7xxc9evYVovvf4mbhlIFwNTs1JlV1///4Fajh96UZIbt2nL1+B7B8/fznGFsDVYNcsYRX04jXUtn///m3ae7SgZcrnr9/aZixBDjYsmnn0Pe2j85++fAPRDAR///6btGitWXAGu7Yrskp0zaLmAWt2HLxy+35UUcvHzyCnQsCv37/zWiaxabkgK0ZoFrMIMA3OOH/t9j+w6j3HzmbW9wE9CeaBwJdv30PyGuDqgQiqWdDU9/TlG99//IQqBHt1wbodjZMX/PnzByr0///rdx+sI3JQNAMT4ML1O6HySOD3nz+FbVOBUsAUAhUCx5aqawxCc2HbFKA9UEmwHqATgOjdx092UXmCJr57j5+DyoHBqUs3RC0CoJqRXfv795/sxol+GVVA5JJQzK3vCVQgZx92+eY9qApI5O07BtUMFQODGcs3RRY1v3zzHug9IJq4cA3QU0A1+r7JT168hir6/x/IZtVyQdF85spNYGYAOunh0xcQEWAM5TRNBKoBIo/ksi9fv0PEgdEJFAFpvnbnARBduH4Hnm+BKQkiCETAMGfTBkWviJn/3mNnIYKp1d1QzWQiTWcA1wsS5+E9q+MAAAAASUVORK5CYII=)](link-to-docs)
@@ -90,7 +90,7 @@ Use the following, where you replace `test` with your plugin name and `link-to-d
 
 Here's how the badge looks: [![](https://img.shields.io/badge/Kong-test-blue.svg?colorA=042943&colorB=00C4BB&style=flat&longCache=true&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4xOdTWsmQAAAIcSURBVDhPY2DRdCYb0Vgzh46btlcCmiAEEdDMb+w9a+Xmr99/FHdM49R1R5PFp5nPyHvfifP/weDvv39LNu4SMfdHVoBPs2VY9q4jpx8+ewnRDwRHz13h1veAK8CpmdfQq6xrRt2EeS7xxc9evYVovvf4mbhlIFwNTs1JlV1///4Fajh96UZIbt2nL1+B7B8/fznGFsDVYNcsYRX04jXUtn///m3ae7SgZcrnr9/aZixBDjYsmnn0Pe2j85++fAPRDAR///6btGitWXAGu7Yrskp0zaLmAWt2HLxy+35UUcvHzyCnQsCv37/zWiaxabkgK0ZoFrMIMA3OOH/t9j+w6j3HzmbW9wE9CeaBwJdv30PyGuDqgQiqWdDU9/TlG99//IQqBHt1wbodjZMX/PnzByr0///rdx+sI3JQNAMT4ML1O6HySOD3nz+FbVOBUsAUAhUCx5aqawxCc2HbFKA9UEmwHqATgOjdx092UXmCJr57j5+DyoHBqUs3RC0CoJqRXfv795/sxol+GVVA5JJQzK3vCVQgZx92+eY9qApI5O07BtUMFQODGcs3RRY1v3zzHug9IJq4cA3QU0A1+r7JT168hir6/x/IZtVyQdF85spNYGYAOunh0xcQEWAM5TRNBKoBIo/ksi9fv0PEgdEJFAFpvnbnARBduH4Hnm+BKQkiCETAMGfTBkWviJn/3mNnIYKp1d1QzWQiTWcA1wsS5+E9q+MAAAAASUVORK5CYII=)](link-to-docs)
 
-See [Issue #908](https://github.com/Kong/docs.konghq.com/issues/908) for more information. Note that we're not currently hosting assets for badges. 
+See [Issue #908](https://github.com/Kong/docs.konghq.com/issues/908) for more information. Note that we're not currently hosting assets for badges.
 
 ## Generate the PDK, Admin API, CLI, and Configuration documentation
 ***
@@ -163,7 +163,9 @@ We run various quality checks at build time to ensure that the documentation is 
 
 The `include-check.sh` script checks for any files in the `app/_includes` folder that depend on a `page.*` variable (e.g. `page.url`). This is not compatible with the `include_cached` gem that we use, and so using `page.*` in an include will fail the build.
 
-> To run the script locally, open a terminal and run `./include-check.sh` whilst in the documentation folder. If there is no output, everything is successful
+> To run the script locally, open a terminal, navigate to the documentation
+folder, and run `./include-check.sh`. If there is no output, everything is
+successful.
 
 In the following example, we can see that `deployment-options-k8s.md` uses a `page.*` variable, and that the include is used in the `kong-for-kubernetes.md` file:
 
@@ -208,3 +210,6 @@ This is an include that uses {{ include.url }}
 ```
 
 The `include_cached` gem uses all passed parameters as the cache lookup key, and this ensures that all required permutations of an include file will be generated.
+
+For guidelines on how to write includes and call them in target topics, see the
+[Kong Docs contributing guidelines](https://docs.konghq.com/contributing/includes). 

--- a/app/_data/docs_nav_contributing.yml
+++ b/app/_data/docs_nav_contributing.yml
@@ -11,6 +11,8 @@
   icon: /assets/images/icons/documentation/icn-references-color.svg
   url: /markdown-rules
   items:
+    - text: Reusable content
+      url: /includes
     - text: Variables
       url: /variables
 

--- a/app/_includes/md/README.md
+++ b/app/_includes/md/README.md
@@ -13,3 +13,8 @@ Examples:
 
 - Content for current version continues to live at the root of the product directory
 - Versioned content (for non-current versions only!) lives in a sub-directory named <version_number>
+
+## Learn how to use includes
+
+For guidelines on how to write includes and call them in target topics, see the
+[Kong Docs contributing guidelines](https://docs.konghq.com/contributing/includes). 

--- a/app/contributing/includes.md
+++ b/app/contributing/includes.md
@@ -1,0 +1,110 @@
+---
+title: Reusable content
+no_version: true
+---
+
+In Jekyll, reusable content is managed using [`include`](https://jekyllrb.com/docs/includes/)
+snippets, which are located in the [`/app/_includes`](https://github.com/Kong/docs.konghq.com/tree/main/app/_includes)
+folder. Use `includes` to reuse snippets of the same content across multiple
+pages.
+
+The examples in this topic reference a [short `include` file with a snippet about installation](https://github.com/Kong/docs.konghq.com/blob/main/app/_includes/md/enterprise/install.md).
+
+Snippets from that `include` file are called with an `include` tag in a few
+target files, such as the
+[Docker installation guide](https://github.com/Kong/docs.konghq.com/blob/main/app/enterprise/2.5.x/deployment/installation/docker.md).
+
+## Create an include
+
+### File formats and directories
+
+Add a Markdown (`.md`) or HTML (`.html`) file to the [`/app/_includes`](https://github.com/Kong/docs.konghq.com/tree/main/app/_includes) directory at the root of the `Kong/docs.konghq.com` repository.
+
+* Markdown `includes` contain snippets of documentation content, for example, common installation steps.
+* HTML `includes` contain pieces of website layout and functionality, for
+example, the footer and navbars.
+
+If your Markdown `include` does not need to belong to a particular product version, place it in a product directory. For example:
+
+- `app/_includes/mesh`
+- `app/_includes/plugins-hub`
+
+If the `include` will be used across products, place it directly in of the
+`app/_includes/md/` directory.
+
+{:.note}
+> If you have different versions of the `include` content:
+- Content for current version continues to live at the root of the product directory
+- Versioned content (for non-current versions only!) lives in a sub-directory named {VERSION_NUMBER}
+
+### Markdown comments
+
+At the top of an `include` file, add a Markdown comment to note the instances
+where this `include` is being used. For example:
+
+```md
+<!-- Shared between all Community Linux installation topics: Amazon Linux,
+ CentOS, Debian, RedHat, and Ubuntu -->
+```
+
+### Page variables
+If using page variables inside an `include`, replace `page` in the variable with
+`include`. For example, `page.kong_version` becomes `include.kong_version`.
+
+```
+This is an include that uses {% raw %}{{ include.kong_version }}{% endraw %}.
+```
+
+This is necessary because we use the `jekyll_include_cache` plugin on the docs
+site, and the plugin needs to know that the variable should not be cached.
+
+## Use an include
+
+To add an `include`, use the `include` tag with the following basic syntax:
+
+```
+{% raw %}{% include_cached /md/install.md %}{% endraw %}
+```
+
+* Declare the tag with `include_cached`
+* Add a path relative to the `_includes` directory
+
+Depending on the content of the snippet, you can pass various parameters to the `include` tag. If the `include` content has a variable anywhere in the text, map it to the [page variable](#page-variables):
+
+```
+{% raw %}{% include_cached /md/install.md kong_version=page.kong_version %}{% endraw %}
+```
+
+This maps `page.kong_version` to the `include.kong_version` from the source include file.
+
+
+### Conditional content
+
+You can add `if` statements to an `include` to create
+variations of the content for use in different contexts. For example, in an
+file named `install.md`, you might have a snippet where the instructions are
+specific to Docker:
+
+```liquid
+{% raw %}{% if include.install == "docker" %}{% endraw %}
+your docker content goes here
+{% raw %}{% endif %}{% endraw %}
+```
+
+In the target file (the file where you want the content to display), call the
+Docker section of the `include`:
+
+```
+{% raw %}{% include_cached /md/install.md install='docker' %}{% endraw %}
+```
+
+{:.important}
+> The syntax for the if statement and the `include` is not the same.
+* When creating an if statement condition based on a string, the string must be
+enclosed in double quotes (`" "`) and use two equals signs: `if include.install == "docker"`
+* When calling the section in an `include_cached` tag, use single quotes (`' '`) and one equals sign: `install='docker'`
+
+
+## include-check script
+
+The Kong docs site runs an `include` check script on every change pushed to the repository. If you run into issues with an `include`, the check will flag them. See more info about the `include` check in our repository [README](https://github.com/Kong/docs.konghq.com/#include-check).


### PR DESCRIPTION
### Summary
Adding guidelines for using includes to the contributing guide, and adding links to the new instructions from both the site and include directory READMEs.

### Reason
Why the contributing guide and not something internal? Because there's no reason to hide these instructions, and if anyone runs into issues, we can send them a link to the guide.

### Testing
https://deploy-preview-3285--kongdocs.netlify.app/contributing/includes/