### PR TITLE
Minor correction to name of Lua phase

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -123,7 +123,7 @@ requested **Route** or **Service**.
 
 
 ### Client Certificate request
-Client certificates are requested in the `ssl_certifica_by_lua` phase where Kong does not
+Client certificates are requested in the `ssl_certificate_by_lua` phase where Kong does not
 have access to `route` and `workspace` information. Due to this information gap, Kong will ask for
 the client certificate on every handshake if the `mtls-auth` plugin is configured on any Route or Service.
 In most cases, the failure of the client to present a client certificate is not going to affect subsequent


### PR DESCRIPTION
Correcting "ssl_certifica_by_lua" to "ssl_certificate_by_lua" to correctly name the phase used in the Client Certificate request.

### Summary
Typo of "ssl_certifica_by_lua" needed to be corrected to "ssl_certificate_by_lua".

### Reason
There was a typo that needed correcting.

### Testing
Nothing to test.
