### PR TITLE
[DOCU-1877] Konnect Dev Portal: add Customization Overview

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -122,6 +122,8 @@
           url: /dev-portal/applications/dev-gen-creds
     - text: Customization
       items:
+        - text: Customization Overview
+          url: /dev-portal/customization/customization-overview
         - text: Public Portal
           url: /dev-portal/customization/public-portal
 

--- a/app/konnect/dev-portal/customization/customization-overview.md
+++ b/app/konnect/dev-portal/customization/customization-overview.md
@@ -1,0 +1,15 @@
+---
+title: Customization Overview
+no_version: true
+---
+
+The Dev Portal can be customized by those with Admin roles via the Appearance settings in {{site.konnect_short_name}}. To access the Appearance settings, click **Dev Portal** then **Appearance**.
+
+Here, you will have the ability to modify the following:
+* Logos: default logo and fav icon
+* Themes
+* Colors: background, text, and button colors
+* Fonts
+
+{:.note}
+> **Note**: To learn how to make your Portal public, see [Enable Public Dev Portal](/konnect/dev-portal/customization/public-portal). To customize your Portal URL, reach out to [Kong Support](https://support.konghq.com/).

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -7,20 +7,7 @@ toc: false
 The Dev Portal is an API Catalog that allows Admin roles to
 document and manage Application registration for your Services. Admin roles publish Services through Konnect, and Developers use those Services.
 
-The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](/konnect/dev-portal/developers/dev-reg/). 
-
-## Customize the Dev Portal appearance
-
-The Dev Portal can be customized by those with Admin roles via the Appearance settings in {{site.konnect_short_name}}. To access the Appearance settings, click **Dev Portal** then **Appearance**.
-
-Here, you will have the ability to modify the following:
-* Logos: default logo and fav icon
-* Themes
-* Colors: background, text, and button colors
-* Fonts
-
-{:.note}
-> **Note**: To learn how to make your Portal public, see [Enable Public Dev Portal](/konnect/dev-portal/administrators/public-portal). To customize your Portal URL, reach out to [Kong Support](https://support.konghq.com/). 
+The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](/konnect/dev-portal/developers/dev-reg/).
 
 ## See also
 


### PR DESCRIPTION
### Summary

Move customization content from entry file to Customization Overview. 

### Reason

Part of the Konnect Dev Portal (cloud) docs reorg to increase usability. 

### Testing

https://deploy-preview-3289--kongdocs.netlify.app/konnect/dev-portal/customization/customization-overview/
