### PR TITLE
Remove hackathon banner

### DIFF
--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -113,36 +113,38 @@ body {
         margin-top: 17.5px;
         background: transparent;
       }
-
-      header.navbar-v2 {
-        transition: transform 0.2s ease-in-out;
-        will-change: transform;
-        height: 95px;
-      }
-
-      header.navbar-v2.closed {
-        transition: 0s ease-in-out;
-      }
-
-      header.closed,
-      header.compress {
-        transform: translateY(-35px);
-      }
-      header:not(.closed) ~ .landing-page {
-        margin-top: 35px;
-      }
-      header:not(.closed) ~ div.page {
-        margin-top: 100px;
-      }
+      // uncomment this section when adding a new promo banner
+      // also uncomment the promo banner sections in /app/_includes/nav-v2.html and gulpfile.js
+      // header.navbar-v2 {
+      //   transition: transform 0.2s ease-in-out;
+      //   will-change: transform;
+      //   height: 95px;
+      // }
+      //
+      // header.navbar-v2.closed {
+      //   transition: 0s ease-in-out;
+      // }
+      //
+      // header.closed,
+      // header.compress {
+      //   transform: translateY(-35px);
+      // }
+      //
+      // header:not(.closed) ~ .landing-page {
+      //   margin-top: 35px;
+      // }
+      // header:not(.closed) ~ div.page {
+      //   margin-top: 100px;
+      // }
     }
   }
 }
 
-// Add maring to page while cookie policy is open
+// Add margin to page while cookie policy is open
 // .page.page-cookie-policy{
 //   // NOTE: Commenting out until summit banner is removed
-//   // margin-top: 50px;
-//   margin-top: 150px;
+//   margin-top: 50px;
+//   // margin-top: 150px;
 //   @media screen and (max-width: 1100px) {
 //     margin-top: 0;
 //   }

--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -139,13 +139,3 @@ body {
     }
   }
 }
-
-// Add margin to page while cookie policy is open
-// .page.page-cookie-policy{
-//   // NOTE: Commenting out until summit banner is removed
-//   margin-top: 50px;
-//   // margin-top: 150px;
-//   @media screen and (max-width: 1100px) {
-//     margin-top: 0;
-//   }
-// }

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -1,11 +1,13 @@
-<header class="navbar-v2">
+<header class="navbar-v2 closed">
   <a class="skip-main" href="#main">Skip to content</a>
-  <div id="promo-banner">
+  <!-- uncomment the promo-banner div when adding a new promo banner
+  <!--also uncomment the promo banner sections in app/assets/stylesheets/header.less and gulpfile.js-->
+  <!-- <div id="promo-banner">
     <div class="container">
       <div class="closebanner"></div> <strong><label>EVENT</label> Join the Kong Summit Hackathon &nbsp;&mdash;<a target="_blank"
           href="https://konghq.com/summit-hackathon">Start Hacking &rarr;</a></strong>
     </div>
-  </div>
+  </div> -->
   <div class="navbar-content">
     <a href="https://konghq.com" class="navbar-brand col col-xl-auto">
       <img src="/assets/images/logos/kong-logo-blue.svg" alt="Kong Logo" id="kong-logo">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,9 @@ var sources = {
     paths.assets + "javascripts/subscribe.js",
     paths.assets + "javascripts/editable-code-snippet.js",
     paths.assets + "javascripts/navbar.js",
-    paths.assets + "javascripts/promo-banner.js",
+    // uncomment the path to promo-banner.js when adding a new promo banner
+    // also uncomment the promo banner sections in app/_assets/stylesheets/header.less and /app/_includes/nav-v2.html -->
+    // paths.assets + "javascripts/promo-banner.js",
     paths.assets + "javascripts/copy-code-snippet-support.js"
   ],
   images: paths.assets + "images/**/*",

--- a/spec/home_spec.rb
+++ b/spec/home_spec.rb
@@ -4,8 +4,9 @@ describe "homepage", type: :feature, js: true do
     expect(find(".landing-page h1").text).to eq("Welcome to Kong Docs")
   end
 
-  it "shows the blue promo banner", js: true do
-    visit "/"
-    expect(page).to have_selector("#promo-banner", visible: true)
-  end
+  # Test commented out while the promo banner is inactive
+  # it "shows the blue promo banner", js: true do
+  #   visit "/"
+  #   expect(page).to have_selector("#promo-banner", visible: true)
+  # end
 end


### PR DESCRIPTION
### Summary
Commenting out promo banner components to remove the Hackathon banner from the doc site.

Also removing the cookie policy margin section of `header.less`; the section has been commented out for the past two years and the navbar has long since been redesigned to account for the cookie policy.

To do: add info on how to edit the promo banner to our team Confluence.

### Reason
Hackthon is over, we don't currently need any banner.

### Testing
Tested locally.

Make sure to test a variety of pages in the preview: plugin hub, landing page, content pages; also test scrolling down the page and resizing down to mobile.

https://deploy-preview-3290--kongdocs.netlify.app/
https://deploy-preview-3290--kongdocs.netlify.app/hub
