### PR TITLE
Remove "alpha" note for Database Encryption & Keyring Management Section

### DIFF
--- a/app/enterprise/2.5.x/property-reference.md
+++ b/app/enterprise/2.5.x/property-reference.md
@@ -3376,9 +3376,7 @@ documentation site.
 Encrypted data is transparently decrypted before being displayed to the Admin
 API or made available to plugins or core routing logic.
 
-Do note that this feature is currently alpha quality. It is strongly
-recommended that this not be enabled on production clusters. No guarantees about
-forward- compatability or stability are provided with this, and mis-management
+No guarantees about forward-compatability or stability are provided with this, and mis-management
 of keyring data will result in irrecoverable data loss.
 
 ---


### PR DESCRIPTION
Removed statement of it being "alpha quality" as this feature has been in since 1.3.0.1 and is production-ready according to sources found by other CREs. Left the note for now on no guarantees of forward-compatibility and the warning around possibly irrevocable data loss if mismanaged.

### Summary
There have been a few support cases filed due to the statement around the keyring and database encryption being in an "alpha state" and "not recommended for production". I believe this statement was true in the 1.x series but no longer applies to current versions according to various sources found by other CREs. The feature is indeed production ready (and if it truly weren't then we need to add a warning to the actual Keyring functionality page too) and users should not be discouraged to deploy in production instances.

### Reason
Prevent unnecessary support cases and confusion with customers. This change may need to be made as far back as 2.0, but I'm unclear on when exactly we considered it no longer alpha and instead production quality, so I wanted to only make it in the latest version for now.

### Testing
No testing needed, but perhaps it may be wise to get a more official statement on this from Engineering? 
