### PR TITLE
[DOCU-1885] Clean up decK getting started guide

### DIFF
--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with decK
+title: Get Started with decK
 ---
 
 Once you have [installed](/deck/{{page.kong_version}}/installation) decK, use this guide to get started with it.

--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -203,7 +203,7 @@ plugins:
 
 ## diff and sync the configuration to Kong Gateway
 
-1. Perform a diff:
+1. Run the diff command:
 
     ```shell
     deck diff

--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -5,7 +5,7 @@ title: Getting Started with decK
 Once you've [installed](/deck/{{page.kong_version}}/installation) decK, use this guide to get started with it.
 
 You can find help in the terminal for any command using the `-help`
-flag, or see the [CLI reference](/deck/{{page.kong_version}}/reference/deck)
+flag, or see the [CLI reference](/deck/{{page.kong_version}}/reference/deck).
 
 ## Install Kong Gateway
 
@@ -23,7 +23,7 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 1. Create a service:
 
     ```shell
-    $ curl -s -XPOST http://localhost:8001/services -d 'name=foo' -d 'url=http://example.com' | jq
+    $ curl -s -X POST http://localhost:8001/services -d 'name=foo' -d 'url=http://example.com' | jq
     {
       "host": "example.com",
       "created_at": 1573161698,
@@ -101,13 +101,26 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 
 ## Export the configuration
 
-1. Export {{site.base_gateway}}'s configuration:
+1. Check that decK recognizes your {{site.base_gateway}} installation:
+
+    ```sh
+    deck konnect ping
+    ```
+
+    If the connection is successful, the terminal displays your gateway version:
+
+    ```sh
+    Successfully connected to Kong!
+    Kong version:  2.5.1
+    ```
+
+2. Export {{site.base_gateway}}'s configuration:
 
     ```shell
     deck dump
     ```
 
-2. Open the generated `kong.yaml` file. If you're using the sample
+3. Open the generated `kong.yaml` file. If you're using the sample
 configuration in this guide, the file should look like this:
 
     ```yaml
@@ -190,7 +203,7 @@ plugins:
 
 ## diff and sync the configuration to Kong Gateway
 
-1. Let's perform a diff:
+1. Perform a diff:
 
     ```shell
     deck diff
@@ -210,7 +223,7 @@ plugins:
     curl -i -X GET http://localhost:8001/services
     ```
 
-4. You can also run the diff command, which should report no changes:
+4. Run the diff command again, which should report no changes:
 
     ```sh
     deck diff
@@ -221,7 +234,7 @@ plugins:
 1. Create a consumer in {{site.base_gateway}}:
 
     ```shell
-    curl -s -XPOST http://localhost:8001/consumers -d 'username=example-consumer' | jq
+    curl -s -X POST http://localhost:8001/consumers -d 'username=example-consumer' | jq
     ```
 
     Response:

--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -2,9 +2,9 @@
 title: Getting Started with decK
 ---
 
-Once you've [installed](/deck/{{page.kong_version}}/installation) decK, use this guide to get started with it.
+Once you have [installed](/deck/{{page.kong_version}}/installation) decK, use this guide to get started with it.
 
-You can find help in the terminal for any command using the `-help`
+You can find help in the terminal for any command using the `--help`
 flag, or see the [CLI reference](/deck/{{page.kong_version}}/reference/deck).
 
 ## Install Kong Gateway

--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -2,149 +2,159 @@
 title: Getting Started with decK
 ---
 
-Once you've [installed](/deck/{{page.kong_version}}/installation) decK, let's get started with it.
+Once you've [installed](/deck/{{page.kong_version}}/installation) decK, use this guide to get started with it.
 
-You can find help in the terminal itself for any command using the `-help`
-flag.
+You can find help in the terminal for any command using the `-help`
+flag, or see the [CLI reference](/deck/{{page.kong_version}}/reference/deck)
 
-## Install Kong
+## Install Kong Gateway
 
-Make sure you've Kong installed and have access to Kong's Admin API.
-In this guide, we're assuming that Kong is running at `http://localhost:8001`.
-Please change it to the network address where Kong is running in your case.
+Make sure you have [{{site.base_gateway}} installed](/install) and have access to Kong's [Admin API](/gateway-oss/latest/admin-api).
 
-## Configuring Kong
+This guide assumes that {{site.base_gateway}} is running at `http://localhost:8001`.
+If your URL is different, change the URL to the network address where the gateway is running.
 
-First, make a few calls to configure Kong.
-If you already have Kong configured with the configuration of your choice,
-you can skip this step.
+## Configure Kong Gateway
 
-```shell
-# create a service
-$ curl -s -XPOST http://localhost:8001/services -d 'name=foo' -d 'url=http://example.com' | jq
-{
-  "host": "example.com",
-  "created_at": 1573161698,
-  "connect_timeout": 60000,
-  "id": "9e36a21e-3e92-44e3-8810-4fb8d80d3518",
-  "protocol": "http",
-  "name": "foo",
-  "read_timeout": 60000,
-  "port": 80,
-  "path": null,
-  "updated_at": 1573161698,
-  "retries": 5,
-  "write_timeout": 60000,
-  "tags": null,
-  "client_certificate": null
-}
+First, make a few calls to configure {{site.base_gateway}}.
 
-# create a route associated with the above service
-$ curl -s -XPOST http://localhost:8001/services/foo/routes -d 'name=bar' -d 'paths[]=/bar' | jq
-{
-  "id": "83c2798d-6bd8-4182-a799-2632c9f670a5",
-  "tags": null,
-  "updated_at": 1573161777,
-  "destinations": null,
-  "headers": null,
-  "protocols": [
-    "http",
-    "https"
-  ],
-  "created_at": 1573161777,
-  "snis": null,
-  "service": {
-    "id": "9e36a21e-3e92-44e3-8810-4fb8d80d3518"
-  },
-  "name": "bar",
-  "preserve_host": false,
-  "regex_priority": 0,
-  "strip_path": true,
-  "sources": null,
-  "paths": [
-    "/bar"
-  ],
-  "https_redirect_status_code": 426,
-  "hosts": null,
-  "methods": null
-}
+If you already have {{site.base_gateway}} set up with the configuration of your choice, you can skip to [exporting the configuration](#export-the-configuration).
 
-# create a global plugin
+1. Create a service:
 
-$ curl -s -XPOST http://localhost:8001/plugins -d 'name=prometheus' | jq
-{
-    "config": {},
-    "consumer": null,
-    "created_at": 1573161872,
-    "enabled": true,
-    "id": "fba8015e-97d0-45ef-9f27-0ad76fef68c8",
-    "name": "prometheus",
-    "protocols": [
-        "grpc",
-        "grpcs",
+    ```shell
+    $ curl -s -XPOST http://localhost:8001/services -d 'name=foo' -d 'url=http://example.com' | jq
+    {
+      "host": "example.com",
+      "created_at": 1573161698,
+      "connect_timeout": 60000,
+      "id": "9e36a21e-3e92-44e3-8810-4fb8d80d3518",
+      "protocol": "http",
+      "name": "foo",
+      "read_timeout": 60000,
+      "port": 80,
+      "path": null,
+      "updated_at": 1573161698,
+      "retries": 5,
+      "write_timeout": 60000,
+      "tags": null,
+      "client_certificate": null
+    }
+    ```
+
+2. Create a route associated with the service:
+
+    ```sh
+    $ curl -s -XPOST http://localhost:8001/services/foo/routes -d 'name=bar' -d 'paths[]=/bar' | jq
+    {
+      "id": "83c2798d-6bd8-4182-a799-2632c9f670a5",
+      "tags": null,
+      "updated_at": 1573161777,
+      "destinations": null,
+      "headers": null,
+      "protocols": [
         "http",
         "https"
-    ],
-    "route": null,
-    "run_on": "first",
-    "service": null,
-    "tags": null
-}
-```
+      ],
+      "created_at": 1573161777,
+      "snis": null,
+      "service": {
+        "id": "9e36a21e-3e92-44e3-8810-4fb8d80d3518"
+      },
+      "name": "bar",
+      "preserve_host": false,
+      "regex_priority": 0,
+      "strip_path": true,
+      "sources": null,
+      "paths": [
+        "/bar"
+      ],
+      "https_redirect_status_code": 426,
+      "hosts": null,
+      "methods": null
+    }
+    ```
+
+3. Create a global plugin:
+
+    ```sh
+    $ curl -s -XPOST http://localhost:8001/plugins -d 'name=prometheus' | jq
+    {
+        "config": {},
+        "consumer": null,
+        "created_at": 1573161872,
+        "enabled": true,
+        "id": "fba8015e-97d0-45ef-9f27-0ad76fef68c8",
+        "name": "prometheus",
+        "protocols": [
+            "grpc",
+            "grpcs",
+            "http",
+            "https"
+        ],
+        "route": null,
+        "run_on": "first",
+        "service": null,
+        "tags": null
+    }
+    ```
 
 ## Export the configuration
 
-Export Kong's configuration:
+1. Export {{site.base_gateway}}'s configuration:
 
-```shell
-$ deck dump
+    ```shell
+    deck dump
+    ```
 
-# look at the kong.yaml file that is generated:
-$ cat kong.yaml
-_format_version: "1.1"
-services:
-- connect_timeout: 60000
-  host: example.com
-  name: foo
-  port: 80
-  protocol: http
-  read_timeout: 60000
-  retries: 5
-  write_timeout: 60000
-  routes:
-  - name: bar
-    paths:
-    - /bar
-    preserve_host: false
-    protocols:
-    - http
-    - https
-    regex_priority: 0
-    strip_path: true
-    https_redirect_status_code: 426
-plugins:
-- name: prometheus
-  enabled: true
-  run_on: first
-  protocols:
-  - grpc
-  - grpcs
-  - http
-  - https
-```
+2. Open the generated `kong.yaml` file. If you're using the sample
+configuration in this guide, the file should look like this:
 
-You've successfully backed up the configuration of your Kong installation.
+    ```yaml
+    _format_version: "1.1"
+    services:
+    - connect_timeout: 60000
+      host: example.com
+      name: foo
+      port: 80
+      protocol: http
+      read_timeout: 60000
+      retries: 5
+      write_timeout: 60000
+      routes:
+      - name: bar
+        paths:
+        - /bar
+        preserve_host: false
+        protocols:
+        - http
+        - https
+        regex_priority: 0
+        strip_path: true
+        https_redirect_status_code: 426
+    plugins:
+    - name: prometheus
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+    ```
+
+You've successfully backed up the configuration of your {{site.base_gateway}} installation.
 
 ## Change the configuration
 
-Let's edit the `kong.yaml` file now. We're going to make the following changes:
+Edit the `kong.yaml` file, making the following changes:
 - Change the `port` of service `foo` to `443`
 - Change the `protocol` of service `foo` to `https`
 - Add another string element `/baz` to the `paths` attribute of route `bar`.
 
-```shell
-# your kong.yaml file should look like:
-$ cat kong.yaml
+Your `kong.yaml` file should now look like this:
+
+```yaml
 _format_version: "1.1"
 services:
 - connect_timeout: 60000
@@ -178,82 +188,119 @@ plugins:
   - https
 ```
 
-## diff and sync the configuration to Kong
+## diff and sync the configuration to Kong Gateway
 
-```shell
-# let's perform a diff
-deck diff
-# you should see decK reporting that the properties you had changed
-# in the file are going to be changed by decK in Kong's database.
+1. Let's perform a diff:
 
-# apply the changes
-deck sync
+    ```shell
+    deck diff
+    ```
+    You should see decK reporting that the properties you had changed
+    in the file are going to be changed by decK in {{site.base_gateway}}'s database.
 
-# curl Kong's Admin API to see the updated route and service in Kong.
+2. Apply the changes:
 
-# you can also run the diff command, which will report no changes
-deck diff
-```
+    ```sh
+    deck sync
+    ```
+
+3. Curl Kong's Admin API to see the updated route and service in {{site.base_gateway}}:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/services
+    ```
+
+4. You can also run the diff command, which should report no changes:
+
+    ```sh
+    deck diff
+    ```
 
 ## Drift detection using decK
 
-Create a consumer in Kong:
+1. Create a consumer in {{site.base_gateway}}:
 
-```shell
-$ curl -s -XPOST http://localhost:8001/consumers -d 'username=dodo' | jq
-{
-  "custom_id": null,
-  "created_at": 1573162649,
-  "id": "ed32faa1-9105-488e-8722-242e9d266717",
-  "tags": null,
-  "username": "dodo"
-}
-```
+    ```shell
+    curl -s -XPOST http://localhost:8001/consumers -d 'username=example-consumer' | jq
+    ```
 
-Note that we have created this consumer in Kong but the consumer doesn't exist
-in the `kong.yaml` file we've saved on disk.
+    Response:
+    ```json
+    {
+      "custom_id": null,
+      "created_at": 1573162649,
+      "id": "ed32faa1-9105-488e-8722-242e9d266717",
+      "tags": null,
+      "username": "example-consumer"
+    }
+    ```
 
-Let's see what decK reports on a diff now:
+    This command creates a consumer in {{site.base_gateway}}, but the consumer doesn't exist in the `kong.yaml` file saved on disk.
 
-```shell
-$ deck diff
-deleting consumer dodo
-```
+2. Check what decK reports on a diff now:
 
-Since the file does not contain the consumer definition, decK reports that
-a `sync` run will delete the consumer from Kong's database.
+    ```shell
+    deck diff
+    ```
 
-Let's go ahead and run the sync process.
+    Response:
+    ```sh
+    deleting consumer example-consumer
+    ```
 
-```shell
-$ deck sync
-```
+    Since the file does not contain the consumer definition, decK reports that
+    a `sync` run will delete the consumer from {{site.base_gateway}}'s database.
 
-Now, looking up the consumer in Kong's database will return a `404`:
+3. Run the sync process:
 
-```shell
-$ curl http://localhost:8001/consumers/dodo
-{"message":"Not found"}
-```
+    ```shell
+    deck sync
+    ```
+
+4. Now, looking up the consumer in {{site.base_gateway}}'s database returns a
+`404`:
+
+    ```shell
+    curl -i -X GET http://localhost:8001/consumers/example-consumer
+    ```
+
+    Response:
+    ```sh
+    HTTP/1.1 404 Not Found
+    Date: Mon, 04 Oct 2021 17:00:50 GMT
+    Content-Type: application/json; charset=utf-8
+    Connection: keep-alive
+    Access-Control-Allow-Origin: *
+    Content-Length: 23
+    X-Kong-Admin-Latency: 2
+    Server: kong/2.5.1
+
+    {"message":"Not found"}
+    ```
 
 This shows how decK can detect changes done directly using Kong's Admin API
 can be detected by decK. You can configure your CI or run a `cronjob` in which
-decK detects if any changes exist in Kong that are not part of your configuration
-file, and alert your teams if such a discrepancy is present.
-
+decK detects if any changes exist in {{site.base_gateway}} that are not part of your configuration file, and alert your teams if such a discrepancy is present.
 
 ## Reset your configuration
 
-Finally, you can reset the configuration of Kong using decK.
-The changes performed by this command are irreversible (unless you've created a
-backup using `deck dump`), so please be careful.
+You can reset the configuration of {{site.kong_gateway}} using decK.
 
+{:.warning}
+> **Warning**: The changes performed by this command are irreversible (unless you've created
+a backup using `deck dump`), so be careful.
 
-```shell
-$ deck reset
+```sh
+deck reset
+```
+
+Response:
+```
 This will delete all configuration from Kong's database.
 > Are you sure? y
 ```
 
-And that's it.
-Start using decK to declaratively configure your Kong installation today!
+## Next steps
+See decK [best practices](/deck/{{page.kong_version}}/guides/best-practices), and check out the individual guides for getting :
+* [Backup and restore of Kong Gateway's configuration](/deck/{{page.kong_version}}/guides/backup-restore)
+* Deduplicate plugin configuration

--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -23,7 +23,7 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 1. Create a service:
 
     ```shell
-    $ curl -s -X POST http://localhost:8001/services -d 'name=foo' -d 'url=http://example.com' | jq
+    curl -s -X POST http://localhost:8001/services -d 'name=foo' -d 'url=http://example.com' | jq
     {
       "host": "example.com",
       "created_at": 1573161698,
@@ -45,7 +45,7 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 2. Create a route associated with the service:
 
     ```sh
-    $ curl -s -XPOST http://localhost:8001/services/foo/routes -d 'name=bar' -d 'paths[]=/bar' | jq
+    curl -s -X POST http://localhost:8001/services/foo/routes -d 'name=bar' -d 'paths[]=/bar' | jq
     {
       "id": "83c2798d-6bd8-4182-a799-2632c9f670a5",
       "tags": null,
@@ -78,7 +78,7 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 3. Create a global plugin:
 
     ```sh
-    $ curl -s -XPOST http://localhost:8001/plugins -d 'name=prometheus' | jq
+    curl -s -X POST http://localhost:8001/plugins -d 'name=prometheus' | jq
     {
         "config": {},
         "consumer": null,


### PR DESCRIPTION
### Summary
* Improving grammar, phrasing, clarity of information, and formatting in decK getting started guide
* Split codeblocks that were just lists of commands into steps that explain what you're doing and why
* Added a couple of commands for better understanding of the process (`deck ping` to check connection, sample curl request to check your config was pushed)

### Reason
Usability. The decK docs have been neglected for a long time, and we have a lot of people using decK.

### Testing
TBA
