### PR TITLE
Adds new v1.4.1 release branch for Kong Mesh

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -529,7 +529,7 @@
   edition: "mesh"
 -
   release: "1.4.x"
-  version: "1.4.0"
+  version: "1.4.1"
   edition: "mesh"
 -
   release: "1.0.x"

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -4,6 +4,16 @@ no_search: true
 no_version: true
 ---
 
+## 1.4.1
+
+> Released on 2021/10/06
+
+### Changes
+
+Built on top of [Kuma 1.3.0](https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#130)
+
+- 
+
 ## 1.4.0
 
 > Released on 2021/08/26


### PR DESCRIPTION
### Reason
Kong Mesh v1.4.1 will be releasing this week and we need a new release branch for that patch release.
### Testing
Will include sample build link when available.