### PR TITLE
[DOCU-1856][DOCU-1893] Accessible badges

### DIFF
--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -1,19 +1,19 @@
 .badge {
   &:after {
-    display: inline-flex;
-    font-weight: 500;
-    font-size: 12px;
-    vertical-align: middle;
-    text-align: center;
-    max-width: 200px;
-    line-height: 14px;
-    height: 14px;
-    width: auto;
-    padding: 3px 10px;
-    font-family: @family-display;
-    border-radius: 10px;
-    margin-left: 7px;
-  }
+      display: inline-flex;
+      font-weight: 500;
+      font-size: 12px;
+      vertical-align: middle;
+      text-align: center;
+      max-width: 200px;
+      line-height: 14px;
+      height: 14px;
+      width: auto;
+      padding: 3px 10px;
+      font-family: @family-display;
+      border-radius: 10px;
+      margin-left: 7px;
+    }
 
   &.plus::after {
       content: "PLUS";
@@ -71,5 +71,12 @@ span.badge {
 
   &:after {
     margin: 2px;
+  }
+}
+
+a.badge {
+  &:hover, &:focus {
+    opacity: 0.7;
+    text-decoration: none;
   }
 }

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -28,7 +28,15 @@
           </ul>
         {% endif %}
 
-        <h1 id="main" tabindex="-1">{{ header_title }}</h1>
+        <h1 id="main" tabindex="-1">{{ header_title }}
+          {% if include.publisher == "Kong Inc." %}
+            {% if include.plus %}
+            <a href="https://konghq.com/pricing" class="badge plus" aria-label="available with plus subscription"></a>
+            {% elsif include.enterprise %}
+            <a href="https://konghq.com/pricing" class="badge enterprise" aria-label="available with enterprise subscription"></a>
+            {% endif %}
+          {% endif %}
+        </h1>
 
         {% if include.header_caption%}
           <p>{{ include.header_caption }}</p>

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -11,7 +11,7 @@ page.kong_latest.release %}
 <div class="page v2 {{ page.class }}" data-url={{ page.url }}>
 
   <div class="container">
-    {% include_cached docs-sidebar.html url=page.url kong_version=page.kong_version edition=page.edition no_version=page.no_version has_version=page.has_version nav_items=page.nav_items edition=page.edition kong_version=page.kong_version kong_latest=page.kong_latest kong_versions=page.kong_versions %}
+    {% include_cached docs-sidebar.html url=page.url kong_version=page.kong_version edition=page.edition no_version=page.no_version has_version=page.has_version nav_items=page.nav_items edition=page.edition kong_version=page.kong_version kong_latest=page.kong_latest kong_versions=page.kong_versions badge=page.badge %}
 
     {% if page.toc == true or page.toc != false and filename != "index.md" and page.is_homepage != true %}
       <aside class="docs-toc">
@@ -102,14 +102,17 @@ page.kong_latest.release %}
             {% endif %}
 
 
-            <h1 tabindex="-1" id="main" class="page-content-title{%
-            if page.badge %} badge{%
-            if page.badge == 'plus' %} plus{% endif %}{%
-            if page.badge == 'enterprise' %} enterprise{% endif %}{%
-            if page.badge == 'oss' %} oss{% endif %}
-            {% endif %}"
-            >{{page.title | flatify }} </h1>
-            {% if page.enterprise %}{% endif %}
+            <h1 tabindex="-1" id="main" class="page-content-title"
+            >{{page.title | flatify }}
+            {% if page.badge %}
+              <a href="https://konghq.com/pricing" {%
+                if page.badge == 'plus' %}class="badge plus" aria-label="available with plus subscription"{% endif %}{%
+                if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with enterprise subscription"{% endif %}{%
+                if page.badge == 'oss' %}class="badge oss" aria-label="open-source only"{% endif %}>
+              </a>
+              {% endif %}
+            </h1>
+
             {% if page.subtitle %}
               <h2 class="page-content-subtitle">{{page.subtitle | flatify }}</h2>
             {% endif %}

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -123,11 +123,11 @@ breadcrumbs:
 
 <div class="page page-extension-profile">
   {% if page.header_icon or page.header_title %}
-    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon header_caption=page.header_caption %}
+    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon header_caption=page.header_caption plus=page.plus enterprise=page.enterprise publisher=page.publisher %}
   {% elsif page.type == concept %}
-    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon header_caption=page.header_caption %}
+    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon header_caption=page.header_caption plus=page.plus enterprise=page.enterprise publisher=page.publisher %}
   {% else %}
-    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon header_caption=page.header_caption %}
+    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon header_caption=page.header_caption plus=page.plus enterprise=page.enterprise publisher=page.publisher %}
   {% endif %}
 
   <div class="container">
@@ -165,10 +165,6 @@ breadcrumbs:
         </div>
       {% endunless %}
     {% endif %}
-      {% if page.enterprise %}
-        <div class="alert alert-ee warning">
-        <strong>{{site.konnect_product_name}} only</strong>: This plugin is only available with a <a href="https://konghq.com/kong-konnect">{{site.konnect_product_name}} subscription</a>. Please inquire about {{site.konnect_product_name}} by <a href="https://konghq.com/request-demo">contacting us</a>.</div>
-      {% endif %}
       {% if page.alpha %}
       <div class="alert alert-ee red condensed margin-bigger">
         <div class="alert-body">

--- a/app/getting-started-guide/2.6.x/dev-portal.md
+++ b/app/getting-started-guide/2.6.x/dev-portal.md
@@ -1,9 +1,7 @@
 ---
 title: Publish, Locate, and Consume Services
+badge: enterprise
 ---
-<div class="alert alert-ee">
-<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This feature is only available with a {{site.konnect_product_name}} subscription.
-</div>
 
 The Kong Developer Portal (Dev Portal) provides a single source of truth for all developers to locate, access, and consume services. With intuitive content management for documentation, streamlined developer onboarding, and role-based access control (RBAC), the Dev Portal provides a comprehensive solution for creating and customizing a unified developer experience.
 

--- a/app/getting-started-guide/2.6.x/manage-teams.md
+++ b/app/getting-started-guide/2.6.x/manage-teams.md
@@ -1,9 +1,7 @@
 ---
 title: Manage Administrative Teams
+badge: enterprise
 ---
-<div class="alert alert-ee">
-<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> This feature is only available with a {{site.konnect_product_name}} subscription.
-</div>
 
 In this topic, you’ll learn how to manage and configure user authorization using workspaces and teams in {{site.ee_product_name}}.
 

--- a/app/getting-started-guide/2.6.x/overview.md
+++ b/app/getting-started-guide/2.6.x/overview.md
@@ -28,13 +28,8 @@ for microservices, delivering unparalleled latency, performance, and scalability
  If you just want the basics, this option will work for you.
 
 ### {{site.ee_product_name}}
-<div class="alert alert-ee">
-<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" />
-This guide also includes some features available with {{site.konnect_product_name}}.
-They'll be called out in blue blocks like this, or in their own Kong Manager
-tabs.
-</div>
-{{site.konnect_product_name}} extends the {{site.base_gateway}} with enterprise
+
+{{site.konnect_product_name}} extends the {{site.base_gateway}} with Enterprise
 features and support. It provides advanced functionality using plugins for
 security, collaboration, performance at scale, and use of advanced protocols.
 
@@ -101,11 +96,11 @@ variable with the actual URL of your {{site.base_gateway}} installation.
 * Throughout this guide, you will have the option to configure Kong in a few
 different ways. Choose your preferred method, if options are available —
 you don’t have to walk through all of them:
-  * Programmatically manage Kong using its REST-based Admin API
-  * Use the Kong Manager GUI *({{site.konnect_product_name}} users only)*
+  * Programmatically manage {{site.base_gateway}} using its REST-based Admin API
+  * Use the Kong Manager GUI *(Not available for open-source Gateway)*
   * Use decK for declarative configuration (YAML)
-* If you're running Kong in Hybrid mode, all tasks contained in this guide take
-place on the Control Plane.
+* If you're running {{site.base_gateway}} in Hybrid mode, all tasks contained
+in this guide take place on the Control Plane.
 * This guide provides Kong Admin API examples in both HTTPie and cURL. If you
 want to use HTTPie, install it from [here](https://httpie.org/).
 * Any references to “{{site.base_gateway}}” refer to features or concepts

--- a/app/getting-started-guide/2.6.x/protect-services.md
+++ b/app/getting-started-guide/2.6.x/protect-services.md
@@ -7,11 +7,10 @@ If you are following the getting started workflow, make sure you have completed 
 
 ## What is Rate Limiting?
 
-Rate Limiting lets you restrict how many requests your upstream services receive from your API consumers, or how often each user can call the API.
+Kong's [Rate Limiting plugin](/hub/kong-inc/rate-limiting) lets you restrict how many requests your upstream services receive from your API consumers, or how often each user can call the API.
 
-<div class="alert alert-ee">
-<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /> For {{site.ee_product_name}}, the Rate Limiting Advanced plugin provides support for the sliding window algorithm to prevent the API from being overloaded near the window boundaries, and adds Redis support for greater performance.
-</div>
+{:.note}
+> The [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced) <span class="badge enterprise"></span> plugin provides support for the sliding window algorithm to prevent the API from being overloaded near the window boundaries, and adds Redis support for greater performance.
 
 ## Why Use Rate Limiting?
 
@@ -47,9 +46,8 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 {% endnavtab %}
 {% navtab Using the Admin API %}
 
-<div class="alert alert-ee">
-<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have a {{site.ee_product_name}} instance, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced with sliding window support instead.
-</div>
+{:.note}
+> **Note:** This section sets up the basic Rate Limiting plugin. If you have a {{site.ee_product_name}} instance, see instructions for **Using Kong Manager** to set up Rate Limiting Advanced with sliding window support instead.
 
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.
 
@@ -77,9 +75,8 @@ $ http -f post :8001/plugins \
 {% endnavtab %}
 {% navtab Using decK (YAML) %}
 
-<div class="alert alert-ee">
-<img class="no-image-expand" src="/assets/images/icons/icn-enterprise-grey.svg" alt="Enterprise" /><strong>Note:</strong> This section sets up the basic Rate Limiting plugin. If you have a {{site.ee_product_name}} instance, see instructions for <strong>Using Kong Manager</strong> to set up Rate Limiting Advanced instead.
-</div>
+{:.note}
+> **Note:** This section sets up the basic Rate Limiting plugin. If you have a {{site.ee_product_name}} instance, see instructions for **Using Kong Manager** to set up Rate Limiting Advanced with sliding window support instead.
 
 1. Add a new `plugins` section to the bottom of your `kong.yaml` file. Enable
 `rate-limiting` with a limit of five (5) requests per minute, stored locally


### PR DESCRIPTION
### Summary
* Adding links to badges that appear in page titles, linking off to pricing page
  * Adding `aria-label` for links, following WGAC guidelines: https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8.html
  * I considered adding tooltips but that's more of a nice-to-have and doesn't add much for accessibility
* Removing Konnect Enterprise subscription banner in favor of badges in plugins
* Replacing banners in Getting Started Guide with either badges, explanations, or simplified them so that badges aren't needed
* Labelling getting started guide dev portal and RBAC pages as enterprise

### Reason
Badges are not accessible. If someone is visually impaired or uses a screenreader, the badge gets passed over completely and they have no way of knowing it exists.

For plugins: request from Gayle for jq plugin, as we have too many banners. 

### Testing
Tested locally on plugins and getting started guide; also tested with WAVE plugin.

Check any Plus or Enterprise plugin, making sure to tab over to the badge:
https://deploy-preview-3302--kongdocs.netlify.app/hub/kong-inc/application-registration/

Sample getting started guide page:
https://deploy-preview-3302--kongdocs.netlify.app/getting-started-guide/2.6.x/manage-teams/

