### PR TITLE
[KIC 2.0] prometheus metrics update

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/references/prometheus.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/prometheus.md
@@ -11,9 +11,9 @@ This document is a reference for the former type.
 
 | Metric name | Description |
 |-------------|-------------|
-| `ingress_controller_configuration_push_count[success=true|false][protocol=db-less|deck]` | Count of successful/failed configuration pushes to Kong. `protocol` describes the configuration protocol (`db-less` or `deck`) in use. `success` describes whether there were unrecoverable errors (`false`) or not (`true`).|
-| `ingress_controller_translation_count[success=true|false]` | Count of translations from Kubernetes state to Kong state. `success` describes whether there were unrecoverable errors (`false`) or not (`true`). |
-| `ingress_controller_configuration_push_duration_milliseconds[success=true|false][protocol=db-less|deck]` | How long it took to push the configuration to Kong, in milliseconds. `protocol` describes the configuration protocol (`db-less` or `deck`) in use. `success` describes whether there were unrecoverable errors (`false`) or not (`true`). |
+| `ingress_controller_configuration_push_count[success=true|false][protocol=db-less|deck]` | Count of successful or failed configuration pushes to Kong. <br><br> `protocol` describes the configuration protocol in use, which can be `db-less` or `deck`. <br><br> `success` logs the status of configuration updates. If `success` is `false`, an unrecoverable error occurred.  If `success` is `true`, the push succeeded with no errors.  |
+| `ingress_controller_translation_count[success=true|false]` | Count of translations from Kubernetes state to Kong state. <br><br> `success` logs the status of configuration updates. If `success` is `false`, an unrecoverable error occurred.  If `success` is `true`, the translation succeeded with no errors. |
+| `ingress_controller_configuration_push_duration_milliseconds[success=true|false][protocol=db-less|deck]` | The amount of time, in milliseconds, that it takes to push the configuration to Kong. <br><br> `protocol` describes the configuration protocol in use, which can be `db-less` or `deck`. <br><br> `success` logs the status of configuration updates. If `success` is `false`, an unrecoverable error occurred.  If `success` is `true`, the push succeeded with no errors. |
 
 In addition to the above, {{site.kic_product_name}} exposes more low-level performance metrics - these may however change from version to version, as they are provided by underlying frameworks of {{site.kic_product_name}}.
 


### PR DESCRIPTION

### Summary
In KIC 2.0 docs, update the metric names and descriptions following changes made in https://github.com/Kong/kubernetes-ingress-controller/issues/1875.

### Reason
The details of the Prometheus metrics available have changed over the course of 2.0 implementation.

### Testing
n/a