### PR TITLE
[DOCU-1895] Add missing parameter for Konnect runtime setup

### DIFF
--- a/app/konnect/runtime-manager/gateway-runtime-conf.md
+++ b/app/konnect/runtime-manager/gateway-runtime-conf.md
@@ -55,19 +55,20 @@ to the file.
     anonymous_reports = off
     vitals_ttl_days = 732
     cluster_mtls = pki
-    cluster_control_plane = <example.cp.konnect.foo>:443
-    cluster_server_name = <kong-cpoutlet-example.service>
-    cluster_telemetry_endpoint = <example.tp.konnect.foo>:443
-    cluster_telemetry_server_name = <kong-telemetry-example.service>
-    cluster_cert = /<path-to-file>/tls.crt
-    cluster_cert_key = /<path-to-file>/tls.key
+    cluster_control_plane = {EXAMPLE.CP.KONNECT.FOO}:443
+    cluster_server_name = {KONG-CPOUTLET-EXAMPLE.SERVICE}
+    cluster_telemetry_endpoint = {EXAMPLE.TP.KONNECT.FOO}:443
+    cluster_telemetry_server_name = {KONG-TELEMETRY-EXAMPLE.SERVICE}
+    cluster_cert = /{PATH_TO_FILE}/tls.crt
+    cluster_ca_cert = /{PATH_TO_FILE}/ca.crt
+    cluster_cert_key = /{PATH_TO_FILE}/tls.key
     ```
 
     See [Parameters](/konnect/runtime-manager/runtime-parameter-reference) for
     descriptions and the matching fields in {{site.konnect_short_name}}.
 
-4. Replace the values in `cluster_cert` and `cluster_cert_key` with the paths
-to your certificate and key files.
+4. Replace the values in `cluster_cert`, `cluster_ca_cert`, and
+`cluster_cert_key` with the paths to your certificate and key files.
 
 5. Restart {{site.base_gateway}} for the settings to take effect:
 

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -99,11 +99,11 @@ remaining configuration details on the **Configure Runtime** page.
     $ docker images
     ```
 
-3. Tag the image ID for easier use, replacing `<IMAGE_ID>` with the one
+3. Tag the image ID for easier use, replacing `{IMAGE_ID}` with the one
 matching your repository:
 
     ```bash
-    $ docker tag <IMAGE_ID> kong-ee
+    $ docker tag {IMAGE_ID} kong-ee
     ```
 
 ### Start Kong Gateway
@@ -119,13 +119,14 @@ $ docker run -d --name kong-gateway-dp1 \
   -e "KONG_ANONYMOUS_REPORTS=off" \
   -e "KONG_VITALS_TTL_DAYS=732" \
   -e "KONG_CLUSTER_MTLS=pki" \
-  -e "KONG_CLUSTER_CONTROL_PLANE=<example.cp.konnect.foo>:443" \
-  -e "KONG_CLUSTER_SERVER_NAME=<kong-cpoutlet-example.service>" \
-  -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=<example.tp.konnect.foo>:443" \
-  -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" \
-  -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" \
-  -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" \
-  --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly \
+  -e "KONG_CLUSTER_CONTROL_PLANE={example.cp.konnect.foo}:443" \
+  -e "KONG_CLUSTER_SERVER_NAME={kong-cpoutlet-example.service}" \
+  -e "KONG_CLUSTER_TELEMETRY_ENDPOINT={example.tp.konnect.foo}:443" \
+  -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME={kong-telemetry-example.service}" \
+  -e "KONG_CLUSTER_CERT=/{PATH_TO_FILE}/tls.crt" \
+  -e "KONG_CLUSTER_CA_CERT=/{PATH_TO_FILE}/ca.crt" \
+  -e "KONG_CLUSTER_CERT_KEY=/{PATH_TO_FILE}/tls.key" \
+  --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly \
   -p 8000:8000 \
   kong-ee
 ```
@@ -138,21 +139,22 @@ docker run -d --name kong-gateway-dp1 `
   -e "KONG_ANONYMOUS_REPORTS=off" `
   -e "KONG_VITALS_TTL_DAYS=732" `
   -e "KONG_CLUSTER_MTLS=pki" `
-  -e "KONG_CLUSTER_CONTROL_PLANE=<example.cp.konnect.foo>:443" `
-  -e "KONG_CLUSTER_SERVER_NAME=<kong-cpoutlet-example.service>" `
-  -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=<example.tp.konnect.foo>:443" `
-  -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<kong-telemetry-example.service>" `
-  -e "KONG_CLUSTER_CERT=/<path-to-file>/tls.crt" `
-  -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/tls.key" `
-  --mount type=bind,source="$(pwd)",target=<path-to-keys-and-certs>,readonly `
+  -e "KONG_CLUSTER_CONTROL_PLANE={EXAMPLE.CP.KONNECT.FOO}:443" `
+  -e "KONG_CLUSTER_SERVER_NAME={KONG-CPOUTLET-EXAMPLE.SERVICE}" `
+  -e "KONG_CLUSTER_TELEMETRY_ENDPOINT={EXAMPLE.TP.KONNECT.FOO}:443" `
+  -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME={KONG-TELEMETRY-EXAMPLE.SERVICE}" `
+  -e "KONG_CLUSTER_CERT=/{PATH_TO_FILE}/tls.crt" `
+  -e "KONG_CLUSTER_CA_CERT=/{PATH_TO_FILE}/ca.crt" `
+  -e "KONG_CLUSTER_CERT_KEY=/{PATH_TO_FILE}/tls.key" `
+  --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly `
   -p 8000:8000 `
   kong-ee
 ```
 {% endnavtab %}
 {% endnavtabs %}
 
-1. Replace the values in `KONG_CLUSTER_CERT` and `KONG_CLUSTER_CERT_KEY` with
-the paths to your certificate and key files.
+1. Replace the values in `KONG_CLUSTER_CERT`, `KONG_CLUSTER_CA_CERT`, and
+`KONG_CLUSTER_CERT_KEY` with the paths to your certificate and key files.
 
 2. Check the **Linux** or **Kubernetes** tabs in the Konnect UI to find the values for
         `KONG_CLUSTER_CONTROL_PLANE`, `KONG_CLUSTER_SERVER_NAME`,

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -63,15 +63,15 @@ you saved earlier:
 
     ```bash
     $ kubectl create secret tls kong-cluster-cert -n kong \
-      --cert=/<path-to-file>/tls.crt \
-      --key=/<path-to-file>/tls.key
+      --cert=/{PATH_TO_FILE}/tls.crt \
+      --key=/{PATH_TO_FILE}/tls.key
     ```
 
 2. Create a generic secret for the `ca.crt` file:
 
     ```bash
     $ kubectl create secret generic kong-cluster-ca -n kong \
-      --from-file=ca.crt=/<path-to-file>/ca.crt
+      --from-file=ca.crt=/{PATH_TO_FILE}/ca.crt
     ```
 
 ### Write and apply configuration
@@ -105,10 +105,10 @@ like this:
       anonymous_reports: off
       vitals_ttl_days: 732
       cluster_mtls: pki
-      cluster_control_plane: <example.cp.konnect.foo>:443
-      cluster_server_name: <kong-cpoutlet-example.service>
-      cluster_telemetry_endpoint: <example.tp.konnect.foo>:443
-      cluster_telemetry_server_name: <kong-telemetry-example.service>
+      cluster_control_plane: {EXAMPLE.CP.KONNECT.FOO}:443
+      cluster_server_name: {KONG-CPOUTLET-EXAMPLE.SERVICE}
+      cluster_telemetry_endpoint: {EXAMPLE.TP.KONNECT.FOO}:443
+      cluster_telemetry_server_name: {KONG-TELEMETRY-EXAMPLE.SERVICE}
       cluster_ca_cert: /etc/secrets/kong-cluster-ca/ca.crt
       cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
       cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
@@ -179,7 +179,7 @@ your {{site.konnect_short_name}} services:
 
 3. With the external IP and one of the available ports (`80` or `443`),
 and assuming that you have configured a service with a route,
-you can now access your service at `<external-IP>:<port>/<route>`.
+you can now access your service at `{EXTERNAL_IP}:{PORT}/{ROUTE}`.
 
     For example, using the values above and a sample route, you now have the
     following:


### PR DESCRIPTION
### Summary
Adding `cluster_ca_cert` to Docker and Linux runtime setup docs. This replaces the older `lua_ssl_trusted_certificate` parameter that was used prior to Gateway 2.5.

Relevant lines:
https://github.com/Kong/docs.konghq.com/pull/3306/files#diff-6fd27928daf34086efd866de0f9d100d430a10ac20c5955cc4c0b8d814e346b4R63

https://github.com/Kong/docs.konghq.com/pull/3306/files#diff-73dc1705f47e8c980c37c5406b86f142560da8daf65415c51669eddffd0f1c50R127

Since, I had to edit a variable, also adjusting styling for variables to match the docs style guide.

### Reason
Multiple people have run into this bug. Reported on Slack.

### Testing
https://deploy-preview-3306--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/
https://deploy-preview-3306--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-conf/
