### PR TITLE
[DOCU-1663] Fix link to Docker Hub from EE docs

### DIFF
--- a/app/_includes/md/2.4.x/docker-install-steps.md
+++ b/app/_includes/md/2.4.x/docker-install-steps.md
@@ -12,12 +12,12 @@ docker pull kong/kong-gateway:{{include.kong_versions[11].version}}-alpine
 {:.important}
 > Some [older {{site.base_gateway}} images](https://support.konghq.com/support/s/article/Downloading-older-Kong-versions)
 are not publicly accessible. If you need a specific patch version and can't
-find it on [Kong's public Docker Hub page](https://hub.docker.com/_/kong), contact
+find it on [Kong's public Docker Hub page](https://hub.docker.com/r/kong/kong-gateway), contact
 [Kong Support](https://support.konghq.com/).
 
 You should now have your {{site.base_gateway}} image locally.
 
-Tag the image. 
+Tag the image.
 
 ```bash
 docker tag kong/kong-gateway:{{include.kong_versions[11].version}}-alpine kong-ee

--- a/app/_includes/md/2.5.x/docker-install-steps.md
+++ b/app/_includes/md/2.5.x/docker-install-steps.md
@@ -12,12 +12,12 @@ docker pull kong/kong-gateway:{{include.kong_versions[12].version}}-alpine
 {:.important}
 > Some [older {{site.base_gateway}} images](https://support.konghq.com/support/s/article/Downloading-older-Kong-versions)
 are not publicly accessible. If you need a specific patch version and can't
-find it on [Kong's public Docker Hub page](https://hub.docker.com/_/kong), contact
+find it on [Kong's public Docker Hub page](https://hub.docker.com/r/kong/kong-gateway), contact
 [Kong Support](https://support.konghq.com/).
 
 You should now have your {{site.base_gateway}} image locally.
 
-Tag the image. 
+Tag the image.
 
 ```bash
 docker tag kong/kong-gateway:{{include.kong_versions[12].version}}-alpine kong-ee

--- a/app/_includes/md/2.6.x/docker-install-steps.md
+++ b/app/_includes/md/2.6.x/docker-install-steps.md
@@ -12,12 +12,12 @@ docker pull kong/kong-gateway:{{include.kong_versions[12].version}}-alpine
 {:.important}
 > Some [older {{site.base_gateway}} images](https://support.konghq.com/support/s/article/Downloading-older-Kong-versions)
 are not publicly accessible. If you need a specific patch version and can't
-find it on [Kong's public Docker Hub page](https://hub.docker.com/_/kong), contact
+find it on [Kong's public Docker Hub page](https://hub.docker.com/r/kong/kong-gateway), contact
 [Kong Support](https://support.konghq.com/).
 
 You should now have your {{site.base_gateway}} image locally.
 
-Tag the image. 
+Tag the image.
 
 ```bash
 docker tag kong/kong-gateway:{{include.kong_versions[12].version}}-alpine kong-ee


### PR DESCRIPTION
### Summary
Switching link to point to Enterprise image instead of open-source gateway.

### Reason
EE installation doc goes to open-source Docker Hub page.

### Testing
TBA
