### PR TITLE
[chore] Fix and update links

### DIFF
--- a/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
+++ b/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
@@ -4,9 +4,9 @@ no_version: true
 ---
 
 When auto approval is enabled, {{site.konnect_short_name}} admins don't
-need to manually approve Developer and Application requests. 
+need to manually approve Developer and Application requests.
 
-If auto approve is not enabled for Developers or Applications, admins will need to approve new Developers and Applications manually. For more information on manual approval, see [Manage Developer Access](/konnect/dev-portal/administrators/manage-devs/) and [Manage Application Registration Requests](/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests/).
+If auto approve is not enabled for Developers or Applications, admins will need to approve new Developers and Applications manually. For more information on manual approval, see [Manage Developer Access](/konnect/dev-portal/access-and-approval/manage-devs/) and [Manage Application Registration Requests](/konnect/dev-portal/applications/manage-app-reg-requests/).
 
 {:.note}
 > If auto approve is enabled through the Portal for Applications, it overrides the Service setting.
@@ -15,7 +15,7 @@ If auto approve is not enabled for Developers or Applications, admins will need 
 
 Auto approve is disabled by default. You can enable and disable approvals at any time. If there are any pending requests when auto approve is enabled, those requests must be manually approved.
 
-1. As an admin, from the [{{site.konnect_short_name}}](https://konnect.konghq.com/) menu, click **Settings**. Then click **Portal**. 
+1. As an admin, from the [{{site.konnect_short_name}}](https://konnect.konghq.com/) menu, click **Settings**. Then click **Portal**.
 
 2. Toggle to enable or disable auto approve for one or both options:
       * Auto Approve Developers

--- a/app/konnect/dev-portal/access-and-approval/manage-devs.md
+++ b/app/konnect/dev-portal/access-and-approval/manage-devs.md
@@ -3,13 +3,13 @@ title: Manage Developer Access
 no_version: true
 ---
 
-Manage developers and [developer registration](/konnect/dev-portal/developers/dev-reg) requests to
+Manage developers and [developer registration](/konnect/dev-portal/access-and-approval/dev-reg) requests to
 access the {{site.konnect_short_name}} Dev Portal. To allow automatic approval of developer registration requests,
-enable [auto approve](/konnect/dev-portal/administrators/auto-approve-devs-apps).
+enable [auto approve](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps).
 
 ## Prerequisite
 
-[**Organization Admin** or **Portal Admin**](/konnect/reference/org-management/#role-definitions)
+[**Organization Admin** or **Portal Admin**](/konnect/org-management/users-and-roles)
 permissions.
 
 ## Developer Status

--- a/app/konnect/dev-portal/applications/application-overview.md
+++ b/app/konnect/dev-portal/applications/application-overview.md
@@ -4,22 +4,22 @@ no_version: true
 toc: true
 ---
 
-Applications consume Services in {{site.konnect_short_name}} via Application-level authentication. Developers, or the persona that logs into the {{site.konnect_short_name}} Dev Portal, use Applications they create in the Dev Portal. 
+Applications consume Services in {{site.konnect_short_name}} via Application-level authentication. Developers, or the persona that logs into the {{site.konnect_short_name}} Dev Portal, use Applications they create in the Dev Portal.
 
-Admins [enable application registration](/konnect/dev-portal/administrators/app-registration/enable-app-reg/) through [konnect.konghq.com](https://konnect.konghq.com) so that Developers can associate Services with Applications. 
+Admins [enable application registration](/konnect/dev-portal/applications/enable-app-reg/) through [konnect.konghq.com](https://konnect.konghq.com) so that Developers can associate Services with Applications.
 
-For a Developer to be able to manage Applications, they must be [granted access by an admin](/konnect/dev-portal/administrators/manage-devs/) to the {{site.konnect_short_name}} Dev Portal. For more information about registering for a {{site.konnect_short_name}} Dev Portal as a Developer, see [Developer Registration](/konnect/dev-portal/developers/dev-reg/). 
+For a Developer to be able to manage Applications, they must be [granted access by an admin](/konnect/dev-portal/access-and-approval/manage-devs/) to the {{site.konnect_short_name}} Dev Portal. For more information about registering for a {{site.konnect_short_name}} Dev Portal as a Developer, see [Developer Registration](/konnect/dev-portal/access-and-approval/dev-reg/).
 
 ## Applications and Services
 
-Multiple Services can be registered to a single Application. In the {{site.konnect_short_name}} Dev Portal, Services registered to an Application will be listed in the Application detail page, available through **My Apps** in the top-right corner dropdown menu beneath the Developer's login email. 
+Multiple Services can be registered to a single Application. In the {{site.konnect_short_name}} Dev Portal, Services registered to an Application will be listed in the Application detail page, available through **My Apps** in the top-right corner dropdown menu beneath the Developer's login email.
 
 The purpose of registering Services to an Application is to consume those Services using the Application-level authentication. Grouping authentication enables direct access to multiple Services.
 
-As an example, the Application can represent a mobile banking app and the Services registered to the Application can be a billing API, a users API, and a legal agreements API. 
+As an example, the Application can represent a mobile banking app and the Services registered to the Application can be a billing API, a users API, and a legal agreements API.
 
 ## Application authentication
 
-Generate Application credentials through the {{site.konnect_short_name}} Dev Portal in the Application detail page. The Application can have multiple credentials, or API keys. For more information about Application Credentials, refer to [Generate Credentials for an Application](/konnect/dev-portal/developers/dev-gen-creds/). 
+Generate Application credentials through the {{site.konnect_short_name}} Dev Portal in the Application detail page. The Application can have multiple credentials, or API keys. For more information about Application Credentials, refer to [Generate Credentials for an Application](/konnect/dev-portal/applications/dev-gen-creds/).
 
-In [konnect.konghq.com](https://konnect.konghq.com), admins can access a list of the installed authentication plugins via **Shared Config**. See [Enable Application Registration for a Service](/konnect/dev-portal/administrators/app-registration/enable-app-reg/) for more information about authentication flows. 
+In [konnect.konghq.com](https://konnect.konghq.com), admins can access a list of the installed authentication plugins via **Shared Config**. See [Enable Application Registration for a Service](/konnect/dev-portal/applications/enable-app-reg/) for more information about authentication flows.

--- a/app/konnect/dev-portal/applications/dev-apps.md
+++ b/app/konnect/dev-portal/applications/dev-apps.md
@@ -4,41 +4,41 @@ no_version: true
 toc: true
 ---
 
-After a Developer is [granted access by an admin](/konnect/dev-portal/administrators/manage-devs/) to the {{site.konnect_short_name}} Dev Portal, they will be able to create, edit, and delete applications.
+After a Developer is [granted access by an admin](/konnect/dev-portal/access-and-approval/manage-devs/) to the {{site.konnect_short_name}} Dev Portal, they will be able to create, edit, and delete applications.
 
-For more information about registering for a {{site.konnect_short_name}} Dev Portal as a Developer, see [Developer Registration](/konnect/dev-portal/developers/dev-reg/). 
+For more information about registering for a {{site.konnect_short_name}} Dev Portal as a Developer, see [Developer Registration](/konnect/dev-portal/access-and-approval/dev-reg/).
 
 {:.note}
-> **Note**: The following is all done through the Dev Portal, not through [konnect.konghq.com](https://konnect.konghq.com). As an admin, find the Dev Portal URL via **Dev Portal** > **Published Services**. 
+> **Note**: The following is all done through the Dev Portal, not through [konnect.konghq.com](https://konnect.konghq.com). As an admin, find the Dev Portal URL via **Dev Portal** > **Published Services**.
 
 ## Create an Application
 
-Developers can create an application and link it to a Service. 
+Developers can create an application and link it to a Service.
 
-1. In the {{site.konnect_short_name}} Dev Portal, click **My Apps** from the dropdown menu in the upper right corner under your login email. 
+1. In the {{site.konnect_short_name}} Dev Portal, click **My Apps** from the dropdown menu in the upper right corner under your login email.
 
-2. On the **My Apps** page, click the **New App** button. 
+2. On the **My Apps** page, click the **New App** button.
 
 3. Fill out the **Create New Application** form with your application name, reference ID, and description. Note that the Reference ID must be unique. If your organization is using the
-   [OIDC](/konnect/dev-portal/administrators/app-registration/enable-app-reg#oidc-flow)
+   [OIDC](/konnect/dev-portal/applications/enable-app-reg#oidc-flow)
    flow for application registration, enter the ID of your third-party OAuth2 claim.
 
 4. Click **Create** to save and see your new application's detail page.    
 
 ## View Application Details
 
-Access and modify applications from an application's details page. Find a list of your current applications on the **My Apps** page, accessible through the dropdown menu in the top right corner under your login email. 
+Access and modify applications from an application's details page. Find a list of your current applications on the **My Apps** page, accessible through the dropdown menu in the top right corner under your login email.
 
-You can do the following through the application details page: 
+You can do the following through the application details page:
 
 - [Edit](#edit-an-application) the name, reference ID, and description of an application.
-- [Generate or delete credentials](/konnect/dev-portal/developers/dev-gen-creds).
-- View a catalog of Services that can be [registered with the application](/konnect/dev-portal/developers/dev-reg-app-service), if no Services are registered yet.
+- [Generate or delete credentials](/konnect/dev-portal/access-and-approval/dev-gen-creds).
+- View a catalog of Services that can be [registered with the application](/konnect/dev-portal/applications/dev-reg-app-service), if no Services are registered yet.
 - View the status of an application registration to a Service.
 
 ## Edit an Application
 
-Edit the name, reference ID, and description of your application by going to **My Apps** in the dropdown menu under your login email, selecting your application, and clicking **Edit**. 
+Edit the name, reference ID, and description of your application by going to **My Apps** in the dropdown menu under your login email, selecting your application, and clicking **Edit**.
 
 ## Delete an Application
 
@@ -46,6 +46,6 @@ You can permanently delete an Application from the Dev Portal:
 
 - On the **My Apps** page in the dropdown menu under your login email, click the cog icon next to an application and click **Delete**.
 
-- Confirm deletion in the pop-up modal. 
+- Confirm deletion in the pop-up modal.
 
 You can also delete an application from the application details page. See [Edit an Application](#edit-an-application). 

--- a/app/konnect/dev-portal/applications/dev-gen-creds.md
+++ b/app/konnect/dev-portal/applications/dev-gen-creds.md
@@ -4,13 +4,13 @@ no_version: true
 toc: true
 ---
 
-A credential, or API key, identifies and authenticates the developer application making a request. Use the API key either in the request URL as a query parameter, or in the request header. 
+A credential, or API key, identifies and authenticates the developer application making a request. Use the API key either in the request URL as a query parameter, or in the request header.
 
-You can permanently delete any credential at any time. See [Delete a credential](#delete-a-credential). 
+You can permanently delete any credential at any time. See [Delete a credential](#delete-a-credential).
 
 ## Generate a credential
 
-A credential, or API key, generated in the {{site.konnect_short_name}} Dev Portal is a 32-character string associated with an Application. An Application can have multiple credentials. 
+A credential, or API key, generated in the {{site.konnect_short_name}} Dev Portal is a 32-character string associated with an Application. An Application can have multiple credentials.
 
 1. In the Dev Portal, click **My Apps** from the dropdown menu under your login email.
 
@@ -19,7 +19,7 @@ A credential, or API key, generated in the {{site.konnect_short_name}} Dev Porta
 3. In the **Authentication** pane, click **Generate Credential**.
 
 4. Test the generated credential by making a call to the service the
-   [Application is registered with](/konnect/dev-portal/developers/dev-reg-app-service)
+   [Application is registered with](/konnect/dev-portal/applications/dev-reg-app-service)
    using your `key-auth` credential:
 
    ```
@@ -28,8 +28,8 @@ A credential, or API key, generated in the {{site.konnect_short_name}} Dev Porta
 
 ## Delete a credential
 
-You can permanently delete a credential. Note that the credential cannot be restored. 
+You can permanently delete a credential. Note that the credential cannot be restored.
 
 1. Navigate to an application's details page.
 
-2. In the **Authentication** pane, click the cog icon of the credential you want to permanently delete and click **Delete**. 
+2. In the **Authentication** pane, click the cog icon of the credential you want to permanently delete and click **Delete**.

--- a/app/konnect/dev-portal/applications/dev-reg-app-service.md
+++ b/app/konnect/dev-portal/applications/dev-reg-app-service.md
@@ -4,15 +4,15 @@ no_version: true
 toc: true
 ---
 
-When [application registration is enabled](/konnect/dev-portal/administrators/app-registration/enable-app-reg/),
+When [application registration is enabled](/konnect/dev-portal/applications/enable-app-reg/),
 developers must register their applications with a Service. Requests for access must be
-[approved by a Konnect admin](/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests) if
-[auto approve](/konnect/dev-portal/administrators/auto-approve-devs-apps) is not enabled.
+[approved by a Konnect admin](/konnect/dev-portal/applications/manage-app-reg-requests) if
+[auto approve](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps) is not enabled.
 
 ## Prerequisites
 
 - Application registration must be enabled for the Service by a {{site.konnect_short_name}} admin.
-- [Create an Application](/konnect/dev-portal/developers/dev-apps#create-an-application).
+- [Create an Application](/konnect/dev-portal/applications/dev-apps#create-an-application).
 
 ## Register an Application
 
@@ -23,9 +23,9 @@ applicable Services.
 1. Log in to the {{site.konnect_short_name}} Dev Portal to access the Service
 Catalog.
 
-2. Click on a Service tile. 
+2. Click on a Service tile.
 
-    Not all Services may have app registration enabled. Contact 
+    Not all Services may have app registration enabled. Contact
     your {{site.konnect_short_name}} admin if you need it enabled on a Service.
 
 3. Click **Register**.
@@ -38,7 +38,7 @@ Catalog.
    and you will be notified by email upon approval. Click **Close**.
 
    You can check the status of your request in the
-   [application details](/konnect/dev-portal/developers/dev-apps/#app-details-page) page.
+   [application details](/konnect/dev-portal/applications/dev-apps/#app-details-page) page.
 
 ## Unregister an Application
 
@@ -65,6 +65,6 @@ the **Services** pane.
 
 If you encounter any of the errors below that appear in the Register dialog, follow the recommended solution.
 
-Error Message | Solution 
+Error Message | Solution
 ------------|------------
-Application registration is not enabled for this Service. | [Enable application registration for the Service](/konnect/dev-portal/administrators/app-registration/enable-app-reg/). Contact your {{site.konnect_short_name}} admin if you do not have the role permissions to do so.
+Application registration is not enabled for this Service. | [Enable application registration for the Service](/konnect/dev-portal/applications/enable-app-reg/). Contact your {{site.konnect_short_name}} admin if you do not have the role permissions to do so.

--- a/app/konnect/dev-portal/applications/disable-app-reg.md
+++ b/app/konnect/dev-portal/applications/disable-app-reg.md
@@ -20,7 +20,7 @@ Service level, disable app registration and then enable it again with the Auto A
 toggle set to disabled.
 
 You can
-[enable application registration](/konnect/dev-portal/administrators/app-registration/enable-app-reg)
+[enable application registration](/konnect/dev-portal/applications/enable-app-reg)
 again any time.
 
 1. From the {{site.konnect_short_name}} menu, click **Services**.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -5,7 +5,7 @@ toc: true
 ---
 
 When application registration is enabled for a Service, developers must
-[register an application](/konnect/dev-portal/developers/dev-reg-app-service)
+[register an application](/konnect/dev-portal/applications/dev-reg-app-service)
 in order to access a Service.
 
 All versions of a Service
@@ -35,12 +35,12 @@ Any other plugins that were enabled manually, such as `rate-limiting`, remain en
 
 ![Konnect Enable App Registration with OIDC](/assets/images/docs/konnect/konnect-enable-app-reg-oidc-toggle.png)
 
-You can [disable application registration](/konnect/dev-portal/administrators/app-registration/disable-app-reg/)
+You can [disable application registration](/konnect/dev-portal/applications/disable-app-reg/)
 any time at your discretion.
 
 ## Prerequisites
 
-- [**Organization Admin** or **Service Admin**](/konnect/reference/org-management/#role-definitions)
+- [**Organization Admin** or **Service Admin**](/konnect/org-management/users-and-roles)
 permissions.
 
 - The Services have been created, versioned, and published to the
@@ -52,7 +52,7 @@ permissions.
     appropriate for your requirements. Refer to your IdP/OP documentation for instructions.
 
   - Be sure to edit the **Reference ID** field in the Dev Portal
-    [Update Application](/konnect/dev-portal/developers/dev-apps#edit-my-app)
+    [Update Application](/konnect/dev-portal/applications/dev-apps#edit-my-app)
     dialog to match to your third-party OAuth2 claim.
 
 ## Enable App Registration for the Key Authentication Flow {#konnect-key-auth-flow}
@@ -76,10 +76,10 @@ permissions.
 
    Any developer registration requests for an application are automatically approved. A {{site.konnect_saas}}
     admin does not need to
-   [manually approve](/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests/) application
+   [manually approve](/konnect/dev-portal/applications/manage-app-reg-requests/) application
    registration requests for developers.
 
-   You can also [enable Auto Approve portal-wide](/konnect/dev-portal/administrators/auto-approve-devs-apps)
+   You can also [enable Auto Approve portal-wide](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps)
    using the Settings page for the Dev Portal. If Auto Approve is
    enabled portal-wide, it overrides the per-Service Auto Approve setting.
 
@@ -121,10 +121,10 @@ permissions.
       Any developer registration
       requests for an application are automatically approved. A {{site.konnect_short_name}}
       cloud admin does not need to
-      [manually approve](/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests/) application
+      [manually approve](/konnect/dev-portal/applications/manage-app-reg-requests/) application
       registration requests for developers.
 
-      You can also [enable Auto Approve portal-wide](/konnect/dev-portal/administrators/auto-approve-devs-apps)
+      You can also [enable Auto Approve portal-wide](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps)
       using the Portal Settings. If Auto Approve is
       enabled or disabled portal-wide, it overrides the per Service Auto Approve setting.
 
@@ -142,7 +142,7 @@ permissions.
    | `Consumer claims` |  Name of the claim that is used to find a consumer. Required. |
    | `Auth method` | The supported authentication method or methods you want to enable. This field should contain only the authentication methods that you need to use; otherwise, you unnecessarily widen the attack surface. Separate multiple entries with a comma. Available options: `password`, `client_credentials`, `authorization_code`, `bearer`, `introspection`, `kong_oauth2`, `refresh_token`, `session`. Required. |
    | `Hide Credentials` | Whether to show or hide the credential from the Upstream service. If enabled, the plugin strips the credential from the request (in the header, query string, or request body that contains the key) before proxying it. Default: disabled. Optional.|
-   | `Auto Approve` | Automatically approve developer registration requests for an application. A Konnect admin does not need to [manually approve](/konnect/dev-portal/administrators/app-registration/manage-app-reg-requests/) application registration requests. Default: disabled. Optional. |
+   | `Auto Approve` | Automatically approve developer registration requests for an application. A Konnect admin does not need to [manually approve](/konnect/dev-portal/applications/manage-app-reg-requests/) application registration requests. Default: disabled. Optional. |
 
    For more background information about OpenID Connect plugin parameters, see
    [Important Configuration Parameters](/hub/kong-inc/openid-connect/#important-configuration-parameters).

--- a/app/konnect/dev-portal/applications/manage-app-connections.md
+++ b/app/konnect/dev-portal/applications/manage-app-connections.md
@@ -4,8 +4,8 @@ no_version: true
 ---
 
 Revoke, reinstate, or delete an application's connection to a Service. When a developer
-[registers a request](/konnect/dev-portal/developers/dev-reg-app-service) to access a Service for an
-application, and the request is approved either [automatically](/konnect/dev-portal/administrators/auto-approve-devs-apps)
+[registers a request](/konnect/dev-portal/applications/dev-reg-app-service) to access a Service for an
+application, and the request is approved either [automatically](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps)
 or by a {{site.konnect_short_name}} admin, it creates an application connection between the
 developer, their applications, and the associated Service Versions.
 
@@ -14,7 +14,7 @@ them about the change in status.--->
 
 ## Prerequisite
 
-[**Organization Admin** or **Service Admin**](/konnect/reference/org-management/#role-definitions)
+[**Organization Admin** or **Service Admin**](/konnect/org-management/users-and-roles)
 permissions.
 
 ## Application Connection to a Service Status

--- a/app/konnect/dev-portal/applications/manage-app-reg-requests.md
+++ b/app/konnect/dev-portal/applications/manage-app-reg-requests.md
@@ -3,15 +3,15 @@ title: Manage Application Registration Requests
 no_version: true
 ---
 
-When a developer [registers an application with a Service](/konnect/dev-portal/developers/dev-reg-app-service),
+When a developer [registers an application with a Service](/konnect/dev-portal/applications/dev-reg-app-service),
 the requests must be approved by an admin if
-[auto approve](/konnect/dev-portal/administrators/auto-approve-devs-apps) is not enabled. When
-[application registration is enabled](/konnect/dev-portal/administrators/app-registration/enable-app-reg),
+[auto approve](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps) is not enabled. When
+[application registration is enabled](/konnect/dev-portal/applications/enable-app-reg),
 developers must register their applications with a Service.
 
 ## Prerequisite
 
-[**Organization Admin** or **Service Admin**](/konnect/reference/org-management/#role-definitions)
+[**Organization Admin** or **Service Admin**](/konnect/org-management/users-and-roles)
 permissions.
 
 ## Application Registration Status
@@ -61,7 +61,7 @@ pending requests is displayed in the Requests menu and the Applications tab.
    An email is sent to the developer to let them know their application registration
    for service access was approved. In the dev portal, the status for the request
    is also updated in the Services pane of the
-   [application details](/konnect/dev-portal/developers/dev-apps#app-details-page) page.
+   [application details](/konnect/dev-portal/applications/dev-apps#app-details-page) page.
 
 ### Reject an app registration request {#reject-app-reg}
 

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -7,8 +7,8 @@ toc: false
 The Dev Portal is an API Catalog that allows Admin roles to
 document and manage Application registration for your Services. Admin roles publish Services through Konnect, and Developers use those Services.
 
-The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](/konnect/dev-portal/developers/dev-reg/).
+The Dev Portal lives at a separate URL from Konnect and requires that all users, including Admin roles, [register as a Developer](/konnect/dev-portal/applications/dev-reg/).
 
 ## See also
 
-* [Application Overview](/konnect/dev-portal/application-overview)
+* [Application Overview](/konnect/dev-portal/applications/application-overview)

--- a/app/konnect/getting-started/declarative-config.md
+++ b/app/konnect/getting-started/declarative-config.md
@@ -21,7 +21,7 @@ registration, or configure custom plugins.
 
 ## Prerequisites
 
-* [**Organization Admin**](/konnect/reference/org-management) permissions.
+* [**Organization Admin**](/konnect/org-management/users-and-roles) permissions.
 * decK v1.7.0 or later [installed](/deck/latest/installation/).
 * Optional: To test your configuration, [set up a simple runtime](/konnect/getting-started/configure-runtime).
 

--- a/app/konnect/getting-started/implement-service.md
+++ b/app/konnect/getting-started/implement-service.md
@@ -86,4 +86,4 @@ For next steps, check out some of the other things you can do in
 * Enable plugins on a [Service](/konnect/manage-plugins/enable-service-plugin/) or a
 [Route](/konnect/manage-plugins/enable-route-plugin/)
 * [Set up the Dev Portal](/konnect/servicehub/dev-portal/service-documentation)
-* [Manage your teams and users with RBAC](/konnect/reference/org-management)
+* [Manage your teams and users with RBAC](/konnect/org-management/users-and-roles)

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -28,10 +28,10 @@ deployment, see the following topics to get started:
 * Use the Dev Portal:
   * [Set up the Dev Portal for a Service](/konnect/servicehub/dev-portal/service-documentation)
   * [Publish a Service version to the Dev Portal](/konnect/servicehub/dev-portal/publish)
-  * Enable [application registration](/konnect/dev-portal/administrators/app-registration/enable-app-reg)
-  * Manage [developer registration](/konnect/dev-portal/administrators/manage-devs)
+  * Enable [application registration](/konnect/dev-portal/applications/enable-app-reg)
+  * Manage [developer registration](/konnect/dev-portal/access-and-approval/manage-devs)
 * Use Vitals to [monitor the status of your Services](/konnect/vitals)
-* Set up [users and roles](/konnect/reference/org-management)
+* Set up [users and roles](/konnect/org-management/users-and-roles)
 * Get familiar with the [Konnect Admin API](/konnect/reference/konnect-api)
 
 ## Self-hosted Konnect

--- a/app/konnect/manage-plugins/index.md
+++ b/app/konnect/manage-plugins/index.md
@@ -26,7 +26,7 @@ routes, and consumers in a cluster &ndash; set it up through the
 ### Functionality differences from self-managed Kong Gateway
 
 Application registration is built into the ServiceHub.
-[Enabling it on a service](/konnect/dev-portal/administrators/app-registration/enable-app-reg)
+[Enabling it on a service](/konnect/dev-portal/applications/enable-app-reg)
 also enables two plugins in read-only mode: ACL, and one of Key Auth or OpenID
 Connect. These plugins appear in the service's plugin list, and you can view their
 configurations, but you can't edit or delete them directly.

--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -32,9 +32,9 @@ ready to manage authentication and authorization through Okta for this
 
 ## Prerequisites and overview of steps
 
-To set up Okta single sign-on (SSO) for {{site.konnect_short_name}}, you need access to an
-Okta admin account and a
-[{{site.konnect_short_name}} admin account](/konnect/reference/org-management/#role-definitions),
+To set up Okta single sign-on (SSO) for {{site.konnect_short_name}}, you need
+access to an Okta admin account and a
+[{{site.konnect_short_name}} admin account](/konnect/org-management/users-and-roles), 
 which you will access concurrently.
 
 Here are the steps you need to complete, in both Okta and

--- a/app/konnect/reference/konnect-api.md
+++ b/app/konnect/reference/konnect-api.md
@@ -7,7 +7,7 @@ no_version: true
 
 This API is designed for internal use and provides full control over a Konnect
 organization and its entities, so care should be taken when setting up
-[user permissions](/konnect/reference/org-management/#role-definitions).
+[user permissions](/konnect/org-management/users-and-roles).
 
 For a list of all endpoints, see:
 * [Konnect API Swagger documentation](https://konnect.konghq.com/docs)
@@ -15,7 +15,7 @@ For a list of all endpoints, see:
 
 You can run {{site.konnect_short_name}} API requests using
 [Insomnia](https://insomnia.rest), Kong's open-source API client. If you have
-Insomnia installed, click the button below to import the Konnect 
+Insomnia installed, click the button below to import the Konnect
 API spec.
 
 <!-- Button to export spec into Insomnia -->
@@ -26,7 +26,7 @@ API spec.
 > **Note**: If you have trouble importing the spec into Insomnia,
 > update to the latest Insomnia version. If you have automatic
 > updates enabled but are still running an older version, restart Insomnia
-> to trigger the update. 
+> to trigger the update.
 
 ## Making a Request to the Konnect API
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -193,7 +193,7 @@ through {{site.konnect_saas}}. This includes:
 ### 2021.02.10
 
 **Portal authentication**
-: You can now [disable authentication on a Dev Portal](/konnect/dev-portal/administrators/public-portal/),
+: You can now [disable authentication on a Dev Portal](/konnect/dev-portal/customization/public-portal/),
 which exposes the Dev Portal publicly to anyone with the link. No one needs to register
 for Dev Portal access.
 : New application registrations aren't available through a public-facing portal.

--- a/app/kubernetes-ingress-controller/2.0.x/references/prometheus.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/prometheus.md
@@ -23,4 +23,4 @@ A non-exhaustive list of these low-level metrics is present in the following pla
 
 [kongplugin-guide]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kongplugin-resource/
 [grafana-guide]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/prometheus-grafana/
-[prom-plugin]: /hub/kong-inc/prometheus/k
+[prom-plugin]: /hub/kong-inc/prometheus/


### PR DESCRIPTION
### Summary
Updating all Konnect dev portal and users and roles links to point to new topic locations. We shouldn't be relying on redirects to do all this work for us; redirects are bad for SEO.

Only one link that's actually broken, and that's in the KIC Prometheus doc.

### Reason
Broken link report: https://github.com/Kong/docs.konghq.com/runs/3785218048?check_suite_focus=true

### Testing
TBA, should spot-check netlify preview