### PR TITLE
[DOCU-1902] Markdown rules and formatting: Add redirects instructions 

### DIFF
--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -96,11 +96,31 @@ For example, if the project path is `app/enterprise/2.1.x/overview`, the path in
 the nav file would be `/overview`, and you would add it to the file
 `app/_data/docs_nav_ee_2.1.x.yml`.
 
+### Add redirects
+
+If you're making an organization change like updating page nesting or renaming a top-level 
+menu item, you'll need to set up a redirect. Redirects prevent `404` pages, and 
+redirect users automatically to the new content location.
+
+1. Navigate to `app` then `_redirects`.
+2. Find the section of the documentation for which the redirect applies. For example, Dev Portal.
+3. Add a new line with the link you want to redirect **from**.
+4. On the same line, add the link you want to redirect **to**.
+
+```bash
+\\ Start the link with what appears after https://docs.konghq.com/.
+
+\\ In the following example, we created a new menu section called Applications 
+in the Dev Portal section of the docs. And we moved the dev-apps page to our
+new menu section. 
+
+/konnect/dev-portal/developers/dev-apps                    /konnect/dev-portal/applications/dev-apps
+```
 
 ## Codeblocks
 
 Codeblocks are containers for your code examples. In Markdown, you can create
-them using three backticks, aka fenced codeblocks:
+them using three backticks, or fenced codeblocks:
 
 ````
 ```bash
@@ -124,10 +144,12 @@ denote a value that the user should edit. Always enclose placeholders in code
 formatting.
 
 ### Inline placeholders
+
 If you're adding a placeholder inline, such as in a sentence, enclose it in single
 backticks: \`{EXAMPLE_TEXT}`
 
 ### Editable placeholders in codeblocks
+
 If you have text in your codeblock that you want the user to edit before running
 the code, you can use editable placeholders.
 

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -23,8 +23,8 @@ no_version: true
 |Avoid generic pronouns             |Once you have added **the inputs section**, ...|Once you have added **this**, ...                  |
 |Don't use _displays_ or _appears_  |Do the thing.                                  |In the blank that **appears**, do the thing.       |
 |---                                |---                                            |---                                                |
-|Use descriptive headings           |Overview                                       |Improve Vitals performance with InfluxDB           |
-|                                   |Query behavior                                 |Query frequency and precision                      |
+|Use descriptive headings           |Improve Vitals performance with InfluxDB       |Overview                                           |
+|                                   |Query frequency and precision                  |Query behavior                                     |
 |---                                |---                                            |---                                                |
 |Use sentence case for headings     |Understanding traffic flow in Kong Gateway     |Understanding Traffic Flow in Kong Gateway         |
 |---                                |---                                            |---                                                |
@@ -32,6 +32,7 @@ no_version: true
 ## Formatting standards
 
 ### Admonitions
+
 - Do not stack admonitions, in other words, list several admonitions one after the other.<br/>
   Admonitions should be carefully selected, called-out text.
 - Admonition types:
@@ -41,10 +42,12 @@ no_version: true
 For more information about formatting admonitions see [markdown-rules](/contributing/markdown-rules/#admonitions).
 
 ## Punctuation rules
+
 - Commas and periods always go inside quotation marks, and colons and semicolons (dashes as well) go outside.
   - For example: “There was a storm last night,” Paul said.
 
 ### Placeholder values
+
 - Use single curly braces, all caps text, and underscores between words.
 
     For example: `{EXAMPLE_VALUE}`
@@ -53,13 +56,16 @@ For more information about formatting admonitions see [markdown-rules](/contribu
     where you want a user to enter their own value.
 
 ## Capitalization guidelines
+
 Follow the user interface (UI). If a term is capitalized in the UI, it should be
 capitalized in the documentation.
 
 ### Kong-specific terms
+
 Capitalize the following Kong-specific terms:
 
 #### Product names
+
 - Kong Konnect (Kong Konnect for first mention, Konnect after)
 - Kong Gateway (Enterprise)
 - Kong Gateway
@@ -67,12 +73,14 @@ Capitalize the following Kong-specific terms:
 - Insomnia
 
 #### Component names
+
 - Dev Portal
 - ServiceHub
 - Vitals
 - Immunity
 
 ### Generic terms
+
 Do not capitalize the following generic terms:
 - plugins
 - control plane
@@ -83,6 +91,7 @@ Do not capitalize the following generic terms:
 - consumer
 
 ## Code formatting
+
 - Separate commands from output.
 - Include properly formatted code comments.
 - For long commands, split the code block into separate lines with `\`
@@ -95,24 +104,28 @@ to avoid horizontal scrolling.
 - Do **NOT** use the command prompt marker ($) in code snippets.
 
 ### Inline code formatting
+
 - Enclose sample code with single backticks.<br/>
   For example: \`sudo yum install /path/to/package.rpm`
 
 ## Images
+
 - Add files to the corresponding product folder by navigating in the repo from **app > assets > images > docs**.
 - When naming/titling image files, use lowercase letters and dashes only.
 - Use SVGs whenever possible, otherwise use PNGs.
 - Limit image file size to ~2MB.
-- Compress and resize images before adding them to the site. 
+- Compress and resize images before adding them to the site.
 - Do not use shadows.
 - Borders can be added to screenshots only `-1px` black.
-- Add an `alt` attribute and detailed description of the image. 
+- Add an `alt` attribute and detailed description of the image.
 
 ## Links
+
 - Don't use link titles like "Read more" and "Click here". Instead, write descriptive titles that properly detail what content is accessible by clicking the link. 
-- If the linked content is a larger area like a panel, add a `title` attribute that describes the linked content to the `a` tag. 
+- If the linked content is a larger area like a panel, add a `title` attribute that describes the linked content to the `a` tag.
 
 ## Reference style guides
+
 - [Valero Style Guide](https://velero.io/docs/v1.5/style-guide/#inline-code-formatting)
 - [Splunk Style Guide](https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Howtouse)
 - [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/)


### PR DESCRIPTION
### Summary

Add redirects instructions to markdown rules and formatting. 

### Reason

Transparency and to help open source contributors. 

### Testing

Local, text-only changes. 
