### PR TITLE
fix: port missing in dig example

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
@@ -174,8 +174,9 @@ Apply the `Deployment` configuration file:
 $ kubectl apply -f coredns-deployment.yaml
 ```
 
-Watch the pods with `kubectl get pods`. Once they are running, you can 
-move on to the next sections: exposing the pods through `Service` and `UDPIngress`.
+Watch the pods with `kubectl -n udpingress-example get pods`. Once they are
+running, you can move on to the next sections: exposing the pods through
+`Service` and `UDPIngress`.
 
 [corefile]:https://coredns.io/manual/toc/#configuration
 [nameservers]:https://datatracker.ietf.org/doc/html/rfc1035#section-6

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
@@ -327,7 +327,7 @@ using `UDPIngress`:
 {% navtab Command %}
 
 ```shell
-$ dig @${KONG_UDP_ENDPOINT} konghq.com
+$ dig @${KONG_UDP_ENDPOINT} -p 9999 konghq.com
 ```
 
 {% endnavtab %}


### PR DESCRIPTION
Somehow the port flag on `dig` didn't make it into the examples, this fixes that.