### PR TITLE
fix: update getting started ingress spec

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
@@ -137,8 +137,10 @@ spec:
       - path: /bar
         pathType: ImplementationSpecific
         backend:
-          serviceName: echo
-          servicePort: 80
+          service:
+            name: echo
+            port:
+              number: 80
 " | kubectl apply -f -
 ingress.extensions/demo-example-com created
 ```


### PR DESCRIPTION
Signed-off-by: JasonWalker <Jason.Walker1@aa.com>

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Small document update in kong docs

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Current doc shows:

```yaml
        backend:
          serviceName: echo
          servicePort: 80
```

This is no longer valid

This PR updates the docs to:

```yaml
        backend:
          service:
            name: echo
            port:
              number: 80
```

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

Kubectl apply will return errors without the new spec format:

```text
[ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend];
```

This spec resolves those errors

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

https://docs.konghq.com/kubernetes-ingress-controller/2.0.x/guides/getting-started/

KIC docs version: 2

