### PR TITLE
[DOCU-1930] Unmark jq plugin as beta

### DIFF
--- a/app/_hub/kong-inc/jq/index.md
+++ b/app/_hub/kong-inc/jq/index.md
@@ -2,7 +2,6 @@
 name: jq
 publisher: Kong Inc.
 versions: 0.0.1
-beta: true
 
 desc: Transform JSON objects included in API requests or responses using jq programs.
 description: |


### PR DESCRIPTION
Remove beta banner from jq plugin for 2.6 GA

### Summary
Removing beta banner from jq plugin as no longer beta with 2.6 GA

### Reason
No longer a beta product

### Testing
N/A

<!-- (Optional) Include link to topic in Netlify preview after it's generated 

