### PR TITLE
Update using-tcpingress.md

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
@@ -39,6 +39,8 @@ Please follow one of the
 If everything is setup correctly, making a request to Kong should return
 HTTP 404 Not Found.
 
+> **Note**: If you are running the example using Minikube on macos, you may need to run `minikube tunnel` in a separate terminal window.  This will allow external LoadBalancer which is not enabled out of the box.
+
 ```bash
 $ curl -i $PROXY_IP
 HTTP/1.1 404 Not Found

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-tcpingress.md
@@ -39,7 +39,11 @@ Please follow one of the
 If everything is setup correctly, making a request to Kong should return
 HTTP 404 Not Found.
 
-> **Note**: If you are running the example using Minikube on macos, you may need to run `minikube tunnel` in a separate terminal window.  This will allow external LoadBalancer which is not enabled out of the box.
+{:.note}
+> **Note**: If you are running the example using Minikube on MacOS, you may need 
+to run [`minikube tunnel`](https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access)
+in a separate terminal window.  This exposes LoadBalancer services 
+externally, which is not enabled by default.
 
 ```bash
 $ curl -i $PROXY_IP


### PR DESCRIPTION
### Summary
Setup port forwarding for minikube running on macos

### Reason
Minikube does not enable an external LoadBalancer service out of the box, hence proxy address is blank when the ingress rules are created.

### Testing
Please follow the steps I listed on the doc to test this feature.
