### PR TITLE
Fix PDF generation

### DIFF
--- a/pdf-generation/create-pdf.js
+++ b/pdf-generation/create-pdf.js
@@ -31,12 +31,12 @@ async function createPDF (name, urls) {
 
             // If the image src is the same as the page href,
             // don't wait for it to load, just pretend that it did
-            if (img.src === document.location.href) {
+            if (img.src === (document.location.origin + document.location.pathname)) {
               return img.dispatchEvent(new CustomEvent("load")); // eslint-disable-line
             }
 
             // Image failed, so it has no height
-            throw new Error('Image failed to load')
+            throw new Error(`Image failed to load: ${img.src} on ${document.location.origin + document.location.pathname}`)
           }
           // Image hasn’t loaded yet, added an event listener to know when it does
           return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Summary
Fix PDF generation for redirects with a URL fragment. The check for `img.src === document.location.href` was failing when a URL fragment was present in `document.location.href`. `img.src` is set to the page URL when a placeholder image is provided (e.g. for a modal) with no `src`.

Switching to use the base URL `origin` and the `pathname` resolves the issue with URL fragments

### Reason
PDF generation is broken on `ee_2.5.x` and `ee_2.6.x`

### Testing
I've tested locally. Once this is on `main`, the PDF generation should work again