### PR TITLE
Fix command in decK getting started guide

### DIFF
--- a/app/deck/1.8.x/guides/getting-started.md
+++ b/app/deck/1.8.x/guides/getting-started.md
@@ -104,7 +104,7 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 1. Check that decK recognizes your {{site.base_gateway}} installation:
 
     ```sh
-    deck konnect ping
+    deck ping
     ```
 
     If the connection is successful, the terminal displays your gateway version:


### PR DESCRIPTION
### Summary
Fixing a command.

### Reason
Accidentally added `konnect` to the command.

### Testing
N/A