### PR TITLE
[DOCU-1938] Add link classes

### DIFF
--- a/app/enterprise/2.6.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.6.x/deployment/installation/amazon-linux-2.md
@@ -2,12 +2,17 @@
 title: Install Kong Gateway on Amazon Linux 2
 ---
 
+<!-- Banner with links to latest downloads -->
+<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
+
 {:.install-banner}
-> Download the latest {{site.base_gateway}} package for [**Amazon Linux 2**]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.amzn2.noarch.rpm)
+> Download the latest {{site.base_gateway}} package for
+> [**Amazon Linux 2**]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.amzn2.noarch.rpm){:.install-link}
 >
 >(latest {{site.base_gateway}} version: {{site.data.kong_latest_ee.version}})
 > <br><br>
-> <span class="install-subtitle">View the list of all [**Amazon Linux 2**]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/) packages </span>
+> <span class="install-subtitle">View the list of all
+> [**Amazon Linux 2**]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/){:.install-listing-link} packages </span>
 
 ## Introduction
 

--- a/app/enterprise/2.6.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.6.x/deployment/installation/amazon-linux.md
@@ -1,13 +1,17 @@
 ---
 title: Install Kong Gateway on Amazon Linux 1
 ---
+<!-- Banner with links to latest downloads -->
+<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
 
 {:.install-banner}
-> Download the latest {{site.base_gateway}} package for [**Amazon Linux 1**]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.amzn1.noarch.rpm)
+> Download the latest {{site.base_gateway}} package for
+> [**Amazon Linux 1**]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.amzn1.noarch.rpm){:.install-link}
 >
 >(latest {{site.base_gateway}} version: {{site.data.kong_latest_ee.version}})
 > <br><br>
-> <span class="install-subtitle">View the list of all [**Amazon Linux 1**]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/) packages </span>
+> <span class="install-subtitle">View the list of all
+> [**Amazon Linux 1**]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/){:.install-listing-link} packages </span>
 
 ## Introduction
 

--- a/app/enterprise/2.6.x/deployment/installation/centos.md
+++ b/app/enterprise/2.6.x/deployment/installation/centos.md
@@ -2,12 +2,19 @@
 title: Install Kong Gateway on CentOS
 ---
 
+<!-- Banner with links to latest downloads -->
+<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
+
 {:.install-banner}
-> Download the latest {{site.base_gateway}} package for [**CentOS 7**]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.el7.noarch.rpm) or [**CentOS 8**]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.el8.noarch.rpm)
+> Download the latest {{site.base_gateway}} package for
+> [**CentOS 7**]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.el7.noarch.rpm){:.install-link} or
+> [**CentOS 8**]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.el8.noarch.rpm){:.install-link}
 >
 >(latest {{site.base_gateway}} version: {{site.data.kong_latest_ee.version}})
 > <br><br>
-> <span class="install-subtitle">View the list of all [**CentOS 7**]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/) or [**CentOS 8**]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/) packages </span>
+> <span class="install-subtitle">View the list of all
+> [**CentOS 7**]({{ site.links.download }}/gateway-2.x-centos-7/Packages/k/){:.install-listing-link} or
+> [**CentOS 8**]({{ site.links.download }}/gateway-2.x-centos-8/Packages/k/){:.install-listing-link} packages </span>
 
 ## Introduction
 

--- a/app/enterprise/2.6.x/deployment/installation/docker.md
+++ b/app/enterprise/2.6.x/deployment/installation/docker.md
@@ -1,8 +1,13 @@
 ---
 title: Install Kong Gateway on Docker
 ---
+
+<!-- Banner with links to latest downloads -->
+<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
+
 {:.install-banner}
-> See the list of Docker tags and pull the [**Kong Gateway Docker image**](https://hub.docker.com/r/kong/kong-gateway/tags)
+> See the list of Docker tags and pull the
+> [**Kong Gateway Docker image**](https://hub.docker.com/r/kong/kong-gateway/tags){:.install-listing-link}
 >
 > (latest {{site.base_gateway}} version: {{site.data.kong_latest_ee.version}})
 

--- a/app/enterprise/2.6.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.6.x/deployment/installation/rhel.md
@@ -2,12 +2,19 @@
 title: Install Kong Gateway on RHEL
 ---
 
+<!-- Banner with links to latest downloads -->
+<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
+
 {:.install-banner}
-> Download the latest {{site.base_gateway}} package for [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.rhel7.noarch.rpm) or [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.rhel8.noarch.rpm)
+> Download the latest {{site.base_gateway}} package for
+> [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.rhel7.noarch.rpm){:.install-link} or
+> [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-enterprise-edition-{{site.data.kong_latest_ee.version}}.rhel8.noarch.rpm){:.install-link}
 >
 >(latest {{site.base_gateway}} version: {{site.data.kong_latest_ee.version}})
 > <br><br>
-> <span class="install-subtitle">View the list of all [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/) or [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/) packages </span>
+> <span class="install-subtitle">View the list of all
+> [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/){:.install-listing-link} or
+> [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/){:.install-listing-link} packages </span>
 
 ## Introduction
 

--- a/app/enterprise/2.6.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.6.x/deployment/installation/ubuntu.md
@@ -2,12 +2,21 @@
 title: Install Kong Gateway on Ubuntu
 ---
 
+<!-- Banner with links to latest downloads -->
+<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
+
 {:.install-banner}
-> Download the latest {{site.base_gateway}} package for Ubuntu [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{site.data.kong_latest_ee.version}}_all.deb), [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{site.data.kong_latest_ee.version}}_all.deb), or [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{site.data.kong_latest_ee.version}}_all.deb)
+> Download the latest {{site.base_gateway}} package for Ubuntu
+> [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{site.data.kong_latest_ee.version}}_all.deb){:.install-link},
+> [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{site.data.kong_latest_ee.version}}_all.deb){:.install-link}, or
+> [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{site.data.kong_latest_ee.version}}_all.deb){:.install-link}
 >
 >(latest {{site.base_gateway}} version: {{site.data.kong_latest_ee.version}})
 > <br><br>
-> <span class="install-subtitle">View the list of all Ubuntu [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/), [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/), or [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/)
+> <span class="install-subtitle">View the list of all Ubuntu
+> [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/){:.install-listing-link},
+> [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/){:.install-listing-link}, or
+> [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/){:.install-listing-link}
 > packages </span>
 
 


### PR DESCRIPTION
### Summary
Adding link classes to installation banners.

### Reason
Easier tracking for link clicks.

### Testing
Tested locally.

Example link: https://deploy-preview-3334--kongdocs.netlify.app/enterprise/2.6.x/deployment/installation/ubuntu/