### PR TITLE
docs: fill out istio testing for kic

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
@@ -61,6 +61,11 @@ For each {{site.kic_product_name}} release, tests are run to verify this documen
 
 | {{site.kic_product_name}} |            1.0.x            |            1.1.x            |            1.2.x            |            1.3.x            |            2.0.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Istio 1.6                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Istio 1.7                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Istio 1.8                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Istio 1.9                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
+| Istio 1.10                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
 | Istio 1.11                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 [istio]:https://istio.io


### PR DESCRIPTION
### Summary

This patch updates the testing matrix for the KIC+Istio guide.

### Reason

Given our [testing results](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1361799115) for the KIC+Istio guide, we've seen that testing succeeds for `v1.9`, and `v1.10` of Istio with KIC `v2.x`.

### Testing

Testing for this is [Automated in KIC](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1361799115)