### PR TITLE
Version support: Add entry for 2.6

### DIFF
--- a/app/enterprise/2.6.x/support-policy.md
+++ b/app/enterprise/2.6.x/support-policy.md
@@ -46,6 +46,7 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  2.6.x.x |  2021-10-14   |     2022-08-24      |      2023-08-24       |
 |  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |
 |  2.4.x.x |  2021-05-18   |     2022-08-24      |      2023-08-24       |  
 |  2.3.x.x |  2021-02-11   |     2022-08-24      |      2023-08-24       |


### PR DESCRIPTION
### Summary
Adding 2.6 to the version support policy table.

### Reason
2.6 went out 10/14.

Does not need to be run by PM; PM has already set a documented support period for 2.x, and the only number that should change is the release date.

### Testing
TBA