### PR TITLE
[DOCU-351] Exit transformer: remove entry for 408 error code

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -88,7 +88,6 @@ unexpected error on an _unknown_ Service or Route will pass through the Exit Tra
 - [405 Method not allowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405)
 - [406 Not acceptable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406)
 - [407 Proxy authentication required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407)
-- [408 Request timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408)
 - [409 Conflict](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409)
 - [410 Gone](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410)
 - [411 Length required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/411)


### PR DESCRIPTION
### Summary
Removing the 408 error code from the list of supported codes for the exit transformer plugin.

### Reason
Due to how NGINX handles 408, Kong's Exit Transformer cannot intercept that particular HTTP method.
https://konghq.atlassian.net/browse/DOCU-351

### Testing
https://deploy-preview-3341--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#http-msgs