### PR TITLE
Adds 2.5.1.1 patch release notes to enterprise changelog

### DIFF
--- a/app/enterprise/changelog.md
+++ b/app/enterprise/changelog.md
@@ -357,7 +357,7 @@ only one or neither of the fields be configured.
   [#7775](https://github.com/Kong/kong/pull/7775)
 
 ## 2.5.1.1
-**Release Date** 2021/10/25
+**Release Date** 2021/10/22
 
 ### Fixes
 


### PR DESCRIPTION
### Reason
We are releasing a 2.5.1.1 patch and the Enterprise release notes need to be updated to reflect those updates.

### Testing
[2.5.1.1 changelog entry](https://deploy-preview-3343--kongdocs.netlify.app/enterprise/changelog/#2511)
