### PR TITLE
Fix blockquote styling

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1253,7 +1253,7 @@ Generic Styling for Desktop
     margin-inline-start: 0;
     margin-inline-end: 0;
     opacity: 0.7;
-    font-style: italic;
+    font-size: 15px;
 
     ol, ul {
       margin-top: 0.5em;
@@ -1283,6 +1283,7 @@ Generic Styling for Desktop
       padding: 15px 18px;
       opacity: 1;
       font-style: normal;
+      font-size: 17px;
     }
 
     &.warning {

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -716,13 +716,6 @@
 
 .page-content-container {
   .page-content {
-    .reading-time {
-      font-size: 15px;
-      display: block;
-      color: #b9b9b9;
-      margin-bottom: 14px;
-      padding-bottom: 1rem;
-    }
 
     @media (max-width: 800px) {
       padding: 0;
@@ -1255,15 +1248,12 @@ Generic Styling for Desktop
   }
 
   blockquote {
-    margin-bottom: 1.3em;
-    padding: 15px 18px;
-    background-color: @blue-100;
     border: none;
-    border-left: solid 3px @blue-400;
-    border-radius: 3px;
     display: block;
     margin-inline-start: 0;
     margin-inline-end: 0;
+    opacity: 0.7;
+    font-style: italic;
 
     ol, ul {
       margin-top: 0.5em;
@@ -1288,15 +1278,11 @@ Generic Styling for Desktop
       display: block;
     }
 
-    &:not(.no-icon)::before {
-      content: "\f05a";
-      font-family: "Font Awesome", FontAwesome;
-      color: @blue-400;
-      display: inline;
-      font-weight: 600;
-      font-size: 17px;
-      padding: 0 10px 0 0;
-      float: left;
+    &.warning, &.important, &.note {
+      margin-bottom: 1em;
+      padding: 15px 18px;
+      opacity: 1;
+      font-style: normal;
     }
 
     &.warning {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -126,7 +126,7 @@
         margin-bottom: 0.1rem;
         list-style-type: disc;
 
-        p {
+        > p {
           // font-size: inherit;
           margin-bottom: 1.2rem;
         }


### PR DESCRIPTION
### Summary
Fixing blockquote styling so that unstyled `>` content is simpler. 
(Also got rid of .reading-time element, we removed read time from pages a long time ago).

### Reason
Too many elements were picking up the note styling, so we had pages full of blue blocks: https://docs.konghq.com/kubernetes-ingress-controller/2.0.x/references/annotations/
https://docs.konghq.com/enterprise/2.6.x/support-policy/

### Testing
https://deploy-preview-3344--kongdocs.netlify.app/enterprise/2.6.x/support-policy/
https://deploy-preview-3344--kongdocs.netlify.app/kubernetes-ingress-controller/2.0.x/references/annotations/