### PR TITLE
[DOCU-1761] add Kong repo link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Looking for the Kong code repo instead?
+    url: https://github.com/Kong/kong
+    about: If you have Kong product related issues, visit our Kong repo.


### PR DESCRIPTION
### Summary

* Add link to Kong repo from Issue templates page

### Reason

Community support
[DOCU-1761](https://konghq.atlassian.net/browse/DOCU-1761)