### PR TITLE
docs: add prom `per_consumer` option and update example

### DIFF
--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -48,6 +48,16 @@ params:
   dbless_compatible: yes
   dbless_explanation: |
     The database will always be reported as reachable in Prometheus with DB-less.
+  config:
+    - name: per_consumer
+      required: false
+      datatype: boolean
+      default: '`false`'
+      description: |
+        A boolean value that determines if per-consumer metrics should be
+        collected.
+        If enabled, a `kong_http_consumer_status` metric will be added to
+        exported metrics.
 
 ---
 
@@ -73,7 +83,7 @@ dashboard: [https://grafana.com/dashboards/7424](https://grafana.com/dashboards/
 ### Available metrics
 
 - **Status codes**: HTTP status codes returned by Upstream services.
-  These are available per service and across all services.
+  These are available per service, across all services and per route per consumer.
 - **Latencies Histograms**: Latency as measured at Kong:
    - **Request**: Total time taken by Kong and Upstream services to serve
      requests.
@@ -116,6 +126,9 @@ kong_bandwidth{type="ingress",service="google"} 254
 # HELP kong_datastore_reachable Datastore reachable from Kong, 0 is unreachable
 # TYPE kong_datastore_reachable gauge
 kong_datastore_reachable 1
+# HELP kong_http_consumer_status HTTP status codes for customer per service/route in Kong
+# TYPE kong_http_consumer_status counter
+kong_http_consumer_status{service="s1",route="s1.route-1",code="200",consumer="<consumer_username>"} 3
 # HELP kong_http_status_total HTTP status codes aggreggated across all services in Kong
 # TYPE kong_http_status_total counter
 kong_http_status_total{code="301"} 2

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -115,74 +115,43 @@ Transfer-Encoding: chunked
 Connection: keep-alive
 Access-Control-Allow-Origin: *
 
-# HELP kong_bandwidth_total Total bandwidth in bytes for all proxied requests in Kong
-# TYPE kong_bandwidth_total counter
-kong_bandwidth_total{type="egress"} 1277
-kong_bandwidth_total{type="ingress"} 254
-# HELP kong_bandwidth Total bandwidth in bytes consumed per service in Kong
+# HELP kong_bandwidth Total bandwidth in bytes consumed per service/route in Kong
 # TYPE kong_bandwidth counter
-kong_bandwidth{type="egress",service="google"} 1277
-kong_bandwidth{type="ingress",service="google"} 254
+kong_bandwidth{type="egress",service="google",route="google.route-1"} 1277
+kong_bandwidth{type="ingress",service="google",route="google.route-1"} 254
 # HELP kong_datastore_reachable Datastore reachable from Kong, 0 is unreachable
 # TYPE kong_datastore_reachable gauge
 kong_datastore_reachable 1
 # HELP kong_http_consumer_status HTTP status codes for customer per service/route in Kong
 # TYPE kong_http_consumer_status counter
 kong_http_consumer_status{service="s1",route="s1.route-1",code="200",consumer="<consumer_username>"} 3
-# HELP kong_http_status_total HTTP status codes aggreggated across all services in Kong
-# TYPE kong_http_status_total counter
-kong_http_status_total{code="301"} 2
-# HELP kong_http_status HTTP status codes per service in Kong
+# HELP kong_http_status HTTP status codes per service/route in Kong
 # TYPE kong_http_status counter
-kong_http_status{code="301",service="google"} 2
+kong_http_status{code="301",service="google",route="google.route-1"} 2
 # HELP kong_latency Latency added by Kong, total request time and upstream latency for each service in Kong
 # TYPE kong_latency histogram
-kong_latency_bucket{type="kong",service="google",le="00001.0"} 1
-kong_latency_bucket{type="kong",service="google",le="00002.0"} 1
+kong_latency_bucket{type="kong",service="google",route="google.route-1",le="00001.0"} 1
+kong_latency_bucket{type="kong",service="google",route="google.route-1",le="00002.0"} 1
 .
 .
 .
-kong_latency_bucket{type="kong",service="google",le="+Inf"} 2
-kong_latency_bucket{type="request",service="google",le="00300.0"} 1
-kong_latency_bucket{type="request",service="google",le="00400.0"} 1
+kong_latency_bucket{type="kong",service="google",route="google.route-1",le="+Inf"} 2
+kong_latency_bucket{type="request",service="google",route="google.route-1",le="00300.0"} 1
+kong_latency_bucket{type="request",service="google",route="google.route-1",le="00400.0"} 1
 .
 .
-kong_latency_bucket{type="request",service="google",le="+Inf"} 2
-kong_latency_bucket{type="upstream",service="google",le="00300.0"} 2
-kong_latency_bucket{type="upstream",service="google",le="00400.0"} 2
+kong_latency_bucket{type="request",service="google",route="google.route-1",le="+Inf"} 2
+kong_latency_bucket{type="upstream",service="google",route="google.route-1",le="00300.0"} 2
+kong_latency_bucket{type="upstream",service="google",route="google.route-1",le="00400.0"} 2
 .
 .
-kong_latency_bucket{type="upstream",service="google",le="+Inf"} 2
-kong_latency_count{type="kong",service="google"} 2
-kong_latency_count{type="request",service="google"} 2
-kong_latency_count{type="upstream",service="google"} 2
-kong_latency_sum{type="kong",service="google"} 2145
-kong_latency_sum{type="request",service="google"} 2672
-kong_latency_sum{type="upstream",service="google"} 527
-# HELP kong_latency_total Latency added by Kong, total request time and upstream latency aggreggated across all services in Kong
-# TYPE kong_latency_total histogram
-kong_latency_total_bucket{type="kong",le="00001.0"} 1
-kong_latency_total_bucket{type="kong",le="00002.0"} 1
-.
-.
-kong_latency_total_bucket{type="kong",le="+Inf"} 2
-kong_latency_total_bucket{type="request",le="00300.0"} 1
-kong_latency_total_bucket{type="request",le="00400.0"} 1
-.
-.
-kong_latency_total_bucket{type="request",le="+Inf"} 2
-kong_latency_total_bucket{type="upstream",le="00300.0"} 2
-kong_latency_total_bucket{type="upstream",le="00400.0"} 2
-.
-.
-.
-kong_latency_total_bucket{type="upstream",le="+Inf"} 2
-kong_latency_total_count{type="kong"} 2
-kong_latency_total_count{type="request"} 2
-kong_latency_total_count{type="upstream"} 2
-kong_latency_total_sum{type="kong"} 2145
-kong_latency_total_sum{type="request"} 2672
-kong_latency_total_sum{type="upstream"} 527
+kong_latency_bucket{type="upstream",service="google",route="google.route-1",le="+Inf"} 2
+kong_latency_count{type="kong",service="google",route="google.route-1"} 2
+kong_latency_count{type="request",service="google",route="google.route-1"} 2
+kong_latency_count{type="upstream",service="google",route="google.route-1"} 2
+kong_latency_sum{type="kong",service="google",route="google.route-1"} 2145
+kong_latency_sum{type="request",service="google",route="google.route-1"} 2672
+kong_latency_sum{type="upstream",service="google",route="google.route-1"} 527
 # HELP kong_nginx_http_current_connections Number of HTTP connections
 # TYPE kong_nginx_http_current_connections gauge
 kong_nginx_http_current_connections{state="accepted"} 8

--- a/app/_hub/kong-inc/prometheus/index.md
+++ b/app/_hub/kong-inc/prometheus/index.md
@@ -56,7 +56,7 @@ params:
       description: |
         A boolean value that determines if per-consumer metrics should be
         collected.
-        If enabled, a `kong_http_consumer_status` metric will be added to
+        If enabled, a `kong_http_consumer_status` metric is added to
         exported metrics.
 
 ---
@@ -83,7 +83,7 @@ dashboard: [https://grafana.com/dashboards/7424](https://grafana.com/dashboards/
 ### Available metrics
 
 - **Status codes**: HTTP status codes returned by Upstream services.
-  These are available per service, across all services and per route per consumer.
+  These are available per service, across all services, and per route per consumer.
 - **Latencies Histograms**: Latency as measured at Kong:
    - **Request**: Total time taken by Kong and Upstream services to serve
      requests.
@@ -124,7 +124,7 @@ kong_bandwidth{type="ingress",service="google",route="google.route-1"} 254
 kong_datastore_reachable 1
 # HELP kong_http_consumer_status HTTP status codes for customer per service/route in Kong
 # TYPE kong_http_consumer_status counter
-kong_http_consumer_status{service="s1",route="s1.route-1",code="200",consumer="<consumer_username>"} 3
+kong_http_consumer_status{service="s1",route="s1.route-1",code="200",consumer="<CONSUMER_USERNAME>"} 3
 # HELP kong_http_status HTTP status codes per service/route in Kong
 # TYPE kong_http_status counter
 kong_http_status{code="301",service="google",route="google.route-1"} 2


### PR DESCRIPTION
### Summary

* Add `per_consumer` to Prometheus plugin docs
* Update Prometheus plugin docs example with new options and remove legacy ones

### Reason

* `per_consumer` exists in Kong code since https://github.com/Kong/kong/commit/7e205b0fb3c1536526943e856e38943dfc8b9a10
* updated example contains outdated informations

### Testing

Changes have been locally tested using `make run` and new doc preview in browser.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
