### PR TITLE
[DOCU-1934] note that FIPS compliance is not supported on macOS

### DIFF
--- a/app/mesh/1.2.x/features/fips-support.md
+++ b/app/mesh/1.2.x/features/fips-support.md
@@ -6,3 +6,6 @@ toc: false
 With version 1.2.0, Kong Mesh provides built-in support for the Federal Information Processing Standard (FIPS-2). Compliance with this standard is typically required for working with U.S. federal government agencies and their contractors.
 
 FIPS support is provided by implementing Envoy's FIPS-compliant mode for BoringSSL. For more information about how it works, see Envoy's [FIPS 140-2 documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#fips-140-2).
+
+{:.important .no-icon}
+> FIPS compliance is not supported on macOS.

--- a/app/mesh/1.2.x/installation/macos.md
+++ b/app/mesh/1.2.x/installation/macos.md
@@ -11,6 +11,9 @@ To install and run {{site.mesh_product_name}} on macOS,:
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
 
+{:.important .no-icon}
+> FIPS compliance is not supported on macOS.
+
 ## Prerequisites
 
 You have a license for {{site.mesh_product_name}}.

--- a/app/mesh/1.3.x/features/fips-support.md
+++ b/app/mesh/1.3.x/features/fips-support.md
@@ -6,3 +6,6 @@ toc: false
 With version 1.2.0, Kong Mesh provides built-in support for the Federal Information Processing Standard (FIPS-2). Compliance with this standard is typically required for working with U.S. federal government agencies and their contractors.
 
 FIPS support is provided by implementing Envoy's FIPS-compliant mode for BoringSSL. For more information about how it works, see Envoy's [FIPS 140-2 documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#fips-140-2).
+
+{:.important .no-icon}
+> FIPS compliance is not supported on macOS.

--- a/app/mesh/1.3.x/installation/macos.md
+++ b/app/mesh/1.3.x/installation/macos.md
@@ -11,6 +11,9 @@ To install and run {{site.mesh_product_name}} on macOS,:
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
 
+{:.important .no-icon}
+> FIPS compliance is not supported on macOS.
+
 ## Prerequisites
 
 You have a license for {{site.mesh_product_name}}.

--- a/app/mesh/1.4.x/features/fips-support.md
+++ b/app/mesh/1.4.x/features/fips-support.md
@@ -6,3 +6,6 @@ toc: false
 With version 1.2.0, Kong Mesh provides built-in support for the Federal Information Processing Standard (FIPS-2). Compliance with this standard is typically required for working with U.S. federal government agencies and their contractors.
 
 FIPS support is provided by implementing Envoy's FIPS-compliant mode for BoringSSL. For more information about how it works, see Envoy's [FIPS 140-2 documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#fips-140-2).
+
+{:.important .no-icon}
+> FIPS compliance is not supported on macOS.

--- a/app/mesh/1.4.x/installation/macos.md
+++ b/app/mesh/1.4.x/installation/macos.md
@@ -11,6 +11,9 @@ To install and run {{site.mesh_product_name}} on macOS,:
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
 
+{:.important .no-icon}
+> FIPS compliance is not supported on macOS.
+
 ## Prerequisites
 
 You have a license for {{site.mesh_product_name}}.


### PR DESCRIPTION
### Summary
Note that FIPS compliance is not supported on macOS (nor on Windows, but we're not shipping Windows yet ...)

### Reason
https://konghq.atlassian.net/browse/DOCU-1934 and see more detailed rationale in linked Trello code task

### Testing
Tested locally for versions 1.2.x, 1.3.x, 1.4.x (FIPS feature and macOS install pages). FIPS compliance shipped with version 1.2.0.

See:
https://deploy-preview-3357--kongdocs.netlify.app/mesh/1.4.x/installation/macos/
https://deploy-preview-3357--kongdocs.netlify.app/mesh/1.4.x/features/fips-support/
and corresponding pages for versions 1.3.x and 1.2.x
