### PR TITLE
[DOCU-916] Add note about Kafka ZooKeeper

### DIFF
--- a/app/_hub/kong-inc/kafka-log/index.md
+++ b/app/_hub/kong-inc/kafka-log/index.md
@@ -184,6 +184,9 @@ params:
 The following guidelines assume that both {{site.ee_product_name}} and `Kafka` have been
 installed on your local machine.
 
+{:.note}
+> **Note**: We use `zookeeper` in the following example, which is not required or has been removed on some Kafka versions. Refer to the [Kafka ZooKeeper documentation](https://kafka.apache.org/documentation/#zk) for more information.
+
 1. Create a `kong-log` topic in your Kafka cluster:
 
     ```

--- a/app/_hub/kong-inc/kafka-upstream/index.md
+++ b/app/_hub/kong-inc/kafka-upstream/index.md
@@ -300,7 +300,7 @@ The following steps assume that {{site.base_gateway}} is installed and the Kafka
 {:.note}
 > **Note**: We use `zookeeper` in the following example, which is not required or has been removed on some Kafka versions. Refer to the [Kafka ZooKeeper documentation](https://kafka.apache.org/documentation/#zk) for more information.
 
-1. Create a topic on Kafka. In this example, we'll set up the topic `kong-upstream` on Kafka:
+1. Create a `kong-upstream` topic in your Kafka cluster:
 
     ```
     ${KAFKA_HOME}/bin/kafka-topics.sh --create \

--- a/app/_hub/kong-inc/kafka-upstream/index.md
+++ b/app/_hub/kong-inc/kafka-upstream/index.md
@@ -209,10 +209,10 @@ params:
 
 ---
 
-### Enabling on a service-less route
+### Enable on a service-less route
 
 ```bash
-$ curl -X POST http://kong:8001/routes/my-route/plugins \
+curl -X POST http://kong:8001/routes/my-route/plugins \
     --data "name=kafka-upstream" \
     --data "config.bootstrap_servers[1].host=localhost" \
     --data "config.bootstrap_servers[1].port=9092" \
@@ -295,9 +295,12 @@ Known limitations:
 
 ## Quickstart
 
-The following guidelines assume that {{site.base_gateway}} is installed and the Kafka Upstream plugin is enabled.
+The following steps assume that {{site.base_gateway}} is installed and the Kafka Upstream plugin is enabled.
 
-1. Create a `kong-upstream` topic in your Kafka cluster:
+{:.note}
+> **Note**: We use `zookeeper` in the following example, which is not required or has been removed on some Kafka versions. Refer to the [Kafka ZooKeeper documentation](https://kafka.apache.org/documentation/#zk) for more information.
+
+1. Create a topic on Kafka. In this example, we'll set up the topic `kong-upstream` on Kafka:
 
     ```
     ${KAFKA_HOME}/bin/kafka-topics.sh --create \


### PR DESCRIPTION
### Summary

* Add note about Kafka Zookeeper to Kafka Log and Kafka Upstream plugin documentation. 

### Reason

Kafka is no longer requiring or removing ZooKeeper. 

https://konghq.atlassian.net/browse/DOCU-916
