### PR TITLE
[DOCU-811] Gateway: Add deprecated endpoint note

### DIFF
--- a/app/enterprise/0.36-x/oasconfig.md
+++ b/app/enterprise/0.36-x/oasconfig.md
@@ -2,7 +2,8 @@
 title: OpenAPI Spec to Kong Entities 
 ---
 
-## Introduction
+{:.important}
+> **Important**: The `/aos-config` endpoint is deprecated and no longer maintained. Instead, convert OpenAPI 3.0 Specs to Declarative Config using [Insomnia](https://insomnia.rest/) or [Inso CLI](https://docs.insomnia.rest/inso-cli/cli-command-reference/inso-generate-config). Learn more about generating [Kong Declarative Config through the Insomnia app](https://docs.insomnia.rest/insomnia/declarative-config).
 
 This Admin API endpoint allows you to read an OpenAPI Spec into Kong to create the appropriate Services and Routes in an automated way. For now, the functionality is in the early stages and is limited to creating Services and Routes in Kong. This endpoint is useful for testing or quick-start scenarios. In future releases, it may be expanded. 
 

--- a/app/enterprise/0.36-x/oasconfig.md
+++ b/app/enterprise/0.36-x/oasconfig.md
@@ -3,7 +3,7 @@ title: OpenAPI Spec to Kong Entities
 ---
 
 {:.important}
-> **Important**: The `/aos-config` endpoint is deprecated and no longer maintained. Instead, convert OpenAPI 3.0 Specs to Declarative Config using [Insomnia](https://insomnia.rest/) or [Inso CLI](https://docs.insomnia.rest/inso-cli/cli-command-reference/inso-generate-config). Learn more about generating [Kong Declarative Config through the Insomnia app](https://docs.insomnia.rest/insomnia/declarative-config).
+> **Important**: The `/oas-config` endpoint is deprecated and no longer maintained. Instead, convert OpenAPI 3.0 Specs to Declarative Config using [Insomnia](https://insomnia.rest/) or [Inso CLI](https://docs.insomnia.rest/inso-cli/cli-command-reference/inso-generate-config). Learn more about generating [Kong Declarative Config through the Insomnia app](https://docs.insomnia.rest/insomnia/declarative-config).
 
 This Admin API endpoint allows you to read an OpenAPI Spec into Kong to create the appropriate Services and Routes in an automated way. For now, the functionality is in the early stages and is limited to creating Services and Routes in Kong. This endpoint is useful for testing or quick-start scenarios. In future releases, it may be expanded. 
 


### PR DESCRIPTION
### Summary

Gateway v. 0.36 endpoint `/oas-config` is deprecated and no longer maintained. Added a warning and directed users over to Insomnia and Inso CLI. 

![Screen Shot 2021-11-04 at 2 29 44 PM](https://user-images.githubusercontent.com/22301405/140423432-92b3c506-0a80-433c-bbdb-8b0253eddf47.png)
Screenshot says `aos` not `oas`, I've fixed this. 

https://deploy-preview-3363--kongdocs.netlify.app/enterprise/0.36-x/oasconfig/