### PR TITLE
[DOCU-1982] admin_listen port warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .DS_Store
+
+# ignore local install file
 install
+# don't ignore the install folder
+!install/
+
 .env
 .che
 .vagrant

--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -1,0 +1,13 @@
+{% if include.desc == "long" %}
+    {:.important}
+    > **Important:** The settings below are intended for non-production use **only**, as they override the default `admin_listen` setting to listen for requests from any source. **Do not** use these settings in environments directly exposed to the internet.
+    >
+    > <br>
+    > If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
+
+{% endif %}
+{% if include.desc == "short" %}
+    {:.important}
+    > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
+
+{% endif %}

--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -1,13 +1,13 @@
 {% if include.desc == "long" %}
-  {:.important}
-  > **Important:** The settings below are intended for non-production use **only**, as they override the default `admin_listen` setting to listen for requests from any source. **Do not** use these settings in environments directly exposed to the internet.
-  >
-  > <br>
-  > If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
+   {:.important}
+   > **Important:** The settings below are intended for non-production use **only**, as they override the default `admin_listen` setting to listen for requests from any source. **Do not** use these settings in environments directly exposed to the internet.
+   >
+   > <br>
+   > If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
 
 {% endif %}
 {% if include.desc == "short" %}
-  {:.important}
-  > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
+   {:.important}
+   > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
 
 {% endif %}

--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -1,13 +1,13 @@
 {% if include.desc == "long" %}
-    {:.important}
-    > **Important:** The settings below are intended for non-production use **only**, as they override the default `admin_listen` setting to listen for requests from any source. **Do not** use these settings in environments directly exposed to the internet.
-    >
-    > <br>
-    > If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
+  {:.important}
+  > **Important:** The settings below are intended for non-production use **only**, as they override the default `admin_listen` setting to listen for requests from any source. **Do not** use these settings in environments directly exposed to the internet.
+  >
+  > <br>
+  > If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
 
 {% endif %}
 {% if include.desc == "short" %}
-    {:.important}
-    > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
+  {:.important}
+  > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway-oss/{{page.kong_version}}/secure-admin-api/).
 
 {% endif %}

--- a/app/enterprise/2.6.x/deployment/installation/amazon-linux-2.md
+++ b/app/enterprise/2.6.x/deployment/installation/amazon-linux-2.md
@@ -203,6 +203,8 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 2. It is necessary to update the administration API setting to listen on the needed network interfaces on the Amazon Linux host. A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
     ```
     admin_listen = 0.0.0.0:8001, 0.0.0.0:8444 ssl
     ```

--- a/app/enterprise/2.6.x/deployment/installation/amazon-linux.md
+++ b/app/enterprise/2.6.x/deployment/installation/amazon-linux.md
@@ -204,6 +204,8 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 2. It is necessary to update the administration API setting to listen on the needed network interfaces on the Amazon Linux host. A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
     ```
     admin_listen = 0.0.0.0:8001, 0.0.0.0:8444 ssl
     ```

--- a/app/enterprise/2.6.x/deployment/installation/centos.md
+++ b/app/enterprise/2.6.x/deployment/installation/centos.md
@@ -202,6 +202,8 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 2. It is necessary to update the administration API setting to listen on the needed network interfaces on the CentOS host. A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
     ```
     admin_listen = 0.0.0.0:8001, 0.0.0.0:8444 ssl
     ```

--- a/app/enterprise/2.6.x/deployment/installation/docker.md
+++ b/app/enterprise/2.6.x/deployment/installation/docker.md
@@ -38,6 +38,8 @@ To complete this installation you will need a Docker-enabled system with proper
 
 ## Step 5. Start the gateway with Kong Manager {#start-gateway}
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
 <pre><code>docker run -d --name kong-ee --network=kong-ee-net \
   -e "KONG_DATABASE=postgres" \
   -e "KONG_PG_HOST=kong-ee-database" \

--- a/app/enterprise/2.6.x/deployment/installation/rhel.md
+++ b/app/enterprise/2.6.x/deployment/installation/rhel.md
@@ -221,6 +221,8 @@ This setting needs to resolve to a network path that will reach the RHEL host.
 
 1. It is necessary to update the administration API setting to listen on the needed network interfaces on the RHEL host. A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
     ```
     admin_listen = 0.0.0.0:8001, 0.0.0.0:8444 ssl
     ```

--- a/app/enterprise/2.6.x/deployment/installation/ubuntu.md
+++ b/app/enterprise/2.6.x/deployment/installation/ubuntu.md
@@ -176,6 +176,8 @@ Setting a password for the **Super Admin** before initial start-up is strongly r
 
 2. It is necessary to update the administration API setting to listen on the needed network interfaces on the host. A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
     ```
     admin_listen = 0.0.0.0:8001, 0.0.0.0:8444 ssl
     ```

--- a/app/enterprise/2.6.x/kong-manager/networking/configuration.md
+++ b/app/enterprise/2.6.x/kong-manager/networking/configuration.md
@@ -28,6 +28,8 @@ Common configurations to enable are
   8444 on localhost. Change [`admin_listen`] if necessary, or set
   [`admin_api_uri`].
 
+{% include_cached /md/admin-listen.md desc='short' %}
+
 * Securing Kong Manager and serving it from a dedicated node
 
   When Kong Manager is **secured and served from a dedicated node**,

--- a/app/enterprise/2.6.x/network.md
+++ b/app/enterprise/2.6.x/network.md
@@ -35,6 +35,9 @@ This is the port where Kong exposes its management API. Hence in production this
 it from unauthorized access.
 
 * `8001` provides Kong's **Admin API** that you can use to operate Kong with HTTP. See [admin_listen].
+
+{% include_cached /md/admin-listen.md desc='short' %}
+
 * `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
 
 ## Firewall

--- a/app/enterprise/2.6.x/plugins/oidc-cognito.md
+++ b/app/enterprise/2.6.x/plugins/oidc-cognito.md
@@ -156,6 +156,8 @@ You can verify the confirmed user from the Cognito page under “General setting
 
 Since AWS Cognito only supports the HTTPS protocol, when you start Kong Enterprise, ensure that HTTPS protocol for Dev Portal is enabled. For example:
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
 ```
 docker run -d --name kong-ee --link kong-ee-database:kong-ee-database \
   -e "KONG_DATABASE=postgres" \

--- a/app/enterprise/2.6.x/proxy.md
+++ b/app/enterprise/2.6.x/proxy.md
@@ -16,14 +16,7 @@ properties:
 - `admin_listen`, which also defines a list of addresses and ports, but those
   should be restricted to only be accessed by administrators, as they expose
   Kong's configuration capabilities: the **Admin API** (`8001` by default).
-
-<div class="alert alert-warning">
-<p><strong>Note:</strong> Starting with Kong 1.0.0 and Kong Enterprise 0.35, the API entity has been removed.
-This document will cover proxying with the new Routes and
-Services entities.</p>
-<p>See an older version of this document if you are using 0.12 or
-below.</p>
-</div>
+{% include_cached /md/admin-listen.md desc='short' %}
 
 ## Terminology
 

--- a/app/enterprise/2.6.x/start-kong-securely.md
+++ b/app/enterprise/2.6.x/start-kong-securely.md
@@ -35,6 +35,8 @@ of authentication.
 For a simple configuration to use for the subsequent Getting
 Started guides:
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
 ```
 enforce_rbac = on
 admin_gui_auth = basic-auth

--- a/app/enterprise/2.6.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.6.x/vitals/vitals-influx-strategy.md
@@ -30,6 +30,8 @@ will work for the purposes of this guide.
 
 #### Start the gateway with Kong Manager
 
+{% include_cached /md/admin-listen.md desc='long' %}
+
 ```bash
 $ docker run -d --name kong-ee --network=kong-ee-net \
   -e "KONG_DATABASE=postgres" \

--- a/app/gateway-oss/2.6.x/network.md
+++ b/app/gateway-oss/2.6.x/network.md
@@ -35,6 +35,9 @@ This is the port where Kong exposes its management API. Hence in production this
 it from unauthorized access.
 
 * `8001` provides Kong's **Admin API** that you can use to operate Kong with HTTP. See [admin_listen].
+
+{% include_cached /md/admin-listen.md desc='short' %}
+
 * `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
 
 ## Firewall

--- a/app/gateway-oss/2.6.x/proxy.md
+++ b/app/gateway-oss/2.6.x/proxy.md
@@ -16,16 +16,11 @@ properties:
 - `admin_listen`, which also defines a list of addresses and ports, but those
   should be restricted to only be accessed by administrators, as they expose
   Kong's configuration capabilities: the **Admin API** (`8001` by default).
+
+{% include_cached /md/admin-listen.md desc='short' %}
+
 - `stream_listen`, which is similar to `proxy_listen` but for Layer 4 (TCP, TLS)
   generic proxy. This is turned off by default.
-
-<div class="alert alert-warning">
-<p><strong>Note:</strong> Starting with 1.0.0, the API entity has been removed.
-This document will cover proxying with the new Routes and
-Services entities.</p>
-<p>See an older version of this document if you are using 0.12 or
-below.</p>
-</div>
 
 ## Terminology
 

--- a/app/install/docker.md
+++ b/app/install/docker.md
@@ -73,10 +73,8 @@ Here is a quick example showing how to connect a Kong container to a Cassandra o
     Kong 0.15, 1.0, and above.
 
 4. **Start Kong**
-   
-   **Warnings:**
-   
-   - *The settings below are intended for non-production use and override the default `admin_listen` setting to listen for requests from any source. Do not use these setting in environments directly exposed to the internet.*
+
+{% include_cached /md/admin-listen.md desc='long' %}
 
     When the migrations have run and your database is ready, start a Kong
     container that will connect to your database container, just like the
@@ -177,9 +175,7 @@ The steps involved in starting Kong in [DB-less mode] are the following:
 
 4. **Start Kong in DB-less mode**
 
-   **Warnings:**
-   
-   - *The settings below are intended for non-production use and override the default admin_listen setting to listen for requests from any source. Do not use these setting in environments directly exposed to the internet.*
+{% include_cached /md/admin-listen.md desc='long' %}
 
    Although it's possible to start the Kong container with just `KONG_DATABASE=off`, it is usually
    desirable to also include the declarative configuration file as a parameter via the

--- a/app/install/docker.md
+++ b/app/install/docker.md
@@ -73,6 +73,10 @@ Here is a quick example showing how to connect a Kong container to a Cassandra o
     Kong 0.15, 1.0, and above.
 
 4. **Start Kong**
+   
+   **Warnings:**
+   
+   - *The settings below are intended for non-production use and override the default `admin_listen` setting to listen for requests from any source. Do not use these setting in environments directly exposed to the internet.*
 
     When the migrations have run and your database is ready, start a Kong
     container that will connect to your database container, just like the
@@ -172,6 +176,10 @@ The steps involved in starting Kong in [DB-less mode] are the following:
 
 
 4. **Start Kong in DB-less mode**
+
+   **Warnings:**
+   
+   - *The settings below are intended for non-production use and override the default admin_listen setting to listen for requests from any source. Do not use these setting in environments directly exposed to the internet.*
 
    Although it's possible to start the Kong container with just `KONG_DATABASE=off`, it is usually
    desirable to also include the declarative configuration file as a parameter via the


### PR DESCRIPTION
### Summary
Expanding on https://github.com/Kong/docs.konghq.com-private/pull/689.

* Creating a reusable `include` file with the `admin_listen` warning with a long and short version. Long version is for examples that set `admin_listen`, short is for mentions of `admin_listen` without a full example.
* Ran a search and added the warning to 2.6.x versions of content in `/gateway-oss`, `/install`, and `/enterprise` docs.
* Fixing the gitignore file, it was catching the `/install/` directory as well as the root install file. Needed to fix to get the Docker topic updated.

### Reason
From Rob Serafini on original PR:

> The admin_listen in the example code in our docs (all over the place) causes kong to listen for admin api requests from any IP address. This example is useful for developers trying Kong out, but should not be used in production.


### Testing
Sample topics:
https://deploy-preview-3364--kongdocs.netlify.app/install/docker/
https://deploy-preview-3364--kongdocs.netlify.app/enterprise/2.6.x/deployment/installation/rhel/#step-6-finalize-configuration-and-verify-installation


