### PR TITLE
[DOCU-1995] Style Guide: note about gateway capitalization

### DIFF
--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -73,7 +73,7 @@ Capitalize the following Kong-specific terms:
 - Insomnia
 
 {:.note}
-> **Note**: Use “gateway” when referring to the general concept of an API gateway. Use “Gateway” as a shorthand for “Kong Gateway”.
+> **Note**: Use lowercase “gateway” when referring to the general concept of an API gateway. Use uppercase “Gateway” as a shorthand for “Kong Gateway”.
 
 #### Component names
 

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -72,6 +72,9 @@ Capitalize the following Kong-specific terms:
 - Kong Mesh (Kong Mesh for first mention, Mesh after)
 - Insomnia
 
+{:.note}
+> **Note**: Use “gateway” when referring to the general concept of an API gateway. Use “Gateway” as a shorthand for “Kong Gateway”.
+
 #### Component names
 
 - Dev Portal

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -73,7 +73,7 @@ Capitalize the following Kong-specific terms:
 - Insomnia
 
 {:.note}
-> **Note**: Use lowercase “gateway” when referring to the general concept of an API gateway. Use uppercase “Gateway” as a shorthand for “Kong Gateway”.
+> **Note**: Use lowercase “gateway” when referring to the general concept of an API gateway. Use uppercase “Gateway” as a shorthand for “Kong Gateway”. When writing about "Kong Gateway", use "Kong Gateway" for the first mention and "Gateway" after.
 
 #### Component names
 


### PR DESCRIPTION
### Summary

Add a note to differentiate "gateway" from "Gateway"

### Reason

Consistency and clarification of how we use this term in different contexts.

### Testing

![Screen Shot 2021-11-10 at 1 46 06 PM](https://user-images.githubusercontent.com/22301405/141198935-ac939681-5765-46ad-a9f2-7af5e43e12c9.png)

Link TBA. 
