### PR TITLE
[DOCU-1998] update Insomnia docs links

### DIFF
--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -48,7 +48,7 @@
           <a href="/kubernetes-ingress-controller/" class="{% if include.edition == 'kubernetes-ingress-controller' %}active{% endif %}">Kubernetes Ingress Controller</a>
         </li>
         <li>
-          <a href="https://support.insomnia.rest/" target="_blank">Insomnia</a>
+          <a href="https://docs.insomnia.rest/" target="_blank">Insomnia</a>
         </li>
         <li>
           <a href="https://kuma.io/docs/" target="_blank">Kuma</a>

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -65,7 +65,7 @@
                   Controller</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="https://support.insomnia.rest/" target="_blank"
+                <a href="https://docs.insomnia.rest/" target="_blank"
                   class="navbar-item navbar-item-docs">Insomnia</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">

--- a/app/contributing/terms.md
+++ b/app/contributing/terms.md
@@ -7,7 +7,7 @@ no_version: true
 
 ## General terms
 
-#### Control plane
+### Control plane
 
 #### Data plane
 (data plane proxy, data plane instance, data plane node)

--- a/archive/studio/old/1.0.x/debugging-with-insomnia.md
+++ b/archive/studio/old/1.0.x/debugging-with-insomnia.md
@@ -33,4 +33,4 @@ Kong Studio will generate the sample requests from the spec file and display the
 
 ![Response Panel](https://doc-assets.konghq.com/studio/1.0/debugging/response-panel.png)
 
-To lean more about generating requests and to full leverage the power of Insomnia, head over to [Insomnia's Documentation](https://support.insomnia.rest/)
+To lean more about generating requests and to full leverage the power of Insomnia, head over to [Insomnia's Documentation](https://docs.insomnia.rest/)


### PR DESCRIPTION
### Summary

Update Insomnia docs links

### Reason

Docs for Insomnia live at new URL: https://docs.insomnia.rest/
