### PR TITLE
[DOCU-1974][DOCU-1976] Konnect: Support for Gateway 2.6 and app reg tagging

### DIFF
--- a/app/_hub/kong-inc/jq/index.md
+++ b/app/_hub/kong-inc/jq/index.md
@@ -9,19 +9,23 @@ description: |
 
   The configuration accepts two sets of options: one for the request and another for the response.
   For both the request and response, a jq program string can be included, along with some jq option flags
-  and a list of media types. 
-  
+  and a list of media types.
+
   One of the configured media types must be included in the `Content-Type` header of
   the request or response for the jq program to run. The default media type in the `Content-Type`
-  header is `application/json`. 
-  
+  header is `application/json`.
+
   In the response context, you can also specify a list of status
-  codes, one of which must match the response status code. 
+  codes, one of which must match the response status code.
   The default response status code is `200`.
 
   {:.note}
-  > **Note:** In the response context the entire body must be buffered to be processed. This requirement also
+  > **Notes:**
+  > * In the response context the entire body must be buffered to be processed. This requirement also
   implies that the `Content-Length` header will be dropped if present, and the body transferred with chunked encoding.
+  > * To use this plugin in Konnect Cloud,
+    [upgrade your runtimes](/konnect/runtime-manager/upgrade) to at least
+    v2.6.0.0.
 
   See jq's documentation on [Basic filters](https://stedolan.github.io/jq/manual/#Basicfilters) for more information on writing programs with jq.
 
@@ -32,7 +36,7 @@ categories:
 
 kong_version_compatibility:
     enterprise_edition:
-      compatible: 
+      compatible:
         - 2.6.x
 
 params:
@@ -51,7 +55,7 @@ params:
       required: semi
       datatype: string
       description: |
-        The jq program to run on the request body. For example, `.[0] | { "X-Foo": .foo }`. 
+        The jq program to run on the request body. For example, `.[0] | { "X-Foo": .foo }`.
         Either `request_jq_program` or `response_jq_plugin` **must** be included in the configuration.
     - name: request_jq_program_options
       required: false
@@ -77,7 +81,7 @@ params:
       required: semi
       datatype: string
       description: |
-        The jq program to run on the response body. For example, `.[0] | { "X-Foo": .foo }`. 
+        The jq program to run on the response body. For example, `.[0] | { "X-Foo": .foo }`.
         Either `request_jq_program` or `response_jq_plugin` **must** be included in configuration.
     - name: response_jq_program_options
       required: false
@@ -108,5 +112,3 @@ params:
         match one of the response status codes on this list for the program to run.
 
 ---
-
-

--- a/app/konnect/deployment/index.md
+++ b/app/konnect/deployment/index.md
@@ -43,12 +43,10 @@ processing invalid requests.
 data plane.
 </div>
 
-|                                   | {{site.konnect_saas}} |
-|-----------------------------------|:--------------------------------:|
-| {{site.ee_product_name}} 2.5.x    | <i class="fa fa-check"></i> ¹    |
-| {{site.ee_product_name}} 2.4.x    | <i class="fa fa-check"></i> ²    |
-| {{site.ee_product_name}} 2.3.x    | <i class="fa fa-check"></i>      |
-| {{site.ee_product_name}} 2.2.x or earlier | <i class="fa fa-times"></i> |
-
-¹⁾ Supports 2.4.1.1 onward.<br>
-²⁾ Supports 2.5.0.1 onward.
+|                                | {{site.konnect_saas}} | First supported patch version
+|--------------------------------|:---------------------:|-----------------------------
+| {{site.ee_product_name}} 2.6.x | <i class="fa fa-check"></i>    | 2.6.0.0
+| {{site.ee_product_name}} 2.5.x | <i class="fa fa-check"></i>    | 2.5.0.1
+| {{site.ee_product_name}} 2.4.x | <i class="fa fa-check"></i>    | 2.4.1.1
+| {{site.ee_product_name}} 2.3.x | <i class="fa fa-check"></i>    | 2.3.0.0
+| {{site.ee_product_name}} 2.2.x or earlier | <i class="fa fa-times"></i> | --

--- a/app/konnect/dev-portal/applications/application-overview.md
+++ b/app/konnect/dev-portal/applications/application-overview.md
@@ -33,9 +33,10 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to
 support application registration for the Service and are managed by
 {{site.konnect_saas}}.
 
-Plugins enabled by app registration cannot be disabled or deleted using the toggle in
-the **Plugins** pane on the Services Version page. To disable or
-delete them, disable app registration.
+To disable or delete a plugin that was enabled by app registration,
+you must disable app registration itself. You can't use the toggle in the
+Plugins pane on a Service version, as the toggle is unavailable for
+{{site.konnect_short_name}}-managed plugins.
 
 ![Konnect Enable App Registration with OIDC](/assets/images/docs/konnect/konnect-enable-app-reg-oidc-toggle.png)
 

--- a/app/konnect/dev-portal/applications/application-overview.md
+++ b/app/konnect/dev-portal/applications/application-overview.md
@@ -23,3 +23,49 @@ As an example, the Application can represent a mobile banking app and the Servic
 Generate Application credentials through the {{site.konnect_short_name}} Dev Portal in the Application detail page. The Application can have multiple credentials, or API keys. For more information about Application Credentials, refer to [Generate Credentials for an Application](/konnect/dev-portal/applications/dev-gen-creds/).
 
 In [konnect.konghq.com](https://konnect.konghq.com), admins can access a list of the installed authentication plugins via **Shared Config**. See [Enable Application Registration for a Service](/konnect/dev-portal/applications/enable-app-reg/) for more information about authentication flows.
+
+## Konnect-managed plugins
+
+When you enable application registration on a Service,
+{{site.konnect_saas}} enables two plugins automatically:
+[ACL](/hub/kong-inc/acl), and one of [Key Authentication](/hub/kong-inc/key-auth)
+or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to
+support application registration for the Service and are managed by
+{{site.konnect_saas}}.
+
+Plugins enabled by app registration cannot be disabled or deleted using the toggle in
+the **Plugins** pane on the Services Version page. To disable or
+delete them, disable app registration.
+
+![Konnect Enable App Registration with OIDC](/assets/images/docs/konnect/konnect-enable-app-reg-oidc-toggle.png)
+
+If using a [declarative configuration](/konnect/getting-started/declarative-config)
+file to manage your Service, these plugins appear in the file. **Do not**
+delete or edit them through declarative configuration, as it will break your Service.
+
+To help differentiate the application registration plugins,
+{{site.konnect_short_name}} automatically adds two metadata tags:
+`konnect-managed-plugin` and `konnect-app-registration`.
+
+For example, if you enable application registration from the
+{{site.konnect_short_name}} GUI and run `deck konnect dump`, you should see
+an entry like this for the ACL plugin:
+
+```yaml
+plugins:
+- name: acl
+  config:
+    allow:
+    - 0003237b-7e77-4ec4-8dd0-b1b587305c28
+    deny: null
+    hide_groups_header: false
+  enabled: true
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https
+  tags:
+  - konnect-managed-plugin
+  - konnect-app-registration
+  ```

--- a/app/konnect/dev-portal/applications/disable-app-reg.md
+++ b/app/konnect/dev-portal/applications/disable-app-reg.md
@@ -3,7 +3,7 @@ title: Disable App Registration for a Service
 no_version: true
 ---
 
-Disable app registration for a Service is when an API
+You can disable app registration for a Service when an API
 no longer requires authentication. If you want to disable Auto Approve at the
 Service level, disable app registration and then enable it again with the Auto Approve
 toggle set to disabled.

--- a/app/konnect/dev-portal/applications/disable-app-reg.md
+++ b/app/konnect/dev-portal/applications/disable-app-reg.md
@@ -3,37 +3,27 @@ title: Disable App Registration for a Service
 no_version: true
 ---
 
-Disabling application registration
-deletes all plugins that were initially enabled for a Service. You cannot manually
-delete a plugin that was automatically enabled by app registration, such as the
-`acl` and `key-auth` or `openid-connect` plugins that
-were automatically enabled in tandem when app registration was enabled.
-When app registration is enabled, you cannot disable
-those authentication plugins either. If you attempt to do so, a modification not
-allowed when application registration message appears. The only way to (indirectly, automatically)
-delete the automatically enabled authentication plugins is to disable app registration.
-Any other plugins that were enabled manually, such as `rate-limiting`, remain enabled.
-
-The main reason for disabling app registration for a Service is when an API
+Disable app registration for a Service is when an API
 no longer requires authentication. If you want to disable Auto Approve at the
 Service level, disable app registration and then enable it again with the Auto Approve
 toggle set to disabled.
+
+Disable application registation from the Service Version page **only**.
+Do not attempt to disable application registration by deleting or disabling the
+read-only application registration plugins (`acl` and `key-auth` or `openid-connect`).
+Attempting to remove them manually will break your Service. See the
+Application Overview section on
+[{{site.konnect_short_name}}-managed plugins](/konnect/dev-portal/applications/application-overview/#konnect-managed-plugins)
+for more information.
 
 You can
 [enable application registration](/konnect/dev-portal/applications/enable-app-reg)
 again any time.
 
-1. From the {{site.konnect_short_name}} menu, click **Services**.
+## Disable app registration
 
-   ![Konnect Services Page](/assets/images/docs/konnect/konnect-services-page.png)
+1. From the {{site.konnect_short_name}} menu, click **Services** and select a Service.
 
-2. Depending on your view, click the tile for the Service in cards view or the row
-   for the Service in table view.
+1. From the **Actions** menu, select **Disable app registration**.
 
-   ![Konnect Disable App Registration](/assets/images/docs/konnect/konnect-disable-app-reg.png)
-
-3. From the **Actions** menu, click **Disable app registration**.
-
-   ![Konnect Confirm Disable App Registration](/assets/images/docs/konnect/konnect-confirm-disable-app-reg.png)
-
-4. Click **Disable**.
+1. Click **Disable**.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -16,10 +16,12 @@ Supported authentication flows are based on the following plugins:
 - [Key Authentication](#konnect-key-auth-flow)
 - [OpenID Connect](#oidc-flow)
 
-The [ACL](/hub/kong-inc/acl) plugin is also automatically enabled in
-conjunction with the `key-auth` or `OIDC` plugins. After app registration is enabled for a Service,
-the `key-auth` or `OIDC` and `ACL` plugins are no longer available on the Plugins page because
-they have already been enabled.
+When you enable application registration, the ACL plugin and your chosen authentication
+plugin (Key Auth or OIDC) are enabled automatically. You can see them in a
+Service version's plugin list, but can't edit or delete them directly. See the
+Application Overview section on
+[{{site.konnect_short_name}}-managed plugins](/konnect/dev-portal/applications/application-overview/#konnect-managed-plugins)
+for more information.
 
 {:.important}
 > **Important:** Developers registered through app registration appear as
@@ -27,13 +29,6 @@ consumers on the
 ![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}
 Shared Config page. Do not delete the ACLs associated with a consumer managed
 by app registration.
-
-Plugins enabled by app registration cannot be disabled using the toggle in the **Plugins** pane
-on the Services Version page. The only way to disable or delete them is to disable app registration,
-which deletes all plugins that were initially enabled with application registration for a Service.
-Any other plugins that were enabled manually, such as `rate-limiting`, remain enabled.
-
-![Konnect Enable App Registration with OIDC](/assets/images/docs/konnect/konnect-enable-app-reg-oidc-toggle.png)
 
 You can [disable application registration](/konnect/dev-portal/applications/disable-app-reg/)
 any time at your discretion.
@@ -57,22 +52,14 @@ permissions.
 
 ## Enable App Registration for the Key Authentication Flow {#konnect-key-auth-flow}
 
-1. From the {{site.konnect_short_name}} menu, click **Services**.
+1. From the {{site.konnect_short_name}} menu, click **Services** and select a
+Service.
 
-   ![Konnect Services Page](/assets/images/docs/konnect/konnect-services-page.png)
+1. From the **Actions** dropdown menu, select **Enable app registration**.
 
-2. Depending on your view, click the tile for the Service in cards view or the row
-   for the Service in table view.
+1. Select `key-auth` from the **Auth Type** list.
 
-   ![Konnect Enable App Registration](/assets/images/docs/konnect/konnect-enable-app-reg-service-menu.png)
-
-3. From the **Actions** menu, click **Enable app registration**.
-
-   ![Konnect Enable App Registration with Key Authentication](/assets/images/docs/konnect/konnect-enable-app-reg-key-auth.png)
-
-4. Select `key-auth` from the **Auth Type** list.
-
-5. (Optional) Click to enable **Auto Approve** for application registrations for the selected Service.
+1. (Optional) Click to enable **Auto Approve** for application registrations for the selected Service.
 
    Any developer registration requests for an application are automatically approved. A {{site.konnect_saas}}
     admin does not need to
@@ -83,25 +70,19 @@ permissions.
    using the Settings page for the Dev Portal. If Auto Approve is
    enabled portal-wide, it overrides the per-Service Auto Approve setting.
 
-6. Click **Enable**.
+1. Click **Enable**.
 
     With app registration enabled, all versions of this service now include
     read-only entries for the `acl` and `key-auth` plugins.
 
-   ![Konnect App Registration Key Auth Plugins](/assets/images/docs/konnect/key-auth-acl-plugins.png)
-
 ## Enable App Registration for the OpenID Connect Flow {#oidc-flow}
 
-1. From the {{site.konnect_short_name}} menu, click **Services**.
+1. From the {{site.konnect_short_name}} menu, click **Services** and select a
+Service.
 
-2. Depending on your view, click the tile for the Service in cards view or the row
-   for the Service in table view.
+1. From the **Actions** menu, click **Enable app registration**.
 
-3. From the **Actions** menu, click **Enable app registration**.
-
-4. Select `openid-connect` (default) from the **Auth Type** list.
-
-   ![Konnect Enable App Registration with OpenID Connect](/assets/images/docs/konnect/konnect-enable-app-reg-oidc.png)
+1. Select `openid-connect` (default) from the **Auth Type** list.
 
    Refer to the [descriptions](#openid-config-params) in the next section for more information
    about each field.
@@ -128,7 +109,7 @@ permissions.
       using the Portal Settings. If Auto Approve is
       enabled or disabled portal-wide, it overrides the per Service Auto Approve setting.
 
-6. Click **Enable**.
+1. Click **Enable**.
 
     With app registration enabled, all versions of this service now include
     read-only entries for the `acl` and `oidc` plugins.

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -88,7 +88,7 @@ remaining configuration details on the **Configure Runtime** page.
 
 
     ```bash
-    $ docker pull kong/kong-gateway:2.5.0.1-alpine
+    $ docker pull kong/kong-gateway:2.6.0.0-alpine
     ```
 
     You should now have your {{site.base_gateway}} image locally.

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -90,7 +90,7 @@ like this:
     ```yaml
     image:
       repository: kong/kong-gateway
-      tag: "2.5.0.1-alpine"
+      tag: "2.6.0.0-alpine"
 
     secretVolumes:
     - kong-cluster-cert

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -8,6 +8,41 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
+## November 2021
+### 2021.11.10
+**{{site.base_gateway}} 2.6.0.0 support**
+: {{site.konnect_saas}} now supports {{site.base_gateway}} 2.6.0.0.
+runtimes. You can keep using existing 2.5.x runtimes, or you can upgrade to
+2.6.0.0 to take advantage of any new features, updates, and bug fixes.
+: This release introduces the new [jq plugin](/hub/kong-inc/jq). It also
+adds new features and improvements to a long list of plugins, including:
+* Broader auth support for [Kafka Log](/hub/kong-inc/kafka-log)
+and [Kafka Upstream](/hub/kong-inc/kafka-upstream)
+* The [Prometheus](/hub/kong-inc/prometheus) plugin can now track the
+`data_plane_cluster_cert_expiry_timestamp` metric, letting you keep an eye on the
+status of you data plane certificates
+* A new `trigger` configuration option for the
+[Request Termination](/hub/kong-inc/request-termination) plugin, which tells the
+plugin to activate only on specific headers or query parameters
+
+: To use any new features in the release and gain access to the jq plugin,
+[start up a new runtime](/konnect/runtime-manager/upgrade).
+
+: For all the changes and new features in {{site.base_gateway}} 2.6.x, see the
+[changelog](/enterprise/changelog/#2600).
+
+**Tags for auth plugins created by application registration**
+: When you enable application registration on a Service,
+{{site.konnect_saas}} enables two plugins automatically: ACL, and one of Key
+Authentication or OIDC. These plugins cannot be edited or deleted directly. To
+help differentiate the Konnect-managed plugins and avoid breaking your Service,
+Konnect now adds two metadata tags for declarative configuration:
+`konnect-managed-plugin` and `konnect-app-registration`.
+See the Dev Portal doc section on
+[{{site.konnect_short_name}}-managed plugins](/konnect/dev-portal/applications/application-overview/#konnect-managed-plugins)
+for more information.
+
+
 ## August 2021
 ### 2021.08.31
 **{{site.base_gateway}} 2.5.0.1 support**

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -16,13 +16,14 @@ runtimes. You can keep using existing 2.5.x runtimes, or you can upgrade to
 2.6.0.0 to take advantage of any new features, updates, and bug fixes.
 : This release introduces the new [jq plugin](/hub/kong-inc/jq). It also
 adds new features and improvements to a long list of plugins, including:
-* Broader auth support for [Kafka Log](/hub/kong-inc/kafka-log)
-and [Kafka Upstream](/hub/kong-inc/kafka-upstream)
-* The [Prometheus](/hub/kong-inc/prometheus) plugin can now track the
+* [Kafka Log](/hub/kong-inc/kafka-log)
+and [Kafka Upstream](/hub/kong-inc/kafka-upstream): Support for TLS, mTLS, and
+SASL auth
+* [Prometheus](/hub/kong-inc/prometheus): Introduces the
 `data_plane_cluster_cert_expiry_timestamp` metric, letting you keep an eye on the
 status of you data plane certificates
-* A new `trigger` configuration option for the
-[Request Termination](/hub/kong-inc/request-termination) plugin, which tells the
+* [Request Termination](/hub/kong-inc/request-termination): Introduces the
+new `trigger` configuration option, which tells the
 plugin to activate only on specific headers or query parameters
 
 : To use any new features in the release and gain access to the jq plugin,


### PR DESCRIPTION
### Summary

Konnect deploy (DOCU-1974):
* Adding changelog entry with app reg tagging and 2.6.x support info
* Updating version numbers in Runtime Manager setup topics
* Adding note to jq plugin (we have similar notes for OPA and mocking plugins from the last release)

Tags for application registration plugins (DOCU-1976):
* Added info about the new tags to the app reg overview
* linking off to said info from enable and disable app reg topics
* minor language cleanup to simplify app reg docs; got rid of a bunch of extra screenshots

### Reason
Konnect deploy Nov 10th. Missed the notification as it got buried in all the other SMT tickets in the production channel.
Support for 2.6.0.0 was added earlier but was not reflected in the UI until last week, so rolling it into this update.

(Accidentally pushed both tickets to this branch, so there's two in one).

### Testing
Konnect release notes: https://deploy-preview-3376--kongdocs.netlify.app/konnect/updates/
Konnect-managed plugins and tags: https://deploy-preview-3376--kongdocs.netlify.app/konnect/dev-portal/applications/application-overview/#konnect-managed-plugins
jq plugin note: https://deploy-preview-3376--kongdocs.netlify.app/hub/kong-inc/jq/
Runtime version compatibility: https://deploy-preview-3376--kongdocs.netlify.app/konnect/deployment/#runtime-compatibility
Versions updated in [Docker](https://deploy-preview-3376--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/#prepare-the-docker-image) and [Kubernetes](https://deploy-preview-3376--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-kubernetes/#write-and-apply-configuration) setup topics
