### PR TITLE
use code 308 instead of 301 for https redirects

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/configuring-https-redirect.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/configuring-https-redirect.md
@@ -93,10 +93,10 @@ Via: kong/1.2.1
 
 To instruct Kong to redirect all HTTP requests matching this Ingress rule to
 HTTPS, update its annotations to limit its protocols to HTTPS only and
-issue a 301 redirect:
+issue a 308 redirect:
 
 ```bash
-$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"https","konghq.com/https-redirect-status-code":"301"}}}'
+$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"https","konghq.com/https-redirect-status-code":"308"}}}'
 ingress.extensions/demo patched
 ```
 
@@ -107,7 +107,7 @@ being issued from Kong:
 
 ```bash
 $ curl $PROXY_IP/foo/headers -I
-HTTP/1.1 301 Moved Permanently
+HTTP/1.1 308 Permanent Redirect
 Date: Tue, 06 Aug 2019 18:04:38 GMT
 Content-Type: text/html
 Content-Length: 167


### PR DESCRIPTION
### Summary
Suggestion to change the http response code cited in the documentation for setting up https redirects on kong gateway routes. This may be applicable to other areas of the documentation outside of the kubernetes ingress controller, if that's the case I'm happy to add those to this PR if someone can point them out.

### Reason
Per the Mozilla Developer Web Docs on http 308 
> A browser redirects to this page and search engines update their links to the resource ... The request method and the 
> body will not be altered, whereas 301 may incorrectly sometimes be changed to a GET method.

curl and other utilities that rely on it (including Postman) exhibit this behavior when they receive http 301 in response to a POST request. I suggest changing this documentation to use code 308 so that clients are still automatically redirected (does not happen with http 426) and the client knows to preserve the original http verb when making its subsequent request to the URL given by the `Location` response header.

### Testing
I configured a route on kong gateway according to the current documentation and observed curl changing the http verb from POST to GET when using a plain http URL matched by that route. I then changed the response code for the route to 308 and this problem was resolved, again using curl and later Postman to verify.