### PR TITLE
Fix "self-hosted" terminology

### DIFF
--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -411,7 +411,7 @@ header.navbar {
             display: flex;
             flex-direction: column;
             justify-content: flex-start;
-            min-height: 108px;
+            min-height: 60px;
           }
 
           .name-link {

--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -16,7 +16,7 @@ features:
           - text: Cloud
             icon: /assets/images/icons/icn-cloud-blue.svg
             url: /konnect/dev-portal
-          - text: Self-hosted
+          - text: Self-managed
             icon: /assets/images/icons/icn-server-blue.svg
             url: /gateway/latest/developer-portal/
 
@@ -27,7 +27,7 @@ features:
           - text: Cloud
             icon: /assets/images/icons/icn-cloud-blue.svg
             url: /konnect/vitals
-          - text: Self-hosted
+          - text: Self-managed
             icon: /assets/images/icons/icn-server-blue.svg
             url: /gateway/latest/vitals/overview
 

--- a/app/_includes/md/gateway-ports.md
+++ b/app/_includes/md/gateway-ports.md
@@ -18,7 +18,7 @@ By default, {{site.base_gateway}} listens on the following ports:
 | [`:8006`](/gateway/latest/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. |
 
 
-Self-hosted ports can be fully customized. Set them in `kong.conf`.
+Self-managed ports can be fully customized. Set them in `kong.conf`.
 
 For Kubernetes or Docker deployments, map ports as needed. For example, if you
 want to expose the Admin API through port `3001`, map `3001:8001`.

--- a/app/_layouts/landing-page.html
+++ b/app/_layouts/landing-page.html
@@ -50,7 +50,7 @@ id: landing-page
             <div class="name-label">
               <div class="link-text">
                 <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="">
-                Self-hosted
+                Self-managed
               </div>
             </div>
           </a>
@@ -114,14 +114,10 @@ id: landing-page
             <a href="/gateway/" class="name-link">
               <div class="name-label">
                 <div class="link-text">
+                  <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="">
                   {{site.base_gateway}} documentation
                 </div>
-                <div class="icon-label">
-                  <img src="/assets/images/icons/icn-doc.svg" alt="">
-                  Self-hosted
-                </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
           </div>
         </div>
@@ -136,26 +132,18 @@ id: landing-page
             <a href="/mesh/" class="name-link">
               <div class="name-label">
                 <div class="link-text">
-                  {{site.mesh_product_name}}
-                </div>
-                <div class="icon-label">
-                  <img src="/assets/images/icons/icn-server.svg" alt="">
-                  Self-hosted version
+                  <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="">
+                  {{site.mesh_product_name}} documentation
                 </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
             <a href="https://kuma.io/docs/" class="name-link">
               <div class="name-label">
                 <div class="link-text">
+                  <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="">
                   Kuma (open-source)
                 </div>
-                <div class="icon-label">
-                  <img src="/assets/images/icons/icn-server.svg" alt="">
-                  Self-hosted version
-                </div>
               </div>
-              <img src="/assets/images/icons/icn-doc.svg" alt="">
             </a>
           </div>
         </div>

--- a/app/contributing/variables.md
+++ b/app/contributing/variables.md
@@ -44,9 +44,9 @@ much of the page content is generated out of a plugin’s front matter.
 Variable | Output | Definition | Syntax
 ---------|--------|------------|-------
 base_gateway | {{site.base_gateway}} | The base API gateway. Use this when talking about a feature that is available for both Community and Enterprise. | {% raw %}`{{site.base_gateway}}`{% endraw %}
-ee_product_name | {{site.ee_product_name}} | The whole self-hosted Enterprise Gateway package, including modules and peripherals, eg Kong Manager, Dev Portal, Vitals, etc. | {% raw %}`{{site.ee_product_name}}`{% endraw %}
+ee_product_name | {{site.ee_product_name}} | The whole self-managed Enterprise Gateway package, including modules and peripherals, eg Kong Manager, Dev Portal, Vitals, etc. | {% raw %}`{{site.ee_product_name}}`{% endraw %}
 ce_product_name | {{site.ce_product_name}} | Kong's open-source API gateway. | {% raw %}`{{site.ce_product_name}}`{% endraw %}
-konnect_product_name | {{site.konnect_product_name}} | The full name of the Kong Konnect platform, cloud and self-hosted. | {% raw %}`{{site.konnect_product_name}}`{% endraw %}
+konnect_product_name | {{site.konnect_product_name}} | The full name of the Kong Konnect platform, both cloud and self-managed. | {% raw %}`{{site.konnect_product_name}}`{% endraw %}
 konnect_short_name | {{site.konnect_short_name}} | The short name of the SaaS Konnect control plane. | {% raw %}`{{site.konnect_short_name}}`{% endraw %}
 konnect_saas | {{site.konnect_saas}} | The full name of the SaaS Konnect control plane.  | {% raw %}`{{site.konnect_saas}}`{% endraw %}
 company_name | {{site.company_name}} | The name of the company. <br> Do not use “Kong” without a modifier to refer to Kong Gateway. Kong refers only to the company. | {% raw %}{{site.company_name}}{% endraw %}

--- a/app/konnect-platform/guides.md
+++ b/app/konnect-platform/guides.md
@@ -14,11 +14,11 @@ in minutes. See the
 [{{site.konnect_saas}} quickstart guide](/konnect/getting-started/) to get
 started.
 
-* **Self-hosted deployment**:
+* **Self-managed deployment**:
 Install {{site.base_gateway}}, then use the {{site.base_gateway}} guide for a
 detailed walkthrough of foundational API gateway concepts, features, and
 capabilities.
     * For a traditional deployment, see the [Kong gateway installation guides](/gateway/latest/install-and-run).
     * For a hybrid mode deployment, use the [hybrid mode post-installation instructions](/gateway/latest/plan-and-deploy/hybrid-mode/hybrid-mode-setup).
     * Once everything is installed, check out the
-    [self-hosted getting started guide](/gateway/latest/get-started/comprehensive).
+    [self-managed getting started guide](/gateway/latest/get-started/comprehensive).

--- a/app/konnect-platform/index.md
+++ b/app/konnect-platform/index.md
@@ -72,7 +72,7 @@ velocity are defined in the following table:
 | {{site.konnect_short_name}} Component {:width=20%:} | Description |
 |------------------------------|-------------|
 | [Insomnia](https://support.insomnia.rest/) | API debugging, design, and testing tool for developers. Allows developers to rapidly explore and consume existing services of different protocols (spawning REST, GraphQL, and gRPC), design services using a spec-based approach, and write and build a suite of tests while collaborating with other developers. <br><br> Using Insomnia, you can generate {{site.base_gateway}} and Kong Ingress Controller runtime configurations directly from their API specs. Developers can rapidly map their API designs to connectivity logic that exposes those designs within a connectivity runtime.  |
-| Dev Portal <br><br>[Cloud docs](/konnect/dev-portal) <br>[Self-hosted docs](/gateway/latest/developer-portal) | Functionality module that enables the formal publishing of API docs to an API catalogue through which developers (typically external to an application team) can discover and formally register to use the API. |
+| Dev Portal <br><br>[Cloud docs](/konnect/dev-portal) <br>[Self-managed docs](/gateway/latest/developer-portal) | Functionality module that enables the formal publishing of API docs to an API catalogue through which developers (typically external to an application team) can discover and formally register to use the API. |
 | [ServiceHub](/konnect/servicehub)<br>(Cloud only) | Functionality module that enables the cataloging of all services into a single system of record. This catalog represents the single source of truth for your organization’s service inventory and their dependencies. By leveraging ServiceHub, application developers can search, discover, and consume existing services to accelerate their time-to-market, while enabling a more consistent end-user experience across the organization’s applications. |
 
 #### Connectivity Runtime Performance
@@ -99,7 +99,7 @@ defined in the following table:
 
 | {{site.konnect_short_name}} Component {:width=20%:} | Description |
 |---------------------------------------|-------------|
-| Vitals <br><br>[Cloud docs](/konnect/vitals) <br>[Self-hosted docs](/gateway/latest/vitals/) | Functionality module that enables the capture and generation of service usage and health monitoring data. This module's capabilities can be enhanced with {{site.konnect_short_name}} plugins that enable monitoring metrics to be streamed to third-party analytics providers such as Datadog and Prometheus. |
+| Vitals <br><br>[Cloud docs](/konnect/vitals) <br>[Self-managed docs](/gateway/latest/vitals/) | Functionality module that enables the capture and generation of service usage and health monitoring data. This module's capabilities can be enhanced with {{site.konnect_short_name}} plugins that enable monitoring metrics to be streamed to third-party analytics providers such as Datadog and Prometheus. |
 | [ServiceHub](/konnect/servicehub) <br>(Cloud only) | Functionality module that enables the cataloging all of all services into a single system of record that represents the single source of truth of your organization’s service inventory and their dependencies. By leveraging ServiceHub, enterprise architects can attain a better understanding of the organization’s inventory of services, in terms of the level of reuse, usage, and operational health of services across different teams and environments. |
 
 #### Cloud-native Service Lifecycle

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -34,6 +34,6 @@ deployment, see the following topics to get started:
 * Set up [users and roles](/konnect/org-management/users-and-roles)
 * Get familiar with the [Konnect Admin API](/konnect/reference/konnect-api)
 
-## Self-hosted Konnect
-If deploying {{site.konnect_short_name}} in a self-hosted environment, see the
+## Self-managed Konnect
+If deploying {{site.konnect_short_name}} in a self-managed environment, see the
 [{{site.ee_product_name}} docs](/gateway/).

--- a/app/konnect/key-concepts-and-terms.md
+++ b/app/konnect/key-concepts-and-terms.md
@@ -67,6 +67,6 @@ service’s consumers are routed to the older version.
 
 ### Functionality Module
 
-Functionality, delivered as a service or in a self-hosted manner, that
+Functionality, delivered as a service or in a self-managed manner, that
 leverages connectivity runtimes to provide a connectivity management capability
 (for example, Dev Portal).

--- a/app/konnect/migrate.md
+++ b/app/konnect/migrate.md
@@ -3,7 +3,7 @@ title: Migrate from Kong Gateway to Konnect Cloud
 no_version: true
 ---
 
-You can migrate any edition of self-hosted {{site.base_gateway}} to
+You can migrate any edition of self-managed {{site.base_gateway}} to
 {{site.konnect_saas}}.
 
 Use [decK](/deck/) to convert and migrate the configuration for most
@@ -150,7 +150,7 @@ You can keep any data plane nodes that are:
 * Running {{site.base_gateway}} (not the open-source package)
 * Are at least version 2.3 or higher
 
-Turn any self-hosted nodes into cloud data plane nodes by registering them
+Turn any self-managed nodes into cloud data plane nodes by registering them
 through the Runtime Manager and adjusting their configurations, or power down
 the old instances and create new data plane nodes through {{site.konnect_saas}}.
 
@@ -174,7 +174,7 @@ location.
     * [Developer registration](/konnect/dev-portal/access-and-approval/dev-reg)
     * [Enable application registration](/konnect/dev-portal/applications/enable-app-reg):
     App registration in {{site.konnect_saas}} works through a different
-    mechanism than in self-hosted {{site.base_gateway}}. Enable app
+    mechanism than in self-managed {{site.base_gateway}}. Enable app
     registration on each service that requires it.
     * [Publish Services to the Dev Portal](/konnect/servicehub/dev-portal/publish):
     The Dev Portal is automatically enabled on a {{site.konnect_saas}} org


### PR DESCRIPTION
### Summary
* Changing instances of "self-hosted" to "self-managed"
* Removing some "self-hosted" labels from the landing page altogether, as they are adding unnecessary complexity

### Reason
"Self-hosted" is not the correct term, it should be "self-managed". This has been set for a while, but we've never gone through to docs to fix this.


### Testing
Main changes are on the landing page: https://deploy-preview-3380--kongdocs.netlify.app/
