### PR TITLE
Chore/adjust installation instructions

### DIFF
--- a/app/gateway/2.6.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.6.x/install-and-run/amazon-linux.md
@@ -17,7 +17,7 @@ title: Install Kong Gateway on Amazon Linux
 
 The {{site.base_gateway}} software is governed by the 
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
-{{site.ce_product_name}} is licensed under an
+Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
@@ -25,92 +25,59 @@ The {{site.base_gateway}} software is governed by the
 * A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong.
 
-## Download
+## Download and Install
 
-You can download an RPM file with the specific version, or pull the whole catalog of versions as a Yum repo.
-
-If you already downloaded the packages manually, move on to [Install](#install).
+You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
 {% navtabs %}
-{% navtab RPM file %}
+{% navtab Package %}
 
-To download the RPM file, choose your Kong Gateway
-package type and use the following command:
+Install {{site.base_gateway}} on Debian from the command line.
 
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm"
-```
+1. Download the Kong package:
+    ```bash
+    ## Kong Gateway
+    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm"
+    ```
 
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm"
-```
+    ```bash
+    ## Kong Gateway (OSS)
+    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm"
+    ```
+
+2. Install the package:
+    ```bash
+    ## Kong Gateway
+    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm
+    ```
+
+    ```bash
+    ## Kong Gateway (OSS)
+    sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm
+    ```
 
 {% endnavtab %}
-{% navtab Yum repo %}
+{% navtab YUM repository %}
 
-To download the Yum repo file, choose your Kong Gateway
-package type and use the following command:
+Install the YUM repository from the command line.
 
-```bash
-## Kong Gateway
-curl {{site.links.download}}/gateway-2.x-amazonlinux-2/config.repo | sudo tee /etc/yum.repos.d/kong-enterprise-edition.repo
-```
+1. Download the Kong APT repository:
+    ```bash
+    curl https://download.konghq.com/gateway-2.x-amazonlinux-2/config.repo | sudo tee /etc/yum.repos.d/kong.repo
+    ```
 
-```bash
-## Kong Gateway (OSS)
-curl {{site.links.download}}/gateway-2.x-amazonlinux-2/config.repo | sudo tee /etc/yum.repos.d/kong.repo
-```
+2. Install Kong:
+    ```bash
+    ## Kong Gateway
+    sudo yum install kong-enterprise-edition
+    ```
+
+    ```bash
+    ## Kong Gateway (OSS)
+    sudo yum install kong
+    ```
 
 {% endnavtab %}
 {% endnavtabs %}
-
-## Install
-
-{% navtabs %}
-{% navtab RPM file %}
-
-To install the RPM file, choose your Kong Gateway package
-type and use the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-To install the Yum repo file, choose your Kong Gateway
-package type and use the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-<!-- Setup content shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL.
-Includes the following sections: Setup configs, Using a database, Using a yaml declarative config file,
-Using a yaml declarative config file, Verify install, Enable and configure Kong Manager, Enable Dev Portal,
-Support, and Next Steps.
-
-Located in the app/_includes/md/gateway folder.
-
-See https://docs.konghq.com/contributing/includes/ for more information about using includes in this project.
--->
 
 {% include_cached /md/gateway/setup.md kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.6.x/install-and-run/amazon-linux.md
@@ -15,7 +15,7 @@ title: Install Kong Gateway on Amazon Linux
 > <span class="install-subtitle">View the list of all 2.x packages for
 > [Amazon Linux 1]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/){:.install-listing-link} and [Amazon Linux 2]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/){:.install-listing-link}  </span>
 
-The {{site.base_gateway}} software is governed by the 
+The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
@@ -35,26 +35,42 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 Install {{site.base_gateway}} on Debian from the command line.
 
 1. Download the Kong package:
-    ```bash
-    ## Kong Gateway
-    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm"
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm"
-    ```
+{% capture download_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm"
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm "{{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm"
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ download_package | indent | replace: " </code>", "</code>" }}
 
 2. Install the package:
-    ```bash
-    ## Kong Gateway
-    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm
-    ```
+{% capture install_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% navtab YUM repository %}
@@ -67,15 +83,23 @@ Install the YUM repository from the command line.
     ```
 
 2. Install Kong:
-    ```bash
-    ## Kong Gateway
-    sudo yum install kong-enterprise-edition
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    sudo yum install kong
-    ```
+{% capture install_from_repo %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -24,7 +24,7 @@ title: Install Kong Gateway on CentOS
 
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
-{{site.ce_product_name}} is licensed under an
+Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
@@ -41,11 +41,13 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 
 Install {{site.base_gateway}} on Debian from the command line.
 
-1. Download the {{site.ce_product_name}} package:
+1. Download the Kong package:
     ```bash
     ## Kong Gateway
     curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.noarch.rpm")
-    
+    ```
+
+    ```bash
     ## Kong Gateway (OSS)
     curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el%{centos_ver}.amd64.rpm")
      ```
@@ -54,7 +56,9 @@ Install {{site.base_gateway}} on Debian from the command line.
     ```bash
     ## Kong Gateway
     sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
-    
+    ```
+
+    ```bash
     ## Kong Gateway (OSS)
     sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
     ```
@@ -64,21 +68,18 @@ Install {{site.base_gateway}} on Debian from the command line.
 
 Install the YUM repository from the command line.
 
-1. Download the {{site.ce_product_name}} APT repository:
+1. Download the Kong APT repository:
     ```bash
     curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
     ```
 
-2. Setup the Kong rpm signing key
-    ```bash
-    rpm --import $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos}/repodata/repomd.xml.key")
-    ```
-
-2. Install {{site.ce_product_name}}:
+2. Install Kong:
     ```bash
     ## Kong Gateway
     sudo yum install kong-enterprise-edition
-    
+    ```
+
+    ```
     ## Kong Gateway (OSS)
     sudo yum install kong
     ```

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -32,166 +32,44 @@ The {{site.base_gateway}} software is governed by the
 * A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong.
 
-## Download
+## Download and Install
 
-Choose between CentOS versions 7 and 8.
-
-You can download an RPM file with the specific version, or pull the whole catalog of versions as a Yum repo.
-
-If you already downloaded the packages manually, move on to [Install](#install).
-
-### CentOS 7
+You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
 {% navtabs %}
-{% navtab RPM file %}
+{% navtab Package %}
 
-Download the RPM file for CentOS 7:
+Install {{site.base_gateway}} on Debian from the command line.
 
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el7.noarch.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el7.noarch.rpm")
-```
+1. Download the {{site.ce_product_name}} package:
+    ```bash
+    curl -Lo kong-{{site.data.kong_latest.version}}.amd64.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-{{site.data.kong_latest.version}}.el%{centos_ver}.amd64.rpm")
+     ```
 
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.el7.amd64.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el7.amd64.rpm")
-```
+2. Install the package:
+    ```bash
+    sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
+    ```
 
 {% endnavtab %}
-{% navtab Yum repo %}
+{% navtab YUM repository %}
 
-Download the Yum repo file for CentOS 7:
+Install the YUM repository from the command line.
 
-```bash
-## Kong Gateway
-curl $(rpm --eval "{{site.links.download}}/gateway-2.x-centos-7/config.repo") | sudo tee /etc/yum.repos.d/kong-enterprise-edition.repo
-```
-
-```bash
-## Kong Gateway (OSS)
-curl $( "{{site.links.download}}/gateway-2.x-centos-7/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
-```
+1. Download the {{site.ce_product_name}} APT repository:
+    ```bash
+    curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
+    ```
+2. Update the repository:
+    ```bash
+    sudo yum clean
+    ```
+3. Install {{site.ce_product_name}}:
+    ```bash
+    sudo yum install -y kong
+    ```
 
 {% endnavtab %}
 {% endnavtabs %}
-
-### CentOS 8
-
-{% navtabs %}
-{% navtab RPM file %}
-
-Download the RPM file for CentOS 8:
-
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el8.noarch.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-8/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el8.noarch.rpm")
-```
-
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.el8.amd64.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-8/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el8.amd64.rpm")
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-Download the Yum repo file for CentOS 8:
-
-```bash
-## Kong Gateway
-curl $(rpm --eval "{{site.links.download}}/gateway-2.x-centos-8/config.repo") | sudo tee /etc/yum.repos.d/kong-enterprise-edition.repo
-```
-
-```bash
-## Kong Gateway (OSS)
-curl $( "{{site.links.download}}/gateway-2.x-centos-8/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-## Install
-
-Choose between CentOS versions 7 and 8.
-
-### CentOS 7
-
-{% navtabs %}
-{% navtab RPM file %}
-
-Install the RPM file for CentOS 7:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el7.noarch.rpm
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong-{{page.kong_versions[page.version-index].ce-version}}.el7.amd64.rpm
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-Install the Yum repo file for CentOS 7:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-### CentOS 8
-
-{% navtabs %}
-{% navtab RPM file %}
-
-Install the RPM file for CentOS 8:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el8.noarch.rpm
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong-{{page.kong_versions[page.version-index].ce-version}}.el8.amd64.rpm
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-Install the Yum repo file for CentOS using the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-<!-- Setup content shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL.
-Includes the following sections: Setup configs, Using a database, Using a yaml declarative config file,
-Using a yaml declarative config file, Verify install, Enable and configure Kong Manager, Enable Dev Portal,
-Support, and Next Steps.
-
-Located in the app/_includes/md/gateway folder.
-
-See https://docs.konghq.com/contributing/includes/ for more information about using includes in this project.
--->
 
 {% include_cached /md/gateway/setup.md kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -34,34 +34,51 @@ Kong is licensed under an
 
 ## Download and Install
 
-You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
+You can install {{site.base_gateway}} by downloading an installation package or
+using our YUM repository.
 
 {% navtabs %}
 {% navtab Package %}
 
-Install {{site.base_gateway}} on Debian from the command line.
+Install {{site.base_gateway}} on CentOS from the command line.
 
 1. Download the Kong package:
-    ```bash
-    ## Kong Gateway
-    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.noarch.rpm")
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el%{centos_ver}.amd64.rpm")
-     ```
+{% capture download_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.noarch.rpm")
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el%{centos_ver}.amd64.rpm")
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ download_package | indent | replace: " </code>", "</code>" }}
 
 2. Install the package:
-    ```bash
-    ## Kong Gateway
-    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
-    ```
+{% capture install_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% navtab YUM repository %}
@@ -74,17 +91,33 @@ Install the YUM repository from the command line.
     ```
 
 2. Install Kong:
-    ```bash
-    ## Kong Gateway
-    sudo yum install kong-enterprise-edition
-    ```
 
-    ```
-    ## Kong Gateway (OSS)
-    sudo yum install kong
-    ```
+{% capture install_from_repo %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% endnavtabs %}
+
+<!-- Setup content shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL.
+Includes the following sections: Setup configs, Using a database, Using a yaml declarative config file,
+Using a yaml declarative config file, Verify install, Enable and configure Kong Manager, Enable Dev Portal,
+Support, and Next Steps.
+Located in the app/_includes/md/gateway folder.
+See https://docs.konghq.com/contributing/includes/ for more information about using includes in this project.
+-->
 
 {% include_cached /md/gateway/setup.md kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -43,12 +43,20 @@ Install {{site.base_gateway}} on Debian from the command line.
 
 1. Download the {{site.ce_product_name}} package:
     ```bash
-    curl -Lo kong-{{site.data.kong_latest.version}}.amd64.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-{{site.data.kong_latest.version}}.el%{centos_ver}.amd64.rpm")
+    ## Kong Gateway
+    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.noarch.rpm")
+    
+    ## Kong Gateway (OSS)
+    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el%{centos_ver}.amd64.rpm")
      ```
 
 2. Install the package:
     ```bash
-    sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
+    ## Kong Gateway
+    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+    
+    ## Kong Gateway (OSS)
+    sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
     ```
 
 {% endnavtab %}
@@ -60,13 +68,19 @@ Install the YUM repository from the command line.
     ```bash
     curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
     ```
-2. Update the repository:
+
+2. Setup the Kong rpm signing key
     ```bash
-    sudo yum clean
+    rpm --import $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos}/repodata/repomd.xml.key")
     ```
-3. Install {{site.ce_product_name}}:
+
+2. Install {{site.ce_product_name}}:
     ```bash
-    sudo yum install -y kong
+    ## Kong Gateway
+    sudo yum install kong-enterprise-edition
+    
+    ## Kong Gateway (OSS)
+    sudo yum install kong
     ```
 
 {% endnavtab %}

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -3,7 +3,7 @@ title: Install Kong Gateway on Debian
 badge: oss
 ---
 {:.install-banner}
-> Download the latest {{site.ce_product_name}} {{page.kong_version}} package for Debian:
+> Download the latest Kong {{page.kong_version}} package for Debian:
 > * [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
 > * [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
 > * [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
@@ -19,7 +19,7 @@ badge: oss
 > [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}
 >  </span>
 
-{{site.ce_product_name}} is licensed under an
+Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
@@ -35,14 +35,14 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 
 Install {{site.base_gateway}} on Debian from the command line.
 
-1. Download the {{site.ce_product_name}} package:
+1. Download the Kong package:
     ```bash
-    curl -Lo kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
      ```
 
 2. Install the package:
     ```bash
-    sudo dpkg -i kong.{{site.data.kong_latest.version}}.amd64.deb
+    sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
     ```
 
 {% endnavtab %}
@@ -50,7 +50,7 @@ Install {{site.base_gateway}} on Debian from the command line.
 
 Install the APT repository from the command line.
 
-1. Download the {{site.ce_product_name}} APT repository:
+1. Download the Kong APT repository:
     ```bash
     echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-debian-$(lsb_release -sc)/ \
     default all" | sudo tee /etc/apt/sources.list.d/kong.list
@@ -59,7 +59,7 @@ Install the APT repository from the command line.
     ```bash
     sudo apt-get update
     ```
-3. Install {{site.ce_product_name}}:
+3. Install Kong:
     ```bash
     apt install -y kong
     ```

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -52,7 +52,7 @@ Install the APT repository from the command line.
 
 1. Download the {{site.ce_product_name}} APT repository:
     ```bash
-    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-debian-$(lsb_release -sc)/
+    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-debian-$(lsb_release -sc)/ \
     default all" | sudo tee /etc/apt/sources.list.d/kong.list
     ```
 2. Update the repository:

--- a/app/gateway/2.6.x/install-and-run/rhel.md
+++ b/app/gateway/2.6.x/install-and-run/rhel.md
@@ -24,7 +24,7 @@ title: Install Kong Gateway on RHEL
 
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
-{{site.ce_product_name}} is licensed under an
+Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
@@ -39,16 +39,28 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 {% navtabs %}
 {% navtab Package %}
 
-Install {{site.base_gateway}} on Debian from the command line.
+Install {{site.base_gateway}} on Amazon Linux from the command line.
 
-1. Download the {{site.ce_product_name}} package:
+1. Download the Kong package:
     ```bash
-    curl -Lo kong-{{site.data.kong_latest.version}}.amd64.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel_ver}/Packages/k/kong-{{site.data.kong_latest.version}}.el%{rhel_ver}.amd64.rpm")
+    ## Kong Gateway
+    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{rhel}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.noarch.rpm")
+    ```
+
+    ```
+    ## Kong Gateway (OSS)
+    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el%{centos_ver}.amd64.rpm")
      ```
 
 2. Install the package:
     ```bash
-    sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
+    ## Kong Gateway
+    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+    ```
+
+    ```
+    ## Kong Gateway (OSS)
+    sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
     ```
 
 {% endnavtab %}
@@ -56,17 +68,20 @@ Install {{site.base_gateway}} on Debian from the command line.
 
 Install the YUM repository from the command line.
 
-1. Download the {{site.ce_product_name}} APT repository:
+1. Download the Kong APT repository:
     ```bash
-    curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel_ver}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
+    curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
     ```
-2. Update the repository:
+
+2. Install Kong:
     ```bash
-    sudo yum clean
+    ## Kong Gateway
+    sudo yum install kong-enterprise-edition
     ```
-3. Install {{site.ce_product_name}}:
+
     ```bash
-    sudo yum install -y kong
+    ## Kong Gateway (OSS)
+    sudo yum install kong
     ```
 
 {% endnavtab %}

--- a/app/gateway/2.6.x/install-and-run/rhel.md
+++ b/app/gateway/2.6.x/install-and-run/rhel.md
@@ -32,167 +32,44 @@ The {{site.base_gateway}} software is governed by the
 * A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong
 
-## Download
+## Download and Install
 
-Choose between RHEL versions 7 and 8.
-
-You can download an RPM file with the specific version, or pull the whole catalog of versions as a Yum repo.
-
-If you already downloaded the packages manually, move on to [Install](#install).
-
-### RHEL 7
+You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
 {% navtabs %}
-{% navtab RPM file %}
+{% navtab Package %}
 
-To download the RPM file for RHEL 7, use the following command:
+Install {{site.base_gateway}} on Debian from the command line.
 
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel7.noarch.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel7.noarch.rpm")
-```
+1. Download the {{site.ce_product_name}} package:
+    ```bash
+    curl -Lo kong-{{site.data.kong_latest.version}}.amd64.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel_ver}/Packages/k/kong-{{site.data.kong_latest.version}}.el%{rhel_ver}.amd64.rpm")
+     ```
 
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rhel7.amd64.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.rhel7.amd64.rpm")
-```
+2. Install the package:
+    ```bash
+    sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
+    ```
 
 {% endnavtab %}
-{% navtab Yum repo %}
+{% navtab YUM repository %}
 
-To download the Yum repo file for RHEL 7, use the following command:
+Install the YUM repository from the command line.
 
-```bash
-## Kong Gateway
-curl $(rpm --eval "{{site.links.download}}/gateway-2.x-rhel-7/config.repo") | sudo tee /etc/yum.repos.d/kong-enterprise-edition.repo
-```
-
-```bash
-## Kong Gateway (OSS)
-curl $( "{{site.links.download}}/gateway-2.x-rhel-7/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
-```
+1. Download the {{site.ce_product_name}} APT repository:
+    ```bash
+    curl $(rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel_ver}/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
+    ```
+2. Update the repository:
+    ```bash
+    sudo yum clean
+    ```
+3. Install {{site.ce_product_name}}:
+    ```bash
+    sudo yum install -y kong
+    ```
 
 {% endnavtab %}
 {% endnavtabs %}
-
-### RHEL 8
-
-{% navtabs %}
-{% navtab RPM file %}
-
-To download the RPM file for RHEL 8, use the following command:
-
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel8.noarch.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel8.noarch.rpm")
-```
-
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rhel8.amd64.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.rhel8.amd64.rpm")
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-To download the Yum repo file for RHEL 8 from the command line, use the following command:
-
-```bash
-## Kong Gateway
-curl $(rpm --eval "{{site.links.download}}/gateway-2.x-rhel-8/config.repo") | sudo tee /etc/yum.repos.d/kong-enterprise-edition.repo
-```
-
-```bash
-## Kong Gateway (OSS)
-curl $( "{{site.links.download}}/gateway-2.x-rhel-8/config.repo") | sudo tee /etc/yum.repos.d/kong.repo
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-## Install
-
-Choose between RHEL versions 7 and 8.
-
-### RHEL 7
-
-{% navtabs %}
-{% navtab RPM file %}
-
-To install the RPM file for RHEL 7, use the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel7.noarch.rpm
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong-{{page.kong_versions[page.version-index].ce-version}}.rhel7.amd64.rpm
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-To install the Yum repo file for RHEL from the command line, use the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-### RHEL 8
-
-{% navtabs %}
-{% navtab RPM file %}
-
-To install the RPM file for RHEL 8 from the command line, use the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel8.noarch.rpm
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong-{{page.kong_versions[page.version-index].ce-version}}.rhel8.amd64.rpm
-```
-
-{% endnavtab %}
-{% navtab Yum repo %}
-
-To install the Yum repo file for RHEL, use the following command:
-
-```bash
-## Kong Gateway
-sudo yum install -y kong-enterprise-edition
-```
-
-```bash
-## Kong Gateway (OSS)
-sudo yum --nogpgcheck install -y kong
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-
-<!-- Setup content shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL.
-Includes the following sections: Setup configs, Using a database, Using a yaml declarative config file,
-Using a yaml declarative config file, Verify install, Enable and configure Kong Manager, Enable Dev Portal,
-Support, and Next Steps.
-
-Located in the app/_includes/md/gateway folder.
-
-See https://docs.konghq.com/contributing/includes/ for more information about using includes in this project.
--->
 
 {% include_cached /md/gateway/setup.md kong_version=page.kong_version %}

--- a/app/gateway/2.6.x/install-and-run/rhel.md
+++ b/app/gateway/2.6.x/install-and-run/rhel.md
@@ -42,26 +42,42 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 Install {{site.base_gateway}} on Amazon Linux from the command line.
 
 1. Download the Kong package:
-    ```bash
-    ## Kong Gateway
-    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{rhel}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.noarch.rpm")
-    ```
 
-    ```
-    ## Kong Gateway (OSS)
-    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-centos-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.el%{centos_ver}.amd64.rpm")
-     ```
+{% capture download_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel%{rhel}.noarch.rpm")
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-%{rhel}/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.rhel%{rhel}.amd64.rpm")
+ ```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ download_package | indent | replace: " </code>", "</code>" }}
 
 2. Install the package:
-    ```bash
-    ## Kong Gateway
-    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
-    ```
 
-    ```
-    ## Kong Gateway (OSS)
-    sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
-    ```
+{% capture install_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% navtab YUM repository %}
@@ -74,15 +90,22 @@ Install the YUM repository from the command line.
     ```
 
 2. Install Kong:
-    ```bash
-    ## Kong Gateway
-    sudo yum install kong-enterprise-edition
-    ```
+{% capture install_from_repo %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
 
-    ```bash
-    ## Kong Gateway (OSS)
-    sudo yum install kong
-    ```
+{{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -47,12 +47,20 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 
 1. Download the {{site.ce_product_name}} package:
     ```bash
+    ## Kong Gateway
+    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
+    
+    ## Kong Gateway (OSS)
     curl -Lo kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
      ```
 
 2. Install the package:
     ```bash
-    sudo dpkg -i kong.{{site.data.kong_latest.version}}.amd64.deb
+    ## Kong Gateway
+    sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
+
+    ## Kong Gateway (OSS)
+    sudo dpkg -i kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
     ```
 
 {% endnavtab %}
@@ -60,17 +68,23 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 
 Install the APT repository from the command line.
 
-1. Download the {{site.ce_product_name}} APT repository:
+1. Setup the {{site.ce_product_name}} APT repository:
     ```bash
-    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -sc)/
+    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -sc)/ \
     default all" | sudo tee /etc/apt/sources.list.d/kong.list
     ```
+
 2. Update the repository:
     ```bash
     sudo apt-get update
     ```
+
 3. Install {{site.ce_product_name}}:
     ```bash
+    ## Kong Gateway
+    apt install -y kong-enterprise-edition
+    
+    ## Kong Gateway
     apt install -y kong
     ```
 

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -28,7 +28,7 @@ title: Install Kong Gateway on Ubuntu
 
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
-{{site.ce_product_name}} is licensed under an
+Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
@@ -45,22 +45,26 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 
 Install {{site.base_gateway}} on Ubuntu from the command line.
 
-1. Download the {{site.ce_product_name}} package:
+1. Download the Kong package:
     ```bash
     ## Kong Gateway
     curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
-    
+    ```
+
+    ```bash
     ## Kong Gateway (OSS)
-    curl -Lo kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
      ```
 
 2. Install the package:
     ```bash
     ## Kong Gateway
     sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
+    ```
 
+    ```bash
     ## Kong Gateway (OSS)
-    sudo dpkg -i kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
+    sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
     ```
 
 {% endnavtab %}
@@ -68,7 +72,7 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 
 Install the APT repository from the command line.
 
-1. Setup the {{site.ce_product_name}} APT repository:
+1. Setup the Kong APT repository:
     ```bash
     echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -sc)/ \
     default all" | sudo tee /etc/apt/sources.list.d/kong.list
@@ -79,11 +83,13 @@ Install the APT repository from the command line.
     sudo apt-get update
     ```
 
-3. Install {{site.ce_product_name}}:
+3. Install Kong:
     ```bash
     ## Kong Gateway
     apt install -y kong-enterprise-edition
-    
+    ```
+
+    ```bash
     ## Kong Gateway
     apt install -y kong
     ```

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -46,26 +46,42 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 Install {{site.base_gateway}} on Ubuntu from the command line.
 
 1. Download the Kong package:
-    ```bash
-    ## Kong Gateway
-    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
-     ```
+{% capture download_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+ ```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ download_package | indent | replace: " </code>", "</code>" }}
 
 2. Install the package:
-    ```bash
-    ## Kong Gateway
-    sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
-    ```
 
-    ```bash
-    ## Kong Gateway (OSS)
-    sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
-    ```
+{% capture install_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% navtab APT repository %}
@@ -84,15 +100,23 @@ Install the APT repository from the command line.
     ```
 
 3. Install Kong:
-    ```bash
-    ## Kong Gateway
-    apt install -y kong-enterprise-edition
-    ```
 
-    ```bash
-    ## Kong Gateway
-    apt install -y kong
-    ```
+{% capture install_from_repo %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+apt install -y kong-enterprise-edition
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+apt install -y kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -36,136 +36,45 @@ The {{site.base_gateway}} software is governed by the
 * A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong
 
-## Download
+## Download and install
 
-Download either a `.deb` package or the whole {{site.base_gateway}} APT repo for Xenial, Focal, or Bionic.
-
-### Packages
-
-{% navtabs %}
-{% navtab Xenial %}
-
-Download the `.deb` file for Xenial:
-
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-xenial/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}_all.deb"
-```
-
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb  "{{ site.links.download }}/gateway-2.x-ubuntu-xenial/Packages/k/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
-```
-
-{% endnavtab %}
-{% navtab Focal %}
-
-Download the `.deb` file for Focal:
-
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-focal/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}_all.deb"
-```
-
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-focal/Packages/k/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
-```
-
-{% endnavtab %}
-{% navtab Bionic %}
-
-Download the `.deb` file for Ubuntu Bionic:
-
-```bash
-## Kong Gateway
-curl -Lo kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-bionic/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}_all.deb"
-```
-
-```bash
-## Kong Gateway (OSS)
-curl -Lo kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-bionic/Packages/k/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-### Apt repository
-
-{% navtabs %}
-{% navtab Xenial %}
-
-Download the APT repo for Xenial:
-
-```bash
-echo "deb [trusted=yes] download.konghq.com/gateway-2.x-ubuntu-xenial default all" | tee /etc/apt/sources.list.d/kong.list
-```
-
-{% endnavtab %}
-{% navtab Focal %}
-
-Download the APT repo for Focal:
-
-```bash
-echo "deb [trusted=yes] download.konghq.com/gateway-2.x-ubuntu-focal default all" | tee /etc/apt/sources.list.d/kong.list
-```
-
-{% endnavtab %}
-{% navtab Bionic %}
-
-Download the APT repo for Bionic:
-
-```bash
-echo "deb [trusted=yes] download.konghq.com/gateway-2.x-ubuntu-bionic default all" | tee /etc/apt/sources.list.d/kong.list
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-## Install
-
-Install {{site.base_gateway}} using a `.deb` package or the APT repo.
+You can install {{site.base_gateway}} by downloading an installation package or using our APT repository.
 
 {% navtabs %}
 {% navtab Package %}
 
-Install {{site.base_gateway}} using the `.deb` package:
+Install {{site.base_gateway}} on Ubuntu from the command line.
 
-```bash
-## Kong Gateway
-sudo apt-get install -fy ./kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb
-```
+1. Download the {{site.ce_product_name}} package:
+    ```bash
+    curl -Lo kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+     ```
 
-```bash
-## Kong Gateway (OSS)
-sudo apt-get install -fy ./kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb
-```
+2. Install the package:
+    ```bash
+    sudo dpkg -i kong.{{site.data.kong_latest.version}}.amd64.deb
+    ```
 
 {% endnavtab %}
-{% navtab APT repo %}
+{% navtab APT repository %}
 
-Install {{site.base_gateway}} using the APT repo for Ubuntu:
+Install the APT repository from the command line.
 
-```bash
-## Kong Gateway
-apt-get install -y kong-enterprise-edition
-```
+1. Download the {{site.ce_product_name}} APT repository:
+    ```bash
+    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -sc)/
+    default all" | sudo tee /etc/apt/sources.list.d/kong.list
+    ```
+2. Update the repository:
+    ```bash
+    sudo apt-get update
+    ```
+3. Install {{site.ce_product_name}}:
+    ```bash
+    apt install -y kong
+    ```
 
-```bash
-## Kong Gateway (OSS)
-apt-get install -y kong
-```
 {% endnavtab %}
 {% endnavtabs %}
-
-<!-- Setup content shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL.
-Includes the following sections: Setup configs, Using a database, Using a yaml declarative config file,
-Using a yaml declarative config file, Verify install, Enable and configure Kong Manager, Enable Dev Portal,
-Support, and Next Steps.
-
-Located in the app/_includes/md/gateway folder.
-
-See https://docs.konghq.com/contributing/includes/ for more information about using includes in this project.
--->
 
 {% include_cached /md/gateway/setup.md kong_version=page.kong_version %}


### PR DESCRIPTION
### Summary
Our installation instructions are kind of part way between the old OSS install instructions and the old enterprise installation instructions. For example we're doing `rpm --eval` in spots that don't do anything

The table of contents is a good example of the change

Before:
![image](https://user-images.githubusercontent.com/697188/142696692-44046c5e-1c40-41a8-862c-d218b34f251d.png)

After:
![image](https://user-images.githubusercontent.com/697188/142696718-153de868-4da1-4ba7-a21a-c4c19a2436e2.png)


### Reason
simplifying docs so folks don't need to choose their release distribution

### Testing
do a `docker run -it --rm x:y` and run through the installation instructions ommitting any `sudo`'s

Before
![image](https://user-images.githubusercontent.com/697188/142696803-f173c4e1-184b-4e22-befc-297fcecc7518.png)

After
![image](https://user-images.githubusercontent.com/697188/142696777-3bc139fb-dd69-45fa-9e6f-75be7e20bf46.png)
