### PR TITLE
[TDX-1630] OIDC: share email as Admin and Dev

### DIFF
--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -120,15 +120,15 @@ description: |
 
   ## Authenticate Dev Portal with OIDC
 
-  You can authenticate a self-managed Dev Portal with this plugin.
+  You can [authenticate a self-managed Dev Portal](/gateway/latest/developer-portal/configuration/authentication/oidc/) with this plugin.
 
   The OIDC plugin enables you to use the same email address for
   both your Admin and your Developer accounts, in case you want to have the same
-  credentials between the Admin GUI and your self-managed Dev Portal. To use the
+  credentials between the Admin GUI (Kong Manager) and your self-managed Dev Portal. To use the
   same email for both accounts, ensure the Admin `username` is not set to the
   account email and that instead, the `custom_id` is set to the account email.
 
-  By default, the Admin GUI and the self-managed Dev Portal require distinct email
+  By default, Kong Manager and the self-managed Dev Portal require distinct email
   addresses.
 
 enterprise: true

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -118,6 +118,19 @@ description: |
   4. `config.audience_required` (if using a public identity provider)
   5. `config.session_secret` (if using the Kong in DB-less mode)
 
+  ## Authenticate Dev Portal with OIDC
+
+  You can authenticate a self-managed Dev Portal with this plugin.
+
+  The OIDC plugin enables you to use the same email address for
+  both your Admin and your Developer accounts, in case you want to have the same
+  credentials between the Admin GUI and your self-managed Dev Portal. To use the
+  same email for both accounts, ensure the Admin `username` is not set to the
+  account email and that instead, the `custom_id` is set to the account email.
+
+  By default, the Admin GUI and the self-managed Dev Portal require distinct email
+  addresses.
+
 enterprise: true
 plus: true
 type: plugin

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/oidc.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/oidc.md
@@ -5,8 +5,8 @@ badge: enterprise
 
 The [OpenID Connect Plugin](/hub/kong-inc/openid-connect/) (OIDC)
 allows the Kong Dev Portal to hook into existing authentication setups using third-party
-*Identity Providers* (IdP) such as Google, Okta, Microsoft Azure AD,
-[Curity](/gateway/{{page.kong_version}}/configure/auth/oidc-curity/#kong-dev-portal-authentication), etc.
+*Identity Providers* (IdP) such as Google, Okta, Microsoft Azure AD, and 
+[Curity](/gateway/{{page.kong_version}}/configure/auth/oidc-curity/#kong-dev-portal-authentication).
 
 [OIDC](/hub/kong-inc/openid-connect/) must be used with
 the `session` method, utilizing cookies for Dev Portal File API requests.
@@ -15,15 +15,19 @@ In addition, a configuration object is required to enable OIDC. Refer to the
 [Sample Configuration Object](#/sample-configuration-object) section of this
 document for more information.
 
+If you want to use the same email address for both your Kong Manager and Dev Portal accounts, ensure the Admin `username` is not set to the account email and that instead, the `custom_id` is set to the account email.
+
 **Note:** The Dev Portal does not automatically create developer accounts on login via OIDC.
 A developer account matching the `consumer_claim` configuration parameter has to be
 created and approved (if auto approve is not enabled) beforehand.
 
 OIDC for the Dev Portal can be enabled in one of the following ways:
 
-- [Kong Manager](#enable-oidc-using-kong-manager)
-- [Kong Admin API (command line)](#enable-oidc-using-the-command-line)
-- [The Kong configuration file](#enable-oidc-using-kongconf)
+- [Portal Session Plugin Config](#portal-session-plugin-config)
+- [Sample Configuration Object](#sample-configuration-object)
+- [Enable OIDC using Kong Manager](#enable-oidc-using-kong-manager)
+- [Enable OIDC using the Command Line](#enable-oidc-using-the-command-line)
+- [Enable OIDC using kong.conf](#enable-oidc-using-kongconf)
 
 
 ## Portal Session Plugin Config
@@ -35,7 +39,7 @@ Session Plugin Config does not apply when using OpenID Connect.
 Below is a sample configuration JSON object for using *Google* as the Identity
 Provider:
 
-```
+```json
 {
   "consumer_by": ["username","custom_id","id"],
   "leeway": 1000,
@@ -73,7 +77,7 @@ configured to allow OpenID Connect to apply the session correctly.
 
 Example:
 
-```
+```json
 {
   "consumer_by": ["username","custom_id","id"],
   "leeway": 1000,
@@ -113,7 +117,7 @@ into the provided text area.
 You can use the Kong Admin API to set up Dev Portal Authentication.
 To patch a Dev Portal's authentication property directly, run:
 
-```
+```bash
 curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE NAME> \
   --data "config.portal_auth=openid-connect"
   "config.portal_auth_conf=<REPLACE WITH JSON CONFIG OBJECT>
@@ -128,7 +132,7 @@ configuration file with the `portal_auth` property.
 
 In your `kong.conf` file, set the property as follows:
 
-```
+```bash
 portal_auth="openid-connect"
 ```
 

--- a/app/gateway/2.6.x/developer-portal/configuration/authentication/oidc.md
+++ b/app/gateway/2.6.x/developer-portal/configuration/authentication/oidc.md
@@ -21,14 +21,6 @@ If you want to use the same email address for both your Kong Manager and Dev Por
 A developer account matching the `consumer_claim` configuration parameter has to be
 created and approved (if auto approve is not enabled) beforehand.
 
-OIDC for the Dev Portal can be enabled in one of the following ways:
-
-- [Portal Session Plugin Config](#portal-session-plugin-config)
-- [Sample Configuration Object](#sample-configuration-object)
-- [Enable OIDC using Kong Manager](#enable-oidc-using-kong-manager)
-- [Enable OIDC using the Command Line](#enable-oidc-using-the-command-line)
-- [Enable OIDC using kong.conf](#enable-oidc-using-kongconf)
-
 
 ## Portal Session Plugin Config
 


### PR DESCRIPTION
### Summary

* add **Authenticate Dev Portal with OIDC** section

### Reason

Closes [TDX-1630](https://konghq.atlassian.net/browse/TDX-1630)

### Testing

https://deploy-preview-3388--kongdocs.netlify.app/hub/kong-inc/openid-connect/#authenticate-dev-portal-with-oidc
