### PR TITLE
[DOCU-2040] Fix link to getting started guide

### DIFF
--- a/app/gateway/2.6.x/install-and-run/macos.md
+++ b/app/gateway/2.6.x/install-and-run/macos.md
@@ -107,7 +107,7 @@ you should start by generating a declarative config file.
 ## Next steps
 
 Check out {{site.base_gateway}}'s series of
-[Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive) guides to get the most
+[Getting Started](/gateway/{{page.kong_version}}/get-started/comprehensive) guides to get the most
 out of {{site.base_gateway}}.
 
-[configuration]: /gateway/latest/reference/configuration#database
+[configuration]: /gateway/{{page.kong_version}}/reference/configuration#database


### PR DESCRIPTION
### Summary
Fixing broken link.

### Reason
Broken link.

### Testing
Looked for the same error throughout the docs, this is the only place place it exists. Other installation topics also have correct links.

https://deploy-preview-3389--kongdocs.netlify.app/gateway/2.6.x/install-and-run/macos/