### PR TITLE
doc(hybrid) add warning for intermediate proxy

### DIFF
--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -31,6 +31,13 @@ by both CP and DP nodes.
 (CA). Kong validates both sides by checking if they are from the same CA. This
 eliminates the risks associated with transporting private keys.
 
+{:.warning}
+> **Warning:** if you have a TLS-aware proxy between the DP and CP nodes, you
+must use PKI mode and set `cluster_server_name` to the CP hostname in
+kong.conf. Shared mode uses a non-standard value for TLS server name
+indication, and this will confuse TLS-aware proxies that rely on SNI to route
+traffic.
+
 For a breakdown of the properties used by these modes, see the
 [configuration reference](#configuration-reference).
 

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -32,9 +32,9 @@ by both CP and DP nodes.
 eliminates the risks associated with transporting private keys.
 
 {:.warning}
-> **Warning:** if you have a TLS-aware proxy between the DP and CP nodes, you
+> **Warning:** If you have a TLS-aware proxy between the DP and CP nodes, you
 must use PKI mode and set `cluster_server_name` to the CP hostname in
-kong.conf. Shared mode uses a non-standard value for TLS server name
+`kong.conf`. Do not use shared mode, as it uses a non-standard value for TLS server name
 indication, and this will confuse TLS-aware proxies that rely on SNI to route
 traffic.
 


### PR DESCRIPTION
### Summary
Add a warning to the TLS mode section instructing users to use PKI mode if they place an intermediate TLS-aware proxy between CP and DP nodes.

### Reason
Hybrid shared mTLS forcibly sets SNI to `kong_clustering`. Intermediate TLS proxies that use SNI to route upstream will almost certainly not recognize this and will misroute traffic or present the wrong certificate. PKI mode allows explicitly setting SNI to the CP hostname, which should be recognized if the intermediate is properly configured.

We do not currently set SNI by default in PKI mode (we probably should), so this instructs users to set that config value also.

### Testing
Await Netlify to see if I broke the warning box.
