### PR TITLE
[DOCU-2041] Add enterprise plugin execution order and missing plugins

### DIFF
--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -9,8 +9,6 @@ chapter: 3
   <a href="http://www.lua.org/">Lua</a>.
 </div>
 
-## Introduction
-
 A {{site.ce_product_name}} Plugin allows you to inject custom logic (in Lua) at several
 entry-points in the life-cycle of a request/response or a tcp stream
 connection as it is proxied by {{site.ce_product_name}}. To do so, the file
@@ -254,22 +252,34 @@ CustomHandler.PRIORITY = 10
 The higher the priority, the sooner your Plugin's phases will be executed in
 regard to other Plugins' phases (such as `:access()`, `:log()`, etc.).
 
-The current order of execution for the bundled Plugins is:
+{% navtabs %}
+{% navtab Open-source or Free mode %}
+
+The following list includes all plugins bundled with open-source
+{{site.base_gateway}} or {{site.base_gateway}} running in Free mode.
+
+{:.note}
+> **Note:** The correlation-id plugin's execution order is different depending
+on whether you're running {{site.base_gateway}} in Free mode or using the
+open-source package.
+
+The current order of execution for the bundled plugins is:
 
 Plugin                      | Priority
 ----------------------------|----------
 pre-function                | `+inf`
+correlation-id <span class="badge free"></span> | 100001
 zipkin                      | 100000
 bot-detection               | 2500
 cors                        | 2000
 session                     | 1900
-kubernetes-sidecar-injector | 1006
 jwt                         | 1005
 oauth2                      | 1004
 key-auth                    | 1003
 ldap-auth                   | 1002
 basic-auth                  | 1001
 hmac-auth                   | 1000
+grpc-gateway                | 998
 ip-restriction              | 990
 request-size-limiting       | 951
 acl                         | 950
@@ -288,10 +298,87 @@ udp-log                     | 8
 tcp-log                     | 7
 loggly                      | 6
 syslog                      | 4
+grpc-web                    | 3
 request-termination         | 2
-correlation-id              | 1
+correlation-id <span class="badge oss"></span> | 1
 post-function               | -1000
 
+{% endnavtab %}
+{% navtab Enterprise %}
+The following list includes all plugins bundled with a {{site.base_gateway}}
+Enterprise subscription.
+
+The current order of execution for the bundled plugins is:
+
+Plugin                      | Priority
+----------------------------|----------
+pre-function                | `+inf`
+correlation-id              | 100001 <!--  CE priority is 1, EE priority is 100001 -->
+zipkin                      | 100000
+exit-transformer            | 9999
+bot-detection               | 2500
+cors                        | 2000
+session                     | 1900
+oauth2-introspection        | 1700
+acme                        | 1007
+mtls-auth                   | 1006
+jwt                         | 1005
+degraphql                   | 1005
+oauth2                      | 1004
+vault-auth                  | 1003
+key-auth                    | 1003
+key-auth-enc                | 1003
+ldap-auth                   | 1002
+ldap-auth-advanced          | 1002
+basic-auth                  | 1001
+openid-connect              | 1000
+hmac-auth                   | 1000
+request-validator           | 999
+jwt-signer                  | 999
+grpc-gateway                | 998
+application-registration    | 995
+ip-restriction              | 990
+request-size-limiting       | 951
+acl                         | 950
+opa                         | 920
+collector                   | 903
+rate-limiting-advanced      | 902
+graphql-rate-limiting-advanced | 902
+rate-limiting               | 901
+response-ratelimiting       | 900
+jq                          | 811
+request-transformer-advanced | 802
+request-transformer         | 801
+response-transformer-advanced | 800
+route-transformer-advanced  | 800
+response-transformer        | 800
+kafka-upstream              | 751
+aws-lambda                  | 750
+azure-functions             | 749
+graphql-proxy-cache-advanced | 100
+proxy-cache-advanced        | 100
+proxy-cache                 | 100
+forward-proxy               | 50
+prometheus                  | 13
+canary                      | 13
+http-log                    | 12
+statsd                      | 11
+statsd-advanced             | 11
+datadog                     | 10
+file-log                    | 9
+udp-log                     | 8
+tcp-log                     | 7
+loggly                      | 6
+kafka-log                   | 5
+syslog                      | 4
+grpc-web                    | 3
+request-termination         | 2
+correlation-id              | 1
+mocking                     | -1
+post-function               | -1000
+
+{% endnavtab %}
+{% endnavtabs %}
 ---
 
 Next: [Plugin configuration &rsaquo;]({{page.book.next}})


### PR DESCRIPTION
### Summary
* Add tabs to plugin dev guide, custom logic page, to separate lists of Enterprise and OSS plugins
* Add Enterprise plugin table - missed in the doc merge
* Add missing plugins: jq, mocking, opa, grpc-gateway, and grpc-web
* Note for correlation ID plugin and labels for Free vs OSS

To find all of this info, I used my install of Kong Gateway 2.6 and ran 
`find . | xargs grep  \.PRIORITY`

### Reason
Missing Enterprise plugins from plugin execution order table.

### Testing
Preview: https://deploy-preview-3393--kongdocs.netlify.app/gateway/2.6.x/plugin-development/custom-logic/#plugins-execution-order
