### PR TITLE
Remove extra correlation-id entry

### DIFF
--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -373,7 +373,6 @@ kafka-log                   | 5
 syslog                      | 4
 grpc-web                    | 3
 request-termination         | 2
-correlation-id              | 1
 mocking                     | -1
 post-function               | -1000
 


### PR DESCRIPTION
### Summary
Removing one extra line from the plugin priority table.

### Reason
The OSS/Free mode table should have two entries for correlation ID, but the Enterprise table should only have one. Accidentally added two entries to both.

### Testing
TBA
