### PR TITLE
[TDX-1631] Dev Portal: Add showExtensions option

### DIFF
--- a/app/gateway/2.6.x/developer-portal/working-with-templates.md
+++ b/app/gateway/2.6.x/developer-portal/working-with-templates.md
@@ -20,6 +20,10 @@ You may use the following tags in templates:
 * `{# comments #}` everything between `{#` and `#}` is considered to be commented out (i.e., not outputted or executed).
 {% endraw %}
 
+## Show custom properties
+
+You may work with custom properties in your OpenAPI spec. To expose custom properties in Dev Portal, add the property `showExtensions` and assign `true`. By default, `showExtensions` is `false`.
+
 ## Partials
 
 Partials are snippets of html that layouts can reference. Partials have access to all the same data that its layout does, and can even call other partials.  Breaking your code into partials can help organize large pages, as well as allow different layouts share common page elements.

--- a/app/gateway/2.6.x/developer-portal/working-with-templates.md
+++ b/app/gateway/2.6.x/developer-portal/working-with-templates.md
@@ -22,7 +22,7 @@ You may use the following tags in templates:
 
 ## Show custom properties
 
-You may work with custom properties in your OpenAPI spec. To expose custom properties in Dev Portal, add the property `showExtensions` and assign `true`. By default, `showExtensions` is `false`.
+You may work with custom properties in your OpenAPI spec. To expose custom properties in Dev Portal, change the property `showExtensions` to `true` in the `spec-renderer.html` file. By default, `showExtensions` is `false`.
 
 ## Partials
 


### PR DESCRIPTION
### Summary

This change applies to self-managed Dev Portal. In "Working with Templates", I added a note that you can add the property `showExtensions` and set it to `true` to show custom properties. 

### Reason

Closes [TDX-1631](https://konghq.atlassian.net/browse/TDX-1631) (not part of 2.7)

### Testing

https://deploy-preview-3401--kongdocs.netlify.app/gateway/2.6.x/developer-portal/working-with-templates/#show-custom-properties
