### PR TITLE
Update Gateway patch versions

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -442,7 +442,7 @@
 
 -
   release: "2.5.x"
-  version: "2.5.1.0"
+  version: "2.5.1.2"
   edition: "enterprise"
   luarocks_version: "2.2.0.0"
   dependencies:
@@ -455,7 +455,7 @@
 -
 # Combined Gateway docs (single-sourced)
   release: "2.6.x"
-  ee-version: "2.6.0.0"
+  ee-version: "2.6.0.1"
   ce-version: "2.6.0"
   edition: "gateway"
   luarocks_version: "2.5.1-0"


### PR DESCRIPTION
### Summary
Updating metadata for latest patch versions.

### Reason
Patch releases went out last week, see changelog: https://docs.konghq.com/gateway/changelog/

### Testing
See versions in https://deploy-preview-3403--kongdocs.netlify.app/gateway/2.6.x/install-and-run/docker/ and  https://deploy-preview-3403--kongdocs.netlify.app/enterprise/2.5.x/deployment/installation/docker/