### PR TITLE
Generate combined gateway versions

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -87,12 +87,10 @@ breadcrumbs:
 {% if page.kong_version_compatibility.community_edition %}
   {% assign compat = true %}
   {% assign ce_compatible = page.kong_version_compatibility.community_edition.compatible %}
-  {% assign ce_incompatible = page.kong_version_compatibility.community_edition.incompatible %}
 {% endif %}
 {% if page.kong_version_compatibility.enterprise_edition %}
   {% assign compat = true %}
   {% assign ee_compatible = page.kong_version_compatibility.enterprise_edition.compatible %}
-  {% assign ee_incompatible = page.kong_version_compatibility.enterprise_edition.incompatible %}
 {% endif %}
 
 {% assign extn_type = site.extensions.types | where: "slug", page.type %}
@@ -395,31 +393,51 @@ breadcrumbs:
           <tr class="kong-compatibility">
             <td colspan="2">
               <ul class="compat-list">
-              {% for v in site.data.kong_versions_ee reversed %}
-                {% if ee_compatible contains v.release or ee_incompatible contains v.release %}
+              {% for v in site.data.kong_versions_gateway reversed %}
+                {% if ee_compatible contains v.release %}
                   {% unless first_ee %}
                   <h6>{{site.ee_product_name}}</h6>{% assign first_ee = true %}
                   {% endunless %}
                   <li>
                   {% if ee_compatible contains v.release %}
                     <i class="fa fa-check"></i>
-                  {% elsif ee_incompatible contains v.release %}
-                    <i class="fa fa-times"></i>
+                  {% endif %}{{ v.release }}
+                  </li>
+                {% endif %}
+              {% endfor %}
+              {% for v in site.data.kong_versions_ee reversed %}
+                {% if ee_compatible contains v.release %}
+                  {% unless first_ee %}
+                  <h6>{{site.ee_product_name}}</h6>{% assign first_ee = true %}
+                  {% endunless %}
+                  <li>
+                  {% if ee_compatible contains v.release %}
+                    <i class="fa fa-check"></i>
                   {% endif %}{{ v.release }}
                   </li>
                 {% endif %}
               {% endfor %}
               </ul><ul class="compat-list">
-              {% for v in site.data.kong_versions_ce reversed %}
-                {% if ce_compatible contains v.release or ce_incompatible contains v.release %}
+              {% for v in site.data.kong_versions_gateway reversed %}
+                {% if ce_compatible contains v.release %}
                   {% unless first_ce %}
                   <h6>{{site.ce_product_name}}</h6>{% assign first_ce = true %}
                   {% endunless %}
                   <li>
                   {% if ce_compatible contains v.release %}
                     <i class="fa fa-check"></i>
-                  {% elsif ce_incompatible contains v.release %}
-                    <i class="fa fa-times"></i>
+                  {% endif %}{{ v.release }}
+                  </li>
+                {% endif %}
+              {% endfor %}
+              {% for v in site.data.kong_versions_ce reversed %}
+                {% if ce_compatible contains v.release %}
+                  {% unless first_ce %}
+                  <h6>{{site.ce_product_name}}</h6>{% assign first_ce = true %}
+                  {% endunless %}
+                  <li>
+                  {% if ce_compatible contains v.release %}
+                    <i class="fa fa-check"></i>
                   {% endif %}{{ v.release }}
                   </li>
                 {% endif %}


### PR DESCRIPTION
### Summary
Add list of `site.data.kong_versions_gateway` versions to the plugin doc. Currently, the doc isn't picking up 2.6.x because it's only generating from the old split CE/EE lists.

### Reason
Currently, the doc isn't picking up 2.6.x because it's only generating from the old split CE/EE lists. 
For example, this plugin is compatible with 2.6.x but the live doc has no versions in the compatibility list (bottom of right sidebar): https://docs.konghq.com/hub/kong-inc/jq/, even though the [source file](https://github.com/Kong/docs.konghq.com/blame/main/app/_hub/kong-inc/jq/index.md#L37) includes the version.

### Testing
All Kong plugins should now have 2.6.x in the sidebar. For example, see https://deploy-preview-3416--kongdocs.netlify.app/hub/kong-inc/jq/, or https://deploy-preview-3416--kongdocs.netlify.app/hub/kong-inc/grpc-web/ for both OSS and EE entries.