### PR TITLE
docs(installation): nuke amazonlinux 1 and jessie install links

### DIFF
--- a/app/gateway/2.6.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.6.x/install-and-run/amazon-linux.md
@@ -8,12 +8,12 @@ title: Install Kong Gateway on Amazon Linux
 {:.install-banner}
 > Download the latest {{page.kong_version}} packages for
 > Amazon Linux:
-> * **Kong Gateway**: [Amazon Linux 1]({{site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn1.noarch.rpm){:.install-link} or [Amazon Linux 2]({{site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm){:.install-link} (version {{page.kong_versions[page.version-index].ee-version}})
+> * **Kong Gateway**: [Amazon Linux 2]({{site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm){:.install-link} (version {{page.kong_versions[page.version-index].ee-version}})
 > * **Kong Gateway (OSS)**: [Amazon Linux 2]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm){:.install-link} (version {{page.kong_versions[page.version-index].ce-version}})
 > <br><br>
 >
 > <span class="install-subtitle">View the list of all 2.x packages for
-> [Amazon Linux 1]({{ site.links.download }}/gateway-2.x-amazonlinux-1/Packages/k/){:.install-listing-link} and [Amazon Linux 2]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/){:.install-listing-link}  </span>
+> [Amazon Linux 2]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/){:.install-listing-link}  </span>
 
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -4,7 +4,6 @@ badge: oss
 ---
 {:.install-banner}
 > Download the latest Kong {{page.kong_version}} package for Debian:
-> * [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
 > * [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
 > * [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
 > * [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
@@ -13,7 +12,6 @@ badge: oss
 >
 > <br>
 > <span class="install-subtitle">View the list of all 2.x packages for
-> [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/){:.install-listing-link},
 > [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/){:.install-listing-link},
 > [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/){:.install-listing-link}, or
 > [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}


### PR DESCRIPTION
### Summary

Amazon Linux 2 was released in 2017 and Amazon Linux 1 EOL including an extention was December 30, 2020

Debian Stretch was released in 2017 and Jessie was EOL was June 30, 2020 (ELTS is 2022).

### Reason

This doesn't change that we release packages for these releases and folks will be able to interprit where to locate them
based on the installation instructions it simply doesn't actively document how to download / install them.

Arguably we should stop doing new releases to EOL releases and only to patch / security but that's a product question I won't explore right now
