### PR TITLE
chore(installation): pin the apt and yum repository version explicitely

### DIFF
--- a/app/gateway/2.6.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.6.x/install-and-run/amazon-linux.md
@@ -88,12 +88,12 @@ Install the YUM repository from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition
+sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong
+sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -96,12 +96,12 @@ Install the YUM repository from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition
+sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong
+sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -61,7 +61,7 @@ Install the APT repository from the command line.
     ```
 3. Install Kong:
     ```bash
-    apt install -y kong
+    apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
     ```
 
 {% endnavtab %}

--- a/app/gateway/2.6.x/install-and-run/rhel.md
+++ b/app/gateway/2.6.x/install-and-run/rhel.md
@@ -94,12 +94,12 @@ Install the YUM repository from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition
+sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong
+sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -105,12 +105,12 @@ Install the APT repository from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-apt install -y kong-enterprise-edition
+apt install -y kong-enterprise-edition={{page.kong_versions[page.version-index].ee-version}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-apt install -y kong
+apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Summary

Install an explicit version when installing from our yum and apt repository for verbosity and anti-failure

### Reason
More verbose is better. Folks that are fluent in yum / apt will know the package version isn't explicitely required but having it by default is better than not.

Ensures that the customer knows exactly what package is being installed
