### PR TITLE
Add support policy to nav

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -3,6 +3,9 @@
   url: /gateway/
   absolute_url: true
   items:
+    - text: Version Support Policy
+      url: /konnect-platform/support-policy
+      absolute_url: true
     - text: Changelog
       url: /gateway/changelog
       absolute_url: true


### PR DESCRIPTION
### Summary
Add version support policy to Gateway nav.

### Reason
Request from CRE. We used to have a link to this policy in the EE nav and now it's hard to find.

### Testing
See entry under introduction: https://deploy-preview-3422--kongdocs.netlify.app/gateway/
