### PR TITLE
[DOCU-2061] Add tls_passthrough to supported plugins

### DIFF
--- a/app/_hub/kong-inc/datadog/index.md
+++ b/app/_hub/kong-inc/datadog/index.md
@@ -58,7 +58,10 @@ params:
     - https
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/http-log/index.md
+++ b/app/_hub/kong-inc/http-log/index.md
@@ -55,11 +55,12 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: http_endpoint

--- a/app/_hub/kong-inc/loggly/index.md
+++ b/app/_hub/kong-inc/loggly/index.md
@@ -52,11 +52,12 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/statsd/index.md
+++ b/app/_hub/kong-inc/statsd/index.md
@@ -59,11 +59,12 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/syslog/index.md
+++ b/app/_hub/kong-inc/syslog/index.md
@@ -52,11 +52,12 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: successful_severity

--- a/app/_hub/kong-inc/tcp-log/index.md
+++ b/app/_hub/kong-inc/tcp-log/index.md
@@ -56,11 +56,12 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/udp-log/index.md
+++ b/app/_hub/kong-inc/udp-log/index.md
@@ -56,11 +56,12 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
     - tcp
     - tls
+    - tls_passthrough
     - udp
+    - grpc
+    - grpcs
   dbless_compatible: 'yes'
   config:
     - name: host


### PR DESCRIPTION
### Summary
Updating plugin protocol lists. 
Companion PR to https://github.com/Kong/docs.konghq.com/pull/3373.

To do: update Enterprise plugins once kong-ee has a 2.7 branch.

### Reason
Support for TLS passthrough.

> If a plugin declares it supports all protocols like file-log:
https://github.com/Kong/kong/blob/master/kong/plugins/file-log/schema.lua#L7, we should add the
`tls_passthrough` to its list.

### Testing
Preview link TBA
