### PR TITLE
docs(rate-limiting) new config option redis_username

### DIFF
--- a/app/_data/extensions/kong-inc/rate-limiting/versions.yml
+++ b/app/_data/extensions/kong-inc/rate-limiting/versions.yml
@@ -1,3 +1,4 @@
+- release: 2.3.x
 - release: 2.2-x
 - release: 2.1-x
 - release: 1.0-x

--- a/app/_hub/kong-inc/rate-limiting/2.2-x.md
+++ b/app/_hub/kong-inc/rate-limiting/2.2-x.md
@@ -1,7 +1,7 @@
 ---
 name: Rate Limiting
 publisher: Kong Inc.
-version: 2.3.x
+version: 2.2.x
 desc: Rate-limit how many HTTP requests can be made in a period of time
 description: |
   Rate limit how many HTTP requests can be made in a given period of seconds, minutes, hours, days, months, or years.
@@ -18,7 +18,6 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 2.7.x
       - 2.6.x
       - 2.5.x
       - 2.4.x
@@ -46,7 +45,6 @@ kong_version_compatibility:
       - 0.2.x
   enterprise_edition:
     compatible:
-      - 2.7.x
       - 2.6.x
       - 2.5.x
       - 2.4.x
@@ -159,11 +157,6 @@ params:
       datatype: integer
       description: |
         When using the `redis` policy, this property specifies the port of the Redis server. By default is `6379`.
-    - name: redis_username
-      required: false
-      datatype: string
-      description: |
-        When using the `redis` policy, this property specifies the username to connect to the Redis server.
     - name: redis_password
       required: false
       datatype: string

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -19,43 +19,11 @@ kong_version_compatibility:
   community_edition:
     compatible:
       - 2.7.x
-      - 2.6.x
-      - 2.5.x
-      - 2.4.x
-      - 2.3.x
-      - 2.2.x
-      - 2.1.x
-      - 2.0.x
-      - 1.4.x
-      - 1.3.x
-      - 1.2.x
-      - 1.1.x
-      - 1.0.x
-      - 0.14.x
-      - 0.13.x
-      - 0.12.x
-      - 0.11.x
-      - 0.10.x
-      - 0.9.x
-      - 0.8.x
-      - 0.7.x
-      - 0.6.x
-      - 0.5.x
-      - 0.4.x
-      - 0.3.x
-      - 0.2.x
+      
   enterprise_edition:
     compatible:
       - 2.7.x
-      - 2.6.x
-      - 2.5.x
-      - 2.4.x
-      - 2.3.x
-      - 2.2.x
-      - 2.1.x
-      - 1.5.x
-      - 1.3-x
-      - 0.36-x
+
 params:
   name: rate-limiting
   service_id: true
@@ -292,6 +260,15 @@ inaccuracies and preventing scaling problems.
 When the selected policy cannot be retrieved, the plugin falls back
 to limiting usage by identifying the IP address. This can happen for several reasons, such as the
 selected header was not sent by the client or the configured service was not found.
+
+---
+
+## Changelog
+
+### 2.3.0
+
+* Added parameters `redis_username`, `redis_ssl`, `redis_ssl_verify`, and `redis_server_name`.
+
 
 [api-object]: /gateway/latest/admin-api/#api-object
 [configuration]: /gateway/latest/reference/configuration

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -169,6 +169,23 @@ params:
       datatype: string
       description: |
         When using the `redis` policy, this property specifies the password to connect to the Redis server.
+    - name: redis_ssl
+      required: true
+      default: '`false`'
+      datatype: boolean
+      description: |
+        When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.
+    - name: redis_ssl_verify
+      required: true
+      default: '`false`'
+      datatype: boolean
+      description: |
+        When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly.
+    - name: redis_server_name  
+      required: false
+      datatype: string
+      description: |
+        When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI)
     - name: redis_timeout
       required: false
       default: '`2000`'


### PR DESCRIPTION
### Summary
This change includes the new config option redis_username and a version bump.

### Reason
This change is needed because of new config option added in Kong/kong#8032 and the version bump in Kong/kong#8108.

### Testing
An automated test for this config option was added in Kong/kong#8032.