### PR TITLE
docs: update external-plugins to have a space

### DIFF
--- a/app/gateway/2.6.x/reference/external-plugins.md
+++ b/app/gateway/2.6.x/reference/external-plugins.md
@@ -15,7 +15,7 @@ those processes, starting, restarting and stopping as necessary.
 
 {{site.base_gateway}} currently maintains a Go language plugin server,
 [go-pluginserver], the corresponding PDK library
-package[go-pdk], the JavaScript language support [kong-js-pdk]
+package [go-pdk], the JavaScript language support [kong-js-pdk]
 and Python language support [kong-python-pdk].
 
 ## Kong Gateway plugin server configuration


### PR DESCRIPTION
### Summary

Add a space before `[go-pdk]()`.

### Reason

Documentation format.

### Testing

None