### PR TITLE
[DOCU-2026] Add jq plugin to compatibility index

### DIFF
--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -426,6 +426,14 @@
       network_config_opts: All
       notes: --
       url: /hub/kong-inc/grpc-web
+    
+    - name: jq
+      free: No
+      plus: No
+      enterprise: Yes
+      network_config_opts: All
+      notes: --
+      url: /hub/kong-inc/jq
 
     - name: Kafka Upstream
       free: No


### PR DESCRIPTION
### Summary
Adding jq plugin to plugin compatibility table.

### Reason
Plugin was missing.

### Testing
https://deploy-preview-3434--kongdocs.netlify.app/konnect-platform/compatibility/plugins/