### PR TITLE
[DOCU-2042] Add plugin dev guides to plugin hub; copyedit

### DIFF
--- a/app/_assets/stylesheets/hub-landing-page.less
+++ b/app/_assets/stylesheets/hub-landing-page.less
@@ -337,16 +337,22 @@
         }
       }
 
-    #introduction, #facet-filters, #scroll-sidebar {
+    #introduction, #facet-filters, #scroll-sidebar, #custom-plugins  {
         padding-bottom: 10px;
         margin-bottom: 10px;
+    }
+
+    #custom-plugins {
+        &:last-child {
+          padding-bottom: 50px;
+        }
     }
 
     // Scroll behavior
     .sticky-top {
         position: -webkit-sticky;
         position: sticky;
-        top: 135px;
+        top: 90px;
         height: calc(100vh - 56px);
         border-right: 1px solid @grey-200;
         overflow-y: scroll;

--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -74,9 +74,24 @@ body_id: page-hub
               </li>
             {% endfor %}
           </ul>
-          <!-- <div class="cta-container">
-            <a class="nav-link" href="/contributing/plugin-docs" target="_blank">List your plugin here</a>
-          </div> -->
+          <h3>Custom Plugins</h3>
+          <ul class="nav flex-column" id="custom-plugins" role="menu">
+              <li class="nav-item" role="menuitem">
+                <a class="nav-link" href="/gateway/latest/pdk" target="_blank">
+                  PDK reference
+                </a>
+              </li>
+              <li class="nav-item" role="menuitem">
+                <a class="nav-link" href="/gateway/latest/plugin-development" target="_blank">
+                  Plugin development guide
+                </a>
+              </li>
+              <li class="nav-item" role="menuitem">
+                <a class="nav-link" href="/gateway/latest/reference/external-plugins" target="_blank">
+                  Plugins in other languages
+                </a>
+              </li>
+          </ul>
         </div>
       </div>
       <div class="hub-cards">

--- a/app/gateway/2.6.x/plugin-development/access-the-datastore.md
+++ b/app/gateway/2.6.x/plugin-development/access-the-datastore.md
@@ -4,8 +4,6 @@ book: plugin_dev
 chapter: 5
 ---
 
-## Introduction
-
 Kong interacts with the model layer through classes we refer to as "DAOs". This
 chapter will detail the available API to interact with the datastore.
 
@@ -41,8 +39,6 @@ local plugins   = kong.db.plugins
 
 Both core entities from Kong and custom entities from plugins are
 available through `kong.db.*`.
-
----
 
 ## The DAO Lua API
 

--- a/app/gateway/2.6.x/plugin-development/admin-api.md
+++ b/app/gateway/2.6.x/plugin-development/admin-api.md
@@ -4,17 +4,12 @@ book: plugin_dev
 chapter: 8
 ---
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> This chapter assumes that you have a relative
-  knowledge of <a href="http://leafo.net/lapis/">Lapis</a>.
-</div>
-
-<div class="alert alert-warning">
-  <strong>Note:</strong> The Admin API extensions are available only
+{:.note}
+> **Notes:**
+> * This chapter assumes that you have a relative
+  knowledge of [Lapis](http://leafo.net/lapis/).
+> * The Admin API extensions are available only
   for HTTP plugins, not Stream plugins.
-</div>
-
-## Introduction
 
 Kong can be configured using a REST interface referred to as the [Admin API].
 Plugins can extend it by adding their own endpoints to accommodate custom
@@ -31,7 +26,7 @@ level of abstraction makes it easy for you to add endpoints.
 kong.plugins.<plugin_name>.api
 ```
 
-## Adding endpoints to the Admin API
+## Add endpoints to the Admin API
 
 Kong will detect and load your endpoints if they are defined in a module named:
 

--- a/app/gateway/2.6.x/plugin-development/custom-entities.md
+++ b/app/gateway/2.6.x/plugin-development/custom-entities.md
@@ -4,8 +4,6 @@ book: plugin_dev
 chapter: 6
 ---
 
-## Introduction
-
 While not all plugins need it, your plugin might need to store more than
 its configuration in the database. In that case, Kong provides you with
 an abstraction on top of its primary datastores which allows you to store
@@ -53,7 +51,7 @@ return {
 This means that there will be a file in `<plugin_name>/migrations/000_base_my_plugin.lua`
 containing the initial migrations. We'll see how this is done in a minute.
 
-## Adding a new migration to an existing plugin
+## Add a new migration to an existing plugin
 
 Sometimes it is necessary to introduce changes after a version of a plugin has already been
 released. A new functionality might be needed. A database table row might need changing.
@@ -80,7 +78,7 @@ return {
 }
 ```
 
-## Migration File syntax
+## Migration file syntax
 
 While Kong's core migrations support both Postgres and Cassandra, custom plugins
 can choose to support either both of them or just one.
@@ -190,9 +188,8 @@ the migrations.
 
 To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
 
----
 
-## Defining a Schema
+## Define a schema
 
 The first step to using custom entities in a custom plugin is defining one
 or more *schemas*.
@@ -462,7 +459,6 @@ To learn more about schemas, see:
   especially [the key-auth one](https://github.com/Kong/kong/blob/{{page.kong_version | replace: "x", "0"}}/kong/plugins/key-auth/daos.lua),
   which was used for this guide as an example.
 
----
 
 ## The custom DAO
 
@@ -473,7 +469,7 @@ accessible through the `kong.db` interface.
 For the example schema above, the DAO generated would be available for plugins
 via `kong.db.keyauth_credentials`.
 
-### Selecting an entity
+### Select an entity
 
 ``` lua
 local entity, err, err_t = kong.db.<name>:select(primary_key)
@@ -506,7 +502,7 @@ if not entity then
 end
 ```
 
-### Iterating over all the entities
+### Iterate over all the entities
 
 ``` lua
 for entity, err on kong.db.<name>:each(entities_per_page) do
@@ -541,7 +537,7 @@ end
 This example iterates over the credentials in pages of 1000 items, logging their ids unless
 an error happens.
 
-### Inserting an entity
+### Insert an entity
 
 ``` lua
 local entity, err, err_t = kong.db.<name>:insert(<values>)
@@ -570,7 +566,7 @@ end
 
 The returned entity, assuming no error happened will have `auto`-filled fields, like `id` and `created_at`.
 
-### Updating an entity
+### Update an entity
 
 ``` lua
 local entity, err, err_t = kong.db.<name>:update(primary_key, <values>)
@@ -596,7 +592,7 @@ end
 
 Notice how the syntax for specifying a primary key is similar to the one used to specify a foreign key.
 
-### Upserting an entity
+### Upsert an entity
 
 ``` lua
 local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
@@ -628,7 +624,7 @@ Two things can happen:
 * If the credential does not exist, then this code is attempting to create
   a new credential, with the given id and Consumer.
 
-### Deleting an entity
+### Delete an entity
 
 ``` lua
 local ok, err, err_t = kong.db.<name>:delete(primary_key)
@@ -656,9 +652,7 @@ if not ok then
 end
 ```
 
----
-
-## Caching custom entities
+## Cache custom entities
 
 Sometimes custom entities are required on every request/response, which in turn
 triggers a query on the datastore every time. This is very inefficient because

--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -4,12 +4,11 @@ book: plugin_dev
 chapter: 3
 ---
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> This chapter assumes that you are familiar with
-  <a href="http://www.lua.org/">Lua</a>.
-</div>
+{:.note}
+> **Note**: This chapter assumes that you are familiar with
+[Lua](http://www.lua.org/).
 
-A {{site.ce_product_name}} Plugin allows you to inject custom logic (in Lua) at several
+A {{site.ce_product_name}} plugin allows you to inject custom logic (in Lua) at several
 entry-points in the life-cycle of a request/response or a tcp stream
 connection as it is proxied by {{site.ce_product_name}}. To do so, the file
 `kong.plugins.<plugin_name>.handler` must return a table with one or
@@ -37,18 +36,17 @@ of {{site.ce_product_name}}'s execution life-cycle:
 |-----------------|-------------------|------------
 | `init_worker`   | [init_worker]     | Executed upon every Nginx worker process's startup.
 | `certificate`   | [ssl_certificate] | Executed during the SSL certificate serving phase of the SSL handshake.
-| `rewrite`       | [rewrite]         | Executed for every request upon its reception from a client as a rewrite phase handler. *NOTE* in this phase neither the `Service` nor the `Consumer` have been identified, hence this handler will only be executed if the Plugin was configured as a global Plugin!
+| `rewrite`       | [rewrite]         | Executed for every request upon its reception from a client as a rewrite phase handler. <br> In this phase, neither the `Service` nor the `Consumer` have been identified, hence this handler will only be executed if the plugin was configured as a global plugin.
 | `access`        | [access]          | Executed for every request from a client and before it is being proxied to the upstream service.
-| `response` | [access] | Replaces both `header_filter()` and `body_filter()`.  Executed after the whole response has been received from the upstream service, but before sending any part of it to the client.
+| `response` | [access] | Replaces both `header_filter()` and `body_filter()`. Executed after the whole response has been received from the upstream service, but before sending any part of it to the client.
 | `header_filter` | [header_filter]   | Executed when all response headers bytes have been received from the upstream service.
-| `body_filter`   | [body_filter]     | Executed for each chunk of the response body received from the upstream service. Since the response is streamed back to the client, it can exceed the buffer size and be streamed chunk by chunk. hence this function can be called multiple times if the response is large. See the [lua-nginx-module] documentation for more details.
+| `body_filter`   | [body_filter]     | Executed for each chunk of the response body received from the upstream service. Since the response is streamed back to the client, it can exceed the buffer size and be streamed chunk by chunk. This function can be called multiple times if the response is large. See the [lua-nginx-module] documentation for more details.
 | `log`           | [log]             | Executed when the last response byte has been sent to the client.
 
-**Note:**
+{:.note}
+> **Note:** If a module implements the `response` function, {{site.ce_product_name}} will automatically activate the "buffered proxy" mode, as if the [`kong.service.request.enable_buffering()` function][enable_buffering] had been called. Because of a current Nginx limitation, this doesn't work for HTTP/2 or gRPC upstreams.
 
-If a module implements the `response` function, {{site.ce_product_name}} will automatically activate the "buffered proxy" mode, as if the [`kong.service.request.enable_buffering()` function][enable_buffering] had been called.  Because of a current Nginx limitation, this doesn't work for HTTP/2 or gRPC upstreams.
-
-To reduce unexpected behaviour changes, {{site.ce_product_name}} does not start if a Plugin implements both `response` and either `header_filter` or `body_filter`.
+To reduce unexpected behaviour changes, {{site.ce_product_name}} does not start if a plugin implements both `response` and either `header_filter` or `body_filter`.
 
 - **[Stream Module]** *is used for Plugins written for TCP and UDP stream connections*
 
@@ -60,9 +58,9 @@ To reduce unexpected behaviour changes, {{site.ce_product_name}} does not start 
 | `certificate`   | [ssl_certificate] | Executed during the SSL certificate serving phase of the SSL handshake.
 
 All of those functions, except `init_worker`, take one parameter which is given
-by {{site.ce_product_name}} upon its invocation: the configuration of your Plugin. This parameter
+by {{site.ce_product_name}} upon its invocation: the configuration of your plugin. This parameter
 is a Lua table, and contains values defined by your users, according to your
-Plugin's schema (described in the `schema.lua` module). More on Plugins schemas
+plugin's schema (described in the `schema.lua` module). More on plugins schemas
 in the [next chapter]({{page.book.next}}).
 
 Note that UDP streams don't have real connections.  {{site.ce_product_name}} will consider all
@@ -82,36 +80,36 @@ considered closed and the `log` function is executed.
 [preread]: https://github.com/openresty/stream-lua-nginx-module#preread_by_lua_block
 [enable_buffering]: /gateway/{{page.kong_version}}/pdk/kong.service.request/#kongservicerequestenable_buffering
 
----
 
 ## handler.lua specifications
 
-{{site.ce_product_name}} processes requests in **phases**. A Plugin is a piece of code that gets
+{{site.ce_product_name}} processes requests in **phases**. A plugin is a piece of code that gets
 activated by {{site.ce_product_name}} as each phase is executed while the request gets proxied.
 
 Phases are limited in what they can do. For example, the `init_worker` phase
 does not have access to the `config` parameter because that information isn't
 available when kong is initializing each worker.
 
-A Plugin's `handler.lua` must return a table containing the functions it must
+A plugin's `handler.lua` must return a table containing the functions it must
 execute on each phase.
 
 {{site.ce_product_name}} can process HTTP and stream traffic. Some phases are executed when
 processing only when processing HTTP traffic, others when processing stream,
 and some (like `init_worker` and `log`) are invoked by both kinds of traffic.
 
-In addition to functions, a Plugin must define two fields:
+In addition to functions, a plugin must define two fields:
 
 * `VERSION` is an informative field, not used by {{site.ce_product_name}} directly. It usually
-  matches the version defined in a Plugin's Rockspec version, when it exists.
-* `PRIORITY` is used to sort Plugins before executing each of their phases.
-  Plugins with a higher priority are executed first. See the "Plugin Execution Order" below
+  matches the version defined in a plugin's Rockspec version, when it exists.
+* `PRIORITY` is used to sort plugins before executing each of their phases.
+  Plugins with a higher priority are executed first. See the
+  [plugin execution order](#plugins-execution-order) below
   for more info about this field.
 
 The following example `handler.lua` file defines custom functions for all
 the possible phases, in both http and stream traffic. It has no functionality
 besides writing a message to the log every time a phase is invoked. Note
-that a Plugin doesn't need to provide functions for all phases.
+that a plugin doesn't need to provide functions for all phases.
 
 ```lua
 local CustomHandler = {
@@ -176,13 +174,13 @@ function CustomHandler.access(self, config)
 end
 ```
 
-The Plugin's logic doesn't need to be all defined inside the `handler.lua` file.
+The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
 It can be be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
 
-For example, the following Plugin splits the functionality into three files.
+For example, the following plugin splits the functionality into three files.
 `access.lua` and `body_filter.lua` return functions. They are in the same
-folder as `handler.lua`, which requires and uses them to build the Plugin:
+folder as `handler.lua`, which requires and uses them to build the plugin:
 
 ```lua
 -- handler.lua
@@ -217,7 +215,6 @@ end
 See [the source code of the Key-Auth Plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/handler.lua)
 for an example of a real-life handler code.
 
----
 
 ## Plugin Development Kit
 
@@ -229,28 +226,27 @@ execute various gateway operations in a way that is guaranteed to be
 forward-compatible with future releases of {{site.ce_product_name}}.
 
 When you are trying to implement some logic that needs to interact with {{site.ce_product_name}}
-(e.g. retrieving request headers, producing a response from a Plugin, logging
+(e.g. retrieving request headers, producing a response from a plugin, logging
 some error or debug information), you should consult the [Plugin Development
 Kit Reference][pdk].
 
----
 
 ## Plugins execution order
 
-Some Plugins might depend on the execution of others to perform some
-operations. For example, Plugins relying on the identity of the consumer have
-to run **after** authentication Plugins. Considering this, {{site.ce_product_name}} defines
-**priorities** between Plugins execution to ensure that order is respected.
+Some plugins might depend on the execution of others to perform some
+operations. For example, plugins relying on the identity of the consumer have
+to run **after** authentication plugins. Considering this, {{site.ce_product_name}} defines
+**priorities** between plugins execution to ensure that order is respected.
 
-Your Plugin's priority can be configured via a property accepting a number in
+Your plugin's priority can be configured via a property accepting a number in
 the returned handler table:
 
 ```lua
 CustomHandler.PRIORITY = 10
 ```
 
-The higher the priority, the sooner your Plugin's phases will be executed in
-regard to other Plugins' phases (such as `:access()`, `:log()`, etc.).
+The higher the priority, the sooner your plugin's phases will be executed in
+regard to other plugins' phases (such as `:access()`, `:log()`, etc.).
 
 {% navtabs %}
 {% navtab Open-source or Free mode %}

--- a/app/gateway/2.6.x/plugin-development/distribution.md
+++ b/app/gateway/2.6.x/plugin-development/distribution.md
@@ -4,8 +4,6 @@ book: plugin_dev
 chapter: 10
 ---
 
-## Introduction
-
 Custom plugins for Kong consist of Lua source files that need to be in the file
 system of each of your Kong nodes. This guide will provide you with
 step-by-step instructions that will make a Kong node aware of your custom
@@ -21,8 +19,8 @@ package manager to do it for you. We recommend LuaRocks as it is installed
 along with Kong when using one of the official distribution packages.
 
 When using LuaRocks, you must create a `rockspec` file, which specifies the
-package contents. For an example see the [Kong plugin
-template][plugin-template], for more info about the format see the LuaRocks
+package contents. For an example, see the [Kong plugin
+template][plugin-template]. For more info about the format, see the LuaRocks
 [documentation on rockspecs][rockspec].
 
 Pack your rock using the following command (from the plugin repo):
@@ -59,149 +57,136 @@ The contents of this archive should be close to the following:
     │           └── schema.lua
     └── <plugin-name>-<version>.rockspec
 
-[Back to top](#introduction)
 
----
-
-## Installing the plugin
+## Install the plugin
 
 For a Kong node to be able to use the custom plugin, the custom plugin's Lua
 sources must be installed on your host's file system. There are multiple ways
-of doing so: via LuaRocks, or manually. Choose one, and jump to section 3.
-
-1. Via LuaRocks from the created 'rock'
-
-    The `.rock` file is a self contained package that can be installed locally
-    or from a remote server.
-
-    If the `luarocks` utility is installed in your system (this is likely the
-    case if you used one of the official installation packages), you can
-    install the 'rock' in your LuaRocks tree (a directory in which LuaRocks
-    installs Lua modules).
-
-    It can be installed by doing:
-
-        $ luarocks install <rock-filename>
-
-    The filename can be a local name, or any of the supported methods, eg.
-    `http://myrepository.lan/rocks/my-plugin-0.1.0-1.all.rock`
-
-2. Via LuaRocks from the source archive
-
-    If the `luarocks` utility is installed in your system (this is likely the
-    case if you used one of the official installation packages), you can
-    install the Lua sources in your LuaRocks tree (a directory in which
-    LuaRocks installs Lua modules).
-
-    You can do so by changing the current directory to the extracted archive,
-    where the rockspec file is:
-
-        $ cd <plugin-name>
-
-    And then run the following:
-
-        $ luarocks make
-
-    This will install the Lua sources in `kong/plugins/<plugin-name>` in your
-    system's LuaRocks tree, where all the Kong sources are already present.
-
-3. Manually
-
-    A more conservative way of installing your plugin's sources is
-    to avoid "polluting" the LuaRocks tree, and instead, point Kong
-    to the directory containing them.
-
-    This is done by tweaking the `lua_package_path` property of your Kong
-    configuration. Under the hood, this property is an alias to the `LUA_PATH`
-    variable of the Lua VM, if you are familiar with it.
-
-    Those properties contain a semicolon-separated list of directories in
-    which to search for Lua sources. It should be set like so in your Kong
-    configuration file:
-
-        lua_package_path = /<path-to-plugin-location>/?.lua;;
-
-    Where:
-
-    * `/<path-to-plugin-location>` is the path to the directory containing the
-      extracted archive. It should be the location of the `kong` directory
-      from the archive.
-    * `?` is a placeholder that will be replaced by
-      `kong.plugins.<plugin-name>` when Kong will try to load your plugin. Do
-      not change it.
-    * `;;` a placeholder for the "the default Lua path". Do not change it.
-
-    Example:
-
-    The plugin `something` being located on the file system such that the
-    handler file is:
-
-        /usr/local/custom/kong/plugins/<something>/handler.lua
-
-    The location of the `kong` directory is: `/usr/local/custom`, hence the
-    proper path setup would be:
-
-        lua_package_path = /usr/local/custom/?.lua;;
-
-    Multiple plugins:
-
-    If you wish to install two or more custom plugins this way, you can set
-    the variable to something like:
-
-        lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
-
-    * `;` is the separator between directories.
-    * `;;` still means "the default Lua path".
-
-    Note: you can also set this property via its environment variable
-    equivalent: `KONG_LUA_PACKAGE_PATH`.
+of doing so: via LuaRocks, or manually. Choose one of the following paths.
 
 Reminder: regardless of which method you are using to install your plugin's
 sources, you must still do so for each node in your Kong cluster.
 
-[Back to top](#introduction)
+### Via LuaRocks from the created 'rock'
 
----
+The `.rock` file is a self contained package that can be installed locally
+or from a remote server.
+
+If the `luarocks` utility is installed in your system (this is likely the
+case if you used one of the official installation packages), you can
+install the 'rock' in your LuaRocks tree (a directory in which LuaRocks
+installs Lua modules).
+
+It can be installed by doing:
+
+    $ luarocks install <rock-filename>
+
+The filename can be a local name, or any of the supported methods, eg.
+`http://myrepository.lan/rocks/my-plugin-0.1.0-1.all.rock`
+
+### Via LuaRocks from the source archive
+
+If the `luarocks` utility is installed in your system (this is likely the
+case if you used one of the official installation packages), you can
+install the Lua sources in your LuaRocks tree (a directory in which
+LuaRocks installs Lua modules).
+
+You can do so by changing the current directory to the extracted archive,
+where the rockspec file is:
+
+    $ cd <plugin-name>
+
+And then run the following:
+
+    $ luarocks make
+
+This will install the Lua sources in `kong/plugins/<plugin-name>` in your
+system's LuaRocks tree, where all the Kong sources are already present.
+
+### Manually
+
+A more conservative way of installing your plugin's sources is
+to avoid "polluting" the LuaRocks tree, and instead, point Kong
+to the directory containing them.
+
+This is done by tweaking the `lua_package_path` property of your Kong
+configuration. Under the hood, this property is an alias to the `LUA_PATH`
+variable of the Lua VM, if you are familiar with it.
+
+Those properties contain a semicolon-separated list of directories in
+which to search for Lua sources. It should be set like so in your Kong
+configuration file:
+
+    lua_package_path = /<path-to-plugin-location>/?.lua;;
+
+Where:
+
+* `/<path-to-plugin-location>` is the path to the directory containing the
+  extracted archive. It should be the location of the `kong` directory
+  from the archive.
+* `?` is a placeholder that will be replaced by
+  `kong.plugins.<plugin-name>` when Kong will try to load your plugin. Do
+  not change it.
+* `;;` a placeholder for the "the default Lua path". Do not change it.
+
+For example, if the plugin `something` is located on the file system and the
+handler file is in the following directory:
+
+    /usr/local/custom/kong/plugins/<something>/handler.lua
+
+The location of the `kong` directory is `/usr/local/custom`, so the
+proper path setup would be:
+
+    lua_package_path = /usr/local/custom/?.lua;;
+
+#### Multiple plugins
+
+If you want to install two or more custom plugins this way, you can set
+the variable to something like:
+
+    lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
+
+* `;` is the separator between directories.
+* `;;` still means "the default Lua path".
+
+You can also set this property via its environment variable
+equivalent: `KONG_LUA_PACKAGE_PATH`.
+
 
 ## Load the plugin
 
-You must now add the custom plugin's name to the `plugins` list in your
+1. Add the custom plugin's name to the `plugins` list in your
 Kong configuration (on each Kong node):
 
-    plugins = bundled,<plugin-name>
+        plugins = bundled,<plugin-name>
 
-Or, if you don't want to include the bundled plugins:
+    Or, if you don't want to include the bundled plugins:
 
-    plugins = <plugin-name>
+        plugins = <plugin-name>
 
 
-If you are using two or more custom plugins, insert commas in between, like so:
+    If you are using two or more custom plugins, insert commas in between, like so:
 
-    plugins = bundled,plugin1,plugin2
+        plugins = bundled,plugin1,plugin2
 
-Or
+    Or
 
-    plugins = plugin1,plugin2
+        plugins = plugin1,plugin2
 
-Note: you can also set this property via its environment variable equivalent:
-`KONG_PLUGINS`.
+    You can also set this property via its environment variable equivalent:
+    `KONG_PLUGINS`.
 
-Reminder: don't forget to update the `plugins` directive for each node
-in your Kong cluster.
+1. Update the `plugins` directive for each node in your Kong cluster.
 
-Reminder: the plugin will take effect after restart kong:
-    
-    kong restart
+1. Restart Kong to apply the plugin:
 
-But, if you want to apply plugin while kong never stop, you can use this:
+        kong restart
 
-    kong prepare
-    kong reload
-    
+    Or, if you want to apply a plugin without stopping Kong, you can use this:
 
-[Back to top](#introduction)
+        kong prepare
+        kong reload
 
----
 
 ## Verify loading the plugin
 
@@ -209,25 +194,21 @@ You should now be able to start Kong without any issue. Consult your custom
 plugin's instructions on how to enable/configure your plugin
 on a Service, Route, or Consumer entity.
 
-To make sure your plugin is being loaded by Kong, you can start Kong with a
+1. To make sure your plugin is being loaded by Kong, you can start Kong with a
 `debug` log level:
 
-    log_level = debug
+        log_level = debug
 
-or:
+    or:
 
-    KONG_LOG_LEVEL=debug
+        KONG_LOG_LEVEL=debug
 
-Then, you should see the following log for each plugin being loaded:
+2. Then, you should see the following log for each plugin being loaded:
 
-    [debug] Loading plugin <plugin-name>
+        [debug] Loading plugin <plugin-name>
 
 
-[Back to top](#introduction)
-
----
-
-## Removing a plugin
+## Remove a plugin
 
 There are three steps to completely remove a plugin.
 
@@ -250,11 +231,9 @@ There are three steps to completely remove a plugin.
    to install the plugin, you can do `luarocks remove <plugin-name>` to remove
    it.
 
-[Back to top](#introduction)
 
----
 
-## Distributing your plugin
+## Distribute your plugin
 
 The preferred way to do so is to use [LuaRocks](https://luarocks.org/), a
 package manager for Lua modules. It calls such modules "rocks". **Your module
@@ -265,42 +244,39 @@ By defining your modules (and their eventual dependencies) in a [rockspec]
 file, you can install those modules on your platform via LuaRocks. You can
 also upload your module on LuaRocks and make it available to everyone!
 
-Here is an example rockspec which would use the "builtin" build type to define
-modules in Lua notation and their corresponding file:
+Here is an [example rockspec][example-rockspec] using the `builtin`
+build type to define modules in Lua notation and their corresponding file.
 
+For more information about the format, see the LuaRocks
+[documentation on rockspecs][rockspec].
 
-For an example see the [Kong plugin template][plugin-template], for more info
-about the format see the LuaRocks [documentation on rockspecs][rockspec].
-
-[Back to top](#introduction)
-
----
 
 ## Troubleshooting
 
 Kong can fail to start because of a misconfigured custom plugin for several
 reasons:
 
-* "plugin is in use but not enabled" -> You configured a custom plugin from
+`plugin is in use but not enabled`
+: You configured a custom plugin from
   another node, and that the plugin configuration is in the database, but the
   current node you are trying to start does not have it in its `plugins`
   directive. To resolve, add the plugin's name to the node's `plugins`
   directive.
 
-* "plugin is enabled but not installed" -> The plugin's name is present in the
-  `plugins` directive, but that Kong is unable to load the `handler.lua`
-  source file from the file system. To resolve, make sure that the
-  [lua_package_path](/gateway/{{page.kong_version}}/reference/configuration/#development-miscellaneous-section)
-  directive is properly set to load this plugin's Lua sources.
+`plugin is enabled but not installed`
+: The plugin's name is present in the `plugins` directive, but Kong can't load
+the `handler.lua` source file from the file system. To resolve, make sure that
+the [lua_package_path](/gateway/{{page.kong_version}}/reference/configuration/#development-miscellaneous-section)
+directive is properly set to load this plugin's Lua sources.
 
-* "no configuration schema found for plugin" -> The plugin is installed,
-  enabled in the `plugins` directive, but Kong is unable to load the
-  `schema.lua` source file from the file system. To resolve, make sure that
-  the `schema.lua` file is present alongside the plugin's `handler.lua` file.
-
-[Back to top](#introduction)
+`no configuration schema found for plugin`
+: The plugin is installed and enabled in the `plugins` directive, but Kong is
+unable to load the `schema.lua` source file from the file system. To resolve,
+make sure tha the `schema.lua` file is present alongside the plugin's
+`handler.lua` file.
 
 ---
 
 [rockspec]: https://github.com/keplerproject/luarocks/wiki/Creating-a-rock
 [plugin-template]: https://github.com/Kong/kong-plugin
+[example-rockspec]: https://github.com/Kong/kong-plugin/blob/master/kong-plugin-myplugin-0.1.0-1.rockspec

--- a/app/gateway/2.6.x/plugin-development/entities-cache.md
+++ b/app/gateway/2.6.x/plugin-development/entities-cache.md
@@ -4,8 +4,6 @@ book: plugin_dev
 chapter: 7
 ---
 
-## Introduction
-
 Your plugin may need to frequently access custom entities (explained in the
 [previous chapter]({{page.book.previous}})) on every request and/or response.
 Usually, loading them once and caching them in-memory dramatically improves
@@ -37,7 +35,7 @@ under heavy load).
 kong.plugins.<plugin_name>.daos
 ```
 
-## Caching custom entities
+## Cache custom entities
 
 Once you have defined your custom entities, you can cache them in-memory in
 your code by using the [kong.cache](/gateway/{{page.kong_version}}/pdk/#kong-cache)
@@ -151,7 +149,7 @@ result in a database query.
 The cache is used in several places in the [Key-Auth plugin handler](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/handler.lua).
 Give that file a look in order to see how an official plugin uses the cache.
 
-### Updating or deleting a custom entity
+### Update or delete a custom entity
 
 Every time a cached custom entity is updated or deleted in the datastore (i.e.
 using the Admin API), it creates an inconsistency between the data in the
@@ -160,11 +158,10 @@ inconsistency, we need to evict the cached entity from the in-memory store and
 force Kong to request it again from the datastore. We refer to this process as
 cache invalidation.
 
----
 
 ## Cache invalidation for your entities
 
-If you wish that your cached entities be invalidated upon a CRUD operation
+If you want your cached entities to be invalidated upon a CRUD operation
 rather than having to wait for them to reach their TTL, you have to follow a
 few steps. This process can be automated for most entities, but manually
 subscribing to some CRUD events might be required to invalidate some entities
@@ -322,7 +319,7 @@ end
 ```
 
 Once the above listeners are in place for the desired entities, you can perform
-manual invalidations of any entity that your plugin has cached as you wish so.
+manual invalidations of any entity that your plugin has cached.
 For instance:
 
 ```lua

--- a/app/gateway/2.6.x/plugin-development/file-structure.md
+++ b/app/gateway/2.6.x/plugin-development/file-structure.md
@@ -4,12 +4,9 @@ book: plugin_dev
 chapter: 2
 ---
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> This chapter assumes that you are familiar with
-  <a href="http://www.lua.org/">Lua</a>.
-</div>
-
-## Introduction
+{:.note}
+> **Note**: This chapter assumes that you are familiar with
+[Lua](http://www.lua.org/).
 
 Consider your plugin as a set of [Lua
 modules](http://www.lua.org/manual/5.1/manual.html#6.3). Each file described in
@@ -20,14 +17,14 @@ load your plugin's modules if their names follow this convention:
 kong.plugins.<plugin_name>.<module_name>
 ```
 
-> Your modules of course need to be accessible through your
-> [package.path](http://www.lua.org/manual/5.1/manual.html#pdf-package.path)
-> variable, which can be tweaked to your needs via the
-> [lua_package_path](/gateway/{{page.kong_version}}/reference/configuration/#lua_package_path)
-> configuration property.
-> However, the preferred way of installing plugins is through
-> [LuaRocks](https://luarocks.org/), which Kong natively integrates with.
-> More on LuaRocks-installed plugins later in this guide.
+Your modules need to be accessible through your
+[package.path](http://www.lua.org/manual/5.1/manual.html#pdf-package.path)
+variable, which can be tweaked to your needs via the
+[lua_package_path](/gateway/{{page.kong_version}}/reference/configuration/#lua_package_path)
+configuration property.
+However, the preferred way of installing plugins is through
+[LuaRocks](https://luarocks.org/), which Kong natively integrates with.
+More on LuaRocks-installed plugins later in this guide.
 
 To make Kong aware that it has to look for your plugin's modules, you'll have
 to add it to the
@@ -57,7 +54,6 @@ optional, and will allow the plugin to implement some extra-functionalities
 Now let's describe exactly what are the modules you can implement and what
 their purpose is.
 
----
 
 ## Basic plugin modules
 
@@ -76,7 +72,6 @@ simple-plugin
   by the user. This module holds the *schema* of that configuration and defines
   rules on it, so that the user can only enter valid configuration values.
 
----
 
 ## Advanced plugin modules
 

--- a/app/gateway/2.6.x/plugin-development/index.md
+++ b/app/gateway/2.6.x/plugin-development/index.md
@@ -4,8 +4,6 @@ book: plugin_dev
 chapter: 1
 ---
 
-# What are plugins and how do they integrate with Kong?
-
 Before going further, it is necessary to briefly explain how Kong is built,
 especially how it integrates with Nginx and what Lua has to do with it.
 
@@ -16,12 +14,12 @@ OpenResty is *not* a fork of Nginx, but a bundle of modules extending its
 capabilities.
 
 Hence, Kong is a Lua application designed to load and execute Lua modules
-(which we more commonly refer to as "*plugins*") and provides an entire
+(which we more commonly refer to as *plugins*) and provides an entire
 development environment for them, including an SDK, database abstractions,
 migrations, and more.
 
 Plugins consist of Lua modules interacting with the request/response objects or
-streams via the **Plugin Development Kit** (or "PDK") to implement arbitrary logic.
+streams via the **Plugin Development Kit** (PDK) to implement arbitrary logic.
 The PDK is a set of Lua functions that a plugin can use to facilitate interactions
 between plugins and the core (or other components) of Kong.
 

--- a/app/gateway/2.6.x/plugin-development/plugin-configuration.md
+++ b/app/gateway/2.6.x/plugin-development/plugin-configuration.md
@@ -4,8 +4,6 @@ book: plugin_dev
 chapter: 4
 ---
 
-## Introduction
-
 Most of the time, it makes sense for your plugin to be configurable to answer
 all of your users' needs. Your plugin's configuration is stored in the
 datastore for Kong to retrieve it and pass it to your
@@ -19,7 +17,7 @@ configuration for your plugin.
 
 Your plugin's configuration is being verified against your schema when a user
 issues a request to the [Admin API] to enable or update a plugin on a given
-Service, Route and/or Consumer.
+Service, Route, or Consumer.
 
 For example, a user performs the following request:
 
@@ -193,7 +191,6 @@ You can also add field validators, to mention a few:
 There are some additional validators, but you get a good idea how you can specify validation
 rules on fields from the above table.
 
----
 
 ### Examples
 

--- a/app/gateway/2.6.x/plugin-development/tests.md
+++ b/app/gateway/2.6.x/plugin-development/tests.md
@@ -2,12 +2,9 @@
 title: Plugin Development - Writing tests
 book: plugin_dev
 chapter: 9
-toc: false
 ---
 
-## Introduction
-
-If you are serious about your plugins, you probably want to write tests for it.
+If you are serious about your plugin, you probably want to write tests for it.
 Unit testing Lua is easy, and [many testing
 frameworks](http://lua-users.org/wiki/UnitTesting) are available. However, you
 might also want to write integration tests. Again, Kong has your back.
@@ -17,7 +14,7 @@ might also want to write integration tests. Again, Kong has your back.
 The preferred testing framework for Kong is
 [busted](http://olivinelabs.com/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
-free to use another one if you wish. In the Kong repository, the busted
+free to use a different one. In the Kong repository, the busted
 executable can be found at `bin/busted`.
 
 Kong provides you with a helper to start and stop it from Lua in your test
@@ -96,12 +93,12 @@ for _, strategy in helpers.each_strategy() do
 end
 ```
 
-> Reminder: With the test Kong configuration file, Kong is running with
+With the test Kong configuration file, Kong is running with
 its proxy listening on port 9000 (HTTP), 9443 (HTTPS)
 and Admin API on port 9001.
 
-If you want to see a real-world example, give a look at the
-[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth)
+For a real-world example, see the
+[Key-Auth plugin specs](https://github.com/Kong/kong/tree/master/spec/03-plugins/09-key-auth).
 
 ---
 


### PR DESCRIPTION
### Summary
Main change in this PR: adding the plugin development guides to the Plugin Hub navigation, and fixing the navigation so that it doesn't cut off the bottom.

Other changes: light copyedit of the Plugin Development Guide, mostly removing redundant headers, updating note styling, and fixing minor phrasing/grammar issues. Slightly heavier copyedit on `distribution.md`, as it was really hard to read in its current state.

### Reason
Was asked to add the plugin dev content to the plugin hub nav, as they're hard to find. 

Beyond that, the plugin dev guide hasn't been edited in years and really needs help.

### Testing
Menu additions: https://deploy-preview-3435--kongdocs.netlify.app/hub/
Plugin dev guide: https://deploy-preview-3435--kongdocs.netlify.app/gateway/2.6.x/plugin-development/
