### PR TITLE
Disable robots.txt on non-main deploys

### DIFF
--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,6 +1,7 @@
 ---
 layout: null
 ---
+{% if jekyll.environment == "production" %}
 User-agent: *
 Disallow: /enterprise/*
 Disallow: /mesh/1.0*
@@ -15,3 +16,7 @@ Disallow: /deck/pre-1.7*
 Disallow: /deck/1.7*
 
 Sitemap: {{site.links.web}}/sitemap.xml
+{% else %}
+User-agent: *
+Disallow: /
+{% endif %}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,10 @@
 [build]
   publish = "dist"
   command = "gulp build"
-  environment = { BUNDLE_WITHOUT = "development", NODE_OPTIONS = "--max_old_space_size=8192" }
+  environment = { JEKYLL_ENV = "development", BUNDLE_WITHOUT = "development", NODE_OPTIONS = "--max_old_space_size=8192" }
+
+[context.main.environment]
+  JEKYLL_ENV = "production"
+
+[context.deploy-preview.environment]
+  JEKYLL_ENV = "preview"


### PR DESCRIPTION
### Summary
Some deploy previews are being indexed by Google. This PR will adds a `disallow` rule to `robots.txt` to stop all search engines indexing the content unless `JEKYLL_ENV` is set to `production` (done via `netlify.toml`)

### Reason

Deploy previews are being indexed, we'd like them not to be:

https://master--kongdocs.netlify.app/enterprise/1.3-x/kong-for-kubernetes/install/
https://marcoam-patch-3--kongdocs.netlify.app/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes/


### Testing
Visit `/robots.txt` in a deploy preview and it should contain the following:

```
User-agent: *
Disallow: /
```

Visit it in production and it should contain:

```
User-agent: *
Disallow: /enterprise/*
Disallow: /mesh/1.0*
Disallow: /mesh/1.1*
Disallow: /mesh/1.2*
Disallow: /gateway-oss/*
Disallow: /kubernetes-ingress-controller/1.0*
Disallow: /kubernetes-ingress-controller/1.1*
Disallow: /kubernetes-ingress-controller/1.2*
Disallow: /getting-started-guide/*
Disallow: /deck/pre-1.7*
Disallow: /deck/1.7*

Sitemap: {{site.links.web}}/sitemap.xml
```
