### PR TITLE
[DOCU-1535] Remove anonymous_reports default override from Konnect Cloud

### DIFF
--- a/app/konnect/runtime-manager/gateway-runtime-conf.md
+++ b/app/konnect/runtime-manager/gateway-runtime-conf.md
@@ -52,7 +52,6 @@ to the file.
     ```sh
     role = data_plane
     database = off
-    anonymous_reports = off
     vitals_ttl_days = 732
     cluster_mtls = pki
     cluster_control_plane = {EXAMPLE.CP.KONNECT.FOO}:443

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -116,7 +116,6 @@ Use the following `docker run` command sample as a guide to compile your actual 
 $ docker run -d --name kong-gateway-dp1 \
   -e "KONG_ROLE=data_plane" \
   -e "KONG_DATABASE=off" \
-  -e "KONG_ANONYMOUS_REPORTS=off" \
   -e "KONG_VITALS_TTL_DAYS=732" \
   -e "KONG_CLUSTER_MTLS=pki" \
   -e "KONG_CLUSTER_CONTROL_PLANE={example.cp.konnect.foo}:443" \
@@ -136,7 +135,6 @@ $ docker run -d --name kong-gateway-dp1 \
 docker run -d --name kong-gateway-dp1 `
   -e "KONG_ROLE=data_plane" `
   -e "KONG_DATABASE=off" `
-  -e "KONG_ANONYMOUS_REPORTS=off" `
   -e "KONG_VITALS_TTL_DAYS=732" `
   -e "KONG_CLUSTER_MTLS=pki" `
   -e "KONG_CLUSTER_CONTROL_PLANE={EXAMPLE.CP.KONNECT.FOO}:443" `

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -102,7 +102,6 @@ like this:
     env:
       role: data_plane
       database: "off"
-      anonymous_reports: off
       vitals_ttl_days: 732
       cluster_mtls: pki
       cluster_control_plane: {EXAMPLE.CP.KONNECT.FOO}:443

--- a/app/konnect/runtime-manager/runtime-parameter-reference.md
+++ b/app/konnect/runtime-manager/runtime-parameter-reference.md
@@ -7,12 +7,16 @@ no_version: true
 
 Refer to these parameters when using the **Advanced** runtime setup option.
 
+The following parameters are the minimum settings required for a data plane instance.
+For further customization, see the
+[{{site.base_gateway}} configuration reference](/gateway/latest/reference/configuration)
+
  Parameter                            | Field in {{site.konnect_short_name}} | Description and Value
 :-------------------------------------|:------------------------------|:----------------------
  [`role`](/gateway/latest/reference/configuration/#role) | n/a  | The role of the node, in this case `data_plane`.
  [`database`](/gateway/latest/reference/configuration/#database) | n/a | Specifies whether this node connects directly to a database. For a data plane, this setting is always `off`.
  [`cluster_mtls`](/gateway/latest/reference/configuration/#cluster_mtls) | n/a | Enables mTLS on connections between the control plane and the data plane. In this case, set to  `"pki"`.
- [`anonymous_reports`](/gateway/latest/reference/configuration/#anonymous_reports) | n/a | Send anonymous usage data such as error stack traces to help improve {{site.konnect_short_name}}. Defaults to `on`.
+
  [`cluster_control_plane`](/gateway/latest/reference/configuration/#cluster_control_plane) | n/a | Sets the address of the {{site.konnect_short_name}} control plane. Must be in the format `host:port`, with port set to `443`. <br><br> **Example:**<br>Control Plane Endpoint in Konnect:<br>`https://example.cp.khcp.konghq.com`<br>Configuration value:<br>`example.cp.khcp.konghq.com:443`
  [`cluster_server_name`](/gateway/latest/reference/configuration/#cluster_server_name) | n/a | The SNI (Server Name Indication extension) to use for data plane connections to the control plane through TLS. When not set, data plane will use `kong_clustering` as the SNI.
  [`cluster_telemetry_endpoint`](/gateway/latest/reference/configuration/#cluster_telemetry_endpoint) | n/a | The address that the data plane uses to send Vitals telemetry data to the control plane. Must be in the format `host:port`, with port set to `443`. <br><br> **Example:**<br>Telemetry Endpoint in Konnect:<br>`https://example.tp.khcp.konghq.com`<br>Configuration value:<br>`example.tp.khcp.konghq.com:443`

--- a/app/konnect/runtime-manager/runtime-parameter-reference.md
+++ b/app/konnect/runtime-manager/runtime-parameter-reference.md
@@ -9,14 +9,13 @@ Refer to these parameters when using the **Advanced** runtime setup option.
 
 The following parameters are the minimum settings required for a data plane instance.
 For further customization, see the
-[{{site.base_gateway}} configuration reference](/gateway/latest/reference/configuration)
+[{{site.base_gateway}} configuration reference](/gateway/latest/reference/configuration).
 
  Parameter                            | Field in {{site.konnect_short_name}} | Description and Value
 :-------------------------------------|:------------------------------|:----------------------
  [`role`](/gateway/latest/reference/configuration/#role) | n/a  | The role of the node, in this case `data_plane`.
  [`database`](/gateway/latest/reference/configuration/#database) | n/a | Specifies whether this node connects directly to a database. For a data plane, this setting is always `off`.
  [`cluster_mtls`](/gateway/latest/reference/configuration/#cluster_mtls) | n/a | Enables mTLS on connections between the control plane and the data plane. In this case, set to  `"pki"`.
-
  [`cluster_control_plane`](/gateway/latest/reference/configuration/#cluster_control_plane) | n/a | Sets the address of the {{site.konnect_short_name}} control plane. Must be in the format `host:port`, with port set to `443`. <br><br> **Example:**<br>Control Plane Endpoint in Konnect:<br>`https://example.cp.khcp.konghq.com`<br>Configuration value:<br>`example.cp.khcp.konghq.com:443`
  [`cluster_server_name`](/gateway/latest/reference/configuration/#cluster_server_name) | n/a | The SNI (Server Name Indication extension) to use for data plane connections to the control plane through TLS. When not set, data plane will use `kong_clustering` as the SNI.
  [`cluster_telemetry_endpoint`](/gateway/latest/reference/configuration/#cluster_telemetry_endpoint) | n/a | The address that the data plane uses to send Vitals telemetry data to the control plane. Must be in the format `host:port`, with port set to `443`. <br><br> **Example:**<br>Telemetry Endpoint in Konnect:<br>`https://example.tp.khcp.konghq.com`<br>Configuration value:<br>`example.tp.khcp.konghq.com:443`


### PR DESCRIPTION
### Summary
Removing `anonymous_reports=off` setting from Konnect Cloud docs.

### Reason
For a gateway data plane, the `anonymous_reports` setting defaults to `on`. In the doc and the Konnect UI, the setting was being explicitly overwritten and users were told to set it to `off`. This is no longer happening in the UI, so the doc is following suit (see https://konghq.atlassian.net/browse/KHCP-1509).

### Testing
https://deploy-preview-3439--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/
https://deploy-preview-3439--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-conf/
https://deploy-preview-3439--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-kubernetes/
https://deploy-preview-3439--kongdocs.netlify.app/konnect/runtime-manager/runtime-parameter-reference/
