### PR TITLE
Fix copy-paste error in decK doc

### DIFF
--- a/app/deck/1.8.x/faqs.md
+++ b/app/deck/1.8.x/faqs.md
@@ -1,4 +1,4 @@
-{{site.base_gateway}}---
+---
 title: Frequently Asked Questions (FAQs)
 ---
 


### PR DESCRIPTION
### Summary
Fixing error that's breaking the page and leading to a 404.

### Reason
Copy-paste error, broken page: https://docs.konghq.com/deck/1.8.x/faqs/

### Testing
TBA
