### PR TITLE
[DOCU-2047] Consumer groups

### DIFF
--- a/app/_data/docs_nav_gateway_2.7.x.yml
+++ b/app/_data/docs_nav_gateway_2.7.x.yml
@@ -343,7 +343,7 @@
             - text: Examples
               url: /admin-api/admins/examples
         - text: Consumer Groups
-          url: /admin-api/admins/reference
+          url: /admin-api/consumer-groups/reference
           items:
             - text: API Reference
               url: /admin-api/consumer-groups/reference

--- a/app/_data/docs_nav_gateway_2.7.x.yml
+++ b/app/_data/docs_nav_gateway_2.7.x.yml
@@ -342,6 +342,13 @@
               url: /admin-api/admins/reference
             - text: Examples
               url: /admin-api/admins/examples
+        - text: Consumer Groups
+          url: /admin-api/admins/reference
+          items:
+            - text: API Reference
+              url: /admin-api/consumer-groups/reference
+            - text: Examples
+              url: /admin-api/consumer-groups/examples
         - text: Event Hooks
           url: /admin-api/event-hooks/reference
           items:

--- a/app/_hub/kong-inc/rate-limiting-advanced/1.5.x.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/1.5.x.md
@@ -2,7 +2,7 @@
 
 name: Rate Limiting Advanced
 publisher: Kong Inc.
-version: 1.6.x
+version: 1.5.x
 
 desc: Upgrades Kong Rate Limiting with more flexibility and higher performance
 description: |
@@ -13,7 +13,6 @@ description: |
   * Support for Redis Sentinel, Redis cluster, and Redis SSL
   * Increased performance: Rate Limiting Advanced has better throughput performance with better accuracy. Configure `sync_rate` to periodically sync with backend storage.
   * More limiting algorithms to choose from: These algorithms are more accurate and they enable configuration with more specificity. Learn more about our algorithms in [How to Design a Scalable Rate Limiting Algorithm](https://konghq.com/blog/how-to-design-a-scalable-rate-limiting-algorithm/).
-  * Consumer groups support: Apply different rate limiting configurations to select groups of consumers.
 
 type: plugin
 enterprise: true
@@ -25,7 +24,6 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
-        - 2.7.x
         - 2.6.x
         - 2.5.x
         - 2.4.x
@@ -287,26 +285,6 @@ params:
         header of denied requests (status = `429`) in order to prevent all the clients
         from coming back at the same time. The lower bound of the jitter is `0`; in this case,
         the `Retry-After` header is equal to the `RateLimit-Reset` header.
-    - name: enforce_consumer_groups
-      required: false
-      default: false
-      value_in_examples: true
-      datatype: boolean
-      description: |
-        Set to `true` to enable `consumer_groups`, which allows the settings
-        from one of the allowed consumer groups to override the given plugin
-        configuration.
-    - name: consumer_groups
-      required: semi
-      default: null
-      value_in_examples:
-        - group1
-        - group2
-      datatype: array of string elements
-      description: |
-        List of consumer groups allowed to override the rate limiting
-        settings for the given Route or Service. Required if
-        `enforce_consumer_groups` is set to `true`.
   extra: |
     **Notes:**
 
@@ -378,13 +356,13 @@ multiple rate limiting windows (e.g., rate limit per minute and per hour, and pe
 Because of limitations with Kong's plugin configuration interface, each *nth* limit will apply to each *nth* window size.
 For example:
 
-<pre><code>curl -X POST http://<div contenteditable="true">{LOCALHOST}</div>:8001/services/<div contenteditable="true">{SERVICE}</div>/plugins \
-  --data "name=rate-limiting-advanced" \
-  --data "config.limit=10" \
-  --data "config.limit=100" \
-  --data "config.window_size=60" \
-  --data "config.window_size=3600" \
-  --data "config.sync_rate=10"</code></pre>
+<pre><code>curl -X POST http://kong:8001/services/<div contenteditable="true">{SERVICE}</div>/plugins \
+  --data name=rate-limiting-advanced \
+  --data config.limit=10 \
+  --data config.limit=100 \
+  --data config.window_size=60 \
+  --data config.window_size=3600 \
+  --data config.sync_rate=10</code></pre>
 
 This example applies rate limiting policies, one of which will trip when 10 hits have been counted in 60 seconds,
 or the other when 100 hits have been counted in 3600 seconds. For more information, see the
@@ -404,15 +382,3 @@ to limit using IP as the identifier. This can happen for several reasons, such a
 selected header was not sent by the client or the configured service was not found.
 
 [`Retry-After`]: https://tools.ietf.org/html/rfc7231#section-7.1.3
-
-## Rate limiting for consumer groups
-
-[ADD LINK TO EXAMPLE DOC IN ADMIN API]
-
----
-
-## Changelog
-
-### Kong Gateway 2.7.x
-
-* Added `enforce_consumer_groups` and `consumer_groups` fields.

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -401,7 +401,7 @@ You can use consumer groups to manage custom rate limiting configuration for
 subsets of consumers. To use consumer groups, you'll need to configure the following parameters:
 
 * `config.enforce_consumer_groups`: Set to true.
-* `config.consumer_groups`: Provide a list of consmer groups that this plugin allows overrides for.
+* `config.consumer_groups`: Provide a list of consumer groups that this plugin allows overrides for.
 
 For guides on working with consumer groups, see the consumer group 
 [examples](/gateway/latest/admin-api/consumer-groups/examples) and 

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -397,7 +397,16 @@ selected header was not sent by the client or the configured service was not fou
 
 ## Rate limiting for consumer groups
 
-[ADD LINK TO EXAMPLE DOC IN ADMIN API]
+You can use consumer groups to manage custom rate limiting configuration for
+subsets of consumers. To use consumer groups, you'll need to configure the following parameters:
+
+* `config.enforce_consumer_groups`: Set to true.
+* `config.consumer_groups`: Provide a list of consmer groups that this plugin allows overrides for.
+
+For guides on working with consumer groups, see the consumer group 
+[examples](/gateway/latest/admin-api/consumer-groups/examples) and 
+[API reference](/gateway/latest/admin-api/consumer-groups/reference) in 
+the Admin API documentation.
 
 ---
 

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -26,16 +26,6 @@ kong_version_compatibility:
     enterprise_edition:
       compatible:
         - 2.7.x
-        - 2.6.x
-        - 2.5.x
-        - 2.4.x
-        - 2.3.x
-        - 2.2.x
-        - 2.1.x
-        - 1.5.x
-        - 1.3-x
-        - 0.36-x
-
 
 params:
   name: rate-limiting-advanced

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -297,6 +297,12 @@ params:
         List of consumer groups allowed to override the rate limiting
         settings for the given Route or Service. Required if
         `enforce_consumer_groups` is set to `true`.
+
+        Flipping `enforce_consumer_groups` from `true` to `false` disables the
+        group override, but does not clear the list of consumer groups.
+        You can then flip `enforce_consumer_groups` to `true` to re-enforce the
+        groups.
+
   extra: |
     **Notes:**
 
@@ -403,9 +409,9 @@ subsets of consumers. To use consumer groups, you'll need to configure the follo
 * `config.enforce_consumer_groups`: Set to true.
 * `config.consumer_groups`: Provide a list of consumer groups that this plugin allows overrides for.
 
-For guides on working with consumer groups, see the consumer group 
-[examples](/gateway/latest/admin-api/consumer-groups/examples) and 
-[API reference](/gateway/latest/admin-api/consumer-groups/reference) in 
+For guides on working with consumer groups, see the consumer group
+[examples](/gateway/latest/admin-api/consumer-groups/examples) and
+[API reference](/gateway/latest/admin-api/consumer-groups/reference) in
 the Admin API documentation.
 
 ---

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -20,7 +20,7 @@ To use consumer groups for rate limiting, configure the plugin with the
 {% navtab cURL %}
 ```bash
 curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
-  -d name=JL
+  --data name=JL
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -51,7 +51,7 @@ instance of the Kong Admin API:
 {% navtab cURL %}
 ```bash
 curl -i -X POST http://{HOSTNAME}:8001/consumers \
-  -d username=DianaPrince
+  --data username=DianaPrince
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -85,7 +85,7 @@ http POST :8001/consumers username=DianaPrince
 {% navtab cURL %}
 ```bash
 curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/JL/consumers \
-  -d consumer=DianaPrince
+  --data consumer=DianaPrince
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -128,14 +128,14 @@ configuring some basic settings:
 {% navtab cURL %}
 ```bash
 curl -i -X POST http://{HOSTNAME}:8001/plugins/  \
-  -d name=rate-limiting-advanced \
-  -d config.limit=5 \
-  -d config.sync_rate=-1 \
-  -d config.window_size=30 \
-  -d config.window_type=sliding \
-  -d config.retry_after_jitter_max=0 \
-  -d config.enforce_consumer_groups=true \
-  -d config.consumer_groups=JL
+  --data name=rate-limiting-advanced \
+  --data config.limit=5 \
+  --data config.sync_rate=-1 \
+  --data config.window_size=30 \
+  --data config.window_type=sliding \
+  --data config.retry_after_jitter_max=0 \
+  --data config.enforce_consumer_groups=true \
+  --data config.consumer_groups=JL
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -174,8 +174,8 @@ change the settings for the `JL` consumer group only:
 {% navtab cURL %}
 ```bash
 curl -i -X PUT http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/  rate-limiting-advanced \
---header 'Content-Type: application/json' \
---data '{ "config": { "limit": [ 10 ], "retry_after_jitter_max": 1, "window_size": [ 10 ] } }'
+  --header 'Content-Type: application/json' \
+  --data '{ "config": { "limit": [ 10 ], "retry_after_jitter_max": 1, "window_size": [ 10 ] } }'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -11,18 +11,31 @@ To use consumer groups for rate limiting, configure the plugin with the
 `enforce_consumer_groups` and `consumer_groups` parameters, then use the
 `/consumer_groups` endpoint to manage the groups.
 
-## Set up a consumer group with consumers
+## Set up consumer group
 
 1. Create a consumer group named `JL`:
 
-    ```bash
-    http POST :8001/consumer_groups name=JL
-    ```
+{% capture create_consumer_group %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
+  -d name=JL
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumer_groups name=JL
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ create_consumer_group | indent | replace: " </code>", "</code>" }}
 
     Response:
+
     ```json
-    HTTP/1.1 201 Created
-    ...
     {
         "created_at": 1638915521,
         "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
@@ -33,14 +46,27 @@ To use consumer groups for rate limiting, configure the plugin with the
 2. Create a consumer, `DianaPrince`, by making the following HTTP request to your
 instance of the Kong Admin API:
 
-    ```bash
-    http POST :8001/consumers username=DianaPrince
-    ```
+{% capture create_consumer %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumers \
+  -d username=DianaPrince
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumers username=DianaPrince
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ create_consumer | indent | replace: " </code>", "</code>" }}
 
     Response:
+
     ```json
-    HTTP/1.1 201 Created
-    ...
     {
         "created_at": 1638915577,
         "custom_id": null,
@@ -54,14 +80,27 @@ instance of the Kong Admin API:
 
 3. Add `DianaPrince` to the `JL` consumer group:
 
-    ```bash
-    http POST :8001/consumer_groups/JL/consumers consumer=DianaPrince
-    ```
+{% capture add_consumer %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/JL/consumers \
+  -d consumer=DianaPrince
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumer_groups/JL/consumers consumer=DianaPrince
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ add_consumer | indent | replace: " </code>", "</code>" }}
 
     Response:
-    ```json
-    HTTP/1.1 201 Created
 
+    ```json
     {
       "consumer_group": {
       "created_at": 1638915521,
@@ -80,22 +119,42 @@ instance of the Kong Admin API:
     }
     ```
 
-## Set up the Rate Limiting Advanced plugin and an override
+## Set up Rate Limiting Advanced config for consumer group
 
 1. Enable the [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced),
 configuring some basic settings:
+{% capture add_plugin %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/plugins/  \
+  -d name=rate-limiting-advanced \
+  -d config.limit=5 \
+  -d config.sync_rate=-1 \
+  -d config.window_size=30 \
+  -d config.window_type=sliding \
+  -d config.retry_after_jitter_max=0 \
+  -d config.enforce_consumer_groups=true \
+  -d config.consumer_groups=JL
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http -f :8001/plugins/  \
+  name=rate-limiting-advanced \
+  config.limit=5 \
+  config.sync_rate=-1 \
+  config.window_size=30 \
+  config.window_type=sliding \
+  config.retry_after_jitter_max=0 \
+  config.enforce_consumer_groups=true \
+  config.consumer_groups=JL
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
 
-    ```bash
-    http -f :8001/plugins/  \
-      name=rate-limiting-advanced \
-      config.limit=5 \
-      config.sync_rate=-1 \
-      config.window_size=30 \
-      config.window_type=sliding \
-      config.retry_after_jitter_max=0 \
-      config.enforce_consumer_groups=true \
-      config.consumer_groups=JL
-    ```
+{{ add_plugin | indent | replace: " </code>", "</code>" }}
 
     For consumer groups, the following parameters are required:
     * `config.enforce_consumer_groups=true`: enables consumer groups for this plugin.
@@ -110,14 +169,30 @@ configuring some basic settings:
 2. The plugin you just set up applies to all consumers in the cluster. Let's
 change the settings for the `JL` consumer group only:
 
-    ```bash
-    http PUT :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
-      config.limit:='[10]' \
-      config.window_size:='[10]' \
-      config.retry_after_jitter_max:=1
-    ```
+{% capture override %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X PUT http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/  rate-limiting-advanced \
+--header 'Content-Type: application/json' \
+--data '{ "config": { "limit": [ 10 ], "retry_after_jitter_max": 1, "window_size": [ 10 ] } }'
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http PUT :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
+  config.limit:='[10]' \
+  config.window_size:='[10]' \
+  config.retry_after_jitter_max:=1
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ override | indent | replace: " </code>", "</code>" }}
 
     Response:
+
     ```json
     {
       "config": {
@@ -134,11 +209,24 @@ change the settings for the `JL` consumer group only:
     }
     ```
 
-3. Now let's check that it worked by looking at the `JL` consumer group object:
+3. Check that it worked by looking at the `JL` consumer group object:
 
-    ```bash
-    http :8001/consumer_groups/JL
-    ```
+{% capture check_group1 %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/JL
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http :8001/consumer_groups/JL
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ check_group1 | indent | replace: " </code>", "</code>" }}
 
     Notice the `plugins` object in the response, along with the parameters that you
     just set for the Rate Limiting Advanced plugin:
@@ -182,15 +270,14 @@ change the settings for the `JL` consumer group only:
     }
     ```
 
-## Remove a consumer from a consumer group - group view
+## Remove consumer from group - group view
 
 1. Check the `JL` consumer group for the consumer name:
 
-    ```bash
-    http :8001/consumer_groups/JL
-    ```
+{{ check_group1 | indent | replace: " </code>", "</code>" }}
 
     Response:
+
     ```json
     {
         "consumer_group": {
@@ -213,22 +300,34 @@ change the settings for the `JL` consumer group only:
 2. Using the username or ID of the consumer (`DianaPrince` in this example),
 remove the consumer from the group:
 
-    ```bash
-    http DELETE :8001/consumer_groups/JL/consumers/DianaPrince
-    ```
+{% capture delete_consumer1 %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/JL/consumers/DianaPrince
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http DELETE :8001/consumer_groups/JL/consumers/DianaPrince
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ delete_consumer1 | indent | replace: " </code>", "</code>" }}
 
     If successful, you will see the following response:
     ```
     HTTP/1.1 204 No Content
     ```
 
-3. To verify, check the consumer object configuration:
+3. To verify, check the consumer group configuration again:
 
-    ```bash
-    http :8001/consumers_groups/JL
-    ```
+{{ check_group1 | indent | replace: " </code>", "</code>" }}
 
     Response, with no consumers assigned:
+
     ```json
     {
         "consumer_group": {
@@ -239,16 +338,30 @@ remove the consumer from the group:
     }
     ```
 
-## Remove a consumer from a group - consumer view
+## Remove consumer from group - consumer view
 
 1. If you know the consumer name and not the consumer group name,
 you can look up the group through the consumer:
 
-    ```bash
-    http :8001/consumers/DianaPrince/consumer_groups
-    ```
+{% capture check_group2 %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X GET http://{HOSTNAME}:8001/consumers/DianaPrince/consumer_groups
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http :8001/consumers/DianaPrince/consumer_groups
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ check_group2 | indent | replace: " </code>", "</code>" }}
 
     Response:
+
     ```json
     {
         "consumer_groups": [
@@ -264,9 +377,22 @@ you can look up the group through the consumer:
 2. Using the username or ID of the group (`JL` in this example),
 remove the consumer from the group:
 
-    ```bash
-    http DELETE :8001/consumers/DianaPrince/consumer_groups/JL
-    ```
+{% capture delete_consumer2 %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X DELETE http://{HOSTNAME}:8001/consumers/DianaPrince/consumer_groups/JL
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http DELETE :8001/consumers/DianaPrince/consumer_groups/JL
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ delete_consumer2 | indent | replace: " </code>", "</code>" }}
 
     If successful, you will see the following response:
     ```
@@ -275,11 +401,10 @@ remove the consumer from the group:
 
 3. To verify, check the consumer object configuration:
 
-    ```bash
-    http :8001/consumers_groups/JL
-    ```
+{{ check_group1 | indent | replace: " </code>", "</code>" }}
 
     Response, with no consumers assigned:
+
     ```json
     {
         "consumer_group": {
@@ -291,16 +416,30 @@ remove the consumer from the group:
     ```
 
 
-## Delete a consumer group
+## Delete consumer group
 
 If you don't need a consumer group anymore, you can delete it. This removes
 all consumers from the group, and deletes the group itself. The consumers in
 the group are not deleted.
 
 1. Delete a consumer group using the following request:
-    ```bash
-    http DELETE :8001/consumer_groups/JL
-    ```
+
+{% capture delete_consumer2 %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/JL
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http DELETE :8001/consumer_groups/JL
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ delete_consumer2 | indent | replace: " </code>", "</code>" }}
 
     If successful, you will see the following response:
     ```
@@ -309,9 +448,22 @@ the group are not deleted.
 
 2. Check the list of consumer groups to verify that the `JL` group is gone:
 
-    ```bash
-    http :8001/consumer_groups
-    ```
+{% capture check_all_groups %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X GET http://{HOSTNAME}:8001/consumer_groups
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http :8001/consumer_groups
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ check_all_groups | indent | replace: " </code>", "</code>" }}
 
     Response:
     ```json
@@ -323,8 +475,21 @@ the group are not deleted.
 
 3. Check a consumer that was in the group to make sure it still exists:
 
-    ```bash
-    http :8001/consumers/DianaPrince
-    ```
+{% capture check_consumer %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X GET http://{HOSTNAME}:8001/consumers/DianaPrince
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http :8001/consumers/DianaPrince
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ check_consumer | indent | replace: " </code>", "</code>" }}
 
     An `HTTP/1.1 200 OK` response means the consumer exists.

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -1,0 +1,10 @@
+---
+title: Consumer Groups Examples
+badge: enterprise
+---
+
+TBA:
+- Flow 1: Create consumers, set up a consumer group, add consumers to it, add an RLA plugin to a service or a route, edit RLA config for a consumer group
+- Flow 2: Using two consumer groups, add consumers and configure stuff
+- Flow 3: Remove a consumer from a group
+- Flow 4: Delete a consumer group

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -3,8 +3,328 @@ title: Consumer Groups Examples
 badge: enterprise
 ---
 
-TBA:
-- Flow 1: Create consumers, set up a consumer group, add consumers to it, add an RLA plugin to a service or a route, edit RLA config for a consumer group
-- Flow 2: Using two consumer groups, add consumers and configure stuff
-- Flow 3: Remove a consumer from a group
-- Flow 4: Delete a consumer group
+You can use consumer groups to manage custom rate limiting configuration for
+subsets of consumers.
+
+The `consumer_groups` endpoint works together with the [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced).
+To use consumer groups for rate limiting, configure the plugin with the
+`enforce_consumer_groups` and `consumer_groups` parameters, then use the
+`/consumer_groups` endpoint to manage the groups.
+
+## Set up a consumer group with consumers
+
+1. Create a consumer group named `JL`:
+
+    ```bash
+    http POST :8001/consumer_groups name=JL
+    ```
+
+    Response:
+    ```json
+    HTTP/1.1 201 Created
+    ...
+    {
+        "created_at": 1638915521,
+        "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
+        "name": "JL"
+    }
+    ```
+
+2. Create a consumer, `DianaPrince`, by making the following HTTP request to your
+instance of the Kong Admin API:
+
+    ```bash
+    http POST :8001/consumers username=DianaPrince
+    ```
+
+    Response:
+    ```json
+    HTTP/1.1 201 Created
+    ...
+    {
+        "created_at": 1638915577,
+        "custom_id": null,
+        "id": "8089a0e6-1d31-4e00-bf51-5b902899b4cb",
+        "tags": null,
+        "type": 0,
+        "username": "DianaPrince",
+        "username_lower": "dianaprince"
+    }
+    ```
+
+3. Add `DianaPrince` to the `JL` consumer group:
+
+    ```bash
+    http POST :8001/consumer_groups/JL/consumers consumer=DianaPrince
+    ```
+
+    Response:
+    ```json
+    HTTP/1.1 201 Created
+
+    {
+      "consumer_group": {
+      "created_at": 1638915521,
+      "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
+      "name": "JL"
+      },
+      "consumers": [
+        {
+            "created_at": 1638915577,
+            "id": "8089a0e6-1d31-4e00-bf51-5b902899b4cb",
+            "type": 0,
+            "username": "DianaPrince",
+            "username_lower": "dianaprince"
+        }
+      ]
+    }
+    ```
+
+## Set up the Rate Limiting Advanced plugin and an override
+
+1. Enable the [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced),
+configuring some basic settings:
+
+    ```bash
+    http -f :8001/plugins/  \
+      name=rate-limiting-advanced \
+      config.limit=5 \
+      config.sync_rate=-1 \
+      config.window_size=30 \
+      config.window_type=sliding \
+      config.retry_after_jitter_max=0 \
+      config.enforce_consumer_groups=true \
+      config.consumer_groups=JL
+    ```
+
+    For consumer groups, the following parameters are required:
+    * `config.enforce_consumer_groups=true`: enables consumer groups for this plugin.
+    * `config.consumer_groups=JL`: specifies a list of groups that this plugin allows overrides for.
+
+    {:.note}
+    > **Note:** In this example, we're configuring the plugin globally, so it will
+    apply to all entities (Services, Routes, and Consumers) in the Kong instance.
+    You can also apply it to a [specific Service or Route](/hub/kong-inc/rate-limiting-advanced)
+    for more granular control.
+
+2. The plugin you just set up applies to all consumers in the cluster. Let's
+change the settings for the `JL` consumer group only:
+
+    ```bash
+    http PUT :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
+      config.limit:='[10]' \
+      config.window_size:='[10]' \
+      config.retry_after_jitter_max:=1
+    ```
+
+    Response:
+    ```json
+    {
+      "config": {
+          "limit": [
+              10
+          ],
+          "retry_after_jitter_max": 1,
+          "window_size": [
+              10
+          ]
+      },
+      "consumer_group": "JL",
+      "plugin": "rate-limiting-advanced"
+    }
+    ```
+
+3. Now let's check that it worked by looking at the `JL` consumer group object:
+
+    ```bash
+    http :8001/consumer_groups/JL
+    ```
+
+    Notice the `plugins` object in the response, along with the parameters that you
+    just set for the Rate Limiting Advanced plugin:
+
+    ```json
+    {
+        "consumer_group": {
+            "created_at": 1638915521,
+            "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
+            "name": "JL"
+        },
+        "consumers": [
+            {
+                "created_at": 1638915577,
+                "id": "8089a0e6-1d31-4e00-bf51-5b902899b4cb",
+                "type": 0,
+                "username": "DianaPrince",
+                "username_lower": "dianaprince"
+            }
+        ],
+        "plugins": [
+            {
+                "config": {
+                    "limit": [
+                        10
+                    ],
+                    "retry_after_jitter_max": 1,
+                    "window_size": [
+                        10
+                    ],
+                    "window_type": "sliding"
+                },
+                "consumer_group": {
+                    "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4"
+                },
+                "created_at": 1638916518,
+                "id": "b7c426a2-6fcc-4bfd-9b7a-b66e8f1ad260",
+                "name": "rate-limiting-advanced"
+            }
+        ]
+    }
+    ```
+
+## Remove a consumer from a consumer group - group view
+
+1. Check the `JL` consumer group for the consumer name:
+
+    ```bash
+    http :8001/consumer_groups/JL
+    ```
+
+    Response:
+    ```json
+    {
+        "consumer_group": {
+            "created_at": 1638915521,
+            "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
+            "name": "JL"
+        },
+        "consumers": [
+            {
+                "created_at": 1638915577,
+                "id": "8089a0e6-1d31-4e00-bf51-5b902899b4cb",
+                "type": 0,
+                "username": "DianaPrince",
+                "username_lower": "dianaprince"
+            }
+        ]
+      }
+      ```
+
+2. Using the username or ID of the consumer (`DianaPrince` in this example),
+remove the consumer from the group:
+
+    ```bash
+    http DELETE :8001/consumer_groups/JL/consumers/DianaPrince
+    ```
+
+    If successful, you will see the following response:
+    ```
+    HTTP/1.1 204 No Content
+    ```
+
+3. To verify, check the consumer object configuration:
+
+    ```bash
+    http :8001/consumers_groups/JL
+    ```
+
+    Response, with no consumers assigned:
+    ```json
+    {
+        "consumer_group": {
+            "created_at": 1638917780,
+            "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
+            "name": "JL"
+        }
+    }
+    ```
+
+## Remove a consumer from a group - consumer view
+
+1. If you know the consumer name and not the consumer group name,
+you can look up the group through the consumer:
+
+    ```bash
+    http :8001/consumers/DianaPrince/consumer_groups
+    ```
+
+    Response:
+    ```json
+    {
+        "consumer_groups": [
+            {
+                "created_at": 1638915521,
+                "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
+                "name": "JL"
+            }
+        ]
+    }
+    ```
+
+2. Using the username or ID of the group (`JL` in this example),
+remove the consumer from the group:
+
+    ```bash
+    http DELETE :8001/consumers/DianaPrince/consumer_groups/JL
+    ```
+
+    If successful, you will see the following response:
+    ```
+    HTTP/1.1 204 No Content
+    ```
+
+3. To verify, check the consumer object configuration:
+
+    ```bash
+    http :8001/consumers_groups/JL
+    ```
+
+    Response, with no consumers assigned:
+    ```json
+    {
+        "consumer_group": {
+            "created_at": 1638917780,
+            "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
+            "name": "JL"
+        }
+    }
+    ```
+
+
+## Delete a consumer group
+
+If you don't need a consumer group anymore, you can delete it. This removes
+all consumers from the group, and deletes the group itself. The consumers in
+the group are not deleted.
+
+1. Delete a consumer group using the following request:
+    ```bash
+    http DELETE :8001/consumer_groups/JL
+    ```
+
+    If successful, you will see the following response:
+    ```
+    HTTP/1.1 204 No Content
+    ```
+
+2. Check the list of consumer groups to verify that the `JL` group is gone:
+
+    ```bash
+    http :8001/consumer_groups
+    ```
+
+    Response:
+    ```json
+    {
+    "data": [],
+    "next": null
+    }
+    ```
+
+3. Check a consumer that was in the group to make sure it still exists:
+
+    ```bash
+    http :8001/consumers/DianaPrince
+    ```
+
+    An `HTTP/1.1 200 OK` response means the consumer exists.

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -173,7 +173,7 @@ change the settings for the `JL` consumer group only:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X PUT http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/  rate-limiting-advanced \
+curl -i -X PUT http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
   --header 'Content-Type: application/json' \
   --data '{ "config": { "limit": [ 10 ], "retry_after_jitter_max": 1, "window_size": [ 10 ] } }'
 ```

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -24,7 +24,7 @@ To use consumer groups for rate limiting, you need to:
 * Assign consumers to groups
 * Configure the Rate Limiting Advanced plugin with the `enforce_consumer_groups`
 and `consumer_groups` parameters, setting up the list of consumer groups that
-the plugin will accept
+the plugin accepts
 * Configure rate limiting for each consumer group, overriding the plugin's
 configuration
 
@@ -63,7 +63,7 @@ http POST :8001/consumer_groups name=JL
     }
     ```
 
-2. Create a consumer, `DianaPrince`:
+1. Create a consumer, `DianaPrince`:
 
 {% capture create_consumer %}
 {% navtabs codeblock %}
@@ -97,7 +97,7 @@ http POST :8001/consumers username=DianaPrince
     }
     ```
 
-3. Add `DianaPrince` to the `JL` consumer group:
+1. Add `DianaPrince` to the `JL` consumer group:
 
 {% capture add_consumer %}
 {% navtabs codeblock %}
@@ -137,13 +137,6 @@ http POST :8001/consumer_groups/JL/consumers consumer=DianaPrince
       ]
     }
     ```
-
-    You can also add a consumer to multiple groups:
-    * If all groups are allowed by the Rate Limiting Advanced plugin,
-    only the first group's settings will apply.
-    * Otherwise, whichever group is specified in the Rate Limiting Advanced
-    plugin will be active.
-
 
 ## Set up Rate Limiting Advanced config for consumer group
 
@@ -190,12 +183,12 @@ http -f :8001/plugins/  \
 
     {:.note}
     > **Note:** In this example, you're configuring the plugin globally, so it
-    will apply to all entities (Services, Routes, and Consumers) in the
+    applies to all entities (Services, Routes, and Consumers) in the
     {{site.base_gateway}} instance. You can also apply it to a
     [specific Service or Route](/hub/kong-inc/rate-limiting-advanced)
     for more granular control.
 
-2. The plugin you just set up applies to all consumers in the cluster. Change
+1. The plugin you just set up applies to all consumers in the cluster. Change
 the rate limiting configuration for the `JL` consumer group only, setting
 the limit to ten requests for every ten seconds:
 
@@ -240,7 +233,7 @@ http PUT :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
     }
     ```
 
-3. Check that it worked by looking at the `JL` consumer group object:
+1. Check that it worked by looking at the `JL` consumer group object:
 
 {% capture check_group1 %}
 {% navtabs codeblock %}
@@ -331,7 +324,7 @@ You can remove a consumer from a group by accessing `/consumers` or
       }
       ```
 
-2. Using the username or ID of the consumer (`DianaPrince` in this example),
+1. Using the username or ID of the consumer (`DianaPrince` in this example),
 remove the consumer from the group:
 
 {% capture delete_consumer1 %}
@@ -351,12 +344,12 @@ http DELETE :8001/consumer_groups/JL/consumers/DianaPrince
 
 {{ delete_consumer1 | indent | replace: " </code>", "</code>" }}
 
-    If successful, you will see the following response:
+    If successful, you receive the following response:
     ```
     HTTP/1.1 204 No Content
     ```
 
-3. To verify, check the consumer group configuration again:
+1. To verify, check the consumer group configuration again:
 
 {{ check_group1 | indent | replace: " </code>", "</code>" }}
 
@@ -411,7 +404,7 @@ http :8001/consumers/DianaPrince/consumer_groups
     }
     ```
 
-2. Using the username or ID of the group (`JL` in this example),
+1. Using the username or ID of the group (`JL` in this example),
 remove the consumer from the group:
 
 {% capture delete_consumer2 %}
@@ -431,12 +424,12 @@ http DELETE :8001/consumers/DianaPrince/consumer_groups/JL
 
 {{ delete_consumer2 | indent | replace: " </code>", "</code>" }}
 
-    If successful, you will see the following response:
+    If successful, you receive the following response:
     ```
     HTTP/1.1 204 No Content
     ```
 
-3. To verify, check the consumer object configuration:
+1. To verify, check the consumer object configuration:
 
 {{ check_group1 | indent | replace: " </code>", "</code>" }}
 
@@ -478,12 +471,12 @@ http DELETE :8001/consumer_groups/JL
 
 {{ delete_consumer2 | indent | replace: " </code>", "</code>" }}
 
-    If successful, you will see the following response:
+    If successful, you receive see the following response:
     ```
     HTTP/1.1 204 No Content
     ```
 
-2. Check the list of consumer groups to verify that the `JL` group is gone:
+1. Check the list of consumer groups to verify that the `JL` group is gone:
 
 {% capture check_all_groups %}
 {% navtabs codeblock %}
@@ -510,7 +503,7 @@ http :8001/consumer_groups
     }
     ```
 
-3. Check a consumer that was in the group to make sure it still exists:
+1. Check a consumer that was in the group to make sure it still exists:
 
 {% capture check_consumer %}
 {% navtabs codeblock %}
@@ -530,3 +523,221 @@ http :8001/consumers/DianaPrince
 {{ check_consumer | indent | replace: " </code>", "</code>" }}
 
     An `HTTP/1.1 200 OK` response means the consumer exists.
+
+
+## Manage multiple consumers
+
+You can perform many `/consumer_groups` operations in bulk.
+
+1. Assuming you deleted the group `JL` in the previous section, create it again,
+along with another group named `Speedsters`:
+
+{% capture create_consumer_group2 %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
+  --data name=JL
+
+curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
+  --data name=Speedsters
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumer_groups name=JL
+
+http POST :8001/consumer_groups name=Speedsters
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ create_consumer_group2 | indent | replace: " </code>", "</code>" }}
+
+1. Create two consumers, `BarryAllen` and `WallyWest`:
+
+{% capture create_two_consumers %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumers \
+  --data username=BarryAllen
+
+curl -i -X POST http://{HOSTNAME}:8001/consumers \
+  --data username=WallyWest
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumers username=BarryAllen
+
+http POST :8001/consumers username=WallyWest
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ create_two_consumers | indent | replace: " </code>", "</code>" }}
+
+1. Add both consumers to the `Speedsters` group:
+{% capture add_two_consumers %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/Speedsters/consumers \
+  --data consumer=BarryAllen \
+  --data consumer=WallyWest
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumer_groups/Speedsters/consumers \
+  consumer:='["BarryAllen", "WallyWest"]'
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ add_two_consumers | indent | replace: " </code>", "</code>" }}
+
+    {{site.base_gateway}} validates the provided list of consumers before assigning
+    them to the consumer group. To pass validation, consumers must exist and must
+    not be in the group already.
+
+    If any consumer fails validation, no consumers are assigned to the group.
+
+    Response, if everything is successful:
+
+    ```json
+    {
+        "consumer_group": {
+            "created_at": 1639432267,
+            "id": "a905151a-5767-40e8-804e-50eec4d0235b",
+            "name": "Speedsters"
+        },
+        "consumers": [
+            {
+                "created_at": 1639432286,
+                "id": "ea904e1d-1f0d-4d5a-8391-cae60cb21d61",
+                "type": 0,
+                "username": "BarryAllen",
+                "username_lower": "barryallen"
+            },
+            {
+                "created_at": 1639432288,
+                "id": "065d8249-6fe6-4d80-a0ae-f159caef7af0",
+                "type": 0,
+                "username": "WallyWest",
+                "username_lower": "wallywest"
+            }
+        ]
+    }
+    ```
+
+1. You can clear all consumers from a group with one request. This may be useful
+if you need to cycle the group for a new batch of users.
+
+    For example, delete all consumers from the `Speedsters` group:
+
+{% capture delete_all_consumers %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Speedsters/consumers
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http DELETE :8001/consumer_groups/Speedsters/consumers
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ delete_all_consumers | indent | replace: " </code>", "</code>" }}
+
+    Response:
+    ```
+    HTTP/1.1 204 No Content
+    ```
+
+1. You can also add a consumer to multiple groups:
+    * If all groups are allowed by the Rate Limiting Advanced plugin,
+    only the first group's settings apply.
+    * Otherwise, whichever group is specified in the Rate Limiting Advanced
+    plugin becomes active.
+
+    Add `BarryAllen` to two groups, `JL` and `Speedsters`:
+
+{% capture add_consumer_many_groups %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X POST http://{HOSTNAME}:8001/consumers/BarryAllen/consumer_groups \
+  --data group=JL \
+  --data group=Speedsters
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http POST :8001/consumers/BarryAllen/consumer_groups \
+  group:='["JL", "Speedsters"]'
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ add_consumer_many_groups | indent | replace: " </code>", "</code>" }}
+
+    The response should look something like this:
+
+    ```json
+    {
+      "consumer": {
+          "created_at": 1639436091,
+          "custom_id": null,
+          "id": "6098d577-6741-4cf8-9c86-e68057b8f970",
+          "tags": null,
+          "type": 0,
+          "username": "BarryAllen",
+          "username_lower": "barryallen"
+      },
+      "consumer_groups": [
+          {
+              "created_at": 1639432267,
+              "id": "a905151a-5767-40e8-804e-50eec4d0235b",
+              "name": "JL"
+          },
+          {
+              "created_at": 1639436107,
+              "id": "2fd2bdd6-690c-4e49-8296-31f55015496d",
+              "name": "Speedsters"
+          }
+      ]
+    }
+    ```
+
+1. Finally, you can also remove a consumer from all groups:
+
+{% capture add_consumer_many_groups %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X DELETE http://{HOSTNAME}:8001/consumers/BarryAllen/consumer_groups
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http DELETE :8001/consumers/BarryAllen/consumer_groups
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ add_consumer_many_groups | indent | replace: " </code>", "</code>" }}
+
+    Response:
+    ```
+    HTTP/1.1 204 No Content
+    ```

--- a/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
@@ -3,7 +3,7 @@ title: Consumer Groups Reference
 badge: enterprise
 ---
 
-You can use consumer groups to manage custom rate limiting configuration for
+Use consumer groups to manage custom rate limiting configuration for
 subsets of consumers.
 
 The `consumer_groups` endpoint works together with the [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced).
@@ -11,6 +11,8 @@ To use consumer groups for rate limiting, configure the plugin with the
 `enforce_consumer_groups` and `consumer_groups` parameters, then use the
 `/consumer_groups` endpoint to manage the groups.
 
+For more information and examples of setting up and managing consumer groups, see the
+[Consumer Groups examples](/gateway/{{page.kong_version}}/admin-api/consumer-groups/examples).
 
 ## List consumer groups
 
@@ -18,9 +20,13 @@ To use consumer groups for rate limiting, configure the plugin with the
 
 **Endpoint**
 
-<div class="endpoint get">/consumer-groups</div>
+<div class="endpoint get">/consumer_groups</div>
 
 **Response**
+
+```
+HTTP/1.1 200 OK
+```
 
 ```json
 {
@@ -44,13 +50,17 @@ To use consumer groups for rate limiting, configure the plugin with the
 
 **Endpoint**
 
-<div class="endpoint get">/consumer-groups/{GROUP_NAME|GROUP_ID}</div>
+<div class="endpoint get">/consumer_groups/{GROUP_NAME|GROUP_ID}</div>
 
 Attribute                             | Description
 ---------:                            | --------  
-`GROUP_NAME|GROUP_ID`<br>*required*  | The name or UUID of the consumer group.
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
 
 **Response**
+
+```
+HTTP/1.1 200 OK
+```
 
 ```json
 {
@@ -67,13 +77,17 @@ Attribute                             | Description
 
 **Endpoint**
 
-<div class="endpoint get">/consumer-groups/{GROUP_NAME|GROUP_ID}/consumers</div>
+<div class="endpoint get">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers</div>
 
 Attribute                             | Description
 ---------:                            | --------  
-`GROUP_NAME|GROUP_ID`<br>*required*  | The name or UUID of the consumer group.
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
 
 **Response**
+
+```
+HTTP/1.1 200 OK
+```
 
 ```json
 {
@@ -98,6 +112,8 @@ Attribute                             | Description
 
 ### List consumer groups for a consumer
 
+View all consumer groups that a consumer is assigned to.
+
 **Endpoint**
 
 <div class="endpoint get">/consumers/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups</div>
@@ -107,6 +123,10 @@ Attribute                             | Description
 `USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer.
 
 **Response**
+
+```
+HTTP/1.1 200 OK
+```
 
 ```json
 {
@@ -125,19 +145,21 @@ Attribute                             | Description
 
 **Endpoint**
 
-<div class="endpoint post">/consumer-groups</div>
+<div class="endpoint post">/consumer_groups</div>
 
 **Request body**
 
-Attribute                             | Description
----------:                            | --------
-`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
+Attribute               | Description
+---------:              | --------
+`name`<br>*required*    | A unique name for the consumer group you want to create.
 
 **Response**
 
-```json
+```
 HTTP 201 Created
+```
 
+```json
 {
   "created_at": 1557522650,
   "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
@@ -147,18 +169,20 @@ HTTP 201 Created
 
 **Endpoint**
 
-<div class="endpoint put">/consumer-groups/{GROUP_NAME}</div>
+<div class="endpoint put">/consumer_groups/{GROUP_NAME}</div>
 
-Attribute                             | Description
----------:                            | --------
-`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
+Attribute                    | Description
+---------:                   | --------
+`GROUP_NAME`<br>*required*   | A unique name for the consumer group you want to create.
 
 
 **Response**
 
-```json
+```
 HTTP 201 Created
+```
 
+```json
 {
   "created_at": 1557522650,
   "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
@@ -168,20 +192,33 @@ HTTP 201 Created
 
 ## Add a consumer to a group
 
-**Endpoint**
-<div class="endpoint post">/consumers/{USERNAME|CONSUMER_ID}/consumer_groups</div>
+Add a consumer to a specific consumer group.
 
-Attribute                             | Description
----------:                            | --------  
-`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer.
+If you add a consumer to multiple groups:
+* If all groups are allowed by the Rate Limiting Advanced plugin,
+only the first group's settings will apply.
+* Otherwise, whichever group is specified in the Rate Limiting Advanced
+plugin will be active.
+
+**Consumers endpoint**
+<div class="endpoint post">/consumers/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups</div>
+
+Attribute                                  | Description
+---------:                                 | --------  
+`CONSUMER_NAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer.
 
 **Request body**
 
 Attribute                             | Description
 ---------:                            | --------   
-`group` *required*                    | The name or ID of the group to add the consumer to.
+`group`<br>*required*                 | The name or ID of the group to add the consumer to.
 
 **Response**
+
+```
+HTTP 201 Created
+```
+
 ```json
 {
     "consumer": {
@@ -203,7 +240,7 @@ Attribute                             | Description
 }
 ```
 
-**Endpoint**
+**Consumer groups endpoint**
 <div class="endpoint post">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers</div>
 
 Attribute                             | Description
@@ -215,9 +252,14 @@ Attribute                             | Description
 
 Attribute                             | Description
 ---------:                            | --------   
-`consumer` *required*                 | The name or ID of the consumer to add to this group.
+`consumer`<br>*required*              | The name or ID of the consumer to add to this group.
 
 **Response**
+
+```
+HTTP 201 Created
+```
+
 ```json
 {
   "consumer_group": {
@@ -243,22 +285,11 @@ Deleting a consumer group removes all consumers from that group. It does
 **not** delete any consumers.
 
 **Endpoint**
-<div class="endpoint delete">/consumer-groups/{GROUP_NAME|GROUP_ID}</div>
+<div class="endpoint delete">/consumer_groups/{GROUP_NAME|GROUP_ID}</div>
 
 Attribute                             | Description
 ---------:                            | --------
 `GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to delete.
-
-## Remove a consumer
-
-### Remove a consumer from all groups
-
-**Endpoint**
-<div class="endpoint delete">/consumers/{USERNAME|CONSUMER_ID}/consumer_groups</div>
-
-Attribute                             | Description
----------:                            | --------
-`USERNAME|CONSUMER_ID`<br>*required*   | The name or UUID of the consumer to remove from all groups.
 
 **Response**
 
@@ -266,15 +297,32 @@ Attribute                             | Description
 HTTP/1.1 204 No Content
 ```
 
-### Remove a consumer from a specific group
+## Remove consumers
+
+### Remove a consumer from all groups
+
+**Endpoint**
+<div class="endpoint delete">/consumers/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups</div>
+
+Attribute                                   | Description
+---------:                                  | --------
+`CONSUMER_NAME|CONSUMER_ID`<br>*required*   | The name or UUID of the consumer to remove from all groups.
+
+**Response**
+
+```
+HTTP/1.1 204 No Content
+```
+
+### Remove a consumer from a consumer group
 
 **Consumer endpoint**
-<div class="endpoint delete">/consumers/{USERNAME|CONSUMER_ID}/consumer_groups/{GROUP_NAME|GROUP_ID}</div>
+<div class="endpoint delete">/consumers/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups/{GROUP_NAME|GROUP_ID}</div>
 
-Attribute                             | Description
----------:                            | --------  
-`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
-`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to remove the consumer from.
+Attribute                                  | Description
+---------:                                 | --------  
+`CONSUMER_NAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
+`GROUP_NAME|GROUP_ID`<br>*required*        | The name or UUID of the consumer group to remove the consumer from.
 
 **Response**
 
@@ -283,12 +331,26 @@ HTTP/1.1 204 No Content
 ```
 
 **Consumer groups endpoint**
-<div class="endpoint delete">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers/{USERNAME|CONSUMER_ID}</div>
+<div class="endpoint delete">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers/{CONSUMER_NAME|CONSUMER_ID}</div>
+
+Attribute                                  | Description
+---------:                                 | --------    
+`GROUP_NAME|GROUP_ID`<br>*required*        | The name or UUID of the consumer group to remove the consumer from.
+`CONSUMER_NAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
+
+**Response**
+
+```
+HTTP/1.1 204 No Content
+```
+
+### Remove all consumers from a consumer group
+
+<div class="endpoint delete">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers</div>
 
 Attribute                             | Description
 ---------:                            | --------    
-`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to remove the consumer from.
-`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to remove all consumers from.
 
 **Response**
 
@@ -297,6 +359,9 @@ HTTP/1.1 204 No Content
 ```
 
 ## Configure rate limiting for a consumer group
+
+Define custom rate limiting settings for a consumer group. This endpoint
+overrides the settings of the Rate Limiting Advanced plugin.
 
 <div class="endpoint put">/consumer_groups/{GROUP_NAME|GROUP_ID}/overrides/plugins/rate-limiting-advanced</div>
 
@@ -314,6 +379,10 @@ Attribute     | Description
 `retry_after_jitter_max`<br>*optional* | The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.
 
 **Response**
+
+```
+HTTP/1.1 201 Created
+```
 
 ```json
 {

--- a/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
@@ -1,0 +1,272 @@
+---
+title: Consumer Groups Reference
+badge: enterprise
+---
+
+You can use consumer groups to manage custom rate limiting configuration for
+subsets of consumers.
+
+The `consumer_groups` endpoint works together with the [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced).
+To use consumer groups for rate limiting, configure the plugin with the
+`enforce_consumer_groups` and `consumer_groups` parameters, then use the
+`/consumer_groups` endpoint to manage the groups.
+
+
+## List consumer groups
+
+### List all consumer groups
+
+**Endpoint**
+
+<div class="endpoint get">/consumer-groups</div>
+
+**Response**
+
+```json
+{
+    "data": [
+        {
+            "created_at": 1557522650,
+            "id": "42b022c1-eb3c-4512-badc-1aee8c0f50b5",
+            "name": "my_group"
+        },
+        {
+            "created_at": 1637706162,
+            "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
+            "name": "my_group2"
+        }
+    ],
+    "next": null
+}
+```
+
+### List a specific consumer group
+
+**Endpoint**
+
+<div class="endpoint get">/consumer-groups/{GROUP_NAME|GROUP_ID}</div>
+
+Attribute                             | Description
+---------:                            | --------  
+`GROUP_NAME|GROUP_ID`<br>*required*  | The name or UUID of the consumer group.
+
+**Response**
+
+```json
+{
+  "plugins": {
+    "rate-limiting-advanced" : {
+      "config": {
+        "limit": 30
+      }
+    }
+  }
+}
+```
+
+
+### List all consumers in a consumer group
+
+**Endpoint**
+
+<div class="endpoint get">/consumer-groups/{GROUP_NAME|GROUP_ID}/consumers</div>
+
+Attribute                             | Description
+---------:                            | --------  
+`GROUP_NAME|GROUP_ID`<br>*required*  | The name or UUID of the consumer group.
+
+**Response**
+
+```json
+TBA
+```
+
+### List consumer groups for a consumer
+
+**Endpoint**
+
+<div class="endpoint get">/consumer/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups</div>
+
+Attribute                             | Description
+---------:                            | --------  
+`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer.
+
+
+## Create a consumer group
+
+**Endpoint**
+
+<div class="endpoint post">/consumer-groups</div>
+
+**Request body**
+
+Attribute                             | Description
+---------:                            | --------
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.                             |
+
+
+**Response**
+
+```json
+HTTP 201 Created
+
+{
+  "created_at": 1557522650,
+  "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
+  "name": "my_group",
+}
+```
+
+**Endpoint**
+
+<div class="endpoint put">/consumer-groups/{GROUP_NAME}</div>
+
+Attribute                             | Description
+---------:                            | --------
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
+
+
+**Response**
+
+```json
+HTTP 201 Created
+
+{
+  "created_at": 1557522650,
+  "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
+  "name": "my_group",
+}
+```
+
+## Add a consumer to a group
+
+**Endpoint**
+<div class="endpoint post">/consumers/{USERNAME|CONSUMER_ID}/consumer_groups</div>
+
+Attribute                             | Description
+---------:                            | --------  
+`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer.
+
+**Request body**
+
+Attribute                             | Description
+---------:                            | --------   
+`group` *required*                    | The name or ID of the group to add the consumer to.
+
+**Response**
+```json
+TBA
+```
+
+**Endpoint**
+<div class="endpoint post">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers</div>
+
+Attribute                             | Description
+---------:                            | --------
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
+
+
+**Request body**
+
+Attribute                             | Description
+---------:                            | --------   
+`consumer` *required*                 | The name or ID of the consumer to add to this group.
+
+**Response**
+```json
+TBA
+```
+
+## Delete a consumer group
+
+Deleting a consumer group removes all consumers from that group. It does
+**not** delete any consumers.
+
+**Endpoint**
+<div class="endpoint delete">/consumer-groups/{GROUP_NAME|GROUP_ID}</div>
+
+Attribute                             | Description
+---------:                            | --------
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to delete.
+
+## Remove a consumer
+
+### Remove a consumer from all groups
+
+**Endpoint**
+<div class="endpoint delete">/consumers/{USERNAME|CONSUMER_ID}/consumer_groups</div>
+
+Attribute                             | Description
+---------:                            | --------
+`USERNAME|CONSUMER_ID`<br>*required*   | The name or UUID of the consumer to remove from all groups.
+
+**Response**
+```json
+TBA
+```
+
+### Remove a consumer from a specific group
+
+**Consumer endpoint**
+<div class="endpoint delete">/consumers/{USERNAME|CONSUMER_ID}/consumer_groups/{GROUP_NAME|GROUP_ID}</div>
+
+Attribute                             | Description
+---------:                            | --------  
+`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to remove the consumer from.
+
+**Response**
+```json
+TBA
+```
+
+**Consumer groups endpoint**
+<div class="endpoint delete">/consumer_groups/{GROUP_NAME|GROUP_ID}/consumers/{USERNAME|CONSUMER_ID}</div>
+
+Attribute                             | Description
+---------:                            | --------    
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to remove the consumer from.
+`USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
+
+**Response**
+```json
+TBA
+```
+
+## Configure rate limiting for a consumer group
+
+<div class="endpoint put">/consumer_groups/{GROUP_NAME|GROUP_ID}/overrides/plugins/rate-limiting-advanced</div>
+
+Attribute                             | Description
+---------:                            | --------    
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to configure.
+
+**Request Body**
+
+Attribute     | Description  
+---------:    | --------
+`limit`       |
+`window_size` |
+`window_type` |
+`retry_after_jitter_max` |
+
+[Q: Are the settings above the only possible settings? Are there less, more? Or can you set anything that the rate limiting advanced plugin has available?]
+
+**Response**
+
+```json
+{
+    "config": {
+        "limit": [
+            10
+        ],
+        "retry_after_jitter_max": 0,
+        "window_size": [
+            10
+        ],
+        "window_type": "sliding"
+    },
+    "group": "test-group",
+    "plugin": "rate-limiting-advanced"
+}
+```

--- a/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
@@ -54,13 +54,11 @@ Attribute                             | Description
 
 ```json
 {
-  "plugins": {
-    "rate-limiting-advanced" : {
-      "config": {
-        "limit": 30
-      }
+    "consumer_group": {
+        "created_at": 1638917780,
+        "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
+        "name": "JL"
     }
-  }
 }
 ```
 
@@ -78,18 +76,49 @@ Attribute                             | Description
 **Response**
 
 ```json
-TBA
+{
+    "consumers": [
+        {
+            "created_at": 1638918560,
+            "id": "288f2bfc-04e2-4ec3-b6f3-40408dff5417",
+            "type": 0,
+            "username": "BarryAllen",
+            "username_lower": "barryallen"
+        },
+        {
+            "created_at": 1638915577,
+            "id": "8089a0e6-1d31-4e00-bf51-5b902899b4cb",
+            "type": 0,
+            "username": "DianaPrince",
+            "username_lower": "dianaprince"
+        }
+    ]
+}
 ```
 
 ### List consumer groups for a consumer
 
 **Endpoint**
 
-<div class="endpoint get">/consumer/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups</div>
+<div class="endpoint get">/consumers/{CONSUMER_NAME|CONSUMER_ID}/consumer_groups</div>
 
 Attribute                             | Description
 ---------:                            | --------  
 `USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer.
+
+**Response**
+
+```json
+{
+    "consumer_groups": [
+        {
+            "created_at": 1638918476,
+            "id": "e2c3f16e-22c7-4ef4-b6e4-ab25c522b339",
+            "name": "JL"
+        }
+    ]
+}
+```
 
 
 ## Create a consumer group
@@ -102,8 +131,7 @@ Attribute                             | Description
 
 Attribute                             | Description
 ---------:                            | --------
-`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.                             |
-
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group.
 
 **Response**
 
@@ -113,7 +141,7 @@ HTTP 201 Created
 {
   "created_at": 1557522650,
   "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
-  "name": "my_group",
+  "name": "JL",
 }
 ```
 
@@ -134,7 +162,7 @@ HTTP 201 Created
 {
   "created_at": 1557522650,
   "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
-  "name": "my_group",
+  "name": "JL",
 }
 ```
 
@@ -155,7 +183,24 @@ Attribute                             | Description
 
 **Response**
 ```json
-TBA
+{
+    "consumer": {
+        "created_at": 1638918560,
+        "custom_id": null,
+        "id": "288f2bfc-04e2-4ec3-b6f3-40408dff5417",
+        "tags": null,
+        "type": 0,
+        "username": "BarryAllen",
+        "username_lower": "barryallen"
+    },
+    "consumer_groups": [
+        {
+            "created_at": 1638918476,
+            "id": "e2c3f16e-22c7-4ef4-b6e4-ab25c522b339",
+            "name": "JL"
+        }
+    ]
+}
 ```
 
 **Endpoint**
@@ -174,7 +219,22 @@ Attribute                             | Description
 
 **Response**
 ```json
-TBA
+{
+  "consumer_group": {
+  "created_at": 1638915521,
+  "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
+  "name": "JL"
+  },
+  "consumers": [
+    {
+        "created_at": 1638915577,
+        "id": "8089a0e6-1d31-4e00-bf51-5b902899b4cb",
+        "type": 0,
+        "username": "DianaPrince",
+        "username_lower": "dianaprince"
+    }
+  ]
+}
 ```
 
 ## Delete a consumer group
@@ -201,8 +261,9 @@ Attribute                             | Description
 `USERNAME|CONSUMER_ID`<br>*required*   | The name or UUID of the consumer to remove from all groups.
 
 **Response**
-```json
-TBA
+
+```
+HTTP/1.1 204 No Content
 ```
 
 ### Remove a consumer from a specific group
@@ -216,8 +277,9 @@ Attribute                             | Description
 `GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to remove the consumer from.
 
 **Response**
-```json
-TBA
+
+```
+HTTP/1.1 204 No Content
 ```
 
 **Consumer groups endpoint**
@@ -229,8 +291,9 @@ Attribute                             | Description
 `USERNAME|CONSUMER_ID`<br>*required*  | The name or UUID of the consumer to remove.
 
 **Response**
-```json
-TBA
+
+```
+HTTP/1.1 204 No Content
 ```
 
 ## Configure rate limiting for a consumer group
@@ -245,12 +308,10 @@ Attribute                             | Description
 
 Attribute     | Description  
 ---------:    | --------
-`limit`       |
-`window_size` |
-`window_type` |
-`retry_after_jitter_max` |
-
-[Q: Are the settings above the only possible settings? Are there less, more? Or can you set anything that the rate limiting advanced plugin has available?]
+`limit`<br>*required*       | An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+`window_size`<br>*required* | An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+`window_type`<br>*optional* | Set the time window type to either `sliding` (default) or `fixed`.
+`retry_after_jitter_max`<br>*optional* | The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.
 
 **Response**
 


### PR DESCRIPTION
### Summary
Consumer groups doc.

* Admin API reference for consumer groups
* Admin API examples for consumer groups: cURL and HTTPie examples
* RLA plugin ref: added two new properties

**For reviewers:** ignore the file `app/_hub/kong-inc/rate-limiting-advanced/1.5.x.md` - this is a new file but with no new content, as a side-effect of the plugin doc versioning. Please review `app/_hub/kong-inc/rate-limiting-advanced/index.md` instead.

### Reason
Consumer groups feature.

### Testing

Tested all examples locally with a 2.7 preview build.

[API Reference](https://deploy-preview-3443--kongdocs.netlify.app/gateway/2.7.x/admin-api/consumer-groups/reference/)
[Examples](https://deploy-preview-3443--kongdocs.netlify.app/gateway/2.7.x/admin-api/consumer-groups/examples/)
[RLA plugin param reference](https://deploy-preview-3443--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/)