### PR TITLE
[DOCU-2067][DOCU-2069] Fix parsing of dbless_compatible field in plugins

### DIFF
--- a/app/_hub/inspur/apig-response-transform/index.md
+++ b/app/_hub/inspur/apig-response-transform/index.md
@@ -26,7 +26,7 @@ params:
   consumer_id: False
   route_id: True
   protocols: ["http","https"]
-  dbless_compatible: True
+  dbless_compatible: 'yes'
   dbless_explanation: It is recommended to use in dbless mode.
   config:
     - name: format

--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -33,6 +33,7 @@ params:
   service_id: true
   route_id: true
   consumer_id: true
+  dbless_compatible: 'yes'
   config:
     - name: proxy_host
       required: true

--- a/app/_hub/kong-inc/grpc-gateway/0.1.x.md
+++ b/app/_hub/kong-inc/grpc-gateway/0.1.x.md
@@ -36,7 +36,7 @@ params:
   name: grpc-gateway
   route_id: true
   protocols: ["http", "https"]
-  dbless_compatible: true
+  dbless_compatible: 'yes'
 
   config:
     - name: proto

--- a/app/_hub/kong-inc/grpc-gateway/index.md
+++ b/app/_hub/kong-inc/grpc-gateway/index.md
@@ -35,7 +35,7 @@ params:
   protocols:
     - http
     - https
-  dbless_compatible: true
+  dbless_compatible: 'yes'
   config:
     - name: proto
       required: false

--- a/app/_hub/kong-inc/grpc-web/0.1.x.md
+++ b/app/_hub/kong-inc/grpc-web/0.1.x.md
@@ -31,7 +31,7 @@ params:
   name: grpc-web
   route_id: true
   protocols: ["http", "https"]
-  dbless_compatible: true
+  dbless_compatible: 'yes'
 
   config:
     - name: proto

--- a/app/_hub/kong-inc/grpc-web/0.2.x.md
+++ b/app/_hub/kong-inc/grpc-web/0.2.x.md
@@ -37,7 +37,7 @@ params:
   name: grpc-web
   route_id: true
   protocols: ["http", "https"]
-  dbless_compatible: true
+  dbless_compatible: 'yes'
 
   config:
     - name: proto

--- a/app/_hub/kong-inc/grpc-web/index.md
+++ b/app/_hub/kong-inc/grpc-web/index.md
@@ -34,7 +34,7 @@ params:
   protocols:
     - http
     - https
-  dbless_compatible: true
+  dbless_compatible: 'yes'
   config:
     - name: proto
       required: false

--- a/app/_hub/kong-inc/opa/index.md
+++ b/app/_hub/kong-inc/opa/index.md
@@ -31,32 +31,34 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
-  protocols: ["http", "https"]
-  dbless_compatible: yes
+  protocols:
+    - http
+    - https
+  dbless_compatible: 'yes'
   config:
     - name: opa_protocol
       required: false
       datatype: string
-      default: "`http`"
+      default: '`http`'
       description: |
         The protocol to use when talking to Open Policy Agent (OPA) server. Allowed protocols are `http` and `https`.
     - name: opa_host
       required: false
       value_in_examples: localhost
       datatype: string
-      default: "`localhost`"
+      default: '`localhost`'
       description: |
         The DNS name or IP address of the OPA server.
     - name: opa_port
       required: false
       value_in_examples: 8181
       datatype: integer
-      default: "`8181`"
+      default: '`8181`'
       description: |
         The port of the OPA server.
     - name: opa_path
       required: true
-      value_in_examples: </v1/data/example/kong/allowBoolean>
+      value_in_examples: '</v1/data/example/kong/allowBoolean>'
       datatype: string
       description: |
         The HTTP path to use when making a request to the OPA server. This is usually the path to the policy and rule to evaluate, prefixed with `/v1/data/`. For example,

--- a/app/_hub/kong-inc/openwhisk/index.md
+++ b/app/_hub/kong-inc/openwhisk/index.md
@@ -35,7 +35,7 @@ params:
   route_id: true
   consumer_id: true
   konnect_examples: false
-  dbless_compatible: yes
+  dbless_compatible: 'yes'
   config:
     - name: host
       required: true

--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -51,6 +51,7 @@ params:
   route_id: true
   consumer_id: true
   konnect_examples: false
+  dbless_compatible: 'yes'
   config:
     - name: remove.headers
       required: false

--- a/app/_hub/yesinteractive/kong-jwt2header/index.md
+++ b/app/_hub/yesinteractive/kong-jwt2header/index.md
@@ -56,7 +56,7 @@ params:
     # List of protocols this plugin is compatible with.
     # Valid values: "http", "https", "tcp", "tls"
     # Example: ["http", "https"]
-  dbless_compatible: true
+  dbless_compatible: 'yes'
     # Degree of compatibility with DB-less mode. Three values allowed:
     # 'yes', 'no' or 'partially'
   dbless_explanation: Fully compatible with DB and DB-less (K8s, Declarative) Kong implementations.

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -170,21 +170,22 @@ breadcrumbs:
       {% if page.type == "plugin" and page.params %}
         <h2 id="configuration">Configuration Reference</h2>
 
-        {% if page.params.dbless_compatible == true %}
+        {% if page.params.dbless_compatible == "yes" %}
           <p>This plugin is <strong>compatible</strong> with DB-less mode.</p>
         {% elsif page.params.dbless_compatible == "partially" %}
           <p>This plugin is <strong>partially compatible</strong> with DB-less mode.</p>
         {% elsif page.params.dbless_compatible != nil %}
           <p>This plugin is <strong>not compatible</strong> with DB-less mode.</p>
         {% endif %}
-        {% if page.params.dbless_compatible == "partially" or page.params.dbless_compatible == true %}
-          <p>In DB-less mode, you configure {{site.base_gateway}} declaratively.
+        {% if page.params.dbless_compatible == "partially" or page.params.dbless_compatible == "yes" %}
+          <p>In DB-less mode, you configure {{site.base_gateway}}
+            <a href="/gateway/latest/reference/db-less-and-declarative-config">declaratively</a>.
             Therefore, the Admin API is mostly read-only. The only tasks it can perform are all
             related to handling the declarative config, including: </p>
             <ul>
-              <li>setting a target's health status in the load balancer</li>
-              <li>validating configurations against schemas</li>
-              <li>uploading the declarative configuration using the <code>/config</code> endpoint</li>
+              <li>Setting a target's health status in the load balancer</li>
+              <li>Validating configurations against schemas</li>
+              <li>Uploading the declarative configuration using the <code>/config</code> endpoint</li>
             </ul>
         {% endif %}
 
@@ -293,7 +294,7 @@ breadcrumbs:
             </ul>
           </td>
         </tr>
-        {% unless page.enterprise or page.params.dbless_compatible == nil %}
+        {% unless page.params.dbless_compatible == nil %}
         <tr>
           <td>DB-less compatible?</td>
           <td>


### PR DESCRIPTION
### Summary
Fixing plugin template to parse the `dbless_compatible` field correctly, and update some formatting and values in plugin docs for consistency & accuracy.

### Reason
Issue reported on Slack. Plugins were showing two different values for db-less compatibility.

### Testing
Spot check some Kong plugins: if the plugin mentions db-less support, the main body text and the sidebar entry should say the same thing.

https://deploy-preview-3444--kongdocs.netlify.app/hub/

[Correlation ID plugin](https://deploy-preview-3444--kongdocs.netlify.app/hub/kong-inc/correlation-id/) (issue was reported here)
