### PR TITLE
[DOCU-2045] Banner for older versions of plugins

### DIFF
--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -322,3 +322,18 @@
     }
   }
 }
+
+.old-version-banner {
+  padding: 10px 20px;
+  display: block;
+  background-color: #fff3d8;
+  border: none;
+  border-radius: 4px;
+  margin-bottom: -20px;
+  margin-top: 20px;
+  .font-source-sans();
+
+  @media (max-width: 1100px) {
+    margin-bottom: -25px;
+  }
+}

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -37,11 +37,15 @@
             {% endif %}
           {% endif %}
         </h1>
-
-        {% if include.header_caption%}
-          <p>{{ include.header_caption }}</p>
-        {% endif %}
       </div>
+      {% if include.extn_versions %}
+        {% unless include.extn_filename == "index.md" %}
+          <div class="old-version-banner">
+          You are browsing documentation for an outdated plugin version.
+          See the <a href="/hub/{{ include.extn_publisher }}/{{ include.extn_slug }}/">latest documentation here</a>.
+          </div>
+        {% endunless %}
+      {% endif %}
     </div>
   </header>
 {% endif %}

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -123,11 +123,11 @@ breadcrumbs:
 
 <div class="page page-extension-profile">
   {% if page.header_icon or page.header_title %}
-    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon header_caption=page.header_caption plus=page.plus enterprise=page.enterprise publisher=page.publisher %}
+    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon plus=page.plus enterprise=page.enterprise publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% elsif page.type == concept %}
-    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon header_caption=page.header_caption plus=page.plus enterprise=page.enterprise publisher=page.publisher %}
+    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon plus=page.plus enterprise=page.enterprise publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% else %}
-    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon header_caption=page.header_caption plus=page.plus enterprise=page.enterprise publisher=page.publisher %}
+    {% include_cached header.html id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon plus=page.plus enterprise=page.enterprise publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% endif %}
 
   <div class="container">


### PR DESCRIPTION
### Summary
Add a banner to older plugin versions. 
Removing non-existent `header_caption` field, it hasn't (ever?) been in use.

Note: The yellow is a bit different form our normal yellow banner tone. It's the new Kongponents yellow; I'll be updating all docs to use the new tones in a future PR.

### Reason
See ticket; we have no visual distinction for older plugin docs, so it's easy to accidentally end up on an old page.

### Testing
Open any kong-inc plugin doc and check latest version vs older version, for example:
* Latest: https://deploy-preview-3446--kongdocs.netlify.app/hub/kong-inc/application-registration/
* Older (see banner, check link): https://deploy-preview-3446--kongdocs.netlify.app/hub/kong-inc/application-registration/1.0.x.html