### PR TITLE
[DOCU-2046] Fix PDF gen (post single-sourcing)

### DIFF
--- a/app/_data/docs_nav_ce_2.4.x.yml
+++ b/app/_data/docs_nav_ce_2.4.x.yml
@@ -1,7 +1,7 @@
 # Generated via autodoc-nav
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /gateway-oss/
+  url: /gateway-oss/2.4.x/
   absolute_url: true
 
 - title: Release Notes

--- a/app/_data/docs_nav_ce_2.5.x.yml
+++ b/app/_data/docs_nav_ce_2.5.x.yml
@@ -1,7 +1,7 @@
 # Generated via autodoc-nav
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /gateway-oss/
+  url: /gateway-oss/2.5.x/
   absolute_url: true
 
 - title: Release Notes

--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -1,6 +1,6 @@
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /enterprise/
+  url: /enterprise/2.3.x/
   absolute_url: true
   items:
     - text: Key Concepts and Terminology

--- a/app/_data/docs_nav_ee_2.4.x.yml
+++ b/app/_data/docs_nav_ee_2.4.x.yml
@@ -1,6 +1,6 @@
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /enterprise/
+  url: /enterprise/2.4.x/
   absolute_url: true
   items:
     - text: Key Concepts and Terminology

--- a/app/_data/docs_nav_ee_2.5.x.yml
+++ b/app/_data/docs_nav_ee_2.5.x.yml
@@ -1,6 +1,6 @@
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /enterprise/
+  url: /enterprise/2.5.x/
   absolute_url: true
   items:
     - text: Key Concepts and Terminology

--- a/pdf-generation/list-versions.js
+++ b/pdf-generation/list-versions.js
@@ -8,7 +8,8 @@ module.exports = async function (path) {
     gsg: 'getting-started-guide',
     kic: 'kubernetes-ingress-controller',
     konnect: 'konnect',
-    mesh: 'mesh'
+    mesh: 'mesh',
+    gateway: 'gateway'
   }
   let files = await fg(`../app/_data/docs_nav_${path}.yml`)
   files = files


### PR DESCRIPTION
### Summary
* Adding `gateway` to list of mapped paths
* Setting versioned URLs for old `/enterprise/` and `/gateway-oss/` landing pages
This should fix PDF generation.

### Reason
Fixes two different errors:
* https://github.com/Kong/docs.konghq.com/runs/4257695434?check_suite_focus=true#step:10:18
  Didn't add `gateway` to list of versions, so it didn't recognize the value
  
* https://github.com/Kong/docs.konghq.com/runs/4257745507?check_suite_focus=true#step:10:17
  The `/enterprise/` and `/gateway-oss/` aliases no longer exist without versions, because the latest version is `/gateway/`. On a live doc, this would be a redirect; on a local build (or a PDF build), it reads as a broken link, so the page can't be found.

### Testing
N/A, have to merge and then test.
