### PR TITLE
Versioned getting started guide URLs

### DIFF
--- a/app/_data/docs_nav_ce_2.0.x.yml
+++ b/app/_data/docs_nav_ce_2.0.x.yml
@@ -3,19 +3,19 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../gateway/latest/get-started/comprehensive
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/overview
     - text: Prepare to Administer
-      url: /../../gateway/latest/get-started/comprehensive/prepare
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/prepare
     - text: Expose your Services
-      url: /../../gateway/latest/get-started/comprehensive/expose-services
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/expose-services
     - text: Protect your Services
-      url: /../../gateway/latest/get-started/comprehensive/protect-services
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/protect-services
     - text: Improve Performance
-      url: /../../gateway/latest/get-started/comprehensive/improve-performance
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/improve-performance
     - text: Secure Services
-      url: /../../gateway/latest/get-started/comprehensive/secure-services
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../gateway/latest/get-started/comprehensive/load-balancing
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/load-balancing
 
 - title: Guides &amp; References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ce_2.1.x.yml
+++ b/app/_data/docs_nav_ce_2.1.x.yml
@@ -3,19 +3,19 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../gateway/latest/get-started/comprehensive
+      url: /../../getting-started-guide/2.1.x/overview
     - text: Prepare to Administer
-      url: /../../gateway/latest/get-started/comprehensive/prepare
+      url: /../../getting-started-guide/2.1.x/prepare
     - text: Expose your Services
-      url: /../../gateway/latest/get-started/comprehensive/expose-services
+      url: /../../getting-started-guide/2.1.x/expose-services
     - text: Protect your Services
-      url: /../../gateway/latest/get-started/comprehensive/protect-services
+      url: /../../getting-started-guide/2.1.x/protect-services
     - text: Improve Performance
-      url: /../../gateway/latest/get-started/comprehensive/improve-performance
+      url: /../../getting-started-guide/2.1.x/improve-performance
     - text: Secure Services
-      url: /../../gateway/latest/get-started/comprehensive/secure-services
+      url: /../../getting-started-guide/2.1.x/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../gateway/latest/get-started/comprehensive/load-balancing
+      url: /../../getting-started-guide/2.1.x/load-balancing
 
 - title: Guides &amp; References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ce_2.2.x.yml
+++ b/app/_data/docs_nav_ce_2.2.x.yml
@@ -3,19 +3,19 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../gateway/latest/get-started/comprehensive
+      url: /../../getting-started-guide/2.2.x/overview
     - text: Prepare to Administer
-      url: /../../gateway/latest/get-started/comprehensive/prepare
+      url: /../../getting-started-guide/2.2.x/prepare
     - text: Expose your Services
-      url: /../../gateway/latest/get-started/comprehensive/expose-services
+      url: /../../getting-started-guide/2.2.x/expose-services
     - text: Protect your Services
-      url: /../../gateway/latest/get-started/comprehensive/protect-services
+      url: /../../getting-started-guide/2.2.x/protect-services
     - text: Improve Performance
-      url: /../../gateway/latest/get-started/comprehensive/improve-performance
+      url: /../../getting-started-guide/2.2.x/improve-performance
     - text: Secure Services
-      url: /../../gateway/latest/get-started/comprehensive/secure-services
+      url: /../../getting-started-guide/2.2.x/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../gateway/latest/get-started/comprehensive/load-balancing
+      url: /../../getting-started-guide/2.2.x/load-balancing
 
 - title: Guides &amp; References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ce_2.3.x.yml
+++ b/app/_data/docs_nav_ce_2.3.x.yml
@@ -32,31 +32,31 @@
     - text: Getting Started Guide
       items:
         - text: Overview
-          url: /gateway/latest/get-started/comprehensive
+          url: /getting-started-guide/2.3.x/overview
           absolute_url: true
           target_blank: true
         - text: Prepare to Administer
-          url: /gateway/latest/get-started/comprehensive/prepare
+          url: /getting-started-guide/2.3.x/prepare
           absolute_url: true
           target_blank: true
         - text: Expose your Services
-          url: /gateway/latest/get-started/comprehensive/expose-services
+          url: /getting-started-guide/2.3.x/expose-services
           absolute_url: true
           target_blank: true
         - text: Protect your Services
-          url: /gateway/latest/get-started/comprehensive/protect-services
+          url: /getting-started-guide/2.3.x/protect-services
           absolute_url: true
           target_blank: true
         - text: Improve Performance
-          url: /gateway/latest/get-started/comprehensive/improve-performance
+          url: /getting-started-guide/2.3.x/improve-performance
           absolute_url: true
           target_blank: true
         - text: Secure Services
-          url: /gateway/latest/get-started/comprehensive/secure-services
+          url: /getting-started-guide/2.3.x/secure-services
           absolute_url: true
           target_blank: true
         - text: Set Up Intelligent Load Balancing
-          url: /gateway/latest/get-started/comprehensive/load-balancing
+          url: /getting-started-guide/2.3.x/load-balancing
           absolute_url: true
 
 - title: Guides &amp; References

--- a/app/_data/docs_nav_ce_2.4.x.yml
+++ b/app/_data/docs_nav_ce_2.4.x.yml
@@ -32,31 +32,31 @@
     - text: Getting Started Guide
       items:
         - text: Overview
-          url: /gateway/latest/get-started/comprehensive
+          url: /getting-started-guide/2.4.x/overview
           absolute_url: true
           target_blank: true
         - text: Prepare to Administer
-          url: /gateway/latest/get-started/comprehensive/prepare
+          url: /getting-started-guide/2.4.x/prepare
           absolute_url: true
           target_blank: true
         - text: Expose your Services
-          url: /gateway/latest/get-started/comprehensive/expose-services
+          url: /getting-started-guide/2.4.x/expose-services
           absolute_url: true
           target_blank: true
         - text: Protect your Services
-          url: /gateway/latest/get-started/comprehensive/protect-services
+          url: /getting-started-guide/2.4.x/protect-services
           absolute_url: true
           target_blank: true
         - text: Improve Performance
-          url: /gateway/latest/get-started/comprehensive/improve-performance
+          url: /getting-started-guide/2.4.x/improve-performance
           absolute_url: true
           target_blank: true
         - text: Secure Services
-          url: /gateway/latest/get-started/comprehensive/secure-services
+          url: /getting-started-guide/2.4.x/secure-services
           absolute_url: true
           target_blank: true
         - text: Set Up Intelligent Load Balancing
-          url: /gateway/latest/get-started/comprehensive/load-balancing
+          url: /getting-started-guide/2.4.x/load-balancing
           absolute_url: true
 
 - title: Guides &amp; References

--- a/app/_data/docs_nav_ce_2.5.x.yml
+++ b/app/_data/docs_nav_ce_2.5.x.yml
@@ -32,31 +32,31 @@
     - text: Getting Started Guide
       items:
         - text: Overview
-          url: /gateway/latest/get-started/comprehensive
+          url: /getting-started-guide/2.5.x/overview
           absolute_url: true
           target_blank: true
         - text: Prepare to Administer
-          url: /gateway/latest/get-started/comprehensive/prepare
+          url: /getting-started-guide/2.5.x/prepare
           absolute_url: true
           target_blank: true
         - text: Expose your Services
-          url: /gateway/latest/get-started/comprehensive/expose-services
+          url: /getting-started-guide/2.5.x/expose-services
           absolute_url: true
           target_blank: true
         - text: Protect your Services
-          url: /gateway/latest/get-started/comprehensive/protect-services
+          url: /getting-started-guide/2.5.x/protect-services
           absolute_url: true
           target_blank: true
         - text: Improve Performance
-          url: /gateway/latest/get-started/comprehensive/improve-performance
+          url: /getting-started-guide/2.5.x/improve-performance
           absolute_url: true
           target_blank: true
         - text: Secure Services
-          url: /gateway/latest/get-started/comprehensive/secure-services
+          url: /getting-started-guide/2.5.x/secure-services
           absolute_url: true
           target_blank: true
         - text: Set Up Intelligent Load Balancing
-          url: /gateway/latest/get-started/comprehensive/load-balancing
+          url: /getting-started-guide/2.5.x/load-balancing
           absolute_url: true
 
 - title: Guides &amp; References

--- a/app/_data/docs_nav_ee_1.5.x.yml
+++ b/app/_data/docs_nav_ee_1.5.x.yml
@@ -83,23 +83,23 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../gateway/latest/get-started/comprehensive
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/overview
     - text: Prepare to Administer
-      url: /../../gateway/latest/get-started/comprehensive/prepare
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/prepare
     - text: Expose your Services
-      url: /../../gateway/latest/get-started/comprehensive/expose-services
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/expose-services
     - text: Protect your Services
-      url: /../../gateway/latest/get-started/comprehensive/protect-services
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/protect-services
     - text: Improve Performance
-      url: /../../gateway/latest/get-started/comprehensive/improve-performance
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/improve-performance
     - text: Secure Services
-      url: /../../gateway/latest/get-started/comprehensive/secure-services
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../gateway/latest/get-started/comprehensive/load-balancing
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/load-balancing
     - text: Manage Administrative Teams
-      url: /../../gateway/latest/get-started/comprehensive/manage-teams
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/manage-teams
     - text: Publish, Locate, and Consume Services
-      url: /../../gateway/latest/get-started/comprehensive/dev-portal
+      url: /../../getting-started-guide/CE-2.0.x_KE-1.5.x/dev-portal
 
 - title: Guides & References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ee_2.1.x.yml
+++ b/app/_data/docs_nav_ee_2.1.x.yml
@@ -136,23 +136,23 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../gateway/latest/get-started/comprehensive
+      url: /../../getting-started-guide/2.1.x/overview
     - text: Prepare to Administer
-      url: /../../gateway/latest/get-started/comprehensive/prepare
+      url: /../../getting-started-guide/2.1.x/prepare
     - text: Expose your Services
-      url: /../../gateway/latest/get-started/comprehensive/expose-services
+      url: /../../getting-started-guide/2.1.x/expose-services
     - text: Protect your Services
-      url: /../../gateway/latest/get-started/comprehensive/protect-services
+      url: /../../getting-started-guide/2.1.x/protect-services
     - text: Improve Performance
-      url: /../../gateway/latest/get-started/comprehensive/improve-performance
+      url: /../../getting-started-guide/2.1.x/improve-performance
     - text: Secure Services
-      url: /../../gateway/latest/get-started/comprehensive/secure-services
+      url: /../../getting-started-guide/2.1.x/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../gateway/latest/get-started/comprehensive/load-balancing
+      url: /../../getting-started-guide/2.1.x/load-balancing
     - text: Manage Administrative Teams
-      url: /../../gateway/latest/get-started/comprehensive/manage-teams
+      url: /../../getting-started-guide/2.1.x/manage-teams
     - text: Publish, Locate, and Consume Services
-      url: /../../gateway/latest/get-started/comprehensive/dev-portal
+      url: /../../getting-started-guide/2.1.x/dev-portal
 
 - title: Guides & References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ee_2.2.x.yml
+++ b/app/_data/docs_nav_ee_2.2.x.yml
@@ -131,23 +131,23 @@
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
   items:
     - text: Overview
-      url: /../../gateway/latest/get-started/comprehensive
+      url: /../../getting-started-guide/2.2.x/overview
     - text: Prepare to Administer
-      url: /../../gateway/latest/get-started/comprehensive/prepare
+      url: /../../getting-started-guide/2.2.x/prepare
     - text: Expose your Services
-      url: /../../gateway/latest/get-started/comprehensive/expose-services
+      url: /../../getting-started-guide/2.2.x/expose-services
     - text: Protect your Services
-      url: /../../gateway/latest/get-started/comprehensive/protect-services
+      url: /../../getting-started-guide/2.2.x/protect-services
     - text: Improve Performance
-      url: /../../gateway/latest/get-started/comprehensive/improve-performance
+      url: /../../getting-started-guide/2.2.x/improve-performance
     - text: Secure Services
-      url: /../../gateway/latest/get-started/comprehensive/secure-services
+      url: /../../getting-started-guide/2.2.x/secure-services
     - text: Set Up Intelligent Load Balancing
-      url: /../../gateway/latest/get-started/comprehensive/load-balancing
+      url: /../../getting-started-guide/2.2.x/load-balancing
     - text: Manage Administrative Teams
-      url: /../../gateway/latest/get-started/comprehensive/manage-teams
+      url: /../../getting-started-guide/2.2.x/manage-teams
     - text: Publish, Locate, and Consume Services
-      url: /../../gateway/latest/get-started/comprehensive/dev-portal
+      url: /../../getting-started-guide/2.2.x/dev-portal
 
 - title: Guides & References
   icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_ee_2.3.x.yml
+++ b/app/_data/docs_nav_ee_2.3.x.yml
@@ -136,40 +136,40 @@
 
 - title: Getting Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
-  url: /gateway/latest/get-started/comprehensive
+  url: /getting-started-guide/2.3.x/overview
   absolute_url: true
   target_blank: true
   items:
     - text: Prepare to Administer
-      url: /gateway/latest/get-started/comprehensive/prepare
+      url: /getting-started-guide/2.3.x/prepare
       absolute_url: true
       target_blank: true
     - text: Expose your Services
-      url: /gateway/latest/get-started/comprehensive/expose-services
+      url: /getting-started-guide/2.3.x/expose-services
       absolute_url: true
       target_blank: true
     - text: Protect your Services
-      url: /gateway/latest/get-started/comprehensive/protect-services
+      url: /getting-started-guide/2.3.x/protect-services
       absolute_url: true
       target_blank: true
     - text: Improve Performance
-      url: /gateway/latest/get-started/comprehensive/improve-performance
+      url: /getting-started-guide/2.3.x/improve-performance
       absolute_url: true
       target_blank: true
     - text: Secure Services
-      url: /gateway/latest/get-started/comprehensive/secure-services
+      url: /getting-started-guide/2.3.x/secure-services
       absolute_url: true
       target_blank: true
     - text: Set Up Intelligent Load Balancing
-      url: /gateway/latest/get-started/comprehensive/load-balancing
+      url: /getting-started-guide/2.3.x/load-balancing
       absolute_url: true
       target_blank: true
     - text: Manage Administrative Teams
-      url: /gateway/latest/get-started/comprehensive/manage-teams
+      url: /getting-started-guide/2.3.x/manage-teams
       absolute_url: true
       target_blank: true
     - text: Publish, Locate, and Consume Services
-      url: /gateway/latest/get-started/comprehensive/dev-portal
+      url: /getting-started-guide/2.3.x/dev-portal
       absolute_url: true
       target_blank: true
 

--- a/app/_data/docs_nav_ee_2.4.x.yml
+++ b/app/_data/docs_nav_ee_2.4.x.yml
@@ -135,40 +135,40 @@
 
 - title: Getting Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
-  url: /gateway/latest/get-started/comprehensive
+  url: /getting-started-guide/2.4.x/overview
   absolute_url: true
   target_blank: true
   items:
     - text: Prepare to Administer
-      url: /gateway/latest/get-started/comprehensive/prepare
+      url: /getting-started-guide/2.4.x/prepare
       absolute_url: true
       target_blank: true
     - text: Expose your Services
-      url: /gateway/latest/get-started/comprehensive/expose-services
+      url: /getting-started-guide/2.4.x/expose-services
       absolute_url: true
       target_blank: true
     - text: Protect your Services
-      url: /gateway/latest/get-started/comprehensive/protect-services
+      url: /getting-started-guide/2.4.x/protect-services
       absolute_url: true
       target_blank: true
     - text: Improve Performance
-      url: /gateway/latest/get-started/comprehensive/improve-performance
+      url: /getting-started-guide/2.4.x/improve-performance
       absolute_url: true
       target_blank: true
     - text: Secure Services
-      url: /gateway/latest/get-started/comprehensive/secure-services
+      url: /getting-started-guide/2.4.x/secure-services
       absolute_url: true
       target_blank: true
     - text: Set Up Intelligent Load Balancing
-      url: /gateway/latest/get-started/comprehensive/load-balancing
+      url: /getting-started-guide/2.4.x/load-balancing
       absolute_url: true
       target_blank: true
     - text: Manage Administrative Teams
-      url: /gateway/latest/get-started/comprehensive/manage-teams
+      url: /getting-started-guide/2.4.x/manage-teams
       absolute_url: true
       target_blank: true
     - text: Publish, Locate, and Consume Services
-      url: /gateway/latest/get-started/comprehensive/dev-portal
+      url: /getting-started-guide/2.4.x/dev-portal
       absolute_url: true
       target_blank: true
 

--- a/app/_data/docs_nav_ee_2.5.x.yml
+++ b/app/_data/docs_nav_ee_2.5.x.yml
@@ -131,40 +131,40 @@
 
 - title: Getting Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg
-  url: /gateway/latest/get-started/comprehensive
+  url: /getting-started-guide/2.5.x/overview
   absolute_url: true
   target_blank: true
   items:
     - text: Prepare to Administer
-      url: /gateway/latest/get-started/comprehensive/prepare
+      url: /getting-started-guide/2.5.x/prepare
       absolute_url: true
       target_blank: true
     - text: Expose your Services
-      url: /gateway/latest/get-started/comprehensive/expose-services
+      url: /getting-started-guide/2.5.x/expose-services
       absolute_url: true
       target_blank: true
     - text: Protect your Services
-      url: /gateway/latest/get-started/comprehensive/protect-services
+      url: /getting-started-guide/2.5.x/protect-services
       absolute_url: true
       target_blank: true
     - text: Improve Performance
-      url: /gateway/latest/get-started/comprehensive/improve-performance
+      url: /getting-started-guide/2.5.x/improve-performance
       absolute_url: true
       target_blank: true
     - text: Secure Services
-      url: /gateway/latest/get-started/comprehensive/secure-services
+      url: /getting-started-guide/2.5.x/secure-services
       absolute_url: true
       target_blank: true
     - text: Set Up Intelligent Load Balancing
-      url: /gateway/latest/get-started/comprehensive/load-balancing
+      url: /getting-started-guide/2.5.x/load-balancing
       absolute_url: true
       target_blank: true
     - text: Manage Administrative Teams
-      url: /gateway/latest/get-started/comprehensive/manage-teams
+      url: /getting-started-guide/2.5.x/manage-teams
       absolute_url: true
       target_blank: true
     - text: Publish, Locate, and Consume Services
-      url: /gateway/latest/get-started/comprehensive/dev-portal
+      url: /getting-started-guide/2.5.x/dev-portal
       absolute_url: true
       target_blank: true
 


### PR DESCRIPTION
### Summary
Set getting started guide links in old split doc navs to go to their respective versions.

### Reason
Issue https://github.com/Kong/docs.konghq.com/issues/3450.

### Testing
Check nav entries for the "Getting Started Guide"  in `/enterprise/` and `/gateway-oss/` docs, they should go to their respective guide versions.

For example, check:
https://deploy-preview-3453--kongdocs.netlify.app/enterprise/2.5.x/
https://deploy-preview-3453--kongdocs.netlify.app/gateway-oss/2.3.x/
