### PR TITLE
chore/ Update 2.7 scope

### DIFF
--- a/app/_data/docs_nav_gateway_2.6.x.yml
+++ b/app/_data/docs_nav_gateway_2.6.x.yml
@@ -1,6 +1,6 @@
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /gateway/
+  url: /gateway/2.6.x/
   absolute_url: true
   items:
     - text: Version Support Policy

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -140,6 +140,12 @@ defaults:
       version-index: 0
 
   - scope:
+      path: "gateway/2.7.x/"
+    values:
+      layout: "docs-v2"
+      version-index: 1
+
+  - scope:
       path: "about"
     values:
       layout: "about"

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -141,6 +141,12 @@ defaults:
       version-index: 0
 
   - scope:
+      path: "gateway/2.7.x/"
+    values:
+      layout: "docs-v2"
+      version-index: 1
+
+  - scope:
       path: "about"
     values:
       layout: "about"


### PR DESCRIPTION
### Summary
* Updating page scope so that it picks up the correct version for install topics.
* Setting absolute version URL for 2.6 so that it doesn't link to 2.7.

### Reason
2.7 release task.

### Testing
* Correct version appears in install topics, eg https://deploy-preview-3454--kongdocs.netlify.app/gateway/2.7.x/install-and-run/docker/
* The gateway 2.6.x introduction nav entry links to https://deploy-preview-3454--kongdocs.netlify.app/gateway/2.6.x/
