### PR TITLE
[DOCU-2075] Add route-by-header plugin to plugin priority list

### DIFF
--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -314,6 +314,7 @@ zipkin                      | 100000
 exit-transformer            | 9999
 bot-detection               | 2500
 cors                        | 2000
+route-by-header             | 2000
 session                     | 1900
 oauth2-introspection        | 1700
 acme                        | 1007


### PR DESCRIPTION
### Summary
Add route by header plugin based on its priority: https://github.com/Kong/kong-ee/blob/d1161cc2172159e98f7385b864894294092e9daf/plugins-ee/route-by-header/kong/plugins/route-by-header/handler.lua#L17

### Reason
Plugin is missing from the list.

### Testing
TBA