### PR TITLE
Release: Kong Gateway 2.6.0.2

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -455,7 +455,7 @@
 -
 # Combined Gateway docs (single-sourced)
   release: "2.6.x"
-  ee-version: "2.6.0.1"
+  ee-version: "2.6.0.2"
   ce-version: "2.6.0"
   edition: "gateway"
   luarocks_version: "2.5.1-0"

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -87,9 +87,9 @@ description: |
      This parameter tells the plugin where to find discovery information, and it is
      the only required parameter. You should specify the `realm` or `iss` for this
      parameter if you don't have a discovery endpoint.
-     
+
      {:.note}
-      > **Note**: This does not have 
+      > **Note**: This does not have
      to match the URL of the `iss` claim in the access tokens being validated. To set
      URLs supported in the `iss` claim, use `config.issuers_allowed`.
   2. Next, you should decide what authentication grants you want to use with this
@@ -282,7 +282,7 @@ params:
         - `none`: do not authenticate
 
 
-        > Private keys can be stored in a database, and they are by the default automatically generated 
+        > Private keys can be stored in a database, and they are by the default automatically generated
         > in the database. It is also possible to specify private keys with `config.client_jwk` directly
         > in the plugin configuration.
     - name: client_secret
@@ -467,8 +467,8 @@ params:
       default: (discovered issuer)
       datatype: array of string elements
       description: |
-        The scopes (`scopes_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases. 
-        - When `["scope1 scope2"]` are in the same array indices, both `scope1` AND `scope2` need to be present in access token (or introspection results). 
+        The scopes (`scopes_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.
+        - When `["scope1 scope2"]` are in the same array indices, both `scope1` AND `scope2` need to be present in access token (or introspection results).
         - When `["scope1", "scope2"]` are in different array indices, either `scope1` OR `scope2` need to be present in access token (or introspection results).
     - name: scopes_claim
       required: false
@@ -481,8 +481,8 @@ params:
       default: null
       datatype: array of string elements
       description: |
-        The audiences (`audience_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases. 
-        - When `["audience1 audience2"]` are in the same array indices, both `audience1` AND `audience2` need to be present in access token (or introspection results). 
+        The audiences (`audience_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.
+        - When `["audience1 audience2"]` are in the same array indices, both `audience1` AND `audience2` need to be present in access token (or introspection results).
         - When `["audience1", "audience2"]` are in different array indices, either `audience1` OR `audience2` need to be present in access token (or introspection results).
     - name: audience_claim
       required: false
@@ -495,8 +495,8 @@ params:
       default: null
       datatype: array of string elements
       description: |
-        The groups (`groups_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases. 
-        - When `["group1 group2"]` are in the same array indices, both `group1` AND `group2` need to be present in access token (or introspection results). 
+        The groups (`groups_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.
+        - When `["group1 group2"]` are in the same array indices, both `group1` AND `group2` need to be present in access token (or introspection results).
         - When `["group1", "group2"]` are in different array indices, either `group1` OR `group2` need to be present in access token (or introspection results).
     - name: groups_claim
       required: false
@@ -509,8 +509,8 @@ params:
       default: null
       datatype: array of string elements
       description: |
-        The roles (`roles_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases. 
-        - When `["role1 role2"]` are in the same array indices, both `role1` AND `role2` need to be present in access token (or introspection results). 
+        The roles (`roles_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.
+        - When `["role1 role2"]` are in the same array indices, both `role1` AND `role2` need to be present in access token (or introspection results).
         - When `["role1", "role2"]` are in different array indices, either `role1` OR `role2` need to be present in access token (or introspection results).
     - name: roles_claim
       required: false
@@ -1106,7 +1106,8 @@ params:
       required: false
       default: null
       datatype: array of host records
-      description: The Redis cluster nodes.
+      description: The Redis cluster node host. Takes an array of `ip:port` or 
+      `hostname:port` values.
     - name: session_redis_cluster_maxredirections
       required: false
       default: null
@@ -1566,7 +1567,8 @@ jwks: |
 In the above parameter list, two configuration settings used an array of records as a data type:
 
 - `config.client_jwk`: array of JWK records (one for each client)
-- `config.session_redis_cluster_nodes`: array of host records
+- `config.session_redis_cluster_nodes`: array of host records, either as IP
+addresses or hostnames
 
 Below are descriptions of the record types.
 
@@ -1583,10 +1585,10 @@ Here is an example of JWK record generated by the plugin itself (see: [JSON Web 
 
 ### Host Record
 
-Host record used with the `config.session_redis_cluster_nodes` is a simple one. It just contains
-`ip` and `port` where the `port` defaults to `6379`.
+The Host record used with the `config.session_redis_cluster_nodes` is simple.
+It contains `ip` or `host`, and the `port` where the `port` defaults to `6379`.
 
-Here is an example of Host record:
+Here is an example of Host the record:
 
 ```json
 {{ page.host }}

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -1106,8 +1106,9 @@ params:
       required: false
       default: null
       datatype: array of host records
-      description: The Redis cluster node host. Takes an array of `ip:port` or 
-      `hostname:port` values.
+      description: |
+        The Redis cluster node host. Takes an array of host records, with
+        either `ip` or `host`, and `port` values.
     - name: session_redis_cluster_maxredirections
       required: false
       default: null
@@ -1568,7 +1569,7 @@ In the above parameter list, two configuration settings used an array of records
 
 - `config.client_jwk`: array of JWK records (one for each client)
 - `config.session_redis_cluster_nodes`: array of host records, either as IP
-addresses or hostnames
+addresses or hostnames, and their ports.
 
 Below are descriptions of the record types.
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -19,7 +19,7 @@ labels, names, headings, and color contrast:
     * Form inputs now have labels
     * Selectable elements now all have accessible names
     * Unique IDs for active elements
-    * Headings levels only increase by one, and are in the correct order
+    * Heading levels only increase by one, and are in the correct order
     * Improved contrast of buttons
 
 * Fixed the Dev Portal API `/applications` endpoint to only accept allowed

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -4,6 +4,35 @@ no_search: true
 no_version: true
 ---
 
+## 2.6.0.2
+**Release Date:** 2021/12/04
+
+### Fixes
+
+#### Dev Portal
+
+* Fixed links in Dev Portal footer.
+
+* Improved accessibility of the Dev Portal, fixing various issues related to
+labels, names, headings, and color contrast:
+    * Keyboard-accessible response examples and "Try it out" sections
+    * Form inputs now have labels
+    * Selectable elements now all have accessible names
+    * Unique IDs for active elements
+    * Headings levels only increase by one, and are in the correct order
+    * Improved contrast of buttons
+
+* Fixed the Dev Portal API `/applications` endpoint to only accept allowed
+fields in a PATCH request.
+
+* Fixed info tooltip crash and rendering issue when viewing the Dev Portal app
+registration service list.
+
+#### Plugins
+- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
+  The plugin now allows Redis Cluster nodes to be specified by hostname, which
+  is helpful if the cluster IPs are not static.
+
 ## 2.6.0.1
 **Release Date:** 2021/11/18
 
@@ -26,7 +55,7 @@ upstream requests.
 Developers now correctly propagate to their associated Consumers.
 
 - Users can now successfully delete admins with the `super-admin` role from
-any workspace, as long as they have the correct permissions, and the associated 
+any workspace, as long as they have the correct permissions, and the associated
 Consumer entity will be deleted as well. This frees up the username for a new
 user. Previously, deleting an admin with a `super-admin` role from a different
 workspace than where it was originally created did not delete the associated

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -68,12 +68,6 @@ issue would occur.
 (garbage can) icon overlapped with the **View** link and caused users to
 accidentally click **Delete**.
 
-#### Plugins
-
-- [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  -  Redis cluster nodes can now be specified by hostname in the
-  `session_redis_cluster_nodes` field.
-
 ### Dependencies
 - Bumped kong-redis-cluster from `1.1-0` to `1.2.0`.
   - With this update, if the entire cluster is restarted and starts up using

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -30,8 +30,9 @@ registration service list.
 
 #### Plugins
 - [OpenID Connect](/hub/kong-inc/openid-connect) (`openid-connect`)
-  The plugin now allows Redis Cluster nodes to be specified by hostname, which
-  is helpful if the cluster IPs are not static.
+  - The plugin now allows Redis Cluster nodes to be specified by hostname
+    through the `session_redis_cluster_nodes` field, which
+    is helpful if the cluster IPs are not static.
 
 ## 2.6.0.1
 **Release Date:** 2021/11/18

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -5,7 +5,7 @@ no_version: true
 ---
 
 ## 2.6.0.2
-**Release Date:** 2021/12/04
+**Release Date:** 2021/12/03
 
 ### Fixes
 


### PR DESCRIPTION
### Summary
Changelog for the Enterprise Gateway 2.6.0.2 patch release and doc update for OIDC param `session_redis_cluster_nodes`.

### Reason
Patch release.

### Testing
[Changelog](https://deploy-preview-3456--kongdocs.netlify.app/gateway/changelog/)
