### PR TITLE
Update mTLS plugin description

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -4,7 +4,7 @@ publisher: Kong Inc.
 version: 1.5.x
 desc: Secure routes and services with client certificate and mutual TLS authentication
 description: |
-  Add mutual TLS authentication based on client-supplied certificate and configured trusted CA list. Automatically maps certificates to **Consumers** based on the common name field.
+  Add mutual TLS authentication based on client-supplied or server-supplied certificate, and on the configured trusted CA list. Automatically maps certificates to **Consumers** based on the common name field.
 enterprise: true
 plus: true
 type: plugin


### PR DESCRIPTION
### Summary
Edit plugin description to mention support for server-supplied certs.

### Reason
Plugin supports both upstream and downstream mTLS; issue reported on Slack.

### Testing
Preview: https://deploy-preview-3457--kongdocs.netlify.app/hub/kong-inc/mtls-auth/
