### PR TITLE
[DOCU-2073] Forward proxy auth parameters

### DIFF
--- a/app/_data/extensions/kong-inc/forward-proxy/versions.yml
+++ b/app/_data/extensions/kong-inc/forward-proxy/versions.yml
@@ -1,4 +1,5 @@
-- release: 1.3-x
+- release: 1.0.6
+- release: 1.0.5
 - release: 0.36-x
 - release: 0.35-x
 - release: 0.34-x

--- a/app/_hub/kong-inc/forward-proxy/1.0.5.md
+++ b/app/_hub/kong-inc/forward-proxy/1.0.5.md
@@ -1,7 +1,7 @@
 ---
 name: Forward Proxy Advanced
 publisher: Kong Inc.
-version: 1.0.x
+version: 1.0.5
 desc: Allows Kong to connect to intermediary transparent HTTP proxies
 description: |
   The Forward Proxy plugin allows Kong to connect to intermediary transparent
@@ -14,9 +14,18 @@ type: plugin
 categories:
   - traffic-control
 kong_version_compatibility:
+  community_edition:
+    compatible: null
   enterprise_edition:
     compatible:
-      - 2.7.x
+      - 2.6.x
+      - 2.5.x
+      - 2.4.x
+      - 2.3.x
+      - 2.2.x
+      - 2.1.x
+      - 1.5.x
+      - 1.3-x
 
 params:
   name: forward-proxy
@@ -46,23 +55,7 @@ params:
       value_in_examples: http
       datatype: string
       description: |
-        The proxy scheme to use when connecting. Only `http` is supported.
-    - name: auth_username
-      required: false
-      default: null
-      value_in_examples: example_user
-      datatype: string
-      description: |
-        The username to authenticate with, if the forward proxy is protected
-        by basic authentication.
-    - name: auth_password
-      required: false
-      default: null
-      value_in_examples: example_pass
-      datatype: string
-      description: |
-        The password to authenticate with, if the forward proxy is protected
-        by basic authentication.
+        The proxy scheme to use when connecting. Currently only `http` is supported.
     - name: https_verify
       required: true
       default: false
@@ -72,17 +65,13 @@ params:
         Whether the server certificate will be verified according to the CA certificates
         specified in
         [lua_ssl_trusted_certificate](https://www.nginx.com/resources/wiki/modules/lua/#lua-ssl-trusted-certificate).
+---
 
-  extra: |
+### Notes
 
-    The plugin attempts to transparently replace upstream connections made by Kong
-    core, sending the request instead to an intermediary forward proxy. Only
-    transparent HTTP proxies are supported; TLS connections (via `CONNECT`)
-    are not supported.
+The plugin attempts to transparently replace upstream connections made by Kong
+ core, sending the request instead to an intermediary forward proxy. Currently
+  only transparent HTTP proxies are supported; TLS connections (via `CONNECT`)
+  are not yet supported.
 
 ---
-## Changelog
-
-### 1.0.6
-
-* Added `auth_username` and `auth_password` parameters for proxy authentication.


### PR DESCRIPTION
### Summary
Adds two auth parameters,`auth_username` and `auth_password`. 

### Reason
https://github.com/Kong/kong-ee/pull/2611

### Testing
Preview: https://deploy-preview-3458--kongdocs.netlify.app/hub/kong-inc/forward-proxy/

**Reviewers**: please ignore the file `app/_hub/kong-inc/forward-proxy/1.0.5.md`, it's the previous version.
