### PR TITLE
Added warning around statsd exporter image

### DIFF
--- a/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
@@ -61,7 +61,20 @@ docker pull kong/statsd-exporter-advanced:0.3.1
 ```
 
 The binary includes features like min/max gauges and Unix domain
-socket support.
+socket support which are not supported in the public project.
+
+{:.important}
+> This Docker image is a Kong fork of the prometheus community project and the mapping rules linked below 
+> will not work with the public image, so please ensure you using the correct one.
+> 
+> You can still use the prometheus community helm chart to deploy the exporter but override the image 
+> and tag in the values file as shown below:
+
+```yaml
+image:
+  repository: kong/statsd-exporter-advanced
+  tag: 0.3.1
+```
 
 StatsD exporter needed to configured with a set of mapping rules to translate
 the StatsD UDP events to Prometheus metrics. A default set of mapping rules can

--- a/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
@@ -64,17 +64,17 @@ The binary includes features like min/max gauges and Unix domain
 socket support which are not supported in the public project.
 
 {:.important}
-> This Docker image is a Kong fork of the prometheus community project and the mapping rules linked below 
-> will not work with the public image, so please ensure you using the correct one.
+> This Docker image is a Kong fork of the Prometheus community project and the mapping rules linked below 
+> do not work with the public image. Ensure you are using the correct one.
 > 
-> You can still use the prometheus community helm chart to deploy the exporter but override the image 
-> and tag in the values file as shown below:
-
-```yaml
-image:
-  repository: kong/statsd-exporter-advanced
-  tag: 0.3.1
-```
+>  If you prefer to use the Prometheus community Helm chart to deploy the exporter, override the image 
+> and tag in the `values` file as shown below:
+> 
+> ```yaml
+> image:
+>  repository: kong/statsd-exporter-advanced
+>  tag: 0.3.1
+> ```
 
 StatsD exporter needed to configured with a set of mapping rules to translate
 the StatsD UDP events to Prometheus metrics. A default set of mapping rules can


### PR DESCRIPTION
### Summary
Added a warning to the page to make it clearer to users that they need to use the Kong statsd exporter forked image and not the public project which will not work with the supplied statsd mapping config

### Reason
I didnt think it was very clear on this page that the statsd exporter was a private forked image from Kong, and that the mappings supplied would not work with the prometheus community image.

### Testing
Deployed it to my cluster and my Grafana dashboards now work

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
