### PR TITLE
Add `keyring_blob_path` to db-encryption guide

### DIFF
--- a/app/enterprise/1.3-x/db-encryption.md
+++ b/app/enterprise/1.3-x/db-encryption.md
@@ -55,6 +55,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/enterprise/1.3-x/db-encryption.md
+++ b/app/enterprise/1.3-x/db-encryption.md
@@ -55,10 +55,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/1.5.x/db-encryption.md
+++ b/app/enterprise/1.5.x/db-encryption.md
@@ -54,10 +54,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/1.5.x/db-encryption.md
+++ b/app/enterprise/1.5.x/db-encryption.md
@@ -54,6 +54,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/enterprise/2.1.x/db-encryption.md
+++ b/app/enterprise/2.1.x/db-encryption.md
@@ -54,10 +54,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/2.1.x/db-encryption.md
+++ b/app/enterprise/2.1.x/db-encryption.md
@@ -54,6 +54,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/enterprise/2.2.x/db-encryption.md
+++ b/app/enterprise/2.2.x/db-encryption.md
@@ -54,10 +54,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/2.2.x/db-encryption.md
+++ b/app/enterprise/2.2.x/db-encryption.md
@@ -54,6 +54,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/enterprise/2.3.x/db-encryption.md
+++ b/app/enterprise/2.3.x/db-encryption.md
@@ -54,10 +54,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/2.3.x/db-encryption.md
+++ b/app/enterprise/2.3.x/db-encryption.md
@@ -54,6 +54,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/enterprise/2.4.x/db-encryption.md
+++ b/app/enterprise/2.4.x/db-encryption.md
@@ -54,10 +54,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/2.4.x/db-encryption.md
+++ b/app/enterprise/2.4.x/db-encryption.md
@@ -54,6 +54,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/enterprise/2.5.x/db-encryption.md
+++ b/app/enterprise/2.5.x/db-encryption.md
@@ -54,10 +54,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 

--- a/app/enterprise/2.5.x/db-encryption.md
+++ b/app/enterprise/2.5.x/db-encryption.md
@@ -54,6 +54,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/gateway/2.6.x/plan-and-deploy/security/db-encryption.md
+++ b/app/gateway/2.6.x/plan-and-deploy/security/db-encryption.md
@@ -53,6 +53,11 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
+When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
+variables to specify path to dump known keys. The dumped keys are encrypted with the public
+RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
+load duing Kong start.
+
 ### Start Kong
 
 Once all Kong nodes in the cluster have been configured, start each node:

--- a/app/gateway/2.6.x/plan-and-deploy/security/db-encryption.md
+++ b/app/gateway/2.6.x/plan-and-deploy/security/db-encryption.md
@@ -53,10 +53,10 @@ $ chown <nginx_user>:<nginx_user> /path/to/generated/cert.pem /path/to/generated
 $ chmod 400 /path/to/generated/cert.pem /path/to/generated/key.pem
 ```
 
-When testing, one may also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` via environmental
-variables to specify path to dump known keys. The dumped keys are encrypted with the public
-RSA key defined via the `keyring_public_key` Kong configuration value, and will be automatically
-load duing Kong start.
+When testing, you can also set `keyring_blob_path` in kong.conf or `KONG_KEYRING_BLOB_PATH` 
+using environmental variables to specify a path to dump known keys. The dumped keys are 
+encrypted with the public RSA key defined in the `keyring_public_key` Kong configuration 
+value, and are automatically loaded during Kong start.
 
 ### Start Kong
 


### PR DESCRIPTION
Mention keyring_blob_path in db-encryption document. The filed exists at
https://github.com/Kong/kong-ee/blob/master/kong.conf.default#L2473