### PR TITLE
[DOCU-2082] Enterprise install & download instructions for Debian

### DIFF
--- a/app/gateway/2.7.x/install-and-run/debian.md
+++ b/app/gateway/2.7.x/install-and-run/debian.md
@@ -5,7 +5,9 @@ title: Install Kong Gateway on Debian
 > Download the latest {{page.kong_version}} package for Debian:
 >
 > * **Kong Gateway**:
-> [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link}
+> [**8 Jessie**]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link},
+> [**9 Stretch**]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link},
+> [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link},
 > or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link}
 > (latest version: {{page.kong_versions[page.version-index].ee-version}})
 > * **Kong Gateway (OSS)**:

--- a/app/gateway/2.7.x/install-and-run/debian.md
+++ b/app/gateway/2.7.x/install-and-run/debian.md
@@ -33,6 +33,10 @@ The {{site.base_gateway}} software is governed by the
 ## Prerequisites
 
 * A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* The following tools are installed:
+  * [`curl`](https://curl.se/)
+  * [`lsb-release`](https://packages.debian.org/lsb-release)
+  * [`apt-transport-https`](https://packages.debian.org/apt-transport-https) (Only if installing the APT repository)
 * (Enterprise only) A `license.json` file from Kong.
 
 ## Download and install

--- a/app/gateway/2.7.x/install-and-run/debian.md
+++ b/app/gateway/2.7.x/install-and-run/debian.md
@@ -1,14 +1,18 @@
 ---
 title: Install Kong Gateway on Debian
-badge: oss
 ---
 {:.install-banner}
-> Download the latest {{site.ce_product_name}} {{page.kong_version}} package for Debian:
-> * [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
-> * [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
-> * [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
-> * [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
+> Download the latest {{page.kong_version}} package for Debian:
 >
+> * **Kong Gateway**:
+> [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link}
+> or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb){:.install-link}
+> (latest version: {{page.kong_versions[page.version-index].ee-version}})
+> * **Kong Gateway (OSS)**:
+> [**8 Jessie**]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link},
+> [**9 Stretch**]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link},
+> [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link},
+> or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
 > (latest version: {{page.kong_versions[page.version-index].ce-version}})
 >
 > <br>
@@ -19,12 +23,15 @@ badge: oss
 > [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}
 >  </span>
 
+The {{site.base_gateway}} software is governed by the
+[Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 {{site.ce_product_name}} is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
 
-You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* (Enterprise only) A `license.json` file from Kong.
 
 ## Download and install
 
@@ -35,36 +42,78 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 
 Install {{site.base_gateway}} on Debian from the command line.
 
-1. Download the {{site.ce_product_name}} package:
-    ```bash
-    curl -Lo kong.{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
-     ```
+1. Download the Kong package:
+
+{% capture download_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ download_package | indent | replace: " </code>", "</code>" }}
 
 2. Install the package:
-    ```bash
-    sudo dpkg -i kong.{{site.data.kong_latest.version}}.amd64.deb
-    ```
+
+{% capture install_package %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% navtab APT repository %}
 
 Install the APT repository from the command line.
 
-1. Download the {{site.ce_product_name}} APT repository:
+1. Download the Kong APT repository:
     ```bash
-    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-debian-$(lsb_release -sc)/
+    echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-debian-$(lsb_release -sc)/ \
     default all" | sudo tee /etc/apt/sources.list.d/kong.list
     ```
 2. Update the repository:
     ```bash
     sudo apt-get update
     ```
-3. Install {{site.ce_product_name}}:
-    ```bash
-    apt install -y kong
-    ```
+3. Install Kong:
+
+{% capture install_from_repo %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+apt install -y kong-enterprise-edition={{page.kong_versions[page.version-index].ee-version}}
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include_cached /md/installation.md kong_version=page.kong_version %}
+{% include_cached /md/gateway/setup.md kong_version=page.kong_version %}


### PR DESCRIPTION
### Summary
Adding download and install instructions to the Debian doc for the `kong-enterprise-edition` package.

### Reason
Support for Debian in 2.7.

### Testing
Preview: https://deploy-preview-3472--kongdocs.netlify.app/gateway/2.7.x/install-and-run/debian/
