### PR TITLE
Plugin: Rate limiting redis SSL properties

### DIFF
--- a/app/_data/extensions/kong-inc/rate-limiting/versions.yml
+++ b/app/_data/extensions/kong-inc/rate-limiting/versions.yml
@@ -1,4 +1,5 @@
-- release: 2.2-x
+- release: 2.3.x
+- release: 2.2.x
 - release: 2.1-x
 - release: 1.0-x
 - release: 0.1-x

--- a/app/_hub/kong-inc/rate-limiting/2.2.x.md
+++ b/app/_hub/kong-inc/rate-limiting/2.2.x.md
@@ -1,7 +1,7 @@
 ---
 name: Rate Limiting
 publisher: Kong Inc.
-version: 2.3.x
+version: 2.2.x
 desc: Rate-limit how many HTTP requests can be made in a period of time
 description: |
   Rate limit how many HTTP requests can be made in a given period of seconds, minutes, hours, days, months, or years.
@@ -18,10 +18,42 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 2.7.x
+      - 2.6.x
+      - 2.5.x
+      - 2.4.x
+      - 2.3.x
+      - 2.2.x
+      - 2.1.x
+      - 2.0.x
+      - 1.4.x
+      - 1.3.x
+      - 1.2.x
+      - 1.1.x
+      - 1.0.x
+      - 0.14.x
+      - 0.13.x
+      - 0.12.x
+      - 0.11.x
+      - 0.10.x
+      - 0.9.x
+      - 0.8.x
+      - 0.7.x
+      - 0.6.x
+      - 0.5.x
+      - 0.4.x
+      - 0.3.x
+      - 0.2.x
   enterprise_edition:
     compatible:
-      - 2.7.x
+      - 2.6.x
+      - 2.5.x
+      - 2.4.x
+      - 2.3.x
+      - 2.2.x
+      - 2.1.x
+      - 1.5.x
+      - 1.3-x
+      - 0.36-x
 params:
   name: rate-limiting
   service_id: true

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -130,6 +130,23 @@ params:
       datatype: string
       description: |
         When using the `redis` policy, this property specifies the password to connect to the Redis server.
+    - name: redis_ssl
+      required: true
+      default: '`false`'
+      datatype: boolean
+      description: |
+        When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.
+    - name: redis_ssl_verify
+      required: true
+      default: '`false`'
+      datatype: boolean
+      description: |
+        When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly.
+    - name: redis_server_name  
+      required: false
+      datatype: string
+      description: |
+        When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI)
     - name: redis_timeout
       required: false
       default: '`2000`'

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -254,6 +254,14 @@ When the selected policy cannot be retrieved, the plugin falls back
 to limiting usage by identifying the IP address. This can happen for several reasons, such as the
 selected header was not sent by the client or the configured service was not found.
 
+---
+
+## Changelog
+
+### 2.3.0
+
+* Added parameters `redis_ssl`, `redis_ssl_verify`, and `redis_server_name`.
+
 [api-object]: /gateway/latest/admin-api/#api-object
 [configuration]: /gateway/latest/reference/configuration
 [consumer-object]: /gateway/latest/admin-api/#consumer-object


### PR DESCRIPTION
### Summary

Bumping Rate Limiting plugin version.
Adding commit (https://github.com/Kong/docs.konghq.com/commit/d4781029a86d0062797c7648cfac806db5bfe06d) from closed PR #3339.

### Reason
Had to split the content from https://github.com/Kong/docs.konghq.com/pull/3426 as `redis_username` is not making it into the 2.7 release, but the options in this PR are.

### Testing
https://deploy-preview-3478--kongdocs.netlify.app/hub/kong-inc/rate-limiting/
