### PR TITLE
[DOCU-2098] Add missing copy code to Docker install

### DIFF
--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -67,10 +67,10 @@ docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
 {% capture tag_image %}
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
-<pre><code>docker tag kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine <div contenteditable="true">{TAG_NAME}</div></code></pre>
+<div class="copy-code-snippet"><pre><code>docker tag kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine <div contenteditable="true">{TAG_NAME}</div></code></pre></div>
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
-<pre><code>docker tag kong:{{page.kong_versions[page.version-index].ce-version}}-alpine <div contenteditable="true">{TAG_NAME}</div></code></pre>
+<div class="copy-code-snippet"><pre><code>docker tag kong:{{page.kong_versions[page.version-index].ce-version}}-alpine <div contenteditable="true">{TAG_NAME}</div></code></pre></div>
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}


### PR DESCRIPTION
### Summary

Add missing copy code button to Docker install guide. 

Closes [DOCU-2098](https://konghq.atlassian.net/browse/DOCU-2098)

### Reason

Reported missing copy code button. 
