### PR TITLE
[DOCU-2101] Add Dev Portal redirects

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -198,9 +198,6 @@
 /enterprise/2.6.x/developer-portal/*                       /gateway/2.6.x/developer-portal/:splat
 /enterprise/latest/developer-portal/*                      /gateway/latest/developer-portal/:splat
 
-/gateway/2.6.x/developer-portal/administration/         /gateway/2.6.x/developer-portal/administration/managing-developers/
-/gateway/2.6.x/developer-portal/configuration/          /gateway/2.6.x/developer-portal/configuration/workspaces/
-
 # GATEWAY REFERENCES
 /admin-api/                            /gateway/latest/admin-api
 /admin-api/*                           /gateway/latest/admin-api/:splat

--- a/app/_redirects
+++ b/app/_redirects
@@ -198,6 +198,8 @@
 /enterprise/2.6.x/developer-portal/*                       /gateway/2.6.x/developer-portal/:splat
 /enterprise/latest/developer-portal/*                      /gateway/latest/developer-portal/:splat
 
+/gateway/2.6.x/developer-portal/administration/         /gateway/2.6.x/developer-portal/administration/managing-developers/
+/gateway/2.6.x/developer-portal/configuration/          /gateway/2.6.x/developer-portal/configuration/workspaces/
 
 # GATEWAY REFERENCES
 /admin-api/                            /gateway/latest/admin-api

--- a/app/gateway/2.6.x/get-started/comprehensive/dev-portal.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/dev-portal.md
@@ -49,8 +49,8 @@ After the Dev Portal is enabled for the Workspace, a few new links appear in the
 You can learn more about personalization in the [the Dev Portal documentation](/gateway/{{page.kong_version}}/developer-portal/), including:
 
 * [Customizing the look and feel of the site and editor](/gateway/{{page.kong_version}}/developer-portal/theme-customization/easy-theme-editing/)
-* [Managing access](/gateway/{{page.kong_version}}/developer-portal/administration/)
-* [Configuring the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/)
+* [Managing access](/gateway/{{page.kong_version}}/developer-portal/administration/managing-developers/)
+* [Configuring the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/workspaces/)
 
 ## Access and Interact with the Dev Portal
 


### PR DESCRIPTION
### Summary

Closes [3487](https://github.com/Kong/docs.konghq.com/issues/3487)

Add two redirects for links that go to 404 from this page: https://docs.konghq.com/gateway/2.6.x/get-started/comprehensive/dev-portal/

Note that Administration and Configuration are menu items that are clicked to open sub-menus and not pages themselves. So I linked instead to a page within those sections.