### PR TITLE
Konnect instructions for Adding Certificate Authorities

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -153,6 +153,8 @@ stored in a separate `ca_certificates` store rather than the main certificates s
 they do not require private keys. To add one, obtain a PEM-encoded copy of your CA certificate
 and POST it to `/ca_certificates`:
 
+{% navtabs %}
+{% navtab Kong Admin API %}
 ```bash
 $ curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
 {
@@ -162,7 +164,27 @@ $ curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
   "id": "322dce96-d434-4e0d-9038-311b3520f0a3"
 }
 ```
+{% endnavtab %}
 
+{% navtab Konnect Cloud %}
+
+Go through the Konnect Manager:
+1. From the Dashboard, select **Shared Config** in the left navigation 
+2. Select **Certificates** 
+3. Click **New Certificate**
+4. Copy and paste your certificate information and select **Create**
+
+You will now see your certificate listed in the **Certificates** tab.
+
+To add a certificate via curl, you are required to have:
+1. Konnect ID
+2. A generated access cookie
+
+```bash
+$ curl -sX POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certificates -F cert=@testCACert.pem --cookie '[generated access cookie]'
+```
+{% endnavtab %}
+{% endnavtabs %}
 The `id` value returned can now be used for mTLS plugin configurations or consumer mappings.
 
 ### Create manual mappings between certificate and Consumer object

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -156,7 +156,7 @@ and POST it to `/ca_certificates`:
 {% navtabs %}
 {% navtab Kong Admin API %}
 ```bash
-$ curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
+curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
 {
   "tags": null,
   "created_at": 1566597621,

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -181,7 +181,7 @@ To add a certificate via curl, you are required to have:
 2. A generated access cookie
 
 ```bash
-$ curl -X POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certificates -F cert=@testCACert.pem --cookie '[generated access cookie]'
+curl -X POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certificates -F cert=@testCACert.pem --cookie '[generated access cookie]'
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_hub/kong-inc/mtls-auth/index.md
+++ b/app/_hub/kong-inc/mtls-auth/index.md
@@ -181,7 +181,7 @@ To add a certificate via curl, you are required to have:
 2. A generated access cookie
 
 ```bash
-$ curl -sX POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certificates -F cert=@testCACert.pem --cookie '[generated access cookie]'
+$ curl -X POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certificates -F cert=@testCACert.pem --cookie '[generated access cookie]'
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
Update to resolve issue #3451

### Summary
Adding in Konnect specific instructions to add certificates to a Kong instance for mtls.

### Reason
#3451 

### Testing
Used the instructions for a customer. Would recommend testing by using these instructions to add certificates

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
https://deploy-preview-3495--kongdocs.netlify.app/
