### PR TITLE
[bug fix] Let right ToC wrap instead of cutting off

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -678,6 +678,7 @@
       padding-top: 6px;
       padding-bottom: 6px;
       border-left: 1px solid transparent;
+      overflow-wrap: break-word;
 
       a {
         img {


### PR DESCRIPTION
### Summary
Fixing nav overflow issue.

### Reason
Nav gets cut off if the text is too long and has no whitespace breaks:

![Screen Shot 2021-12-15 at 5 50 34 PM](https://user-images.githubusercontent.com/54370747/146293307-ff4914e8-945e-475b-96fd-24ad684cb441.png)


### Testing
Check that nav entries wrap instead of cutting off: https://deploy-preview-3498--kongdocs.netlify.app/gateway/2.6.x/pdk/kong.service.response/

