### PR TITLE
chore/Sync 2.6.x and 2.7.x directories

### DIFF
--- a/app/gateway/2.7.x/get-started/comprehensive/dev-portal.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/dev-portal.md
@@ -49,8 +49,8 @@ After the Dev Portal is enabled for the Workspace, a few new links appear in the
 You can learn more about personalization in the [the Dev Portal documentation](/gateway/{{page.kong_version}}/developer-portal/), including:
 
 * [Customizing the look and feel of the site and editor](/gateway/{{page.kong_version}}/developer-portal/theme-customization/easy-theme-editing/)
-* [Managing access](/gateway/{{page.kong_version}}/developer-portal/administration/)
-* [Configuring the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/)
+* [Managing access](/gateway/{{page.kong_version}}/developer-portal/administration/managing-developers/)
+* [Configuring the Dev Portal](/gateway/{{page.kong_version}}/developer-portal/configuration/workspaces/)
 
 ## Access and Interact with the Dev Portal
 

--- a/app/gateway/2.7.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/manage-teams.md
@@ -242,7 +242,7 @@ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpo
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8001/secureworkspace/rbac/roles/admin/endpoints/ \
+http :8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
   endpoint='*' \
   workspace=SecureWorkspace \
   actions='*' \
@@ -317,7 +317,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
     *Or using HTTPie:*
 
     ```sh
-    http :8001/default/rbac/users Kong-Admin-Token:secureadmintoken
+    http :8001/SecureWorkspace/rbac/users Kong-Admin-Token:secureadmintoken
     ```
     This time, you should get a `200 OK` success message and a list of users.
 

--- a/app/gateway/2.7.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-prometheus-strategy.md
@@ -60,7 +60,20 @@ docker pull kong/statsd-exporter-advanced:0.3.1
 ```
 
 The binary includes features like min/max gauges and Unix domain
-socket support.
+socket support which are not supported in the public project.
+
+{:.important}
+> This Docker image is a Kong fork of the Prometheus community project and the mapping rules linked below
+> do not work with the public image. Ensure you are using the correct one.
+>
+>  If you prefer to use the Prometheus community Helm chart to deploy the exporter, override the image
+> and tag in the `values` file as shown below:
+>
+> ```yaml
+> image:
+>  repository: kong/statsd-exporter-advanced
+>  tag: 0.3.1
+> ```
 
 StatsD exporter needed to configured with a set of mapping rules to translate
 the StatsD UDP events to Prometheus metrics. A default set of mapping rules can


### PR DESCRIPTION
### Summary
Copying over changes made in 2.6.x since the 2.7.x directory was created.

Based on the following merge: 4b676d1


### Reason
No automatic change syncing between directories. Have to make these changes manually.

### Testing
https://deploy-preview-3499--kongdocs.netlify.app/gateway/2.7.x/vitals/vitals-prometheus-strategy/#download-and-configure-statsd-exporter - added warning block
https://deploy-preview-3499--kongdocs.netlify.app/gateway/2.7.x/install-and-run/docker/ - editable fields in Docker install
