### PR TITLE
[DOCU-1953] Make navtabs accessible

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -451,6 +451,7 @@ $("a[data-filter]").on("keypress", function(e) {
 
   // navtabs
   const navtabs = $("div[data-navtab-id]");
+
   navtabs.on("click", function () {
     const navtabTitle = $(this);
     const navtabID = navtabTitle.data("navtab-id");
@@ -466,6 +467,20 @@ $("a[data-filter]").on("keypress", function(e) {
     navtabContent.siblings().css("display", "none");
     navtabContent.css("display", "block");
   });
+
+  navtabs.on("keypress", function(e) {
+    const navtabTitle = $(this);
+    const navtabID = navtabTitle.data("navtab-id");
+    const navtabContent = $(`div[data-navtab-content='${navtabID}']`);
+
+    if (e.keyCode === 13) {
+      navtabTitle.siblings().removeClass("active");
+      navtabTitle.addClass("active");
+      navtabContent.siblings().css("display", "none");
+      navtabContent.css("display", "block");
+    }
+  });
+
   // set first navtab as active
   $(".navtabs").each(function (index, navtabs) {
     $(navtabs).find("div[data-navtab-content]").css("display", "none");

--- a/app/_plugins/navtabs.rb
+++ b/app/_plugins/navtabs.rb
@@ -56,16 +56,16 @@ module Jekyll
       def get_template
         <<-EOF
 <div class="navtabs <%= @class %>">
-  <div class="navtab-titles">
+  <div class="navtab-titles" role="tablist">
   <% environment['navtabs-' + navtabs_id].each_with_index do |(title, value), index| %>
-    <div data-navtab-id="navtab-<%= navtabs_id %>-<%= index %>" class="navtab-title">
+    <div data-navtab-id="navtab-<%= navtabs_id %>-<%= index %>" class="navtab-title" role="tab" aria-controls="navtab-id-<%= index %>" tabindex="0">
       <%= title %>
     </div>
   <% end %>
   </div>
   <div class="navtab-contents">
   <% environment['navtabs-' + navtabs_id].each_with_index do |(title, value), index| %>
-    <div data-navtab-content="navtab-<%= navtabs_id %>-<%= index %>" class="navtab-content">
+    <div data-navtab-content="navtab-<%= navtabs_id %>-<%= index %>" class="navtab-content" role="tabpanel" id="navtab-id-<%= index %>" tabindex="0" aria-labelledby="navtab-id-<%= index %>" >
       <%= value %>
     </div>
   <% end %>


### PR DESCRIPTION
### Summary
Adding the ability to tab through navtab elements. 

### Reason
Making docs accessible.

### Testing
Tab through some tabs. Sample pages:
https://deploy-preview-3502--kongdocs.netlify.app/hub/kong-inc/basic-auth/
https://deploy-preview-3502--kongdocs.netlify.app/gateway/2.7.x/get-started/comprehensive/protect-services/

Use `tab` to move forward and `shift+tab` to move backward, and press the `Enter` key to switch to a tab.