### PR TITLE
[bugfix] RLA plugin: add 1.6.x version

### DIFF
--- a/app/_data/extensions/kong-inc/rate-limiting-advanced/versions.yml
+++ b/app/_data/extensions/kong-inc/rate-limiting-advanced/versions.yml
@@ -1,3 +1,4 @@
+- release: 1.6.x
 - release: 1.5.x
 - release: 1.4.x
 - release: 1.3.x


### PR DESCRIPTION
### Summary
Adding 1.6.x to the Rate Limiting Advanced plugin's list of versions.

### Reason
Plugin version was bumped, but I missed updating this metadata file.

### Testing
https://deploy-preview-3505--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/ - check that versions 1.6.x, 1.5.x, and 1.4.x exist in the dropdown.
