### PR TITLE
Update cert-manager docs link

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -43,7 +43,7 @@ deployment.extensions/kong created
 
 ## Set up cert-manager
 
-Please follow cert-manager's [documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html)
+Please follow cert-manager's [documentation](https://cert-manager.io/docs/installation/)
 on how to install cert-manager onto your cluster.
 
 Once installed, verify all the components are running using:

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -43,7 +43,7 @@ deployment.extensions/kong created
 
 ## Set up cert-manager
 
-Please follow cert-manager's [documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html)
+Please follow cert-manager's [documentation](https://cert-manager.io/docs/installation/)
 on how to install cert-manager onto your cluster.
 
 Once installed, verify all the components are running using:

--- a/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
@@ -43,7 +43,7 @@ deployment.extensions/kong created
 
 ## Set up cert-manager
 
-Please follow cert-manager's [documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html)
+Please follow cert-manager's [documentation](https://cert-manager.io/docs/installation/)
 on how to install cert-manager onto your cluster.
 
 Once installed, verify all the components are running using:

--- a/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
@@ -43,7 +43,7 @@ deployment.extensions/kong created
 
 ## Set up cert-manager
 
-Please follow cert-manager's [documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html)
+Please follow cert-manager's [documentation](https://cert-manager.io/docs/installation/)
 on how to install cert-manager onto your cluster.
 
 Once installed, verify all the components are running using:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -43,7 +43,7 @@ deployment.extensions/kong created
 
 ## Set up cert-manager
 
-Please follow cert-manager's [documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html)
+Please follow cert-manager's [documentation](https://cert-manager.io/docs/installation/)
 on how to install cert-manager onto your cluster.
 
 Once installed, verify all the components are running using:


### PR DESCRIPTION
### Summary
Update the link to install cert-manager as the [current link](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html) leads to 404

### Reason
[Current link](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html) to cert-manager docs leads to 404

### Testing
Check the new link (https://cert-manager.io/docs/installation/)

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
