### PR TITLE
Update apiVersion for ClusterIssuer to cert-manager.io/v1

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -160,7 +160,7 @@ Via: kong/1.1.2
 First, setup a ClusterIssuer for cert-manager
 
 ```bash
-$ echo "apiVersion: cert-manager.io/v1alpha2
+$ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -236,7 +236,7 @@ Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  certmanager.k8s.io/v1alpha1
+API Version:  certmanager.k8s.io/v1
 Kind:         Certificate
 Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
@@ -249,7 +249,7 @@ Metadata:
     Name:                  demo-example-com
     UID:                   261d15d3-9464-11e9-9965-42010a8a01ad
   Resource Version:        19561898
-  Self Link:               /apis/certmanager.k8s.io/v1alpha1/namespaces/default/certificates/demo-example-com
+  Self Link:               /apis/certmanager.k8s.io/v1/namespaces/default/certificates/demo-example-com
   UID:                     014d3f1d-9465-11e9-9965-42010a8a01ad
 Spec:
   Acme:

--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -178,12 +178,6 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
-*Note*: If you run into issues configuring this,
-be sure that the group (`cert-manager.io`) and
-version (`v1alpha2`) match those in the output of
-`kubectl describe crd clusterissuer`.
-This directs cert-manager which CA authority to use to issue the certificate.
-
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -178,6 +178,12 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
+*Note*: If you run into issues configuring this,
+be sure that the group (`cert-manager.io`) and
+version (`v1`) match those in the output of
+`kubectl describe crd clusterissuer`.
+This directs cert-manager which CA authority to use to issue the certificate.
+
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -160,7 +160,7 @@ Via: kong/1.1.2
 First, setup a ClusterIssuer for cert-manager
 
 ```bash
-$ echo "apiVersion: cert-manager.io/v1alpha2
+$ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -236,7 +236,7 @@ Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  certmanager.k8s.io/v1alpha1
+API Version:  certmanager.k8s.io/v1
 Kind:         Certificate
 Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
@@ -249,7 +249,7 @@ Metadata:
     Name:                  demo-example-com
     UID:                   261d15d3-9464-11e9-9965-42010a8a01ad
   Resource Version:        19561898
-  Self Link:               /apis/certmanager.k8s.io/v1alpha1/namespaces/default/certificates/demo-example-com
+  Self Link:               /apis/certmanager.k8s.io/v1/namespaces/default/certificates/demo-example-com
   UID:                     014d3f1d-9465-11e9-9965-42010a8a01ad
 Spec:
   Acme:

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -178,12 +178,6 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
-*Note*: If you run into issues configuring this,
-be sure that the group (`cert-manager.io`) and
-version (`v1alpha2`) match those in the output of
-`kubectl describe crd clusterissuer`.
-This directs cert-manager which CA authority to use to issue the certificate.
-
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -178,6 +178,12 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
+*Note*: If you run into issues configuring this,
+be sure that the group (`cert-manager.io`) and
+version (`v1`) match those in the output of
+`kubectl describe crd clusterissuer`.
+This directs cert-manager which CA authority to use to issue the certificate.
+
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
@@ -160,7 +160,7 @@ Via: kong/1.1.2
 First, setup a ClusterIssuer for cert-manager
 
 ```bash
-$ echo "apiVersion: cert-manager.io/v1alpha2
+$ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
@@ -236,7 +236,7 @@ Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  certmanager.k8s.io/v1alpha1
+API Version:  certmanager.k8s.io/v1
 Kind:         Certificate
 Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
@@ -249,7 +249,7 @@ Metadata:
     Name:                  demo-example-com
     UID:                   261d15d3-9464-11e9-9965-42010a8a01ad
   Resource Version:        19561898
-  Self Link:               /apis/certmanager.k8s.io/v1alpha1/namespaces/default/certificates/demo-example-com
+  Self Link:               /apis/certmanager.k8s.io/v1/namespaces/default/certificates/demo-example-com
   UID:                     014d3f1d-9465-11e9-9965-42010a8a01ad
 Spec:
   Acme:

--- a/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
@@ -178,12 +178,6 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
-*Note*: If you run into issues configuring this,
-be sure that the group (`cert-manager.io`) and
-version (`v1alpha2`) match those in the output of
-`kubectl describe crd clusterissuer`.
-This directs cert-manager which CA authority to use to issue the certificate.
-
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
@@ -178,6 +178,12 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
+*Note*: If you run into issues configuring this,
+be sure that the group (`cert-manager.io`) and
+version (`v1`) match those in the output of
+`kubectl describe crd clusterissuer`.
+This directs cert-manager which CA authority to use to issue the certificate.
+
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
@@ -160,7 +160,7 @@ Via: kong/1.1.2
 First, setup a ClusterIssuer for cert-manager
 
 ```bash
-$ echo "apiVersion: cert-manager.io/v1alpha2
+$ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
@@ -236,7 +236,7 @@ Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  certmanager.k8s.io/v1alpha1
+API Version:  certmanager.k8s.io/v1
 Kind:         Certificate
 Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
@@ -249,7 +249,7 @@ Metadata:
     Name:                  demo-example-com
     UID:                   261d15d3-9464-11e9-9965-42010a8a01ad
   Resource Version:        19561898
-  Self Link:               /apis/certmanager.k8s.io/v1alpha1/namespaces/default/certificates/demo-example-com
+  Self Link:               /apis/certmanager.k8s.io/v1/namespaces/default/certificates/demo-example-com
   UID:                     014d3f1d-9465-11e9-9965-42010a8a01ad
 Spec:
   Acme:

--- a/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
@@ -178,12 +178,6 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
-*Note*: If you run into issues configuring this,
-be sure that the group (`cert-manager.io`) and
-version (`v1alpha2`) match those in the output of
-`kubectl describe crd clusterissuer`.
-This directs cert-manager which CA authority to use to issue the certificate.
-
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
@@ -178,6 +178,12 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
+*Note*: If you run into issues configuring this,
+be sure that the group (`cert-manager.io`) and
+version (`v1`) match those in the output of
+`kubectl describe crd clusterissuer`.
+This directs cert-manager which CA authority to use to issue the certificate.
+
 Next, update your Ingress resource to provision a certificate and then use it:
 
 ```bash

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -180,10 +180,6 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
-*Note*: If you run into issues configuring this,
-be sure that the group (`cert-manager.io`) and
-version (`v1alpha2`) match those in the output of
-`kubectl describe crd clusterissuer`.
 This directs cert-manager which CA authority to use to issue the certificate.
 
 Next, update your Ingress resource to provision a certificate and then use it:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -180,6 +180,10 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
+*Note*: If you run into issues configuring this,
+be sure that the group (`cert-manager.io`) and
+version (`v1`) match those in the output of
+`kubectl describe crd clusterissuer`.
 This directs cert-manager which CA authority to use to issue the certificate.
 
 Next, update your Ingress resource to provision a certificate and then use it:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -241,7 +241,7 @@ Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  certmanager.k8s.io/v1alpha1
+API Version:  certmanager.k8s.io/v1
 Kind:         Certificate
 Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
@@ -254,7 +254,7 @@ Metadata:
     Name:                  demo-example-com
     UID:                   261d15d3-9464-11e9-9965-42010a8a01ad
   Resource Version:        19561898
-  Self Link:               /apis/certmanager.k8s.io/v1alpha1/namespaces/default/certificates/demo-example-com
+  Self Link:               /apis/certmanager.k8s.io/v1/namespaces/default/certificates/demo-example-com
   UID:                     014d3f1d-9465-11e9-9965-42010a8a01ad
 Spec:
   Acme:

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -162,7 +162,7 @@ Via: kong/1.1.2
 First, setup a ClusterIssuer for cert-manager
 
 ```bash
-$ echo "apiVersion: cert-manager.io/v1alpha2
+$ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -180,10 +180,6 @@ spec:
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
 
-*Note*: If you run into issues configuring this,
-be sure that the group (`cert-manager.io`) and
-version (`v1alpha2`) match those in the output of
-`kubectl describe crd clusterissuer`.
 This directs cert-manager which CA authority to use to issue the certificate.
 
 Next, update your Ingress resource to provision a certificate and then use it:

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -241,7 +241,7 @@ Name:         demo-example-com
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  certmanager.k8s.io/v1alpha1
+API Version:  certmanager.k8s.io/v1
 Kind:         Certificate
 Metadata:
   Creation Timestamp:  2019-06-21T20:41:54Z
@@ -254,7 +254,7 @@ Metadata:
     Name:                  demo-example-com
     UID:                   261d15d3-9464-11e9-9965-42010a8a01ad
   Resource Version:        19561898
-  Self Link:               /apis/certmanager.k8s.io/v1alpha1/namespaces/default/certificates/demo-example-com
+  Self Link:               /apis/certmanager.k8s.io/v1/namespaces/default/certificates/demo-example-com
   UID:                     014d3f1d-9465-11e9-9965-42010a8a01ad
 Spec:
   Acme:

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -179,7 +179,10 @@ spec:
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```
-
+*Note*: If you run into issues configuring this,
+be sure that the group (`cert-manager.io`) and
+version (`v1`) match those in the output of
+`kubectl describe crd clusterissuer`.
 This directs cert-manager which CA authority to use to issue the certificate.
 
 Next, update your Ingress resource to provision a certificate and then use it:

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -162,7 +162,7 @@ Via: kong/1.1.2
 First, setup a ClusterIssuer for cert-manager
 
 ```bash
-$ echo "apiVersion: cert-manager.io/v1alpha2
+$ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod


### PR DESCRIPTION
### Summary
Update the apiVersion for ClusterIssuer from `cert-manager.io/v1alpha2` to `cert-manager.io/v1` as per https://cert-manager.io/docs/configuration/acme/dns01/route53/#creating-an-issuer-or-clusterissuer
### Reason
The apiVersion `cert-manager.io/v1alpha2` was not recognized when the _ClusterIssuer_ object is created.
![image](https://user-images.githubusercontent.com/52544819/146666355-ebe94722-2c57-4520-b3c2-8208060dfe55.png)


### Testing
Follow the steps in https://docs.konghq.com/kubernetes-ingress-controller/1.3.x/guides/cert-manager/ except use `cert-manager.io/v1` as the apiVersion

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
