### PR TITLE
docs(gateway) fix plugin development guide about update/upsert

### DIFF
--- a/app/enterprise/2.1.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.1.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -548,10 +548,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -575,10 +575,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)
@@ -612,7 +612,7 @@ Example:
 
 ``` lua
 local ok, err = kong.db.keyauth_credentials:delete({
-   id = "2b6a2022-770a-49df-874d-11e2bf2634f5" 
+   id = "2b6a2022-770a-49df-874d-11e2bf2634f5"
 })
 
 if not ok then

--- a/app/enterprise/2.2.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.2.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -548,10 +548,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -575,10 +575,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)
@@ -612,7 +612,7 @@ Example:
 
 ``` lua
 local ok, err = kong.db.keyauth_credentials:delete({
-   id = "2b6a2022-770a-49df-874d-11e2bf2634f5" 
+   id = "2b6a2022-770a-49df-874d-11e2bf2634f5"
 })
 
 if not ok then

--- a/app/enterprise/2.3.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.3.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -548,10 +548,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -575,10 +575,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/enterprise/2.4.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.4.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -548,10 +548,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -575,10 +575,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/enterprise/2.5.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.5.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -548,10 +548,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -575,10 +575,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/gateway-oss/2.0.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.0.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)
@@ -647,7 +647,7 @@ Example:
 
 ``` lua
 local ok, err = kong.db.keyauth_credentials:delete({
-   id = "2b6a2022-770a-49df-874d-11e2bf2634f5" 
+   id = "2b6a2022-770a-49df-874d-11e2bf2634f5"
 })
 
 if not ok then

--- a/app/gateway-oss/2.1.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.1.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)
@@ -647,7 +647,7 @@ Example:
 
 ``` lua
 local ok, err = kong.db.keyauth_credentials:delete({
-   id = "2b6a2022-770a-49df-874d-11e2bf2634f5" 
+   id = "2b6a2022-770a-49df-874d-11e2bf2634f5"
 })
 
 if not ok then

--- a/app/gateway-oss/2.2.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.2.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)
@@ -647,7 +647,7 @@ Example:
 
 ``` lua
 local ok, err = kong.db.keyauth_credentials:delete({
-   id = "2b6a2022-770a-49df-874d-11e2bf2634f5" 
+   id = "2b6a2022-770a-49df-874d-11e2bf2634f5"
 })
 
 if not ok then

--- a/app/gateway-oss/2.3.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.3.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/gateway-oss/2.4.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.4.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/gateway-oss/2.5.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.5.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/gateway/2.6.x/plugin-development/custom-entities.md
+++ b/app/gateway/2.6.x/plugin-development/custom-entities.md
@@ -226,7 +226,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -579,10 +579,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -606,10 +606,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/app/gateway/2.7.x/plugin-development/custom-entities.md
+++ b/app/gateway/2.7.x/plugin-development/custom-entities.md
@@ -586,10 +586,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
   { key = "updated_secret" },
-})
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -613,10 +613,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/archive/enterprise/2.6.x/plugin-development/custom-entities.md
+++ b/archive/enterprise/2.6.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -548,10 +548,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -575,10 +575,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)

--- a/archive/gateway-oss/2.6.x/plugin-development/custom-entities.md
+++ b/archive/gateway-oss/2.6.x/plugin-development/custom-entities.md
@@ -97,7 +97,7 @@ return {
         "created_at"   TIMESTAMP WITHOUT TIME ZONE,
         "col1"         TEXT
       );
-    
+
       DO $$
       BEGIN
         CREATE INDEX IF NOT EXISTS "my_plugin_table_col1"
@@ -115,7 +115,7 @@ return {
         created_at  timestamp,
         col1        text
       );
-      
+
       CREATE INDEX IF NOT EXISTS ON my_plugin_table (col1);
     ]],
   }
@@ -229,7 +229,7 @@ return {
     cache_key             = { "key" },
     generate_admin_api    = true,
     admin_api_name        = "key-auths",
-    admin_api_nested_name = "key-auth",    
+    admin_api_nested_name = "key-auth",
     fields = {
       {
         -- a value to be inserted by the DAO itself
@@ -318,7 +318,7 @@ Here is a description of some top-level properties:
   <td><code>boolean</code> (optional)</td>
   <td>
     When <code>generate_admin_api</code> is enabled the admin api auto-generator uses the <code>name</code>
-    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the 
+    to derive the collection urls for the auto-generated admin api. Sometimes you may want to name the
     collection urls differently from the <code>name</code>. E.g. with DAO <code>keyauth_credentials</code>
     we actually wanted the auto-generator to generate endpoints for this dao with alternate and more
     url-friendly name <code>key-auths</code>, e.g. <code>http://&lt;KONG_ADMIN&gt;/key-auths</code> instead of
@@ -583,10 +583,10 @@ The returned entity will be the entity after the update takes place, or `nil` + 
 The following example modifies the `key` field of an existing credential given the credential's id:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:update({
+local entity, err = kong.db.keyauth_credentials:update(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { key = "updated_secret" },
-})
+  { key = "updated_secret" }
+)
 
 if not entity then
   kong.log.err("Error when updating keyauth credential: " .. err)
@@ -610,10 +610,10 @@ local entity, err, err_t = kong.db.<name>:upsert(primary_key, <values>)
 Given this code:
 
 ``` lua
-local entity, err = kong.db.keyauth_credentials:upsert({
+local entity, err = kong.db.keyauth_credentials:upsert(
   { id = "2b6a2022-770a-49df-874d-11e2bf2634f5" },
-  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } },
-})
+  { consumer = { id = "a96145fb-d71e-4c88-8a5a-2c8b1947534c" } }
+)
 
 if not entity then
   kong.log.err("Error when upserting keyauth credential: " .. err)


### PR DESCRIPTION
### Summary

The update/upsert instructions in the plugin development guide had two extra brackets. This PR removes them from all 2.x versions of enterprise and OSS gateway.

### Reason

Reported by a community user in https://github.com/Kong/kong/discussions/7616.
