### PR TITLE
Fix link in mesh doc

### DIFF
--- a/app/mesh/1.5.x/features/kds-auth.md
+++ b/app/mesh/1.5.x/features/kds-auth.md
@@ -315,4 +315,4 @@ The result looks like:
 
 ## Additional security
 
-By default, a connection from the remote control plane to the global control plane is secured with TLS. You should also configure the remote control plane to [verify the certificate authority (CA) of the global control plane](https://kuma.io/docs/1.0.8/security/certificates/){:target="_blank"}.
+By default, a connection from the remote control plane to the global control plane is secured with TLS. You should also configure the remote control plane to [verify the certificate authority (CA) of the global control plane](https://kuma.io/docs/latest/security/certificates/#control-plane-to-control-plane-multizone){:target="_blank"}.


### PR DESCRIPTION
### Summary
Fixing link to point to latest version of Kuma docs, not a versioned page. 

### Reason
Resolves https://github.com/Kong/docs.konghq.com/issues/3477.

### Testing
Check link in https://deploy-preview-3516--kongdocs.netlify.app/mesh/1.5.x/features/kds-auth/#additional-security.