### PR TITLE
Remove OSS-only label from Debian tile

### DIFF
--- a/app/gateway/2.7.x/install-and-run/index.md
+++ b/app/gateway/2.7.x/install-and-run/index.md
@@ -48,7 +48,6 @@ disable_image_expand: true
   <a href="/gateway/{{page.kong_version}}/install-and-run/debian" class="docs-grid-install-block no-description">
     <img class="install-icon" src="/assets/images/icons/documentation/debian-logo.jpg" alt="" />
     <div class="install-text">Debian
-    <br> <span class="badge oss" aria-label="open-source only"></span>
     </div>
   </a>
 


### PR DESCRIPTION
### Summary
Removing "OSS-only" badge from Debian install tile.

### Reason
As of Gateway 2.7, support for Enterprise installations now exists and is documented.

### Testing
See Debian tile: https://deploy-preview-3520--kongdocs.netlify.app/gateway/2.7.x/install-and-run/