### PR TITLE
[DOCU-1973] Fix attribute and broken formatting in db keyring encryption

### DIFF
--- a/app/enterprise/1.3-x/admin-api/db-encryption.md
+++ b/app/enterprise/1.3-x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 **Response**
@@ -143,7 +143,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/enterprise/1.3-x/admin-api/db-encryption.md
+++ b/app/enterprise/1.3-x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 **Response**

--- a/app/enterprise/1.3-x/admin-api/db-encryption.md
+++ b/app/enterprise/1.3-x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,8 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
-
 
 **Response**
 

--- a/app/enterprise/1.5.x/admin-api/db-encryption.md
+++ b/app/enterprise/1.5.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 **Response**
@@ -143,7 +143,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/enterprise/1.5.x/admin-api/db-encryption.md
+++ b/app/enterprise/1.5.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 **Response**

--- a/app/enterprise/1.5.x/admin-api/db-encryption.md
+++ b/app/enterprise/1.5.x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,8 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
-
 
 **Response**
 

--- a/app/enterprise/2.1.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.1.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 

--- a/app/enterprise/2.1.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.1.x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,7 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/enterprise/2.1.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.1.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -144,7 +144,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/enterprise/2.2.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.2.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 

--- a/app/enterprise/2.2.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.2.x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,7 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/enterprise/2.2.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.2.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -144,7 +144,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/enterprise/2.3.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.3.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 

--- a/app/enterprise/2.3.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.3.x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,7 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/enterprise/2.3.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.3.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -144,7 +144,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/enterprise/2.4.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.4.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 

--- a/app/enterprise/2.4.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.4.x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,7 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/enterprise/2.4.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.4.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -144,7 +144,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/enterprise/2.5.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.5.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 

--- a/app/enterprise/2.5.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.5.x/admin-api/db-encryption.md
@@ -65,7 +65,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -104,7 +103,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/enterprise/2.5.x/admin-api/db-encryption.md
+++ b/app/enterprise/2.5.x/admin-api/db-encryption.md
@@ -101,7 +101,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -144,7 +144,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/gateway/2.6.x/admin-api/db-encryption.md
+++ b/app/gateway/2.6.x/admin-api/db-encryption.md
@@ -102,7 +102,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -145,7 +145,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/gateway/2.6.x/admin-api/db-encryption.md
+++ b/app/gateway/2.6.x/admin-api/db-encryption.md
@@ -66,7 +66,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -105,7 +104,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/gateway/2.7.x/admin-api/db-encryption.md
+++ b/app/gateway/2.7.x/admin-api/db-encryption.md
@@ -102,7 +102,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 
@@ -145,7 +145,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `id`             | 8-byte key identifier.        |
+| `key`             | 8-byte key identifier.        |
 
 
 **Response**

--- a/app/gateway/2.7.x/admin-api/db-encryption.md
+++ b/app/gateway/2.7.x/admin-api/db-encryption.md
@@ -66,7 +66,6 @@ HTTP 200 OK
 ```
 
 ## Import Exported Keyring
->>>>>>> public_repo/master
 
 *This endpoint is only available with the `cluster` keyring strategy.*
 
@@ -105,7 +104,6 @@ HTTP 201 Created
 | ---------        | -----------                   |
 | `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
->>>>>>> public_repo/master
 
 
 **Response**

--- a/app/gateway/2.7.x/admin-api/db-encryption.md
+++ b/app/gateway/2.7.x/admin-api/db-encryption.md
@@ -102,7 +102,7 @@ HTTP 201 Created
 
 | Attribute        | Description                   |
 | ---------        | -----------                   |
-| `key`             | 8-byte key identifier.        |
+| `id`             | 8-byte key identifier.        |
 | `data`           | Base64-encoded keyring export material. |
 
 


### PR DESCRIPTION
### Summary
* Fixing wrong attribute value for `/keyring/remove` from `id` to `key`.
* Fixing broken formatting

### Reason
Broken formatting and wrong attribute name.

### Testing
https://deploy-preview-3521--kongdocs.netlify.app/gateway/2.7.x/admin-api/db-encryption/