### PR TITLE
OIDC plugin: Fix typo in param name

### DIFF
--- a/app/_hub/kong-inc/openid-connect/2.0.x.md
+++ b/app/_hub/kong-inc/openid-connect/2.0.x.md
@@ -77,39 +77,39 @@ description: |
 
   This plugin can be used for authentication in conjunction with the
   [Application Registration](/hub/kong-inc/application-registration) plugin.
-  
+
   ## Important Configuration Parameters
-    
+
   This plugin contains many configuration parameters that might seem overwhelming
   at the start. Here is a list of parameters that you should focus on first:
-    
+
   1. The first parameter you should configure is: `config.issuer`.
-    
+
      This parameter tells the plugin where to find discovery information, and it is
      the only required parameter. You should specify the `realm` or `iss` for this
      parameter if you don't have a discovery endpoint.
-    
+
   2. Next, you should decide what authentication grants you want to use with this
      plugin, so configure: `config.auth_methods`.
-    
+
      That parameter should contain only the grants that you want to
      use; otherwise, you inadvertently widen the attack surface.
-    
+
   3. In many cases, you also need to specify `config.client_id`, and if your identity provider
      requires authentication, such as on a token endpoint, you will need to specify the client
      authentication credentials too, for example `config.client_secret`.
-    
+
   4. If you are using a public identity provider, such as Google, you should limit
      the audience with `config.audience_required` to contain only your `config.client_id`.
      You may also need to adjust `config.audience_claim` in case your identity provider
      uses a non-standard claim (other than `aud` as specified in JWT standard). This is
      because, for example Google, shares the public keys with different clients.
-    
+
   5. If you are using Kong in DB-less mode with the declarative configuration, you
      should set up `config.session_secret` if you are also using the session cookie
      authentication. Otherwise, each of your Nginx workers across all your
      nodes will encrypt and sign the cookies with their own secrets.
-    
+
   In summary, start with the following parameters:
 
   1. `config.issuer`
@@ -184,7 +184,7 @@ params:
       datatype: boolean
       description: |
         Specifies whether the plugin should try to refresh (soon to be) expired access tokens if the
-        plugin has a `refresh_token` available. 
+        plugin has a `refresh_token` available.
     - name: hide_credentials
       required: false
       default: true
@@ -212,7 +212,7 @@ params:
       description: |
         The discovery endpoint (or just the issuer identifier).
         > When using Kong with the database, the discovery information and the JWKS
-        > are cached to the Kong configuration database. 
+        > are cached to the Kong configuration database.
     - name: rediscovery_lifetime
       required: false
       default: 30
@@ -225,9 +225,9 @@ params:
     - name: client_id
       required: false
       value_in_examples: [ "<client-id>" ]
-      default: 
+      default:
       datatype: array of string elements (the plugin supports multiple clients)
-      description: | 
+      description: |
         The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.
         Other settings that are associated with the client are:
         - `config.client_secret`
@@ -240,7 +240,7 @@ params:
         - `config.unauthorized_redirect_uri`
         - `config.forbidden_redirect_uri`
         - `config.unexpected_redirect_uri`
-        
+
         > Use the same array index when configuring related settings for the client.
     - name: client_arg
       required: false
@@ -263,19 +263,19 @@ params:
         - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body
         - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body
         - `none`: do not authenticate
-        
-        > Private keys can be stored in a database, and they are by the default automatically generated 
+
+        > Private keys can be stored in a database, and they are by the default automatically generated
         > in the database. It is also possible to specify private keys with `config.client_jwk` directly
         > in the plugin configuration.
     - name: client_secret
       required: false
       value_in_examples: [ "<client-secret>" ]
-      default: 
+      default:
       datatype: array of string elements (one for each client)
       description: |
         The client secret.
         > Specify one if using `client_secret_*` authentication with the client on
-        > the identity provider endpoints. 
+        > the identity provider endpoints.
     - name: client_jwk
       required: false
       default: "(plugin managed)"
@@ -286,7 +286,7 @@ params:
       required: false
       default: '(client_secret_jwt: "HS256", private_key_jwt: "RS256")'
       datatype: array of string elements (one for each client)
-      description: | 
+      description: |
         The algorithm to use for `client_secret_jwt` (only `HS***`) or `private_key_jwt` authentication:
         - `HS256`: HMAC using SHA-256
         - `HS384`: HMAC using SHA-384
@@ -314,7 +314,7 @@ params:
         - `cookie`: search the HTTP request cookies specified with `config.bearer_token_cookie_name`
     - name: bearer_token_cookie_name
       required: false
-      default: 
+      default:
       datatype: string
       description: The name of the cookie in which the bearer token is passed.
     - name: introspect_jwt_tokens
@@ -357,7 +357,7 @@ params:
         - `body`: search the HTTP request body
     - name: refresh_token_param_name
       required: false
-      default: 
+      default:
       datatype: string
       description: The name of the parameter used to pass the refresh token.
     - group: ID Token
@@ -373,24 +373,24 @@ params:
         - `body`: search the HTTP request body
     - name: id_token_param_name
       required: false
-      default: 
+      default:
       datatype: string
       description: The name of the parameter used to pass the id token.
     - group: Consumer Mapping
       description: Parameters for mapping external identity provider managed identities to Kong managed ones.
     - name: consumer_claim
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The claim used for consumer mapping.
     - name: consumer_by
       required: false
-      default: [ "username", "custom_id" ] 
+      default: [ "username", "custom_id" ]
       datatype: array of string elements
       description: |
         Consumer fields used for mapping:
         - `id`: try to find the matching Consumer by `id`
-        - `username`: try to find the matching Consumer by `username` 
+        - `username`: try to find the matching Consumer by `username`
         - `custom_id`: try to find the matching Consumer by `custom_id`
     - name: consumer_optional
       required: false
@@ -401,7 +401,7 @@ params:
       description: Parameters for mapping external identity provider managed identities to a Kong credential (virtual in this case).
     - name: credential_claim
       required: false
-      default: [ "sub" ] 
+      default: [ "sub" ]
       datatype: array of string elements
       description: The claim used to derive a virtual credential (for instance, for the rate-limiting plugin), in case the Consumer mapping is not used.
     - group: Issuer Verification
@@ -413,7 +413,7 @@ params:
     - group: Authorization
     - name: authenticated_groups_claim
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: |
         The claim that contains authenticated groups. This setting can be used together
@@ -432,7 +432,7 @@ params:
       description: The claim that contains the scopes.
     - name: audience_required
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The audience required to be in the access token.
     - name: audience_claim
@@ -442,7 +442,7 @@ params:
       description: The claim that contains the audience.
     - name: groups_required
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The groups required to be in the access token.
     - name: groups_claim
@@ -452,7 +452,7 @@ params:
       description: The claim that contains the groups.
     - name: roles_required
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The roles required to be in the access token.
     - name: roles_claim
@@ -469,17 +469,17 @@ params:
       description: Verify tokens for standard claims.
     - name: leeway
       required: false
-      default: 0 
+      default: 0
       datatype: integer
       description: Allow some leeway on the ttl / expiry verification.      
     - name: domains
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The allowed values for the `hd` claim.
     - name: max_age
       required: false
-      default: 
+      default:
       datatype: integer
       description: The maximum age (in seconds) compared to the `auth_time` claim.
     - name: jwt_session_claim
@@ -489,7 +489,7 @@ params:
       description: The claim to match against the JWT session cookie.
     - name: jwt_session_cookie
       required: false
-      default: 
+      default:
       datatype: string
       description: The name of the JWT session cookie.
     - group: Signature Verification
@@ -505,7 +505,7 @@ params:
       description: Enable shared secret, for example, HS256, signatures (when disabled they will not be accepted).
     - name: ignore_signature
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: |
         Skip the token signature verification on certain grants:      
@@ -543,12 +543,12 @@ params:
       description: Parameters for the headers for the upstream service request.
     - name: upstream_headers_claims
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The upstream header claims.
     - name: upstream_headers_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The upstream header names for the claim values.
     - name: upstream_access_token_header  
@@ -558,59 +558,59 @@ params:
       description: The upstream access token header.
     - name: upstream_access_token_jwk_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream access token JWK header.
     - name: upstream_id_token_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream id token header.
     - name: upstream_id_token_jwk_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream id token JWK header.
     - name: upstream_refresh_token_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream refresh token header.
     - name: upstream_user_info_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream user info header.
     - name: upstream_user_info_jwt_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream user info JWT header (in case the user info returns a JWT response).
     - name: upstream_introspection_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream introspection header.
     - name: upstream_introspection_jwt_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream introspection header (in case the introspection returns a JWT response).
     - name: upstream_session_id_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The upstream session id header.
-    - group: Downstream Headers 
+    - group: Downstream Headers
       description: Parameters for the headers for the downstream response.
     - name: downstream_headers_claims
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The downstream header claims.
     - name: downstream_headers_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The downstream header names for the claim values.
     - name: downstream_access_token_header  
@@ -620,47 +620,47 @@ params:
       description: The downstream access token header.
     - name: downstream_access_token_jwk_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream access token JWK header.
     - name: downstream_id_token_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream id token header.
     - name: downstream_id_token_jwk_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream id token JWK header.
     - name: downstream_refresh_token_header  
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream refresh token header.
     - name: downstream_user_info_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream user info header.
     - name: downstream_user_info_jwt_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream user info JWT header (in case the user info returns a JWT response).
     - name: downstream_introspection_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream introspection header.
     - name: downstream_introspection_jwt_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream introspection header (in case the introspection returns a JWT response).
     - name: downstream_session_id_header
       required: false
-      default: 
+      default:
       datatype: string
       description: The downstream session id header.
     - group: Cross-Origin Resource Sharing (CORS)
@@ -722,7 +722,7 @@ params:
         Where to redirect the client when `login_action` is set to `redirect`.
         > Tip: Leave this empty and the plugin will redirect the client to the URL that originally initiated the
         > flow with possible query args preserved from the original request when `config.preserve_query_args`
-        > is enabled. 
+        > is enabled.
     - group: Logout
       description: Parameters for triggering logout with the plugin and the actions to take on logout.
     - name: logout_query_arg
@@ -829,7 +829,7 @@ params:
       description: The authorization cookie Path flag.
     - name: authorization_cookie_domain
       required: false
-      default: 
+      default:
       datatype: string
       description: The authorization cookie Domain flag.
     - name: authorization_cookie_samesite
@@ -868,7 +868,7 @@ params:
       description: The session cookie lifetime in seconds.           
     - name: session_cookie_idletime
       required: false
-      default: 
+      default:
       datatype: integer
       description: The session cookie idle time in seconds.           
     - name: session_cookie_renew
@@ -883,12 +883,12 @@ params:
       description: The session cookie Path flag.
     - name: session_cookie_domain
       required: false
-      default: 
+      default:
       datatype: string
       description: The session cookie Domain flag.
     - name: session_cookie_samesite
       required: false
-      default: '"Lax"' 
+      default: '"Lax"'
       datatype: string
       description: |
         Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks:
@@ -922,7 +922,7 @@ params:
       description: The session secret.
     - name: disable_session
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: |
         Disable issuing the session cookie with the specified grants:
@@ -973,7 +973,7 @@ params:
       description: The memcached session key prefix.
     - name: session_memcache_socket
       required: false
-      default: 
+      default:
       datatype: string
       description: The memcached unix socket path.
     - name: session_memcache_host
@@ -994,7 +994,7 @@ params:
       description: The Redis session key prefix.
     - name: session_redis_socket
       required: false
-      default: 
+      default:
       datatype: string
       description: The Redis unix socket path.
     - name: session_redis_host
@@ -1039,17 +1039,17 @@ params:
       description: Verify Redis server certificate.
     - name: session_redis_server_name
       required: false
-      default: 
+      default:
       datatype: string
       description: The SNI used for connecting the Redis server.
     - name: session_redis_cluster_nodes
       required: false
-      default: 
+      default:
       datatype: array of host records
       description: The Redis cluster nodes.
     - name: session_redis_cluster_maxredirections
       required: false
-      default: 
+      default:
       datatype: integer
       description: The Redis cluster maximum redirects.      
     - group: Endpoints
@@ -1127,12 +1127,12 @@ params:
     - group: Discovery Endpoint Arguments
     - name: discovery_headers_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header names passed to the discovery endpoint.
     - name: discovery_headers_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header values passed to the discovery endpoint.  
     - group: Authorization Endpoint Arguments
@@ -1158,72 +1158,72 @@ params:
       description: The scopes passed to the authorization and token endpoints.
     - name: audience
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: The audience passed to the authorization endpoint.
     - name: redirect_uri
       required: false
-      default: "(request uri)" 
+      default: "(request uri)"
       datatype: array of urls (one for each client)
       description: The redirect URI passed to the authorization and token endpoints.
     - name: authorization_query_args_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra query argument names passed to the authorization endpoint.
     - name: authorization_query_args_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
-      description: Extra query argument values passed to the authorization endpoint. 
+      description: Extra query argument values passed to the authorization endpoint.
     - name: authorization_query_args_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra query arguments passed from the client to the authorization endpoint.
     - group: Token Endpoint Arguments
     - name: token_headers_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header names passed to the token endpoint.
     - name: token_headers_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header values passed to the token endpoint.  
     - name: token_headers_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra headers passed from the client to the token endpoint.
     - name: token_post_args_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra post argument names passed to the token endpoint.
     - name: token_post_args_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra post argument values passed to the token endpoint.
     - name: token_post_args_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra post arguments passed from the client to the token endpoint.
     - group: Token Endpoint Response Headers
       description: Parameters for an uncommon use case of sending certain token endpoint headers to the downstream client.
     - name: token_headers_replay
-      default: 
+      default:
       datatype: array of string elements
       description: The names of token endpoint response headers to forward to the downstream client.
     - name: token_headers_prefix
-      default: 
+      default:
       datatype: string
       description: Add a prefix to the token endpoint response headers before forwarding them to the downstream client.
     - name: token_headers_grants
-      default: 
+      default:
       datatype: array of string elements
       description: |
         Enable the sending of the token endpoint response headers only with certain granst:
@@ -1248,32 +1248,32 @@ params:
         - `application/jwt`: introspection response as JWT (from the obsolete IETF draft document)
     - name: introspection_headers_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header names passed to the introspection endpoint.
     - name: introspection_headers_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header values passed to the introspection endpoint.
     - name: introspection_headers_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra headers passed from the client to the introspection endpoint.
     - name: introspection_post_args_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra post argument names passed to the introspection endpoint.
     - name: introspection_post_args_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra post argument values passed to the introspection endpoint.
     - name: introspection_post_args_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra post arguments passed from the client to the introspection endpoint.
     - group: User Info Endpoint Arguments
@@ -1287,32 +1287,32 @@ params:
         - `application/jwt`: user info response as JWT (from the obsolete IETF draft document)
     - name: userinfo_headers_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header names passed to the user info endpoint.
     - name: userinfo_headers_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra header values passed to the user info endpoint.  
     - name: userinfo_headers_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra headers passed from the client to the user info endpoint.
     - name: userinfo_query_args_names
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra query argument names passed to the user info endpoint.
     - name: userinfo_query_args_values
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra query argument values passed to the user info endpoint.
     - name: userinfo_query_args_client
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Extra query arguments passed from the client to the user info endpoint.
     - group: HTTP Client
@@ -1344,27 +1344,27 @@ params:
       description: Parameters only needed if the HTTP(S) requests to identity provider need to go through a proxy server.
     - name: http_proxy
       required: false
-      default: 
+      default:
       datatype: url
       description: The HTTP proxy
     - name: http_proxy_authorization
       required: false
-      default: 
+      default:
       datatype: string
       description: The HTTP proxy authorization.      
     - name: https_proxy
       required: false
-      default: 
+      default:
       datatype: url
       description: The HTTPS proxy
     - name: https_proxy_authorization
       required: false
-      default: 
+      default:
       datatype: string
       description: The HTTPS proxy authorization.      
     - name: no_proxy
       required: false
-      default: 
+      default:
       datatype: array of string elements
       description: Do not use proxy with these hosts.
     - group: Cache TTLs
@@ -1375,12 +1375,12 @@ params:
       description: The default cache ttl in seconds that is used in case the cached object does not specify the expiry.
     - name: cache_ttl_max
       required: false
-      default: 
+      default:
       datatype: integer
       description: The maximum cache ttl in seconds (enforced).
     - name: cache_ttl_min
       required: false
-      default: 
+      default:
       datatype: integer
       description: The minimum cache ttl in seconds (enforced).
     - name: cache_ttl_neg
@@ -1517,7 +1517,7 @@ Here is an example of JWK record generated by the plugin itself (see: [JSON Web 
 
 ```json
 {{ page.jwk }}
-``` 
+```
 
 ### Host Record
 
@@ -1528,7 +1528,7 @@ Here is an example of Host record:
 
 ```json
 {{ page.host }}
-``` 
+```
 
 ## Admin API
 
@@ -1645,7 +1645,7 @@ HTTP 200 OK
 
 <div class="endpoint delete indent">/openid-connect/jwks</div>
 
-Deleting JWKS will also cause auto-generation of a new JWK set, so 
+Deleting JWKS will also cause auto-generation of a new JWK set, so
 `DELETE` will actually cause a key rotation.
 
 ##### Response
@@ -1690,7 +1690,7 @@ difficulties during this phase, please refer to the [Keycloak documentation](htt
 3. Create verified user `john` with the non-temporary password `doe` that we can use with the password grant:
    <br><br>
    <img src="/assets/images/docs/openid-connect/keycloak-user-john.png">
-   
+
 Alternatively you can [download the exported Keycloak configuration](/assets/images/docs/openid-connect/keycloak.json),
 and use it to configure the Keycloak. Please refer to [Keycloak import documentation](https://www.keycloak.org/docs/latest/server_admin/#_export_import)
 for more information.
@@ -1884,10 +1884,10 @@ HTTP/1.1 200 OK
 
 1. Open the Service Page with some query arguments:
    ```bash
-   open http://service.test:8000/?hello=world 
+   open http://service.test:8000/?hello=world
    ```
    <img src="/assets/images/docs/openid-connect/authorization-code-flow-1.png">
-   
+
 2. See that the browser is redirected to the Keycloak login page:
    <br><br>
    <img src="/assets/images/docs/openid-connect/authorization-code-flow-2.png">
@@ -1897,7 +1897,7 @@ HTTP/1.1 200 OK
    <br><br>
    <img src="/assets/images/docs/openid-connect/authorization-code-flow-3.png">
 4. Done.
-   
+
 It looks rather simple from the user point of view, but what really happened is
 described in [the diagram](#authorization-code-flow) above.
 
@@ -1962,7 +1962,7 @@ HTTP/1.1 200 OK
    }   
    ```
 2. Done.
-   
+
 > If you make another request using the same credentials, you should see that Kong adds less
 > latency to the request as it has cached the token endpoint call to Keycloak.
 
@@ -2029,7 +2029,7 @@ HTTP/1.1 200 OK
    }   
    ```
 2. Done.
-   
+
 > If you make another request using the same credentials, you should see that Kong adds less
 > latency to the request as it has cached the token endpoint call to Keycloak.
 
@@ -2150,7 +2150,7 @@ Let's patch the plugin that we created in the [Kong configuration](#kong-configu
 http -f patch :8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
   config.bearer_token_param_type=header                          \
   config.auth_methods=bearer                                     \
-  config.auth_methods=password # only enabled for demoing purposes 
+  config.auth_methods=password # only enabled for demoing purposes
 ```
 ```http
 HTTP/1.1 200 OK
@@ -2328,7 +2328,7 @@ HTTP/1.1 200 OK
             "userinfo",
             "password"
         ],
-        "bearer_token_param_type": [ "header" ] 
+        "bearer_token_param_type": [ "header" ]
     }
 }
 ```
@@ -2411,7 +2411,7 @@ or [introspection authentication](#introspection-authentication):
        "token_type": "bearer"
    }
    ```
-   
+
 At this point we should be able to retrieve a new access token with:
 
 ```bash
@@ -2425,7 +2425,7 @@ Output:
 ```
 <access-token>
 ```
-   
+
 #### Patch the Plugin
 
 Let's patch the plugin that we created in the [Kong configuration](#kong-configuration) step:
@@ -2540,7 +2540,7 @@ HTTP/1.1 200 OK
 1. Request the service with basic authentication credentials (created in the [Keycloak configuration](#keycloak-configuration) step),
    and store the session:
    ```bash
-   http -v -a john:doe --session=john :8000 
+   http -v -a john:doe --session=john :8000
    ```
    ```http
    GET / HTTP/1.1
@@ -2738,7 +2738,7 @@ HTTP/1.1 403 Forbidden
 }
 ```
 
-A few words about `config.scopes_claim` and `config.scores_required` (and the similar configuration options).
+A few words about `config.scopes_claim` and `config.scopes_required` (and the similar configuration options).
 You may have noticed that `config.scopes_claim` is an array of string elements. Why? It is used to traverse
 the JSON when looking up a claim, take for example this imaginary payload:
 
@@ -2915,7 +2915,7 @@ HTTP/1.1 403 Forbidden
 The third option for authorization is to use Kong consumers and dynamically map
 from a claim value to a Kong consumer. This means that we restrict the access to
 only those that do have a matching Kong consumer. Kong consumers can have ACL
-groups attached to them and be further authorized with the 
+groups attached to them and be further authorized with the
 [Kong ACL Plugin](/hub/kong-inc/acl/).
 
 As a remainder our token payload looks like this:
@@ -3032,7 +3032,7 @@ in `Authorization: Bearer <access-token>` header to the upstream service (this c
 `config.upstream_access_token_header`). The claim values can be taken from:
 - an access token,
 - an id token,
-- an introspection response, or 
+- an introspection response, or
 - a user info response
 
 Let's take a look for an access token payload:
@@ -3096,7 +3096,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-See the [configuration parameters](#parameters) for other options. 
+See the [configuration parameters](#parameters) for other options.
 
 ## Logout
 

--- a/app/_hub/kong-inc/openid-connect/2.1.x.md
+++ b/app/_hub/kong-inc/openid-connect/2.1.x.md
@@ -2803,7 +2803,7 @@ HTTP/1.1 403 Forbidden
 }
 ```
 
-A few words about `config.scopes_claim` and `config.scores_required` (and the similar configuration options).
+A few words about `config.scopes_claim` and `config.scopes_required` (and the similar configuration options).
 You may have noticed that `config.scopes_claim` is an array of string elements. Why? It is used to traverse
 the JSON when looking up a claim, take for example this imaginary payload:
 

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -2811,7 +2811,7 @@ HTTP/1.1 403 Forbidden
 }
 ```
 
-A few words about `config.scopes_claim` and `config.scores_required` (and the similar configuration options).
+A few words about `config.scopes_claim` and `config.scopes_required` (and the similar configuration options).
 You may have noticed that `config.scopes_claim` is an array of string elements. Why? It is used to traverse
 the JSON when looking up a claim, take for example this imaginary payload:
 
@@ -3321,7 +3321,7 @@ mean other gateways, load balancers, NATs, and such in front of Kong. If there i
 ### 2.2.0
 
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled,
- the `config.client_id`, `config.client_secret`, `config.session_auth`, and 
+ the `config.client_id`, `config.client_secret`, `config.session_auth`, and
  `config.session_redis_auth` parameter values will be encrypted.
 
   Additionally, the `d`, `p`, `q`, `dp`, `dq`, `qi`, `oth`, `r`, `t`, and `k`


### PR DESCRIPTION
### Summary
Fixing typo.

### Reason
Typo, should be `config.scopes_required` instead of `scores`. Reported on Slack.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
