### PR TITLE
[DOCU-2035] Badge tooltips

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -683,3 +683,34 @@ $(".closebanner").on("click", function () {
   $(".navbar-v2").addClass("closed");
   localStorage.setItem("closebanner-hackathon", "closebanner");
 });
+
+
+jQuery(function () {
+    // $(".badge").wrap( "<div class='tooltip'></div>" );
+    // // $(".badge").addClass("tooltiptext");
+
+
+  // $(".badge").addClass("tooltip");
+
+    $(".badge.enterprise").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" );
+    $(".badge.plus").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" );
+    $(".badge.free").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" );
+    $(".badge.oss").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available in open-source only'></div></div>" );
+    $(".badge.dbless").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" );
+
+    //
+    // $( "<div class='tooltip'></div>" ).insertAfter(".badge");
+    // // $(".badge").addClass("tooltiptext");
+
+    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" ).insertAfter(".badge.enterprise");
+    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" ).insertAfter(".badge.plus");
+    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" ).insertAfter(".badge.free");
+    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available in open-source only'></div></div>" ).insertAfter(".badge.oss");
+    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" ).insertAfter(".badge.dbless");
+
+    // $( "<div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" ).insertAfter(".badge.enterprise");
+    // $( "<div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" ).insertAfter(".badge.plus");
+    // $( "<div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" ).insertAfter(".badge.free");
+    // $( "<div class='tooltiptext' data-title='Available in open-source only'></div></div>" ).insertAfter(".badge.oss");
+    // $( "<div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" ).insertAfter(".badge.dbless");
+});

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -686,11 +686,9 @@ $(".closebanner").on("click", function () {
 
 
 jQuery(function () {
-    // $(".badge").wrap( "<div class='tooltip'></div>" );
-    // // $(".badge").addClass("tooltiptext");
 
-
-  // $(".badge").addClass("tooltip");
+  // Attempt #3 at applying classes to badges: this approach adds two divs,
+  // tooltip and tooltiptext, inside whichever element has a badge
 
     $(".badge.enterprise").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" );
     $(".badge.plus").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" );
@@ -698,15 +696,20 @@ jQuery(function () {
     $(".badge.oss").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available in open-source only'></div></div>" );
     $(".badge.dbless").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" );
 
-    //
-    // $( "<div class='tooltip'></div>" ).insertAfter(".badge");
-    // // $(".badge").addClass("tooltiptext");
+  // Attempt #2: Add two divs, tooltip and tooltiptext, after (not inside)
+  // whichever element has a badge
 
     // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" ).insertAfter(".badge.enterprise");
     // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" ).insertAfter(".badge.plus");
     // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" ).insertAfter(".badge.free");
     // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available in open-source only'></div></div>" ).insertAfter(".badge.oss");
     // $( "<div class='tooltip'><div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" ).insertAfter(".badge.dbless");
+
+  // Attempt #1: Wrap the element with a .badge class with one div, tooltip
+  // Apply a tooltiptext class to the same element that already has a badge class
+
+    // $(".badge").wrap( "<div class='tooltip'></div>" );
+    // $(".badge").addClass("tooltiptext");
 
     // $( "<div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" ).insertAfter(".badge.enterprise");
     // $( "<div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" ).insertAfter(".badge.plus");

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -685,35 +685,16 @@ $(".closebanner").on("click", function () {
 });
 
 
+// Tooltips for badges
 jQuery(function () {
-
-  // Attempt #3 at applying classes to badges: this approach adds two divs,
-  // tooltip and tooltiptext, inside whichever element has a badge
-
-    $(".badge.enterprise").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" );
-    $(".badge.plus").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" );
-    $(".badge.free").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" );
-    $(".badge.oss").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Available in open-source only'></div></div>" );
-    $(".badge.dbless").prepend( "<div class='tooltip'><div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" );
-
-  // Attempt #2: Add two divs, tooltip and tooltiptext, after (not inside)
-  // whichever element has a badge
-
-    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" ).insertAfter(".badge.enterprise");
-    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" ).insertAfter(".badge.plus");
-    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" ).insertAfter(".badge.free");
-    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Available in open-source only'></div></div>" ).insertAfter(".badge.oss");
-    // $( "<div class='tooltip'><div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" ).insertAfter(".badge.dbless");
-
-  // Attempt #1: Wrap the element with a .badge class with one div, tooltip
-  // Apply a tooltiptext class to the same element that already has a badge class
-
-    // $(".badge").wrap( "<div class='tooltip'></div>" );
-    // $(".badge").addClass("tooltiptext");
-
-    // $( "<div class='tooltiptext' data-title='Available with Enterprise subscription'></div></div>" ).insertAfter(".badge.enterprise");
-    // $( "<div class='tooltiptext' data-title='Available with Plus subscription (Konnect Cloud)'></div></div>" ).insertAfter(".badge.plus");
-    // $( "<div class='tooltiptext' data-title='Available in Free mode (not open-source)'></div></div>" ).insertAfter(".badge.free");
-    // $( "<div class='tooltiptext' data-title='Available in open-source only'></div></div>" ).insertAfter(".badge.oss");
-    // $( "<div class='tooltiptext' data-title='Compatible with DB-less deployments'></div></div>" ).insertAfter(".badge.dbless");
+    $('.badge.enterprise')
+      .append( '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription</span></div>' );
+    $('.badge.plus')
+      .append( '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Konnect Cloud)</span></div>' );
+    $('.badge.free')
+      .append( '<div class="tooltip"><span class="tooltiptext">Available in Free mode (not open-source)</span></div>' );
+    $('.badge.oss')
+      .append( '<div class="tooltip"><span class="tooltiptext" >Available in open-source only</span></div>' );
+    $('.badge.dbless')
+      .append( '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>' );
 });

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -692,9 +692,9 @@ jQuery(function () {
     $('.badge.plus')
       .append( '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Konnect Cloud)</span></div>' );
     $('.badge.free')
-      .append( '<div class="tooltip"><span class="tooltiptext">Available in Free mode (not open-source)</span></div>' );
+      .append( '<div class="tooltip"><span class="tooltiptext">Available in Enterprise Free mode (without a license)</span></div>' );
     $('.badge.oss')
-      .append( '<div class="tooltip"><span class="tooltiptext" >Available in open-source only</span></div>' );
+      .append( '<div class="tooltip"><span class="tooltiptext" >Available in Kong open-source only</span></div>' );
     $('.badge.dbless')
       .append( '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>' );
 });

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -1,23 +1,23 @@
 .badge {
+  display: inline-flex;
   &:after {
-      display: inline-flex;
-      font-weight: 500;
-      font-size: 12px;
+      display: inline-block;
+      font-weight: 600;
+      font-size: 11px;
       vertical-align: middle;
       text-align: center;
       max-width: 200px;
-      line-height: 14px;
-      height: 14px;
+      line-height: 15px;
+      height: 15px;
       width: auto;
-      padding: 3px 10px;
+      padding: 2px 8px;
       font-family: @family-display;
       border-radius: 10px;
-      margin-left: 7px;
-    }
+      position: relative;
+  }
 
   &.plus::after {
       content: "PLUS";
-      opacity: 0.8;
       color: white;
       border-color: @blue-500;
       background-color: @blue-500;
@@ -26,14 +26,12 @@
   &.enterprise::after {
       content: "ENTERPRISE";
       color: white;
-      opacity: 0.8;
       border-color: @black-80;
       background-color: @black-80;
     }
 
   &.free::after {
       content: "FREE";
-      // opacity: 0.8;
       color: black;
       border-color: @black-20;
       background-color: @black-20;
@@ -41,7 +39,6 @@
 
   &.dbless::after {
       content: "DB-LESS COMPATIBLE";
-      opacity: 0.8;
       color: white;
       border-color: @green-500;
       background-color: @green-500;
@@ -49,7 +46,6 @@
 
   &.beta::after {
       content: "BETA";
-      opacity: 0.7;
       color: white;
       border-color: @red-700;
       background-color: @red-700;
@@ -58,25 +54,132 @@
 
   &.oss::after {
       content: "OSS ONLY";
-      opacity: 0.7;
       color: white;
       border-color: #6e30bf;
       background-color: #6e30bf;
       text-align: center;
     }
+
+
+  // Tooltip container
+  .tooltip {
+    position: relative;
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    visibility: hidden;
+  }
+
+  // Tooltip text styling
+  &:hover {
+    .tooltiptext[data-title]:after {
+      font-family: @family-display;
+      content: attr(data-title);
+      display: block;
+      font-size: 13px;
+      font-weight: 400;
+      line-height: 20px;
+      left: 0;
+      top: 100%;
+      margin-top: 0.5rem;
+      color: #fff;
+      width: 150px;
+      background-color: @black-80;
+      text-align: center;
+      padding: 5px;
+      border-radius: 4px;
+      position: absolute;
+      z-index: 10;
+      visibility: visible;
+    }
+  }
 }
 
 span.badge {
   vertical-align: text-bottom;
+}
 
-  &:after {
-    margin: 2px;
-  }
+h2.badge, h3.badge, h4.badge, h5.badge {
+    &:after {
+      margin-left: 7px;
+    }
+
+    // &:hover {
+    //   .tooltiptext[data-title]:before {
+    //     font-weight: 400;
+    //     font-size: 13px;
+    //   }
+    // }
 }
 
 a.badge {
   &:hover, &:focus {
-    opacity: 0.7;
+    opacity: 0.9;
     text-decoration: none;
+  }
+}
+
+// Tooltips in tables; for the last table row, the tooltip moves to the right of
+// the element so that the table doesn't add a scrollbar
+table > tbody > tr {
+  td {
+      .badge {
+        .tooltip {
+          vertical-align: bottom;
+          right: 0;
+        }
+        &:hover {
+        .tooltiptext[data-title]:after {
+          bottom: 140%;
+          vertical-align: top;
+          left: unset;
+          margin-left: 2px;
+          margin-bottom: -5px;
+          top: unset;
+          }
+        }
+      }
+    }
+  //
+  // &:last-of-type {
+  //   .badge {
+  //     &:hover {
+  //       .tooltiptext[data-title]:before {
+  //         left: 100%;
+  //         bottom: 0;
+  //         top: -100%;
+  //         margin-left: 2px;
+  //         }
+  //       }
+  //     }
+  //   }
+  }
+
+// Tooltips in h1 elements (page titles)
+h1 {
+  .badge {
+    &:hover {
+      .tooltiptext[data-title]:after {
+      margin-top: 0.2rem;
+      }
+    }
+  }
+}
+
+// Tooltips in the plugin hub doc sidebar
+.about-extn-table {
+  .badge {
+      .tooltip {
+        vertical-align: top;
+      }
+
+    &:hover {
+      .tooltiptext[data-title]:after {
+        top: unset;
+        bottom: unset;
+        left: unset;
+        right: unset;
+      }
+    }
   }
 }

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -61,38 +61,37 @@
     }
 
 
-  // Tooltip container
-  .tooltip {
-    position: relative;
-    display: inline-block;
-    margin: 0;
-    padding: 0;
-    visibility: hidden;
-  }
+    // Tooltip container
+    .tooltip {
+      position: relative;
+      display: inline-block;
+      padding: 0;
+    }
 
-  // Tooltip text styling
-  &:hover {
-    .tooltiptext[data-title]:after {
+    // Tooltip text styling
+    .tooltiptext {
       font-family: @family-display;
-      content: attr(data-title);
-      display: block;
+      width: 150px;
+      display: none;
       font-size: 13px;
       font-weight: 400;
       line-height: 20px;
-      left: 0;
-      top: 100%;
-      margin-top: 0.5rem;
+      margin-top: 0.1rem;
       color: #fff;
-      width: 150px;
+      top: 100%;
       background-color: @black-80;
       text-align: center;
       padding: 5px;
       border-radius: 4px;
       position: absolute;
       z-index: 10;
-      visibility: visible;
     }
-  }
+
+    &:hover {
+       .tooltiptext {
+        display: block;
+      }
+    }
 }
 
 span.badge {
@@ -104,12 +103,26 @@ h2.badge, h3.badge, h4.badge, h5.badge {
       margin-left: 7px;
     }
 
-    // &:hover {
-    //   .tooltiptext[data-title]:before {
-    //     font-weight: 400;
-    //     font-size: 13px;
-    //   }
-    // }
+  &:hover {
+    .tooltiptext {
+      top: 70%;
+      left: 7px;
+    }
+  }
+}
+
+// badges and tooltips on page titles
+h1.badge {
+    &:after {
+      margin-left: 7px;
+    }
+
+  &:hover {
+    .tooltiptext {
+      right: 0;
+      top: 0;
+    }
+  }
 }
 
 a.badge {
@@ -122,63 +135,25 @@ a.badge {
 // Tooltips in tables; for the last table row, the tooltip moves to the right of
 // the element so that the table doesn't add a scrollbar
 table > tbody > tr {
-  td {
-      .badge {
-        .tooltip {
-          vertical-align: bottom;
-          right: 0;
-        }
-        &:hover {
-        .tooltiptext[data-title]:after {
-          bottom: 140%;
-          vertical-align: top;
-          left: unset;
-          margin-left: 2px;
-          margin-bottom: -5px;
+  &:last-of-type {
+    .badge {
+      &:hover {
+        .tooltiptext {
+          left: 100%;
+          bottom: 105%;
           top: unset;
           }
         }
       }
     }
-  //
-  // &:last-of-type {
-  //   .badge {
-  //     &:hover {
-  //       .tooltiptext[data-title]:before {
-  //         left: 100%;
-  //         bottom: 0;
-  //         top: -100%;
-  //         margin-left: 2px;
-  //         }
-  //       }
-  //     }
-  //   }
   }
-
-// Tooltips in h1 elements (page titles)
-h1 {
-  .badge {
-    &:hover {
-      .tooltiptext[data-title]:after {
-      margin-top: 0.2rem;
-      }
-    }
-  }
-}
 
 // Tooltips in the plugin hub doc sidebar
 .about-extn-table {
   .badge {
-      .tooltip {
-        vertical-align: top;
-      }
-
     &:hover {
-      .tooltiptext[data-title]:after {
-        top: unset;
-        bottom: unset;
-        left: unset;
-        right: unset;
+      .tooltiptext {
+        left: -50px;
       }
     }
   }

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -858,6 +858,7 @@ Generic Styling for Desktop
     max-width: 100%;
     font-size: 16px;
     overflow-x: auto;
+    overflow-y: visible;
     border: none;
     border-collapse: collapse;
     border-radius: 3px;
@@ -905,10 +906,7 @@ Generic Styling for Desktop
     border-bottom: 2px solid @steel-200;
     border-top: none;
     position: -webkit-sticky;
-    position: sticky;
     vertical-align: bottom;
-    top: 0;
-    z-index: 2;
     text-transform: uppercase;
   }
 

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -858,7 +858,6 @@ Generic Styling for Desktop
     max-width: 100%;
     font-size: 16px;
     overflow-x: auto;
-    overflow-y: visible;
     border: none;
     border-collapse: collapse;
     border-radius: 3px;


### PR DESCRIPTION
### Summary
Adding tooltips to `FREE`, `ENTERPRISE`, `PLUS`, `OSS ONLY`, and `DB-LESS COMPATIBLE` badges. 

Didn't add a tooltip for the `BETA` badge, as I couldn't figure out what to say that wasn't obvious from the badge label.

### Reason
Lots of confusion around the meaning of the badge labels, particularly the FREE and PLUS badges. 

### Testing
Test in various scenarios:

* In-text labels, for example (need to adjust top margin): [Gateway intro](https://deploy-preview-3523--kongdocs.netlify.app/gateway/)

* H1 headers (page titles): [plugin page](https://deploy-preview-3523--kongdocs.netlify.app/hub/kong-inc/application-registration/) and [main doc page](https://deploy-preview-3523--kongdocs.netlify.app/gateway/2.7.x/vitals/vitals-reports/)

* Tables in main content body, for example in the [contributing guidelines](https://deploy-preview-3523--kongdocs.netlify.app/contributing/markdown-rules/#badges) - last item in table should fit
  
* Tables in plugin sidebar. For example, see the sidebar on [this plugin](https://deploy-preview-3523--kongdocs.netlify.app/hub/kong-inc/application-registration/) (scroll on the right nav)
  