### PR TITLE
Use Netlify _redirects for aliases

### DIFF
--- a/app/_plugins/alias_generator.rb
+++ b/app/_plugins/alias_generator.rb
@@ -1,4 +1,4 @@
-# Alias Generator for Posts.
+# Alias Generator for Posts using Netlify _redirects
 #
 # Generates redirect pages for posts with aliases set in the YAML Front Matter.
 #
@@ -21,34 +21,28 @@
 #     alias: [/first-alias/index.html, /second-alias/index.html]
 #   ---
 #
-# Author: Thomas Mango
-# Site: http://thomasmango.com
-# Plugin Source: http://github.com/tsmango/jekyll_alias_generator
-# Site Source: http://github.com/tsmango/tsmango.github.com
-# Plugin License: MIT
+# Author: Michael Heap
+# Site: http://michaelheap.com
 
 module Jekyll
 
   class AliasGenerator < Generator
 
     def generate(site)
-      @site = site
-      @generated = {}
+      @redirects = []
 
-      process_posts
-      process_pages
-    end
-
-    def process_posts
-      @site.posts.docs.each do |post|
-        generate_aliases(post.url, post.data['alias'])
-      end
-    end
-
-    def process_pages
-      @site.pages.each do |page|
+      site.pages.each do |page|
         generate_aliases(page.destination('').gsub(/index\.(html|htm)$/, ''), page)
       end
+
+      # Read existing _redirects file
+      existing = File.read("#{__dir__}/../_redirects").to_s + "\n"
+
+      # Write out a _redirects file
+      page = PageWithoutAFile.new(site, __dir__, '', '_redirects')
+      page.content = existing + @redirects.join("\n")
+      page.data['layout'] = nil
+      site.pages << page
     end
 
     def generate_aliases(destination_path, page)
@@ -56,102 +50,19 @@ module Jekyll
       alias_paths ||= Array.new
       alias_paths << aliases
       alias_paths.compact!
+      alias_paths.flatten!
 
-      alias_paths.flatten.each do |alias_path|
+      alias_paths.each do |alias_path|
         alias_path = alias_path.to_s
-
-        alias_dir = File.extname(alias_path).empty? ? alias_path : File.dirname(alias_path)
-        alias_file = File.extname(alias_path).empty? ? "index.html" : File.basename(alias_path)
-
-        fs_path_to_dir = File.join(@site.dest, alias_dir)
-        alias_index_path = File.join(alias_dir, alias_file)
-
-        FileUtils.mkdir_p(fs_path_to_dir)
-
-        File.open(File.join(fs_path_to_dir, alias_file), "w") do |file|
-          file.write(alias_template(page, destination_path))
-        end
-
-        (alias_index_path.split("/").size).times do |sections|
-          target = alias_index_path.split("/")[1, sections + 1].join("/")
-          target_version = page.data["kong_versions"].last["release"]
-
-          # We only want to generate each alias once
-
-          # This code snippet works by generating a redirect for every segment of a URL
-          # e.g. enterprise/2.4.x/developer-portal/using-the-editor/ will generate:
-          # enterprise/latest => enterprise/2.4.x
-          # enterprise/latest/developer-portal => enterprise/2.4.x/developer-portal
-          # enterprise/latest/developer-portal/using-the-editor => enterprise/2.4.x/developer-portal/using-the-editor
-
-          # This works until you have two pages with a common base URL such as:
-          # enterprise/2.4.x/developer-portal/working-with-templates/index.html
-          # enterprise/2.4.x/developer-portal/using-the-editor/
-
-          # In this instance, enterprise/2.4.x/developer-portal will be generated twice
-          # and jekyll will complain with the following error:
-          # Conflict: The following destination is shared by multiple files
-
-          # To resolve this, we keep track of all URLs we generate a redirect for and skip
-          # the generation if the version they're pointing to are the same
-
-          # If two redirects point to different versions, we raise an error as this
-          # should never happen
-
-          # If the versions match, skip generation
-          next if @generated[target] && target_version == @generated[target]
-
-          # Otherwise error if the two versions are different
-          raise "Two pages point to different versions: #{target} (#{target_version} and #{@generated[target]})" if @generated[target]
-
-          @generated[target] = target_version
-          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, target, "")
+        if page.data['permalink']
+          # Pages with a permalink set can have a redirect added directly
+          @redirects.push("#{alias_path}\t#{page.data['permalink']}")
+        else
+          # Pages where we replace /latest/ with the latest release version
+          new_url = alias_path.gsub("latest", page.data["kong_versions"].last["release"])
+          @redirects.push("#{alias_path}\t#{new_url}")
         end
       end
-    end
-
-    def alias_template(page, destination_path)
-      <<-EOF
-<!DOCTYPE html>
-<html>
-  <head>
-    <link rel="canonical" href="#{destination_path}"/>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <noscript><meta http-equiv="refresh" content="0;url=#{destination_path}" /></noscript>
-  </head>
-  <body>
-  Redirecting...
-  <script>
-    var latest = '#{page.data["kong_versions"].last["release"]}';
-    var destination = window.location.pathname.replace(/latest/i, latest);
-    var urlsplit = window.location.href.split('latest');
-
-    if ( urlsplit && urlsplit.length > 0 && (urlsplit[1] === '/' || typeof urlsplit[1] === 'undefined') ) {
-      window.location.href = '#{page.data["permalink"]}';
-    } else {
-      window.location.href = destination + (window.location.hash || '');
-    }
-
-  </script>
-  </body>
-</html>
-      EOF
-    end
-  end
-
-  class AliasFile < StaticFile
-    require 'set'
-
-    def destination(dest)
-      File.join(dest, @dir)
-    end
-
-    def modified?
-      return false
-    end
-
-    def write(dest)
-      return true
     end
   end
 end

--- a/app/_plugins/versions.rb
+++ b/app/_plugins/versions.rb
@@ -165,10 +165,9 @@ module Jekyll
         if templateName == "index.md"
           # the / page
           page.data["permalink"] = "#{urlPath}/"
-          page.data["alias"] = ["#{urlPath}/latest", "#{urlPath}/#{latestRelease}/index.html"]
+          page.data["alias"] = ["#{urlPath}/latest", "#{urlPath}/#{latestRelease}", "#{urlPath}/#{latestRelease}/index.html"]
         elsif /index\.(md|html)/.match(parts.last)
           # all other nested index pages
-          # /latest/plugin-development/index/index.html -> /latest/plugin-development/index.html
           page.data["alias"] = page.data["alias"].sub(/index/, "")
         end
       end

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -73,9 +73,6 @@ extensions:
     # - name: dev portal extension
     #   slug: dev-mod
 
-include:
-  - _redirects
-
 exclude:
   - node_modules
   - jekyll-cache

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -73,9 +73,6 @@ extensions:
     # - name: dev portal extension
     #   slug: dev-mod
 
-include:
-  - _redirects
-
 # location vars
 icons_dir: assets/images/icons
 


### PR DESCRIPTION
### Summary
This PR updates our alias generator to add an entry to the Netlify _redirects file instead of writing out a file with Javascript to redirect

### Reason
Broken link checking can't follow JavaScript redirects, so we need to switch to HTTP redirects

### Testing
Try out a page that gets redirected by an alias. Here's a list from production:

```

/kubernetes-ingress-controller/latest/deployment/admission-webhook	/kubernetes-ingress-controller/2.1.x/deployment/admission-webhook
/kubernetes-ingress-controller/latest/deployment/aks	/kubernetes-ingress-controller/2.1.x/deployment/aks
/kubernetes-ingress-controller/latest/references/annotations	/kubernetes-ingress-controller/2.1.x/references/annotations
/kubernetes-ingress-controller/latest/guides/cert-manager	/kubernetes-ingress-controller/2.1.x/guides/cert-manager
/kubernetes-ingress-controller/latest/references/cli-arguments	/kubernetes-ingress-controller/2.1.x/references/cli-arguments
/kubernetes-ingress-controller/latest/guides/configure-acl-plugin	/kubernetes-ingress-controller/2.1.x/guides/configure-acl-plugin
/kubernetes-ingress-controller/latest/guides/configuring-custom-entities	/kubernetes-ingress-controller/2.1.x/guides/configuring-custom-entities
/kubernetes-ingress-controller/latest/guides/configuring-fallback-service	/kubernetes-ingress-controller/2.1.x/guides/configuring-fallback-service
/kubernetes-ingress-controller/latest/guides/configuring-health-checks	/kubernetes-ingress-controller/2.1.x/guides/configuring-health-checks
/kubernetes-ingress-controller/latest/guides/configuring-https-redirect	/kubernetes-ingress-controller/2.1.x/guides/configuring-https-redirect
/kubernetes-ingress-controller/latest/concepts/custom-resources	/kubernetes-ingress-controller/2.1.x/concepts/custom-resources
/kubernetes-ingress-controller/latest/references/custom-resources	/kubernetes-ingress-controller/2.1.x/references/custom-resources
/gateway/latest/admin-api/db-encryption	/gateway/2.7.x/admin-api/db-encryption
/kubernetes-ingress-controller/latest/concepts/deployment	/kubernetes-ingress-controller/2.1.x/concepts/deployment
/kubernetes-ingress-controller/latest/concepts/design	/kubernetes-ingress-controller/2.1.x/concepts/design
/kubernetes-ingress-controller/latest/deployment/eks	/kubernetes-ingress-controller/2.1.x/deployment/eks
/kubernetes-ingress-controller/latest/faq	/kubernetes-ingress-controller/2.1.x/faq
/kubernetes-ingress-controller/latest/guides/getting-started-istio	/kubernetes-ingress-controller/2.1.x/guides/getting-started-istio
/kubernetes-ingress-controller/latest/guides/getting-started	/kubernetes-ingress-controller/2.1.x/guides/getting-started
/kubernetes-ingress-controller/latest/deployment/gke	/kubernetes-ingress-controller/2.1.x/deployment/gke
/kubernetes-ingress-controller/latest/concepts/ha-and-scaling	/kubernetes-ingress-controller/2.1.x/concepts/ha-and-scaling
/kubernetes-ingress-controller/latest	/kubernetes-ingress-controller/
/kubernetes-ingress-controller/2.1.x	/kubernetes-ingress-controller/
/kubernetes-ingress-controller/2.1.x/index.html	/kubernetes-ingress-controller/
/gateway/latest/install-and-run/	/gateway/2.7.x/install-and-run/
/kubernetes-ingress-controller/latest/concepts/ingress-classes	/kubernetes-ingress-controller/2.1.x/concepts/ingress-classes
/kubernetes-ingress-controller/latest/concepts/ingress-versions	/kubernetes-ingress-controller/2.1.x/concepts/ingress-versions
/kubernetes-ingress-controller/latest/deployment/k4k8s-enterprise	/kubernetes-ingress-controller/2.1.x/deployment/k4k8s-enterprise
/kubernetes-ingress-controller/latest/concepts/k4k8s-with-kong-enterprise	/kubernetes-ingress-controller/2.1.x/concepts/k4k8s-with-kong-enterprise
/kubernetes-ingress-controller/latest/deployment/k4k8s	/kubernetes-ingress-controller/2.1.x/deployment/k4k8s
/kubernetes-ingress-controller/latest/deployment/kong-enterprise	/kubernetes-ingress-controller/2.1.x/deployment/kong-enterprise
/kubernetes-ingress-controller/latest/deployment/minikube	/kubernetes-ingress-controller/2.1.x/deployment/minikube
/kubernetes-ingress-controller/latest/guides/overview	/kubernetes-ingress-controller/2.1.x/guides/overview
/kubernetes-ingress-controller/latest/deployment/overview	/kubernetes-ingress-controller/2.1.x/deployment/overview
/kubernetes-ingress-controller/latest/references/plugin-compatibility	/kubernetes-ingress-controller/2.1.x/references/plugin-compatibility
/kubernetes-ingress-controller/latest/guides/preserve-client-ip	/kubernetes-ingress-controller/2.1.x/guides/preserve-client-ip
/kubernetes-ingress-controller/latest/guides/prometheus-grafana	/kubernetes-ingress-controller/2.1.x/guides/prometheus-grafana
/kubernetes-ingress-controller/latest/references/prometheus	/kubernetes-ingress-controller/2.1.x/references/prometheus
/kubernetes-ingress-controller/latest/guides/redis-rate-limiting	/kubernetes-ingress-controller/2.1.x/guides/redis-rate-limiting
/kubernetes-ingress-controller/latest/concepts/security	/kubernetes-ingress-controller/2.1.x/concepts/security
/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins	/kubernetes-ingress-controller/2.1.x/guides/setting-up-custom-plugins
/kubernetes-ingress-controller/latest/troubleshooting	/kubernetes-ingress-controller/2.1.x/troubleshooting
/kubernetes-ingress-controller/latest/guides/upgrade	/kubernetes-ingress-controller/2.1.x/guides/upgrade
/kubernetes-ingress-controller/latest/guides/upstream-mtls	/kubernetes-ingress-controller/2.1.x/guides/upstream-mtls
/kubernetes-ingress-controller/latest/guides/using-consumer-credential-resource	/kubernetes-ingress-controller/2.1.x/guides/using-consumer-credential-resource
/kubernetes-ingress-controller/latest/guides/using-external-service	/kubernetes-ingress-controller/2.1.x/guides/using-external-service
/kubernetes-ingress-controller/latest/guides/using-ingress-with-grpc	/kubernetes-ingress-controller/2.1.x/guides/using-ingress-with-grpc
/kubernetes-ingress-controller/latest/guides/using-kong-with-knative	/kubernetes-ingress-controller/2.1.x/guides/using-kong-with-knative
/kubernetes-ingress-controller/latest/guides/using-kongclusterplugin-resource	/kubernetes-ingress-controller/2.1.x/guides/using-kongclusterplugin-resource
/kubernetes-ingress-controller/latest/guides/using-kongingress-resource	/kubernetes-ingress-controller/2.1.x/guides/using-kongingress-resource
/kubernetes-ingress-controller/latest/guides/using-kongplugin-resource	/kubernetes-ingress-controller/2.1.x/guides/using-kongplugin-resource
/kubernetes-ingress-controller/latest/guides/using-mtls-auth-plugin	/kubernetes-ingress-controller/2.1.x/guides/using-mtls-auth-plugin
/kubernetes-ingress-controller/latest/guides/using-oidc-plugin	/kubernetes-ingress-controller/2.1.x/guides/using-oidc-plugin
/kubernetes-ingress-controller/latest/guides/using-rewrites	/kubernetes-ingress-controller/2.1.x/guides/using-rewrites
/kubernetes-ingress-controller/latest/guides/using-tcpingress	/kubernetes-ingress-controller/2.1.x/guides/using-tcpingress
/kubernetes-ingress-controller/latest/guides/using-udpingress	/kubernetes-ingress-controller/2.1.x/guides/using-udpingress
/kubernetes-ingress-controller/latest/references/version-compatibility	/kubernetes-ingress-controller/2.1.x/references/version-compatibility
```
