### PR TITLE
[DOCU-2117] Consumer groups not supported with deck

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -414,6 +414,10 @@ For guides on working with consumer groups, see the consumer group
 [API reference](/gateway/latest/admin-api/consumer-groups/reference) in
 the Admin API documentation.
 
+{:.note}
+> **Note:** Consumer groups are not supported in declarative configuration with
+decK. If you have consumer groups in your configuration, decK will ignore them.
+
 ---
 
 ## Changelog

--- a/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/examples.md
@@ -31,6 +31,10 @@ configuration
 For all possible requests, see the
 [Consumer Groups reference](/gateway/{{page.kong_version}}/admin-api/consumer-groups/reference).
 
+{:.note}
+> **Note:** Consumer groups are not supported in declarative configuration with
+decK. If you have consumer groups in your configuration, decK will ignore them.
+
 ## Set up consumer group
 
 1. Create a consumer group named `JL`:

--- a/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
@@ -14,6 +14,10 @@ To use consumer groups for rate limiting, configure the plugin with the
 For more information and examples of setting up and managing consumer groups, see the
 [Consumer Groups examples](/gateway/{{page.kong_version}}/admin-api/consumer-groups/examples).
 
+{:.note}
+> **Note:** Consumer groups are not supported in declarative configuration with
+decK. If you have consumer groups in your configuration, decK will ignore them.
+
 ## List consumer groups
 
 ### List all consumer groups

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -24,6 +24,8 @@ and use the `/consumer_groups` endpoint to manage the groups.
   * [Consumer groups reference](/gateway/2.7.x/admin-api/consumer-groups/reference)
   * [Consumer groups examples](/gateway/2.7.x/admin-api/consumer-groups/examples)
 
+     This feature is currently not supported with declarative configuration.
+
 * The data plane configuration cache can now be encrypted or turned off entirely.
  Two new configuration options have been added:
   * [`data_plane_config_cache_mode`](/gateway/2.7.x/reference/configuration/#data_plane_config_cache_mode):
@@ -338,6 +340,10 @@ effect on the following plugins and fields:
   * Kafka Upstream: `config.authentication.user` and `config.authentication.password`
   * OpenID Connect: the fields `d`, `p`, `q`, `dp`, `dq`, `qi`, `oth`, `r`, `t`, and `k`
   inside `openid_connect_jwks.previous[...].` and `openid_connect_jwks.keys[...]`
+
+* Consumer groups are not supported in declarative configuration with
+decK. If you have consumer groups in your configuration, decK will ignore them.
+
 
 ## 2.6.0.2
 **Release Date:** 2021/12/03


### PR DESCRIPTION
### Summary
Add notice about no declarative config support to 2.7 changelog, rate limiting advanced doc, and consumer groups docs.

### Reason
Feature is not supported in decK.

### Testing
https://deploy-preview-3539--kongdocs.netlify.app/gateway/2.7.x/admin-api/consumer-groups/examples/
https://deploy-preview-3539--kongdocs.netlify.app/gateway/changelog/#enterprise