### PR TITLE
docs(mesh): add comments to example Vault mTLS config

### DIFF
--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -206,12 +206,12 @@ spec:
             tls: # options for connecting to Vault via TLS
               skipVerify: false   # if set to true, caCert is optional, should only be used in development
               caCert:             # caCert is used to verify the TLS certificate presented by Vault
-                secret: sec-1     # can be file, secret or inline
-              serverName: ""      # the SNI to use when connecting to Vault
+                secret: sec-1     # one of secret, inline, or inlineString
+              serverName: ""      # optional. The SNI to use when connecting to Vault
 
             auth: # how to authenticate Kong Mesh when connecting to Vault
               token:
-                secret: token-1  # can be file, secret or inlineString
+                secret: token-1  # one of secret, inline, or inlineString
               tls:
                 clientKey:
                   secret: sec-2  # can be file, secret or inline

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -173,7 +173,7 @@ Vault, you must provide credentials in the configuration of the `mesh` object of
 You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
 
 You can provide these values inline for testing purposes only, as a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/documentation/secrets/).
+same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/).
 
 Here's an example of a configuration with a `vault`-backed CA:
 

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -202,12 +202,14 @@ spec:
             pki: kmesh-pki-default # name of the configured PKI
             role: dataplane-proxies # name of the role that will be used to generate data plane proxy certificates
             commonName: {% raw %}'{{ tag "kuma.io/service" }}.mesh'{% endraw %} # optional. If set, then commonName is added to the certificate. You can use "tag" directive to pick a tag which will be base for commonName.
-            tls:
-              caCert:
-                secret: sec-1
-              skipVerify: false # if set to true, caCert is optional. Set to true only for development
-              serverName: "" # verify sever name
-            auth: # only one auth options is allowed so it's either "token" or "tls"
+
+            tls: # options for connecting to Vault via TLS
+              skipVerify: false   # if set to true, caCert is optional, should only be used in development
+              caCert:             # caCert is used to verify the TLS certificate presented by Vault
+                secret: sec-1     # can be file, secret or inline
+              serverName: ""      # the SNI to use when connecting to Vault
+
+            auth: # how to authenticate Kong Mesh when connecting to Vault
               token:
                 secret: token-1  # can be file, secret or inlineString
               tls:


### PR DESCRIPTION
### Summary

Add some missing comments for config fields. @jakubdyszkiewicz 

### Reason

Purpose of some fields was unclear

https://deploy-preview-3541--kongdocs.netlify.app/mesh/1.5.x/features/vault/#navtab-id-1
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
