### PR TITLE
Fix Kong with Knative guide

### DIFF
--- a/app/kubernetes-ingress-controller/2.1.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/using-kong-with-knative.md
@@ -83,7 +83,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: v0.13.0
+    serving.knative.dev/release: v1.1.0
 data:
   35.247.39.83.nip.io: ""
 ' | kubectl apply -f -


### PR DESCRIPTION
### Summary
Fix Kong with Knative guide

### Reason
The guide had some errors and knative version was really old.

### Testing
Following the steps in the guide.
