### PR TITLE
Fix Edit This Page link on branches

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -20,7 +20,7 @@ page.kong_latest.release %}
         <i class="far fa-list-alt expand-toc"></i>
         <div class="github-links">
           <p>
-            <a href="https://github.com/Kong/docs.konghq.com/edit/main/app/{{page.path}}" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ page.path }}" target="_blank">
               <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
           </p>
           <p>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -254,7 +254,7 @@ breadcrumbs:
           <a href="/hub"><i class="fa fa-chevron-left"></i>Back to Kong Plugin Hub</a>
         </p>
         <p>
-          <a href="https://github.com/Kong/docs.konghq.com/edit/main/app/{{page.path}}" target="_blank">
+          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{page.path}}" target="_blank">
             <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
         </p>
         <p>

--- a/app/_plugins/environment_variables.rb
+++ b/app/_plugins/environment_variables.rb
@@ -1,0 +1,9 @@
+module Jekyll
+
+  class EnvironmentVariablesGenerator < Generator
+    def generate(site)
+      site.config['git_branch'] = ENV['HEAD'] || 'main'
+    end
+  end
+
+end


### PR DESCRIPTION
### Summary
Update the "Edit this page" link on branches to point to the correct branch on GitHub

### Reason
Builds are failing when new files are added on a branch as the "Edit this page" link points to a file that doesn't exist on `main` on GitHub

### Testing
Check the "Edit this page" link on Netlify. It should point you to the `fix-edit-page-link` branch on GitHub
