### PR TITLE
Fix overlapping module/version selector dropdowns

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -48,6 +48,7 @@ jQuery(function () {
     e.stopPropagation();
 
     $('#module-list').toggleClass('open');
+    $('#version-list').removeClass('open');
 
     $(document).one('click', function closeMenu(e) {
       if ($('#module-list').has(e.target).length === 0) {
@@ -100,6 +101,7 @@ jQuery(function () {
     e.stopPropagation();
 
     $('#version-list').toggleClass('open');
+    $('#module-list').removeClass('open');
 
     $(document).one('click', function closeMenu(e) {
       if ($('#version-list').has(e.target).length === 0) {


### PR DESCRIPTION
### Summary
Automatically close the module/version dropdown when the other is clicked

### Reason
The version dropdown can currently overlap the module dropdown unexpectedly.

### Testing
Open the version dropdown, then click on the module dropdown. The version dropdown should automatically be closed
