### PR TITLE
Fix broken links to DB-less and Declarative config on Admin API

### DIFF
--- a/app/gateway/2.6.x/admin-api/index.md
+++ b/app/gateway/2.6.x/admin-api/index.md
@@ -601,7 +601,7 @@ target_data: |
 ## DB-less Mode
 
 
-In [DB-less mode](../db-less-and-declarative-config), the Admin API can be used to load a new declarative
+In [DB-less mode](../reference/db-less-and-declarative-config/), the Admin API can be used to load a new declarative
 configuration, and for inspecting the current configuration. In DB-less mode,
 the Admin API for each Kong node functions independently, reflecting the memory state
 of that particular Kong node. This is the case because there is no database
@@ -652,7 +652,7 @@ are erased from memory, and the entities specified in the
 given file take their place.
 
 To learn more about the file format, see the
-[declarative configuration](../db-less-and-declarative-config) documentation.
+[declarative configuration](../reference/db-less-and-declarative-config/) documentation.
 
 
 <div class="endpoint post indent">/config</div>

--- a/app/gateway/2.7.x/admin-api/index.md
+++ b/app/gateway/2.7.x/admin-api/index.md
@@ -603,7 +603,7 @@ target_data: |
 ## DB-less Mode
 
 
-In [DB-less mode](../db-less-and-declarative-config), the Admin API can be used to load a new declarative
+In [DB-less mode](../reference/db-less-and-declarative-config/), the Admin API can be used to load a new declarative
 configuration, and for inspecting the current configuration. In DB-less mode,
 the Admin API for each Kong node functions independently, reflecting the memory state
 of that particular Kong node. This is the case because there is no database
@@ -650,7 +650,7 @@ are erased from memory, and the entities specified in the
 given file take their place.
 
 To learn more about the file format, see the
-[declarative configuration](../db-less-and-declarative-config) documentation.
+[declarative configuration](../reference/db-less-and-declarative-config/) documentation.
 
 
 <div class="endpoint post indent">/config</div>


### PR DESCRIPTION
### Summary
The DB-less and Declarative config section was moved to _reference_ and the link on the admin API was not updated

### Reason
Broken link

### Testing
Search for "declarative config" on /gateway/2.7.x/admin-api/ and make sure it goes to the correct page
