### PR TITLE
[DOCU-2123] Cloud Dev Portal: Add custom domain page

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -123,11 +123,12 @@
         - text: Generate Credentials for an Application
           url: /dev-portal/applications/dev-gen-creds
     - text: Customization
+      url: /dev-portal/customization/customization-overview
       items:
-        - text: Customization Overview
-          url: /dev-portal/customization/customization-overview
         - text: Public Portal
           url: /dev-portal/customization/public-portal
+        - text: Add a Custom Domain
+          url: /dev-portal/customization/custom-domain
 
 - title: Konnect Vitals
   icon: /assets/images/icons/documentation/icn-vitals.svg

--- a/app/konnect/dev-portal/customization/custom-domain.md
+++ b/app/konnect/dev-portal/customization/custom-domain.md
@@ -3,18 +3,18 @@ title: Add a Custom Domain
 no_version: true
 ---
 
-All Dev Portals have an assigned, generated Dev Portal URL. To further customize your Dev Portal, you can add a custom domain. When set up properly, users can access both the assigned URL and the custom URL.
+All Dev Portals have an auto-generated default Dev Portal URL. To further customize your Dev Portal, you can add a custom domain. When set up properly, users can access both the default URL and the custom URL.
 
 ## Prerequisites
 
 * Access to your organization's {{site.konnect_short_name}} Admin UI.
-* A domain with access to configure that domain's CNAME. Kong does not offer any custom domains as a service.
+* A domain and access to configure that domain's CNAME. Kong does not offer any custom domains as a service.
 * An X.509 certificate, which comes with a private key.
-* Your organization's FQDN (Full Qualified Domain Name), which is listed in the {{site.konnect_short_name}} Admin UI. For example, `https://kong121212.portal.konnect.konghq.com/`.
+* Your organization's auto-generated default Dev Portal URL, which is in the {{site.konnect_short_name}} Admin UI. For example, `https://kong121212.portal.konnect.konghq.com/`.
 
-## Direct your CNAME to the Dev Portal assigned URL
+## Direct your CNAME to the default Dev Portal URL
 
-In your custom domain DNS records, direct your CNAME to your Dev Portal's assigned URL, or FQDN. Check your DNS resolution to ensure this was done properly.
+In your custom domain DNS records, direct your CNAME to your Dev Portal's default URL. Check your DNS resolution to ensure this was done properly.
 
 ## Add a custom Dev Portal domain
 
@@ -33,10 +33,10 @@ Add a custom Dev Portal domain through your organization's {{site.konnect_short_
    * **Private Key**: Add the private key that came with your X.509 certificate.
 
    {:.note}
-   > **Note**: You will **not** be able to see view or edit keys in the UI once you submit the form. To change your custom domain URL, X.509 certificate, or private key, delete your certificate and re-enter your custom domain URL, X.509 certificate, and private key.
+   > **Note**: You will **not** be able to view or edit keys in the UI once you submit the form. To change your custom domain URL, X.509 certificate, or private key, delete your certificate and re-enter your custom domain URL, X.509 certificate, and private key.
 
 1. Once you've entered all fields, click **Save Certificate**.
 
-1. Test to see if your custom domain works. You'll see the custom domain listed in your Dev Portal under your assigned Dev Portal URL, even if it doesn't work properly.
+1. Test to see if your custom URL works. You'll see the custom URL listed in your Dev Portal under your default Dev Portal URL, even if it doesn't work properly.
 
-    Your site may not resolve immediately. If you can't reach your custom domain, check your DNS records. If there are no issues and your site is unreachable, wait for your site to propagate.
+    Your site may not resolve immediately. If you can't reach your custom URL, check your DNS records. If there are no issues and your site is unreachable, wait for your site to propagate.

--- a/app/konnect/dev-portal/customization/custom-domain.md
+++ b/app/konnect/dev-portal/customization/custom-domain.md
@@ -37,6 +37,6 @@ Add a custom Dev Portal domain through your organization's {{site.konnect_short_
 
 1. Once you've entered all fields, click **Save Certificate**.
 
-You'll see the custom domain listed in your Dev Portal under your assigned Dev Portal URL, even if it doesn't work properly. Always test to see if your custom domain works.
+1. Test to see if your custom domain works. You'll see the custom domain listed in your Dev Portal under your assigned Dev Portal URL, even if it doesn't work properly.
 
-Your site may not resolve immediately. If you can't reach your custom domain, check your DNS records. If there are no issues and your site is unreachable, wait for your site to propagate.
+    Your site may not resolve immediately. If you can't reach your custom domain, check your DNS records. If there are no issues and your site is unreachable, wait for your site to propagate.

--- a/app/konnect/dev-portal/customization/custom-domain.md
+++ b/app/konnect/dev-portal/customization/custom-domain.md
@@ -1,0 +1,42 @@
+---
+title: Add a Custom Domain
+no_version: true
+---
+
+All Dev Portals have an assigned, generated Dev Portal URL. To further customize your Dev Portal, you can add a custom domain. When set up properly, users can access both the assigned URL and the custom URL.
+
+## Prerequisites
+
+* Access to your organization's {{site.konnect_short_name}} Admin UI.
+* A domain with access to configure that domain's CNAME. Kong does not offer any custom domains as a service.
+* A signed certificate, which comes with a private key.
+* Your organization's FQDN (Full Qualified Domain Name), which is listed in the {{site.konnect_short_name}} Admin UI. For example, `https://kong121212.portal.konnect.konghq.com/`.
+
+## Direct your CNAME to the Dev Portal assigned URL
+
+In your custom domain DNS records, direct your CNAME to your Dev Portal's assigned URL, or FQDN. Check your DNS resolution to ensure this was done properly.
+
+## Add a custom Dev Portal domain
+
+Add a custom Dev Portal domain through your organization's {{site.konnect_short_name}} Admin UI.
+
+1. Click **Dev Portal**, then **Portal URL**.
+
+1. Enter the following fields.
+
+   * **Custom Portal URL**: Enter the full domain, including subdomain (if applicable). Don't include a path. It's not necessary to include the URL protocol, for example, `https://`.
+
+   * **X.509 Certificate**: Obtain your certificate and add it to the field, including the certification header and footer. For example, a header may look like: `-----BEGIN CERTIFICATE-----`.
+
+        This certificate ensures that your custom domain site is trusted and that the browser doesn't show a warning when users land on the page.
+
+   * **Private Key**: Add the private key that came with your X.509 certificate.
+
+   {:.note}
+   > **Note**: You will **not** be able to see view or edit keys in the UI once you submit the form. To change your custom domain URL, X.509 certificate, or private key, delete your certificate and re-enter your custom domain URL, X.509 certificate, and private key.
+
+1. Once you've entered all fields, click **Save Certificate**.
+
+You'll see the custom domain listed in your Dev Portal under your assigned Dev Portal URL, even if it doesn't work properly. Always test to see if your custom domain works.
+
+Your site may not resolve immediately. If you can't reach your custom domain, check your DNS records. If there are no issues and your site is unreachable, wait for your site to propagate.

--- a/app/konnect/dev-portal/customization/custom-domain.md
+++ b/app/konnect/dev-portal/customization/custom-domain.md
@@ -9,7 +9,7 @@ All Dev Portals have an assigned, generated Dev Portal URL. To further customize
 
 * Access to your organization's {{site.konnect_short_name}} Admin UI.
 * A domain with access to configure that domain's CNAME. Kong does not offer any custom domains as a service.
-* A signed certificate, which comes with a private key.
+* An X.509 certificate, which comes with a private key.
 * Your organization's FQDN (Full Qualified Domain Name), which is listed in the {{site.konnect_short_name}} Admin UI. For example, `https://kong121212.portal.konnect.konghq.com/`.
 
 ## Direct your CNAME to the Dev Portal assigned URL


### PR DESCRIPTION
### Summary

* Add custom domain page to Cloud Dev Portal documentation
* Move "Customization Overview" to Customization toggle menu

### Reason

Users need further information about the custom domain option for Cloud Dev Portal.

### Testing

All content changes.

https://deploy-preview-3551--kongdocs.netlify.app/konnect/dev-portal/customization/custom-domain/
