### PR TITLE
docs(oidc): add docs for 'resolve_distributed_claims'

### DIFF
--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -1501,8 +1501,9 @@ params:
       default: false
       datatype: boolean
       description: |
-        Distributed Claims are represented by using special _claim_names and _claim_sources members of the JSON object containing the Claims.
-        This config option allows explicitly enables resolving these distributed claims.
+        Distributed claims are represented by the `_claim_names` and `_claim_sources` members 
+        of the JSON object containing the claims.
+        If this parameter is set to `true`, the plugin explicitly resolves these distributed claims.
 
 
 issuer_body: |

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -1496,6 +1496,15 @@ params:
       default: true
       datatype: boolean
       description: Cache the user info requests.
+    - name: resolve_distributed_claims
+      required: false
+      default: false
+      datatype: boolean
+      description: |
+        Distributed Claims are represented by using special _claim_names and _claim_sources members of the JSON object containing the Claims.
+        This config option allows explicitly enables resolving these distributed claims.
+
+
 issuer_body: |
   Attributes | Description
   ---:| ---


### PR DESCRIPTION

### Summary
https://openid.net/specs/openid-connect-core-1_0.html#DistributedExample

### Reason
Distributed/Aggregated Claims are defined in the openid-connect spec.
Internal: FTI-2978


### Testing
Testing is included in the respective plugin/lib implementations.


Signed-off-by: Joshua Schmid <jaiks@posteo.de>

dependent on:

* https://github.com/Kong/kong-ee/pull/2856
* Kong/kong-openid-connect#38