### PR TITLE
[DOCU-2138] Fix multi-line copy to clipboard

### DIFF
--- a/app/_assets/javascripts/copy-code-snippet-support.js
+++ b/app/_assets/javascripts/copy-code-snippet-support.js
@@ -60,7 +60,7 @@ jQuery(function () {
         snippet
           .find("code")
           .text()
-          .replace(/^\s*\$\s*/gi, "")
+          .replace(/^\s*\$\s*/gim, "")
       );
       copyInput.select();
       document.execCommand("copy");


### PR DESCRIPTION
### Summary
The existing replacement regex didn't support multiple line replacement as
it was missing the `m` modifier.

Multi-line replacement is required when there are multiple commands in a single code block

### Reason
Fix copy to clipboard on pages such as https://docs.konghq.com/gateway/2.7.x/reference/clustering/ (search for `node A`)

### Testing
Try copying the `node A` code block to your clipboard. There will be no `$` present in the review app, but the second command will be prefixed with a `$` on production
