### PR TITLE
fix(kic) restore K8S examples to Kong plugins

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/1.3-x.md
+++ b/app/_hub/kong-inc/exit-transformer/1.3-x.md
@@ -25,7 +25,6 @@ params:
   route_id: true
   consumer_id: false
   yaml_examples: false
-  k8s_examples: false
   konnect_examples: false
   protocols: ["http", "https"]
   config:

--- a/app/_hub/kong-inc/exit-transformer/index.md
+++ b/app/_hub/kong-inc/exit-transformer/index.md
@@ -30,7 +30,6 @@ params:
   route_id: true
   consumer_id: false
   yaml_examples: false
-  k8s_examples: false
   konnect_examples: false
   protocols:
     - http

--- a/app/_hub/kong-inc/jq/index.md
+++ b/app/_hub/kong-inc/jq/index.md
@@ -42,7 +42,6 @@ params:
   route_id: true
   consumer_id: true
   yaml_examples: false
-  k8s_examples: false
   konnect_examples: false
   protocols:
     - http

--- a/app/_hub/kong-inc/oauth2/0.1.x.md
+++ b/app/_hub/kong-inc/oauth2/0.1.x.md
@@ -60,7 +60,6 @@ params:
   route_id: false
   consumer_id: false
   yaml_examples: false
-  k8s_examples: false
   konnect_examples: false
   config:
     - name: scopes

--- a/app/_hub/kong-inc/oauth2/1.0.x.md
+++ b/app/_hub/kong-inc/oauth2/1.0.x.md
@@ -71,7 +71,6 @@ params:
   consumer_id: false
   protocols: ["http", "https"]
   yaml_examples: false
-  k8s_examples: false
   konnect_examples: false
   dbless_compatible: no
   dbless_explanation: |

--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -50,7 +50,6 @@ params:
     - grpc
     - grpcs
   yaml_examples: false
-  k8s_examples: false
   konnect_examples: false
   dbless_compatible: 'no'
   dbless_explanation: |


### PR DESCRIPTION
### Summary
Remove `k8s_examples: false` from all Kong, Inc. plugin metadata.

### Reason
It's not clear why these were omitted in the first place--I'm guessing that they were removed because these plugins don't support DB-less mode (it's the common thread between them), but you can use KIC YAML configuration to configure these plugins for a DB-backed KIC+Kong instance.

We should provide KIC config for them as such. They're marked DB-less incompatible separately.

Optional review request to the rest of the team if someone else recalls some other reason we disabled these.

### Testing
Awaiting Netlify to confirm examples appear.
