### PR TITLE
Add ability to mark link checker as manually reviewed

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,9 +1,26 @@
 name: Broken Links
 on:
   pull_request:
-    types: [synchronize, ready_for_review, opened]
+    types: [synchronize, ready_for_review, opened, labeled, unlabeled]
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if manual review has been performed
+        uses: actions/github-script@v5
+        id: labels
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+            return labels.map(l => l.name).includes('ci:manual-approve:link-validation')
+    outputs:
+      result: ${{ steps.labels.outputs.result }}
   build:
+    needs: [check]
+    if: needs.check.outputs.result == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ This test framework can also be used to test behavior added with JavaScript, but
 
 We run various quality checks at build time to ensure that the documentation is maintainable.
 
+Some of the checks can be manually marked as approved using labels:
+
+* `ci:manual-approve:link-validation` - mark link checking as successful. Useful when Netlify returns a `HTTP 400` error and the links are validated manually
+
 ### include-check
 
 The `include-check.sh` script checks for any files in the `app/_includes` folder that depend on a `page.*` variable (e.g. `page.url`). This is not compatible with the `include_cached` gem that we use, and so using `page.*` in an include will fail the build.


### PR DESCRIPTION
### Summary
Manually mark PR link checks as successful by applying the `ci:manual-approve:link-validation` label

### Reason
Link checking fails in some cases with a HTTP 400 from Netlify. Whilst we reproduce the issue, we want a way to make the build pass. Whilst we _can_ merge with a failing workflow, it leaves a red cross in the PR list which isn't ideal

### Testing
Add the `ci:manual-approve:link-validation` label to this PR and watch as the `build` job in the `check-links` workflow is skipped
