### PR TITLE
Make sidebar consistent with site top nav

### DIFF
--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -33,10 +33,7 @@
           <a href="/mesh/" {% if include.edition == 'mesh' %}class="active"{% endif %}>Kong Mesh</a>
         </li>
         <li role="menuitem" tabindex="-1">
-          <a href="https://kuma.io/docs/" target="_blank">Kuma</a>
-        </li>
-        <li>
-          <a href="https://support.insomnia.rest/" target="_blank">Insomnia</a>
+          <a href="/hub/">Plugin Hub</a>
         </li>
         <li role="menuitem" tabindex="-1" {% if include.edition == 'deck' %} class="active"{% endif %}>
           <a href="/deck/" {% if include.edition == 'deck' %}class="active"{% endif %}>decK</a>
@@ -44,11 +41,11 @@
         <li role="menuitem" tabindex="-1" {% if include.edition == 'kubernetes-ingress-controller' %} class="active"{% endif %}" >
           <a href="/kubernetes-ingress-controller/" {% if include.edition == 'kubernetes-ingress-controller' %}class="active"{% endif %}>Kubernetes Ingress Controller</a>
         </li>
-        <li role="menuitem" tabindex="-1">
-          <a href="/hub/">Plugin Hub</a>
-        </li>
         <li>
           <a href="https://docs.insomnia.rest/" target="_blank">Insomnia</a>
+        </li>
+        <li role="menuitem" tabindex="-1">
+          <a href="https://kuma.io/docs/" target="_blank">Kuma</a>
         </li>
         <hr>
         <li role="menuitem" tabindex="-1" {% if include.edition == 'konnect_platform' %} class="active"{% endif %}>


### PR DESCRIPTION
### Summary
Removing duplicate entry for Insomnia and updating the sidebar menu to match the one in the top nav of the site.

### Reason
Inconsistent menus and an old duplicate link to Insomnia.

### Testing
Check that the left sidebar dropdown on any doc page (eg https://deploy-preview-3566--kongdocs.netlify.app/gateway/) matches the Docs dropdown in the top navigation of the site. 

Insomnia link should go to docs.insomnia.rest, not support.insomnia.rest.
