### PR TITLE
[DOCU-157][DOCU-399][DOCU-1450] Remove deprecated api entity

### DIFF
--- a/app/_hub/kong-inc/acme/index.md
+++ b/app/_hub/kong-inc/acme/index.md
@@ -19,7 +19,6 @@ kong_version_compatibility:
       - 2.7.x
 params:
   name: acme
-  api_id: false
   service_id: false
   route_id: false
   consumer_id: false

--- a/app/_hub/kong-inc/forward-proxy/index.md
+++ b/app/_hub/kong-inc/forward-proxy/index.md
@@ -20,7 +20,6 @@ kong_version_compatibility:
 
 params:
   name: forward-proxy
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true

--- a/app/_hub/kong-inc/oauth2-introspection/index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/index.md
@@ -37,7 +37,6 @@ kong_version_compatibility:
       - 0.36-x
 params:
   name: oauth2-introspection
-  api_id: true
   service_id: true
   route_id: true
   konnect_examples: false

--- a/app/_hub/kong-inc/request-transformer-advanced/0.36-x.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/0.36-x.md
@@ -24,7 +24,6 @@ kong_version_compatibility:
 
 params:
   name: request-transformer-advanced
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true
@@ -154,10 +153,10 @@ Note: Plugin creates a non mutable table of request headers, querystrings, and c
 
 #### Examples Using Template as Value
 
-Add an API `test` with `uris` configured with a named capture group `user_id`
+Add a Service named `test` with `uris` configured with a named capture group `user_id`:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis \
+$ curl -X POST http://localhost:8001/services \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
     --data-urlencode 'uris=/requests/user/(?<user_id>\w+)' \
@@ -169,7 +168,7 @@ and its value is being set with the value sent with header `x-user-id` or
 with the default value alice is `header` is missing.
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/test/plugins \
+$ curl -X POST http://localhost:8001/services/test/plugins \
     --data "name=request-transformer-advanced" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
     --data "config.remove.headers=x-user-id"
@@ -203,7 +202,7 @@ remove –> replace –> add –> append
 Add multiple headers by passing each header:value pair separately:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
   --data "config.add.headers[2]=h2:v1"
@@ -216,7 +215,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers by passing comma separated header:value pair:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
 ```
@@ -228,7 +227,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers passing config as JSON body:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
 ```
@@ -240,7 +239,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add a querystring and a header:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
   --data "config.add.headers=h1:v1"
@@ -260,7 +259,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Append multiple headers and remove a body parameter:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
   --data "config.remove.body=p1" \
@@ -279,7 +278,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers and querystring parameters if not already set:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \
   --data "config.add.querystring=q1:v2,q2:v1" \

--- a/app/_hub/kong-inc/request-transformer-advanced/1.3-x.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/1.3-x.md
@@ -25,7 +25,6 @@ kong_version_compatibility:
 
 params:
   name: request-transformer-advanced
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true
@@ -207,10 +206,10 @@ above).
 
 ### Examples Using Template as Value
 
-Add an API `test` with `uris` configured with a named capture group `user_id`
+Add a Service named `test` with `uris` configured with a named capture group `user_id`:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis \
+$ curl -X POST http://localhost:8001/services \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
     --data-urlencode 'uris=/requests/user/(?<user_id>\w+)' \
@@ -231,7 +230,7 @@ and its value is being set with the value sent with header `x-user-id` or
 with the default value alice is `header` is missing.
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/test/plugins \
+$ curl -X POST http://localhost:8001/services/test/plugins \
     --data "name=request-transformer-advanced" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
     --data "config.remove.headers=x-user-id"
@@ -265,7 +264,7 @@ remove –> replace –> add –> append
 Add multiple headers by passing each header:value pair separately:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
   --data "config.add.headers[2]=h2:v1"
@@ -278,7 +277,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers by passing comma separated header:value pair:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
 ```
@@ -290,7 +289,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers passing config as JSON body:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
 ```
@@ -302,7 +301,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add a querystring and a header:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
   --data "config.add.headers=h1:v1"
@@ -322,7 +321,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Append multiple headers and remove a body parameter:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
   --data "config.remove.body=p1" \
@@ -341,7 +340,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers and querystring parameters if not already set:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \
   --data "config.add.querystring=q1:v2,q2:v1" \

--- a/app/_hub/kong-inc/request-transformer-advanced/1.5.x.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/1.5.x.md
@@ -26,7 +26,6 @@ kong_version_compatibility:
 
 params:
   name: request-transformer-advanced
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true
@@ -208,10 +207,10 @@ above).
 
 ### Examples Using Template as Value
 
-Add an API `test` with `uris` configured with a named capture group `user_id`
+Add a Service named `test` with `uris` configured with a named capture group `user_id`:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis \
+$ curl -X POST http://localhost:8001/services \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
     --data-urlencode 'uris=/requests/user/(?<user_id>\w+)' \
@@ -232,7 +231,7 @@ and its value is being set with the value sent with header `x-user-id` or
 with the default value alice is `header` is missing.
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/test/plugins \
+$ curl -X POST http://localhost:8001/services/test/plugins \
     --data "name=request-transformer-advanced" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
     --data "config.remove.headers=x-user-id"
@@ -266,7 +265,7 @@ remove –> replace –> add –> append
 Add multiple headers by passing each header:value pair separately:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
   --data "config.add.headers[2]=h2:v1"
@@ -279,7 +278,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers by passing comma separated header:value pair:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
 ```
@@ -291,7 +290,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers passing config as JSON body:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
 ```
@@ -303,7 +302,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add a querystring and a header:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
   --data "config.add.headers=h1:v1"
@@ -323,7 +322,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Append multiple headers and remove a body parameter:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
   --data "config.remove.body=p1" \
@@ -342,7 +341,7 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 Add multiple headers and querystring parameters if not already set:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+$ curl -X POST http://localhost:8001/services/mockbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \
   --data "config.add.querystring=q1:v2,q2:v1" \

--- a/app/_hub/kong-inc/request-transformer/1.2.x.md
+++ b/app/_hub/kong-inc/request-transformer/1.2.x.md
@@ -186,10 +186,10 @@ above).
 
 ### Examples Using Template as Value
 
-Add an API `test` with `uris` configured with a named capture group `user_id`
+Add a Service named `test` with `uris` configured with a named capture group `user_id`:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis \
+$ curl -X POST http://localhost:8001/services \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
     --data-urlencode 'uris=/requests/user/(?<user_id>\w+)' \
@@ -201,7 +201,7 @@ whose value is being set with the value sent with header `x-user-id` or
 with the default value `alice` is `header` is missing.
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/test/plugins \
+$ curl -X POST http://localhost:8001/services/test/plugins \
     --data "name=request-transformer" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
     --data "config.remove.headers=x-user-id"

--- a/app/_hub/kong-inc/request-transformer/index.md
+++ b/app/_hub/kong-inc/request-transformer/index.md
@@ -212,8 +212,8 @@ params:
 
 ## Template as a Value
 
-You can use any of the current request headers, query params, and captured URI groups as a
-template to populate the above supported configuration fields.
+You can use any of the current request headers, query params, and captured URI
+groups as templates to populate supported configuration fields.
 
 | Request Param | Template
 | ------------- | -----------
@@ -221,10 +221,15 @@ template to populate the above supported configuration fields.
 | querystring   | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`)
 | captured URIs | `$(uri_captures.<group-name>)` or `$(uri_captures["<group-name>"])`)
 
-To escape a template, wrap it inside quotes and pass it inside another template.<br>
-`$('$(some_escaped_template)')`
+To escape a template, wrap it inside quotes and pass inside another template.
+For example:
 
-Note: The plugin creates a non-mutable table of request headers, querystrings, and captured URIs
+```
+$('$(something_that_needs_to_escaped)')
+```
+
+{:.note}
+> **Note:** The plugin creates a non-mutable table of request headers, querystrings, and captured URIs
 before transformation. Therefore, any update or removal of params used in a template
 does not affect the rendered value of a template.
 
@@ -263,7 +268,8 @@ already there:
         return "Basic " .. value  -- added proper prefix
       end)())
 
-*NOTE:* Especially in multi-line templates like the example above, make sure not
+{:.note}
+> **Note:** Especially in multi-line templates like the example above, make sure not
 to add any trailing white space or new lines. Because these would be outside the
 placeholders, they would be considered part of the template, and hence would be
 appended to the generated value.
@@ -274,10 +280,10 @@ above).
 
 ### Examples Using Template as a Value
 
-Add an API `test` with `uris` configured with a named capture group `user_id`:
+Add a Service named `test` with `uris` configured with a named capture group `user_id`:
 
 ```bash
-$ curl -X POST http://localhost:8001/apis \
+$ curl -X POST http://localhost:8001/services \
     --data 'name=test' \
     --data 'upstream_url=http://mockbin.com' \
     --data-urlencode 'uris=/requests/user/(?<user_id>\w+)' \
@@ -289,7 +295,7 @@ whose value is being set with the value sent with header `x-user-id` or
 with the default value `alice`. The `header` is missing.
 
 ```bash
-$ curl -X POST http://localhost:8001/apis/test/plugins \
+$ curl -X POST http://localhost:8001/services/test/plugins \
     --data "name=request-transformer" \
     --data-urlencode "config.add.headers=x-consumer-id:\$(headers['x-user-id'] or 'alice')" \
     --data "config.remove.headers=x-user-id"
@@ -301,10 +307,10 @@ Now send a request without setting header `x-user-id`:
 $ curl -i -X GET localhost:8000/requests/user/foo
 ```
 
-The plugin adds a new header `x-consumer-id` with value `alice` before proxying
-request upstream.
+The plugin adds a new header `x-consumer-id` with the value `alice` before
+proxying the request upstream.
 
-Now try sending request with header `x-user-id` set:
+Now try sending request with the header `x-user-id` set:
 
 ```bash
 $ curl -i -X GET localhost:8000/requests/user/foo \
@@ -316,22 +322,21 @@ with the header `x-user-id`, i.e.`bob`.
 
 ## Order of execution
 
-Plugin performs the response transformation in the following order:
+This plugin performs the response transformation in the following order:
 
 * remove → rename → replace → add → append
 
 ## Examples
 
-<div class="alert alert-info.blue" role="alert">
-  <strong>Kubernetes users:</strong> version <code>v1beta1</code> of the Ingress
+{:.note}
+> **Kubernetes users:** Version `v1beta1` of the Ingress
   specification does not allow the use of named regex capture groups in paths.
   If you use the ingress controller, you should use unnamed groups, e.g.
-  <code>(\w+)/</code> instead of <code>(?&lt;user_id&gt;\w+)</code>. You can access
-  these based on their order in the URL path, e.g. <code>$(uri_captures[1])</code>
-  will obtain the value of the first capture group.
-</div>
+  `(\w+)/`instead of `(?&lt;user_id&gt;\w+)`. You can access
+  these based on their order in the URL path. For example `$(uri_captures[1])`
+  obtains the value of the first capture group.
 
-In the following examples, the plugin enabled on a Service. This would work
+In the following examples, the plugin is enabled on a Service. This would work
 similarly for Routes.
 
 - Add multiple headers by passing each `header:value` pair separately:

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -58,7 +58,6 @@ kong_version_compatibility:
       - 0.36-x
 params:
   name: response-ratelimiting
-  api_id: false
   service_id: true
   route_id: true
   consumer_id: true
@@ -232,7 +231,5 @@ X-RateLimit-Remaining-Videos: 3
 X-RateLimit-Remaining-Images: 0
 ```
 
-[api-object]: /gateway/latest/admin-api/#api-object
 [configuration]: /gateway/latest/reference/configuration
 [consumer-object]: /gateway/latest/admin-api/#consumer-object
-

--- a/app/_hub/kong-inc/route-by-header/index.md
+++ b/app/_hub/kong-inc/route-by-header/index.md
@@ -27,7 +27,6 @@ kong_version_compatibility:
       - 0.36-x
 params:
   name: route-by-header
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true

--- a/app/_hub/kong-inc/statsd-advanced/index.md
+++ b/app/_hub/kong-inc/statsd-advanced/index.md
@@ -4,8 +4,7 @@ publisher: Kong Inc.
 version: 2.2.x
 desc: Send metrics to StatsD with more flexible options
 description: |
-  Log [metrics](#metrics) for a Service, Route (or the deprecated API entity)
-  to a StatsD server.
+  Log [metrics](#metrics) for a Service or Route to a StatsD server.
   It can also be used to log metrics on [Collectd](https://collectd.org/)
   daemon by enabling its
   [StatsD plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
@@ -36,7 +35,6 @@ kong_version_compatibility:
       - 0.36-x
 params:
   name: statsd-advanced
-  api_id: false
   service_id: true
   route_id: true
   consumer_id: true

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -585,7 +585,4 @@ default/sample values as needed:
 {% if include.params.consumer_id %}
   {{ plugin_config_for_consumer | markdownify }}
 {% endif %}
-{% if include.params.api_id %}
-  {{ plugin_config_for_api | markdownify }}
-{% endif %}
 {{ plugin_global_config | markdownify }}

--- a/app/gateway/2.7.x/admin-api/rbac/reference.md
+++ b/app/gateway/2.7.x/admin-api/rbac/reference.md
@@ -390,12 +390,12 @@ ___
 exact matches, or contain wildcards, represented by `*`.
 
 - Exact matches; eg:
-  * /apis/
-  * /apis/foo
+  * /services/
+  * /services/foo
 
 - Wildcards; eg:
-  * /apis/*
-  * /apis/*/plugins
+  * /services/*
+  * /services/*/plugins
 
 Where `*` replaces exactly one segment between slashes (or the end of
 the path).

--- a/app/gateway/2.7.x/configure/auth/allowing-multiple-authentication-methods.md
+++ b/app/gateway/2.7.x/configure/auth/allowing-multiple-authentication-methods.md
@@ -34,17 +34,17 @@ The `anonymous` consumer does not correspond to any real user, and will only ser
 Next, we add both Key Auth and Basic Auth plugins to our consumer, and set the anonymous fallback to the consumer we created earlier.
 
 ```bash
-$ curl -sX POST kong-admin:8001/apis/example-api/plugins/ \
+$ curl -sX POST kong-admin:8001/services/example-service/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "key-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
 
-{"created_at":1517528304000,"config":{"key_in_body":false,"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a","run_on_preflight":true,"key_names":["apikey"]},"id":"bb884f7b-4e48-4166-8c80-c858b5a4c357","name":"key-auth","api_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
+{"created_at":1517528304000,"config":{"key_in_body":false,"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a","run_on_preflight":true,"key_names":["apikey"]},"id":"bb884f7b-4e48-4166-8c80-c858b5a4c357","name":"key-auth","service_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
 
-$ curl -sX POST kong-admin:8001/apis/example-api/plugins/ \
+$ curl -sX POST kong-admin:8001/services/example-service/plugins/ \
     -H "Content-Type: application/json" \
     --data '{"name": "basic-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
 
-{"created_at":1517528499000,"config":{"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"},"id":"e5a40543-debe-4225-a879-a54901368e6d","name":"basic-auth","api_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
+{"created_at":1517528499000,"config":{"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"},"id":"e5a40543-debe-4225-a879-a54901368e6d","name":"basic-auth","service_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
 ```
 
 If using [OpenID Connect](/hub/kong-inc/openid-connect), you must also set `config.consumer_claim` along with `anonymous`, as setting `anonymous` alone will not map that consumer.

--- a/app/gateway/2.7.x/configure/auth/oidc-auth0.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-auth0.md
@@ -26,7 +26,8 @@ If you have not done so already, [create a **Service**][add-service] to protect.
 Add an OpenID plugin configuration using the parameters in the example below using an HTTP client or Kong Manager. Auth0's token endpoint [requires passing the API identifier in the `audience` parameter][audience-required], which must be added as a custom argument:
 
 ```bash
-$ curl -i -X POST http://kong:8001/kong-admin/apis/<API name>/plugins --data name="openid-connect" \
+$ curl -i -X POST http://kong:8001/kong-admin/services/{SERVICE_NAME}/plugins \
+  --data name="openid-connect" \
   --data config.auth_methods="client_credentials" \
   --data config.issuer="https://<auth0 API name>.auth0.com/.well-known/openid-configuration" \
   --data config.token_post_args_names="audience" \

--- a/app/gateway/2.7.x/configure/auth/oidc-google.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-google.md
@@ -18,14 +18,15 @@ You can optionally customize the consent screen to inform clients who/what appli
 
 ## Kong Configuration
 
-If you have not yet [added a **Service**][add-service], go ahead and do so. Again, note that you should be able to secure this API with HTTPS, so if you are configuring a host, use a hostname you have a certificate for.
+If you have not yet [added a **Service**][add-service], go ahead and do so. Again, note that you should be able to secure this Service with HTTPS, so if you are configuring a host, use a hostname you have a certificate for.
 
 ### Basic Plugin Configuration
 
-Add a plugin with the configuration below to your API using an HTTP client or Kong Manager. Make sure to use the same redirect URI as configured earlier:
+Add a plugin with the configuration below to your Service using an HTTP client or Kong Manager. Make sure to use the same redirect URI as configured earlier:
 
 ```bash
-$ curl -i -X POST http://kong:8001/apis/example/plugins --data name="openid-connect" \
+$ curl -i -X POST http://kong:8001/services/{SERVICE_NAME}/plugins \
+  --data name="openid-connect" \
   --data config.issuer="https://accounts.google.com/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID" \
   --data config.client_secret="YOUR_CLIENT_SECRET" \
@@ -33,7 +34,7 @@ $ curl -i -X POST http://kong:8001/apis/example/plugins --data name="openid-conn
   --data config.scopes="openid,email"
 ```
 
-Visiting a URL matched by that API in a browser will now redirect to Google's authentication site and return you to the redirect URI after authenticating. You'll note, however, that we did not configure anything to map authentication to consumers and that no consumer is associated with the subsequent request. Indeed, if you have configured other plugins that rely on consumer information, such as the ACL plugin, you will not have access. At present, the plugin configuration confirms that
+Visiting a URL matched by that Service in a browser will now redirect to Google's authentication site and return you to the redirect URI after authenticating. You'll note, however, that we did not configure anything to map authentication to consumers and that no consumer is associated with the subsequent request. Indeed, if you have configured other plugins that rely on consumer information, such as the ACL plugin, you will not have access. At present, the plugin configuration confirms that
 users have a Google account, but doesn't do anything with that information.
 
 Depending on your needs, it may not be necessary to associate clients with a consumer. You can, for example, configure the `domains` parameter to limit access to a internal users if you have a G Suite hosted domain, or configure `upstream_headers_claims` to send information about the user upstream (e.g. their email, a profile picture, their name, etc.) for use in your applications or for analytics.
@@ -47,7 +48,7 @@ $ curl -i -X POST http://kong:8001/consumers/ \
   --data username="Yoda" \
   --data custom_id="user@example.com"
 
-$ curl -i -X PATCH http://kong:8001/apis/example/plugins/<OIDC plugin ID> \
+$ curl -i -X PATCH http://kong:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="email"
 ```


### PR DESCRIPTION
### Summary
Scrub the `/apis` endpoint from the plugin docs and the latest version of Gateway docs. 

Question for reviewers: should I backport these edits? That is, should I scrub this endpoint from all supported versions of Gateway, at least? 

### Reason
The API entity was replaced with Service in CE 0.13/EE 0.32 - that is, very very long ago, pretty much at the start of Kong's lifetime. We have many languishing tickets mentioning this deprecated endpoint.

### Testing
TBA
