### PR TITLE
[DOCU-866] Remove marketplaces install tab from mesh docs

### DIFF
--- a/app/_data/docs_nav_mesh_1.1.x.yml
+++ b/app/_data/docs_nav_mesh_1.1.x.yml
@@ -35,11 +35,7 @@
       url: /installation/ubuntu
     - text: macOS
       url: /installation/macos
-    - text: Marketplaces
-      items:
-        - text: Azure (AKS)
-          url: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh
-          absolute_url: true
+
 
 - title: Enterprise Features
   icon: /assets/images/icons/documentation/icn-enterprise-blue.svg

--- a/app/_data/docs_nav_mesh_1.2.x.yml
+++ b/app/_data/docs_nav_mesh_1.2.x.yml
@@ -36,12 +36,7 @@
       url: /installation/ubuntu
     - text: macOS
       url: /installation/macos
-    - text: Marketplaces
-      items:
-        - text: Azure (AKS)
-          url: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh
-          absolute_url: true
-          target_blank: true
+
 
 - title: Enterprise Features
   icon: /assets/images/icons/documentation/icn-enterprise-blue.svg

--- a/app/_data/docs_nav_mesh_1.3.x.yml
+++ b/app/_data/docs_nav_mesh_1.3.x.yml
@@ -36,12 +36,6 @@
       url: /installation/ubuntu
     - text: macOS
       url: /installation/macos
-    - text: Marketplaces
-      items:
-        - text: Azure (AKS)
-          url: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh
-          absolute_url: true
-          target_blank: true
 
 - title: Enterprise Features
   icon: /assets/images/icons/documentation/icn-enterprise-blue.svg

--- a/app/_data/docs_nav_mesh_1.4.x.yml
+++ b/app/_data/docs_nav_mesh_1.4.x.yml
@@ -36,12 +36,6 @@
       url: /installation/ubuntu
     - text: macOS
       url: /installation/macos
-    - text: Marketplaces
-      items:
-        - text: Azure (AKS)
-          url: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh
-          absolute_url: true
-          target_blank: true
 
 - title: Enterprise Features
   icon: /assets/images/icons/documentation/icn-enterprise-blue.svg

--- a/app/_data/docs_nav_mesh_1.5.x.yml
+++ b/app/_data/docs_nav_mesh_1.5.x.yml
@@ -38,12 +38,6 @@
       url: /installation/macos
     - text: Windows
       url: /installation/windows
-    - text: Marketplaces
-      items:
-        - text: Azure (AKS)
-          url: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh
-          absolute_url: true
-          target_blank: true
 
 - title: Enterprise Features
   icon: /assets/images/icons/documentation/icn-enterprise-blue.svg

--- a/app/mesh/1.1.x/install.md
+++ b/app/mesh/1.1.x/install.md
@@ -10,7 +10,7 @@ seamless experience, {{site.mesh_product_name}} follows the same installation
 and configuration procedures as Kuma, but with {{site.mesh_product_name}}-specific binaries.
 
 On this page, you will find access to the official {{site.mesh_product_name}}
-distributions that provide a drop-in replacement to Kuma's native binaries, plus 
+distributions that provide a drop-in replacement to Kuma's native binaries, plus
 links to cloud marketplace integrations.
 
 **The latest {{site.mesh_product_name}} version is
@@ -81,23 +81,11 @@ links to cloud marketplace integrations.
 </div>
 
 {% endnavtab %}
-{% navtab Marketplaces %}
-
-<div class="docs-grid-install">
-
-  <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
-    <div class="install-text">Azure</div>
-  </a>
-
-</div>
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ## Licensing
 
-Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning. 
+Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning.
 
 You have a 30-day grace period after the license expires. Make sure to renew your license before the grace period ends.
 

--- a/app/mesh/1.2.x/install.md
+++ b/app/mesh/1.2.x/install.md
@@ -10,7 +10,7 @@ seamless experience, {{site.mesh_product_name}} follows the same installation
 and configuration procedures as Kuma, but with {{site.mesh_product_name}}-specific binaries.
 
 On this page, you will find access to the official {{site.mesh_product_name}}
-distributions that provide a drop-in replacement to Kuma's native binaries, plus 
+distributions that provide a drop-in replacement to Kuma's native binaries, plus
 links to cloud marketplace integrations.
 
 **The latest {{site.mesh_product_name}} version is
@@ -81,23 +81,11 @@ links to cloud marketplace integrations.
 </div>
 
 {% endnavtab %}
-{% navtab Marketplaces %}
-
-<div class="docs-grid-install">
-
-  <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
-    <div class="install-text">Azure</div>
-  </a>
-
-</div>
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ## Licensing
 
-Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning. 
+Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning.
 
 You have a 30-day grace period after the license expires. Make sure to renew your license before the grace period ends.
 

--- a/app/mesh/1.3.x/install.md
+++ b/app/mesh/1.3.x/install.md
@@ -10,7 +10,7 @@ seamless experience, {{site.mesh_product_name}} follows the same installation
 and configuration procedures as Kuma, but with {{site.mesh_product_name}}-specific binaries.
 
 On this page, you will find access to the official {{site.mesh_product_name}}
-distributions that provide a drop-in replacement to Kuma's native binaries, plus 
+distributions that provide a drop-in replacement to Kuma's native binaries, plus
 links to cloud marketplace integrations.
 
 **The latest {{site.mesh_product_name}} version is
@@ -81,23 +81,11 @@ links to cloud marketplace integrations.
 </div>
 
 {% endnavtab %}
-{% navtab Marketplaces %}
-
-<div class="docs-grid-install">
-
-  <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
-    <div class="install-text">Azure</div>
-  </a>
-
-</div>
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ## Licensing
 
-Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning. 
+Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning.
 
 You have a 30-day grace period after the license expires. Make sure to renew your license before the grace period ends.
 

--- a/app/mesh/1.4.x/install.md
+++ b/app/mesh/1.4.x/install.md
@@ -10,7 +10,7 @@ seamless experience, {{site.mesh_product_name}} follows the same installation
 and configuration procedures as Kuma, but with {{site.mesh_product_name}}-specific binaries.
 
 On this page, you will find access to the official {{site.mesh_product_name}}
-distributions that provide a drop-in replacement to Kuma's native binaries, plus 
+distributions that provide a drop-in replacement to Kuma's native binaries, plus
 links to cloud marketplace integrations.
 
 **The latest {{site.mesh_product_name}} version is
@@ -81,23 +81,11 @@ links to cloud marketplace integrations.
 </div>
 
 {% endnavtab %}
-{% navtab Marketplaces %}
-
-<div class="docs-grid-install">
-
-  <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
-    <div class="install-text">Azure</div>
-  </a>
-
-</div>
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ## Licensing
 
-Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning. 
+Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning.
 
 You have a 30-day grace period after the license expires. Make sure to renew your license before the grace period ends.
 

--- a/app/mesh/1.5.x/install.md
+++ b/app/mesh/1.5.x/install.md
@@ -10,7 +10,7 @@ seamless experience, {{site.mesh_product_name}} follows the same installation
 and configuration procedures as Kuma, but with {{site.mesh_product_name}}-specific binaries.
 
 On this page, you will find access to the official {{site.mesh_product_name}}
-distributions that provide a drop-in replacement to Kuma's native binaries, plus 
+distributions that provide a drop-in replacement to Kuma's native binaries, plus
 links to cloud marketplace integrations.
 
 **The latest {{site.mesh_product_name}} version is
@@ -81,23 +81,11 @@ links to cloud marketplace integrations.
 </div>
 
 {% endnavtab %}
-{% navtab Marketplaces %}
-
-<div class="docs-grid-install">
-
-  <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongmesh" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
-    <div class="install-text">Azure</div>
-  </a>
-
-</div>
-
-{% endnavtab %}
 {% endnavtabs %}
 
 ## Licensing
 
-Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning. 
+Your {{site.mesh_product_name}} license includes an expiration date and the number of data plane proxies you can deploy. If you deploy more proxies than your license allows, you receive a warning.
 
 You have a 30-day grace period after the license expires. Make sure to renew your license before the grace period ends.
 


### PR DESCRIPTION
### Summary
Removing marketplaces tab and nav link.

### Reason
This link and marketplace posting is not maintained (it's still on Mesh 1.1). The alliances team is handling it separately instead, and all marketplaces/alliances links will live on the marketing site.

This content has already been removed for Gateway. See the DOCU ticket (DOCU-866) for more information.

### Testing
https://deploy-preview-3568--kongdocs.netlify.app/mesh/1.5.x/install/ - no tab for "marketplaces", and no nav entry for it either.