### PR TITLE
[DOCU-2112][DOCU-2113] Remove 25-hour limit for Vitals with InfluxDB

### DIFF
--- a/app/enterprise/2.1.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.1.x/vitals/vitals-influx-strategy.md
@@ -123,6 +123,4 @@ syscall per request.
 Currently, Vitals InfluxDB data points are not downsampled or managed via
 retention policy by Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Currently, Kong Vitals ignores data points
-older than 25 hours; it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points. 

--- a/app/enterprise/2.2.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.2.x/vitals/vitals-influx-strategy.md
@@ -123,6 +123,4 @@ syscall per request.
 Currently, Vitals InfluxDB data points are not downsampled or managed via
 retention policy by Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Currently, Kong Vitals ignores data points
-older than 25 hours; it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points.

--- a/app/enterprise/2.3.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.3.x/vitals/vitals-influx-strategy.md
@@ -123,6 +123,4 @@ syscall per request.
 Currently, Vitals InfluxDB data points are not downsampled or managed via
 retention policy by Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Currently, Kong Vitals ignores data points
-older than 25 hours; it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points.

--- a/app/enterprise/2.4.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.4.x/vitals/vitals-influx-strategy.md
@@ -222,6 +222,4 @@ microsecond precision requires an additional syscall per request.
 Vitals InfluxDB data points are not downsampled or managed by a
 retention policy through Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Kong Vitals ignores data points
-older than 25 hours, so it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points.

--- a/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
@@ -222,6 +222,4 @@ microsecond precision requires an additional syscall per request.
 Vitals InfluxDB data points are not downsampled or managed by a
 retention policy through Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Kong Vitals ignores data points
-older than 25 hours, so it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points.

--- a/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
@@ -274,6 +274,4 @@ microsecond precision requires an additional syscall per request.
 Vitals InfluxDB data points are not downsampled or managed by a
 retention policy through Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Kong Vitals ignores data points
-older than 25 hours, so it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points.

--- a/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
@@ -273,6 +273,4 @@ microsecond precision requires an additional syscall per request.
 Vitals InfluxDB data points are not downsampled or managed by a
 retention policy through Kong. InfluxDB operators are encouraged to manually manage
 the retention policy of the `kong` database to reduce the disk space and memory
-needed to manage Vitals data points. Kong Vitals ignores data points
-older than 25 hours, so it is safe to create a retention policy with a 25-hour
-duration for measurements written by Kong.
+needed to manage Vitals data points.


### PR DESCRIPTION
### Summary
Removing a sentence that mentions a 25-hour data retention limit for Vitals with InfluxDB. 
Cleared it from all 2.x docs to reduce confusion.

### Reason
The 25-hour data retention limitation is only applicable when using Postgres or Cassandra as a backing DB. 
It is not true with InfluxDB, and in fact, the mention of a strictretention policy is directly contradicting a sentence earlier in the paragraph, which states:

> Vitals InfluxDB data points are not downsampled or managed by a retention policy through Kong.

### Testing
Sample topics:
https://deploy-preview-3569--kongdocs.netlify.app/gateway/2.7.x/vitals/vitals-influx-strategy/#managing-the-retention-policy-of-the-kong-database 

https://deploy-preview-3569--kongdocs.netlify.app/enterprise/2.5.x/vitals/vitals-influx-strategy/#managing-the-retention-policy-of-the-kong-database 
