### PR TITLE
Automatically apply review:tech to Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "labels": ["review:tech"]
+}


### PR DESCRIPTION
### Summary
Automatically apply the `review:tech` labels to Renovate PRs

### Reason
The build will fail without it, and it helps us triage PRs more easily

### Testing

We'll have to wait for Renovate to raise a PR. It's been implemented using the details on the [Renovate docs](https://docs.renovatebot.com/configuration-options/)
