### PR TITLE
Fix positioning of `name` datatype for plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -21,8 +21,8 @@ breadcrumbs:
   <tbody>
     <tr>
       <td><code>name</code>
-        <br><i>required</i></td>
-        <br><br><strong>Type: </strong>string
+        <br><i>required</i>
+        <br><br><strong>Type: </strong>string</td>
       <td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code>.</td>
     </tr>
 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -23,7 +23,7 @@ breadcrumbs:
       <td><code>name</code>
         <br><i>required</i>
         <br><br><strong>Type: </strong>string</td>
-      <td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code>.</td>
+      <td>The name of the plugin, in this case <code>{{ page.params.name }}</code>.</td>
     </tr>
 
     {% if page.params.service_id %}


### PR DESCRIPTION
### Summary
Fix typo on closing table cell tag (`</td>`). 

### Reason
Closing tag is in the wrong place, so the `Type: string` line ends up outside the table:
![Screen Shot 2022-01-24 at 9 54 29 AM](https://user-images.githubusercontent.com/54370747/150837579-43b14d96-a050-4342-b3fa-0cd06abbc95d.png)

### Testing
TBA
Check any plugin