### PR TITLE
doc(kic) update version compatibility tables

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
@@ -24,6 +24,7 @@ By Kong, we are here referring to the official distribution of the Open-Source K
 | Kong 2.4.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kong 2.5.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kong 2.6.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.7.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 ## Kong Enterprise
 
@@ -40,6 +41,7 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kong Enterprise 2.4.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kong Enterprise 2.5.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kong Enterprise 2.6.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.7.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 ## Kubernetes
 
@@ -55,6 +57,7 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.22           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.23           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
 
 ## Istio
 

--- a/app/kubernetes-ingress-controller/2.1.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.1.x/references/version-compatibility.md
@@ -59,6 +59,7 @@ other enterprise functionality, built on top of the Open-Source Kong Gateway.
 | Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.22           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.23           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 ## Istio
 


### PR DESCRIPTION
### Summary
Updates KIC version compatibility tables for Kong 2.7 and Kubernetes 1.23

### Reason
We've run the versions we expect to work on 1.23 on 1.23, and they did:
https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1747707378
https://github.com/Kong/kubernetes-ingress-controller/actions/runs/1747833961

TestDeployAllInOneDBLESSNoLoadBalancer and TestDeployAllInOnePostgresWithMultipleReplicas, which are expected to fail on 2.0.x (their fixes are only in 2.1.x--I need to update the workflow a bit to let you choose the E2E test version, since it's currently locked to the tests in main)

We know of no breaking changes in Kong 2.7 that would break compatibility with versions that are supported with 2.6

### Testing
Check netlify to confirm tables not busted.