### PR TITLE
Remove max height from codeblocks

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -819,7 +819,6 @@
     margin: 1.3em 0;
     padding: 12px 17px;
     border-radius: 3px;
-    max-height: 400px;
     overflow: auto;
 
     &::-webkit-scrollbar {


### PR DESCRIPTION
### Summary
Removing height limit from codeblocks to avoid vertical scrollbars.

Not doing: removing the horizontal scroll. That can cause confusion due to awkward line breaks, so leaving it as is for now.  We can decide if letting lines wrap is fine in the future.

### Reason
Originally, max height was added to codeblocks to stop pages from getting really stretched out. However, this has proven to be a poor solution, and has created some awkward UX 
- occasionally, code blocks add a scrollbar for one or two lines
- other times, there are both horizontal and vertical scrollbars, and navigating the codeblocks gets difficult
- if someone wants to highlight the codeblock to copy the text, scrolling is awkward. yes, we provide a copy-code button, but not everyone uses it

Awkward codeblock examples:
docs.konghq.com/deck/1.10.x/reference/deck/
docs.konghq.com/mesh/1.5.x/features/vault/#configure-mesh

### Testing
TBA