### PR TITLE
Ensure sidebar + top nav module list is consistent

### DIFF
--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -28,7 +28,7 @@
     <div class="separator"></div>
     <div class="navbar-items" role="navigation" aria-label="Main menu">
       <ul class="navbar-items" role="menubar">
-        <li aria-haspopup="true" role="menuitem"
+        <li id="top-module-list" aria-haspopup="true" role="menuitem"
           class="navbar-item main-menu-item with-submenu{% if include.layout != 'landing-page' %} active{% endif %}"
           onclick="toggleSubmenuVisible(this)">
           <a href="/" tabindex="0" id="docs-link">Docs</a>
@@ -67,7 +67,7 @@
               </li>
               <hr>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/contributing/" class="navbar-item navbar-item-docs">Doc contribution guidelines</a>
+                <a href="/contributing/" class="navbar-item navbar-item-docs">Docs contribution guidelines</a>
               </li>
               </div>
           </ul>

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -1,4 +1,22 @@
 describe "sidebar", type: :feature, js: true do
+
+  describe "Module Switcher", type: :feature, js: true do
+    it "has the same products, in the same order as the top 'Docs' dropdown" do
+      visit "/gateway/"
+
+      sidebarUrls = page.all('#module-list a', minimum: 1, visible: false).map do |link|
+        { link.text(:all) => link[:href] }
+      end.reduce({}, :merge)
+
+      topNavUrls = page.all('#top-module-list .navbar-item-submenu a', minimum: 1, visible: false).map do |link|
+        { link.text(:all) => link[:href] }
+      end.reduce({}, :merge)
+
+      expect(sidebarUrls).to eql(topNavUrls)
+    end
+  end
+
+
   describe "Version Switcher", type: :feature, js: true do
     it "links to the same page if it exists in previous versions" do
       visit "/enterprise/2.5.x/deployment/installation/docker/"


### PR DESCRIPTION
### Summary
Followup on #3566 

Now that the sidebar / top nav are consistent, let's add a test to make sure it never gets out of sync again.

I also added a missing `s` from the top navigation that the test highlighted.

### Reason
One less thing for people to have to remember. The build will fail if we forget to change one of the two sections

### Testing
The tests will pass
