### PR TITLE
Add labels reminder to PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,14 @@ Trello card, etc. -->
 
 <!-- (Optional) Include link to topic in Netlify preview after it's generated 
 (around 10mins after PR is created) -->
+
+<!--
+
+When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:
+
+    review:copyedit: Request for writer review.
+    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
+    review:tech: Request for technical review from an SME.
+
+At least one of these labels must be applied to a PR or the build will fail.
+-->


### PR DESCRIPTION
### Summary
Add a reminder to use a label when submitting a PR to the PR template

### Reason
I keep forgetting to add a label

### Testing
N/A
