### PR TITLE
Update require-review-label.yml

### DIFF
--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: minimum
           count: 1


### PR DESCRIPTION
### Summary
When a label is added _after_ a PR is opened, the original commit will still be marked as failing. This is due to the action we use reading `event.json` rather than using the API (see https://github.com/mheap/github-action-required-labels/issues/14)

This PR adds a `GITHUB_TOKEN` which allows us to add a label then re-run the job to get a green tick

### Reason
Misleading build failures are bad. We can fix them

### Testing
This PR will pass
