### PR TITLE
Release: Gateway patches 2.7.1.0 and 2.6.0.3

### DIFF
--- a/app/gateway/2.6.x/reference/configuration.md
+++ b/app/gateway/2.6.x/reference/configuration.md
@@ -786,6 +786,16 @@ Valid values to this setting are:
 
 ---
 
+#### cluster_max_payload
+
+This sets the maximum payload size allowed to be sent across from CP to DP in
+Hybrid mode.
+
+Default is 4Mb - 4 * 1024 * 1024 due to historical reasons.
+
+**Default:** `4194304`
+
+---
 
 ### NGINX section
 

--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -624,6 +624,9 @@ Valid values to this setting are:
 - `pki`: use `cluster_ca_cert`, `cluster_server_name` and `cluster_cert` for
   verification. These are different certificates for each DP node, but issued by
   a cluster-wide common CA certificate: `cluster_ca_cert`.
+- `pki_check_cn`: similar to `pki`, but additionally
+   checks for the Common Name of the data plane certificate specified in
+   `cluster_allowed_common_names`.
 
 **Default:** `shared`
 
@@ -673,6 +676,18 @@ This field is ignored if `cluster_mtls` is set to `shared`.
 
 ---
 
+#### cluster_allowed_common_names
+
+The list of Common Names that are allowed to connect to the control plane. 
+Multiple entries may be supplied in a comma-separated string. When not
+set, only Data Planes with the same parent domain as the
+Control Plane cert are allowed to connect.
+
+This field is ignored if `cluster_mtls` is not set to `pki_check_cn`.
+
+**Default:** none
+
+---
 
 ### Hybrid Mode Data Plane section
 

--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -817,6 +817,16 @@ Valid values to this setting are:
 
 ---
 
+#### cluster_max_payload
+
+This sets the maximum payload size allowed to be sent across from CP to DP in
+Hybrid mode.
+
+Default is 4Mb - 4 * 1024 * 1024 due to historical reasons.
+
+**Default:** `4194304`
+
+---
 
 ### NGINX section
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -10,11 +10,16 @@ no_version: true
 ### Features
 
 #### Enterprise
-* You can now configure [`cluster_max_payload`](/gateway/latest/reference/configuration/#cluster-max-payload)
+* You can now configure [`cluster_max_payload`](/gateway/latest/reference/configuration/#cluster_max_payload)
 for hybrid mode deployments. This configuration option sets the maximum payload
 size allowed to be sent across from the control plane to the data plane. If your
 environment has large configurations that generate `payload too big` errors
 and don't get applied to the data planes, use this setting to adjust the limit.
+* When using PKI for certificate verification in hybrid mode, you can now 
+configure a list Common Names allowed to connect to a control plane with the
+[`cluster_allowed_common_names`](/gateway/latest/reference/configuration/#cluster_allowed_common_names)
+option. If not set, only data planes with the same parent domain as the control
+plane cert are allowed.
 
 ### Fixes
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -15,7 +15,7 @@ for hybrid mode deployments. This configuration option sets the maximum payload
 size allowed to be sent across from the control plane to the data plane. If your
 environment has large configurations that generate `payload too big` errors
 and don't get applied to the data planes, use this setting to adjust the limit.
-* When using PKI for certificate verification in hybrid mode, you can now 
+* When using PKI for certificate verification in hybrid mode, you can now
 configure a list Common Names allowed to connect to a control plane with the
 [`cluster_allowed_common_names`](/gateway/latest/reference/configuration/#cluster_allowed_common_names)
 option. If not set, only data planes with the same parent domain as the control
@@ -421,6 +421,9 @@ on Kong Gateway usage now travels through an encrypted connection.
 with Azure AD.
 * Fixed a timer leak that caused the timers to be exhausted and failed to start
 any other timers used by Kong, showing the error `too many pending timers`.
+* Fixed an issue with icon alignment in Kong Manager, where the **Delete**
+(garbage can) icon overlapped with the **View** link and caused users to
+accidentally click **Delete**.
 
 #### Dev Portal
 * Fixed the Dev Portal Application Services list to allow pagination.
@@ -497,10 +500,6 @@ workspace than where it was originally created did not delete the associated
 Consumer entity, and the username would remain locked. For example, if the
 admin was created in workspace `dev` and deleted from workspace `QA`, this
 issue would occur.
-
-- Fixed an issue with icon alignment in Kong Manager, where the **Delete**
-(garbage can) icon overlapped with the **View** link and caused users to
-accidentally click **Delete**.
 
 ### Dependencies
 - Bumped kong-redis-cluster from `1.1-0` to `1.2.0`.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -47,7 +47,7 @@ access to multiple workspaces.
     namespaces. Now, it uses a single timer for all namespace maintenance.
 
 * [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
-  * Fixed a 500 error which occurred when consumer groups were enforced but no
+  * Fixed a 500 error that occurred when consumer groups were enforced but no
   proper configurations were provided. Now, if no specific consumer group
   configuration exists, the consumer group defaults to the original plugin
   configuration.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -32,6 +32,14 @@ any other timers used by Kong, showing the error `too many pending timers`.
 * Fix an issue where, if `data_plane_config_cache_mode` was set to `off`, the
 data plane received no updates from the control plane.
 
+#### Core
+* Reschedule resolve timer only when the previous one has finished. 
+[#8344](https://github.com/Kong/kong/pull/8344)
+* Plugins, and any entities implemented with subchemas, now can use the 
+`transformations` and `shorthand_fields` properties, which were previously 
+only available for non-subschema entities. 
+[#8146](https://github.com/Kong/kong/pull/8146)
+
 #### Plugins
 
 * [Rate Limiting](/hub/kong-inc/rate-limiting) (`rate-limiting`)

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -31,8 +31,6 @@ with Azure AD.
 any other timers used by Kong, showing the error `too many pending timers`.
 * Fix an issue where, if `data_plane_config_cache_mode` was set to `off`, the
 data plane received no updates from the control plane.
-* Fixed a performance issue with Kong Manager, which occurred when admins had
-access to multiple workspaces.
 
 #### Plugins
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -16,7 +16,7 @@ size allowed to be sent across from the control plane to the data plane. If your
 environment has large configurations that generate `payload too big` errors
 and don't get applied to the data planes, use this setting to adjust the limit.
 * When using PKI for certificate verification in hybrid mode, you can now
-configure a list Common Names allowed to connect to a control plane with the
+configure a list of Common Names allowed to connect to a control plane with the
 [`cluster_allowed_common_names`](/gateway/latest/reference/configuration/#cluster_allowed_common_names)
 option. If not set, only data planes with the same parent domain as the control
 plane cert are allowed.
@@ -38,7 +38,7 @@ access to multiple workspaces.
 
 * [Rate Limiting](/hub/kong-inc/rate-limiting) (`rate-limiting`)
   * Fixed a 500 error associated with performing arithmetic functions on a nil
-  value by adding a nil value check after `performing ngx.shared.dict` operations.
+  value by adding a nil value check after performing `ngx.shared.dict` operations.
   * Fixed a timer leak that caused the timers to be exhausted and failed to
   start any other timers used by Kong, showing the error `too many pending timers`.
 
@@ -405,7 +405,7 @@ decK. If you have consumer groups in your configuration, decK will ignore them.
 ### Features
 
 #### Enterprise
-* You can now configure [`cluster_max_payload`](/gateway/latest/reference/configuration/#cluster-max-payload)
+* You can now configure [`cluster_max_payload`](/gateway/latest/reference/configuration/#cluster_max_payload)
 for hybrid mode deployments. This configuration option sets the maximum payload
 size allowed to be sent across from the control plane to the data plane. If your
 environment has large configurations that generate `payload too big` errors

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -4,6 +4,53 @@ no_search: true
 no_version: true
 ---
 
+## 2.7.1.0
+**Release Date:** 2022/01/27
+
+### Features
+
+#### Enterprise
+* You can now configure [`cluster_max_payload`](/gateway/latest/reference/configuration/#cluster-max-payload)
+for hybrid mode deployments. This configuration option sets the maximum payload
+size allowed to be sent across from the control plane to the data plane. If your
+environment has large configurations that generate `payload too big` errors
+and don't get applied to the data planes, use this setting to adjust the limit.
+
+### Fixes
+
+#### Enterprise
+
+* Fixed an issue where OIDC authentication into Kong Manager failed when used
+with Azure AD.
+* Fixed a timer leak that caused the timers to be exhausted and failed to start
+any other timers used by Kong, showing the error `too many pending timers`.
+* Fix an issue where, if `data_plane_config_cache_mode` was set to `off`, the
+data plane received no updates from the control plane.
+* Fixed a performance issue with Kong Manager, which occurred when admins had
+access to multiple workspaces.
+
+#### Plugins
+
+* [Rate Limiting](/hub/kong-inc/rate-limiting) (`rate-limiting`)
+  * Fixed a 500 error associated with performing arithmetic functions on a nil
+  value by adding a nil value check after `performing ngx.shared.dict` operations.
+  * Fixed a timer leak that caused the timers to be exhausted and failed to
+  start any other timers used by Kong, showing the error `too many pending timers`.
+
+    Before, the plugin used one timer for each namespace maintenance process,
+    increasing timer usage on instances with a large number of rate limiting
+    namespaces. Now, it uses a single timer for all namespace maintenance.
+
+* [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
+  * Fixed a 500 error which occurred when consumer groups were enforced but no
+  proper configurations were provided. Now, if no specific consumer group
+  configuration exists, the consumer group defaults to the original plugin
+  configuration.
+
+* [Exit Transformer](/hub/kong-inc/exit-transformer) (`exit-transformer`)
+  * Fix an issue where the Exit Transformer plugin
+  would break the plugin iterator, causing later plugins not to run.
+
 ## 2.7.0.0
 **Release Date:** 2021/12/16
 
@@ -196,6 +243,9 @@ Consumer entity, and the username would remain locked. For example, if the
 admin was created in workspace `dev` and deleted from workspace `QA`, this
 issue would occur.
 
+* Phone home metrics are now sent over TLS, meaning that any analytics data
+on Kong Gateway usage now travels through an encrypted connection.
+
 #### Dev Portal
 * Dev Portal OpenID Connect authentication now properly redirects users based on
 the values of `login_redirect_uri` and `forbidden_redirect_uri` set in `portal_auth`.
@@ -344,6 +394,44 @@ effect on the following plugins and fields:
 * Consumer groups are not supported in declarative configuration with
 decK. If you have consumer groups in your configuration, decK will ignore them.
 
+## 2.6.0.3
+**Release Date:** 2022/01/27
+
+### Features
+
+#### Enterprise
+* You can now configure [`cluster_max_payload`](/gateway/latest/reference/configuration/#cluster-max-payload)
+for hybrid mode deployments. This configuration option sets the maximum payload
+size allowed to be sent across from the control plane to the data plane. If your
+environment has large configurations that generate `payload too big` errors
+and don't get applied to the data planes, use this setting to adjust the limit.
+
+### Fixes
+
+#### Enterprise
+
+* Phone home metrics are now sent over TLS, meaning that any analytics data
+on Kong Gateway usage now travels through an encrypted connection.
+* Fixed an issue where OIDC authentication into Kong Manager failed when used
+with Azure AD.
+* Fixed a timer leak that caused the timers to be exhausted and failed to start
+any other timers used by Kong, showing the error `too many pending timers`.
+
+#### Dev Portal
+* Fixed the Dev Portal Application Services list to allow pagination.
+* Fixed a table border styling issue.
+* Fixed issues with modal accessibility.
+
+#### Plugins
+
+* [Rate Limiting](/hub/kong-inc/rate-limiting) (`rate-limiting`) and
+[Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
+  * Fixed a timer leak that caused the timers to be exhausted and failed to
+  start any other timers used by Kong, showing the error `too many pending timers`.
+
+    Before, the plugin used one timer for each namespace maintenance process,
+    increasing timer usage on instances with a large number of rate limiting
+    namespaces. Now, it uses a single timer for all namespace maintenance.
 
 ## 2.6.0.2
 **Release Date:** 2021/12/03


### PR DESCRIPTION
### Summary
* Changelog entries for 2.7.1.0 and 2.6.0.3.
* Adding a config reference doc entry for the new parameter `cluster_max_payload`.
  * Note to reviewers: the text for this entry is unedited and getting added as-is from the `kong.conf.default` file. Not changing it to avoid conflicts with autodoc generation; will need to be edited in the source file.

Also note that the wiki lists this change for 2.6.0.3:
> Fix The garbage can icon overlaps the View link which causes users to click Delete instead of View

However, this change already went in with 2.6.0.1 (https://docs.konghq.com/gateway/changelog/#2601) - was there a regression, did it not actually go into 2.6.0.1, or is it just mislabelled?

### Reason
Patch releases.

### Testing
https://deploy-preview-3592--kongdocs.netlify.app/gateway/changelog/
