### PR TITLE
[DOCU-1942] Consistent tab titles

### DIFF
--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -218,7 +218,7 @@ or sample values as needed:
 {% endnavtab %}
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
-{% navtab Manager %}
+{% navtab Kong Manager %}
 Configure this plugin on a service:
 
 1. In Kong Manager, select the workspace.
@@ -351,7 +351,7 @@ or sample values as needed:
 {% endnavtab %}
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
-{% navtab Manager %}
+{% navtab Kong Manager %}
 Configure this plugin on a route:
 
 1. In Kong Manager, select the workspace.
@@ -466,7 +466,7 @@ plugins:
 {% endnavtab %}
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
-{% navtab Manager %}
+{% navtab Kong Manager %}
 Configure this plugin on a consumer:
 
 1. In Kong Manager, select the workspace.

--- a/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
@@ -65,39 +65,6 @@ URL `http://mockbin.org`.
 The service is created, and the page automatically redirects back to the
 `example_service` overview page.
 {% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-1. In the `kong.yaml` file you exported in
-[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
-define a Service with the name `example_service` and the URL
-`http://mockbin.org`:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-    ```
-2. Save the file. From your terminal, sync the configuration to update your
-gateway instance:
-
-    ``` bash
-    deck sync
-    ```
-
-    The message should show that you’re creating a service:
-
-    ```
-    creating service example_service
-    Summary:
-    Created: 1
-    Updated: 0
-    Deleted: 0
-    ```
-
-{% endnavtab %}
 {% navtab Using the Admin API %}
 
 <!-- codeblock tabs -->
@@ -137,6 +104,39 @@ http :8001/services/example_service
 {% endnavtab %}
 {% endnavtabs %}
 <!-- end codeblock tabs -->
+
+{% endnavtab %}
+{% navtab Using decK (YAML) %}
+
+1. In the `kong.yaml` file you exported in
+[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
+define a Service with the name `example_service` and the URL
+`http://mockbin.org`:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+    ```
+2. Save the file. From your terminal, sync the configuration to update your
+gateway instance:
+
+    ``` bash
+    deck sync
+    ```
+
+    The message should show that you’re creating a service:
+
+    ```
+    creating service example_service
+    Summary:
+    Created: 1
+    Updated: 0
+    Deleted: 0
+    ```
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -236,7 +236,7 @@ A `201` message indicates the Route was created successfully.
 3. (Optional) You can update your local file with the new configuration:
 
     <div class="alert alert-warning">
-   
+
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>

--- a/app/gateway/2.7.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/expose-services.md
@@ -65,39 +65,6 @@ URL `http://mockbin.org`.
 The service is created, and the page automatically redirects back to the
 `example_service` overview page.
 {% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-1. In the `kong.yaml` file you exported in
-[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
-define a Service with the name `example_service` and the URL
-`http://mockbin.org`:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-    ```
-2. Save the file. From your terminal, sync the configuration to update your
-gateway instance:
-
-    ``` bash
-    deck sync
-    ```
-
-    The message should show that you’re creating a service:
-
-    ```
-    creating service example_service
-    Summary:
-    Created: 1
-    Updated: 0
-    Deleted: 0
-    ```
-
-{% endnavtab %}
 {% navtab Using the Admin API %}
 
 <!-- codeblock tabs -->
@@ -137,6 +104,39 @@ http :8001/services/example_service
 {% endnavtab %}
 {% endnavtabs %}
 <!-- end codeblock tabs -->
+
+{% endnavtab %}
+{% navtab Using decK (YAML) %}
+
+1. In the `kong.yaml` file you exported in
+[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
+define a Service with the name `example_service` and the URL
+`http://mockbin.org`:
+
+    ``` yaml
+    _format_version: "1.1"
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+    ```
+2. Save the file. From your terminal, sync the configuration to update your
+gateway instance:
+
+    ``` bash
+    deck sync
+    ```
+
+    The message should show that you’re creating a service:
+
+    ```
+    creating service example_service
+    Summary:
+    Created: 1
+    Updated: 0
+    Deleted: 0
+    ```
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -236,7 +236,7 @@ A `201` message indicates the Route was created successfully.
 3. (Optional) You can update your local file with the new configuration:
 
     <div class="alert alert-warning">
-   
+
     <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
     overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
     </div>


### PR DESCRIPTION
### Summary
* Making sure that the tab titles for the Kong Manager tabs on plugin hub examples are consistent.
* Fixing inconsistent tab order in a getting started guide topic (single-sourced versions)

### Reason
Issue came up in https://github.com/Kong/docs.konghq.com/pull/3587. If the title is inconsistent, then the matching tabs on the same page won't open.

We also have a bug ticket for a similar issue (consistent tab order), DOCU-1942. To avoid confusion, when a matching tab opens, it should be in the same order in all tab blocks on the page.

### Testing
https://deploy-preview-3593--kongdocs.netlify.app/hub/kong-inc/basic-auth/ - tabs are titled "Kong Manager", not "Manager"
https://deploy-preview-3593--kongdocs.netlify.app/gateway/2.7.x/get-started/comprehensive/expose-services/ - titles for tab groups are in consistent order