### PR TITLE
Sidebar rendering speed improvements

### DIFF
--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -5,7 +5,7 @@
       <i class="sidebar-toggle"></i>
     {% endif %}
     <li class="breadcrumb-item">
-      {% if include.edition =='enterprise' or include.edition =='konnect' or include.edition =='konnect-platform' or include.edition == 'mesh' or page.edition == 'gateway' %}
+      {% if include.edition =='enterprise' or include.edition =='konnect' or include.edition =='konnect-platform' or include.edition == 'mesh' or include.edition == 'gateway' %}
         Kong Konnect Platform
       {% elsif include.edition == 'contributing' %}
         Contribute to the docs
@@ -21,7 +21,7 @@
       {% elsif include.edition == 'deck' %}<a href="/deck/">decK</a>
       {% elsif include.edition == 'kubernetes-ingress-controller' %}<a href="/kubernetes-ingress-controller/{{include.kong_version}}/">{{site.kic_product_name}}</a>
       {% elsif include.edition == 'gateway-oss' %}<a href="/gateway-oss/{{include.kong_version}}/">{{site.ce_product_name}}</a>
-      {% elsif page.edition == 'gateway' %}<a href="/gateway/{{page.kong_version}}/">{{site.base_gateway}}</a>
+      {% elsif include.edition == 'gateway' %}<a href="/gateway/{{include.kong_version}}/">{{site.base_gateway}}</a>
       {% elsif include.edition == 'getting-started-guide' %}<a href="/getting-started-guide/{{include.kong_version}}/overview">Get Started with Kong Gateway</a>
       {% elsif include.edition == 'contributing' %}<a href="/contributing/">Style guide and contribution guidelines</a>
       {% endif %}

--- a/app/_includes/docs-sidebar-item.html
+++ b/app/_includes/docs-sidebar-item.html
@@ -6,7 +6,7 @@
   {% for item in include.items %}
   {% if item.items %}
   {% assign id = include.id | append: '-' | append: forloop.index %}
-  {% include docs-sidebar-item.html id=id docs_url=include.docs_url items=item.items title=item.text url=item.url absolute_url=item.absolute_url active=item_active %}
+  {% include_cached docs-sidebar-item.html id=id docs_url=include.docs_url items=item.items title=item.text url=item.url absolute_url=item.absolute_url active=item_active %}
   {% else %}
   {% assign url = include.docs_url | append: item.url %}
   {% assign last_url_char = item.url | slice: -1, 1 %}
@@ -44,4 +44,4 @@
 {% assign item_url = false %}
 {% endif %}
 
-{% include accordion-item.html id=include.id icon=include.icon url=item_url label=include.title content=item_content %}
+{% include_cached accordion-item.html id=include.id icon=include.icon url=item_url label=include.title content=item_content %}

--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -141,7 +141,7 @@
   <ul class="accordion-container">
     <input id="accordion-opened" type="text" />
     {% for nav in include.nav_items %}
-    {% include docs-sidebar-item.html id=forloop.index docs_url=docs_url items=nav.items url=nav.url absolute_url=nav.absolute_url target=item.target icon=nav.icon title=nav.title %}
+    {% include_cached docs-sidebar-item.html id=forloop.index docs_url=docs_url items=nav.items url=nav.url absolute_url=nav.absolute_url target=item.target icon=nav.icon title=nav.title %}
     {% endfor %}
   </ul>
 </aside>

--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -14,7 +14,7 @@
           {% elsif include.edition == 'deck' %}decK
           {% elsif include.edition == 'kubernetes-ingress-controller' %}{{site.kic_product_name}}
           {% elsif include.edition == 'gateway-oss' %}{{site.ce_product_name}}
-          {% elsif page.edition == 'gateway' %}{{site.base_gateway}}
+          {% elsif include.edition == 'gateway' %}{{site.base_gateway}}
           {% elsif include.edition == 'getting-started-guide' %}Get Started with Kong Gateway
           {% elsif include.edition == 'contributing' %}Contribution guidelines
           {% endif %}
@@ -62,8 +62,8 @@
     <div class="versions-dropdown dropdown">
       <button class="dropdown-button" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
         <span>
-          Version {{page.kong_version}}
-          {% if page.kong_version == page.kong_latest.release and page.edition != 'gateway-oss' and page.edition != 'enterprise' and page.edition != 'getting-started-guide' %}
+          Version {{include.kong_version}}
+          {% if include.kong_version == include.kong_latest.release and include.edition != 'gateway-oss' and include.edition != 'enterprise' and include.edition != 'getting-started-guide' %}
             <span>(latest)</span>
           {% endif %}
         </span>
@@ -81,12 +81,12 @@
           {% assign version_page_url = include.url | replace: include.kong_version, ver.release %}
           {% capture version_page_exists %}{% page_exists {{version_page_url}} %}{% endcapture %}
         <li {% if include.kong_version==ver.release %}class="active" {% endif %} role="menuitem" tabindex="-1">
-          <a href="{% if version_page_exists == 'true' %}{{version_page_url}}{% else %}/{% if include.edition == 'gateway-oss' %}gateway-oss/{% endif %}{% if include.edition == 'enterprise' %}enterprise/{% endif %}{% if page.edition == 'gateway' %}gateway/{% endif %}{% if include.edition == 'mesh' %}mesh/{% endif %}{% if include.edition == 'kubernetes-ingress-controller' %}kubernetes-ingress-controller/{% endif %}{% if include.edition == 'contributing' %}contributing/{% endif %}{% if include.edition == 'deck' %}deck/{% endif %}{{ver.release}}{% endif %}"
+          <a href="{% if version_page_exists == 'true' %}{{version_page_url}}{% else %}/{% if include.edition == 'gateway-oss' %}gateway-oss/{% endif %}{% if include.edition == 'enterprise' %}enterprise/{% endif %}{% if include.edition == 'gateway' %}gateway/{% endif %}{% if include.edition == 'mesh' %}mesh/{% endif %}{% if include.edition == 'kubernetes-ingress-controller' %}kubernetes-ingress-controller/{% endif %}{% if include.edition == 'contributing' %}contributing/{% endif %}{% if include.edition == 'deck' %}deck/{% endif %}{{ver.release}}{% endif %}"
             {% if ver.release==include.kong_version %} class="active" {% endif %}
             data-version-id="{{ver.release}}"
           >
             {{ver.release}}
-            {% if ver.release == page.kong_latest.release and include.edition != 'enterprise' and include.edition != 'gateway-oss' and page.edition != 'getting-started-guide' %} <em>(latest)</em>
+            {% if ver.release == include.kong_latest.release and include.edition != 'enterprise' and include.edition != 'gateway-oss' and include.edition != 'getting-started-guide' %} <em>(latest)</em>
             {% endif %}
           </a>
         </li>
@@ -132,8 +132,8 @@
   {% assign docs_url = '/deck/' | append: include.kong_version %}
   {% elsif include.edition == 'gateway-oss' %}
   {% assign docs_url = '/gateway-oss/' | append: include.kong_version %}
-  {% elsif page.edition == 'gateway' %}
-  {% assign docs_url = '/gateway/' | append: page.kong_version %}
+  {% elsif include.edition == 'gateway' %}
+  {% assign docs_url = '/gateway/' | append: include.kong_version %}
   {% elsif include.edition == 'contributing' %}
   {% assign docs_url = '/contributing' %}
   {% endif %}

--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -1,7 +1,7 @@
 {% unless include.name and include.path contains '_hub' %}
 {% capture page_title %}{{
 include.title | escape }}{% if include.kong_version and include.no_version != true %} - v{{ include.kong_version | escape }}{% endif %}{% if include.title %} | {% endif %}{{
-site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if page.path contains "/hub/" %}{{ include.title }}{% else %}{{ include.name }}{% endif %}
+site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if include.path contains "/hub/" %}{{ include.title }}{% else %}{{ include.name }}{% endif %}
 {{ include.type }} | {{site.title}}{% endcapture %}
 {% endunless %}
 

--- a/app/_includes/md/deb.md
+++ b/app/_includes/md/deb.md
@@ -45,4 +45,4 @@ $ sudo apt install -y kong
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/installation.md %}
+{% include_cached /md/installation.md kong_version=page.kong_version %}

--- a/app/_includes/md/installation.md
+++ b/app/_includes/md/installation.md
@@ -57,7 +57,7 @@ to `off` and the `declarative_config` option to the path of your `kong.yml` file
 as `root` and the worker processes as `kong` by default.
 If this is not the desired behavior, you can switch the NGINX master process to run on the built-in
 `kong` user or to a custom non-root user before starting Kong. For more
-information, see [Running Kong as a Non-Root User](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user).
+information, see [Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/plan-and-deploy/kong-user).
 
 1. Start {{site.base_gateway}}:
     ```bash

--- a/app/_includes/md/rpm.md
+++ b/app/_includes/md/rpm.md
@@ -94,4 +94,4 @@ $ sudo yum install -y kong
 {% endnavtab %}
 {% endnavtabs %}
 
-{% include /md/installation.md %}
+{% include_cached /md/installation.md kong_version=page.kong_version %}


### PR DESCRIPTION
### Summary
Reduce duplication during sidebar navigation item rendering.

The `include-check.sh` script previously added was used to make sure we don't depend on any `page.*` level variables in includes. Passing them in to the `include_cached` function breaks the cache for each permutation of `page.*` input

### Reason
Save some build minutes on Netlify, make life better for people running the docs locally

Original build time:

![image](https://user-images.githubusercontent.com/59130/151589134-eb24017b-40ea-45b1-bc85-98a8ec5becd5.png)

After switching to `include_cached` for the sidebar:

![image](https://user-images.githubusercontent.com/59130/151589761-9c6d630f-42de-463b-b3bc-1319f4d6d8f1.png)

### Testing
This needs extensive testing. Check the sidebar on different products _and_ different versions.

I'm 95% confident with this change thanks to the `include-check.sh` work
