### PR TITLE
Fix codeblock in Mesh Vault doc

### DIFF
--- a/app/mesh/1.4.x/features/vault.md
+++ b/app/mesh/1.4.x/features/vault.md
@@ -30,7 +30,7 @@ Vault server and provide the appropriate credentials. {{site.mesh_product_name}}
 uses these parameters to authenticate the control plane and generate the
 data plane certificates.
 
-When {{site.mesh_product_name}} is running in `vault` mode, the backend communicates with Vault and ensures 
+When {{site.mesh_product_name}} is running in `vault` mode, the backend communicates with Vault and ensures
 that Vault's PKI automatically issues data plane certificates and rotates them for
 each proxy.
 
@@ -38,7 +38,7 @@ each proxy.
 
 The `vault` mTLS backend expects a configured PKI and role for generating data plane proxy certificates.
 
-The following steps show how to configure Vault for {{site.mesh_product_name}} with a mesh named 
+The following steps show how to configure Vault for {{site.mesh_product_name}} with a mesh named
 `default`. For your environment, replace `default` with the appropriate mesh name.
 
 #### Step 1. Configure the Certificate Authority
@@ -135,12 +135,16 @@ vault write kmesh-pki-default/roles/dataplane-proxies \
   ext_key_usage="ExtKeyUsageServerAuth,ExtKeyUsageClientAuth" \
   client_flag=true \
   require_cn=false \
-  allowed_domains="mesh" \ # use only when commonName in mTLS Vault backend is set
-  allow_subdomains=true \ # use only when commonName in mTLS Vault backend is set
+  allowed_domains="mesh" \
+  allow_subdomains=true \
   basic_constraints_valid_for_non_ca=true \
   max_ttl="720h" \
   ttl="720h"
 ```
+
+{:.note}
+> **Note:** Use the `allowed_domains` and `allow_subdomains` parameters
+**only** when `commonName` is set in the mTLS Vault backend.
 
 #### Step 3. Create a policy to use the new role:
 

--- a/app/mesh/1.4.x/features/vault.md
+++ b/app/mesh/1.4.x/features/vault.md
@@ -174,7 +174,7 @@ Vault, you must provide credentials in the configuration of the `mesh` object of
 You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
 
 You can provide these values inline for testing purposes only, as a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/documentation/secrets/).
+same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/).
 
 Here's an example of a configuration with a `vault`-backed CA:
 

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -30,7 +30,7 @@ Vault server and provide the appropriate credentials. {{site.mesh_product_name}}
 uses these parameters to authenticate the control plane and generate the
 data plane certificates.
 
-When {{site.mesh_product_name}} is running in `vault` mode, the backend communicates with Vault and ensures 
+When {{site.mesh_product_name}} is running in `vault` mode, the backend communicates with Vault and ensures
 that Vault's PKI automatically issues data plane certificates and rotates them for
 each proxy.
 
@@ -41,7 +41,7 @@ it will handle keeping the token renewed.
 
 The `vault` mTLS backend expects a configured PKI and role for generating data plane proxy certificates.
 
-The following steps show how to configure Vault for {{site.mesh_product_name}} with a mesh named 
+The following steps show how to configure Vault for {{site.mesh_product_name}} with a mesh named
 `default`. For your environment, replace `default` with the appropriate mesh name.
 
 #### Step 1. Configure the Certificate Authority
@@ -138,12 +138,16 @@ vault write kmesh-pki-default/roles/dataplane-proxies \
   ext_key_usage="ExtKeyUsageServerAuth,ExtKeyUsageClientAuth" \
   client_flag=true \
   require_cn=false \
-  allowed_domains="mesh" \ # use only when commonName in mTLS Vault backend is set
-  allow_subdomains=true \ # use only when commonName in mTLS Vault backend is set
+  allowed_domains="mesh" \
+  allow_subdomains=true \
   basic_constraints_valid_for_non_ca=true \
   max_ttl="720h" \
   ttl="720h"
 ```
+
+{:.note}
+> **Note:** Use the `allowed_domains` and `allow_subdomains` parameters
+**only** when `commonName` is set in the mTLS Vault backend.
 
 #### Step 3. Create a policy to use the new role:
 


### PR DESCRIPTION
### Summary
Moved comments out of a codeblock into a note.

### Reason
Fixes https://github.com/Kong/docs.konghq.com/issues/3525. Because of the comments, if you copy this text and then paste it into a terminal, it will generate an error. 

### Testing
https://deploy-preview-3597--kongdocs.netlify.app/mesh/1.5.x/features/vault/#step-2-create-a-role-for-generating-data-plane-proxy-certificates