### PR TITLE
Remove scroll-to-top button from mobile

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1703,6 +1703,6 @@ Generic Styling for Desktop
   }
 
   @media (max-width: 800px) {
-    right: 50%;
+    display: none;
   }
 }


### PR DESCRIPTION
### Summary
Hiding the scroll-to-top button on mobile, as it shouldn't be used there. 

### Reason
Scrolling to the top on a phone or tablet is built into the device and we're unnecessarily crowding the screen with this button.

### Testing
https://deploy-preview-3598--kongdocs.netlify.app/gateway/ (or any page): open the link on mobile, or resize your browser to 800px width or less, and make sure the scroll-to-top button doesn't appear.