### PR TITLE
Fix sidebar toggle visibility on mobile

### DIFF
--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,9 +1,7 @@
 <div id="breadcrumbs">
   {% assign crumbs = include.dir | split: '/' %}
   <ul class="breadcrumbs">
-    {% if include.no_version == false or include.has_version == true %}
       <i class="sidebar-toggle"></i>
-    {% endif %}
     <li class="breadcrumb-item">
       {% if include.edition =='enterprise' or include.edition =='konnect' or include.edition =='konnect-platform' or include.edition == 'mesh' or include.edition == 'gateway' %}
         Kong Konnect Platform

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -37,7 +37,7 @@ page.kong_latest.release %}
 
     <div class="page-content-container v2 {% if page.no_version == true and page.has_version == false and page.nav_items == nil %}no-sidebar{% endif %}" id="documentation">
       <div class="toggles {% if page.no_version == true and page.has_version == false and page.nav_items == nil %}no-sidebar{% endif %}">
-        {% if page.toc == true or page.toc != false and filename != "index.md" and page.is_homepage != true and page.is_homepage != true %}
+        {% if page.toc == true or page.toc != false and filename != "index.md" %}
           <i class="far fa-list-alt toc-sidebar-toggle"></i>
         {% endif %}
       </div>


### PR DESCRIPTION
### Summary
Remove restrictions so that sidebar toggle always appears on mobile. There is no reason for it to be hidden.

### Reason

Fixes https://github.com/Kong/docs.konghq.com/issues/3153.

Mobile issue: On unversioned docs, and occasionally on doc landing pages, the icon to open the left sidebar does not appear, so there is no way to access the table of contents. 

Normal doc (versioned, icon works):

<img src="https://user-images.githubusercontent.com/54370747/151626977-85f4e603-cddc-4e18-a07f-4a4c30b7085c.png" width=40% height=40%>

Unversioned doc, icon missing:

<img src="https://user-images.githubusercontent.com/54370747/151626994-1535e39f-9286-4ebf-95df-4aa7d3d689a0.png" width=40% height=40%>

### Testing

Tested on chrome and firefox on my phone, and with chrome on desktop.

https://deploy-preview-3599--kongdocs.netlify.app/konnect/
https://deploy-preview-3599--kongdocs.netlify.app/konnect-platform/

Open the links on mobile, or resize your browser to 800px width or less, and make sure that the icon to open the left sidebar is always there and is useable.