### PR TITLE
docs(oauth2) remove the nonexistent persistent_refresh_token field

### DIFF
--- a/app/_hub/kong-inc/oauth2/index.md
+++ b/app/_hub/kong-inc/oauth2/index.md
@@ -164,13 +164,6 @@ params:
       description: |
         An optional boolean value that indicates whether an OAuth refresh token is
         reused when refreshing an access token.
-    - name: persistent_refresh_token
-      required: true
-      default: false
-      datatype: boolean
-      description: |
-        An optional boolean value that indicates whether an OAuth refresh token is
-        persisted when refreshing an access token.
     - name: pkce
       required: false
       default: '`lax`'


### PR DESCRIPTION

### Summary
Remove the nonexistent persistent_refresh_token field

### Reason
From https://github.com/Kong/kong/issues/8348
Orignal PR https://github.com/Kong/kong/pull/5264, `persistent_refresh_token` was mentioned in the PR as first iterration but only `reuse_refresh_token` is merged.
The extra field was added in https://github.com/Kong/docs.konghq.com/commit/6b970cb77e73098802034a55e272e87c58c1a5d1

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
