### PR TITLE
Improve header contrast

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -278,14 +278,14 @@ h4 {
 }
 
 h5 {
-  font-size: 1.6rem;
-  font-weight: 500;
+  font-size: 1.5rem;
+  font-weight: 400;
   color: @steel-500;
 }
 
 h6 {
   font-size: 1.2rem;
-  font-weight: 500;
+  font-weight: 400;
   color: @steel-500;
 }
 

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -249,8 +249,7 @@ h1, h2, h3, h4, h5, h6, .page-header-section-title {
 
 h1, .page-header-section-title {
   font-size: 4rem;
-  font-weight: 400;
-  color: #262e33;
+  font-weight: 500;
   margin-top: 1em;
   margin-bottom: 1em;
 }
@@ -268,24 +267,26 @@ h2 {
 
 h3 {
   margin-top: 2.9rem;
-  font-size: 1.9rem;
+  font-size: 2rem;
   font-weight: 500;
 }
 
 h4 {
-  font-size: 1.6rem;
+  font-size: 1.7rem;
   font-weight: 500;
-  color: @gray-dark;
+  color: @steel-500;
 }
 
 h5 {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   font-weight: 500;
+  color: @steel-500;
 }
 
 h6 {
   font-size: 1.2rem;
   font-weight: 500;
+  color: @steel-500;
 }
 
 h2+h3, h3+h4 {

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -250,30 +250,52 @@ h1, h2, h3, h4, h5, h6, .page-header-section-title {
 h1, .page-header-section-title {
   font-size: 4rem;
   font-weight: 400;
+  color: #262e33;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+h2, h3, h4, h5, h6 {
+  font-family: @family-display;
+  margin-bottom: 1rem;
 }
 
 h2 {
-  font-size: 36px;
-  font-weight: 400;
+  margin-top: 3.2rem;
+  font-size: 2.5rem;
+  font-weight: 500;
 }
 
 h3 {
-  font-size: 26px;
+  margin-top: 2.9rem;
+  font-size: 1.9rem;
+  font-weight: 500;
 }
 
 h4 {
-  font-size: 20px;
-  font-weight: 600;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: @gray-dark;
 }
 
 h5 {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: 1.4rem;
+  font-weight: 500;
 }
 
 h6 {
-  .font-source-sans-sc();
-  font-size: 14px;
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+h2+h3, h3+h4 {
+  margin-top: 1rem;
+}
+
+> h1:first-child,
+> h2:first-child,
+> h3:first-child {
+  margin-top: 0;
 }
 
 figure {

--- a/app/_assets/stylesheets/hub-landing-page.less
+++ b/app/_assets/stylesheets/hub-landing-page.less
@@ -21,6 +21,7 @@
       font-weight: 400;
       font-size: 20px;
       line-height: 28px;
+      margin-top: 0;
       color: #4c6d80;
     }
 
@@ -30,6 +31,7 @@
         font-weight: 500;
         letter-spacing: .5px;
         text-transform: uppercase;
+        margin-top: 0;
         margin-left: 1.2rem;
     }
 

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -380,7 +380,7 @@
       color: #062e4d;
       margin-bottom: 0.1em;
       margin-top: 0.1em;
-      font: lighter 38px/40px Roboto;
+      font: 500 38px/40px Roboto;
       scroll-margin-top: 100px;
     }
 
@@ -680,69 +680,8 @@
     }
   }
 
-  p,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    .font-source-sans();
-    color: @font-color;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4 {
-    margin-bottom: 1em;
-    font-weight: 600;
-  }
-
-  h2,
-  h3 {
-    font-weight: 600;
-    color: #262e33;
-  }
-
-  h1 {
-    font-size: 36px;
-    color: #262e33;
-    margin-top: 1em;
-    margin-bottom: 0.8em;
-    font-weight: 100;
-  }
-
   .alert + h1 {
     margin-top: 1em;
-  }
-
-  h2 {
-    font-size: 30px;
-    margin-top: 2em;
-    margin-bottom: 0.8em;
-  }
-
-  h3 {
-    font-size: 30px;
-    margin-top: 0.8em;
-    margin-bottom: 0.8em;
-  }
-
-  h4 {
-    margin-top: 1.3em;
-    margin-bottom: 0.7em;
-  }
-
-  h5 {
-    margin-top: 1.2em;
-    margin-bottom: 0.8em;
-  }
-
-  > h1:first-child,
-  > h2:first-child,
-  > h3:first-child {
-    margin-top: 0;
   }
 
   ol {

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -149,40 +149,6 @@
       width: -webkit-stretch;
       width: stretch;
     }
-
-    // titles proportions overridden from base.less
-
-    h2, h3, h4, h5, h6 {
-      font-family: @family-display;
-      margin-bottom: 1.2rem;
-    }
-
-    h2 {
-      margin-top: 3.2rem;
-      font-size: 2.7rem;
-      font-weight: normal;
-    }
-
-    h3 {
-      margin-top: 2.7rem;
-      font-size: 2.1rem;
-      font-weight: normal;
-    }
-
-    h4 {
-      font-size: 1.7rem;
-      font-weight: bold;
-    }
-
-    h5 {
-      font-size: 1.4rem;
-      font-weight: normal;
-    }
-
-    h6 {
-      font-size: 1.2rem;
-      font-weight: bold;
-    }
   }
 
   &.v2 {
@@ -202,8 +168,8 @@
 
       .page-content-title {
         color: #062e4d;
-        margin-bottom: 0.4em;
-        font: lighter 34px/40px Roboto;
+        margin-bottom: 0.5em;
+        font: 500 34px/40px Roboto;
         scroll-margin-top: 100px;
 
         &::before {
@@ -213,10 +179,10 @@
 
       .page-content-subtitle {
         max-width: 800px;
-        margin-top: 16px;
-        margin-bottom: 2rem;
+        margin-top: 0;
+        margin-bottom: 3rem;
         opacity: 0.6;
-        font: lighter 16px/20px Roboto;
+        font: lighter 17px/20px Roboto;
 
         &::before {
           display: none;

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -84,37 +84,6 @@
   .content {
     padding-top: 37px;
 
-    h2, h3, h4, h5, h6 {
-      font-family: @family-display;
-      margin-bottom: 1.2rem;
-    }
-
-    h2 {
-      font-size: 2.7rem;
-      font-weight: normal;
-    }
-
-    h3 {
-      margin-top: 2.7rem;
-      font-size: 2.1rem;
-      font-weight: normal;
-    }
-
-    h4 {
-      font-size: 1.7rem;
-      font-weight: bold;
-    }
-
-    h5 {
-      font-size: 1.4rem;
-      font-weight: bold;
-    }
-
-    h6 {
-      font-size: 1.2rem;
-      font-weight: bold;
-    }
-
     ol {
         padding-left: 2rem;
         counter-reset: base;

--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -19,6 +19,12 @@ header.navbar {
   padding: 120px 40px 96px;
   font-family: Roboto, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 
+  h1, h2, h3, h4, h5 {
+    margin-top: 0;
+    margin-bottom: 2rem;
+    letter-spacing: 0;
+  }
+
   h1 {
     text-align: center;
     font-weight: bold;

--- a/app/gateway/2.7.x/install-and-run/index.md
+++ b/app/gateway/2.7.x/install-and-run/index.md
@@ -59,11 +59,11 @@ disable_image_expand: true
   </a>
 </div>
 
-### Deployment options
+## Deployment options
 
 {% include_cached /md/gateway/deployment-options.md kong_version=page.kong_version %}
 
-### Installation paths
+## Installation paths
 
 Some installation topics provide multiple package types and installation options.
 Choose your preferred mode when following installation steps:


### PR DESCRIPTION
### Summary

* Consolidate base header settings in `base.less` and remove duplicate header styling from `page.less`, `docs.less`, and `extension.less`. The basic header styling should be (and is, mostly) consistent across our docs; changing header styling for specific purposes (eg page titles in specific contexts) should be done through classes whenever possible. This way, styling doesn't overlap and makes it easier for maintainers to find the source of any particular style.
* Increasing font weights for better visual contrast, and adjusting margins for clearer relationships between headers and preceding/following text. Compare:

  Old: 
  ![Screen Shot 2022-01-31 at 11 11 30 AM](https://user-images.githubusercontent.com/54370747/151857193-ddad5913-94d1-48d4-a819-37df99f24d69.png)

  New:
  ![Screen Shot 2022-01-31 at 11 11 44 AM](https://user-images.githubusercontent.com/54370747/151857190-713c229b-c290-4d52-b70d-c1876e310184.png)

### Reason
It needs to be more obvious where the docs are sectioned. Current header style blends into the text.

### Testing
Need to look through a variety of content to make sure this styling works everywhere.

Some page examples in different contexts:
* https://deploy-preview-3604--kongdocs.netlify.app/gateway/ - example of a product landing page with title (h1) and a subtitle. Page is also using h2s and h3s.
* https://deploy-preview-3604--kongdocs.netlify.app/konnect-platform/key-concepts/ - sample basic page without a subtitle
* https://deploy-preview-3604--kongdocs.netlify.app/konnect/updates/ - example of h2/h3 headers coming right after each other
* https://deploy-preview-3604--kongdocs.netlify.app/hub/kong-inc/basic-auth/ - same header styling used on a sample plugin hub page
* https://deploy-preview-3604--kongdocs.netlify.app/gateway/2.7.x/admin-api/ - page headers go all the way to h4s and h5s
* https://deploy-preview-3604--kongdocs.netlify.app/ - landing page, no changes. make sure that spacing hasn't changed
* https://deploy-preview-3604--kongdocs.netlify.app/hub/ - plugin hub landing page, one very small adjustment to header margins.