### PR TITLE
Update gateway versions based on 2.7 and 2.6 patch releases

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -330,7 +330,7 @@
 -
 # Combined Gateway docs (single-sourced)
   release: "2.6.x"
-  ee-version: "2.6.0.2"
+  ee-version: "2.6.0.3"
   ce-version: "2.6.0"
   edition: "gateway"
   luarocks_version: "2.5.1-0"
@@ -346,7 +346,7 @@
   lua_doc: true
 -
   release: "2.7.x"
-  ee-version: "2.7.0.0"
+  ee-version: "2.7.1.0"
   ce-version: "2.7.0"
   edition: "gateway"
   luarocks_version: "2.5.1-0"


### PR DESCRIPTION
### Summary
Bumping Gateway versions to latest available (double-checked against downloads.konghq.com and our Docker Hub listings).

### Reason
Companion update to https://github.com/Kong/docs.konghq.com/pull/3592. Forgot to bump the versions.

### Testing
TBA