### PR TITLE
[DOCU-2166] Fix decK 1.9 and 1.10 installation instructions

### DIFF
--- a/app/deck/1.10.x/installation.md
+++ b/app/deck/1.10.x/installation.md
@@ -28,7 +28,7 @@ the Github [release page](https://github.com/kong/deck/releases)
 or install by downloading a compressed archive, which contains the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v{{page.kong_versions[2].version}}/deck_{{page.kong_versions[2].version}}_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v{{page.kong_versions[4].version}}/deck_{{page.kong_versions[4].version}}_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```

--- a/app/deck/1.9.x/installation.md
+++ b/app/deck/1.9.x/installation.md
@@ -28,7 +28,7 @@ the Github [release page](https://github.com/kong/deck/releases)
 or install by downloading a compressed archive, which contains the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v{{page.kong_versions[2].version}}/deck_{{page.kong_versions[2].version}}_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v{{page.kong_versions[3].version}}/deck_{{page.kong_versions[3].version}}_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```


### PR DESCRIPTION
### Summary
Fix the `kong_versions` entry for `decK` 1.9 and 1.10

### Reason
Existing installation instructions are inaccurate

### Testing
Check the following URLs:

* https://deploy-preview-3606--kongdocs.netlify.app//deck/1.9.x/installation/
* https://deploy-preview-3606--kongdocs.netlify.app//deck/1.10.x/installation/