### PR TITLE
Gulpfile updates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,9 +119,7 @@ function jekyll(cb) {
     profile = "-dev";
   }
 
-  var command =
-    `bundle exec jekyll build --config jekyll${profile}.yml --profile --destination ` +
-    paths.dist;
+  var command = `bundle exec jekyll build --config jekyll${profile}.yml --profile`
 
   childProcess.exec(command, function (err, stdout, stderr) {
     log(stdout);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -423,7 +423,6 @@ function build_site(steps, append) {
   // These are the steps that always run for every build
   // If set_dev is called, some of these methods behave differently
   steps = steps.concat([
-    clean,
     gulp.parallel(js, images, fonts, css),
     jekyll,
     html,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,14 +128,6 @@ function jekyll(cb) {
   });
 }
 
-function html() {
-  return gulp
-    .src(paths.dist + "/**/*.html")
-    .pipe($.plumber())
-    .pipe(gulp.dest(paths.dist))
-    .pipe($.if(!dev, $.size()));
-}
-
 // Lua Tasks
 function pdk_docs(cb) {
   var KONG_PATH,
@@ -378,7 +370,7 @@ function clean() {
 }
 
 function watch_files() {
-  gulp.watch(sources.content, gulp.series(jekyll, html, reload_browser));
+  gulp.watch(sources.content, gulp.series(jekyll, reload_browser));
   gulp.watch(sources.styles, styles);
   gulp.watch(sources.images, gulp.series(images, reload_browser));
   gulp.watch(sources.js, gulp.series(js, reload_browser));
@@ -400,7 +392,6 @@ gulp.task("styles", styles);
 gulp.task("images", gulp.series(set_dev, images));
 gulp.task("fonts", fonts);
 gulp.task("jekyll", jekyll);
-gulp.task("html", html);
 
 // Lua Tasks
 gulp.task("pdk_docs", pdk_docs);
@@ -423,7 +414,6 @@ function build_site(steps, append) {
   steps = steps.concat([
     gulp.parallel(js, images, fonts, css),
     jekyll,
-    html,
     styles,
   ]);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ var browserSync = require("browser-sync").create();
 var childProcess = require("child_process");
 var log = require("fancy-log");
 var del = require("del");
-var ghPages = require("gh-pages");
 var gulp = require("gulp");
 var path = require("path");
 var fs = require("fs");
@@ -377,8 +376,7 @@ var reload_browser = (done) => {
 };
 
 function clean() {
-  ghPages.clean();
-  return del(["dist", ".gh-pages"]);
+  return del(["dist"]);
 }
 
 function watch_files() {


### PR DESCRIPTION
### Summary

1. Speed up the build by removing the implicit call to `clean`.
2. Delete the HTML size report that we don't use
3. Remove remaining references to GH Pages

### Reason
This is best explained with a 70 second video

https://user-images.githubusercontent.com/59130/151998634-aded07c0-6de8-41b9-b8b8-bb3929f7f77d.mp4

### Testing
Run `gulp` locally