### PR TITLE
[DOCU-2114] Fix Docker install instructions

### DIFF
--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -226,7 +226,7 @@ to help you set up and enhance your first Service.
 In particular, right after installation you might want to:
 * [Create a service and a route](/gateway/{{page.kong_version}}/get-started/comprehensive/expose-services)
 * [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
-* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Secure your services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
 * [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
 
 ### Clean up containers
@@ -241,7 +241,6 @@ docker container rm kong-gateway
 docker container rm kong-database
 docker network rm kong-net
 ```
-
 
 ## Install Kong Gateway in DB-less mode
 
@@ -293,13 +292,13 @@ backed up by a Redis cluster).
     This guide assumes you named the file `kong.yml`.
 
 1.  Save your declarative configuration locally, and note the filepath.
-For this example, we're using `/kong/declarative/kong.yml`.
 
 ### Start Kong Gateway in DB-less mode
 
 {% include_cached /md/admin-listen.md desc='long' %}
 
-1. Run the following command to start a container with {{site.base_gateway}}.
+1. From the same directory where you just created the `kong.yml` file,
+run the following command to start a container with {{site.base_gateway}}:
 
 {% capture start_container %}
 {% navtabs codeblock %}
@@ -307,7 +306,7 @@ For this example, we're using `/kong/declarative/kong.yml`.
 ```sh
 docker run -d --name kong-dbless \
  --network=kong-net \
- -v "$(pwd)"/kong/declarative:/kong/declarative/ \
+ -v "$(pwd):/kong/declarative/" \
  -e "KONG_DATABASE=off" \
  -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
@@ -331,7 +330,7 @@ docker run -d --name kong-dbless \
 ```sh
 docker run -d --name kong-dbless \
  --network=kong-net \
- -v "$(pwd)"/kong/declarative:/kong/declarative/ \
+ -v "$(pwd):/kong/declarative/" \
  -e "KONG_DATABASE=off" \
  -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
@@ -353,7 +352,7 @@ docker run -d --name kong-dbless \
     Where:
     * `--name` and `--network`: The name of the container to create,
     and the Docker network it communicates on.
-    * `-v "$(pwd)"/path/to/source:/path/to/target/`: Mount a directory on your
+    * `-v $(pwd):/path/to/target/`: Mount the current directory on your
     local filesystem to a directory in the Docker container. This makes the
     `kong.yml` file visible from the Docker container.
     * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
@@ -361,7 +360,7 @@ docker run -d --name kong-dbless \
     backing database for configuration storage.
     * [`KONG_DECLARATIVE_CONFIG`](/gateway/{{page.kong_version}}/reference/configuration/#declarative_config):
     The path to a declarative configuration file inside the container.
-    This path should match the path that you're mapping with `-v`.
+    This path should match the target path that you're mapping with `-v`.
     * All [`_LOG`](/gateway/{{page.kong_version}}/reference/configuration/#general-section)
     parameters: set filepaths for the logs to output to, or use the values in
     the example to  print messages and errors to `stdout` and `stderr`.
@@ -396,7 +395,7 @@ to help you set up and enhance your first Service.
 If you use the sample `kong.yml` in this guide, you already have a Service and
 a Route configured. Here are a few more things to check out:
 * [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
-* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Secure your services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
 * [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
 
 ### Clean up containers
@@ -406,9 +405,7 @@ can clean them up using the following commands:
 
 ```
 docker kill kong-dbless
-docker kill kong-database
 docker container rm kong-dbless
-docker container rm kong-database
 docker network rm kong-net
 ```
 

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -175,7 +175,7 @@ docker run -d --name kong \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_USER=kong" \
- -e "KONG_PG_PASSWORD=kong" \
+ -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -35,28 +35,16 @@ The {{site.base_gateway}} software is governed by the
 * A Docker-enabled system with proper Docker access
 * (Enterprise only) A `license.json` file from Kong
 
-## Pull the Kong Gateway image
+Choose a path to install Kong Gateway:
+* [With a database](#install-kong-gateway-with-a-database): Use a database to
+store Kong entity configurations. Can use the Admin API or declarative
+configuration files to configure Kong.
+* [Without a database (DB-less mode)](#install-kong-gateway-in-db-less-mode):
+Store Kong configuration in-memory on the node. In this mode, the Admin API is
+read only, and you have to manage Kong using declarative configuration.
 
-Pull the Docker image:
-
-{% navtabs codeblock %}
-{% navtab Kong Gateway %}
-```bash
-docker pull kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-```bash
-docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-You should now have your {{site.base_gateway}} image locally.
-
-Next, choose a path and install Kong Gateway:
-* [With a database](#install-kong-gateway-with-a-database)
-* [Without a database (DB-less mode)](#install-kong-gateway-in-db-less-mode)
+If this is your first time trying out Kong Gateway, we recommend installing it
+with a database.
 
 ## Install Kong Gateway with a database
 
@@ -105,7 +93,7 @@ docker run --rm --network=kong-net \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PASSWORD=test" \
-kong/kong-gateway kong migrations bootstrap
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine kong migrations bootstrap
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -114,7 +102,7 @@ docker run --rm --network=kong-net \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
-kong kong migrations bootstrap
+kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migrations bootstrap
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -122,19 +110,19 @@ kong kong migrations bootstrap
 {{ migrations | indent | replace: " </code>", "</code>" }}
 
     Where:
-    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database)
-     is the database type, or `off` if setting up a data plane for [hybrid mode](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode/hybrid-mode-setup).
-    * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings)
-    is the name of the Postgres Docker container that is communicating over the
+    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
+     Specifies the type of database that Kong is using.
+    * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
+    The name of the Postgres Docker container that is communicating over the
     `kong-net` network, from the previous step.
-    * [`KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings)
+    * [`KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
     The password that you set when bringing up the Postgres container in the
     previous step.
     * `KONG_PASSWORD` (Enterprise only): The default password for the admin
     super user for Kong Gateway.
-    * `kong/kong-gateway kong migrations bootstrap` or `kong kong migrations bootstrap`:
-    In order, this is the Kong Gateway container tag, followed by the command
-    to Kong to prepare the Postgres database.
+    * `{IMAGE-NAME:TAG} kong migrations bootstrap`:
+    In order, this is the Kong Gateway container name and tag, followed by the
+    command to Kong to prepare the Postgres database.
 
 ### Start Kong Gateway
 
@@ -165,12 +153,12 @@ docker run -d --name kong-gateway \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway
+ kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```sh
-docker run -d --name kong \
+docker run -d --name kong-gateway \
  --network=kong-net \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
@@ -185,7 +173,7 @@ docker run -d --name kong \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:latest
+ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
  ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -193,16 +181,16 @@ docker run -d --name kong \
 {{ start_container | indent | replace: " </code>", "</code>" }}
 
     Where:
-    * `--name` and `--network`: The tag of the {{site.base_gateway}} image that
-    you're using, and the Docker network it communicates on.
+    * `--name` and `--network`: The name of the container to create,
+    and the Docker network it communicates on.
     * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
-    Specifies whether this node connects directly to a database.
+    Specifies the type of database that Kong is using.
     * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
     The name of the Postgres Docker container that is communicating over the
     `kong-net` network.
     * [`KONG_PG_USER` and `KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
      The Postgres username and password. Kong Gateway needs the login information
-     to store configurations in this database.
+     	to store configuration data in the `KONG_PG_HOST` database.
     * All [`_LOG`](/gateway/{{page.kong_version}}/reference/configuration/#general-section)
     parameters: set filepaths for the logs to output to, or use the values in
     the example to  print messages and errors to `stdout` and `stderr`.
@@ -222,64 +210,58 @@ docker run -d --name kong \
 
     You should receive a `200` status code.
 
-1. (Not available in OSS) Verify that Kong Manager is running by accessing it using the URL specified in `KONG_ADMIN_GUI_URL`:
+1. (Not available in OSS) Verify that Kong Manager is running by accessing it
+using the URL specified in `KONG_ADMIN_GUI_URL`:
 
     ```
     http://localhost:8002
     ```
 
+### Get started with Kong Gateway
+
+Now that you have a running Gateway instance, Kong provides a series of
+[getting started guides](/gateway/{{page.kong_version}}/get-started/comprehensive/)
+to help you set up and enhance your first Service.
+
+In particular, right after installation you might want to:
+* [Create a service and a route](/gateway/{{page.kong_version}}/get-started/comprehensive/expose-services)
+* [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
+* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
+
+### Clean up containers
+
+If you're done testing Kong Gateway and no longer need the containers, you
+can clean them up using the following commands:
+
+```
+docker kill kong-gateway
+docker kill kong-database
+docker container rm kong-gateway
+docker container rm kong-database
+docker network rm kong-net
+```
+
+
 ## Install Kong Gateway in DB-less mode
 
-The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_version}}/reference/db-less-and-declarative-config) are the following:
+The following steps walk you through starting Kong Gateway in
+[DB-less mode](/gateway/{{page.kong_version}}/reference/db-less-and-declarative-config).
 
-### Set up a Docker volume
+### Create a Docker network
 
-1. Create a Docker network:
+Run the following command:
 
-    ```bash
-    docker network create kong-net
-    ```
+```bash
+docker network create kong-net
+```
 
-    You can name this network anything you want. We use `kong-net` as
-    an example throughout this guide.
+You can name this network anything you want. We use `kong-net` as
+an example throughout this guide.
 
-    This step is not strictly needed for running Kong in DB-less mode, but it is a good
-    precaution in case you want to add other things in the future (like a Rate Limiting plugin
-    backed up by a Redis cluster).
-
-1. Create a Docker volume:
-
-    ```bash
-    docker volume create kong-vol
-    ```
-
-    For the purposes of this guide, a [Docker Volume][Docker Volume] is a folder inside the host machine which
-    can be mapped into a folder in the container. In this guide, we name the
-    volume `kong-vol`.
-
-1. Inspect the Docker volume:
-
-    ```bash
-    docker volume inspect kong-vol
-    ```
-
-    The result should be similar to this:
-
-    ```json
-    [
-        {
-            "CreatedAt": "2019-05-28T12:40:09Z",
-            "Driver": "local",
-            "Labels": {},
-            "Mountpoint": "/var/lib/docker/volumes/kong-vol/_data",
-            "Name": "kong-vol",
-            "Options": {},
-            "Scope": "local"
-        }
-    ]
-    ```
-
-    Notice the `MountPoint` entry. You will need that path in the next step.
+This step is not strictly needed for running Kong in DB-less mode, but it is a good
+precaution in case you want to add other things in the future (like a Rate Limiting plugin
+backed up by a Redis cluster).
 
 ### Prepare your configuration file
 
@@ -289,11 +271,29 @@ The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_versi
     described in the [Declarative Configuration format] guide. Add whatever core
     entities (Services, Routes, Plugins, Consumers, etc) you need to this file.
 
+    For example, a simple file with a Service and a Route
+    could look something like this:
+
+    ```yaml
+    _format_version: "1.1"
+    _transform: true
+
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: example_route
+        paths:
+        - /mock
+        strip_path: true
+    ```
+
     This guide assumes you named the file `kong.yml`.
 
-1.  Save your declarative configuration file inside the `MountPoint` path
-mentioned in the previous step. In the case of this
-guide, that would be `/var/lib/docker/volumes/kong-vol/_data/kong.yml`.
+1.  Save your declarative configuration locally, and note the filepath.
+For this example, we're using `/kong/declarative/kong.yml`.
 
 ### Start Kong Gateway in DB-less mode
 
@@ -301,22 +301,15 @@ guide, that would be `/var/lib/docker/volumes/kong-vol/_data/kong.yml`.
 
 1. Run the following command to start a container with {{site.base_gateway}}.
 
-   Although it's possible to start the Kong container with just
-   `KONG_DATABASE=off`, we recommend also including the declarative configuration
-   file as a parameter via the `KONG_DECLARATIVE_CONFIG` variable name. To do
-   this, you need to make the file visible from within the container.
-   Use the `-v` flag, which maps the Docker volume to the
-   `/usr/local/kong/declarative` folder in the container.
-
 {% capture start_container %}
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```sh
-docker run -d --name kong-gateway \
+docker run -d --name kong-dbless \
  --network=kong-net \
- -v "kong-vol:/usr/local/kong/declarative" \
+ -v "$(pwd)"/kong/declarative:/kong/declarative/ \
  -e "KONG_DATABASE=off" \
- -e "KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yml" \
+ -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
@@ -331,16 +324,16 @@ docker run -d --name kong-gateway \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway
+ kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```sh
-docker run -d --name kong \
+docker run -d --name kong-dbless \
  --network=kong-net \
- -v "kong-vol:/usr/local/kong/declarative" \
+ -v "$(pwd)"/kong/declarative:/kong/declarative/ \
  -e "KONG_DATABASE=off" \
- -e "KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yml" \
+ -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
@@ -350,7 +343,7 @@ docker run -d --name kong \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:latest
+ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
  ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -358,11 +351,11 @@ docker run -d --name kong \
 {{ start_container | indent | replace: " </code>", "</code>" }}
 
     Where:
-    * `--name` and `--network`: The tag of the {{site.base_gateway}} image that
-    you're using, and the Docker network it communicates on.
-    * `-v kong-vol:/usr/local/kong/declarative`: The name of the Docker volume
-    you created in a previous step mapped to the location of your declarative
-    configuration file.
+    * `--name` and `--network`: The name of the container to create,
+    and the Docker network it communicates on.
+    * `-v "$(pwd)"/path/to/source:/path/to/target/`: Mount a directory on your
+    local filesystem to a directory in the Docker container. This makes the
+    `kong.yml` file visible from the Docker container.
     * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
      Sets the database to `off` to tell Kong not to use any
     backing database for configuration storage.
@@ -394,14 +387,33 @@ docker run -d --name kong \
 [Declarative Configuration format]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/#the-declarative-configuration-format
 [Docker Volume]: https://docs.docker.com/storage/volumes/
 
+### Get started with Kong Gateway
+
+Now that you have a running Gateway instance, Kong provides a series of
+[getting started guides](/gateway/{{page.kong_version}}/get-started/comprehensive/)
+to help you set up and enhance your first Service.
+
+If you use the sample `kong.yml` in this guide, you already have a Service and
+a Route configured. Here are a few more things to check out:
+* [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
+* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
+
+### Clean up containers
+
+If you're done testing Kong Gateway and no longer need the containers, you
+can clean them up using the following commands:
+
+```
+docker kill kong-dbless
+docker kill kong-database
+docker container rm kong-dbless
+docker container rm kong-database
+docker network rm kong-net
+```
+
 ## Troubleshooting
 
 If you did not receive a `200 OK` status code or need assistance completing
 setup, reach out to your support contact or head over to the
 [Support Portal](https://support.konghq.com/support/s/).
-
-## Next Steps
-
-Check out {{site.base_gateway}}'s series of
-[Getting Started](/gateway/{{page.kong_version}}/get-started/comprehensive/) guides to get the most
-out of {{site.base_gateway}}.

--- a/app/gateway/2.7.x/install-and-run/docker.md
+++ b/app/gateway/2.7.x/install-and-run/docker.md
@@ -228,7 +228,7 @@ Now that you have a running Gateway instance, Kong provides a series of
 In particular, right after installation you might want to:
 * [Create a service and a route](/gateway/{{page.kong_version}}/get-started/comprehensive/expose-services)
 * [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
-* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Secure your services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
 * [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
 
 ### Clean up containers
@@ -243,7 +243,6 @@ docker container rm kong-gateway
 docker container rm kong-database
 docker network rm kong-net
 ```
-
 
 ## Install Kong Gateway in DB-less mode
 
@@ -295,13 +294,13 @@ backed up by a Redis cluster).
     This guide assumes you named the file `kong.yml`.
 
 1.  Save your declarative configuration locally, and note the filepath.
-For this example, we're using `/kong/declarative/kong.yml`.
 
 ### Start Kong Gateway in DB-less mode
 
 {% include_cached /md/admin-listen.md desc='long' %}
 
-1. Run the following command to start a container with {{site.base_gateway}}.
+1. From the same directory where you just created the `kong.yml` file,
+run the following command to start a container with {{site.base_gateway}}:
 
 {% capture start_container %}
 {% navtabs codeblock %}
@@ -309,7 +308,7 @@ For this example, we're using `/kong/declarative/kong.yml`.
 ```sh
 docker run -d --name kong-dbless \
  --network=kong-net \
- -v "$(pwd)"/kong/declarative:/kong/declarative/ \
+ -v "$(pwd):/kong/declarative/" \
  -e "KONG_DATABASE=off" \
  -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
@@ -333,7 +332,7 @@ docker run -d --name kong-dbless \
 ```sh
 docker run -d --name kong-dbless \
  --network=kong-net \
- -v "$(pwd)"/kong/declarative:/kong/declarative/ \
+ -v "$(pwd):/kong/declarative/" \
  -e "KONG_DATABASE=off" \
  -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
@@ -355,7 +354,7 @@ docker run -d --name kong-dbless \
     Where:
     * `--name` and `--network`: The name of the container to create,
     and the Docker network it communicates on.
-    * `-v "$(pwd)"/path/to/source:/path/to/target/`: Mount a directory on your
+    * `-v $(pwd):/path/to/target/`: Mount the current directory on your
     local filesystem to a directory in the Docker container. This makes the
     `kong.yml` file visible from the Docker container.
     * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
@@ -363,7 +362,7 @@ docker run -d --name kong-dbless \
     backing database for configuration storage.
     * [`KONG_DECLARATIVE_CONFIG`](/gateway/{{page.kong_version}}/reference/configuration/#declarative_config):
     The path to a declarative configuration file inside the container.
-    This path should match the path that you're mapping with `-v`.
+    This path should match the target path that you're mapping with `-v`.
     * All [`_LOG`](/gateway/{{page.kong_version}}/reference/configuration/#general-section)
     parameters: set filepaths for the logs to output to, or use the values in
     the example to  print messages and errors to `stdout` and `stderr`.
@@ -398,7 +397,7 @@ to help you set up and enhance your first Service.
 If you use the sample `kong.yml` in this guide, you already have a Service and
 a Route configured. Here are a few more things to check out:
 * [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
-* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Secure your services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
 * [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
 
 ### Clean up containers
@@ -408,9 +407,7 @@ can clean them up using the following commands:
 
 ```
 docker kill kong-dbless
-docker kill kong-database
 docker container rm kong-dbless
-docker container rm kong-database
 docker network rm kong-net
 ```
 

--- a/app/gateway/2.7.x/install-and-run/docker.md
+++ b/app/gateway/2.7.x/install-and-run/docker.md
@@ -177,7 +177,7 @@ docker run -d --name kong \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_USER=kong" \
- -e "KONG_PG_PASSWORD=kong" \
+ -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \

--- a/app/gateway/2.7.x/install-and-run/docker.md
+++ b/app/gateway/2.7.x/install-and-run/docker.md
@@ -35,28 +35,16 @@ The {{site.base_gateway}} software is governed by the
 * A Docker-enabled system with proper Docker access
 * (Enterprise only) A `license.json` file from Kong
 
-## Pull the Kong Gateway image
+Choose a path to install Kong Gateway:
+* [With a database](#install-kong-gateway-with-a-database): Use a database to
+store Kong entity configurations. Can use the Admin API or declarative
+configuration files to configure Kong.
+* [Without a database (DB-less mode)](#install-kong-gateway-in-db-less-mode):
+Store Kong configuration in-memory on the node. In this mode, the Admin API is
+read only, and you have to manage Kong using declarative configuration.
 
-Pull the Docker image:
-
-{% navtabs codeblock %}
-{% navtab Kong Gateway %}
-```bash
-docker pull kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-```bash
-docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-You should now have your {{site.base_gateway}} image locally.
-
-Next, choose a path and install Kong Gateway:
-* [With a database](#install-kong-gateway-with-a-database)
-* [Without a database (DB-less mode)](#install-kong-gateway-in-db-less-mode)
+If this is your first time trying out Kong Gateway, we recommend installing it
+with a database.
 
 ## Install Kong Gateway with a database
 
@@ -107,7 +95,7 @@ docker run --rm --network=kong-net \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PASSWORD=test" \
-kong/kong-gateway kong migrations bootstrap
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine kong migrations bootstrap
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -116,7 +104,7 @@ docker run --rm --network=kong-net \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
-kong kong migrations bootstrap
+kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migrations bootstrap
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -124,19 +112,19 @@ kong kong migrations bootstrap
 {{ migrations | indent | replace: " </code>", "</code>" }}
 
     Where:
-    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database)
-     is the database type, or `off` if setting up a data plane for [hybrid mode](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode/hybrid-mode-setup).
-    * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings)
-    is the name of the Postgres Docker container that is communicating over the
+    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
+     Specifies the type of database that Kong is using.
+    * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
+    The name of the Postgres Docker container that is communicating over the
     `kong-net` network, from the previous step.
-    * [`KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings)
+    * [`KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
     The password that you set when bringing up the Postgres container in the
     previous step.
     * `KONG_PASSWORD` (Enterprise only): The default password for the admin
     super user for Kong Gateway.
-    * `kong/kong-gateway kong migrations bootstrap` or `kong kong migrations bootstrap`:
-    In order, this is the Kong Gateway container tag, followed by the command
-    to Kong to prepare the Postgres database.
+    * `{IMAGE-NAME:TAG} kong migrations bootstrap`:
+    In order, this is the Kong Gateway container name and tag, followed by the
+    command to Kong to prepare the Postgres database.
 
 ### Start Kong Gateway
 
@@ -167,12 +155,12 @@ docker run -d --name kong-gateway \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway
+ kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```sh
-docker run -d --name kong \
+docker run -d --name kong-gateway \
  --network=kong-net \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
@@ -187,7 +175,7 @@ docker run -d --name kong \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:latest
+ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
  ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -195,16 +183,16 @@ docker run -d --name kong \
 {{ start_container | indent | replace: " </code>", "</code>" }}
 
     Where:
-    * `--name` and `--network`: The tag of the {{site.base_gateway}} image that
-    you're using, and the Docker network it communicates on.
+    * `--name` and `--network`: The name of the container to create,
+    and the Docker network it communicates on.
     * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
-    Specifies whether this node connects directly to a database.
+    Specifies the type of database that Kong is using.
     * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
     The name of the Postgres Docker container that is communicating over the
     `kong-net` network.
     * [`KONG_PG_USER` and `KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
      The Postgres username and password. Kong Gateway needs the login information
-     to store configurations in this database.
+     	to store configuration data in the `KONG_PG_HOST` database.
     * All [`_LOG`](/gateway/{{page.kong_version}}/reference/configuration/#general-section)
     parameters: set filepaths for the logs to output to, or use the values in
     the example to  print messages and errors to `stdout` and `stderr`.
@@ -224,64 +212,58 @@ docker run -d --name kong \
 
     You should receive a `200` status code.
 
-1. (Not available in OSS) Verify that Kong Manager is running by accessing it using the URL specified in `KONG_ADMIN_GUI_URL`:
+1. (Not available in OSS) Verify that Kong Manager is running by accessing it
+using the URL specified in `KONG_ADMIN_GUI_URL`:
 
     ```
     http://localhost:8002
     ```
 
+### Get started with Kong Gateway
+
+Now that you have a running Gateway instance, Kong provides a series of
+[getting started guides](/gateway/{{page.kong_version}}/get-started/comprehensive/)
+ to help you set up and enhance your first Service.
+
+In particular, right after installation you might want to:
+* [Create a service and a route](/gateway/{{page.kong_version}}/get-started/comprehensive/expose-services)
+* [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
+* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
+
+### Clean up containers
+
+If you're done testing Kong Gateway and no longer need the containers, you
+can clean them up using the following commands:
+
+```
+docker kill kong-gateway
+docker kill kong-database
+docker container rm kong-gateway
+docker container rm kong-database
+docker network rm kong-net
+```
+
+
 ## Install Kong Gateway in DB-less mode
 
-The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_version}}/reference/db-less-and-declarative-config) are the following:
+The following steps walk you through starting Kong Gateway in
+[DB-less mode](/gateway/{{page.kong_version}}/reference/db-less-and-declarative-config).
 
-### Set up a Docker volume
+### Create a Docker network
 
-1. Create a Docker network:
+Run the following command:
 
-    ```bash
-    docker network create kong-net
-    ```
+```bash
+docker network create kong-net
+```
 
-    You can name this network anything you want. We use `kong-net` as
-    an example throughout this guide.
+You can name this network anything you want. We use `kong-net` as
+an example throughout this guide.
 
-    This step is not strictly needed for running Kong in DB-less mode, but it is a good
-    precaution in case you want to add other things in the future (like a Rate Limiting plugin
-    backed up by a Redis cluster).
-
-1. Create a Docker volume:
-
-    ```bash
-    docker volume create kong-vol
-    ```
-
-    For the purposes of this guide, a [Docker Volume][Docker Volume] is a folder inside the host machine which
-    can be mapped into a folder in the container. In this guide, we name the
-    volume `kong-vol`.
-
-1. Inspect the Docker volume:
-
-    ```bash
-    docker volume inspect kong-vol
-    ```
-
-    The result should be similar to this:
-
-    ```json
-    [
-        {
-            "CreatedAt": "2019-05-28T12:40:09Z",
-            "Driver": "local",
-            "Labels": {},
-            "Mountpoint": "/var/lib/docker/volumes/kong-vol/_data",
-            "Name": "kong-vol",
-            "Options": {},
-            "Scope": "local"
-        }
-    ]
-    ```
-
-    Notice the `MountPoint` entry. You will need that path in the next step.
+This step is not strictly needed for running Kong in DB-less mode, but it is a good
+precaution in case you want to add other things in the future (like a Rate Limiting plugin
+backed up by a Redis cluster).
 
 ### Prepare your configuration file
 
@@ -291,11 +273,29 @@ The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_versi
     described in the [Declarative Configuration format] guide. Add whatever core
     entities (Services, Routes, Plugins, Consumers, etc) you need to this file.
 
+    For example, a simple file with a Service and a Route
+    could look something like this:
+
+    ```yaml
+    _format_version: "1.1"
+    _transform: true
+
+    services:
+    - host: mockbin.org
+      name: example_service
+      port: 80
+      protocol: http
+      routes:
+      - name: example_route
+        paths:
+        - /mock
+        strip_path: true
+    ```
+
     This guide assumes you named the file `kong.yml`.
 
-1.  Save your declarative configuration file inside the `MountPoint` path
-mentioned in the previous step. In the case of this
-guide, that would be `/var/lib/docker/volumes/kong-vol/_data/kong.yml`.
+1.  Save your declarative configuration locally, and note the filepath.
+For this example, we're using `/kong/declarative/kong.yml`.
 
 ### Start Kong Gateway in DB-less mode
 
@@ -303,22 +303,15 @@ guide, that would be `/var/lib/docker/volumes/kong-vol/_data/kong.yml`.
 
 1. Run the following command to start a container with {{site.base_gateway}}.
 
-   Although it's possible to start the Kong container with just
-   `KONG_DATABASE=off`, we recommend also including the declarative configuration
-   file as a parameter via the `KONG_DECLARATIVE_CONFIG` variable name. To do
-   this, you need to make the file visible from within the container.
-   Use the `-v` flag, which maps the Docker volume to the
-   `/usr/local/kong/declarative` folder in the container.
-
 {% capture start_container %}
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```sh
-docker run -d --name kong-gateway \
+docker run -d --name kong-dbless \
  --network=kong-net \
- -v "kong-vol:/usr/local/kong/declarative" \
+ -v "$(pwd)"/kong/declarative:/kong/declarative/ \
  -e "KONG_DATABASE=off" \
- -e "KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yml" \
+ -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
@@ -333,16 +326,16 @@ docker run -d --name kong-gateway \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway
+ kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```sh
-docker run -d --name kong \
+docker run -d --name kong-dbless \
  --network=kong-net \
- -v "kong-vol:/usr/local/kong/declarative" \
+ -v "$(pwd)"/kong/declarative:/kong/declarative/ \
  -e "KONG_DATABASE=off" \
- -e "KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yml" \
+ -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
@@ -352,7 +345,7 @@ docker run -d --name kong \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:latest
+ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
  ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -360,11 +353,11 @@ docker run -d --name kong \
 {{ start_container | indent | replace: " </code>", "</code>" }}
 
     Where:
-    * `--name` and `--network`: The tag of the {{site.base_gateway}} image that
-    you're using, and the Docker network it communicates on.
-    * `-v kong-vol:/usr/local/kong/declarative`: The name of the Docker volume
-    you created in a previous step mapped to the location of your declarative
-    configuration file.
+    * `--name` and `--network`: The name of the container to create,
+    and the Docker network it communicates on.
+    * `-v "$(pwd)"/path/to/source:/path/to/target/`: Mount a directory on your
+    local filesystem to a directory in the Docker container. This makes the
+    `kong.yml` file visible from the Docker container.
     * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
      Sets the database to `off` to tell Kong not to use any
     backing database for configuration storage.
@@ -396,14 +389,33 @@ docker run -d --name kong \
 [Declarative Configuration format]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/#the-declarative-configuration-format
 [Docker Volume]: https://docs.docker.com/storage/volumes/
 
+### Get started with Kong Gateway
+
+Now that you have a running Gateway instance, Kong provides a series of
+[getting started guides](/gateway/{{page.kong_version}}/get-started/comprehensive/)
+to help you set up and enhance your first Service.
+
+If you use the sample `kong.yml` in this guide, you already have a Service and
+a Route configured. Here are a few more things to check out:
+* [Configure a plugin](/gateway/{{page.kong_version}}/get-started/comprehensive/protect-services)
+* [Secure your Services with authentication](/gateway/{{page.kong_version}}/get-started/comprehensive/secure-services)
+* [Load balance traffic across targets](/gateway/{{page.kong_version}}/get-started/comprehensive/load-balancing)
+
+### Clean up containers
+
+If you're done testing Kong Gateway and no longer need the containers, you
+can clean them up using the following commands:
+
+```
+docker kill kong-dbless
+docker kill kong-database
+docker container rm kong-dbless
+docker container rm kong-database
+docker network rm kong-net
+```
+
 ## Troubleshooting
 
 If you did not receive a `200 OK` status code or need assistance completing
 setup, reach out to your support contact or head over to the
 [Support Portal](https://support.konghq.com/support/s/).
-
-## Next Steps
-
-Check out {{site.base_gateway}}'s series of
-[Getting Started](/gateway/{{page.kong_version}}/get-started/comprehensive/) guides to get the most
-out of {{site.base_gateway}}.

--- a/app/gateway/2.7.x/install-and-run/docker.md
+++ b/app/gateway/2.7.x/install-and-run/docker.md
@@ -35,18 +35,10 @@ The {{site.base_gateway}} software is governed by the
 * A Docker-enabled system with proper Docker access
 * (Enterprise only) A `license.json` file from Kong
 
-## Install Kong Gateway with a database
+## Pull the Kong Gateway image
 
-Set up a {{site.base_gateway}} container with a PostgreSQL database to store
-Kong configuration.
+Pull the Docker image:
 
-{% include_cached /md/enterprise/cassandra-deprecation.md %}
-
-### Pull and tag the Kong Gateway image
-
-1. Pull the Docker image:
-
-{% capture pull_image %}
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
@@ -59,52 +51,92 @@ docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
 ```
 {% endnavtab %}
 {% endnavtabs %}
-{% endcapture %}
-{{ pull_image | indent | replace: " </code>", "</code>" }}
 
-   You should now have your {{site.base_gateway}} image locally.
+You should now have your {{site.base_gateway}} image locally.
 
-2. Tag the image:
+Next, choose a path and install Kong Gateway:
+* [With a database](#install-kong-gateway-with-a-database)
+* [Without a database (DB-less mode)](#install-kong-gateway-in-db-less-mode)
 
-{% capture tag_image %}
-{% navtabs codeblock %}
-{% navtab Kong Gateway %}
-<div class="copy-code-snippet"><pre><code>docker tag kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine <div contenteditable="true">{TAG_NAME}</div></code></pre></div>
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-<div class="copy-code-snippet"><pre><code>docker tag kong:{{page.kong_versions[page.version-index].ce-version}}-alpine <div contenteditable="true">{TAG_NAME}</div></code></pre></div>
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-{{ tag_image | indent | replace: " </code>", "</code>" }}
+## Install Kong Gateway with a database
+
+Set up a {{site.base_gateway}} container with a PostgreSQL database to store
+Kong configuration.
+
+{% include_cached /md/enterprise/cassandra-deprecation.md %}
 
 ### Prepare the database
 
-1. Create a custom Docker network to allow the containers to discover and communicate with each other:
+1. Create a custom Docker network to allow the containers to discover and
+communicate with each other:
 
-   <pre><code>docker network create <div contenteditable="true">{NETWORK_NAME}</div></code></pre>
+    ```sh
+    docker network create kong-net
+    ```
+
+    You can name this network anything you want. We use `kong-net` as
+    an example throughout this guide.
 
 1. Start a PostgreSQL container:
 
-   <pre><code>docker run -d --name <div contenteditable="true">{PG_CONTAINER_NAME}</div> \
-     --network=<div contenteditable="true">{NETWORK_NAME}</div> \
+    ```sh
+    docker run -d --name kong-database \
+     --network=kong-net \
      -p 5432:5432 \
-     -e "POSTGRES_USER=<div contenteditable="true">{DATABASE_USER}</div>" \
-     -e "POSTGRES_DB=<div contenteditable="true">{DATABASE_NAME}</div>" \
-     -e "POSTGRES_PASSWORD=<div contenteditable="true">{DATABASE_PASSWORD}</div>" \
+     -e "POSTGRES_USER=kong" \
+     -e "POSTGRES_DB=kong" \
+     -e "POSTGRES_PASSWORD=kongpass" \
      postgres:9.6
-   </code></pre>
+    ```
+
+    * `POSTGRES_USER` and `POSTGRES_DB`: Set these values to `kong`. This is
+    the default value that Kong Gateway expects.
+    * `POSTGRES_PASSWORD`: Set the database password to any string.
+
+    In this example, the Postgres container named `kong-database` can
+    communicate with any containers on the `kong-net` network.
 
 1. Prepare the Kong database:
+
 {% capture migrations %}
-<pre><code>docker run --rm --network=<div contenteditable="true">{NETWORK_NAME}</div> \
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```sh
+docker run --rm --network=kong-net \
  -e "KONG_DATABASE=postgres" \
- -e "KONG_PG_HOST=<div contenteditable="true">{PG_CONTAINER_NAME}</div>" \
- -e "KONG_PG_PASSWORD=<div contenteditable="true">{CONTAINER_PASSWORD}</div>" \
- -e "KONG_PASSWORD=<div contenteditable="true">{PASSWORD}</div>" \
- <div contenteditable="true">{TAG_NAME}</div> <div contenteditable="true">{DATABASE_NAME}</div> migrations bootstrap</code></pre>
+ -e "KONG_PG_HOST=kong-database" \
+ -e "KONG_PG_PASSWORD=kongpass" \
+ -e "KONG_PASSWORD=test" \
+kong/kong-gateway kong migrations bootstrap
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```sh
+docker run --rm --network=kong-net \
+ -e "KONG_DATABASE=postgres" \
+ -e "KONG_PG_HOST=kong-database" \
+ -e "KONG_PG_PASSWORD=kongpass" \
+kong kong migrations bootstrap
+```
+{% endnavtab %}
+{% endnavtabs %}
 {% endcapture %}
 {{ migrations | indent | replace: " </code>", "</code>" }}
+
+    Where:
+    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database)
+     is the database type, or `off` if setting up a data plane for [hybrid mode](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode/hybrid-mode-setup).
+    * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings)
+    is the name of the Postgres Docker container that is communicating over the
+    `kong-net` network, from the previous step.
+    * [`KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings)
+    The password that you set when bringing up the Postgres container in the
+    previous step.
+    * `KONG_PASSWORD` (Enterprise only): The default password for the admin
+    super user for Kong Gateway.
+    * `kong/kong-gateway kong migrations bootstrap` or `kong kong migrations bootstrap`:
+    In order, this is the Kong Gateway container tag, followed by the command
+    to Kong to prepare the Postgres database.
 
 ### Start Kong Gateway
 
@@ -114,18 +146,19 @@ docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
 {% capture start_container %}
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
-<div class="copy-code-snippet"><pre><code>docker run -d --name <div contenteditable="true">{GATEWAY_CONTAINER_NAME}</div> \
- --network=<div contenteditable="true">{NETWORK_NAME}</div> \
+```sh
+docker run -d --name kong-gateway \
+ --network=kong-net \
  -e "KONG_DATABASE=postgres" \
- -e "KONG_PG_HOST=<div contenteditable="true">{PG_HOST_NAME}</div>" \
- -e "KONG_PG_USER=<div contenteditable="true">{PG_USER_NAME}</div>" \
- -e "KONG_PG_PASSWORD=<div contenteditable="true">{DATABASE_PASSWORD}</div>" \
+ -e "KONG_PG_HOST=kong-database" \
+ -e "KONG_PG_USER=kong" \
+ -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
- -e "KONG_ADMIN_GUI_URL=http://<div contenteditable="true">{HOSTNAME}</div>:8002" \
+ -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 8001:8001 \
@@ -134,16 +167,17 @@ docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong-ee</code></pre></div>
+ kong/kong-gateway
+```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
-<div class="copy-code-snippet"><pre><code>docker run -d --name <div contenteditable="true">{GATEWAY_CONTAINER_NAME}</div> \
- --network=<div contenteditable="true">{NETWORK_NAME}</div> \
+```sh
+docker run -d --name kong \
+ --network=kong-net \
  -e "KONG_DATABASE=postgres" \
- -e "KONG_PG_HOST=<div contenteditable="true">{PG_HOST_NAME}</div>" \
- -e "KONG_PG_USER=<div contenteditable="true">{PG_USER_NAME}</div>" \
+ -e "KONG_PG_HOST=kong-database" \
+ -e "KONG_PG_USER=kong" \
  -e "KONG_PG_PASSWORD=kong" \
- -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
@@ -153,61 +187,79 @@ docker pull kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:latest</code></pre></div>
+ kong:latest
+ ```
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}
 {{ start_container | indent | replace: " </code>", "</code>" }}
 
-   {:.note}
-   > **Note**: The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should be preceded by a protocol, for example, `http://`.
+    Where:
+    * `--name` and `--network`: The tag of the {{site.base_gateway}} image that
+    you're using, and the Docker network it communicates on.
+    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
+    Specifies whether this node connects directly to a database.
+    * [`KONG_PG_HOST`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
+    The name of the Postgres Docker container that is communicating over the
+    `kong-net` network.
+    * [`KONG_PG_USER` and `KONG_PG_PASSWORD`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings):
+     The Postgres username and password. Kong Gateway needs the login information
+     to store configurations in this database.
+    * All [`_LOG`](/gateway/{{page.kong_version}}/reference/configuration/#general-section)
+    parameters: set filepaths for the logs to output to, or use the values in
+    the example to  print messages and errors to `stdout` and `stderr`.
+    * [`KONG_ADMIN_LISTEN`](/gateway/{{page.kong_version}}/reference/configuration/#admin_listen):
+    The port that the Kong Admin API listens on for requests.
+    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
+    (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
+    (for example, `http://`).
 
-2. Verify your installation:
+1. Verify your installation:
 
     Access the `/services` endpoint using the Admin API:
 
-    <pre><code>curl -i -X GET --url http://<div contenteditable="true">{HOSTNAME}</div>:8001/services</code></pre>
+    ```sh
+    curl -i -X GET --url http://localhost:8001/services
+    ```
 
     You should receive a `200` status code.
 
-3. (Not available in OSS) Verify that Kong Manager is running by accessing it using the URL specified in `KONG_ADMIN_GUI_URL`:
+1. (Not available in OSS) Verify that Kong Manager is running by accessing it using the URL specified in `KONG_ADMIN_GUI_URL`:
 
-      <pre><code>http://<div contenteditable="true">{HOSTNAME}</div>:8002</code></pre>
+    ```
+    http://localhost:8002
+    ```
 
-## Install Gateway in DB-less mode
-
-{:.important}
-> **Important**: Running {{site.base_gateway}} on Docker in DB-less mode is
-supported for both Enterprise and OSS images. However, there is currently no
-documentation for setting up an Enterprise image in DB-less mode, so adjust the
-following steps as needed for an Enterprise deploy.
+## Install Kong Gateway in DB-less mode
 
 The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_version}}/reference/db-less-and-declarative-config) are the following:
 
-1. Create a Docker network:
+### Set up a Docker volume
 
-    This is the same as in the Pg/Cassandra guide. We're also using `kong-net` as the
-    network name and it can also be changed to something else.
+1. Create a Docker network:
 
     ```bash
     docker network create kong-net
     ```
 
+    You can name this network anything you want. We use `kong-net` as
+    an example throughout this guide.
+
     This step is not strictly needed for running Kong in DB-less mode, but it is a good
-    precaution in case you want to add other things in the future (like a rate-limiting plugin
+    precaution in case you want to add other things in the future (like a Rate Limiting plugin
     backed up by a Redis cluster).
 
-2. Create a Docker volume:
-
-    For the purposes of this guide, a [Docker Volume][Docker Volume] is a folder inside the host machine which
-    can be mapped into a folder in the container. Volumes have a name. In this case we're going
-    to name ours `kong-vol`
+1. Create a Docker volume:
 
     ```bash
     docker volume create kong-vol
     ```
 
-    You should be able to inspect the volume now:
+    For the purposes of this guide, a [Docker Volume][Docker Volume] is a folder inside the host machine which
+    can be mapped into a folder in the container. In this guide, we name the
+    volume `kong-vol`.
+
+1. Inspect the Docker volume:
 
     ```bash
     docker volume inspect kong-vol
@@ -229,33 +281,41 @@ The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_versi
     ]
     ```
 
-    Notice the `MountPoint` entry. We will need that path in the next step.
+    Notice the `MountPoint` entry. You will need that path in the next step.
 
-3. Prepare your declarative configuration file:
+### Prepare your configuration file
 
-    The syntax and properties are described on the [Declarative Configuration Format] guide.
+1. Prepare your declarative configuration file in `.yml` or `.json` format.
 
-    Add whatever core entities (Services, Routes, Plugins, Consumers, etc) you need there.
+    The syntax and properties are
+    described in the [Declarative Configuration format] guide. Add whatever core
+    entities (Services, Routes, Plugins, Consumers, etc) you need to this file.
 
-    On this guide we'll assume you named it `kong.yml`.
+    This guide assumes you named the file `kong.yml`.
 
-    Save it inside the `MountPoint` path mentioned in the previous step. In the case of this
-    guide, that would be `/var/lib/docker/volumes/kong-vol/_data/kong.yml`
+1.  Save your declarative configuration file inside the `MountPoint` path
+mentioned in the previous step. In the case of this
+guide, that would be `/var/lib/docker/volumes/kong-vol/_data/kong.yml`.
 
+### Start Kong Gateway in DB-less mode
 
-4. Run the following command to start a container with {{site.base_gateway}}.
+{% include_cached /md/admin-listen.md desc='long' %}
 
-   Although it's possible to start the Kong container with `KONG_DATABASE=off`, it is usually
-   desirable to also include the declarative configuration file as a parameter via the
-   `KONG_DECLARATIVE_CONFIG` variable name. To do this, we need to make the file
-   "visible" from within the container. Use the `-v` flag, which maps
-   the Docker volume to the `/usr/local/kong/declarative` folder in the container.
+1. Run the following command to start a container with {{site.base_gateway}}.
+
+   Although it's possible to start the Kong container with just
+   `KONG_DATABASE=off`, we recommend also including the declarative configuration
+   file as a parameter via the `KONG_DECLARATIVE_CONFIG` variable name. To do
+   this, you need to make the file visible from within the container.
+   Use the `-v` flag, which maps the Docker volume to the
+   `/usr/local/kong/declarative` folder in the container.
 
 {% capture start_container %}
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
-<div class="copy-code-snippet"><pre><code>docker run -d --name <div contenteditable="true">{GATEWAY_CONTAINER_NAME}</div> \
- --network=<div contenteditable="true">{NETWORK_NAME}</div> \
+```sh
+docker run -d --name kong-gateway \
+ --network=kong-net \
  -v "kong-vol:/usr/local/kong/declarative" \
  -e "KONG_DATABASE=off" \
  -e "KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yml" \
@@ -264,7 +324,7 @@ The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_versi
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
- -e "KONG_ADMIN_GUI_URL=http://<div contenteditable="true">{HOSTNAME}</div>:8002" \
+ -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 8001:8001 \
@@ -273,11 +333,13 @@ The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_versi
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong-ee</code></pre></div>
+ kong/kong-gateway
+```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
-<div class="copy-code-snippet"><pre><code>docker run -d --name <div contenteditable="true">{GATEWAY_CONTAINER_NAME}</div> \
- --network=<div contenteditable="true">{NETWORK_NAME}</div> \
+```sh
+docker run -d --name kong \
+ --network=kong-net \
  -v "kong-vol:/usr/local/kong/declarative" \
  -e "KONG_DATABASE=off" \
  -e "KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yml" \
@@ -290,22 +352,48 @@ The steps involved in starting Kong in [DB-less mode](/gateway/{{page.kong_versi
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:latest</code></pre></div>
+ kong:latest
+ ```
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}
 {{ start_container | indent | replace: " </code>", "</code>" }}
 
-5. Verify that {{site.base_gateway}} is running:
+    Where:
+    * `--name` and `--network`: The tag of the {{site.base_gateway}} image that
+    you're using, and the Docker network it communicates on.
+    * `-v kong-vol:/usr/local/kong/declarative`: The name of the Docker volume
+    you created in a previous step mapped to the location of your declarative
+    configuration file.
+    * [`KONG_DATABASE`](/gateway/{{page.kong_version}}/reference/configuration/#database):
+     Sets the database to `off` to tell Kong not to use any
+    backing database for configuration storage.
+    * [`KONG_DECLARATIVE_CONFIG`](/gateway/{{page.kong_version}}/reference/configuration/#declarative_config):
+    The path to a declarative configuration file inside the container.
+    This path should match the path that you're mapping with `-v`.
+    * All [`_LOG`](/gateway/{{page.kong_version}}/reference/configuration/#general-section)
+    parameters: set filepaths for the logs to output to, or use the values in
+    the example to  print messages and errors to `stdout` and `stderr`.
+    * [`KONG_ADMIN_LISTEN`](/gateway/{{page.kong_version}}/reference/configuration/#admin_listen):
+    The port that the Kong Admin API listens on for requests.
+    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
+    (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
+    (for example, `http://`).
 
-    <pre><code>curl -i http://<div contenteditable="true">{HOSTNAME}</div>:8001</code></pre>
+1. Verify that {{site.base_gateway}} is running:
 
-    For example, get a list of services:
+    ```sh
+    curl -i http://localhost:8001
+    ```
 
-    <pre><code>curl -i http://<div contenteditable="true">{HOSTNAME}</div>:8001/services</code></pre>
+    Test an endpoint. For example, get a list of services:
+
+    ```sh
+    curl -i http://localhost:8001/services
+    ```
 
 [DB-less mode]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/
-[Declarative Configuration Format]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/#the-declarative-configuration-format
+[Declarative Configuration format]: /gateway/{{page.kong_version}}/reference/db-less-and-declarative-config/#the-declarative-configuration-format
 [Docker Volume]: https://docs.docker.com/storage/volumes/
 
 ## Troubleshooting


### PR DESCRIPTION
### Summary

Based on the confusion caused by editable placeholders and a few other changes, fixing the Docker install instructions for Gateway:
- Removing editable placeholders and replacing with hardcoded values. If a user needs to change any values, they can change them.
- Adding descriptions for parameters, so that if they want to customize the install, they know what each param does
- Cleaning up order of instructions and chunking up the DB-less mode section
- Cleaning up DB-less mode text
- FIxing `migrations` command
- Removing step to tag docker image:
  - We were tagging the OSS `kong` image  as `kong`, which is redundant
  - We shouldn't use `kong-ee` anymore. The Enterprise image name is `kong/kong-gateway`, which is fairly clear as it is and is different from the OSS image.

**Explanations for a couple of specific changes:**
- Why remove `KONG_CASSANDRA_CONTACT_POINTS`? 
  - Cassandra support is deprecated and will be removed, so we shouldn't be using Cassandra in our examples. Also, the examples configure a Postgres database, and it's really strange that there's one param that configures something for Cassandra.
-  Why set `KONG_ADMIN_GUI_URL` to `localhost` instead of a placeholder? 
   - `localhost` really is a placeholder. By using this value instead of something like `<hostname>`, people can copy+paste more easily. It can also be confusing to figure out what your hostname is; this provides a default that they can adjust.

**Tested everything that I could:**
- The database-backed instructions (both OSS and Enterprise) work as documented, and you can copy-paste the content with no changes if you want, and it'll all work. 
- Had trouble testing the db-less mode section as documented, as it doesn't really work on MacOS (known limitation based on volume locations). If someone else can test that, that would be ideal.

### Reason
The installation doc was broken and we were getting lots of reports about it.

### Testing
https://deploy-preview-3608--kongdocs.netlify.app/gateway/2.7.x/install-and-run/docker/
Run through the instructions, if possible, and install Gateway.