### PR TITLE
[DOCU-1698] External link icons + update font awesome

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -759,3 +759,37 @@
     width: 100%;
   }
 }
+
+// External link icons in both left and right sidebars
+.docs-toc, .docs-sidebar, .landing-page {
+  a:not([href^='https://konghq.com']):not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):after {
+      font-family: 'FontAwesome';
+      content: " \f35d";
+      margin-left: 0.4rem;
+      font-size: 12px;
+  }
+}
+
+// External icons in content body, excluding badges
+.content {
+  a:not(.badge):not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):after {
+      font-family: 'FontAwesome';
+      content: " \f35d";
+      margin-left: 0.2rem;
+      margin-right: 0.2rem;
+      vertical-align: middle;
+      font-size: 12px;
+      font-weight: lighter;
+  }
+}
+
+// External link icons in top site navbar
+.navbar-items {
+  a:not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):not([class='navbar-button']):after {
+      font-family: 'FontAwesome';
+      content: " \f35d";
+      margin-left: 0.2rem;
+      font-size: 11px;
+      // opacity: 0.5;
+  }
+}

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -761,7 +761,7 @@
 }
 
 // External link icons in both left and right sidebars
-.docs-toc, .docs-sidebar, .landing-page {
+.docs-sidebar, .landing-page {
   a:not([href^='https://konghq.com']):not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):after {
       font-family: 'FontAwesome';
       content: " \f35d";
@@ -784,12 +784,11 @@
 }
 
 // External link icons in top site navbar
-.navbar-items {
+.navbar-item-submenu {
   a:not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):not([class='navbar-button']):after {
       font-family: 'FontAwesome';
       content: " \f35d";
       margin-left: 0.2rem;
       font-size: 11px;
-      // opacity: 0.5;
   }
 }

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -772,7 +772,7 @@
 
 // External icons in content body, excluding badges
 .content {
-  a:not(.badge):not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):after {
+  a:not(.badge, .install-link, .install-listing-link):not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):after {
       font-family: 'FontAwesome';
       content: " \f35d";
       margin-left: 0.2rem;

--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -9,8 +9,16 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if include.p
 
   {% if jekyll.environment == "production" %}
   <!-- OneTrust Cookies Consent Notice start for konghq.com -->
-  <script type="text/javascript" src="https://cdn.cookielaw.org/consent/2c4de954-6bec-4e93-8086-64cb113f151a/OtAutoBlock.js" ></script>
-  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="2c4de954-6bec-4e93-8086-64cb113f151a" ></script>
+  <script
+    type="text/javascript"
+    src="https://cdn.cookielaw.org/consent/2c4de954-6bec-4e93-8086-64cb113f151a/OtAutoBlock.js" >
+  </script>
+  <script
+    src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+    type="text/javascript"
+    charset="UTF-8"
+    data-domain-script="2c4de954-6bec-4e93-8086-64cb113f151a" >
+  </script>
   <script type="text/javascript">
   function OptanonWrapper() { }
   </script>
@@ -57,12 +65,12 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if include.p
     name="google-site-verification"
     content="CrU3zp02dNKTe8NSAipL4NCPkrIjDXG8fViTZ-MIzP4"
   />
-  <link
-    rel="stylesheet"
-    href="https://use.fontawesome.com/releases/v5.4.1/css/all.css"
-    integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz"
-    crossorigin="anonymous"
-  />
+
+  <!-- FontAwesome icon font -->
+  <script
+    src="https://kit.fontawesome.com/1332a92967.js" 
+    crossorigin="anonymous">
+  </script>
 
   <!-- New Relic -->
   {% include newrelic.html %}


### PR DESCRIPTION
### Summary
* Adding external link icons. 
  * Went with the pure CSS route; can also do this with JS, if reviewers think that would be better.
* Updating font-awesome using their latest docs; the version we were using didn't have a lot of the newer icons, including an external link icon. Nowadays, they provide a script to add to your site instead of referencing a versioned stylesheet. This way, it should stay up-to-date.

**Exceptions:** No link icons on buttons, on badges, or in the footer. For buttons and badges, this is a stylistic choice; for the footer, it's for consistency with the konghq.com site. 

**@ Reviewers:** Should these icons also be left out of the navbar, for consistency with our other sites? Additionally, there's some jumpiness because of the way the page loads, with text loading first and then icons. It's mainly obvious in the navbar.

### Reason
Accessibility guidelines state that external links, especially any links that open in a new tab, must have some warning. For consistency, I've applied the icon to all external links.

A subsequent PR should also add hidden labels on the links to label them external, and notify screenreaders that this link will open in a new tab/window.

Sources:
Guidelines for links: https://www.w3.org/TR/WCAG20-TECHS
Failure conditions: https://www.w3.org/TR/WCAG20-TECHS/F22.html

https://accessibility.oit.ncsu.edu/it-accessibility-at-nc-state/developers/accessibility-handbook/mouse-and-keyboard-events/links/links-and-new-windows/

### Testing
https://deploy-preview-3610--kongdocs.netlify.app/ - scroll down on the landing page, links to Insomnia and Kuma are labelled with the icon
Look through docs overall for instances of the icon.
