### PR TITLE
doc(kic) add KIC Grafana dashboard

### DIFF
--- a/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
@@ -75,6 +75,9 @@ grafana:
         gnetId: 7424  # Install the following Grafana dashboard in the
         revision: 5   # instance: https://grafana.com/dashboards/7424
         datasource: Prometheus
+      kic-dash:
+        gnetId: 15662
+        datasource: Prometheus
   
 ```
 

--- a/app/kubernetes-ingress-controller/2.1.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/prometheus-grafana.md
@@ -75,6 +75,9 @@ grafana:
         gnetId: 7424  # Install the following Grafana dashboard in the
         revision: 5   # instance: https://grafana.com/dashboards/7424
         datasource: Prometheus
+      kic-dash:
+        gnetId: 15662
+        datasource: Prometheus
   
 ```
 


### PR DESCRIPTION
### Summary
Add the KIC dashboard to the Prometheus/Grafana guide

### Reason
https://grafana.com/grafana/dashboards/15662 is now available.

### Testing

```
helm install trp prometheus-community/kube-prometheus-stack -f /tmp/values.yaml
```
with [values.yaml.txt](https://github.com/Kong/docs.konghq.com/files/7982635/values.yaml.txt), confirming that the dashboards appear.
