### PR TITLE
Use quoted struct tags for golang configuration

### DIFF
--- a/app/gateway/2.7.x/reference/external-plugins.md
+++ b/app/gateway/2.7.x/reference/external-plugins.md
@@ -144,8 +144,8 @@ datastore, add field tags as defined in the `encoding/json` package:
 
 ```go
 type MyConfig struct {
-    Path   string `json:my_file_path`
-    Reopen bool   `json:reopen`
+    Path   string `json:"my_file_path"`
+    Reopen bool   `json:"reopen"`
 }
 ```
 


### PR DESCRIPTION
### Summary
This adds quotes to the Golang struct tags.

### Reason
The current Golang config struct has a minor error in that the struct tags are missing. This would cause an issue when encoding/decoding the json configs. Example: https://go.dev/play/p/2hCSyXzXWgR

### Testing
[Here is an example of it in action](https://go.dev/play/p/2hCSyXzXWgR)

