### PR TITLE
Update konglabs links and variables

### DIFF
--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -82,7 +82,7 @@
           <a href="https://konghq.com/community/" class="navbar-item">Community</a>
         </li>
         <li role="menuitem" class="main-menu-item">
-          <a href="https://education.konghq.com/" class="navbar-item">Kong Academy</a>
+          <a href="{{site.links.learn}}" class="navbar-item">Kong Academy</a>
         </li>
       </ul>
       <a href="https://konghq.com/contact-sales" class="navbar-button">

--- a/app/contributing/variables.md
+++ b/app/contributing/variables.md
@@ -3,54 +3,46 @@ title: Using Variables
 no_version: true
 ---
 
-The product name variables are defined in the site config file, `jekyll.yml`:
+Use variable in content text, links, and in codeblocks.
 
-```yaml
-# product name vars
-ee_product_name: Kong Gateway
-ce_product_name: Kong Gateway (OSS)
-base_gateway: Kong Gateway
-mesh_product_name: Kong Mesh
-kic_product_name: Kubernetes Ingress Controller
-konnect_product_name: Kong Konnect
-konnect_short_name: Konnect
-konnect_saas: Konnect SaaS
-package_name: Kong Konnect
-company_name: Kong Inc.
+Do not use in:
+* Page front matter: This is an important note for plugins in particular, as
+much of the page content is generated out of a plugin’s front matter.
+* Auto-generated docs (eg Admin API).
+* Page titles or headings.
 
-# Konnect tier vars
-free_tier: Kong Gateway
-plus_tier: Kong Konnect Plus
-enterprise_tier: Kong Konnect Enterprise
-```
+## Product names
+
+For specific product name definitions and when to use what, see [word choice and naming](/contributing/word-choice).
+
+Variable | Output | Definition
+---------|--------|-----------
+{% raw %}`{{site.base_gateway}}`{% endraw %} | {{site.base_gateway}} | The Kong API Gateway. Use this in most situations, including: <br><br> &#8226; When talking about a feature that is available for both open-source and Enterprise <br> &#8226; When referring to the Enterprise image used in any mode, with a license or without.
+{% raw %}`{{site.ee_product_name}}`{% endraw %} | {{site.ee_product_name}} | (Legacy variable, do not use) The whole self-managed Enterprise Gateway package, including modules and peripherals, eg Kong Manager, Dev Portal, Vitals, etc.
+{% raw %}`{{site.ce_product_name}}`{% endraw %} | {{site.ce_product_name}} | Kong's open-source API gateway. Use when referring to something that's _only_ available in open-source.
+{% raw %}`{{site.konnect_product_name}}`{% endraw %}| {{site.konnect_product_name}} | The full name of the Kong Konnect platform, both cloud and self-managed.
+{% raw %}`{{site.konnect_short_name}}`{% endraw %} | {{site.konnect_short_name}} | The short name of the SaaS Konnect control plane.
+{% raw %}`{{site.konnect_saas}}`{% endraw %} | {{site.konnect_saas}} | The full name of the SaaS Konnect control plane.
+{% raw %}`{{site.company_name}}`{% endraw %} | {{site.company_name}} | The name of the company. <br><br> Sometimes "Kong" is used to refer to Kong Gateway. For branding reasons, we should avoid using this term to refer to Kong Gateway going forward, however, user communities will continue to use this term as shorthand.
+
+## Links
+
+Variable | Output | Definition
+---------|--------|-----------
+{% raw %}`{{site.links.learn}}`{% endraw %} | https://education.konghq.com | Link to the current location of Kong Academy or a similar education site.
+{% raw %}`{{site.links.download}}`{% endraw %} | https://download.konghq.com | Kong's product download site.
+{% raw %}`{{site.links.web}}`{% endraw %} | https://docs.konghq.com | Kong Docs website.
+
+## Update or add variables
+
+The product name variables are defined in the site config file, `jekyll.yml`.
 
 If you need to update the variable text, add, or remove a variable, edit
 `jekyll.yml` and `jekyll-dev.yml` in the root of the site repository.
 
 For a new variable, use the following syntax: `<variable>:<output>`
 
-Do: use in content text, in links, in codeblocks.
-
-Do not use in:
-* Page front matter: This is an important note for plugins in particular, as
-much of the page content is generated out of a plugin’s front matter.
-
-* Auto-generated docs (eg Admin API).
-
-* Page titles or headings.
-
-## Product names
-
-Variable | Output | Definition | Syntax
----------|--------|------------|-------
-base_gateway | {{site.base_gateway}} | The base API gateway. Use this when talking about a feature that is available for both Community and Enterprise. | {% raw %}`{{site.base_gateway}}`{% endraw %}
-ee_product_name | {{site.ee_product_name}} | The whole self-managed Enterprise Gateway package, including modules and peripherals, eg Kong Manager, Dev Portal, Vitals, etc. | {% raw %}`{{site.ee_product_name}}`{% endraw %}
-ce_product_name | {{site.ce_product_name}} | Kong's open-source API gateway. | {% raw %}`{{site.ce_product_name}}`{% endraw %}
-konnect_product_name | {{site.konnect_product_name}} | The full name of the Kong Konnect platform, both cloud and self-managed. | {% raw %}`{{site.konnect_product_name}}`{% endraw %}
-konnect_short_name | {{site.konnect_short_name}} | The short name of the SaaS Konnect control plane. | {% raw %}`{{site.konnect_short_name}}`{% endraw %}
-konnect_saas | {{site.konnect_saas}} | The full name of the SaaS Konnect control plane.  | {% raw %}`{{site.konnect_saas}}`{% endraw %}
-company_name | {{site.company_name}} | The name of the company. <br> Do not use “Kong” without a modifier to refer to Kong Gateway. Kong refers only to the company. | {% raw %}{{site.company_name}}{% endraw %}
-
+<!--
 ## Versions
 
 > WORK IN PROGRESS
@@ -93,4 +85,4 @@ E.g., if you want to pull the first version of the doc, you would use {{page.kon
 
 {{page.kong_versions[0].version}}
 
-{{page.kong_versions[1].version}}
+{{page.kong_versions[1].version}} -->

--- a/app/enterprise/1.3-x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.3-x/kong-for-kubernetes/install.md
@@ -113,7 +113,7 @@ $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip
 ```
 
 It might take a while for your cloud provider to associate the IP address to the `kong-proxy` service.
-Once you have installed Kong, see the [getting started tutorial](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/guides/getting-started.md).
+Once you have installed Kong, see the [getting started tutorial](/kubernetes-ingress-controller/latest/guides/getting-started).
 
 ## Next steps...
 See [Using Kong for Kubernetes Enterprise](/enterprise/{{page.kong_version}}/kong-for-kubernetes/using-kong-for-kubernetes) for information about Concepts, How-to guides, Reference guides, and using Plugins.

--- a/app/enterprise/1.3-x/kong-for-kubernetes/install.md
+++ b/app/enterprise/1.3-x/kong-for-kubernetes/install.md
@@ -18,7 +18,6 @@ Before installing Kong for Kubernetes Enterprise, be sure you have the following
 - A valid Kong Enterprise License
   * If you have a license, continue to [Step 1. Set Kong Enterprise License](#step-1-set-kong-enterprise-license) below. If you need your license file information, contact Kong Support.
   * If you need a license, request a trial license through our [Request Demo](https://konghq.com/request-demo/) page.
-  * Or, try out Kong for Kubernetes Enterprise using a live tutorial at [https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/)
 - An Enterprise Docker image for {{page.kong_version}}.
 
   If you have lost access to your {{page.kong_version}} image, Kong recommends

--- a/app/enterprise/2.2.x/introduction/index.md
+++ b/app/enterprise/2.2.x/introduction/index.md
@@ -60,8 +60,7 @@ Kong Studio enables spec-first development for all REST and GraphQL services. Wi
 There are a few ways to test out the gateway's Plus or Enterprise features:
 
 * Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
-* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
-[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* Check out learning labs at [Kong Academy]({{site.links.learn}}).
 * If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to

--- a/app/enterprise/2.3.x/index.md
+++ b/app/enterprise/2.3.x/index.md
@@ -63,8 +63,7 @@ and start testing out Gateway's open source features with Kong Manager today.
 There are a few ways to test out the gateway's Plus or Enterprise features:
 
 * Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
-* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
-[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* Check out learning labs at [Kong Academy]({{site.links.learn}}).
 * If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to

--- a/app/enterprise/2.4.x/index.md
+++ b/app/enterprise/2.4.x/index.md
@@ -63,8 +63,7 @@ and start testing out Gateway's open source features with Kong Manager today.
 There are a few ways to test out the gateway's Plus or Enterprise features:
 
 * Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
-* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
-[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* Check out learning labs at [Kong Academy]({{site.links.learn}}).
 * If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to

--- a/app/enterprise/2.5.x/index.md
+++ b/app/enterprise/2.5.x/index.md
@@ -63,8 +63,7 @@ and start testing out Gateway's open source features with Kong Manager today.
 There are a few ways to test out the gateway's Plus or Enterprise features:
 
 * Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
-* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
-[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* Check out learning labs at [Kong Academy]({{site.links.learn}}).
 * If you are interested in evaluating Enterprise features locally, the
 Kong sales team manages evaluation licenses as part of a formal sales process.
 The best way to get started with the sales process is to

--- a/app/gateway/2.6.x/index.md
+++ b/app/gateway/2.6.x/index.md
@@ -158,8 +158,7 @@ own data planes.
 There are a few ways to test out the Gateway's Plus or Enterprise features:
 
 * Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
-* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
-[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* Check out learning labs at [Kong Academy]({{site.links.learn}}).
 * If you are interested in evaluating Enterprise features locally,
 [request a demo](https://konghq.com/get-started/#request-demo) and a Kong
 representative will reach out with details to get you started.

--- a/app/gateway/2.7.x/index.md
+++ b/app/gateway/2.7.x/index.md
@@ -158,8 +158,7 @@ own data planes.
 There are a few ways to test out the Gateway's Plus or Enterprise features:
 
 * Sign up for a [free trial of {{site.konnect_product_name}} Plus](https://konnect.konghq.com/register).
-* Try out {{site.base_gateway}} on Kubernetes using a live tutorial at
-[https://www.konglabs.io/kubernetes/](https://www.konglabs.io/kubernetes/).
+* Check out learning labs at [Kong Academy]({{site.links.learn}}).
 * If you are interested in evaluating Enterprise features locally,
 [request a demo](https://konghq.com/get-started/#request-demo) and a Kong
 representative will reach out with details to get you started.

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -25,6 +25,7 @@ links:
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters
   download: https://download.konghq.com
   instaclustr: "https://www.instaclustr.com/products/kong/?utm_source=partnership&utm_medium=link&utm_campaign=mashape"
+  learn: https://education.konghq.com # kong academy
 repos:
   kong: https://github.com/Kong/kong
   docs: https://github.com/Kong/docs.konghq.com

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -25,6 +25,7 @@ links:
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters
   download: https://download.konghq.com
   instaclustr: "https://www.instaclustr.com/products/kong/?utm_source=partnership&utm_medium=link&utm_campaign=mashape"
+  learn: https://education.konghq.com # kong academy
 repos:
   kong: https://github.com/Kong/kong
   docs: https://github.com/Kong/docs.konghq.com


### PR DESCRIPTION
### Summary
konglabs.io doesn't exist anymore and has been replaced with education.konghq.com. 

- In the interest of maintainability, I've defined a variable for a `learn` link pointing to Kong Academy and replaced all the old links with the variable. This way, if the link changes again in the future, we can just update the variable definition.

- Added a table for link variables to our contributing guide, and cleaned up the variables topic a bit. 
  - Removed the codeblock with variables, it was redundant with the table.
  - Commented out the broken version variable section.

### Testing
https://deploy-preview-3617--kongdocs.netlify.app/gateway/#try-in-konnect
https://deploy-preview-3617--kongdocs.netlify.app/contributing/variables