### PR TITLE
Dev Portal API doc disclaimer

### DIFF
--- a/app/api/developer-portal.json
+++ b/app/api/developer-portal.json
@@ -7,7 +7,7 @@
     "contact": {
       "name": "Michael Heap"
     },
-    "description": "Welcome to the documentation for the Kong Enterprise edition Dev Portal API."
+    "description": "Welcome to the documentation for the Dev Portal API, self-managed edition. <br><br><b>Disclaimer:</b> This document is currently in beta. It might not contain all possible endpoints and requests, and request descriptions are not complete. <br>If you find a missing request or run into an error in the documentation, please file an issue in our <a href=\"https://github.com/Kong/docs.konghq.com/issues\">Github repository</a>, or submit a PR to update the <a href=\"https://github.com/Kong/docs.konghq.com/blob/main/app/api/developer-portal.json\">Dev Portal API spec</a>."
   },
   "paths": {
     "/auth": {


### PR DESCRIPTION
### Summary
Adding a disclaimer to the intro page of the dev portal API doc to say that yes, we know it's incomplete, please file issues or PRs letting us know exactly what errors you ran into.

### Reason
Doc has been our for two days and this has come up a couple of times already. There is no "edit in github" or "report and issue" link on the side like there is in our other content, so I'm adding these links on the landing page for now.

### Testing
https://deploy-preview-3618--kongdocs.netlify.app/gateway/2.7.x/developer-portal/portal-api/#/
