### PR TITLE
Improve "on this page" & github links sidebar

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -555,7 +555,6 @@ $("a[data-filter]").on("keypress", function(e) {
    * To disable for whole page you can add 'disable_image_expand: true' to page Front Matter block. Example:
    * ---
    * title: Install Kong Enterprise
-   * toc: false
    * disable_image_expand: true
    * ---
    */

--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -23,7 +23,7 @@ body {
     display: none;
   }
 
-  @media (min-width: 1080px) {
+  @media (min-width: 1101px) {
     body.banner {
       #promo-banner {
         position: fixed;

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -313,7 +313,7 @@ ul.navbar-item-submenu {
           }
         }
 
-        @media screen and (min-width: 801px) and (max-width: 1300px) {
+        @media screen and (min-width: 801px) and (max-width: 1100px) {
           padding-right: 0;
 
           &.no-sidebar {
@@ -654,7 +654,7 @@ ul.navbar-item-submenu {
     height: auto;
   }
 
-  @media screen and (max-width: 1300px) {
+  @media screen and (max-width: 1100px) {
     .sidebar-toggle {
       visibility: visible;
     }

--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -698,7 +698,7 @@
     outline: 1px solid @blue-200;
   }
 
-  @media screen and (min-width: 1301px) {
+  @media screen and (min-width: 1101px) {
       &.collapsed {
         width: 50px;
         overflow-y: hidden;
@@ -723,7 +723,7 @@
       }
   }
 
-  @media screen and (max-width: 1300px) {
+  @media screen and (max-width: 1100px) {
     &:not(#plugin-toc) {
       position: fixed;
       right: 0;

--- a/app/_includes/toc.html
+++ b/app/_includes/toc.html
@@ -70,7 +70,7 @@
             {% capture listItemClass %}{:.{{ include.item_class | replace: '%level%', headerLevel }}} {% endcapture %}
         {% endif %}
 
-        {% capture my_toc %}{{ my_toc }}
+        {% capture my_toc %}{% if firstHeader %}<div class="docs-toc-title"><a href="#">On this page</a></div>{% endif %}{{ my_toc }}
 {{ space }}{{ listModifier }} {{ listItemClass }} [{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if firstHeader %}{:.active}{% endif %}{% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}
 
         {% assign firstHeader = false %}

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -27,16 +27,14 @@ page.kong_latest.release %}
               <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue"/>Report an issue</a>
           </p>
         </div>
-        {% if page.toc == true or page.toc != false and filename != "index.md" %}
+        {% if page.toc == true or page.toc != false %}
         {% include_cached toc.html html=content anchor_class="scroll-to" h_min=2 h_max=3 %}
         {% endif %}
       </aside>
 
     <div class="page-content-container v2 {% if page.no_version == true and page.has_version == false and page.nav_items == nil %}no-sidebar{% endif %}" id="documentation">
       <div class="toggles {% if page.no_version == true and page.has_version == false and page.nav_items == nil %}no-sidebar{% endif %}">
-        {% if page.toc == true or page.toc != false and filename != "index.md" %}
           <i class="far fa-list-alt toc-sidebar-toggle"></i>
-        {% endif %}
       </div>
 
       <div class="page-content">

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -13,7 +13,6 @@ page.kong_latest.release %}
   <div class="container">
     {% include_cached docs-sidebar.html url=page.url kong_version=page.kong_version edition=page.edition no_version=page.no_version has_version=page.has_version nav_items=page.nav_items edition=page.edition kong_version=page.kong_version kong_latest=page.kong_latest kong_versions=page.kong_versions badge=page.badge version_index=page.version_index %}
 
-    {% if page.toc == true or page.toc != false and filename != "index.md" and page.is_homepage != true %}
       <aside class="docs-toc">
         <i class="fa fa-times close-sidebar"></i>
         <i class="fa fa-chevron-right collapse-toc"></i>
@@ -28,12 +27,10 @@ page.kong_latest.release %}
               <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue"/>Report an issue</a>
           </p>
         </div>
-        <div class="docs-toc-title">
-          <a href="#">On this page</a>
-        </div>
+        {% if page.toc == true or page.toc != false and filename != "index.md" %}
         {% include_cached toc.html html=content anchor_class="scroll-to" h_min=2 h_max=3 %}
+        {% endif %}
       </aside>
-    {% endif %}
 
     <div class="page-content-container v2 {% if page.no_version == true and page.has_version == false and page.nav_items == nil %}no-sidebar{% endif %}" id="documentation">
       <div class="toggles {% if page.no_version == true and page.has_version == false and page.nav_items == nil %}no-sidebar{% endif %}">

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -260,9 +260,6 @@ breadcrumbs:
         </p>
       </div>
       {% unless page.toc == false %}
-        <div class="docs-toc-title">
-          <a href="#">On this page</a>
-        </div>
         {% include_cached toc.html html=full_content anchor_class="scroll-to" h_min=2 h_max=3 %}
       {% endunless %}
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -24,10 +24,6 @@ Plugin Hub docs have specialized front matter elements. See the
 : Disables the version selector dropdown. Set this on pages that belong to
 unversioned doc sets like `/konnect/`.
 
-`toc: false`
-: Disables the right-hand nav for the page; useful if the page is short and has
-one or no headers.
-
 `beta: true` or `alpha: true`
 : Labels the page as beta or alpha; adds a banner to the top of the page.
 
@@ -50,14 +46,14 @@ beta: true
 ---
 ```
 
-A Kong Gateway doc (with versions) that you don't want people to copy code from
-and has no headings, so you also want to disable the page nav:
+A Kong Gateway doc (with versions) that you don't want people to copy code from,
+and where you don't want any of the images to be expandable:
 
 ```yaml
 ---
 title: My Gateway API Doc
 class: no-copy-code
-toc: false
+disable_image_expand: true
 ---
 ```
 

--- a/app/deck/1.10.x/compatibility-promise.md
+++ b/app/deck/1.10.x/compatibility-promise.md
@@ -1,6 +1,5 @@
 ---
 title: Compatibility Promise
-toc: false
 ---
 
 decK's compatibility guarantees are:

--- a/app/deck/1.10.x/guides/backup-restore.md
+++ b/app/deck/1.10.x/guides/backup-restore.md
@@ -1,6 +1,5 @@
 ---
 title: Backup and Restore of Kong's Configuration
-toc: false
 ---
 
 You can use decK to back up and restore a subset or the entirety of

--- a/app/deck/1.10.x/guides/best-practices.md
+++ b/app/deck/1.10.x/guides/best-practices.md
@@ -1,6 +1,5 @@
 ---
 title: Best Practices when using decK
-toc: false
 ---
 
 - Always ensure that you have one decK process running at any time. Multiple
@@ -13,25 +12,25 @@ toc: false
   in the guide to practicing
   [distributed configuration](/deck/{{page.kong_version}}/guides/distributed-configuration).
 - Always use a pinned version of decK and Kong.
-  Use a specific version of decK in production to achieve declarative 
+  Use a specific version of decK in production to achieve declarative
   configuration. If you upgrade to a new version of decK or Kong,
   please safely test the changes in a staging environment first.
-- decK does not manage encryption of sensitive information. The state file 
+- decK does not manage encryption of sensitive information. The state file
   stores the private keys of your certificates and credentials of consumers in
   plaintext. Be careful in how and where you store
   this file to avoid any security breaches.
-  Always store the sensitive information in an encrypted form and provide a plaintext 
+  Always store the sensitive information in an encrypted form and provide a plaintext
   version of it on a need-only basis.
 - If you have many consumers in your database, do not export
-  or manage them using decK. Declarative configuration is only meant for entity 
-  configuration. It is not meant for end-user data, which can easily grow into 
+  or manage them using decK. Declarative configuration is only meant for entity
+  configuration. It is not meant for end-user data, which can easily grow into
   hundreds of thousands or millions of records.
 - Always run a `deck diff` command before running a `deck sync`
   to ensure that the change is correct.
 - Adopt a [CI-driven configuration](/deck/{{page.kong_version}}/guides/ci-driven-configuration) practice.
 - Always secure Kong's Admin API with a reliable authentication method.
 - Do not write the state file by hand to avoid errors.
-  Use Kong's Admin API to configure Kong for the first time, then 
+  Use Kong's Admin API to configure Kong for the first time, then
   export the configuration to a declarative configuration file. Any
   subsequent changes should be made by manually editing the file and pushing
   the change via CI. If you're making a larger change, make the change in Kong first, then

--- a/app/deck/1.10.x/guides/ci-driven-configuration.md
+++ b/app/deck/1.10.x/guides/ci-driven-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: CI-driven Configuration
-toc: false
 ---
 
 ## Configuration as code

--- a/app/deck/1.10.x/guides/deduplicate-plugin-configuration.md
+++ b/app/deck/1.10.x/guides/deduplicate-plugin-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: De-duplicate Plugin Configuration
-toc: false
 ---
 
 In some use cases, you might want to create a number of plugins associated with

--- a/app/deck/1.10.x/guides/environment-variables.md
+++ b/app/deck/1.10.x/guides/environment-variables.md
@@ -1,6 +1,5 @@
 ---
 title: Using environment variables with decK
-toc: false
 ---
 
 When you use decK to apply configurations to {{site.base_gateway}},

--- a/app/deck/1.10.x/guides/multi-file-state.md
+++ b/app/deck/1.10.x/guides/multi-file-state.md
@@ -1,6 +1,5 @@
 ---
 title: Using Multiple Files to Store Configuration
-toc: false
 ---
 
 decK can construct a state by combining multiple JSON or YAML files inside a

--- a/app/konnect-platform/compatibility/index.md
+++ b/app/konnect-platform/compatibility/index.md
@@ -1,7 +1,6 @@
 ---
 title: Kong Platform Compatibility
 no_version: true
-toc: false
 redirect_to: /konnect-platform/
 ---
 

--- a/app/konnect-platform/guides.md
+++ b/app/konnect-platform/guides.md
@@ -1,7 +1,6 @@
 ---
 title: Get Started with the Konnect Platform
 no_version: true
-toc: false
 ---
 
 {{site.konnect_product_name}} is a versatile platform. To get started, choose

--- a/app/konnect/deployment/license-management.md
+++ b/app/konnect/deployment/license-management.md
@@ -1,7 +1,6 @@
 ---
 title: License Management in Konnect Cloud
 no_version: true
-toc: false
 ---
 
 When you create a {{site.konnect_saas}} account, a license is

--- a/app/konnect/dev-portal/index.md
+++ b/app/konnect/dev-portal/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dev Portal Overview
 no_version: true
-toc: false
 ---
 
 The Dev Portal is an API Catalog that allows Admin roles to

--- a/app/konnect/shared-config/index.md
+++ b/app/konnect/shared-config/index.md
@@ -1,7 +1,6 @@
 ---
 title: Shared Config
 no_version: true
-toc: false
 ---
 
 Use the ![icon](/assets/images/icons/konnect/konnect-shared-config.svg){:.inline .no-image-expand}

--- a/app/mesh/1.5.x/features/fips-support.md
+++ b/app/mesh/1.5.x/features/fips-support.md
@@ -1,6 +1,5 @@
 ---
 title: Kong Mesh - FIPS Support
-toc: false
 ---
 
 With version 1.2.0, {{site.mesh_product_name}} provides built-in support for the Federal Information Processing Standard (FIPS-2). Compliance with this standard is typically required for working with U.S. federal government agencies and their contractors.


### PR DESCRIPTION
### Summary and reasons

Improvements to the right-side "On this page" navigation:
* If sidebar is open, toggle is always visible. This fixes the issue of having a hidden sidebar creating space on pages where it shouldn't. 
  * For example: https://docs.konghq.com/gateway/2.7.x/admin-api/ - with the sidebar and toggle completely hidden, there is no way to close the sidebar, and therefore no way to make the text expand to fill the page. You have to switch to some other page, toggle the sidebar, and then return here for it to work. This change fixes that.
* Github links are now always visible, even if the page has no headers.
* Hide 'on this page' if there are no headers
  * Current behavior: even if there are no h2 or h3 elements on the page, an "On this page" link appears (for example: https://docs.konghq.com/gateway/2.7.x/developer-portal/).

### Testing
Check pages without a ToC, they should have github links and a panel toggle:
https://deploy-preview-3624--kongdocs.netlify.app/gateway/2.7.x/admin-api/
https://deploy-preview-3624--kongdocs.netlify.app/gateway/2.7.x/developer-portal

Check any other pages to make sure that the "On this page" title for the nav displays correctly, for example:
https://deploy-preview-3624--kongdocs.netlify.app/gateway/
https://deploy-preview-3624--kongdocs.netlify.app/gateway/changelog/
https://deploy-preview-3624--kongdocs.netlify.app/hub/kong-inc/application-registration/
