### PR TITLE
Re-add missing alpha and beta banners

### DIFF
--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -52,6 +52,14 @@
       text-align: center;
     }
 
+  &.alpha::after {
+      content: "TECH PREVIEW";
+      color: white;
+      border-color: @steel-400;
+      background-color: @steel-400;
+      text-align: center;
+    }
+
   &.oss::after {
       content: "OSS ONLY";
       color: white;

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -101,6 +101,17 @@ page.kong_latest.release %}
               <h2 class="page-content-subtitle">{{page.subtitle | flatify }}</h2>
             {% endif %}
 
+            {% if page.alpha %}
+            <blockquote class="warning no-icon">
+              This feature is released as a <a href="/konnect-platform/key-concepts/#tech-preview"><span class="badge alpha" role="link" aria-label="tech preview"></span></a> (alpha-quality) and should not be deployed in a production environment.
+            </blockquote>
+            {% endif %}
+            {% if page.beta %}
+            <blockquote class="warning no-icon">
+              This feature is released as <a href="/konnect-platform/key-concepts/#beta"><span class="badge beta" role="link" aria-label="beta"></span></a> and should not be deployed in a production environment.
+            </blockquote>
+            {% endif %}
+
             {{ content }}
 
           </div>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -143,17 +143,14 @@ breadcrumbs:
       {% endunless %}
     {% endif %}
       {% if page.alpha %}
-      <div class="alert alert-ee red condensed margin-bigger">
-        <div class="alert-body">
-          <div class="tag red">Tech Preview</div>
-          <p><strong>WARNING:</strong> This plugin is released as <a href="/konnect-platform/key-concepts/#tech-preview">tech preview</a> and should not be deployed in a production environment.</p>
-          </div>
-      </div>
+      <blockquote class="warning no-icon">
+        This plugin is released as a <a href="/konnect-platform/key-concepts/#tech-preview"><span class="badge alpha" role="link" aria-label="tech preview"></span></a> (alpha-quality) and should not be deployed in a production environment.
+      </blockquote>
       {% endif %}
       {% if page.beta %}
-      <div class="alert alert-red">
-        This plugin is released as <a href="/konnect-platform/key-concepts/#beta"><span class="badge beta"></span></a> and should not be deployed in a production environment.
-      </div>
+      <blockquote class="warning no-icon">
+        This plugin is released as <a href="/konnect-platform/key-concepts/#beta"><span class="badge beta" role="link" aria-label="beta"></span></a> and should not be deployed in a production environment.
+      </blockquote>
       {% endif %}
 
       {{ page.description | markdownify }}

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -525,6 +525,7 @@ Badge | HTML tag | Markdown tag
 <span class="badge enterprise"></span> | `<span class="badge enterprise"></span>` | `{:.badge .enterprise}`
 <span class="badge dbless"></span> | `<span class="badge dbless"></span>` | `{:.badge .dbless}`
 <span class="badge beta"></span> | `<span class="badge beta"></span>` | `{:.badge .beta}`
+<span class="badge alpha"></span> | `<span class="badge alpha"></span>` | `{:.badge .alpha}`
 <span class="badge oss"></span> | `<span class="badge oss"></span>` | `{:.badge .oss}`
 
 For example, you can use the Markdown tag on headers:


### PR DESCRIPTION
### Summary
* Add conditional alpha and beta banners to main docs layout
* Update alpha and beta banners on plugins layout
* Create a badge for alpha/tech preview 
  * Went with the name "tech preview" as that's what Konnect is using instead of alpha, but added (alpha quality) in brackets because our open-source projects are more used to this terminology. "Alpha" is also used in decK flags.

### Reason
We're missing `alpha` and `beta` tag handling logic from the `docs-v2.html` layout, although it does exist in the `extension.html` layout. Noted in https://github.com/Kong/docs.konghq.com/pull/3621#issuecomment-1029444084.

### Testing

Tested by applying `alpha: true` and `beta: true` to a few random pages.

<img width="812" alt="Screen Shot 2022-02-03 at 7 21 41 PM" src="https://user-images.githubusercontent.com/54370747/152466804-8ee25749-b1a5-4c17-af61-39adad8bc687.png">

<img width="894" alt="Screen Shot 2022-02-03 at 7 22 01 PM" src="https://user-images.githubusercontent.com/54370747/152466801-30066257-edd8-4a74-81da-10e077d599a5.png">

