### PR TITLE
Update OSS gateway version to 2.7.1

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -347,7 +347,7 @@
 -
   release: "2.7.x"
   ee-version: "2.7.1.0"
-  ce-version: "2.7.0"
+  ce-version: "2.7.1"
   edition: "gateway"
   luarocks_version: "2.5.1-0"
   dependencies:


### PR DESCRIPTION
### Summary
Update version metadata.

### Reason
2.7.1 Docker image was published today: https://hub.docker.com/_/kong?tab=tags

### Testing
Check any installation page, Kong Gateway (OSS) tab:
https://deploy-preview-3626--kongdocs.netlify.app/gateway/2.7.x/install-and-run/centos/?tab=kong-gateway-oss