### PR TITLE
[DOCU-449] Add missing kong user info

### DIFF
--- a/app/enterprise/2.3.x/deployment/kong-user.md
+++ b/app/enterprise/2.3.x/deployment/kong-user.md
@@ -2,26 +2,23 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ee_product_name}} on a GNU/Linux system, you can
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user and group instead of `root`.
-This makes the Nginx master and worker processes run as the `kong` user and
-group, overriding any settings in the
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/enterprise/{{page.kong_version}}/property-reference/#nginx_user)
-configuration property.
+configuration property. It is also possible to run Kong as a custom non-root user.
 
-<div class="alert alert-warning">
-<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-  <b>Warning</b>
-  <br>The Nginx master process needs to run as <code>root</code> for
-  Nginx to execute certain actions (for example, to listen on the privileged
-  port 80).
-  <br>
-  <br>Although running Kong as the <code>kong</code> user
-  and group does provide more security, we advise that a system and network
-  administration evaluation be performed before making this decision. Otherwise,
-  Kong nodes might become unavailable due to insufficient permissions to execute
-  privileged system calls in the operating system.
-</div>
+{:.important}
+> **Important:** The Nginx master process needs to run as `root` for
+Nginx to execute certain actions (for example, to listen on the privileged
+port 80).
+<br><br>
+> Although running Kong as the `kong` user and group
+does provide more security, we advise that a system and network
+administration evaluation be performed before making this decision. Otherwise,
+Kong nodes might become unavailable due to insufficient permissions to execute
+privileged system calls in the operating system.
 
 ## Prerequisites
 
@@ -32,12 +29,31 @@ configuration property.
 * [RHEL](/enterprise/{{page.kong_version}}/deployment/installation/rhel)
 * [Ubuntu](/enterprise/{{page.kong_version}}/deployment/installation/ubuntu)
 
-## Run Kong Enterprise as a non-root user
+## Run {{site.base_gateway}} as the built-in kong user
 
-1. Switch to the `kong` user and group:
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+
+1. Switch to the built-in `kong` user:
+
     ```sh
     $ su kong
     ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```
+
+## Run {{site.base_gateway}} as a custom non-root user
+
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+
+1. Add the user to the `kong` group
+
+    ```sh
+    sudo usermod -aG kong your-user
+    ```
+
 2. Start Kong:
 
     ```sh

--- a/app/enterprise/2.4.x/deployment/kong-user.md
+++ b/app/enterprise/2.4.x/deployment/kong-user.md
@@ -2,26 +2,23 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ee_product_name}} on a GNU/Linux system, you can
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user and group instead of `root`.
-This makes the Nginx master and worker processes run as the `kong` user and
-group, overriding any settings in the
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/enterprise/{{page.kong_version}}/property-reference/#nginx_user)
-configuration property.
+configuration property. It is also possible to run Kong as a custom non-root user.
 
-<div class="alert alert-warning">
-<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-  <b>Warning</b>
-  <br>The Nginx master process needs to run as <code>root</code> for
-  Nginx to execute certain actions (for example, to listen on the privileged
-  port 80).
-  <br>
-  <br>Although running Kong as the <code>kong</code> user
-  and group does provide more security, we advise that a system and network
-  administration evaluation be performed before making this decision. Otherwise,
-  Kong nodes might become unavailable due to insufficient permissions to execute
-  privileged system calls in the operating system.
-</div>
+{:.important}
+> **Important:** The Nginx master process needs to run as `root` for
+Nginx to execute certain actions (for example, to listen on the privileged
+port 80).
+<br><br>
+> Although running Kong as the `kong` user and group
+does provide more security, we advise that a system and network
+administration evaluation be performed before making this decision. Otherwise,
+Kong nodes might become unavailable due to insufficient permissions to execute
+privileged system calls in the operating system.
 
 ## Prerequisites
 
@@ -32,12 +29,31 @@ configuration property.
 * [RHEL](/enterprise/{{page.kong_version}}/deployment/installation/rhel)
 * [Ubuntu](/enterprise/{{page.kong_version}}/deployment/installation/ubuntu)
 
-## Run Kong Enterprise as a non-root user
+## Run {{site.base_gateway}} as the built-in kong user
 
-1. Switch to the `kong` user and group:
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+
+1. Switch to the built-in `kong` user:
+
     ```sh
     $ su kong
     ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```
+
+## Run {{site.base_gateway}} as a custom non-root user
+
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+
+1. Add the user to the `kong` group
+
+    ```sh
+    sudo usermod -aG kong your-user
+    ```
+
 2. Start Kong:
 
     ```sh

--- a/app/enterprise/2.5.x/deployment/kong-user.md
+++ b/app/enterprise/2.5.x/deployment/kong-user.md
@@ -2,26 +2,23 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ee_product_name}} on a GNU/Linux system, you can
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user and group instead of `root`.
-This makes the Nginx master and worker processes run as the `kong` user and
-group, overriding any settings in the
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/enterprise/{{page.kong_version}}/property-reference/#nginx_user)
-configuration property.
+configuration property. It is also possible to run Kong as a custom non-root user.
 
-<div class="alert alert-warning">
-<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-  <b>Warning</b>
-  <br>The Nginx master process needs to run as <code>root</code> for
-  Nginx to execute certain actions (for example, to listen on the privileged
-  port 80).
-  <br>
-  <br>Although running Kong as the <code>kong</code> user
-  and group does provide more security, we advise that a system and network
-  administration evaluation be performed before making this decision. Otherwise,
-  Kong nodes might become unavailable due to insufficient permissions to execute
-  privileged system calls in the operating system.
-</div>
+{:.important}
+> **Important:** The Nginx master process needs to run as `root` for
+Nginx to execute certain actions (for example, to listen on the privileged
+port 80).
+<br><br>
+> Although running Kong as the `kong` user and group
+does provide more security, we advise that a system and network
+administration evaluation be performed before making this decision. Otherwise,
+Kong nodes might become unavailable due to insufficient permissions to execute
+privileged system calls in the operating system.
 
 ## Prerequisites
 
@@ -32,12 +29,31 @@ configuration property.
 * [RHEL](/enterprise/{{page.kong_version}}/deployment/installation/rhel)
 * [Ubuntu](/enterprise/{{page.kong_version}}/deployment/installation/ubuntu)
 
-## Run Kong Enterprise as a non-root user
+## Run {{site.base_gateway}} as the built-in kong user
 
-1. Switch to the `kong` user and group:
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+
+1. Switch to the built-in `kong` user:
+
     ```sh
     $ su kong
     ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```
+
+## Run {{site.base_gateway}} as a custom non-root user
+
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+
+1. Add the user to the `kong` group
+
+    ```sh
+    sudo usermod -aG kong your-user
+    ```
+
 2. Start Kong:
 
     ```sh

--- a/app/gateway-oss/2.3.x/kong-user.md
+++ b/app/gateway-oss/2.3.x/kong-user.md
@@ -2,26 +2,23 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ce_product_name}} on a GNU/Linux system, you can
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user and group instead of `root`.
-This makes the Nginx master and worker processes run as the `kong` user and
-group, overriding any settings in the
-[`nginx_user`](/{{page.kong_version}}/configuration/#nginx_user)
-configuration property.
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
+[`nginx_user`](/gateway-oss/{{page.kong_version}}/configuration/#nginx_user)
+configuration property. It is also possible to run Kong as a custom non-root user.
 
-<div class="alert alert-warning">
-<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-  <b>Warning</b>
-  <br>The Nginx master process needs to run as <code>root</code> for
-  Nginx to execute certain actions (for example, to listen on the privileged
-  port 80).
-  <br>
-  <br>Although running Kong as the <code>kong</code> user
-  and group does provide more security, we advise that a system and network
-  administration evaluation be performed before making this decision. Otherwise,
-  Kong nodes might become unavailable due to insufficient permissions to execute
-  privileged system calls in the operating system.
-</div>
+{:.important}
+> **Important:** The Nginx master process needs to run as `root` for
+Nginx to execute certain actions (for example, to listen on the privileged
+port 80).
+<br><br>
+> Although running Kong as the `kong` user and group
+does provide more security, we advise that a system and network
+administration evaluation be performed before making this decision. Otherwise,
+Kong nodes might become unavailable due to insufficient permissions to execute
+privileged system calls in the operating system.
 
 ## Prerequisites
 
@@ -32,12 +29,31 @@ configuration property.
 * [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
-## Run Kong Gateway as a non-root user
+## Run {{site.base_gateway}} as the built-in kong user
 
-1. Switch to the `kong` user and group:
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+
+1. Switch to the built-in `kong` user:
+
     ```sh
     $ su kong
     ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```
+
+## Run {{site.base_gateway}} as a custom non-root user
+
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+
+1. Add the user to the `kong` group
+
+    ```sh
+    sudo usermod -aG kong your-user
+    ```
+
 2. Start Kong:
 
     ```sh

--- a/app/gateway-oss/2.4.x/kong-user.md
+++ b/app/gateway-oss/2.4.x/kong-user.md
@@ -2,26 +2,23 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ce_product_name}} on a GNU/Linux system, you can
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user and group instead of `root`.
-This makes the Nginx master and worker processes run as the `kong` user and
-group, overriding any settings in the
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/gateway-oss/{{page.kong_version}}/configuration/#nginx_user)
-configuration property.
+configuration property. It is also possible to run Kong as a custom non-root user.
 
-<div class="alert alert-warning">
-<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-  <b>Warning</b>
-  <br>The Nginx master process needs to run as <code>root</code> for
-  Nginx to execute certain actions (for example, to listen on the privileged
-  port 80).
-  <br>
-  <br>Although running Kong as the <code>kong</code> user
-  and group does provide more security, we advise that a system and network
-  administration evaluation be performed before making this decision. Otherwise,
-  Kong nodes might become unavailable due to insufficient permissions to execute
-  privileged system calls in the operating system.
-</div>
+{:.important}
+> **Important:** The Nginx master process needs to run as `root` for
+Nginx to execute certain actions (for example, to listen on the privileged
+port 80).
+<br><br>
+> Although running Kong as the `kong` user and group
+does provide more security, we advise that a system and network
+administration evaluation be performed before making this decision. Otherwise,
+Kong nodes might become unavailable due to insufficient permissions to execute
+privileged system calls in the operating system.
 
 ## Prerequisites
 
@@ -32,12 +29,31 @@ configuration property.
 * [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
-## Run Kong Gateway as a non-root user
+## Run {{site.base_gateway}} as the built-in kong user
 
-1. Switch to the `kong` user and group:
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+
+1. Switch to the built-in `kong` user:
+
     ```sh
     $ su kong
     ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```
+
+## Run {{site.base_gateway}} as a custom non-root user
+
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+
+1. Add the user to the `kong` group
+
+    ```sh
+    sudo usermod -aG kong your-user
+    ```
+
 2. Start Kong:
 
     ```sh

--- a/app/gateway-oss/2.5.x/kong-user.md
+++ b/app/gateway-oss/2.5.x/kong-user.md
@@ -2,26 +2,23 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ce_product_name}} on a GNU/Linux system, you can
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
 configure Kong to run as the built-in `kong` user and group instead of `root`.
-This makes the Nginx master and worker processes run as the `kong` user and
-group, overriding any settings in the
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/gateway-oss/{{page.kong_version}}/configuration/#nginx_user)
-configuration property.
+configuration property. It is also possible to run Kong as a custom non-root user.
 
-<div class="alert alert-warning">
-<i class="fas fa-exclamation-triangle" style="color:orange; margin-right:3px"></i>
-  <b>Warning</b>
-  <br>The Nginx master process needs to run as <code>root</code> for
-  Nginx to execute certain actions (for example, to listen on the privileged
-  port 80).
-  <br>
-  <br>Although running Kong as the <code>kong</code> user
-  and group does provide more security, we advise that a system and network
-  administration evaluation be performed before making this decision. Otherwise,
-  Kong nodes might become unavailable due to insufficient permissions to execute
-  privileged system calls in the operating system.
-</div>
+{:.important}
+> **Important:** The Nginx master process needs to run as `root` for
+Nginx to execute certain actions (for example, to listen on the privileged
+port 80).
+<br><br>
+> Although running Kong as the `kong` user and group
+does provide more security, we advise that a system and network
+administration evaluation be performed before making this decision. Otherwise,
+Kong nodes might become unavailable due to insufficient permissions to execute
+privileged system calls in the operating system.
 
 ## Prerequisites
 
@@ -32,12 +29,31 @@ configuration property.
 * [Red Hat](/install/redhat)
 * [Ubuntu](/install/ubuntu)
 
-## Run Kong Gateway as a non-root user
+## Run {{site.base_gateway}} as the built-in kong user
 
-1. Switch to the `kong` user and group:
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+
+1. Switch to the built-in `kong` user:
+
     ```sh
     $ su kong
     ```
+2. Start Kong:
+
+    ```sh
+    kong start
+    ```
+
+## Run {{site.base_gateway}} as a custom non-root user
+
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+
+1. Add the user to the `kong` group
+
+    ```sh
+    sudo usermod -aG kong your-user
+    ```
+
 2. Start Kong:
 
     ```sh

--- a/app/gateway/2.6.x/plan-and-deploy/kong-user.md
+++ b/app/gateway/2.6.x/plan-and-deploy/kong-user.md
@@ -2,9 +2,10 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ee_product_name}} on a GNU/Linux system, you can
-configure Kong to run as the built-in `kong` user instead of the `root` user.
-This makes the Nginx master and worker processes use the built-in `kong` user and group credentials, overriding any settings in the
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
+configure Kong to run as the built-in `kong` user and group instead of `root`.
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/gateway/{{page.kong_version}}/reference/configuration/#nginx_user)
 configuration property. It is also possible to run Kong as a custom non-root user.
 
@@ -13,7 +14,7 @@ configuration property. It is also possible to run Kong as a custom non-root use
 Nginx to execute certain actions (for example, to listen on the privileged
 port 80).
 <br><br>
-> Although running Kong as the `kong` user
+> Although running Kong as the `kong` user and group
 does provide more security, we advise that a system and network
 administration evaluation be performed before making this decision. Otherwise,
 Kong nodes might become unavailable due to insufficient permissions to execute
@@ -27,9 +28,9 @@ privileged system calls in the operating system.
 * [RHEL](/gateway/{{page.kong_version}}/install-and-run/rhel)
 * [Ubuntu](/gateway/{{page.kong_version}}/install-and-run/ubuntu)
 
-## Run {{site.ee_product_name}} as the built-in kong user
+## Run {{site.base_gateway}} as the built-in kong user
 
-When {{site.ee_product_name}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
 
 1. Switch to the built-in `kong` user:
 
@@ -42,9 +43,9 @@ When {{site.ee_product_name}} is installed with a package management system such
     kong start
     ```
 
-## Run {{site.ee_product_name}} as a custom non-root user
+## Run {{site.base_gateway}} as a custom non-root user
 
-It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.ee_product_name}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
 
 1. Add the user to the `kong` group
 

--- a/app/gateway/2.7.x/plan-and-deploy/kong-user.md
+++ b/app/gateway/2.7.x/plan-and-deploy/kong-user.md
@@ -2,9 +2,10 @@
 title: Running Kong as a Non-Root User
 ---
 
-After installing {{site.ee_product_name}} on a GNU/Linux system, you can
-configure Kong to run as the built-in `kong` user instead of the `root` user.
-This makes the Nginx master and worker processes use the built-in `kong` user and group credentials, overriding any settings in the
+After installing {{site.base_gateway}} on a GNU/Linux system, you can
+configure Kong to run as the built-in `kong` user and group instead of `root`.
+This makes the Nginx master and worker processes run as the built-in `kong`
+user and group, overriding any settings in the
 [`nginx_user`](/gateway/{{page.kong_version}}/reference/configuration/#nginx_user)
 configuration property. It is also possible to run Kong as a custom non-root user.
 
@@ -13,7 +14,7 @@ configuration property. It is also possible to run Kong as a custom non-root use
 Nginx to execute certain actions (for example, to listen on the privileged
 port 80).
 <br><br>
-> Although running Kong as the `kong` user
+> Although running Kong as the `kong` user and group
 does provide more security, we advise that a system and network
 administration evaluation be performed before making this decision. Otherwise,
 Kong nodes might become unavailable due to insufficient permissions to execute
@@ -27,9 +28,9 @@ privileged system calls in the operating system.
 * [RHEL](/gateway/{{page.kong_version}}/install-and-run/rhel)
 * [Ubuntu](/gateway/{{page.kong_version}}/install-and-run/ubuntu)
 
-## Run {{site.ee_product_name}} as the built-in kong user
+## Run {{site.base_gateway}} as the built-in kong user
 
-When {{site.ee_product_name}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
+When {{site.base_gateway}} is installed with a package management system such as `APT` or `YUM`, a default `kong` user and a default `kong` group are created. All the files installed by the package are owned by the `kong` user and group.
 
 1. Switch to the built-in `kong` user:
 
@@ -42,9 +43,9 @@ When {{site.ee_product_name}} is installed with a package management system such
     kong start
     ```
 
-## Run {{site.ee_product_name}} as a custom non-root user
+## Run {{site.base_gateway}} as a custom non-root user
 
-It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.ee_product_name}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
+It is also possible to run Kong as a custom non-root user. Since all the files installed by the {{site.base_gateway}} package are owned by the `kong` group, a user that belongs to that group should be permitted to perform the same operations as the `kong` user.
 
 1. Add the user to the `kong` group
 


### PR DESCRIPTION
### Summary
* Add missing custom non-root user instructions to Gateway (OSS and EE) 2.3-2.5 docs
* Slight adjustment to 2.6 and 2.7 for language that was missing from it, plus updating variables
* Minor cleanup to alert syntax

### Reason
The topic accidentally diverged in 2.3.x. Changes were made in 2.2.x but not picked up by the next version.

The topic was mostly fixed in the single-sourcing audit and is therefore mostly accurate in 2.6.x and 2.7.x.

### Testing
Current Gateway: https://deploy-preview-3629--kongdocs.netlify.app/gateway/2.7.x/plan-and-deploy/kong-user/

Old Enterprise: https://deploy-preview-3629--kongdocs.netlify.app/enterprise/2.5.x/deployment/kong-user/
Old Gateway OSS: https://deploy-preview-3629--kongdocs.netlify.app/gateway-oss/2.5.x/kong-user/