### PR TITLE
[DOCU-1651] Fix hybrid mode docker instructions

### DIFF
--- a/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
- 
+
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.
@@ -353,7 +353,7 @@ follow the instructions to:
 
     For `shared` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -364,12 +364,12 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/cluster.crt" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     For `pki` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -383,7 +383,7 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/ca-cert.pem" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     Where:

--- a/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
@@ -383,7 +383,7 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/ca-cert.pem" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-dp
+    kong-ee
     ```
 
     Where:

--- a/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
- 
+
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.
@@ -353,7 +353,7 @@ follow the instructions to:
 
     For `shared` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -364,12 +364,12 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/cluster.crt" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     For `pki` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -383,7 +383,7 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/ca-cert.pem" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-dp
     ```
 
     Where:

--- a/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
@@ -34,7 +34,7 @@ For a breakdown of the properties used by these modes, see the
 {% navtabs %}
 {% navtab Shared mode %}
 <div class="alert alert-warning">
- 
+
   <strong>Protect the Private Key.</strong> Ensure the private key file can only be accessed by
   Kong nodes belonging to the cluster. If the key is compromised, you must
   regenerate and replace certificates and keys on all CP and DP nodes.
@@ -353,7 +353,7 @@ follow the instructions to:
 
     For `shared` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -364,12 +364,12 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/cluster.crt" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     For `pki` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -383,7 +383,7 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/ca-cert.pem" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     Where:

--- a/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
@@ -379,7 +379,7 @@ follow the instructions to:
 
     For `shared` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -390,12 +390,12 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/cluster.crt" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     For `pki` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -409,7 +409,7 @@ follow the instructions to:
     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=/<path-to-file>/ca-cert.pem" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     Where:

--- a/app/enterprise/2.5.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.5.x/deployment/hybrid-mode-setup.md
@@ -352,8 +352,8 @@ point them to the Control Plane, set certificate/key parameters to point at
 the location of your certificates and keys, and ensure the database
 is disabled.
 
-In addition, the certificate from `cluster_cert` (in `shared` mode) or `cluster_ca_cert` 
-(in `pki` mode) is automatically added to the trusted chain in 
+In addition, the certificate from `cluster_cert` (in `shared` mode) or `cluster_ca_cert`
+(in `pki` mode) is automatically added to the trusted chain in
 [`lua_ssl_trusted_certificate`](/enterprise/{{page.kong_version}}/property-reference/#lua_ssl_trusted_certificate).
 
 {:.warning}
@@ -381,7 +381,7 @@ follow the instructions to:
 
     For `shared` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -391,12 +391,12 @@ follow the instructions to:
     -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     For `pki` certificate mode, use:
     ```bash
-    $ docker run -d --name kong-ee-dp1 --network=kong-ee-net \
+    $ docker run -d --name kong-dp --network=kong-ee-net \
     -e "KONG_ROLE=data_plane" \
     -e "KONG_DATABASE=off" \
     -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
@@ -409,7 +409,7 @@ follow the instructions to:
     -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
     --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
     -p 8000:8000 \
-    kong-ee-dp1
+    kong-ee
     ```
 
     Where:

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -390,37 +390,86 @@ follow the instructions to:
 1. Bring up your Data Plane container with the following settings:
 
     For `shared` certificate mode, use:
-    ```bash
-    docker run -d --name kong-ee-dp1 --network=kong-ee-net \
-    -e "KONG_ROLE=data_plane" \
-    -e "KONG_DATABASE=off" \
-    -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
-    -e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
-    -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
-    -e "KONG_CLUSTER_CERT=/<path-to-file>/cluster.crt" \
-    -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
-    --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
-    -p 8000:8000 \
-    kong-ee-dp1
-    ```
+
+{% capture shared-mode-cp %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_CERT=/<path-to-file>/cluster.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_CERT=/<path-to-file>/cluster.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ shared-mode-cp | indent | replace: " </code>", "</code>" }}
 
     For `pki` certificate mode, use:
-    ```bash
-    docker run -d --name kong-ee-dp1 --network=kong-ee-net \
-    -e "KONG_ROLE=data_plane" \
-    -e "KONG_DATABASE=off" \
-    -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
-    -e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
-    -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
-    -e "KONG_CLUSTER_MTLS=pki" \
-    -e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
-    -e "KONG_CLUSTER_CERT=data-plane.crt" \
-    -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
-    -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
-    --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
-    -p 8000:8000 \
-    kong-ee-dp1
-    ```
+
+{% capture pki-mode-cp %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_MTLS=pki" \
+-e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
+-e "KONG_CLUSTER_CERT=data-plane.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_MTLS=pki" \
+-e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
+-e "KONG_CLUSTER_CERT=data-plane.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ pki-mode-cp | indent | replace: " </code>", "</code>" }}
 
     Where:
 

--- a/app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -390,37 +390,86 @@ follow the instructions to:
 1. Bring up your data plane container with the following settings:
 
     For `shared` certificate mode, use:
-    ```bash
-    docker run -d --name kong-ee-dp1 --network=kong-ee-net \
-    -e "KONG_ROLE=data_plane" \
-    -e "KONG_DATABASE=off" \
-    -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
-    -e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
-    -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
-    -e "KONG_CLUSTER_CERT=/<path-to-file>/cluster.crt" \
-    -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
-    --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
-    -p 8000:8000 \
-    kong-ee-dp1
-    ```
+
+{% capture shared-mode-cp %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_CERT=/<path-to-file>/cluster.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_CERT=/<path-to-file>/cluster.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ shared-mode-cp | indent | replace: " </code>", "</code>" }}
 
     For `pki` certificate mode, use:
-    ```bash
-    docker run -d --name kong-ee-dp1 --network=kong-ee-net \
-    -e "KONG_ROLE=data_plane" \
-    -e "KONG_DATABASE=off" \
-    -e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
-    -e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
-    -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
-    -e "KONG_CLUSTER_MTLS=pki" \
-    -e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
-    -e "KONG_CLUSTER_CERT=data-plane.crt" \
-    -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
-    -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
-    --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
-    -p 8000:8000 \
-    kong-ee-dp1
-    ```
+
+{% capture pki-mode-cp %}
+{% navtabs codeblock %}
+{% navtab Kong Gateway %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_MTLS=pki" \
+-e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
+-e "KONG_CLUSTER_CERT=data-plane.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+docker run -d --name kong-dp --network=kong-net \
+-e "KONG_ROLE=data_plane" \
+-e "KONG_DATABASE=off" \
+-e "KONG_PROXY_LISTEN=0.0.0.0:8000" \
+-e "KONG_CLUSTER_CONTROL_PLANE=control-plane.<admin-hostname>.com:8005" \
+-e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
+-e "KONG_CLUSTER_MTLS=pki" \
+-e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
+-e "KONG_CLUSTER_CERT=data-plane.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
+--mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
+-p 8000:8000 \
+kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ pki-mode-cp | indent | replace: " </code>", "</code>" }}
 
     Where:
 


### PR DESCRIPTION
### Summary
* Enterprise Gateway 2.1-2.5: Fixed the image name to point to the tag that they set in the Docker install instructions
* Gateway 2.6-2.7: Updated hybrid mode docker instructions to use EE/OSS tabs and variables for image name to match the 2.6 and 2.7 docker installation instructions

### Reason
Image names are wrong, and hybrid mode instructions in 2.6 and 2.7 no longer work as-is with the CP Docker installation instructions.

### Testing
New doc: https://deploy-preview-3630--kongdocs.netlify.app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup/

Old Enterprise doc: https://deploy-preview-3630--kongdocs.netlify.app/enterprise/2.5.x/deployment/hybrid-mode-setup/
