### PR TITLE
Update Konnect docs with 2.7 gateway support

### DIFF
--- a/app/konnect/deployment/index.md
+++ b/app/konnect/deployment/index.md
@@ -43,6 +43,7 @@ data plane.
 
 |                                | {{site.konnect_saas}} | First supported patch version
 |--------------------------------|:---------------------:|-----------------------------
+| {{site.ee_product_name}} 2.7.x | <i class="fa fa-check"></i>    | 2.7.0.0
 | {{site.ee_product_name}} 2.6.x | <i class="fa fa-check"></i>    | 2.6.0.0
 | {{site.ee_product_name}} 2.5.x | <i class="fa fa-check"></i>    | 2.5.0.1
 | {{site.ee_product_name}} 2.4.x | <i class="fa fa-check"></i>    | 2.4.1.1

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -132,7 +132,7 @@ $ docker run -d --name kong-dp \
 {% endnavtab %}
 {% navtab Windows PowerShell %}
 ```powershell
-docker run -d --name kong-gateway-dp1 `
+docker run -d --name kong-dp `
   -e "KONG_ROLE=data_plane" `
   -e "KONG_DATABASE=off" `
   -e "KONG_VITALS_TTL_DAYS=732" `

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -88,7 +88,7 @@ remaining configuration details on the **Configure Runtime** page.
 
 
     ```bash
-    $ docker pull kong/kong-gateway:2.6.0.0-alpine
+    $ docker pull kong/kong-gateway:2.7.0.0-alpine
     ```
 
     You should now have your {{site.base_gateway}} image locally.
@@ -113,7 +113,7 @@ Use the following `docker run` command sample as a guide to compile your actual 
 {% navtabs codeblock %}
 {% navtab Any Unix shell %}
 ```sh
-$ docker run -d --name kong-gateway-dp1 \
+$ docker run -d --name kong-dp \
   -e "KONG_ROLE=data_plane" \
   -e "KONG_DATABASE=off" \
   -e "KONG_VITALS_TTL_DAYS=732" \
@@ -127,7 +127,7 @@ $ docker run -d --name kong-gateway-dp1 \
   -e "KONG_CLUSTER_CERT_KEY=/{PATH_TO_FILE}/tls.key" \
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly \
   -p 8000:8000 \
-  kong-ee
+  kong/kong-gateway:2.7.0.0-alpine
 ```
 {% endnavtab %}
 {% navtab Windows PowerShell %}
@@ -146,7 +146,7 @@ docker run -d --name kong-gateway-dp1 `
   -e "KONG_CLUSTER_CERT_KEY=/{PATH_TO_FILE}/tls.key" `
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly `
   -p 8000:8000 `
-  kong-ee
+  kong/kong-gateway:2.7.0.0-alpine
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -90,7 +90,7 @@ like this:
     ```yaml
     image:
       repository: kong/kong-gateway
-      tag: "2.6.0.0-alpine"
+      tag: "2.7.0.0-alpine"
 
     secretVolumes:
     - kong-cluster-cert

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -10,7 +10,7 @@ services.
 
 ## January 2022
 
-### 2022.1.14
+### 2022.01.14
 **Custom Domain for Dev Portal**
 : You can now set a custom domain for your Dev Portal through the {{site.konnect_saas}} Admin UI.
 
@@ -18,6 +18,20 @@ services.
 
 **Headers are modifiable**
 : You can now set a welcome message and primary header through the Admin UI for your Dev Portal.
+
+## December 2021
+
+### 2021.12.21
+**{{site.base_gateway}} 2.7.0.0 support**
+: {{site.konnect_saas}} now supports {{site.base_gateway}} 2.7.0.0 runtimes.
+You can keep using existing 2.6.x runtimes, or you can upgrade to
+2.7.0.0 to take advantage of any new features, updates, and bug fixes.
+
+: For all the changes and new features in {{site.base_gateway}} 2.7.x, see the
+[changelog](/gateway/changelog/#2600).
+
+: To use any new features in the release,
+[start up a new 2.7.0.0 runtime](/konnect/runtime-manager/upgrade).
 
 ## November 2021
 
@@ -33,7 +47,7 @@ for more information.
 
 ### 2021.11.10
 **{{site.base_gateway}} 2.6.0.0 support**
-: {{site.konnect_saas}} now supports {{site.base_gateway}} 2.6.0.0.
+: {{site.konnect_saas}} now supports {{site.base_gateway}} 2.6.0.0
 runtimes. You can keep using existing 2.5.x runtimes, or you can upgrade to
 2.6.0.0 to take advantage of any new features, updates, and bug fixes.
 : This release introduces the new [jq plugin](/hub/kong-inc/jq). It also


### PR DESCRIPTION
### Summary
* Update changelog.
* Update runtime setup docs with 2.7 versions
* Update deployment table with 2.7
* Use tagged image for Docker container

### Reason
2.7 support went out in December and we missed it. Found out by testing, tracked down date in production channel.

### Testing
https://deploy-preview-3631--kongdocs.netlify.app/konnect/updates/

Check that the version is 2.7 and not 2.6:
https://deploy-preview-3631--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/
https://deploy-preview-3631--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-kubernetes/