### PR TITLE
Update oidc.md

### DIFF
--- a/app/gateway/2.6.x/configure/auth/kong-manager/oidc.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/oidc.md
@@ -76,11 +76,11 @@ Assign the new **Admin** at least one **Role** so they can log in and access
 Kong entities.
 
 ```bash
-$ http POST :8001/admins/<admin_email>/roles roles="<role-name>"
+$ http POST :8001/admins/<admin_email>/roles roles="<role-name>" Kong-Admin-Token:<RBAC_TOKEN>
 ```
 
 For example, if we wanted to grant **hal9000@sky.net** the **Role** of **Super Admin**:
 
 ```bash
-$ http POST :8001/admins/hal9000@sky.net/roles roles="super-admin"
+$ http POST :8001/admins/hal9000@sky.net/roles roles="super-admin" Kong-Admin-Token:<RBAC_TOKEN>
 ```


### PR DESCRIPTION
included missing header for role addition command.

### Summary
Missing header.

### Reason
This is required to execute this command.

### Testing

without

```
rkazak@kong-mbp docker % http POST :26001/admins/rohinton.kazak@konghq.com/roles roles="super-admin"
HTTP/1.1 401 Unauthorized
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://localhost:26002
Connection: keep-alive
Content-Length: 69
Content-Type: application/json; charset=utf-8
Date: Tue, 08 Feb 2022 17:16:01 GMT
Server: kong/2.6.0.0-enterprise-edition
X-Kong-Admin-Latency: 12
X-Kong-Admin-Request-ID: ceaVKSc4a7tq4lnAskILW4zvVKRBDtAX
vary: Origin

{
    "message": "Invalid credentials. Token or User credentials required"
}
```
with

```
rkazak@kong-mbp docker % http POST :26001/admins/rohinton.kazak@konghq.com/roles roles="super-admin" Kong-Admin-Token:admin
HTTP/1.1 201 Created
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://localhost:26002
Connection: keep-alive
Content-Length: 232
Content-Type: application/json; charset=utf-8
Date: Tue, 08 Feb 2022 17:16:10 GMT
Server: kong/2.6.0.0-enterprise-edition
X-Kong-Admin-Latency: 198
X-Kong-Admin-Request-ID: Xyi9aL1MUbkHOkKbHEbEmvx1US7l21OC
vary: Origin

{
    "roles": [
        {
            "comment": "Full access to all endpoints, across all workspaces",
            "created_at": 1644339667,
            "id": "4fbf844c-dd4b-40a9-950a-76d2e3f14bc4",
            "is_default": false,
            "name": "super-admin",
            "ws_id": "b1ac7e42-2b5d-45cf-a86c-959a5c5d0fee"
        }
    ]
}
```

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
