### PR TITLE
[DOCU-360] Note for db_export support

### DIFF
--- a/app/gateway/2.6.x/reference/cli.md
+++ b/app/gateway/2.6.x/reference/cli.md
@@ -74,6 +74,10 @@ Options:
 
 ```
 
+{:.note}
+> **Note:** `db_export` is only supported with open-source
+{{site.base_gateway}} packages.
+
 [Back to top](#introduction)
 
 ---

--- a/app/gateway/2.7.x/reference/cli.md
+++ b/app/gateway/2.7.x/reference/cli.md
@@ -70,6 +70,10 @@ Options:
 
 ```
 
+{:.note}
+> **Note:** `db_export` is only supported with open-source
+{{site.base_gateway}} packages.
+
 ---
 
 


### PR DESCRIPTION
### Summary
Adding notes to Gateway 2.6 and 2.7 docs that db_export is only supported in OSS.

### Reason
Doc ticket asks to remove notes from old content that `db_export` is not supported, but after testing and research, it turns out it's the other way around. 
`db_export` does not work with Kong Enterprise, and wasn’t supposed to. In the changelog for 1.5, there is a fix listed that says it was accidentally available in 1.3: [Kong Gateway Changelog](https://docs.konghq.com/gateway/changelog/#fixes-55) 

Manually tested with 2.7 and 2.6, `db_export` does not work. In 2.6 it simply does nothing; in 2.7 it throws plugin errors.

### Testing
https://deploy-preview-3633--kongdocs.netlify.app/gateway/2.7.x/reference/cli/#kong-config
https://deploy-preview-3633--kongdocs.netlify.app/gateway/2.6.x/reference/cli/#kong-config