### PR TITLE
[DOCU-1472] Fix Kong-Debug header name

### DIFF
--- a/app/enterprise/0.35-x/proxy.md
+++ b/app/enterprise/0.35-x/proxy.md
@@ -479,7 +479,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/enterprise/0.36-x/proxy.md
+++ b/app/enterprise/0.36-x/proxy.md
@@ -479,7 +479,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/1.2.x/proxy.md
+++ b/app/gateway-oss/1.2.x/proxy.md
@@ -479,7 +479,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/1.3.x/proxy.md
+++ b/app/gateway-oss/1.3.x/proxy.md
@@ -1293,4 +1293,4 @@ just covered.
 [ngx-proxy-next-upstream]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/1.3.x/proxy.md
+++ b/app/gateway-oss/1.3.x/proxy.md
@@ -566,7 +566,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/1.4.x/proxy.md
+++ b/app/gateway-oss/1.4.x/proxy.md
@@ -1295,4 +1295,4 @@ just covered.
 [ngx-proxy-next-upstream]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/1.4.x/proxy.md
+++ b/app/gateway-oss/1.4.x/proxy.md
@@ -568,7 +568,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/1.5.x/proxy.md
+++ b/app/gateway-oss/1.5.x/proxy.md
@@ -1295,4 +1295,4 @@ just covered.
 [ngx-proxy-next-upstream]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/1.5.x/proxy.md
+++ b/app/gateway-oss/1.5.x/proxy.md
@@ -568,7 +568,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/2.0.x/proxy.md
+++ b/app/gateway-oss/2.0.x/proxy.md
@@ -571,7 +571,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/2.0.x/proxy.md
+++ b/app/gateway-oss/2.0.x/proxy.md
@@ -1364,4 +1364,4 @@ just covered.
 [ngx-proxy-next-upstream]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/2.1.x/proxy.md
+++ b/app/gateway-oss/2.1.x/proxy.md
@@ -571,7 +571,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/2.1.x/proxy.md
+++ b/app/gateway-oss/2.1.x/proxy.md
@@ -1369,4 +1369,4 @@ just covered.
 [ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/2.2.x/proxy.md
+++ b/app/gateway-oss/2.2.x/proxy.md
@@ -1372,4 +1372,4 @@ just covered.
 [ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/2.2.x/proxy.md
+++ b/app/gateway-oss/2.2.x/proxy.md
@@ -571,7 +571,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/2.3.x/proxy.md
+++ b/app/gateway-oss/2.3.x/proxy.md
@@ -1372,4 +1372,4 @@ just covered.
 [ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/2.3.x/proxy.md
+++ b/app/gateway-oss/2.3.x/proxy.md
@@ -571,7 +571,7 @@ defined URIs, in this order:
 Take care to avoid writing regex rules that are overly broad and may consume
 traffic intended for a prefix rule. Adding a rule with the path `/version/.*` to
 the ruleset above would likely consume some traffic intended for the `/version`
-prefix path. If you see unexpected behavior, sending `X-Kong-Debug: 1` in your
+prefix path. If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched Route ID in the response headers for
 troubleshooting purposes.
 

--- a/app/gateway-oss/2.4.x/proxy.md
+++ b/app/gateway-oss/2.4.x/proxy.md
@@ -1416,4 +1416,4 @@ just covered.
 [ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log

--- a/app/gateway-oss/2.5.x/proxy.md
+++ b/app/gateway-oss/2.5.x/proxy.md
@@ -1433,4 +1433,4 @@ just covered.
 [ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [conf-grpc-service]: /gateway-oss/{{page.kong_version}}/getting-started/configuring-a-grpc-service
-[file-log]: //file-log
+[file-log]: /hub/kong-inc/file-log


### PR DESCRIPTION
### Summary
Scrub `X-Kong-Debug` and replace with `Kong-Debug`.

### Reason
Header name is wrong.