### PR TITLE
[DOCU-1643] Update links in Canary Release plugin

### DIFF
--- a/app/_hub/kong-inc/canary/0.3.x.md
+++ b/app/_hub/kong-inc/canary/0.3.x.md
@@ -156,14 +156,14 @@ instantly switch all traffic to _Service A_.
 ### Upstream Healthchecks
 
 The configuration item `upstream_fallback` uses
-[**Upstream Healthchecks**](/gateway/latest/admin-api/#upstream-objects)
+[**Upstream Healthchecks**](/gateway/latest/admin-api/#upstream-object)
 to skip applying the Canary upstream if it does not have at least one healthy
 target. For this configuration to take effect, the following conditions must be met:
 
  - As this configuration relies on Kong's balancer (and healthchecks),
  the name specified in `config.upstream_host` must point to a valid Kong Upstream
  object
- - [**Healthchecks**](/gateway/latest/reference/health-checks-circuit-breakers/) are
+ - [**Healthchecks**](/gateway/latest/reference/health-checks-circuit-breakers/#enabling-and-disabling-health-checks) are
  enabled in the canary upstream, i.e., the upstream specified in `upstream_host`
  needs to have healthchecks enabled it. It works with both passive and active
  healthchecks.

--- a/app/_hub/kong-inc/canary/0.4.x.md
+++ b/app/_hub/kong-inc/canary/0.4.x.md
@@ -165,14 +165,14 @@ instantly switch all traffic to _Service A_.
 ### Upstream Healthchecks
 
 The configuration item `upstream_fallback` uses
-[**Upstream Healthchecks**](/gateway/latest/admin-api/#upstream-objects)
+[**Upstream Healthchecks**](/gateway/latest/admin-api/#upstream-object)
 to skip applying the Canary upstream if it does not have at least one healthy
 target. For this configuration to take effect, the following conditions must be met:
 
  - As this configuration relies on Kong's balancer (and healthchecks),
  the name specified in `config.upstream_host` must point to a valid Kong Upstream
  object
- - [**Healthchecks**](/gateway/latest/reference/health-checks-circuit-breakers/) are
+ - [**Healthchecks**](/gateway/latest/reference/health-checks-circuit-breakers/#enabling-and-disabling-health-checks) are
  enabled in the canary upstream, i.e., the upstream specified in `upstream_host`
  needs to have healthchecks enabled it. It works with both passive and active
  healthchecks.

--- a/app/_hub/kong-inc/canary/index.md
+++ b/app/_hub/kong-inc/canary/index.md
@@ -185,14 +185,14 @@ instantly switch all traffic to _Service A_.
 ### Upstream Healthchecks
 
 The configuration item `upstream_fallback` uses
-[**Upstream Healthchecks**](/gateway/latest/admin-api/#upstream-objects)
+[**Upstream Healthchecks**](/gateway/latest/admin-api/#upstream-object)
 to skip applying the Canary upstream if it does not have at least one healthy
 target. For this configuration to take effect, the following conditions must be met:
 
  - As this configuration relies on Kong's balancer (and healthchecks),
  the name specified in `config.upstream_host` must point to a valid Kong Upstream
  object
- - [**Healthchecks**](/gateway/latest/reference/health-checks-circuit-breakers/) are
+ - [**Healthchecks**](/gateway/latest/reference/health-checks-circuit-breakers/#enabling-and-disabling-health-checks) are
  enabled in the canary upstream, i.e., the upstream specified in `upstream_host`
  needs to have healthchecks enabled it. It works with both passive and active
  healthchecks.


### PR DESCRIPTION
### Summary

Update Upstream Healthchecks general links to section-specific links. 

Changed on all version containing these links.

### Reason

Addresses [DOCU-1643](https://konghq.atlassian.net/browse/DOCU-1643).

### Testing

https://deploy-preview-3640--kongdocs.netlify.app/hub/kong-inc/canary/#upstream-healthchecks