### PR TITLE
[DOCU-1612] Remove db version content from Property Reference datastore section

### DIFF
--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -1622,11 +1622,6 @@ Routes, Services, Consumers, and Plugins) in a database, and
 all Kong nodes belonging to the same cluster must connect themselves to the same
 database.
 
-Kong supports the following database versions:
-
-- **PostgreSQL**: 9.5 and above.
-- **Cassandra**: 2.2 and above.
-
 When not using a database, Kong is said to be in "DB-less mode": it will keep
 its entities in memory, and each node needs to have this data entered via a
 declarative configuration file, which can be specified through the


### PR DESCRIPTION
### Summary

Remove db version content from Property Reference datastore section in 2.7.x. 

### Reason

Addresses [DOCU-1612](https://konghq.atlassian.net/browse/DOCU-1612).

### Testing

Link TBA.
