### PR TITLE
[DOCU-2128] remove version-specific text from on-prem Dev Portal docs

### DIFF
--- a/app/gateway/2.7.x/developer-portal/administration/application-registration/auth-provider-strategy.md
+++ b/app/gateway/2.7.x/developer-portal/administration/application-registration/auth-provider-strategy.md
@@ -3,22 +3,7 @@ title: Authorization Provider Strategy for Application Registration
 badge: enterprise
 ---
 
-In the 1.5.x beta version of the Application
-Registration plugin, the feature was tightly coupled with OAuth2. Kong was the
-only available system of record (SoR) for application credentials and the OAuth
-configuration was done directly within the Application Registration plugin.
-
-In the {{site.ee_product_name}} 2.1.x version, authentication was decoupled from the
-Application Registration plugin. Support has been added for third-party OAuth2
-providers. Developers have the flexibility to choose from either
-Kong or a third-party identity provider (IdP) as the system of record for
-application credentials. With third-party (external) OAuth2 support, developers
-can centralize application credential management with the
-[supported identity provider](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#idps)
-of their choice.
-
-In the {{site.ee_product_name}} 2.2.1.x version and later, support has been added
-for the Key Authentication plugin to use with Kong as the system of record.
+{{site.ee_product_name}} supports adding the Key Authentication plugin to use with Kong as the system of record.
 
 ## Supported Authentication Plugins
 

--- a/app/gateway/2.7.x/developer-portal/administration/application-registration/auth-provider-strategy.md
+++ b/app/gateway/2.7.x/developer-portal/administration/application-registration/auth-provider-strategy.md
@@ -3,7 +3,6 @@ title: Authorization Provider Strategy for Application Registration
 badge: enterprise
 ---
 
-{{site.ee_product_name}} supports adding the Key Authentication plugin to use with Kong as the system of record.
 
 ## Supported Authentication Plugins
 

--- a/app/gateway/2.7.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/gateway/2.7.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -8,8 +8,7 @@ authenticate with supported Authentication plugins against a Service on Kong. Ei
 external identity provider admins can selectively admit access to Services using Kong Manager.
 
 ## Prerequisites
-* {{site.ee_product_name}} is installed, version 2.1.0.0 or later. If you plan to use
-key authentication, version 2.2.1.0 or later.
+
 * Dev Portal is enabled on the same Workspace as the Service.
 * The Service is created and enabled with HTTPS.
 * Authentication is enabled on the Dev Portal.

--- a/app/gateway/2.7.x/developer-portal/administration/application-registration/enable-key-auth-plugin.md
+++ b/app/gateway/2.7.x/developer-portal/administration/application-registration/enable-key-auth-plugin.md
@@ -11,7 +11,6 @@ You can use the same Client ID credential for a Service that has the OAuth2 plug
 
 ## Prerequisites
 
-* {{site.ee_product_name}} is installed, version 2.2.1.0 or later.
 * Create a Service.
 * Enable the [Application Registration plugin](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
 * Activate your application for a Service if you have not already done so. The

--- a/app/gateway/2.7.x/developer-portal/configuration/smtp.md
+++ b/app/gateway/2.7.x/developer-portal/configuration/smtp.md
@@ -14,8 +14,7 @@ curl http://localhost:8001/workspaces/<WORKSPACE_NAME> \
 
 If they are not modified manually, the Dev Portal will use the default value defined in the Kong Configuration file.
 
-In 1.3.0.1 or greater, [Dev Portal email content and styling can be customized via template files](/gateway/{{page.kong_version}}/developer-portal/theme-customization/emails/)
-
+Dev Portal email content and styling can be customized via [template files](/gateway/{{page.kong_version}}/developer-portal/theme-customization/emails/).
 
 ## portal_invite_email
 
@@ -105,7 +104,7 @@ the link above to change your password.
 **Default:** `on`
 
 **Description:**
-When enabled, developers will receive an email after successfully reseting their Dev Portal account password.
+When enabled, developers will receive an email after successfully resetting their Dev Portal account password.
 
 When disabled, developers will still be able to reset their account passwords, but will not receive a confirmation email.
 

--- a/app/gateway/2.7.x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -11,7 +11,6 @@ webpages or load additional JavaScript.
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Portal Legacy is turned off
 * The Kong Developer Portal is enabled and running
 * The [kong-portal-cli tool](/gateway/{{page.kong_version}}/developer-portal/helpers/cli) is installed locally

--- a/app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -7,7 +7,6 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Access to Kong Manager
 * The Developer Portal is enabled and running
 

--- a/app/gateway/2.7.x/developer-portal/theme-customization/emails.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/emails.md
@@ -9,7 +9,7 @@ Email files can be managed in the same way as other files for rendering, via edi
 This feature is **not** supported on legacy portal mode.
 
 If no email templates are loaded, Kong will fall back to the same emails as {{site.base_gateway}} 1.3.0.0.
-By default on 1.3.0.1 and newer, enabling a non-legacy portal on new workspaces loads default editable email templates.
+Enabling a non-legacy portal on new workspaces loads default editable email templates.
 For existing non-legacy Portals, editable email templates must be loaded manually.
 
 Email-specific values are templated in tokens that work similarly to templating in portal layouts and partials.
@@ -18,7 +18,6 @@ Not all tokens are supported on all emails.
 
 ## Prerequisites
 
-* {{site.base_gateway}} **1.3.0.1** or later
 * The Kong Developer Portal is not running in **Legacy Mode**
 * The Kong Developer Portal is enabled and running
 * [The emails you want are enabled in kong](/gateway/{{page.kong_version}}/developer-portal/configuration/smtp/#portal_invite_email)

--- a/app/gateway/2.7.x/developer-portal/theme-customization/markdown-extended.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/markdown-extended.md
@@ -12,7 +12,6 @@ improves rendering significantly, especially for tables.
 
 ## Prerequisites
 
-* {{site.base_gateway}} 2.1 or later
 * Access to Kong Manager
 * The Developer Portal is enabled and running
 

--- a/app/gateway/2.7.x/developer-portal/theme-customization/single-page-app.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/single-page-app.md
@@ -76,7 +76,7 @@ For this example, place the angular build inside a `workspaces/default/themes/as
 
 ### Mounting an SPA
 
-In order to load our js we need to mount the JS, to do this let's create a new layout page, for this example, call it `spa.html`.
+To load our JS, we need to mount it. Let's create a new layout page. 
 
 Create a file called `spa.html` in `workspaces/default/themes/layouts`.
 

--- a/app/gateway/2.7.x/developer-portal/theme-customization/single-page-app.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/single-page-app.md
@@ -9,7 +9,6 @@ To view the basic example Angular template from this guide, visit the [`example/
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Portal Legacy is turned off
 * The Developer Portal is enabled and running
 * kong-portal-cli tool is installed locally
@@ -77,7 +76,7 @@ For this example, place the angular build inside a `workspaces/default/themes/as
 
 ### Mounting an SPA
 
-In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example, call it `spa.html`.
+In order to load our js we need to mount the JS, to do this let's create a new layout page, for this example, call it `spa.html`.
 
 Create a file called `spa.html` in `workspaces/default/themes/layouts`.
 

--- a/app/gateway/2.7.x/developer-portal/using-the-editor.md
+++ b/app/gateway/2.7.x/developer-portal/using-the-editor.md
@@ -9,7 +9,6 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Access to Kong Manager
 * The Kong Developer Portal is **enabled** and **running**
 


### PR DESCRIPTION
### Summary

Remove version-specific text from on-prem Dev Portal docs.

### Reason

Addresses [DOCU-2128](https://konghq.atlassian.net/browse/DOCU-2128).

### Testing

Click through on-prem Dev Portal documentation prerequisites: https://deploy-preview-3643--kongdocs.netlify.app/gateway/2.7.x/developer-portal/
