### PR TITLE
Release: Gateway 2.6.0.4

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -330,7 +330,7 @@
 -
 # Combined Gateway docs (single-sourced)
   release: "2.6.x"
-  ee-version: "2.6.0.3"
+  ee-version: "2.6.0.4"
   ce-version: "2.6.0"
   edition: "gateway"
   luarocks_version: "2.5.1-0"

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -419,6 +419,16 @@ effect on the following plugins and fields:
 * Consumer groups are not supported in declarative configuration with
 decK. If you have consumer groups in your configuration, decK will ignore them.
 
+## 2.6.0.4
+**Release Date** 2022/02/10
+
+### Fixes
+
+#### Enterprise
+* Fixed an issue with Kong Manager OIDC authentication, which caused the error
+`“attempt to call method 'select_by_username_ignore_case' (a nil value)”`
+and prevented login with OIDC.
+
 ## 2.6.0.3
 **Release Date:** 2022/01/27
 


### PR DESCRIPTION
### Summary
Changelog for gateway patch release and a version bump.

Same change is going into 2.7.1.2. It's in a separate PR (https://github.com/Kong/docs.konghq.com/pull/3645) in case the releases don't go out at the same time.

### Reason
Patch release.

### Testing
https://deploy-preview-3644--kongdocs.netlify.app/gateway/changelog/#2604