### PR TITLE
[DOCU-1929] Supported response codes for Mocking plugin

### DIFF
--- a/app/_hub/kong-inc/mocking/0.1.x.md
+++ b/app/_hub/kong-inc/mocking/0.1.x.md
@@ -20,6 +20,8 @@ description: |
   - Easily enable and disable the Mocking plugin for flexibility when
     testing API behavior.
 
+  This plugin can mock `200`, `201`, and `204` responses.
+
   {:.note}
   > To use this plugin in Konnect Cloud,
   [upgrade your runtimes](/konnect/runtime-manager/upgrade) to at least
@@ -194,6 +196,10 @@ Prerequisites:
 - An Open API Specification (`yaml` or `json`) that has at least one API method with an
   embedded example response. Multiple examples within a spec are supported. See the
   [Stock API spec example](#stock-spec).
+
+    {:.note}
+    > **Note:** The spec must contain `200`, `201`, or `204` responses. The
+    Mocking plugin doesn't support any other response status codes.
 
 Tutorial steps:
 

--- a/app/_hub/kong-inc/mocking/index.md
+++ b/app/_hub/kong-inc/mocking/index.md
@@ -19,6 +19,8 @@ description: |
   - Easily enable and disable the Mocking plugin for flexibility when
     testing API behavior.
 
+  This plugin can mock `200`, `201`, and `204` responses.
+
   {:.note}
   > To use this plugin in Konnect Cloud,
   [upgrade your runtimes](/konnect/runtime-manager/upgrade) to at least
@@ -201,6 +203,10 @@ Prerequisites:
 - An Open API Specification (`yaml` or `json`) that has at least one API method with an
   embedded example response. Multiple examples within a spec are supported. See the
   [Stock API spec example](#stock-spec).
+
+  {:.note}
+  > **Note:** The spec must contain `200`, `201`, or `204` responses. The
+  Mocking plugin doesn't support any other response status codes.
 
 Tutorial steps:
 


### PR DESCRIPTION
### Summary
Document supported response codes for the Mocking plugin. 

### Reason
The mocking plugin only supports `200`, `201`, and `204` responses.
See https://github.com/Kong/kong-plugin-mocking/blob/master/kong/plugins/mocking/handler.lua#L202.

### Testing
https://deploy-preview-3646--kongdocs.netlify.app/hub/kong-inc/mocking/