### PR TITLE
[DOCU-486] Fix typos and styling issues

### DIFF
--- a/app/kubernetes-ingress-controller/1.0.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/aks.md
@@ -6,10 +6,10 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 
 1. A fully functional AKS cluster.
    Please follow Azure's Guide to
-   [setup an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+   [set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
 1. Basic understanding of Kubernetes
-1. A working `kubectl`  linked to the AKS Kubernetes
-   cluster we will work on. The above AKS setup guide will help
+1. A working `kubectl` linked to the AKS Kubernetes
+   cluster you'll work on. The above AKS setup guide will help
    you set this up.
 
 ## Deploy the {{site.kic_product_name}} {#deploy-kic}
@@ -36,7 +36,7 @@ It will take a few minutes for all containers to start and report
 healthy status.
 
 Alternatively, you can use our helm chart as well.
-Please ensure that you've Tiller working and then execute:
+Please ensure that you have Tiller working and then execute:
 
 ```bash
 $ helm repo add kong https://charts.konghq.com
@@ -51,10 +51,10 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 *Note:* this process could take up to five minutes the first time.
 
-## Setup environment variables
+## Set up environment variables
 
-Next, we will setup an environment variable with the IP address at which
-Kong is accesssible. This will be used to actually send reqeusts into the
+Next, set up an environment variable with the IP address at which
+Kong is accessible. This will be used to actually send requests into the
 Kubernetes cluster.
 
 Execute the following command to get the IP address at which Kong is accessible:
@@ -65,13 +65,13 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)             
 kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Let's setup an environment variable to hold the IP address:
+Let's set up an environment variable to hold the IP address:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
 ```
 
-> Note: It may take a while for Google to actually associate the
+> Note: It may take a while for Microsoft Azure to actually associate the
 IP address to the `kong-proxy` Service.
 
 Once you've installed the {{site.kic_product_name}}, please follow our

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
@@ -6,10 +6,10 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 
 1. A fully functional AKS cluster.
    Please follow Azure's Guide to
-   [setup an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+   [set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
 1. Basic understanding of Kubernetes
-1. A working `kubectl`  linked to the AKS Kubernetes
-   cluster we will work on. The above AKS setup guide will help
+1. A working `kubectl` linked to the AKS Kubernetes
+   cluster you'll work on. The above AKS setup guide will help
    you set this up.
 
 ## Deploy the {{site.kic_product_name}} {#deploy-kic}
@@ -36,7 +36,7 @@ It will take a few minutes for all containers to start and report
 healthy status.
 
 Alternatively, you can use our helm chart as well.
-Please ensure that you've Tiller working and then execute:
+Please ensure that you have Tiller working and then execute:
 
 ```bash
 $ helm repo add kong https://charts.konghq.com
@@ -48,10 +48,10 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 *Note:* this process could take up to five minutes the first time.
 
-## Setup environment variables
+## Set up environment variables
 
-Next, we will setup an environment variable with the IP address at which
-Kong is accessible. This will be used to actually send reqeusts into the
+Next, set up an environment variable with the IP address at which
+Kong is accessible. This will be used to actually send requests into the
 Kubernetes cluster.
 
 Execute the following command to get the IP address at which Kong is accessible:
@@ -62,7 +62,7 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)             
 kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Let's setup an environment variable to hold the IP address:
+Let's set up an environment variable to hold the IP address:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/aks.md
@@ -6,10 +6,10 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 
 1. A fully functional AKS cluster.
    Please follow Azure's Guide to
-   [setup an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+   [set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
 1. Basic understanding of Kubernetes
 1. A working `kubectl`  linked to the AKS Kubernetes
-   cluster we will work on. The above AKS setup guide will help
+   cluster you'll work on. The above AKS setup guide will help
    you set this up.
 
 ## Deploy the {{site.kic_product_name}} {#deploy-kic}
@@ -36,7 +36,7 @@ It will take a few minutes for all containers to start and report
 healthy status.
 
 Alternatively, you can use our helm chart as well.
-Please ensure that you've Tiller working and then execute:
+Please ensure that you have Tiller working and then execute:
 
 ```bash
 $ helm repo add kong https://charts.konghq.com
@@ -48,10 +48,10 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 *Note:* this process could take up to five minutes the first time.
 
-## Setup environment variables
+## Set up environment variables
 
-Next, we will setup an environment variable with the IP address at which
-Kong is accessible. This will be used to actually send reqeusts into the
+Next, set up an environment variable with the IP address at which
+Kong is accessible. This will be used to actually send requests into the
 Kubernetes cluster.
 
 Execute the following command to get the IP address at which Kong is accessible:
@@ -62,7 +62,7 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)             
 kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Let's setup an environment variable to hold the IP address:
+Let's set up an environment variable to hold the IP address:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/aks.md
@@ -6,9 +6,9 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 
 1. A fully functional AKS cluster.
    Please follow Azure's Guide to
-   [setup an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+   [set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
 1. Basic understanding of Kubernetes
-1. A working `kubectl`  linked to the AKS Kubernetes
+1. A working `kubectl` linked to the AKS Kubernetes
    cluster we will work on. The above AKS setup guide will help
    you set this up.
 
@@ -36,7 +36,7 @@ It will take a few minutes for all containers to start and report
 healthy status.
 
 Alternatively, you can use our helm chart as well.
-Please ensure that you've Tiller working and then execute:
+Please ensure that you have Tiller working and then execute:
 
 ```bash
 $ helm repo add kong https://charts.konghq.com
@@ -48,10 +48,10 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 *Note:* this process could take up to five minutes the first time.
 
-## Setup environment variables
+## Set up environment variables
 
-Next, we will setup an environment variable with the IP address at which
-Kong is accessible. This will be used to actually send reqeusts into the
+Next, set up an environment variable with the IP address at which
+Kong is accessible. This will be used to actually send requests into the
 Kubernetes cluster.
 
 Execute the following command to get the IP address at which Kong is accessible:
@@ -62,7 +62,7 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)             
 kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Let's setup an environment variable to hold the IP address:
+Let's set up an environment variable to hold the IP address:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/aks.md
@@ -6,10 +6,10 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 
 1. A fully functional AKS cluster.
    Please follow Azure's Guide to
-   [setup an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+   [set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
 1. Basic understanding of Kubernetes
-1. A working `kubectl`  linked to the AKS Kubernetes
-   cluster we will work on. The above AKS setup guide will help
+1. A working `kubectl` linked to the AKS Kubernetes
+   cluster you'll work on. The above AKS setup guide will help
    you set this up.
 
 ## Deploy the {{site.kic_product_name}} {#deploy-kic}
@@ -36,7 +36,7 @@ It will take a few minutes for all containers to start and report
 healthy status.
 
 Alternatively, you can use our helm chart as well.
-Please ensure that you've Tiller working and then execute:
+Please ensure that you have Tiller working and then execute:
 
 ```bash
 $ helm repo add kong https://charts.konghq.com
@@ -48,10 +48,10 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 *Note:* this process could take up to five minutes the first time.
 
-## Setup environment variables
+## Set up environment variables
 
-Next, we will setup an environment variable with the IP address at which
-Kong is accessible. This will be used to actually send reqeusts into the
+Next, set up an environment variable with the IP address at which
+Kong is accessible. This will be used to actually send requests into the
 Kubernetes cluster.
 
 Execute the following command to get the IP address at which Kong is accessible:
@@ -62,7 +62,7 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)             
 kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Let's setup an environment variable to hold the IP address:
+Let's set up an environment variable to hold the IP address:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/aks.md
@@ -6,10 +6,10 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 
 1. A fully functional AKS cluster.
    Please follow Azure's Guide to
-   [setup an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+   [set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
 1. Basic understanding of Kubernetes
-1. A working `kubectl`  linked to the AKS Kubernetes
-   cluster we will work on. The above AKS setup guide will help
+1. A working `kubectl` linked to the AKS Kubernetes
+   cluster you'll work on. The above AKS setup guide will help
    you set this up.
 
 ## Deploy the {{site.kic_product_name}} {#deploy-kic}
@@ -36,7 +36,7 @@ It will take a few minutes for all containers to start and report
 healthy status.
 
 Alternatively, you can use our helm chart as well.
-Please ensure that you've Tiller working and then execute:
+Please ensure that you have Tiller working and then execute:
 
 ```bash
 $ helm repo add kong https://charts.konghq.com
@@ -48,10 +48,10 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 *Note:* this process could take up to five minutes the first time.
 
-## Setup environment variables
+## Set up environment variables
 
-Next, we will setup an environment variable with the IP address at which
-Kong is accessible. This will be used to actually send reqeusts into the
+Next, set up an environment variable with the IP address at which
+Kong is accessible. This will be used to actually send requests into the
 Kubernetes cluster.
 
 Execute the following command to get the IP address at which Kong is accessible:
@@ -62,7 +62,7 @@ NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)             
 kong-proxy   LoadBalancer   10.63.250.199   203.0.113.42   80:31929/TCP,443:31408/TCP   57d
 ```
 
-Let's setup an environment variable to hold the IP address:
+Let's set up an environment variable to hold the IP address:
 
 ```bash
 $ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)


### PR DESCRIPTION
### Summary

Fix typos and styling issues in Azure Kubernetes Ingress Control for all versions of documentation.

### Reason

Addresses [DOCU-486](https://konghq.atlassian.net/browse/DOCU-486)

### Testing

https://deploy-preview-3651--kongdocs.netlify.app/kubernetes-ingress-controller/2.1.x/deployment/aks/
https://deploy-preview-3651--kongdocs.netlify.app/kubernetes-ingress-controller/2.0.x/deployment/aks/
https://deploy-preview-3651--kongdocs.netlify.app/kubernetes-ingress-controller/1.3.x/deployment/aks/
https://deploy-preview-3651--kongdocs.netlify.app/kubernetes-ingress-controller/1.2.x/deployment/aks/
https://deploy-preview-3651--kongdocs.netlify.app/kubernetes-ingress-controller/1.1.x/deployment/aks/
https://deploy-preview-3651--kongdocs.netlify.app/kubernetes-ingress-controller/1.0.x/deployment/aks/
