### PR TITLE
[DOCU-1583] Fix Mesh license variable

### DIFF
--- a/app/_includes/md/mesh/install-universal-run.md
+++ b/app/_includes/md/mesh/install-universal-run.md
@@ -12,7 +12,7 @@ $ cd kong-mesh-{{include.kong_latest.version}}/bin
 Then, run the control plane with:
 
 ```sh
-$ KUMA_LICENSE_PATH=/path/to/file/license.json kuma-cp run
+$ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 Where `/path/to/file/license.json` is the path to a valid


### PR DESCRIPTION
### Summary

In includes file for Kong Mesh, swap `KUMA_LICENSE_PATH` for `KMESH_LICENSE_PATH`.

### Reason

Addresses [DOCU-1583](https://konghq.atlassian.net/browse/DOCU-1583)

### Testing

Check the includes file in file changes. The change applies on multiple pages, including the following:

https://deploy-preview-3652--kongdocs.netlify.app/mesh/1.5.x/installation/amazonlinux/#2-run-kong-mesh
