### PR TITLE
[DOCU-2185] Update Admin API note

### DIFF
--- a/app/gateway-oss/2.4.x/admin-api.md
+++ b/app/gateway-oss/2.4.x/admin-api.md
@@ -1263,7 +1263,7 @@ Services can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Service
 
@@ -1394,7 +1394,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Service
 
@@ -1460,7 +1460,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Service
 
@@ -1539,7 +1539,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Service
 
@@ -1645,7 +1645,7 @@ Routes can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Route
 
@@ -1766,7 +1766,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Route
 
@@ -1822,7 +1822,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Route
 
@@ -1891,7 +1891,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Route
 
@@ -1942,7 +1942,7 @@ Consumers can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Consumer
 
@@ -2032,7 +2032,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Consumer
 
@@ -2077,7 +2077,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Consumer
 
@@ -2135,7 +2135,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Consumer
 
@@ -2225,7 +2225,7 @@ would have otherwise matched config B.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Plugin
 
@@ -2398,7 +2398,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Plugin
 
@@ -2466,7 +2466,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Plugin
 
@@ -2547,7 +2547,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Plugin
 
@@ -2674,7 +2674,7 @@ Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Certificate
 
@@ -2764,7 +2764,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Certificate
 
@@ -2809,7 +2809,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Certificate
 
@@ -2867,7 +2867,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Certificate
 
@@ -2915,7 +2915,7 @@ CA Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create CA Certificate
 
@@ -2995,7 +2995,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update CA Certificate
 
@@ -3030,7 +3030,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update CA Certificate
 
@@ -3078,7 +3078,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete CA Certificate
 
@@ -3118,7 +3118,7 @@ SNIs can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create SNI
 
@@ -3229,7 +3229,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update SNI
 
@@ -3275,7 +3275,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update SNI
 
@@ -3334,7 +3334,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete SNI
 
@@ -3390,7 +3390,7 @@ Upstreams can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Upstream
 
@@ -3511,7 +3511,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Upstream
 
@@ -3567,7 +3567,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Upstream
 
@@ -3636,7 +3636,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Upstream
 
@@ -3803,7 +3803,7 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Target Associated to a Specific Upstream
 
@@ -3867,7 +3867,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Update a target.
 
@@ -3895,7 +3895,7 @@ HTTP 201 Created
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Remove a target from the load balancer.
 
@@ -3923,7 +3923,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "healthy" in the entire Kong cluster.
@@ -3962,7 +3962,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "unhealthy" in the entire Kong cluster.

--- a/app/gateway-oss/2.5.x/admin-api.md
+++ b/app/gateway-oss/2.5.x/admin-api.md
@@ -1267,7 +1267,7 @@ Services can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Service
 
@@ -1398,7 +1398,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Service
 
@@ -1464,7 +1464,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Service
 
@@ -1543,7 +1543,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Service
 
@@ -1657,7 +1657,7 @@ Routes can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Route
 
@@ -1778,7 +1778,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Route
 
@@ -1834,7 +1834,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Route
 
@@ -1903,7 +1903,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Route
 
@@ -1954,7 +1954,7 @@ Consumers can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Consumer
 
@@ -2044,7 +2044,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Consumer
 
@@ -2089,7 +2089,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Consumer
 
@@ -2147,7 +2147,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Consumer
 
@@ -2237,7 +2237,7 @@ would have otherwise matched config B.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Plugin
 
@@ -2410,7 +2410,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Plugin
 
@@ -2478,7 +2478,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Plugin
 
@@ -2559,7 +2559,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Plugin
 
@@ -2686,7 +2686,7 @@ Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Certificate
 
@@ -2776,7 +2776,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Certificate
 
@@ -2821,7 +2821,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Certificate
 
@@ -2879,7 +2879,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Certificate
 
@@ -2927,7 +2927,7 @@ CA Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create CA Certificate
 
@@ -3007,7 +3007,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update CA Certificate
 
@@ -3042,7 +3042,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update CA Certificate
 
@@ -3090,7 +3090,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete CA Certificate
 
@@ -3130,7 +3130,7 @@ SNIs can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create SNI
 
@@ -3241,7 +3241,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update SNI
 
@@ -3287,7 +3287,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update SNI
 
@@ -3346,7 +3346,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete SNI
 
@@ -3402,7 +3402,7 @@ Upstreams can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Upstream
 
@@ -3523,7 +3523,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Upstream
 
@@ -3579,7 +3579,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Upstream
 
@@ -3648,7 +3648,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Upstream
 
@@ -3815,7 +3815,7 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Target Associated to a Specific Upstream
 
@@ -3879,7 +3879,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Update a target.
 
@@ -3907,7 +3907,7 @@ HTTP 201 Created
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Remove a target from the load balancer.
 
@@ -3935,7 +3935,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "healthy" in the entire Kong cluster.
@@ -3974,7 +3974,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "unhealthy" in the entire Kong cluster.

--- a/app/gateway/2.6.x/admin-api/index.md
+++ b/app/gateway/2.6.x/admin-api/index.md
@@ -1320,7 +1320,7 @@ Services can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Service
 
@@ -1451,7 +1451,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Service
 
@@ -1517,7 +1517,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Service
 
@@ -1596,7 +1596,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Service
 
@@ -1710,7 +1710,7 @@ Routes can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Route
 
@@ -1831,7 +1831,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Route
 
@@ -1887,7 +1887,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Route
 
@@ -1956,7 +1956,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Route
 
@@ -2007,7 +2007,7 @@ Consumers can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Consumer
 
@@ -2097,7 +2097,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Consumer
 
@@ -2142,7 +2142,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Consumer
 
@@ -2200,7 +2200,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Consumer
 
@@ -2290,7 +2290,7 @@ would have otherwise matched config B.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Plugin
 
@@ -2463,7 +2463,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Plugin
 
@@ -2531,7 +2531,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Plugin
 
@@ -2612,7 +2612,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Plugin
 
@@ -2739,7 +2739,7 @@ Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Certificate
 
@@ -2829,7 +2829,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Certificate
 
@@ -2874,7 +2874,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Certificate
 
@@ -2932,7 +2932,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Certificate
 
@@ -2980,7 +2980,7 @@ CA Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create CA Certificate
 
@@ -3060,7 +3060,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update CA Certificate
 
@@ -3095,7 +3095,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update CA Certificate
 
@@ -3143,7 +3143,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete CA Certificate
 
@@ -3183,7 +3183,7 @@ SNIs can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create SNI
 
@@ -3294,7 +3294,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update SNI
 
@@ -3340,7 +3340,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update SNI
 
@@ -3399,7 +3399,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete SNI
 
@@ -3455,7 +3455,7 @@ Upstreams can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Upstream
 
@@ -3576,7 +3576,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Upstream
 
@@ -3632,7 +3632,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Upstream
 
@@ -3701,7 +3701,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Upstream
 
@@ -3868,7 +3868,7 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Target Associated to a Specific Upstream
 
@@ -3932,7 +3932,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Update a target.
 
@@ -3960,7 +3960,7 @@ HTTP 201 Created
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Remove a target from the load balancer.
 
@@ -3988,7 +3988,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "healthy" in the entire Kong cluster.
@@ -4027,7 +4027,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "unhealthy" in the entire Kong cluster.

--- a/app/gateway/2.7.x/admin-api/index.md
+++ b/app/gateway/2.7.x/admin-api/index.md
@@ -1318,7 +1318,7 @@ Services can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Service
 
@@ -1449,7 +1449,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Service
 
@@ -1515,7 +1515,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Service
 
@@ -1594,7 +1594,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Service
 
@@ -1711,7 +1711,7 @@ Routes can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Route
 
@@ -1832,7 +1832,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Route
 
@@ -1888,7 +1888,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Route
 
@@ -1957,7 +1957,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Route
 
@@ -2008,7 +2008,7 @@ Consumers can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Consumer
 
@@ -2098,7 +2098,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Consumer
 
@@ -2143,7 +2143,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Consumer
 
@@ -2201,7 +2201,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Consumer
 
@@ -2291,7 +2291,7 @@ would have otherwise matched config B.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Plugin
 
@@ -2464,7 +2464,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Plugin
 
@@ -2532,7 +2532,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Plugin
 
@@ -2613,7 +2613,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Plugin
 
@@ -2740,7 +2740,7 @@ Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Certificate
 
@@ -2830,7 +2830,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Certificate
 
@@ -2875,7 +2875,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Certificate
 
@@ -2933,7 +2933,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Certificate
 
@@ -2981,7 +2981,7 @@ CA Certificates can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create CA Certificate
 
@@ -3061,7 +3061,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update CA Certificate
 
@@ -3096,7 +3096,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update CA Certificate
 
@@ -3144,7 +3144,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete CA Certificate
 
@@ -3184,7 +3184,7 @@ SNIs can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create SNI
 
@@ -3295,7 +3295,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update SNI
 
@@ -3341,7 +3341,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update SNI
 
@@ -3400,7 +3400,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete SNI
 
@@ -3456,7 +3456,7 @@ Upstreams can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Upstream
 
@@ -3577,7 +3577,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Update Upstream
 
@@ -3633,7 +3633,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Or Update Upstream
 
@@ -3702,7 +3702,7 @@ See POST and PATCH responses.
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Delete Upstream
 
@@ -3869,7 +3869,7 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 ##### Create Target Associated to a Specific Upstream
 
@@ -3933,7 +3933,7 @@ HTTP 200 OK
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Update a target.
 
@@ -3961,7 +3961,7 @@ HTTP 201 Created
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Remove a target from the load balancer.
 
@@ -3989,7 +3989,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "healthy" in the entire Kong cluster.
@@ -4028,7 +4028,7 @@ HTTP 204 No Content
 
 
 {:.note}
-> **Note**: Not available in DB-less mode.
+> **Note**: This API is not available in DB-less mode.
 
 Set the current health status of an individual address resolved by a target
 in the load balancer to "unhealthy" in the entire Kong cluster.


### PR DESCRIPTION
### Summary

In the Admin API documentation, change `Not available in DB-less mode.` to `This API is not available in DB-less mode.`

### Reason

Addresses [DOCU-2185](https://konghq.atlassian.net/browse/DOCU-2185)

### Testing

One example: https://deploy-preview-3653--kongdocs.netlify.app/gateway/2.7.x/admin-api/#add-service
