### PR TITLE
Breaking change note for Kong Manager changelog entry in 2.7.0.0

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -123,6 +123,14 @@ to your identity provider. Instead, admins are created on first
 login and their roles are assigned based on their group membership in your
 IdP. This feature also partly resolves a problem with creating admins for both
 Kong Manager and Dev Portal.
+
+    {:.important}
+    > **Important:** This feature introduces a **breaking change**. The
+    `admin_claim` parameter replaces the `consumer_claim` parameter required by
+    previous versions. You must update your OIDC config file to keep OIDC
+    authentication working for Kong Manager. For more information, see 
+    [OIDC Authenticated Group Mapping](/gateway/2.7.x/configure/auth/kong-manager/oidc-mapping).
+
 * Kong Manager now provides a simplified, organized form for configuring the
 OpenID Connect plugin. Users can now easily identify a common set of required
 parameters to configure the plugin, and add custom configurations as needed.


### PR DESCRIPTION
### Summary
Adding an alert banner for the Kong Manager changelog entry in 2.7.0.0 to say that it was a breaking change and what exactly changed. 

### Reason
We introduced a breaking change for Kong Manager in 2.7.0.0 but it wasn't labelled as a breaking change, and users have already run into problems with it.

### Testing
https://deploy-preview-3654--kongdocs.netlify.app/gateway/changelog/#kong-manager