### PR TITLE
[DOCU-876] Correlation ID Plugin: edit Nginx param

### DIFF
--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -137,7 +137,8 @@ To edit your Nginx parameters, do the following:
 1. Locate [{{site.base_gateway}}'s template files](/gateway/latest/reference/configuration/#custom-nginx-templates) and make a copy of `nginx_kong.lua`.
 1. Add a `log_format` section on the root level of the config file which includes the
   `$sent_http_Kong_Request_ID` variable.
-   In the following example, we created a new log format named `customformat`.
+
+   In the following example, we create a new log format named `customformat`.
    It's a copy of the default `combined` log format, but the last line adds
    `$sent_http_Kong_Request_ID`, preceded by the string `Kong-Request-ID=`.
    Marking the variable this way is optional, and will make testing the feature easier.
@@ -151,16 +152,16 @@ To edit your Nginx parameters, do the following:
                  'Kong-Request-ID="$sent_http_Kong_Request_ID"';
    ```
 
-1. Use your custom log format for the proxy access log phase. This means locating the following line:
+1. Use your custom log format for the proxy access log phase. Locate the following line:
    
    ```
    access_log ${PROXY_ACCESS_LOG};
    ```
 
-     Modifying it by adding the `customformat` format that we just created:
+     Modify it by adding the `customformat` format that we just created:
 
    ```
-   access_log ${{PROXY_ACCESS_LOG}} customformat;
+   access_log ${% raw %}{{PROXY_ACCESS_LOG}}{% endraw %} customformat;
    ```
 
      Note that the file contains several `access_log` entries. Only modify the line
@@ -180,6 +181,6 @@ To edit your Nginx parameters, do the following:
 
    You should now see Correlation ID entries in the access log.
 
-Learn more in [Custom Nginx templates & embedding Kong](/latest/configuration/#custom-nginx-templates--embedding-kong).
+Learn more in [Custom Nginx templates & embedding Kong](/gateway/latest/reference/configuration/#custom-nginx-templates--embedding-kong).
 
 You can also use this plugin along with one of the [logging plugins](/hub/#logging), or store the ID on your backend.

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -130,4 +130,20 @@ form parameter      | description
 
 ### Can I see my correlation ids in my Kong logs?
 
-The correlation id doesn't show up in the Nginx access or error logs. However, you can use this plugin along with one of the Logging plugins, or store the id on your backend.
+You can see your correlation ID in the Nginx access or error logs if you edit your Nginx logging parameters.
+
+To edit your Nginx parameters, do the following:
+
+1. In `/usr/local/share/lua/5.1/kong/templates/nginx_kong.lua`, add to a `log_format` section:
+
+     ```
+     log_format kvformat '<snipped_for_brevity> > > > > Kong-Request-ID="$sent_http_Kong_Request_ID" ';
+     ```
+
+2. Reference it using: `access_log $PROXY_ACCESS_LOG kvformat;`
+
+3. Reload Kong and tail the access log. You should see the entries for the Correlation ID in there.
+
+Learn more in [Custom Nginx templates & embedding Kong](/latest/configuration/#custom-nginx-templates--embedding-kong).
+
+Note that you can also use this plugin along with one of the Logging plugins, or store the id on your backend.

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -134,10 +134,11 @@ You can see your correlation ID in the Nginx access or error logs if you edit yo
 
 To edit your Nginx parameters, do the following:
 
-1. In `/usr/local/share/lua/5.1/kong/templates/nginx_kong.lua`, add to a `log_format` section:
+1. Locate [{{site.base_gateway}}'s template files](/gateway/latest/reference/configuration/#custom-nginx-templates) and make a copy of `nginx_kong.lua`. 
+2. Add a `log_format` section:
 
      ```
-     log_format kvformat '<snipped_for_brevity> > > > > Kong-Request-ID="$sent_http_Kong_Request_ID" ';
+     log_format kvformat '<snipped_for_brevity> Kong-Request-ID="$sent_http_Kong_Request_ID" ';
      ```
 
 2. Reference it using: `access_log $PROXY_ACCESS_LOG kvformat;`
@@ -146,4 +147,4 @@ To edit your Nginx parameters, do the following:
 
 Learn more in [Custom Nginx templates & embedding Kong](/latest/configuration/#custom-nginx-templates--embedding-kong).
 
-Note that you can also use this plugin along with one of the Logging plugins, or store the id on your backend.
+You can also use this plugin along with one of the [logging plugins](/hub/#logging), or store the ID on your backend.

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -175,7 +175,7 @@ To edit your Nginx parameters, do the following:
 3. Tail the access log:
 
    ```
-   tail logs/access.log
+   tail /usr/local/kong/logs/access.log
    ```
 
    You should now see Correlation ID entries in the access log.

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -128,7 +128,7 @@ form parameter      | description
 
 ## FAQ
 
-### Can I see my correlation ids in my Kong logs?
+### Can I see my correlation IDs in my Kong logs?
 
 You can see your correlation ID in the Nginx access or error logs if you edit your Nginx logging parameters.
 

--- a/app/_hub/kong-inc/correlation-id/index.md
+++ b/app/_hub/kong-inc/correlation-id/index.md
@@ -134,35 +134,51 @@ You can see your correlation ID in the Nginx access or error logs if you edit yo
 
 To edit your Nginx parameters, do the following:
 
-1. Locate [{{site.base_gateway}}'s template files](/gateway/latest/reference/configuration/#custom-nginx-templates) and make a copy of `nginx_kong.lua`. 
-2. Add a `log_format` section on the root level of the config file which includes the
-  `$sent_http_Kong_Request_ID` variable. 
-   On the following example, we created a new log format called `customformat`.
-   It's a copy of the default `combined` log format, but the last line adds 
-   `$sent_http_Kong_Request_ID`, preceded by the string `Kong-Request-ID=`. 
-   Marking the variable this way is optional, but will make testing the feature easier.
-   You can further customize the `log_format` by adding or removing
+1. Locate [{{site.base_gateway}}'s template files](/gateway/latest/reference/configuration/#custom-nginx-templates) and make a copy of `nginx_kong.lua`.
+1. Add a `log_format` section on the root level of the config file which includes the
+  `$sent_http_Kong_Request_ID` variable.
+   In the following example, we created a new log format named `customformat`.
+   It's a copy of the default `combined` log format, but the last line adds
+   `$sent_http_Kong_Request_ID`, preceded by the string `Kong-Request-ID=`.
+   Marking the variable this way is optional, and will make testing the feature easier.
+   Further customize the `log_format` by adding or removing
    [variables](http://nginx.org/en/docs/http/ngx_http_log_module.html):
 
-     ```
-     log_format customformat '$remote_addr - $remote_user [$time_local] '
-                    '"$request" $status $body_bytes_sent  '
-                    '"$http_referer" "$http_user_agent" '
-                    'Kong-Request-ID="$sent_http_Kong_Request_ID"';
-     ```
+   ```
+   log_format customformat '$remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent  '
+                 '"$http_referer" "$http_user_agent" '
+                 'Kong-Request-ID="$sent_http_Kong_Request_ID"';
+   ```
 
-2. Use your custom log format for the proxy access log phase. This means locating this line:
-     ```
-     access_log ${{PROXY_ACCESS_LOG}};
-     ```
-     And then modifying it by adding the `customformat` format that we just created:
-     ```
-     access_log ${{PROXY_ACCESS_LOG}} customformat;
-     ```
-     Note: the file contains several `access_log` entries. You should only modify the line
-     which uses `${{PROXY_ACCESS_LOG}}`, not the others.
+1. Use your custom log format for the proxy access log phase. This means locating the following line:
+   
+   ```
+   access_log ${PROXY_ACCESS_LOG};
+   ```
 
-3. Reload Kong and tail the access log. You should see the entries for the Correlation ID in there.
+     Modifying it by adding the `customformat` format that we just created:
+
+   ```
+   access_log ${{PROXY_ACCESS_LOG}} customformat;
+   ```
+
+     Note that the file contains several `access_log` entries. Only modify the line
+     that uses `${PROXY_ACCESS_LOG}`.
+
+2. Reload Kong:
+
+   ```
+   kong reload
+   ```
+  
+3. Tail the access log:
+
+   ```
+   tail logs/access.log
+   ```
+
+   You should now see Correlation ID entries in the access log.
 
 Learn more in [Custom Nginx templates & embedding Kong](/latest/configuration/#custom-nginx-templates--embedding-kong).
 


### PR DESCRIPTION
### Summary

Add info about how to edit an Nginx param in Correlation ID plugin docs.

### Reason

Addresses [DOCU-876](https://konghq.atlassian.net/browse/DOCU-876).

### Testing

@lena-larionova for the technical review, do you know someone we can ping? The original task creator is not at Kong. 

https://deploy-preview-3656--kongdocs.netlify.app/hub/kong-inc/correlation-id/#can-i-see-my-correlation-ids-in-my-kong-logs
