### PR TITLE
[DOCU-1467] Add headers to Proxy Reference

### DIFF
--- a/app/gateway/2.7.x/reference/proxy.md
+++ b/app/gateway/2.7.x/reference/proxy.md
@@ -1009,10 +1009,13 @@ the client:
 - `Via: kong/x.x.x`, where `x.x.x` is the Kong version in use
 - `X-Kong-Proxy-Latency: <latency>`, where `latency` is the time in milliseconds
   between Kong receiving the request from the client and sending the request to
-  your upstream service.
+  your upstream service
 - `X-Kong-Upstream-Latency: <latency>`, where `latency` is the time in
   milliseconds that Kong was waiting for the first byte of the upstream service
-  response.
+  response
+- `x-Forwarded-Path` is all content trailing the hostname of `X-Forwarded-Host`
+- `X-Forwarded-Host` is the hostname through which the traffic is forwarded
+- `X-Forwarded-Prefix` is the first portion of the host path through which the traffic is forwarded
 
 Once the headers are sent to the client, Kong will start executing
 registered plugins for the Route and/or Service that implement the


### PR DESCRIPTION
### Summary

Add header descriptions to Proxy Reference.

### Reason

Addresses [DOCU-1467](https://konghq.atlassian.net/browse/DOCU-1467)

### Testing

@lena-larionova this will likewise require a technical review, who should I ping?

https://deploy-preview-3657--kongdocs.netlify.app/gateway/2.7.x/reference/proxy/#5-response
