### PR TITLE
Update Vault documentation

### DIFF
--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -169,6 +169,14 @@ vault token create -format=json -policy="kmesh-default-dataplane-proxies" | jq -
 
 The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 
+{:.note}
+> Be aware there are some failure modes where the `vault` CLI will return a token that is invalid 
+even though an error was encountered (for example, if the policy creation in step 3 fails then 
+the `vault` command in step 4 will return a token but will also expose an error). In 
+such situations, using `jq` to parse the output will hide the error message provided in the `vault` 
+CLI output. It may be useful to manually parse the output instead of using `jq` so that the full 
+output of the `vault` CLI command is available.
+
 ### Configure Mesh
 
 `kuma-cp` communicates directly with Vault. To connect to
@@ -177,7 +185,10 @@ Vault, you must provide credentials in the configuration of the `mesh` object of
 You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
 
 You can provide these values inline for testing purposes only, as a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/).
+same host as `kuma-cp`, or contained in a `secret`. When using a `secret`, it should be a mesh-scoped 
+secret (see [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/) for details 
+on mesh-scoped secrets versus global secrets). On Kubernetes, this mesh-scoped secret should be stored 
+in the system namespace ("kong-mesh-system" by default).
 
 Here's an example of a configuration with a `vault`-backed CA:
 

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -188,7 +188,7 @@ You can provide these values inline for testing purposes only, as a path to a fi
 same host as `kuma-cp`, or contained in a `secret`. When using a `secret`, it should be a mesh-scoped 
 secret (see [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/) for details 
 on mesh-scoped secrets versus global secrets). On Kubernetes, this mesh-scoped secret should be stored 
-in the system namespace ("kong-mesh-system" by default).
+in the system namespace ("kong-mesh-system" by default) and should be configured as `type: system.kuma.io/secret`.
 
 Here's an example of a configuration with a `vault`-backed CA:
 

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -170,12 +170,13 @@ vault token create -format=json -policy="kmesh-default-dataplane-proxies" | jq -
 The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 
 {:.note}
-> Be aware there are some failure modes where the `vault` CLI will return a token that is invalid 
-even though an error was encountered (for example, if the policy creation in step 3 fails then 
-the `vault` command in step 4 will return a token but will also expose an error). In 
-such situations, using `jq` to parse the output will hide the error message provided in the `vault` 
-CLI output. It may be useful to manually parse the output instead of using `jq` so that the full 
-output of the `vault` CLI command is available.
+> **Note:** There are some failure modes where the `vault` CLI still returns a token 
+even though an error was encountered and the token is invalid. For example, if the 
+policy creation fails in the previous step, then the `vault token create` command 
+both returns a token and exposes an error. In such situations, using `jq` to parse 
+the output hides the error message provided in the `vault` CLI output. Manually 
+parse the output instead of using `jq` so that the full output of the `vault` CLI 
+command is available.
 
 ### Configure Mesh
 

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -189,7 +189,7 @@ You can provide these values inline for testing purposes only, as a path to a fi
 same host as `kuma-cp`, or contained in a `secret`. When using a `secret`, it should be a mesh-scoped 
 secret (see [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/) for details 
 on mesh-scoped secrets versus global secrets). On Kubernetes, this mesh-scoped secret should be stored 
-in the system namespace ("kong-mesh-system" by default) and should be configured as `type: system.kuma.io/secret`.
+in the system namespace (`kong-mesh-system` by default) and should be configured as `type: system.kuma.io/secret`.
 
 Here's an example of a configuration with a `vault`-backed CA:
 


### PR DESCRIPTION
This PR updates the Vault documentation.

Fixes #3545

### Summary
This PR adds some documentation to the Vault section. Specifically, it calls out the need to use mesh-scoped secrets and highlights a potential problem when using `jq` to filter the output of the command to create the Vault token.

### Reason
The current documentation is unclear about the need to use a mesh-scoped secret. The current documentation also does not call out that the use of `jq` _may_ mask errors encountered in the process of creating the necessary Vault token.

### Testing
These changes arose out of my attempt to use the Vault documentation. The confirmation regarding the need to use a mesh-scoped secret came from Engineering; I haven't personally tested/verified. As for the invalid token situation, it can be replicated:

1. Intentionally introduce an error trying to create the policy in step 3 of the Vault documentation.
2. Run the command listed in step 4. A token will be returned, but it will be invalid/won't work. You can test the token with the `vault` CLI to see if it lets you list/retrieve data from Vault.
3. Repeat the command in step 4 but omit the use of `jq`. A token will still be returned, but in the full output of the `vault` command you'll see an error.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
