### PR TITLE
[DOCU-2140] Admin API: Remove wording about cannot delete/modify

### DIFF
--- a/app/gateway/2.7.x/admin-api/index.md
+++ b/app/gateway/2.7.x/admin-api/index.md
@@ -3851,8 +3851,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added, modified, or deleted. Changes take effect on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.


### PR DESCRIPTION
### Summary

Remove wording in Admin API docs Target Object that says targets cannot be modified or deleted.

### Reason

Addresses [DOCU-2140](https://konghq.atlassian.net/browse/DOCU-2140)

### Testing

https://deploy-preview-3663--kongdocs.netlify.app/gateway/2.7.x/admin-api/#target-object
