### PR TITLE
[DOCU-1068] Hybrid Mode: rm Vitals from telemetry mentions

### DIFF
--- a/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.1.x/deployment/hybrid-mode-setup.md
@@ -245,7 +245,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -291,7 +291,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -409,7 +409,7 @@ follow the instructions to:
     extension) to use for Data Plane connections to the Control Plane through
     TLS. When not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
 3. If needed, bring up any subsequent Data Planes using the same settings.
@@ -480,7 +480,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     to use for Data Plane connections to the Control Plane through TLS. When
     not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
 3. Restart Kong for the settings to take effect:
@@ -540,8 +540,8 @@ Parameter | Description | CP or DP {:width=10%:}
 `role` <br>*Required* | Determines whether the {{site.ee_product_name}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
 `cluster_listen` <br>*Optional* | List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. Defaults to `0.0.0.0:8005`. Note this port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
 `proxy_listen` <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-`cluster_telemetry_listen` <br>*Optional* | List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. Defaults to `0.0.0.0:8006`. Note this port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-`cluster_telemetry_endpoint` <br>*Required* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+`cluster_telemetry_listen` <br>*Optional* | List of addresses and ports on which the Control Plane will listen for Data Plane telemetry data. Defaults to `0.0.0.0:8006`. Note this port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+`cluster_telemetry_endpoint` <br>*Required* | The port that the Data Plane uses to send telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
 `cluster_control_plane` <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the `cluster_listen` property on the Control Plane node. Ignored on Control Plane nodes. | DP
 `cluster_mtls` <br>*Optional* | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. Defaults to `"shared"`. See below sections for differences in mTLS modes. | Both
 
@@ -552,7 +552,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 `cluster_cert` and `cluster_cert_key` <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 `cluster_ca_cert` <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 `cluster_server_name` <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-`cluster_telemetry_server_name` |  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+`cluster_telemetry_server_name` |  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next Steps
 

--- a/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.2.x/deployment/hybrid-mode-setup.md
@@ -245,7 +245,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -291,7 +291,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -409,7 +409,7 @@ follow the instructions to:
     extension) to use for Data Plane connections to the Control Plane through
     TLS. When not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
 3. If needed, bring up any subsequent Data Planes using the same settings.
@@ -480,7 +480,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     to use for Data Plane connections to the Control Plane through TLS. When
     not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
 3. Restart Kong for the settings to take effect:
@@ -548,8 +548,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/enterprise/{{page.kong_version}}/property-reference/#role) <br>*Required* | Determines whether the {{site.ee_product_name}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
 [`proxy_listen`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
 [`cluster_control_plane`](/enterprise/{{page.kong_version}}/property-reference/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
 [`cluster_mtls`](/enterprise/{{page.kong_version}}/property-reference/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 [`lua_ssl_trusted_certificate`](/enterprise/{{page.kong_version}}/property-reference/#lua_ssl_trusted_certificate) <br>*Optional* | Comma-separated list of paths to certificate authority files for Lua cosockets in PEM format. | DP
@@ -561,7 +561,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert) and [`cluster_cert_key`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next Steps
 

--- a/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.3.x/deployment/hybrid-mode-setup.md
@@ -245,7 +245,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -291,7 +291,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -409,7 +409,7 @@ follow the instructions to:
     extension) to use for Data Plane connections to the Control Plane through
     TLS. When not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
 3. If needed, bring up any subsequent Data Planes using the same settings.
@@ -480,7 +480,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     to use for Data Plane connections to the Control Plane through TLS. When
     not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
 3. Restart Kong for the settings to take effect:
@@ -548,8 +548,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/enterprise/{{page.kong_version}}/property-reference/#role) <br>*Required* | Determines whether the {{site.ee_product_name}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
 [`proxy_listen`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
 [`cluster_control_plane`](/enterprise/{{page.kong_version}}/property-reference/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
 [`cluster_mtls`](/enterprise/{{page.kong_version}}/property-reference/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 [`lua_ssl_trusted_certificate`](/enterprise/{{page.kong_version}}/property-reference/#lua_ssl_trusted_certificate) <br>*Optional* | Comma-separated list of paths to certificate authority files for Lua cosockets in PEM format. | DP
@@ -561,7 +561,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert) and [`cluster_cert_key`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next Steps
 

--- a/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.4.x/deployment/hybrid-mode-setup.md
@@ -245,7 +245,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -291,7 +291,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -435,7 +435,7 @@ follow the instructions to:
     extension) to use for Data Plane connections to the Control Plane through
     TLS. When not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
 3. If needed, bring up any subsequent Data Planes using the same settings.
@@ -506,7 +506,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     to use for Data Plane connections to the Control Plane through TLS. When
     not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
 3. Restart Kong for the settings to take effect:
@@ -591,8 +591,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/enterprise/{{page.kong_version}}/property-reference/#role) <br>*Required* | Determines whether the {{site.ee_product_name}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
 [`proxy_listen`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
 [`cluster_control_plane`](/enterprise/{{page.kong_version}}/property-reference/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
 [`cluster_mtls`](/enterprise/{{page.kong_version}}/property-reference/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 [`lua_ssl_trusted_certificate`](/enterprise/{{page.kong_version}}/property-reference/#lua_ssl_trusted_certificate) <br>*Optional* | Comma-separated list of paths to certificate authority files for Lua cosockets in PEM format. | DP
@@ -604,7 +604,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert) and [`cluster_cert_key`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next Steps
 

--- a/app/enterprise/2.5.x/deployment/hybrid-mode-setup.md
+++ b/app/enterprise/2.5.x/deployment/hybrid-mode-setup.md
@@ -243,7 +243,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -289,7 +289,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -429,7 +429,7 @@ follow the instructions to:
     extension) to use for Data Plane connections to the Control Plane through
     TLS. When not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
 3. If needed, bring up any subsequent Data Planes using the same settings.
@@ -493,7 +493,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     to use for Data Plane connections to the Control Plane through TLS. When
     not set, Data Plane will use `kong_clustering` as the SNI.
       > **Note:** You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
 3. Restart Kong for the settings to take effect:
@@ -578,8 +578,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/enterprise/{{page.kong_version}}/property-reference/#role) <br>*Required* | Determines whether the {{site.ee_product_name}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
 [`proxy_listen`](/enterprise/{{page.kong_version}}/property-reference/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+[`cluster_telemetry_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`cluster_telemetry_endpoint`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_endpoint) <br>*Required* | The port that the Data Plane uses to send telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
 [`cluster_control_plane`](/enterprise/{{page.kong_version}}/property-reference/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/enterprise/{{page.kong_version}}/property-reference/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
 [`cluster_mtls`](/enterprise/{{page.kong_version}}/property-reference/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 
@@ -590,7 +590,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert) and [`cluster_cert_key`](/enterprise/{{page.kong_version}}/property-reference/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/enterprise/{{page.kong_version}}/property-reference/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/enterprise/{{page.kong_version}}/property-reference/#cluster_telemetry_server_name) |  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next Steps
 

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -253,7 +253,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -299,7 +299,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for Data Plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     Control Plane will need to be accessible by all Data Planes it controls through
     any firewalls you may have in place.
 
@@ -492,13 +492,13 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
     TLS. When not set, Data Plane will use `kong_clustering` as the SNI.
 
     : You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
     `KONG_CLUSTER_TELEMETRY_ENDPOINT`
-    : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
+    : Optional setting, needed for telemetry gathering. Not available in open-source deployments.
 
-2. If needed, bring up any subsequent Data Planes using the same settings.
+1. If needed, bring up any subsequent Data Planes using the same settings.
 
 {% endnavtab %}
 {% navtab Using kong.conf %}
@@ -560,11 +560,11 @@ and follow the instructions in Steps 1 and 2 **only** to download
     not set, Data Plane will use `kong_clustering` as the SNI.
 
     : You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
     `cluster_telemetry_endpoint`
-    : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
+    : Optional setting, needed for telemetry gathering. Not available in open-source deployments.
 
 3. Restart Kong for the settings to take effect:
     ```bash
@@ -649,8 +649,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/gateway/{{page.kong_version}}/reference/configuration/#role) <br>*Required* | Determines whether the {{site.base_gateway}} instance is a Control Plane or a Data Plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the Control Plane will listen for incoming Data Plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
 [`proxy_listen`](/gateway/{{page.kong_version}}/reference/configuration/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on Control Plane nodes. | DP
-[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
-[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the Data Plane uses to send Vitals telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
+[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the Control Plane will listen for Data Plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on Data Plane nodes. | CP
+[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the Data Plane uses to send telemetry data to the Control Plane. Ignored on Control Plane nodes. | DP
 [`cluster_control_plane`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_control_plane) <br>*Required* | Address and port that the Data Plane nodes use to connect to the Control Plane. Must point to the port configured using the [`cluster_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_listen) property on the Control Plane node. Ignored on Control Plane nodes. | DP
 [`cluster_mtls`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_mtls) <br>*Optional* <br><br>**Default:** `"shared"` | One of `"shared"` or `"pki"`. Indicates whether Hybrid Mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 
@@ -661,7 +661,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_cert) and [`cluster_cert_key`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next steps
 

--- a/app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -253,7 +253,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for data plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     control plane will need to be accessible by all data planes it controls through
     any firewalls you may have in place.
 
@@ -299,7 +299,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for data plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     control plane will need to be accessible by all data planes it controls through
     any firewalls you may have in place.
 
@@ -492,11 +492,11 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
     TLS. When not set, data plane will use `kong_clustering` as the SNI.
 
     : You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
     `KONG_CLUSTER_TELEMETRY_ENDPOINT`
-    : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
+    : Optional setting, needed for telemetry gathering. Not available in open-source deployments.
 
     You can also choose to encrypt or disable the data plane configuration
     cache with some additional settings:
@@ -511,7 +511,7 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
     : An optional custom path to the config cache. Not available in open-source
     deployments.
 
-2. If needed, bring up any subsequent data planes using the same settings.
+1. If needed, bring up any subsequent data planes using the same settings.
 
 {% endnavtab %}
 {% navtab Using kong.conf %}
@@ -573,11 +573,11 @@ and follow the instructions in Steps 1 and 2 **only** to download
     not set, data plane will use `kong_clustering` as the SNI.
 
     : You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
     `cluster_telemetry_endpoint`
-    : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
+    : Optional setting, needed for telemetry gathering. Not available in open-source deployments.
 
     You can also choose to encrypt or disable the data plane configuration
     cache with some additional settings:
@@ -675,8 +675,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/gateway/{{page.kong_version}}/reference/configuration/#role) <br>*Required* | Determines whether the {{site.base_gateway}} instance is a control plane or a data plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the control plane will listen for incoming data plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on data plane nodes. | CP
 [`proxy_listen`](/gateway/{{page.kong_version}}/reference/configuration/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on control plane nodes. | DP
-[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the control plane will listen for data plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on data plane nodes. | CP
-[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the data plane uses to send Vitals telemetry data to the control plane. Ignored on control plane nodes. | DP
+[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the control plane will listen for data plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on data plane nodes. | CP
+[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the data plane uses to send telemetry data to the control plane. Ignored on control plane nodes. | DP
 [`cluster_control_plane`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_control_plane) <br>*Required* | Address and port that the data plane nodes use to connect to the control plane. Must point to the port configured using the [`cluster_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_listen) property on the control plane node. Ignored on control plane nodes. | DP
 [`cluster_mtls`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_mtls) <br>*Optional* <br><br>**Default:** `shared` | One of `shared` or `pki`. Indicates whether hybrid mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 [`data_plane_config_cache_mode`](/gateway/{{page.kong_version}}/reference/configuration/#data_plane_config_cache_mode) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `unencrypted` | Determines how the data plane configuration cache is stored. <br> &#8226; `unencrypted`: Stores configuration without encrypting it in `config.cache.json.gz` <br> &#8226; `encrypted`: Encrypts and stores the configuration cache in `.config.cache.jwt` (hidden file). <br> &#8226; `off`: The data plane does not cache configuration | DP
@@ -689,7 +689,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_cert) and [`cluster_cert_key`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next steps
 


### PR DESCRIPTION
### Summary

On Hybrid Mode Setup pages for Gateway 2.1.x and newer, change `Vitals telemetry` to `telemetry`.  

### Reason

Addresses [DOCU-1068](https://konghq.atlassian.net/browse/DOCU-1068)

### Testing

Newest version: https://deploy-preview-3667--kongdocs.netlify.app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup/
