### PR TITLE
decK CLI ref cleanup for 1.11

### DIFF
--- a/app/deck/1.11.x/reference/deck.md
+++ b/app/deck/1.11.x/reference/deck.md
@@ -10,44 +10,44 @@ It can be used to export, import, or sync entities to Kong.
 ## Flags
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-  -h, --help                           help for deck
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+-h, --help                           help for deck
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_completion.md
+++ b/app/deck/1.11.x/reference/deck_completion.md
@@ -71,49 +71,49 @@ Then source this file from your PowerShell profile.
 ## Flags
 
 ```
-  -h, --help   help for completion
+-h, --help   help for completion
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 ## See also

--- a/app/deck/1.11.x/reference/deck_convert.md
+++ b/app/deck/1.11.x/reference/deck_convert.md
@@ -13,53 +13,53 @@ deck convert [flags]
 ## Flags
 
 ```
-      --from string          format of the source file, allowed formats: [kong-gateway]
-  -h, --help                 help for convert
-      --input-file string    configuration file to be converted. Use '-' to read from stdin.
-      --output-file string   file to write configuration to after conversion. Use '-' to write to stdout.
-      --to string            desired format of the output, allowed formats: [konnect]
+    --from string          format of the source file, allowed formats: [kong-gateway]
+-h, --help                 help for convert
+    --input-file string    configuration file to be converted. Use '-' to read from stdin.
+    --output-file string   file to write configuration to after conversion. Use '-' to write to stdout.
+    --to string            desired format of the output, allowed formats: [konnect]
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_diff.md
+++ b/app/deck/1.11.x/reference/deck_diff.md
@@ -16,63 +16,63 @@ deck diff [flags]
 ## Flags
 
 ```
-  -h, --help                  help for diff
-      --non-zero-exit-code    return exit code 2 if there is a diff present,
-                              exit code 0 if no diff is found,
-                              and exit code 1 if an error occurs.
-      --parallelism int       Maximum number of concurrent operations. (default 10)
-      --rbac-resources-only   sync only the RBAC resources (Kong Enterprise only).
-      --select-tag strings    only entities matching tags specified via this flag are diffed.
-                              When this setting has multiple tag values, entities must match each of them.
-      --silence-events        disable printing events to stdout
-      --skip-consumers        do not diff consumers or any plugins associated with consumers
-  -s, --state strings         file(s) containing Kong's configuration.
-                              This flag can be specified multiple times for multiple files.
-                              Use '-' to read from stdin. (default [kong.yaml])
-  -w, --workspace string      Diff configuration with a specific workspace (Kong Enterprise only).
-                              This takes precedence over _workspace fields in state files.
+-h, --help                  help for diff
+    --non-zero-exit-code    return exit code 2 if there is a diff present,
+                            exit code 0 if no diff is found,
+                            and exit code 1 if an error occurs.
+    --parallelism int       Maximum number of concurrent operations. (default 10)
+    --rbac-resources-only   sync only the RBAC resources (Kong Enterprise only).
+    --select-tag strings    only entities matching tags specified via this flag are diffed.
+                            When this setting has multiple tag values, entities must match each of them.
+    --silence-events        disable printing events to stdout
+    --skip-consumers        do not diff consumers or any plugins associated with consumers
+-s, --state strings         file(s) containing Kong's configuration.
+                            This flag can be specified multiple times for multiple files.
+                            Use '-' to read from stdin. (default [kong.yaml])
+-w, --workspace string      Diff configuration with a specific workspace (Kong Enterprise only).
+                            This takes precedence over _workspace fields in state files.
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_dump.md
+++ b/app/deck/1.11.x/reference/deck_dump.md
@@ -15,59 +15,59 @@ deck dump [flags]
 ## Flags
 
 ```
-      --all-workspaces        dump configuration of all Workspaces (Kong Enterprise only).
-      --format string         output file format: json or yaml. (default "yaml")
-  -h, --help                  help for dump
-  -o, --output-file string    file to which to write Kong's configuration.Use '-' to write to stdout. (default "kong")
-      --rbac-resources-only   export only the RBAC resources (Kong Enterprise only).
-      --select-tag strings    only entities matching tags specified with this flag are exported.
-                              When this setting has multiple tag values, entities must match every tag.
-      --skip-consumers        skip exporting consumers and any plugins associated with consumers.
-      --with-id               write ID of all entities in the output
-  -w, --workspace string      dump configuration of a specific Workspace(Kong Enterprise only).
-      --yes                   assume 'yes' to prompts and run non-interactively.
+    --all-workspaces        dump configuration of all Workspaces (Kong Enterprise only).
+    --format string         output file format: json or yaml. (default "yaml")
+-h, --help                  help for dump
+-o, --output-file string    file to which to write Kong's configuration.Use '-' to write to stdout. (default "kong")
+    --rbac-resources-only   export only the RBAC resources (Kong Enterprise only).
+    --select-tag strings    only entities matching tags specified with this flag are exported.
+                            When this setting has multiple tag values, entities must match every tag.
+    --skip-consumers        skip exporting consumers and any plugins associated with consumers.
+    --with-id               write ID of all entities in the output
+-w, --workspace string      dump configuration of a specific Workspace(Kong Enterprise only).
+    --yes                   assume 'yes' to prompts and run non-interactively.
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_konnect.md
+++ b/app/deck/1.11.x/reference/deck_konnect.md
@@ -11,49 +11,49 @@ might have breaking changes in future releases.
 ## Flags
 
 ```
-  -h, --help   help for konnect
+-h, --help   help for konnect
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_konnect_diff.md
+++ b/app/deck/1.11.x/reference/deck_konnect_diff.md
@@ -18,57 +18,57 @@ deck konnect diff [flags]
 ## Flags
 
 ```
-  -h, --help                 help for diff
-      --include-consumers    export consumers, associated credentials and any plugins associated with consumers.
-      --non-zero-exit-code   return exit code 2 if there is a diff present,
-                             exit code 0 if no diff is found,
-                             and exit code 1 if an error occurs.
-      --parallelism int      Maximum number of concurrent operations. (default 100)
-      --silence-events       disable printing events to stdout
-  -s, --state strings        file(s) containing Konnect's configuration.
-                             This flag can be specified multiple times for multiple files. (default [konnect.yaml])
+-h, --help                 help for diff
+    --include-consumers    export consumers, associated credentials and any plugins associated with consumers.
+    --non-zero-exit-code   return exit code 2 if there is a diff present,
+                           exit code 0 if no diff is found,
+                           and exit code 1 if an error occurs.
+    --parallelism int      Maximum number of concurrent operations. (default 100)
+    --silence-events       disable printing events to stdout
+-s, --state strings        file(s) containing Konnect's configuration.
+                           This flag can be specified multiple times for multiple files. (default [konnect.yaml])
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_konnect_dump.md
+++ b/app/deck/1.11.x/reference/deck_konnect_dump.md
@@ -18,55 +18,55 @@ deck konnect dump [flags]
 ## Flags
 
 ```
-      --format string        output file format: json or yaml. (default "yaml")
-  -h, --help                 help for dump
-      --include-consumers    export consumers, associated credentials and any plugins associated with consumers.
-  -o, --output-file string   file to which to write Kong's configuration. (default "konnect")
-      --with-id              write ID of all entities in the output.
-      --yes                  Assume 'yes' to prompts and run non-interactively.
+    --format string        output file format: json or yaml. (default "yaml")
+-h, --help                 help for dump
+    --include-consumers    export consumers, associated credentials and any plugins associated with consumers.
+-o, --output-file string   file to which to write Kong's configuration. (default "konnect")
+    --with-id              write ID of all entities in the output.
+    --yes                  Assume 'yes' to prompts and run non-interactively.
 ```
 
 ## Flags inherited from parent commands
 
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_konnect_ping.md
+++ b/app/deck/1.11.x/reference/deck_konnect_ping.md
@@ -16,49 +16,49 @@ deck konnect ping [flags]
 ## Flags
 
 ```
-  -h, --help   help for ping
+-h, --help   help for ping
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_konnect_sync.md
+++ b/app/deck/1.11.x/reference/deck_konnect_sync.md
@@ -15,54 +15,54 @@ deck konnect sync [flags]
 ## Flags
 
 ```
-  -h, --help                help for sync
-      --include-consumers   export consumers, associated credentials and any plugins associated with consumers.
-      --parallelism int     Maximum number of concurrent operations. (default 100)
-      --silence-events      disable printing events to stdout
-  -s, --state strings       file(s) containing Konnect's configuration.
-                            This flag can be specified multiple times for multiple files. (default [konnect.yaml])
+-h, --help                help for sync
+    --include-consumers   export consumers, associated credentials and any plugins associated with consumers.
+    --parallelism int     Maximum number of concurrent operations. (default 100)
+    --silence-events      disable printing events to stdout
+-s, --state strings       file(s) containing Konnect's configuration.
+                          This flag can be specified multiple times for multiple files. (default [konnect.yaml])
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_ping.md
+++ b/app/deck/1.11.x/reference/deck_ping.md
@@ -12,51 +12,51 @@ deck ping [flags]
 ## Flags
 
 ```
-  -h, --help               help for ping
-  -w, --workspace string   Ping configuration with a specific Workspace (Kong Enterprise only).
-                           Useful when RBAC permissions are scoped to a Workspace.
+-h, --help               help for ping
+-w, --workspace string   Ping configuration with a specific Workspace (Kong Enterprise only).
+                         Useful when RBAC permissions are scoped to a Workspace.
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_reset.md
+++ b/app/deck/1.11.x/reference/deck_reset.md
@@ -16,56 +16,56 @@ deck reset [flags]
 ## Flags
 
 ```
-      --all-workspaces        reset configuration of all workspaces (Kong Enterprise only).
-  -f, --force                 Skip interactive confirmation prompt before reset.
-  -h, --help                  help for reset
-      --rbac-resources-only   reset only the RBAC resources (Kong Enterprise only).
-      --select-tag strings    only entities matching tags specified via this flag are deleted.
-                              When this setting has multiple tag values, entities must match every tag.
-      --skip-consumers        do not reset consumers or any plugins associated with consumers.
-  -w, --workspace string      reset configuration of a specific workspace(Kong Enterprise only).
+    --all-workspaces        reset configuration of all workspaces (Kong Enterprise only).
+-f, --force                 Skip interactive confirmation prompt before reset.
+-h, --help                  help for reset
+    --rbac-resources-only   reset only the RBAC resources (Kong Enterprise only).
+    --select-tag strings    only entities matching tags specified via this flag are deleted.
+                            When this setting has multiple tag values, entities must match every tag.
+    --skip-consumers        do not reset consumers or any plugins associated with consumers.
+-w, --workspace string      reset configuration of a specific workspace(Kong Enterprise only).
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_sync.md
+++ b/app/deck/1.11.x/reference/deck_sync.md
@@ -12,83 +12,63 @@ deck sync [flags]
 ## Flags
 
 ```
-      --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations
-                                          for related entities (usually for Cassandra deployments).
-                                          See 'db_update_propagation' in kong.conf.
-  -h, --help                              help for sync
-      --parallelism int                   Maximum number of concurrent operations. (default 10)
-      --rbac-resources-only               diff only the RBAC resources (Kong Enterprise only).
-      --select-tag strings                only entities matching tags specified via this flag are synced.
-                                          When this setting has multiple tag values, entities must match every tag.
-      --silence-events                    disable printing events to stdout
-      --skip-consumers                    do not sync consumers or any plugins associated with consumers.
-  -s, --state strings                     file(s) containing Kong's configuration.
-                                          This flag can be specified multiple times for multiple files.
-                                          Use '-' to read from stdin. (default [kong.yaml])
-      --workspace string                  Sync configuration to a specific workspace (Kong Enterprise only).
-                                          This takes precedence over _workspace fields in state files.
+    --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations
+                                        for related entities (usually for Cassandra deployments).
+                                        See 'db_update_propagation' in kong.conf.
+-h, --help                              help for sync
+    --parallelism int                   Maximum number of concurrent operations. (default 10)
+    --rbac-resources-only               diff only the RBAC resources (Kong Enterprise only).
+    --select-tag strings                only entities matching tags specified via this flag are synced.
+                                        When this setting has multiple tag values, entities must match every tag.
+    --silence-events                    disable printing events to stdout
+    --skip-consumers                    do not sync consumers or any plugins associated with consumers.
+-s, --state strings                     file(s) containing Kong's configuration.
+                                        This flag can be specified multiple times for multiple files.
+                                        Use '-' to read from stdin. (default [kong.yaml])
+    --workspace string                  Sync configuration to a specific workspace (Kong Enterprise only).
+                                        This takes precedence over _workspace fields in state files.
 ```
 
-## Flags inherited from parent commands
+### Flags inherited from parent commands
 
 ```
-      --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations
-                                          for related entities (usually for Cassandra deployments).
-                                          See 'db_update_propagation' in kong.conf.
-  -h, --help                              help for sync
-      --parallelism int                   Maximum number of concurrent operations. (default 10)
-      --rbac-resources-only               diff only the RBAC resources (Kong Enterprise only).
-      --select-tag strings                only entities matching tags specified via this flag are synced.
-                                          When this setting has multiple tag values, entities must match every tag.
-      --silence-events                    disable printing events to stdout
-      --skip-consumers                    do not sync consumers or any plugins associated with consumers.
-  -s, --state strings                     file(s) containing Kong's configuration.
-                                          This flag can be specified multiple times for multiple files.
-                                          Use '-' to read from stdin. (default [kong.yaml])
-      --workspace string                  Sync configuration to a specific workspace (Kong Enterprise only).
-                                          This takes precedence over _workspace fields in state files.
-```
-
-### Options inherited from parent commands
-
-```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_validate.md
+++ b/app/deck/1.11.x/reference/deck_validate.md
@@ -8,8 +8,8 @@ It reads all the specified state files and reports YAML/JSON
 parsing issues. It also checks for foreign relationships
 and alerts if there are broken relationships, or missing links present.
 
-No communication takes places between decK and Kong during the execution of
-this command unless the `--online` flag is used.
+No communication takes place between decK and Kong Gateway during the execution
+of this command unless the `--online` flag is used.
 
 
 ```
@@ -19,59 +19,59 @@ deck validate [flags]
 ## Flags
 
 ```
-  -h, --help                  help for validate
-      --online                perform validations against Kong API. When this flag is used, validation is done
-                              via communication with Kong. This increases the time for validation but catches
-                              significant errors. No resource is created in Kong.
-      --parallelism int       Maximum number of concurrent requests to Kong. (default 10)
-      --rbac-resources-only   indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).
-  -s, --state strings         file(s) containing Kong's configuration.
-                              This flag can be specified multiple times for multiple files.
-                              Use '-' to read from stdin. (default [kong.yaml])
-  -w, --workspace string      validate configuration of a specific workspace (Kong Enterprise only).
-                              This takes precedence over _workspace fields in state files.
+-h, --help                  help for validate
+    --online                perform validations against Kong API. When this flag is used, validation is done
+                            via communication with Kong. This increases the time for validation but catches
+                            significant errors. No resource is created in Kong.
+    --parallelism int       Maximum number of concurrent requests to Kong. (default 10)
+    --rbac-resources-only   indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).
+-s, --state strings         file(s) containing Kong's configuration.
+                            This flag can be specified multiple times for multiple files.
+                            Use '-' to read from stdin. (default [kong.yaml])
+-w, --workspace string      validate configuration of a specific workspace (Kong Enterprise only).
+                            This takes precedence over _workspace fields in state files.
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 

--- a/app/deck/1.11.x/reference/deck_version.md
+++ b/app/deck/1.11.x/reference/deck_version.md
@@ -12,49 +12,49 @@ deck version [flags]
 ## Flags
 
 ```
-  -h, --help   help for version
+-h, --help   help for version
 ```
 
 ## Flags inherited from parent commands
 
 ```
-      --analytics                      Share anonymized data to help improve decK.
-                                       Use --analytics=false to disable this. (default true)
-      --ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT environment variable.
-                                       This takes precedence over --ca-cert-file flag.
-      --ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_CA_CERT_FILE environment variable.
-      --config string                  Config file (default is $HOME/.deck.yaml).
-      --headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                       This flag can be specified multiple times to inject multiple headers.
-      --kong-addr string               HTTP address of Kong's Admin API.
-                                       This value can also be set using the environment variable DECK_KONG_ADDR
-                                        environment variable. (default "http://localhost:8001")
-      --kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                       You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
-      --konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
-      --konnect-email string           Email address associated with your Konnect account.
-      --konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
-      --konnect-password-file string   File containing the password to your Konnect account.
-      --no-color                       Disable colorized output
-      --skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
-      --timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
-      --tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
-      --tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                       This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
-      --tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                       This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
-      --tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                       This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
-      --tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SERVER_NAME environment variable.
-      --tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                       This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
-      --verbose int                    Enable verbose logging levels
-                                       Setting this value to 2 outputs all HTTP requests/responses
-                                       between decK and Kong.
+--analytics                      Share anonymized data to help improve decK.
+                                 Use --analytics=false to disable this. (default true)
+--ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT environment variable.
+                                 This takes precedence over --ca-cert-file flag.
+--ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
+--config string                  Config file (default is $HOME/.deck.yaml).
+--headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+                                 This flag can be specified multiple times to inject multiple headers.
+--kong-addr string               HTTP address of Kong's Admin API.
+                                 This value can also be set using the environment variable DECK_KONG_ADDR
+                                  environment variable. (default "http://localhost:8001")
+--kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+--konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
+--konnect-email string           Email address associated with your Konnect account.
+--konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
+--konnect-password-file string   File containing the password to your Konnect account.
+--no-color                       Disable colorized output
+--skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
+--timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
+--tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+--tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+--tls-client-key string          PEM-encoded private key for the corresponding client certificate .
+                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+--tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
+                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+--tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+--tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
+                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
+--verbose int                    Enable verbose logging levels
+                                 Setting this value to 2 outputs all HTTP requests/responses
+                                 between decK and Kong.
 ```
 
 


### PR DESCRIPTION
### Summary

- Reduce whitespace at the start of codeblocks
- Remove duplicate section in `deck sync`
- Typo fix

### Reason
Found some errors when prepping release branch.

### Testing
https://deploy-preview-3670--kongdocs.netlify.app/deck/1.11.x/reference/deck/ - able to see more of the codeblock without scrolling. Still not pretty, but this helps for now, until we reformat this content.

https://deploy-preview-3670--kongdocs.netlify.app/deck/1.11.x/reference/deck_sync/ - no more extra section