### PR TITLE
[DOCU-978] Add Hybrid Mode note for Vitals

### DIFF
--- a/app/enterprise/2.1.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.1.x/vitals/vitals-influx-strategy.md
@@ -43,6 +43,11 @@ vitals_strategy = influxdb
 vitals_tsdb_address = 127.0.0.1:8086 # the IP or hostname, and port, of InfluxDB
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 As with other Kong configurations, changes take effect on kong reload or kong
 restart.
 

--- a/app/enterprise/2.1.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.1.x/vitals/vitals-influx-strategy.md
@@ -44,8 +44,8 @@ vitals_tsdb_address = 127.0.0.1:8086 # the IP or hostname, and port, of InfluxDB
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 As with other Kong configurations, changes take effect on kong reload or kong

--- a/app/enterprise/2.1.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.1.x/vitals/vitals-prometheus-strategy.md
@@ -114,6 +114,11 @@ $ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/enterprise/2.1.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.1.x/vitals/vitals-prometheus-strategy.md
@@ -115,8 +115,8 @@ $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that

--- a/app/enterprise/2.2.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.2.x/vitals/vitals-influx-strategy.md
@@ -43,6 +43,11 @@ vitals_strategy = influxdb
 vitals_tsdb_address = 127.0.0.1:8086 # the IP or hostname, and port, of InfluxDB
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 As with other Kong configurations, changes take effect on kong reload or kong
 restart.
 

--- a/app/enterprise/2.2.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.2.x/vitals/vitals-influx-strategy.md
@@ -44,8 +44,8 @@ vitals_tsdb_address = 127.0.0.1:8086 # the IP or hostname, and port, of InfluxDB
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 As with other Kong configurations, changes take effect on kong reload or kong

--- a/app/enterprise/2.2.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.2.x/vitals/vitals-prometheus-strategy.md
@@ -114,6 +114,11 @@ $ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/enterprise/2.2.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.2.x/vitals/vitals-prometheus-strategy.md
@@ -115,8 +115,8 @@ $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that

--- a/app/enterprise/2.3.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.3.x/vitals/vitals-influx-strategy.md
@@ -43,6 +43,11 @@ vitals_strategy = influxdb
 vitals_tsdb_address = 127.0.0.1:8086 # the IP or hostname, and port, of InfluxDB
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 As with other Kong configurations, changes take effect on kong reload or kong
 restart.
 

--- a/app/enterprise/2.3.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.3.x/vitals/vitals-influx-strategy.md
@@ -44,8 +44,8 @@ vitals_tsdb_address = 127.0.0.1:8086 # the IP or hostname, and port, of InfluxDB
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 As with other Kong configurations, changes take effect on kong reload or kong

--- a/app/enterprise/2.3.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.3.x/vitals/vitals-prometheus-strategy.md
@@ -114,6 +114,11 @@ $ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/enterprise/2.3.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.3.x/vitals/vitals-prometheus-strategy.md
@@ -115,8 +115,8 @@ $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that

--- a/app/enterprise/2.4.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.4.x/vitals/vitals-influx-strategy.md
@@ -102,6 +102,11 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 | docker exec -i kong-ee /bin/sh
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 ## Understanding Vitals data using InfluxDB measurements
 
 Kong Vitals records metrics in two InfluxDB measurements:

--- a/app/enterprise/2.4.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.4.x/vitals/vitals-influx-strategy.md
@@ -103,8 +103,8 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 ## Understanding Vitals data using InfluxDB measurements

--- a/app/enterprise/2.4.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.4.x/vitals/vitals-prometheus-strategy.md
@@ -114,6 +114,11 @@ $ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/enterprise/2.4.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.4.x/vitals/vitals-prometheus-strategy.md
@@ -115,8 +115,8 @@ $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that

--- a/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
@@ -102,6 +102,11 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 | docker exec -i kong-ee /bin/sh
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 ## Understanding Vitals data using InfluxDB measurements
 
 Kong Vitals records metrics in two InfluxDB measurements:

--- a/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-influx-strategy.md
@@ -103,8 +103,8 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 ## Understanding Vitals data using InfluxDB measurements

--- a/app/enterprise/2.5.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-prometheus-strategy.md
@@ -114,6 +114,11 @@ $ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/enterprise/2.5.x/vitals/vitals-prometheus-strategy.md
+++ b/app/enterprise/2.5.x/vitals/vitals-prometheus-strategy.md
@@ -115,8 +115,8 @@ $ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/enterprise/{{page.kong_version}}/property-reference/#vitals_strategy) 
+and [`vitals_tsdb_address`](/enterprise/{{page.kong_version}}/property-reference/#vitals_tsdb_address) 
 on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that

--- a/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
@@ -155,7 +155,9 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
 
 ## Understanding Vitals data using InfluxDB measurements
 

--- a/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
@@ -154,6 +154,9 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 | docker exec -i kong-ee /bin/sh
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+
 ## Understanding Vitals data using InfluxDB measurements
 
 Kong Vitals records metrics in two InfluxDB measurements:

--- a/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
@@ -161,7 +161,9 @@ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.

--- a/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-prometheus-strategy.md
@@ -160,6 +160,9 @@ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
@@ -153,6 +153,9 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 | docker exec -i kong-ee /bin/sh
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+
 ## Understanding Vitals data using InfluxDB measurements
 
 Kong Vitals records metrics in two InfluxDB measurements:

--- a/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
@@ -154,7 +154,9 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
 
 ## Understanding Vitals data using InfluxDB measurements
 

--- a/app/gateway/2.7.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-prometheus-strategy.md
@@ -159,6 +159,9 @@ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 

--- a/app/gateway/2.7.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-prometheus-strategy.md
@@ -160,7 +160,9 @@ export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes.
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
 
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.

--- a/app/gateway/2.8.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.8.x/vitals/vitals-influx-strategy.md
@@ -153,6 +153,11 @@ $ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kon
 | docker exec -i kong-ee /bin/sh
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 ## Understanding Vitals data using InfluxDB measurements
 
 Kong Vitals records metrics in two InfluxDB measurements:

--- a/app/gateway/2.8.x/vitals/vitals-prometheus-strategy.md
+++ b/app/gateway/2.8.x/vitals/vitals-prometheus-strategy.md
@@ -159,6 +159,11 @@ export KONG_VITALS_STATSD_ADDRESS=statsd-node:9125
 export KONG_VITALS_TSDB_ADDRESS=prometheus-node:9090
 ```
 
+{:.note}
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+on both the control plane and all data planes.
+
 Please update `statsd-node` and `prometheus-node` with the actual hostname that
 runs StatsD exporter and Prometheus.
 


### PR DESCRIPTION
### Summary

Add note on InfluxDB and Prometheus that on Hybrid Mode, you need to configure `vitals_strategy` and `vitals_tsdb_address` on both the Control Plane and all Data Planes. Added to 2.6.x and 2.7.x

### Reason

Addresses [DOCU-978](https://konghq.atlassian.net/browse/DOCU-978)

### Testing

https://deploy-preview-3671--kongdocs.netlify.app/gateway/2.7.x/vitals/vitals-prometheus-strategy/#enable-vitals-with-prometheus-strategy-in-kong
https://deploy-preview-3671--kongdocs.netlify.app//gateway/2.7.x/vitals/vitals-influx-strategy/#configure-kong-gateway