### PR TITLE
[DOCU-2187] Add config.canary_by_header_name to canary plugin

### DIFF
--- a/app/_data/extensions/kong-inc/canary/versions.yml
+++ b/app/_data/extensions/kong-inc/canary/versions.yml
@@ -1,3 +1,4 @@
+- release: 0.6.x
 - release: 0.5.x
 - release: 0.4.x
 - release: 0.3.x

--- a/app/_hub/kong-inc/canary/0.5.x.md
+++ b/app/_hub/kong-inc/canary/0.5.x.md
@@ -1,7 +1,7 @@
 ---
 name: Canary Release
 publisher: Kong Inc.
-version: 0.6.x
+version: 0.5.x
 desc: Slowly roll out software changes to a subset of users
 description: |
   Reduce the risk of introducing a new software version in production by slowly
@@ -14,7 +14,6 @@ categories:
 kong_version_compatibility:
   enterprise_edition:
     compatible:
-      - 2.8.x
       - 2.7.x
       - 2.6.x
       - 2.5.x
@@ -116,13 +115,6 @@ params:
       datatype: string
       description: |
         Header name whose value will be used as hash input. Required if `config.hash` is set to `header`.
-    - name: canary_by_header_name
-      required: null
-      default: null
-      value_in_examples: null
-      datatype: string
-      description: |
-        Header name that, when present on a request, will override the configured canary functionality. If the configured header is present with the value `always` then the request will always go to the canary upstream. If the header is present with the value `never` then the request will never go to the canary upstream. For all other values, the configured canary rules will be applied.
 ---
 
 ### Usage
@@ -174,13 +166,6 @@ _Service A_ and _Service B_ on consecutive requests.
 
 Canary provides an automatic fallback if, for some reason, a Consumer, Header, or IP can
 not be identified. The fallback order is `consumer`->`ip`->`none`.
-
-### Overriding the Canary
-
-In some cases, it may be desirable to allow clients to pick _Service A_ or _Service B_
-instead of applying the configured canary rules. By setting the `config.canary_by_header_name`,
-clients can send the value `always` to always use the canary service (_Service B_) or send the
-value `never` to never use the canary service (always use _Service A_).
 
 ### Finalizing the Canary
 

--- a/app/_hub/kong-inc/canary/index.md
+++ b/app/_hub/kong-inc/canary/index.md
@@ -122,7 +122,15 @@ params:
       value_in_examples: null
       datatype: string
       description: |
-        Header name that, when present on a request, will override the configured canary functionality. If the configured header is present with the value `always` then the request will always go to the canary upstream. If the header is present with the value `never` then the request will never go to the canary upstream. For all other values, the configured canary rules will be applied.
+        Header name that, when present on a request, overrides the configured canary 
+        functionality. 
+        
+        * If the configured header is present with the value `always`, the request will 
+        always go to the canary upstream. 
+        * If the header is present with the value `never`, the request will never go to the 
+        canary upstream. 
+        
+        For all other values, the configured canary rules will be applied.
 ---
 
 ### Usage
@@ -177,7 +185,7 @@ not be identified. The fallback order is `consumer`->`ip`->`none`.
 
 ### Overriding the Canary
 
-In some cases, it may be desirable to allow clients to pick _Service A_ or _Service B_
+In some cases, you may want to allow clients to pick _Service A_ or _Service B_
 instead of applying the configured canary rules. By setting the `config.canary_by_header_name`,
 clients can send the value `always` to always use the canary service (_Service B_) or send the
 value `never` to never use the canary service (always use _Service A_).

--- a/app/_hub/kong-inc/canary/index.md
+++ b/app/_hub/kong-inc/canary/index.md
@@ -15,16 +15,6 @@ kong_version_compatibility:
   enterprise_edition:
     compatible:
       - 2.8.x
-      - 2.7.x
-      - 2.6.x
-      - 2.5.x
-      - 2.4.x
-      - 2.3.x
-      - 2.2.x
-      - 2.1.x
-      - 1.5.x
-      - 1.3-x
-      - 0.36-x
 params:
   name: canary
   service_id: true
@@ -219,3 +209,11 @@ target. For this configuration to take effect, the following conditions must be 
  enabled in the canary upstream, i.e., the upstream specified in `upstream_host`
  needs to have healthchecks enabled it. It works with both passive and active
  healthchecks.
+
+---
+
+## Changelog
+
+### Kong Gateway 2.8.x (plugin version 0.6.0)
+
+* Added the `canary_by_header_name` configuration parameter.


### PR DESCRIPTION
### Summary
Add documentation for new config.canary_by_header_name for canary plugin

### Reason
Addresses DOCU-2187

### Testing
