### PR TITLE
[DOCU-385] Dev Portal styling doesn't carry over

### DIFF
--- a/app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -12,6 +12,9 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 
 ## The Appearance Tab
 
+{:.note}
+> **Note**: Styling does not automatically carry over from the default Dev Portal to different Dev Portals in other Workspaces. Use the [Dev Portal CLI](/gateway/latest/developer-portal/helpers/cli) to manually copy templates to Workspaces where you want to duplicate the styling.
+
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 

--- a/app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -13,7 +13,7 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 ## The Appearance Tab
 
 {:.note}
-> **Note**: Styling does not automatically carry over from the default Dev Portal to different Dev Portals in other Workspaces. Use the [Dev Portal CLI](/gateway/latest/developer-portal/helpers/cli) to manually copy templates to Workspaces where you want to duplicate the styling.
+> **Note**: Styling does not automatically carry over from the default Dev Portal to different Dev Portals in other workspaces. Use the [Dev Portal CLI](/gateway/latest/developer-portal/helpers/cli) to manually copy templates to workspaces where you want to duplicate the styling.
 
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.


### PR DESCRIPTION
### Summary

Add a note that on-prem Dev Portal doesn't carry over between default Dev Portal and other Workspaces.

### Reason

Addresses [DOCU-385](https://konghq.atlassian.net/browse/DOCU-385)

### Testing

https://deploy-preview-3675--kongdocs.netlify.app/gateway/2.7.x/developer-portal/theme-customization/easy-theme-editing/#the-appearance-tab