### PR TITLE
[DOCU-1848] Clarify wording in Kong Manager

### DIFF
--- a/app/enterprise/2.1.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.1.x/kong-manager/administration/workspaces/add-workspace.md
@@ -42,25 +42,27 @@ Name the new **Workspace**.
 
 ![Name the New Workspace](https://konghq.com/wp-content/uploads/2018/11/km-name-ws.png)
 
-⚠️ **WARNING**: Each **Workspace** name should be unique,
+{:.important}
+> **Warning**: Each **Workspace** name should be unique,
 regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+{:.important}
+> **Warning**: Do not name workspaces the same as these major API names (paths) 
 in Admin API:
-
-* Admins
-* APIs
-* Certificates
-* Consumers
-* Plugins
-* Portal
-* Routes
-* Services
-* SNIs
-* Upstreams
-* Vitals
+>
+> * Admins
+> * APIs
+> * Certificates
+> * Consumers
+> * Plugins
+> * Portal
+> * Routes
+> * Services
+> * SNIs
+> * Upstreams
+> * Vitals
 
 ## Step 3
 

--- a/app/enterprise/2.1.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.1.x/kong-manager/administration/workspaces/add-workspace.md
@@ -47,8 +47,8 @@ regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major
-routes in Kong Manager:
+⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+in Admin API:
 
 * Admins
 * APIs

--- a/app/enterprise/2.2.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.2.x/kong-manager/administration/workspaces/add-workspace.md
@@ -42,25 +42,27 @@ Name the new **Workspace**.
 
 ![Name the New Workspace](https://konghq.com/wp-content/uploads/2018/11/km-name-ws.png)
 
-⚠️ **WARNING**: Each **Workspace** name should be unique,
+{:.important}
+> **Warning**: Each **Workspace** name should be unique,
 regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+{:.important}
+> **Warning**: Do not name workspaces the same as these major API names (paths) 
 in Admin API:
-
-* Admins
-* APIs
-* Certificates
-* Consumers
-* Plugins
-* Portal
-* Routes
-* Services
-* SNIs
-* Upstreams
-* Vitals
+>
+> * Admins
+> * APIs
+> * Certificates
+> * Consumers
+> * Plugins
+> * Portal
+> * Routes
+> * Services
+> * SNIs
+> * Upstreams
+> * Vitals
 
 ## Step 3
 

--- a/app/enterprise/2.2.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.2.x/kong-manager/administration/workspaces/add-workspace.md
@@ -47,8 +47,8 @@ regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major
-routes in Kong Manager:
+⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+in Admin API:
 
 * Admins
 * APIs

--- a/app/enterprise/2.3.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.3.x/kong-manager/administration/workspaces/add-workspace.md
@@ -42,25 +42,27 @@ Name the new **Workspace**.
 
 ![Name the New Workspace](https://konghq.com/wp-content/uploads/2018/11/km-name-ws.png)
 
-⚠️ **WARNING**: Each **Workspace** name should be unique,
+{:.important}
+> **Warning**: Each **Workspace** name should be unique,
 regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+{:.important}
+> **Warning**: Do not name workspaces the same as these major API names (paths) 
 in Admin API:
-
-* Admins
-* APIs
-* Certificates
-* Consumers
-* Plugins
-* Portal
-* Routes
-* Services
-* SNIs
-* Upstreams
-* Vitals
+>
+> * Admins
+> * APIs
+> * Certificates
+> * Consumers
+> * Plugins
+> * Portal
+> * Routes
+> * Services
+> * SNIs
+> * Upstreams
+> * Vitals
 
 ## Step 3
 

--- a/app/enterprise/2.3.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.3.x/kong-manager/administration/workspaces/add-workspace.md
@@ -47,8 +47,8 @@ regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major
-routes in Kong Manager:
+⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+in Admin API:
 
 * Admins
 * APIs

--- a/app/enterprise/2.4.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.4.x/kong-manager/administration/workspaces/add-workspace.md
@@ -42,25 +42,27 @@ Name the new **Workspace**.
 
 ![Name the New Workspace](https://konghq.com/wp-content/uploads/2018/11/km-name-ws.png)
 
-⚠️ **WARNING**: Each **Workspace** name should be unique,
+{:.important}
+> **Warning**: Each **Workspace** name should be unique,
 regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+{:.important}
+> **Warning**: Do not name workspaces the same as these major API names (paths) 
 in Admin API:
-
-* Admins
-* APIs
-* Certificates
-* Consumers
-* Plugins
-* Portal
-* Routes
-* Services
-* SNIs
-* Upstreams
-* Vitals
+>
+> * Admins
+> * APIs
+> * Certificates
+> * Consumers
+> * Plugins
+> * Portal
+> * Routes
+> * Services
+> * SNIs
+> * Upstreams
+> * Vitals
 
 ## Step 3
 

--- a/app/enterprise/2.4.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.4.x/kong-manager/administration/workspaces/add-workspace.md
@@ -47,8 +47,8 @@ regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major
-routes in Kong Manager:
+⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+in Admin API:
 
 * Admins
 * APIs

--- a/app/enterprise/2.5.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.5.x/kong-manager/administration/workspaces/add-workspace.md
@@ -42,25 +42,27 @@ Name the new **Workspace**.
 
 ![Name the New Workspace](https://konghq.com/wp-content/uploads/2018/11/km-name-ws.png)
 
-⚠️ **WARNING**: Each **Workspace** name should be unique,
+{:.important}
+> **Warning**: Each **Workspace** name should be unique,
 regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+{:.important}
+> **Warning**: Do not name workspaces the same as these major API names (paths) 
 in Admin API:
-
-* Admins
-* APIs
-* Certificates
-* Consumers
-* Plugins
-* Portal
-* Routes
-* Services
-* SNIs
-* Upstreams
-* Vitals
+>
+> * Admins
+> * APIs
+> * Certificates
+> * Consumers
+> * Plugins
+> * Portal
+> * Routes
+> * Services
+> * SNIs
+> * Upstreams
+> * Vitals
 
 ## Step 3
 

--- a/app/enterprise/2.5.x/kong-manager/administration/workspaces/add-workspace.md
+++ b/app/enterprise/2.5.x/kong-manager/administration/workspaces/add-workspace.md
@@ -47,8 +47,8 @@ regardless of letter case. For example, naming one
 **Workspace** "Payments" and another one "payments" will
 create two different workspaces that appear identical.
 
-⚠️ **WARNING**: Do not name Workspaces the same as these major
-routes in Kong Manager:
+⚠️ **WARNING**: Do not name Workspaces the same as these major API names (paths) 
+in Admin API:
 
 * Admins
 * APIs

--- a/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/workspaces.md
@@ -52,8 +52,8 @@ color / icon for the new Workspace.
     **Workspace** "Payments" and another one "payments" will
     create two different workspaces that appear identical.
 
-    Do not name Workspaces the same as these major routes in Kong
-    Manager:
+    Do not name Workspaces the same as these major API names (paths) 
+    in Admin API:
 
     ```
     • Admins

--- a/app/gateway/2.7.x/configure/auth/kong-manager/workspaces.md
+++ b/app/gateway/2.7.x/configure/auth/kong-manager/workspaces.md
@@ -52,8 +52,8 @@ color / icon for the new Workspace.
     **Workspace** "Payments" and another one "payments" will
     create two different workspaces that appear identical.
 
-    Do not name Workspaces the same as these major routes in Kong
-    Manager:
+    Do not name Workspaces the same as these major API names (paths) 
+    in Admin API:
 
     ```
     • Admins


### PR DESCRIPTION
### Summary

Replace wording about Workspace naming in Kong Manager doc

### Reason

Addresses [DOCU-1848](https://konghq.atlassian.net/browse/DOCU-1848)

### Testing

On 2.7.x: https://deploy-preview-3676--kongdocs.netlify.app/gateway/2.7.x/configure/auth/kong-manager/workspaces/#creating-new-workspaces
