### PR TITLE
[DOCU-885] Add missing status_listen

### DIFF
--- a/app/enterprise/1.5.x/property-reference.md
+++ b/app/enterprise/1.5.x/property-reference.md
@@ -248,6 +248,22 @@ the Admin interface for this node, enabling a
 capabilities) pulling its configuration changes
 from the database.
 
+### status_listen
+
+**Default:** `off`
+
+**Description:**
+
+Comma-separated list of addresses and ports on which the Status API should
+listen.
+
+The Status API is a read-only endpoint allowing monitoring tools to retrieve
+metrics, healthiness, and other non-sensitive information of the current Kong
+node.
+
+This value can be set to `off`, disabling the Status API for this node.
+
+**Example:** `status_listen = 0.0.0.0:8100`
 
 ### nginx_user
 

--- a/app/enterprise/2.1.x/property-reference.md
+++ b/app/enterprise/2.1.x/property-reference.md
@@ -876,6 +876,23 @@ The Status API is a read-only endpoint allowing monitoring tools to retrieve
 metrics, healthiness, and other non-sensitive information of the current Kong
 node.
 
+This value can be set to `off`, disabling the Status API for this node.
+
+Example: `status_listen = 0.0.0.0:8100`
+
+**Default:** `off`
+
+---
+
+#### status_listen
+
+Comma-separated list of addresses and ports on which the Status API should
+listen.
+
+The Status API is a read-only endpoint allowing monitoring tools to retrieve
+metrics, healthiness, and other non-sensitive information of the current Kong
+node.
+
 The following suffix can be specified for each pair:
 
 - `ssl` will require that all connections made through a particular


### PR DESCRIPTION
### Summary

Add missing `status_listen` to 1.5.x and 2.1.x. Checked elsewhere. 

### Reason

Addresses [DOCU-885](https://konghq.atlassian.net/browse/DOCU-885)

### Testing

** Note that I matched that page's styling, so these two records look different.

https://deploy-preview-3677--kongdocs.netlify.app/enterprise/1.5.x/property-reference/#status_listen
https://deploy-preview-3677--kongdocs.netlify.app/enterprise/2.1.x/property-reference/#status_listen
