### PR TITLE
Related to DOCU-2140 Admin API rm cannot del/mod

### DIFF
--- a/app/enterprise/2.2.x/admin-api/index.md
+++ b/app/enterprise/2.2.x/admin-api/index.md
@@ -2833,8 +2833,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added. Changes are effectuated on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/enterprise/2.3.x/admin-api/index.md
+++ b/app/enterprise/2.3.x/admin-api/index.md
@@ -2833,8 +2833,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added. Changes are effectuated on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/enterprise/2.4.x/admin-api/index.md
+++ b/app/enterprise/2.4.x/admin-api/index.md
@@ -3095,8 +3095,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added. Changes are effectuated on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/enterprise/2.5.x/admin-api/index.md
+++ b/app/enterprise/2.5.x/admin-api/index.md
@@ -3105,8 +3105,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added. Changes are effectuated on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/gateway-oss/2.2.x/admin-api.md
+++ b/app/gateway-oss/2.2.x/admin-api.md
@@ -3476,8 +3476,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added. Changes are effectuated on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/gateway-oss/2.3.x/admin-api.md
+++ b/app/gateway-oss/2.3.x/admin-api.md
@@ -3484,8 +3484,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added, modified, or deleted. Changes take effect on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/gateway-oss/2.4.x/admin-api.md
+++ b/app/gateway-oss/2.4.x/admin-api.md
@@ -3785,8 +3785,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added, modified, or deleted. Changes take effect on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/gateway-oss/2.5.x/admin-api.md
+++ b/app/gateway-oss/2.5.x/admin-api.md
@@ -3797,8 +3797,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added, modified, or deleted. Changes take effect on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.

--- a/app/gateway/2.6.x/admin-api/index.md
+++ b/app/gateway/2.6.x/admin-api/index.md
@@ -3850,8 +3850,7 @@ A target is an ip address/hostname with a port that identifies an instance of a 
 service. Every upstream can have many targets, and the targets can be
 dynamically added, modified, or deleted. Changes take effect on the fly.
 
-Because the upstream maintains a history of target changes, the targets cannot
-be deleted or modified. To disable a target, post a new one with `weight=0`;
+To disable a target, post a new one with `weight=0`;
 alternatively, use the `DELETE` convenience method to accomplish the same.
 
 The current target object definition is the one with the latest `created_at`.


### PR DESCRIPTION
### Summary

Removes cannot delete or modify wording for older docs versions on combined, Enterprise, and OSS. 

Applied to 2.2.x and newer.

### Reason

See related https://github.com/Kong/docs.konghq.com/pull/3663

### Testing

Example on 2.2.x: https://deploy-preview-3681--kongdocs.netlify.app/enterprise/2.2.x/admin-api/#target-object
