### PR TITLE
[DOCU-493] response trans adv plugin: missing params

### DIFF
--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -54,10 +54,6 @@ params:
   konnect_examples: false
   dbless_compatible: 'yes'
   config:
-    - name: tags
-      required: false
-      datatype: array of string elements
-      description: Set of strings for grouping and filtering.
     - name: remove.headers
       required: false
       value_in_examples:
@@ -87,7 +83,7 @@ params:
     - name: rename.if_status
       required: false
       datatype: array of string elements
-      description: List of `500:Internal Server Error` response status code pairs, where the value will rename the status code description.
+      description: List of response status codes or status code ranges to which the transformation will apply. Empty means all response codes.
     - name: replace.headers
       required: false
       datatype: array of string elements

--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -54,6 +54,10 @@ params:
   konnect_examples: false
   dbless_compatible: 'yes'
   config:
+    - name: tags
+      required: false
+      datatype: array of string elements
+      description: Set of strings for grouping and filtering.
     - name: remove.headers
       required: false
       value_in_examples:
@@ -80,6 +84,10 @@ params:
       required: false
       datatype: array of string elements
       description: 'List of `headername1:headername2` pairs. If a header with `headername1` exists and `headername2` is valid, rename header to `headername2`.'
+    - name: rename.if_status
+      required: false
+      datatype: array of string elements
+      description: List of `500:Internal Server Error` response status code pairs, where the value will rename the status code description.
     - name: replace.headers
       required: false
       datatype: array of string elements


### PR DESCRIPTION
### Summary

Add missing parameters to Response Transformed Advanced plugin.

### Reason

Addresses [DOCU-493](https://konghq.atlassian.net/browse/DOCU-493)

### Testing

Requires an engineer to ensure the definition for `config.rename.if_status` is accurate. **EDIT**: Shane provided a correction and I've incorporated it. I've also removed `tags`.

https://deploy-preview-3682--kongdocs.netlify.app/hub/kong-inc/response-transformer-advanced/#parameters