### PR TITLE
Changelogs and version fixes for 2.8 plugins

### DIFF
--- a/app/_data/extensions/kong-inc/graphql-rate-limiting-advanced/versions.yml
+++ b/app/_data/extensions/kong-inc/graphql-rate-limiting-advanced/versions.yml
@@ -1,2 +1,2 @@
-- release: 2.3.x
-- release: 1.3.x
+- release: 0.2.x
+- release: 0.1.x

--- a/app/_data/extensions/kong-inc/proxy-cache-advanced/versions.yml
+++ b/app/_data/extensions/kong-inc/proxy-cache-advanced/versions.yml
@@ -1,2 +1,2 @@
-- release: 2.2.x
-- release: 1.3-x
+- release: 0.5.x
+- release: 0.4.x

--- a/app/_data/extensions/kong-inc/response-ratelimiting/versions.yml
+++ b/app/_data/extensions/kong-inc/response-ratelimiting/versions.yml
@@ -1,2 +1,2 @@
-- release: 1.0-x
-- release: 0.1-x
+- release: 2.0.x
+- release: 1.0.x

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/0.1.x.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/0.1.x.md
@@ -2,7 +2,7 @@
 
 name: GraphQL Rate Limiting Advanced
 publisher: Kong Inc.
-version: 1.3-x
+version: 0.1.x
 
 desc: Provide rate limiting for GraphQL queries
 description: |
@@ -18,10 +18,6 @@ categories:
 kong_version_compatibility:
     enterprise_edition:
       compatible:
-        - 2.3.x
-        - 2.2.x
-        - 2.1.x
-        - 1.5.x
         - 1.3-x
 
 params:

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -1,7 +1,7 @@
 ---
 name: GraphQL Rate Limiting Advanced
 publisher: Kong Inc.
-version: 2.3.x
+version: 0.2.x
 desc: Provide rate limiting for GraphQL queries
 description: |
   The GraphQL Rate Limiting Advanced plugin provides rate limiting for GraphQL queries. The
@@ -23,7 +23,6 @@ kong_version_compatibility:
       - 2.2.x
       - 2.1.x
       - 1.5.x
-      - 1.3-x
 params:
   name: graphql-rate-limiting-advanced
   service_id: true
@@ -647,3 +646,14 @@ To update `score_factor`:
 $ curl -i -X PATCH http://kong:8001/plugins/{plugin_id} \
   --data config.score_factor=1
 ```
+
+---
+
+## Changelog
+
+### Kong Gateway 2.8.x (plugin version 0.2.5)
+
+* Added the `redis.username` and `redis.sentinel_username` configuration parameters.
+* Fixed plugin versions in the documentation. Previously, the plugin versions
+were labelled as `1.3-x` and `2.3.x`. They are now updated to align with the
+plugin's actual versions, `0.1.x` and `0.2.x`.

--- a/app/_hub/kong-inc/openid-connect/index.md
+++ b/app/_hub/kong-inc/openid-connect/index.md
@@ -1525,7 +1525,7 @@ params:
       default: false
       datatype: boolean
       description: |
-        Distributed claims are represented by the `_claim_names` and `_claim_sources` members 
+        Distributed claims are represented by the `_claim_names` and `_claim_sources` members
         of the JSON object containing the claims.
         If this parameter is set to `true`, the plugin explicitly resolves these distributed claims.
 
@@ -3352,7 +3352,18 @@ mean other gateways, load balancers, NATs, and such in front of Kong. If there i
 
 ## Changelog
 
-### 2.2.0
+### Kong Gateway 2.8.x (plugin version 2.2.1)
+
+* Added the `session_redis_username` and `session_redis_password` configuration
+parameters.
+
+    {:.important}
+    > These parameters replace the `session_redis_auth` field, which is
+    now **deprecated** and planned to be removed in 3.x.x.
+
+* Added the `resolve_distributed_claims` configuration parameter.
+
+### Kong Gateway 2.7.x (plugin version 2.2.0)
 
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled,
  the `config.client_id`, `config.client_secret`, `config.session_auth`, and

--- a/app/_hub/kong-inc/proxy-cache-advanced/0.4.x.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/0.4.x.md
@@ -2,7 +2,7 @@
 
 name: Proxy Caching Advanced
 publisher: Kong Inc.
-version: 1.3-x
+version: 0.4.x
 
 desc: Cache and serve commonly requested responses in Kong
 description: |
@@ -18,9 +18,6 @@ kong_version_compatibility:
       compatible:
     enterprise_edition:
       compatible:
-        - 2.1.x
-        - 1.5.x
-        - 1.3-x
         - 0.36-x
         - 0.35-x
         - 0.34-x

--- a/app/_hub/kong-inc/proxy-cache-advanced/index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/index.md
@@ -1,7 +1,7 @@
 ---
 name: Proxy Caching Advanced
 publisher: Kong Inc.
-version: 2.2.x
+version: 0.5.x
 desc: Cache and serve commonly requested responses in Kong
 description: |
   This plugin provides a reverse proxy cache implementation for Kong. It caches
@@ -29,9 +29,7 @@ kong_version_compatibility:
       - 2.1.x
       - 1.5.x
       - 1.3-x
-      - 0.36-x
-      - 0.35-x
-      - 0.34-x
+
 params:
   name: proxy-cache-advanced
   service_id: true
@@ -411,3 +409,15 @@ HTTP 204 No Content
 ```
 
 Note that this endpoint purges all cache entities across all `proxy-cache-advanced` plugins.
+
+---
+
+## Changelog
+
+### Kong Gateway 2.8.x (plugin version 0.5.7)
+
+* Added the `redis.sentinel_username` and `redis.sentinel_password` configuration
+parameters.
+* Fixed plugin versions in the documentation. Previously, the plugin versions
+were labelled as `1.3-x` and `2.2.x`. They are now updated to align with the
+plugin's actual versions, `0.4.x` and `0.5.x`.

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -438,6 +438,10 @@ decK. If you have consumer groups in your configuration, decK will ignore them.
 
 ## Changelog
 
-### Kong Gateway 2.7.x
+### Kong Gateway 2.8.x (plugin version 1.6.1)
 
-* Added `enforce_consumer_groups` and `consumer_groups` fields.
+* Added the `redis.username` and `redis.sentinel_username` configuration parameters.
+
+### Kong Gateway 2.7.x (plugin version 1.6.0)
+
+* Added the `enforce_consumer_groups` and `consumer_groups` configuration parameters.

--- a/app/_hub/kong-inc/rate-limiting/index.md
+++ b/app/_hub/kong-inc/rate-limiting/index.md
@@ -263,9 +263,13 @@ selected header was not sent by the client or the configured service was not fou
 
 ## Changelog
 
-### 2.3.0
+### Kong Gateway 2.8.x (plugin version 2.3.1)
 
-* Added parameters `redis_ssl`, `redis_ssl_verify`, and `redis_server_name`.
+* Added the `redis_username` configuration parameter.
+
+### Kong Gateway 2.7.x (plugin version 2.3.0)
+
+* Added the `redis_ssl`, `redis_ssl_verify`, and `redis_server_name` configuration parameters.
 
 [api-object]: /gateway/latest/admin-api/#api-object
 [configuration]: /gateway/latest/reference/configuration

--- a/app/_hub/kong-inc/response-ratelimiting/1.0.x.md
+++ b/app/_hub/kong-inc/response-ratelimiting/1.0.x.md
@@ -1,7 +1,7 @@
 ---
 name: Response Rate Limiting
 publisher: Kong Inc.
-version: 0.1-x
+version: 1.0.x
 
 desc: Rate-limiting based on a custom response header value
 description: |
@@ -167,4 +167,3 @@ X-RateLimit-Remaining-Images: 0
 [api-object]: /gateway/latest/admin-api/#api-object
 [configuration]: /gateway/latest/reference/configuration
 [consumer-object]: /gateway/latest/admin-api/#consumer-object
-

--- a/app/_hub/kong-inc/response-ratelimiting/index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/index.md
@@ -1,7 +1,7 @@
 ---
 name: Response Rate Limiting
 publisher: Kong Inc.
-version: 1.0.0
+version: 2.0.x
 desc: Rate-limiting based on a custom response header value
 description: |
   This plugin allows you to limit the number of requests a developer can make
@@ -34,16 +34,6 @@ kong_version_compatibility:
       - 1.2.x
       - 1.1.x
       - 1.0.x
-      - 0.14.x
-      - 0.13.x
-      - 0.12.x
-      - 0.11.x
-      - 0.10.x
-      - 0.9.x
-      - 0.8.x
-      - 0.7.x
-      - 0.6.x
-      - 0.5.x
   enterprise_edition:
     compatible:
       - 2.7.x
@@ -238,3 +228,13 @@ X-RateLimit-Remaining-Images: 0
 
 [configuration]: /gateway/latest/reference/configuration
 [consumer-object]: /gateway/latest/admin-api/#consumer-object
+
+---
+## Changelog
+
+### Kong Gateway 2.8.x (plugin version 2.0.1)
+
+* Added the `redis_username` configuration parameter.
+* Fixed plugin versions in the documentation. Previously, the plugin versions
+were labelled as `0.1-x` and `1.0-x`. They are now updated to align with the
+plugin's actual versions, `1.0.x` and `2.0.x`.


### PR DESCRIPTION
### Summary
* Create changelog entries for plugins edited in https://github.com/Kong/docs.konghq.com/pull/3540 and https://github.com/Kong/docs.konghq.com/pull/3553.
* Out of the plugins I added changelogs to, also fixed versions for `proxy-cache-advanced`, `graphql-rate-limiting-advanced`, and `response-ratelimiting` plugins. These versions were not following the actual plugin versions, and they weren't following Kong Gateway versions either, so the versions were basically made up. If I left them as-is, the changelog entries would've only made things more confusing.
  * Added changelog entries to call out the doc changes as well, in case a user notices the version changes.

### Reason
Missing plugin changelog entries.

### Testing

To find the correct plugin versions to set, I went digging in the old plugin repositories and compared their version bumps to doc release dates.

Previews:

- [OIDC](https://deploy-preview-3683--kongdocs.netlify.app/hub/kong-inc/openid-connect/#changelog)
- [GraphQL rate limiting adv](https://deploy-preview-3683--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/#changelog)
  -   Also check version dropdown
- [Proxy cache adv](https://deploy-preview-3683--kongdocs.netlify.app/hub/kong-inc/proxy-cache-advanced/#changelog)
  -  Also check version dropdown
- [Rate limiting adv](https://deploy-preview-3683--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/#changelog)
- [Rate limiting](https://deploy-preview-3683--kongdocs.netlify.app/hub/kong-inc/rate-limiting/#changelog)
- [Response rate limiting](https://deploy-preview-3683--kongdocs.netlify.app/hub/kong-inc/response-ratelimiting/#changelog)
  -  Also check version dropdown
