### PR TITLE
[DOCU-1618] RM deprecated Target endpoints

### DIFF
--- a/app/enterprise/2.1.x/admin-api/index.md
+++ b/app/enterprise/2.1.x/admin-api/index.md
@@ -2595,15 +2595,46 @@ HTTP 200 OK
 
 ### Retrieve Upstream
 
-##### Retrieve Upstream
-
 <div class="endpoint get">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
+
 ---
+
+### Update Upstream
+
+<div class="endpoint patch">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
+
+*Request Body*
+
+{{ page.upstream_body }}
+
+
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
 
 ### Update Or Create Upstream
 
@@ -2645,13 +2676,17 @@ See POST and PATCH responses.
 
 ### Delete Upstream
 
-##### Delete Upstream
-
 <div class="endpoint delete">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+*Response*
+
+```
+HTTP 204 No Content
+```
 
 ---
 

--- a/app/enterprise/2.1.x/admin-api/index.md
+++ b/app/enterprise/2.1.x/admin-api/index.md
@@ -197,7 +197,6 @@ plugin_body: |
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Defaults to `null`. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated consumer.  Defaults to `null`. With form-encoded, the notation is `consumer.id=<consumer_id>`. With JSON, use `"consumer":{"id":"<consumer_id>"}`.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
-    `run_on` |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. Possible values are `"http"`, `"https"`, `"tcp"`, and `"tls"`. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will may only support `"tcp"` and `"tls"`.  Defaults to `["grpc", "grpcs", "http", "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Defaults to `true`.
     `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering.
@@ -211,7 +210,6 @@ plugin_json: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -226,7 +224,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -238,7 +235,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["tcp", "tls"],
         "enabled": true,
         "tags": ["admin", "high-priority", "critical"]
@@ -2607,70 +2603,9 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
----
-
-### Update Upstream
-
-##### Update Upstream
-
-<div class="endpoint patch">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
-*Request Body*
-
-{{ page.upstream_body }}
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
 ---
 
 ### Update Or Create Upstream
-
-##### Create Or Update Upstream
 
 <div class="endpoint put">/upstreams/{name or id}</div>
 
@@ -2678,17 +2613,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
-
-*Request Body*
+#### Request Body
 
 {{ page.upstream_body }}
 
@@ -2708,14 +2633,13 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-*Response*
+#### Response
 
 ```
 HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
-
 
 ---
 
@@ -2728,23 +2652,6 @@ See POST and PATCH responses.
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
-*Response*
-
-```
-HTTP 204 No Content
-```
-
 
 ---
 
@@ -2840,13 +2747,13 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 *Request Body*
@@ -2869,13 +2776,13 @@ HTTP 201 Created
 
 ### List Targets
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 *Response*

--- a/app/enterprise/2.2.x/admin-api/index.md
+++ b/app/enterprise/2.2.x/admin-api/index.md
@@ -2609,12 +2609,20 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
 
 ---
 
 ### Update Upstream
 
-##### Update Upstream
 
 <div class="endpoint patch">/upstreams/{name or id}</div>
 
@@ -2622,11 +2630,24 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
+*Request Body*
+
+{{ page.upstream_body }}
+
+
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
+
 ---
 
 ### Update or Create Upstream
-
-##### Create or Update Upstream
 
 <div class="endpoint put">/upstreams/{name or id}</div>
 
@@ -2666,13 +2687,17 @@ See POST and PATCH responses.
 
 ### Delete Upstream
 
-#### Delete Upstream
-
 <div class="endpoint delete">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+*Response*
+
+```
+HTTP 204 No Content
+```
 
 ---
 

--- a/app/enterprise/2.2.x/admin-api/index.md
+++ b/app/enterprise/2.2.x/admin-api/index.md
@@ -205,7 +205,6 @@ plugin_body: |
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Defaults to `null`. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated consumer.  Defaults to `null`. With form-encoded, the notation is `consumer.id=<consumer_id>`. With JSON, use `"consumer":{"id":"<consumer_id>"}`.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
-    `run_on` |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. Possible values are `"http"`, `"https"`, `"tcp"`, and `"tls"`. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will may only support `"tcp"` and `"tls"`.  Defaults to `["grpc", "grpcs", "http", "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Defaults to `true`.
     `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering.
@@ -219,7 +218,6 @@ plugin_json: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -234,7 +232,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -246,7 +243,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["tcp", "tls"],
         "enabled": true,
         "tags": ["admin", "high-priority", "critical"]
@@ -2607,33 +2603,11 @@ HTTP 200 OK
 
 ### Retrieve Upstream
 
-##### Retrieve Upstream
-
 <div class="endpoint get">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
-
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
 
 
 ---
@@ -2648,32 +2622,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
-*Request Body*
-
-{{ page.upstream_body }}
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
 ---
 
 ### Update or Create Upstream
@@ -2686,17 +2634,7 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
-
-##### Create or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
-
-*Request Body*
+#### Request Body
 
 {{ page.upstream_body }}
 
@@ -2716,7 +2654,7 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-*Response*
+#### Response
 
 ```
 HTTP 201 Created or HTTP 200 OK
@@ -2724,35 +2662,17 @@ HTTP 201 Created or HTTP 200 OK
 
 See POST and PATCH responses.
 
-
 ---
 
 ### Delete Upstream
 
-##### Delete Upstream
+#### Delete Upstream
 
 <div class="endpoint delete">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
-*Response*
-
-```
-HTTP 204 No Content
-```
-
 
 ---
 
@@ -2849,11 +2769,11 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ##### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 *Request Body*
@@ -2876,13 +2796,13 @@ HTTP 201 Created
 
 ### List Targets
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 *Response*

--- a/app/enterprise/2.3.x/admin-api/index.md
+++ b/app/enterprise/2.3.x/admin-api/index.md
@@ -2603,13 +2603,21 @@ HTTP 200 OK
 
 ### Retrieve Upstream
 
-##### Retrieve Upstream
-
 <div class="endpoint get">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
+
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
 
 ---
 
@@ -2621,6 +2629,21 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
+*Request Body*
+
+{{ page.upstream_body }}
+
+
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
+
 ---
 
 ### Update or Create Upstream
@@ -2630,16 +2653,6 @@ Attributes | Description
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
----
-
-### Delete Upstream
-
-<div class="endpoint delete">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
 #### Request Body
 
@@ -2668,6 +2681,22 @@ HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
+
+---
+
+### Delete Upstream
+
+<div class="endpoint delete">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+*Response*
+
+```
+HTTP 204 No Content
+```
 
 ---
 

--- a/app/enterprise/2.3.x/admin-api/index.md
+++ b/app/enterprise/2.3.x/admin-api/index.md
@@ -205,7 +205,6 @@ plugin_body: |
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Defaults to `null`. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated consumer.  Defaults to `null`. With form-encoded, the notation is `consumer.id=<consumer_id>`. With JSON, use `"consumer":{"id":"<consumer_id>"}`.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
-    `run_on` |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. Possible values are `"http"`, `"https"`, `"tcp"`, and `"tls"`. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will may only support `"tcp"` and `"tls"`.  Defaults to `["grpc", "grpcs", "http", "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Defaults to `true`.
     `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering.
@@ -219,7 +218,6 @@ plugin_json: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -234,7 +232,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -246,7 +243,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["tcp", "tls"],
         "enabled": true,
         "tags": ["admin", "high-priority", "critical"]
@@ -2615,32 +2611,9 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
 ---
 
 ### Update Upstream
-
-##### Update Upstream
 
 <div class="endpoint patch">/upstreams/{name or id}</div>
 
@@ -2648,37 +2621,9 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
-*Request Body*
-
-{{ page.upstream_body }}
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
 ---
 
 ### Update or Create Upstream
-
-##### Create or Update Upstream
 
 <div class="endpoint put">/upstreams/{name or id}</div>
 
@@ -2686,17 +2631,17 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
+---
 
-##### Create or Update Upstream Associated to a Specific Target
+### Delete Upstream
 
-<div class="endpoint put">/targets/{target host:port or id}/upstream</div>
+<div class="endpoint delete">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-*Request Body*
+#### Request Body
 
 {{ page.upstream_body }}
 
@@ -2716,43 +2661,13 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-*Response*
+#### Response
 
 ```
 HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
-
-
----
-
-### Delete Upstream
-
-##### Delete Upstream
-
-<div class="endpoint delete">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
-*Response*
-
-```
-HTTP 204 No Content
-```
-
 
 ---
 
@@ -2847,13 +2762,13 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 *Request Body*
@@ -2876,13 +2791,13 @@ HTTP 201 Created
 
 ### List Targets
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 *Response*

--- a/app/enterprise/2.4.x/admin-api/index.md
+++ b/app/enterprise/2.4.x/admin-api/index.md
@@ -2865,13 +2865,21 @@ HTTP 200 OK
 
 ### Retrieve Upstream
 
-##### Retrieve Upstream
-
 <div class="endpoint get">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
+
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
 
 ---
 
@@ -2884,6 +2892,21 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
+*Request Body*
+
+{{ page.upstream_body }}
+
+
+*Response*
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
+
 ---
 
 ### Update or Create Upstream
@@ -2893,16 +2916,6 @@ Attributes | Description
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
----
-
-### Delete Upstream
-
-<div class="endpoint delete">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
 #### Request Body
 
@@ -2931,6 +2944,22 @@ HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
+
+---
+
+### Delete Upstream
+
+<div class="endpoint delete">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+*Response*
+
+```
+HTTP 204 No Content
+```
 
 ---
 

--- a/app/enterprise/2.4.x/admin-api/index.md
+++ b/app/enterprise/2.4.x/admin-api/index.md
@@ -205,7 +205,6 @@ plugin_body: |
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Defaults to `null`. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated consumer.  Defaults to `null`. With form-encoded, the notation is `consumer.id=<consumer_id>`. With JSON, use `"consumer":{"id":"<consumer_id>"}`.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
-    `run_on` |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. Possible values are `"http"`, `"https"`, `"tcp"`, and `"tls"`. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will may only support `"tcp"` and `"tls"`.  Defaults to `["grpc", "grpcs", "http", "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Defaults to `true`.
     `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering.
@@ -219,7 +218,6 @@ plugin_json: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -234,7 +232,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -246,7 +243,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["tcp", "tls"],
         "enabled": true,
         "tags": ["admin", "high-priority", "critical"]
@@ -2877,32 +2873,10 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
 ---
 
 ### Update Upstream
 
-##### Update Upstream
 
 <div class="endpoint patch">/upstreams/{name or id}</div>
 
@@ -2910,37 +2884,9 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
-*Request Body*
-
-{{ page.upstream_body }}
-
-
-*Response*
-
-```
-HTTP 200 OK
-```
-
-```json
-{{ page.upstream_json }}
-```
-
-
 ---
 
 ### Update or Create Upstream
-
-##### Create or Update Upstream
 
 <div class="endpoint put">/upstreams/{name or id}</div>
 
@@ -2948,17 +2894,17 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
+---
 
-##### Create or Update Upstream Associated to a Specific Target
+### Delete Upstream
 
-<div class="endpoint put">/targets/{target host:port or id}/upstream</div>
+<div class="endpoint delete">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-*Request Body*
+#### Request Body
 
 {{ page.upstream_body }}
 
@@ -2978,43 +2924,13 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-*Response*
+#### Response
 
 ```
 HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
-
-
----
-
-### Delete Upstream
-
-##### Delete Upstream
-
-<div class="endpoint delete">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
-*Response*
-
-```
-HTTP 204 No Content
-```
-
 
 ---
 
@@ -3109,13 +3025,13 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 *Request Body*
@@ -3138,13 +3054,13 @@ HTTP 201 Created
 
 ### List Targets
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 *Response*

--- a/app/enterprise/2.5.x/admin-api/index.md
+++ b/app/enterprise/2.5.x/admin-api/index.md
@@ -205,7 +205,6 @@ plugin_body: |
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Defaults to `null`. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated consumer.  Defaults to `null`. With form-encoded, the notation is `consumer.id=<consumer_id>`. With JSON, use `"consumer":{"id":"<consumer_id>"}`.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
-    `run_on` |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. Possible values are `"http"`, `"https"`, `"tcp"`, and `"tls"`. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will may only support `"tcp"` and `"tls"`.  Defaults to `["grpc", "grpcs", "http", "https"]`.
     `enabled`<br>*optional* | Whether the plugin is applied. Defaults to `true`.
     `tags`<br>*optional* |  An optional set of strings associated with the Plugin, for grouping and filtering.
@@ -219,7 +218,6 @@ plugin_json: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -234,7 +232,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"]
@@ -246,7 +243,6 @@ plugin_data: |
         "service": null,
         "consumer": null,
         "config": {"hour":500, "minute":20},
-        "run_on": "first",
         "protocols": ["tcp", "tls"],
         "enabled": true,
         "tags": ["admin", "high-priority", "critical"]
@@ -2879,25 +2875,13 @@ HTTP 200 OK
 
 ### Retrieve Upstream
 
-##### Retrieve Upstream
-
 <div class="endpoint get">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
-*Response*
+#### Response
 
 ```
 HTTP 200 OK
@@ -2907,12 +2891,9 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Upstream
-
-##### Update Upstream
 
 <div class="endpoint patch">/upstreams/{name or id}</div>
 
@@ -2920,22 +2901,12 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
-*Request Body*
+#### Request Body
 
 {{ page.upstream_body }}
 
 
-*Response*
+#### Response
 
 ```
 HTTP 200 OK
@@ -2945,12 +2916,9 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update or Create Upstream
-
-##### Create or Update Upstream
 
 <div class="endpoint put">/upstreams/{name or id}</div>
 
@@ -2958,17 +2926,17 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
+---
 
-##### Create or Update Upstream Associated to a Specific Target
+### Delete Upstream
 
-<div class="endpoint put">/targets/{target host:port or id}/upstream</div>
+<div class="endpoint delete">/upstreams/{name or id}</div>
 
 Attributes | Description
 ---:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-*Request Body*
+#### Request Body
 
 {{ page.upstream_body }}
 
@@ -2988,43 +2956,13 @@ Notice that specifying a `name` in the URL and a different one in the request
 body is not allowed.
 
 
-*Response*
+#### Response
 
 ```
 HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
-
-
----
-
-### Delete Upstream
-
-##### Delete Upstream
-
-<div class="endpoint delete">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete">/targets/{target host:port or id}/upstream</div>
-
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
-*Response*
-
-```
-HTTP 204 No Content
-```
-
 
 ---
 
@@ -3119,13 +3057,13 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 *Request Body*
@@ -3148,13 +3086,13 @@ HTTP 201 Created
 
 ### List Targets
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get">/upstreams/{upstream_id}/targets</div>
 
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 *Response*

--- a/app/enterprise/2.5.x/admin-api/index.md
+++ b/app/enterprise/2.5.x/admin-api/index.md
@@ -2926,16 +2926,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
----
-
-### Delete Upstream
-
-<div class="endpoint delete">/upstreams/{name or id}</div>
-
-Attributes | Description
----:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
 #### Request Body
 
 {{ page.upstream_body }}
@@ -2963,6 +2953,22 @@ HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
+
+---
+
+### Delete Upstream
+
+<div class="endpoint delete">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+*Response*
+
+```
+HTTP 204 No Content
+```
 
 ---
 

--- a/app/gateway-oss/2.1.x/admin-api.md
+++ b/app/gateway-oss/2.1.x/admin-api.md
@@ -3181,17 +3181,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
 #### Response
 
 ```
@@ -3226,17 +3215,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
 
 #### Request Body
 
@@ -3277,17 +3255,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
 
 #### Request Body
 
@@ -3341,17 +3308,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
 
 #### Response
 
@@ -3483,14 +3439,14 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3515,12 +3471,12 @@ HTTP 201 Created
 
 ##### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response

--- a/app/gateway-oss/2.2.x/admin-api.md
+++ b/app/gateway-oss/2.2.x/admin-api.md
@@ -3189,17 +3189,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
 #### Response
 
 ```
@@ -3210,12 +3199,10 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Upstream
 
-##### Update Upstream
 
 <div class="endpoint patch indent">/upstreams/{upstream name or id}</div>
 
@@ -3225,7 +3212,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
 
-##### Update Upstream Associated to a Specific Certificate
+#### Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint patch indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3234,17 +3221,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
 
 #### Request Body
 
@@ -3285,16 +3261,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
 
 
 #### Request Body
@@ -3349,17 +3315,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
 
 #### Response
 

--- a/app/gateway-oss/2.3.x/admin-api.md
+++ b/app/gateway-oss/2.3.x/admin-api.md
@@ -3197,17 +3197,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
 #### Response
 
 ```
@@ -3218,12 +3207,9 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Upstream
-
-##### Update Upstream
 
 <div class="endpoint patch indent">/upstreams/{upstream name or id}</div>
 
@@ -3232,8 +3218,7 @@ Attributes | Description
 ---:| ---
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Certificate
+#### Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint patch indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3242,22 +3227,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
-#### Request Body
-
-{{ page.upstream_body }}
-
 
 #### Response
 
@@ -3274,7 +3243,6 @@ HTTP 200 OK
 
 ### Update Or Create Upstream
 
-##### Create Or Update Upstream
 
 <div class="endpoint put indent">/upstreams/{upstream name or id}</div>
 
@@ -3284,7 +3252,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
 
-##### Create Or Update Upstream Associated to a Specific Certificate
+#### Create Or Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint put indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3293,17 +3261,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
 
 #### Request Body
 
@@ -3338,7 +3295,6 @@ See POST and PATCH responses.
 
 ### Delete Upstream
 
-##### Delete Upstream
 
 <div class="endpoint delete indent">/upstreams/{upstream name or id}</div>
 
@@ -3347,8 +3303,7 @@ Attributes | Description
 ---:| ---
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-##### Delete Upstream Associated to a Specific Certificate
+#### Delete Upstream Associated to a Specific Certificate
 
 <div class="endpoint delete indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3358,23 +3313,11 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
 #### Response
 
 ```
 HTTP 204 No Content
 ```
-
 
 ---
 
@@ -3498,14 +3441,14 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_d}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3528,14 +3471,14 @@ HTTP 201 Created
 
 ### List Targets
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response

--- a/app/gateway-oss/2.4.x/admin-api.md
+++ b/app/gateway-oss/2.4.x/admin-api.md
@@ -3482,17 +3482,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
 #### Response
 
 ```
@@ -3502,7 +3491,6 @@ HTTP 200 OK
 ```json
 {{ page.upstream_json }}
 ```
-
 
 ---
 
@@ -3533,17 +3521,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
 #### Request Body
 
 {{ page.upstream_body }}
@@ -3559,7 +3536,6 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Or Create Upstream
@@ -3569,7 +3545,7 @@ HTTP 200 OK
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Create Or Update Upstream
+#### Create Or Update Upstream
 
 <div class="endpoint put indent">/upstreams/{upstream name or id}</div>
 
@@ -3579,7 +3555,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
 
-##### Create Or Update Upstream Associated to a Specific Certificate
+#### Create Or Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint put indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3588,17 +3564,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
 
 #### Request Body
 
@@ -3627,7 +3592,6 @@ HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
-
 
 ---
 
@@ -3658,23 +3622,11 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
 #### Response
 
 ```
 HTTP 204 No Content
 ```
-
 
 ---
 
@@ -3804,14 +3756,14 @@ Targets can be both [tagged and filtered by tags](#tags).
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3835,14 +3787,14 @@ HTTP 201 Created
 ### List Targets
 {:.badge .dbless}
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response

--- a/app/gateway-oss/2.5.x/admin-api.md
+++ b/app/gateway-oss/2.5.x/admin-api.md
@@ -3474,8 +3474,6 @@ HTTP 200 OK
 ### Retrieve Upstream
 {:.badge .dbless}
 
-##### Retrieve Upstream
-
 <div class="endpoint get indent">/upstreams/{upstream name or id}</div>
 
 {:.indent}
@@ -3484,7 +3482,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
 
-##### Retrieve Upstream Associated to a Specific Certificate
+#### Retrieve Upstream Associated to a Specific Certificate
 
 <div class="endpoint get indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3493,17 +3491,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
-
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
 
 #### Response
 
@@ -3514,7 +3501,6 @@ HTTP 200 OK
 ```json
 {{ page.upstream_json }}
 ```
-
 
 ---
 
@@ -3545,17 +3531,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
-
 #### Request Body
 
 {{ page.upstream_body }}
@@ -3570,7 +3545,6 @@ HTTP 200 OK
 ```json
 {{ page.upstream_json }}
 ```
-
 
 ---
 
@@ -3601,17 +3575,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
-
 #### Request Body
 
 {{ page.upstream_body }}
@@ -3639,7 +3602,6 @@ HTTP 201 Created or HTTP 200 OK
 ```
 
 See POST and PATCH responses.
-
 
 ---
 
@@ -3670,23 +3632,11 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
 #### Response
 
 ```
 HTTP 204 No Content
 ```
-
 
 ---
 
@@ -3816,14 +3766,14 @@ Targets can be both [tagged and filtered by tags](#tags).
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3847,14 +3797,14 @@ HTTP 201 Created
 ### List Targets
 {:.badge .dbless}
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
----:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+---:| ---_
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response

--- a/app/gateway/2.6.x/admin-api/index.md
+++ b/app/gateway/2.6.x/admin-api/index.md
@@ -210,7 +210,6 @@ plugin_body: |
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
-    `run_on`<br>*optional* (Enterprise only) |  Control on which Kong nodes this plugin will run, given a Service Mesh scenario. Accepted values are: * `first`, meaning "run on the first Kong node that is encountered by the request". On an API Getaway scenario, this is the usual operation, since there is only one Kong node in between source and destination. In a sidecar-to-sidecar Service Mesh scenario, this means running the plugin only on the Kong sidecar of the outbound connection. * `second`, meaning "run on the second node that is encountered by the request". This option is only relevant for sidecar-to-sidecar Service Mesh scenarios: this means running the plugin only on the Kong sidecar of the inbound connection. * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar scenario. This is useful for tracing/logging plugins.  Defaults to `"first"`.
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled` | Whether the plugin is applied. Default: `true`.
     `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
@@ -3547,17 +3546,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
 #### Response
 
 ```
@@ -3568,7 +3556,6 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Upstream
@@ -3578,7 +3565,7 @@ HTTP 200 OK
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Update Upstream
+#### Update Upstream
 
 <div class="endpoint patch indent">/upstreams/{upstream name or id}</div>
 
@@ -3588,7 +3575,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
 
-##### Update Upstream Associated to a Specific Certificate
+#### Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint patch indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3597,17 +3584,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
 
 #### Request Body
 
@@ -3624,17 +3600,12 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Or Create Upstream
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
-
-##### Create Or Update Upstream
 
 <div class="endpoint put indent">/upstreams/{upstream name or id}</div>
 
@@ -3643,8 +3614,7 @@ Attributes | Description
 ---:| ---
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
-
-##### Create Or Update Upstream Associated to a Specific Certificate
+#### Create Or Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint put indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3653,17 +3623,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
 
 #### Request Body
 
@@ -3693,17 +3652,12 @@ HTTP 201 Created or HTTP 200 OK
 
 See POST and PATCH responses.
 
-
 ---
 
 ### Delete Upstream
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
-
-##### Delete Upstream
 
 <div class="endpoint delete indent">/upstreams/{upstream name or id}</div>
 
@@ -3713,7 +3667,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
 
-##### Delete Upstream Associated to a Specific Certificate
+#### Delete Upstream Associated to a Specific Certificate
 
 <div class="endpoint delete indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3723,23 +3677,11 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
-
 #### Response
 
 ```
 HTTP 204 No Content
 ```
-
 
 ---
 
@@ -3864,19 +3806,17 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3900,14 +3840,14 @@ HTTP 201 Created
 ### List Targets
 {:.badge .dbless}
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response
@@ -3928,13 +3868,10 @@ HTTP 200 OK
 
 ### Update Target
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
 Update a target.
-
 
 <div class="endpoint patch indent">/upstreams/{upstream name or id}/targets/{host:port or id}</div>
 
@@ -3944,19 +3881,15 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to update the target.
 `host:port or id`<br>**required** | The host:port combination element of the target to update, or the `id` of an existing target entry.
 
-
 #### Response
 
 ```
 HTTP 201 Created
 ```
 
-
 ---
 
 ### Delete Target
-
-
 
 {:.note}
 > **Note**: This API is not available in DB-less mode.
@@ -3972,13 +3905,11 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
 `host:port or id`<br>**required** | The host:port combination element of the target to remove, or the `id` of an existing target entry.
 
-
 #### Response
 
 ```
 HTTP 204 No Content
 ```
-
 
 ---
 

--- a/app/gateway/2.7.x/admin-api/index.md
+++ b/app/gateway/2.7.x/admin-api/index.md
@@ -3528,7 +3528,7 @@ HTTP 200 OK
 ### Retrieve Upstream
 {:.badge .dbless}
 
-##### Retrieve Upstream
+#### Retrieve Upstream
 
 <div class="endpoint get indent">/upstreams/{upstream name or id}</div>
 
@@ -3538,7 +3538,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
 
-##### Retrieve Upstream Associated to a Specific Certificate
+#### Retrieve Upstream Associated to a Specific Certificate
 
 <div class="endpoint get indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3547,17 +3547,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
-
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
 
 #### Response
 
@@ -3569,17 +3558,12 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Upstream
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
-
-##### Update Upstream
 
 <div class="endpoint patch indent">/upstreams/{upstream name or id}</div>
 
@@ -3588,8 +3572,7 @@ Attributes | Description
 ---:| ---
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
 
-
-##### Update Upstream Associated to a Specific Certificate
+#### Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint patch indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3598,17 +3581,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
 
 #### Request Body
 
@@ -3625,17 +3597,13 @@ HTTP 200 OK
 {{ page.upstream_json }}
 ```
 
-
 ---
 
 ### Update Or Create Upstream
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Create Or Update Upstream
 
 <div class="endpoint put indent">/upstreams/{upstream name or id}</div>
 
@@ -3645,7 +3613,7 @@ Attributes | Description
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
 
 
-##### Create Or Update Upstream Associated to a Specific Certificate
+#### Create Or Update Upstream Associated to a Specific Certificate
 
 <div class="endpoint put indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3654,17 +3622,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
 
 #### Request Body
 
@@ -3694,17 +3651,12 @@ HTTP 201 Created or HTTP 200 OK
 
 See POST and PATCH responses.
 
-
 ---
 
 ### Delete Upstream
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
-
-##### Delete Upstream
 
 <div class="endpoint delete indent">/upstreams/{upstream name or id}</div>
 
@@ -3713,8 +3665,7 @@ Attributes | Description
 ---:| ---
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
 
-
-##### Delete Upstream Associated to a Specific Certificate
+#### Delete Upstream Associated to a Specific Certificate
 
 <div class="endpoint delete indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
 
@@ -3723,17 +3674,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
 
 #### Response
 
@@ -3865,19 +3805,17 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ### Add Target
 
-
-
 {:.note}
 > **Note**: This API is not available in DB-less mode.
 
-##### Create Target Associated to a Specific Upstream
+#### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_d`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3901,14 +3839,14 @@ HTTP 201 Created
 ### List Targets
 {:.badge .dbless}
 
-##### List Targets Associated to a Specific Upstream
+#### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response
@@ -3984,8 +3922,6 @@ HTTP 204 No Content
 ---
 
 ### Set Target Address As Healthy
-
-
 
 {:.note}
 > **Note**: This API is not available in DB-less mode.

--- a/app/gateway/2.8.x/admin-api/index.md
+++ b/app/gateway/2.8.x/admin-api/index.md
@@ -3593,17 +3593,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
 
-
-##### Retrieve Upstream Associated to a Specific Target
-
-<div class="endpoint get indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be retrieved.
-
-
 #### Response
 
 ```
@@ -3643,17 +3632,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
-
-
-##### Update Upstream Associated to a Specific Target
-
-<div class="endpoint patch indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be updated.
-
 
 #### Request Body
 
@@ -3699,17 +3677,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
-
-
-##### Create Or Update Upstream Associated to a Specific Target
-
-<div class="endpoint put indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be created or updated.
-
 
 #### Request Body
 
@@ -3768,17 +3735,6 @@ Attributes | Description
 ---:| ---
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
-
-
-##### Delete Upstream Associated to a Specific Target
-
-<div class="endpoint delete indent">/targets/{target host:port or id}/upstream</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`target host:port or id`<br>**required** | The unique identifier **or** the host:port of the Target associated to the Upstream to be deleted.
-
 
 #### Response
 
@@ -3917,12 +3873,12 @@ Targets can be both [tagged and filtered by tags](#tags).
 
 ##### Create Target Associated to a Specific Upstream
 
-<div class="endpoint post indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint post indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body
@@ -3948,12 +3904,12 @@ HTTP 201 Created
 
 ##### List Targets Associated to a Specific Upstream
 
-<div class="endpoint get indent">/upstreams/{upstream host:port or id}/targets</div>
+<div class="endpoint get indent">/upstreams/{upstream_id}/targets</div>
 
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream host:port or id`<br>**required** | The unique identifier or the `host:port` attribute of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
+`upstream_id`<br>**required** | The unique identifier of the Upstream whose Targets are to be retrieved. When using this endpoint, only Targets associated to the specified Upstream will be listed.
 
 
 #### Response


### PR DESCRIPTION
### Summary

All the following from EE, CE, and Gateway (single sourced) 2.1.x and newer.

1. Remove endpoints that meet the following form:

```
/targets
/targets/{targets}
/targets/{targets}/upstream
```

2. Remove `run_on`
3. For list targets and add targets, remove `host:port`

### Reason

Addresses [DOCU-1618](https://konghq.atlassian.net/browse/DOCU-1618)

### Testing

Applied to 2.1.x and newer. Here's the latest from our single sourced Gateway docs:

**Note that the indenting was there to begin with - I didn't modify the styling. 

https://deploy-preview-3684--kongdocs.netlify.app/gateway/2.7.x/admin-api/
https://deploy-preview-3684--kongdocs.netlify.app/gateway/2.6.x/admin-api/
