### PR TITLE
remove unnecessary / in the URL

### DIFF
--- a/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
@@ -306,7 +306,7 @@ You now have a consumer with an API key provisioned to access the route.
 
 To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
 ```
-http://<admin-hostname>:8000/mock/?apikey=apikey
+http://<admin-hostname>:8000/mock?apikey=apikey
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.7.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/secure-services.md
@@ -306,7 +306,7 @@ You now have a consumer with an API key provisioned to access the route.
 
 To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
 ```
-http://<admin-hostname>:8000/mock/?apikey=apikey
+http://<admin-hostname>:8000/mock?apikey=apikey
 ```
 
 {% endnavtab %}


### PR DESCRIPTION
The `/` before `?apikey ` is not needed, so remove it.
http://<admin-hostname>:8000/mock/?apikey=apikey

### Summary
The URL in the doc has a no required `/`. 
User may hit a 404 error if using the URL on the website. 

### Reason
Can't verify the auth with the provided URL

### Testing
Using the Browser directly. 

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
