### PR TITLE
doc(external-plugins) use pip3 and mention API reference

### DIFF
--- a/app/enterprise/2.4.x/external-plugins.md
+++ b/app/enterprise/2.4.x/external-plugins.md
@@ -432,7 +432,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:

--- a/app/enterprise/2.5.x/external-plugins.md
+++ b/app/enterprise/2.5.x/external-plugins.md
@@ -437,7 +437,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:

--- a/app/gateway-oss/2.4.x/external-plugins.md
+++ b/app/gateway-oss/2.4.x/external-plugins.md
@@ -439,7 +439,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:

--- a/app/gateway-oss/2.5.x/external-plugins.md
+++ b/app/gateway-oss/2.5.x/external-plugins.md
@@ -440,7 +440,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:

--- a/app/gateway/2.6.x/reference/external-plugins.md
+++ b/app/gateway/2.6.x/reference/external-plugins.md
@@ -440,7 +440,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:
@@ -471,7 +471,7 @@ schema of plugin, it shares the same syntax as it's a Lua plugin. `version` and 
 defines the version number and priority of execution respectively.
 
 **Note**: Check out [this repository](https://github.com/Kong/kong-python-pdk/tree/master/examples)
-for example Python plugins.
+for example Python plugins and [API reference](https://kong.github.io/kong-python-pdk/py-modindex.html).
 
 #### 1. Phase Handlers
 

--- a/app/gateway/2.7.x/reference/external-plugins.md
+++ b/app/gateway/2.7.x/reference/external-plugins.md
@@ -440,7 +440,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:
@@ -471,7 +471,7 @@ schema of plugin, it shares the same syntax as it's a Lua plugin. `version` and 
 defines the version number and priority of execution respectively.
 
 **Note**: Check out [this repository](https://github.com/Kong/kong-python-pdk/tree/master/examples)
-for example Python plugins.
+for example Python plugins and [API reference](https://kong.github.io/kong-python-pdk/py-modindex.html).
 
 #### 1. Phase Handlers
 


### PR DESCRIPTION
Use pip3 (Python 3.x) in instruction and reference to the API reference link.