### PR TITLE
Contributing guide: fix link format & minor edits

### DIFF
--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -260,7 +260,9 @@ Here's some more content.
 {% endnavtab %}
 {% endnavtabs %}
 
-You can automatically select a specific tab (or set of tabs) on a page using the `tab` URL parameter e.g. https://docs.konghq.com/gateway/2.7.x/get-started/comprehensive/protect-services/?tab=using-deck-yaml
+You can automatically select a specific tab (or set of tabs) on a page using the `tab` URL parameter. 
+For example:
+https://docs.konghq.com/gateway/2.7.x/get-started/comprehensive/protect-services/?tab=using-deck-yaml
 
 The value provided to `?tab` is the lowercase title of the navtab, with all non-alphanumeric characters removed and spaces replaced with `-`.
 
@@ -272,18 +274,19 @@ Examples:
 
 If you're unsure what value to use, view the page source and search for `data-slug` to see the generated slug.
 
-If there are multiple sets of tabs to enable, you may provide multiple tab names, separated by a comma:
+If there are multiple sets of tabs to enable, you can provide multiple tab names, separated by a comma:
 
 ```
 ?tab=using-the-admin-api,using-deck-yaml
 ```
 
-This will activate the `Using the Admin API` tab, then the `Using decK (YAML)` tabs. The order may be important if you are reusing tab names across contexts. See `/gateway/2.7.x/get-started/comprehensive/protect-services/?tab=using-the-admin-api,using-deck-yaml` for an example.
+This will activate the `Using the Admin API` tab, then the `Using decK (YAML)` tabs. The order may be important if you are reusing tab names across contexts. 
+See this [sample link to the getting started guide with Admin API and decK tabs selected](/gateway/2.7.x/get-started/comprehensive/protect-services/?tab=using-the-admin-api,using-deck-yaml).
 
-When using `?tab=` it *must* be before any URL fragments (`#`) in the URL:
+When using `?tab=`, it *must* come before any URL fragments (`#`) in the URL:
 
-* ✅ /gateway/2.7.x/get-started/comprehensive/protect-services/?tab=using-deck-yaml#validate-rate-limiting
-* ❌ /gateway/2.7.x/get-started/comprehensive/protect-services/#validate-rate-limiting/?tab=using-deck-yaml
+* ✅ Good URL: /gateway/2.7.x/get-started/comprehensive/protect-services/?tab=using-deck-yaml#validate-rate-limiting
+* ❌ Bad URL: /gateway/2.7.x/get-started/comprehensive/protect-services/#validate-rate-limiting/?tab=using-deck-yaml
 
 ### Tabs for codeblocks
 


### PR DESCRIPTION
### Summary
Turn a codephrase into a link, and make some minor grammar/format edits. 

### Reason
Long codephrase was extending the page size on mobile.

![](https://files.slack.com/files-pri/T0DS5NB27-F033V2Z3UGL/screenshot_20220218-100354.png)

Long-term CSS fix: we should make sure codephrases wrap on mobile. 

### Testing
TBA