### PR TITLE
docs(admin-api/index.md) configuration_hash in /status

### DIFF
--- a/app/gateway/2.8.x/admin-api/index.md
+++ b/app/gateway/2.8.x/admin-api/index.md
@@ -1097,7 +1097,8 @@ HTTP 200 OK
         "connections_reading": 0,
         "connections_writing": 1,
         "connections_waiting": 0
-    }
+    },
+    "configuration_hash": "779742c3d7afee2e38f977044d2ed96b"
 }
 ```
 
@@ -1148,6 +1149,8 @@ HTTP 200 OK
     * `reachable`: A boolean value reflecting the state of the
       database connection. Please note that this flag **does not**
       reflect the health of the database itself.
+* `configuration_hash`: The hash of the current configuration. This field is
+  only returned when the Kong node is running in DB-less or data-plane mode.
 
 
 ---


### PR DESCRIPTION
### Summary

Added description for the field `configuration_hash` in the `/status` endpoint.

### Reason

https://github.com/Kong/kong/pull/8214
https://github.com/Kong/kong/pull/8425

### Testing

`$ http :8001/status` when running Kong in dbless mode.

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
