### PR TITLE
[DOCU-2192] Forward proxy mTLS support

### DIFF
--- a/app/_data/extensions/kong-inc/forward-proxy/versions.yml
+++ b/app/_data/extensions/kong-inc/forward-proxy/versions.yml
@@ -1,4 +1,5 @@
-- release: 1.0.6
+- release: 1.2.x
+- release: 1.1.x
 - release: 1.0.5
 - release: 0.36-x
 - release: 0.35-x

--- a/app/_hub/kong-inc/forward-proxy/1.1.x.md
+++ b/app/_hub/kong-inc/forward-proxy/1.1.x.md
@@ -1,7 +1,7 @@
 ---
 name: Forward Proxy Advanced
 publisher: Kong Inc.
-version: 1.2.x
+version: 1.1.x
 desc: Allows Kong to connect to intermediary transparent HTTP proxies
 description: |
   The Forward Proxy plugin allows Kong to connect to intermediary transparent
@@ -16,7 +16,7 @@ categories:
 kong_version_compatibility:
   enterprise_edition:
     compatible:
-      - 2.8.x
+      - 2.7.x
 
 params:
   name: forward-proxy
@@ -25,73 +25,19 @@ params:
   consumer_id: true
   dbless_compatible: 'yes'
   config:
-    - name: http_proxy_host
-      required: semi
+    - name: proxy_host
+      required: true
       default: null
-      value_in_examples: http://example.com
+      value_in_examples: example.com
       datatype: string
       description: |
-        The HTTP hostname or IP address of the forward proxy to which to connect.
-        Required if `http_proxy_port` is set.
-
-        At least one of `http_proxy_host` or `https_proxy_host` must be specified.
-    - name: http_proxy_port
-      required: semi
+        The hostname or IP address of the forward proxy to which to connect.
+    - name: proxy_port
+      required: true
       default: null
       value_in_examples: 80
       datatype: string
       description: |
-        The TCP port of the HTTP forward proxy to which to connect.
-        Required if `http_proxy_host` is set.
-
-        At least one of `http_proxy_port` or `https_proxy_port` must be specified.
-    - name: https_proxy_host
-      required: semi
-      default: null
-      value_in_examples:
-      datatype: string
-      description: |
-        The HTTPS hostname or IP address of the forward proxy to which to connect.
-        Required if `https_proxy_port` is set.
-
-        At least one of `http_proxy_host` or `https_proxy_host` must be specified.
-    - name: https_proxy_port
-      required: semi
-      default: null
-      value_in_examples:
-      datatype: string
-      description: |
-        The TCP port of the HTTPS forward proxy to which to connect.
-        Required if `https_proxy_host` is set.
-
-        At least one of `http_proxy_port` or `https_proxy_port` must be specified.
-    - name: proxy_host
-      required: false
-      default: null
-      value_in_examples:
-      datatype: string
-      description: |
-
-        {:.important}
-        > This parameter is deprecated as of Kong Gateway 2.8.0.0 and
-        is planned to be removed in 3.x.x.
-        > <br>
-        > Use `http_proxy_host` or `https_proxy_host` instead.
-
-        The hostname or IP address of the forward proxy to which to connect.
-    - name: proxy_port
-      required: false
-      default: null
-      value_in_examples:
-      datatype: string
-      description: |
-
-        {:.important}
-        > This parameter is deprecated as of Kong Gateway 2.8.0.0 and
-        is planned to be removed in 3.x.x.
-        > <br>
-        > Use `http_proxy_host` or `https_proxy_host` instead.
-
         The TCP port of the forward proxy to which to connect.
     - name: proxy_scheme
       required: true
@@ -136,19 +82,6 @@ params:
 ---
 ## Changelog
 
-### Kong Gateway 2.8.x (plugin version 1.2.0)
-
-* Added `http_proxy_host`, `http_proxy_port`, `https_proxy_host`, and
-`https_proxy_port` configuration parameters for mTLS support.
-
-    {:.important}
-    > These parameters replace the `proxy_port` and `proxy_host` fields, which
-    are now **deprecated** and planned to be removed in 3.x.x.
-
-* Fixed a plugin version in the documentation. Previously, there was a plugin
-version labelled as `1.0.x`. It is now updated to align with the
-plugin's actual version, `1.1.x`.
-
-### Kong Gateway 2.7.x (plugin version 1.1.0)
+### 1.1.0
 
 * Added `auth_username` and `auth_password` parameters for proxy authentication.


### PR DESCRIPTION
### Summary
* Added `http_proxy_host`, `http_proxy_port`, `https_proxy_host`, and
`https_proxy_port` configuration parameters for mTLS support. 
* Labelling `proxy_host` and `proxy_port` as deprecated.
* Fixed previous plugin version, it was labelled incorrectly. See https://github.com/Kong/kong-ee/blob/master/plugins-ee/forward-proxy/CHANGELOG.md. 

This doc likely needs more detail. What else needs to be configured for an mTLS connection? 

### Reason
Gateway 2.8 includes changes to the forward proxy plugin.
Eng PR: https://github.com/Kong/kong-ee/pull/2950

### Testing
Doc preview: https://deploy-preview-3691--kongdocs.netlify.app/hub/kong-inc/forward-proxy/