### PR TITLE
Update & fix docs site footer

### DIFF
--- a/app/_assets/stylesheets/footer.less
+++ b/app/_assets/stylesheets/footer.less
@@ -109,7 +109,7 @@
  */
 
 [class^="marketing-footer"] {
-  .font-source-sans();
+  font-family: @family-display;
   width: 100%;
   padding: @gutter-flex-2x 0 0;
 
@@ -152,9 +152,6 @@
       }
 
       > li {
-        font-family: Roboto, -apple-system, system-ui, BlinkMacSystemFont,
-          "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-
         #subscription_form .error-message.message {
           display: inline-block;
           width: 100%;
@@ -215,15 +212,14 @@
             color: #409ecb;
           }
         }
-        h5 {
+        .footer-category {
           color: #7d91b3;
           -webkit-transform: none;
           transform: none;
           font-size: 16px;
           font-weight: 600;
           margin-bottom: 1rem;
-          font-family: Roboto, -apple-system, system-ui, BlinkMacSystemFont,
-            "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+          letter-spacing: 0.5px;
         }
         a {
           font-size: 15px;
@@ -455,6 +451,8 @@
 
   .legal {
     padding: 0rem 0 1rem;
+    font-size: 15px;
+
     .container {
       max-width: 100%;
       padding: 0 2em;
@@ -564,9 +562,8 @@
         width: 100%;
         display: inline-block;
         text-align: center;
-        font-size: 16px !important;
         a {
-          font-weight: 500;
+          letter-spacing: 0.5;
         }
         b {
           color: #ccc;

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -5,7 +5,7 @@
         <div class="logo">
           <img src="/assets/images/KogoBlue.svg" alt="Kong" />
         </div>
-        <h5>THE CLOUD CONNECTIVITY COMPANY</h5>
+        <div class="footer-category">THE CLOUD CONNECTIVITY COMPANY</div>
         <p>
           Kong powers reliable digital connections across APIs, hybrid and
           multi-cloud environments.
@@ -24,50 +24,50 @@
           <ul>
             <li>
               <a
-                href="http://konghq.com/about-kong-inc/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/about-kong-inc/"
                 >Company</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/customers/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/customers/"
                 >Customers</a
               >
             </li>
 
             <li>
               <a
-                href="http://konghq.com/events/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/events/"
                 >Events</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/investors/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/investors/"
                 >Investors</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/careers/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/careers/"
                 >Careers <span>Hiring!</span></a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/partners/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/partners/"
                 >Partners</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/press-room/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/press-room/"
                 >Press</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/contact/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/contact/"
                 >Contact</a
               >
             </li>
@@ -76,24 +76,36 @@
       </li>
       <li>
         <nav>
-          <h5>Products</h5>
+          <div class="footer-category">Products</div>
           <ul>
             <li>
               <a
-                href="http://konghq.com/kong-konnect/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/kong-konnect/"
                 >Kong Konnect</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/get-started/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/kong/"
+                >Kong Gateway</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://konghq.com/kong-mesh/"
+                >Kong Mesh</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://konghq.com/contact-sales/"
                 >Get Started</a
               >
             </li>
             <li>
               <a
-                href="http://konghq.com/subscriptions/?itm_source=website&itm_medium=footer-nav"
-                >Subscriptions</a
+                href="https://konghq.com/pricing/"
+                >Pricing</a
               >
             </li>
           </ul>
@@ -101,42 +113,42 @@
       </li>
       <li>
         <nav>
-          <h5>Resources</h5>
+          <div class="footer-category">Resources</div>
           <ul>
             <li>
               <a
-                href="https://konghq.com/resources/?content=ebooks&itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/resources/?content=ebooks"
                 target="blank"
                 >eBooks</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/resources/?content=webinarss&itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/resources/?content=webinars"
                 >Webinars</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/resources/?content=whitepaper,datasheet,case-studies&itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/resources/?content=whitepaper,datasheet,case-studies"
                 >Briefs</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/blog/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/blog/"
                 >Blog</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/learning-center/api-gateway/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/learning-center/api-gateway/"
                 >API Gateway</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/learning-center/microservices/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/learning-center/microservices/"
                 >Microservices</a
               >
             </li>
@@ -145,7 +157,7 @@
       </li>
       <li>
         <nav>
-          <h5>Open Source</h5>
+          <div class="footer-category">Open Source</div>
           <ul>
             <li>
               <a
@@ -155,25 +167,25 @@
             </li>
             <li>
               <a
-                href="http://konghq.com/community/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/community/"
                 >Kong Community</a
               >
             </li>
             <li>
               <a
-                href="https://github.com/Kong/kubernetes-ingress-controller/?itm_source=website&itm_medium=footer-nav"
+                href="https://github.com/Kong/kubernetes-ingress-controller/"
                 >Kubernetes Ingress</a
               >
             </li>
             <li>
               <a
-                href="https://kuma.io/?itm_source=website&itm_medium=footer-nav"
+                href="https://kuma.io/"
                 >Kuma</a
               >
             </li>
             <li>
               <a
-                href="https://insomnia.rest/?itm_source=website&itm_medium=footer-nav"
+                href="https://insomnia.rest/"
                 >Insomnia</a
               >
             </li>
@@ -182,41 +194,41 @@
       </li>
       <li>
         <nav>
-          <h5>Solutions</h5>
+          <div class="footer-category">Solutions</div>
           <ul>
             <li>
               <a
-                href="https://konghq.com/solutions/use-cases/decentralize-applications-and-services/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/solutions/monolith-to-microservices/"
                 >Decentralize</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/solutions/use-cases/secure-and-govern-apis-and-services/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/solutions/secure-and-govern-apis/"
                 >Secure & Govern</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/solutions/use-cases/create-a-developer-platform/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/solutions/create-a-developer-platform/"
                 >Create a Dev Platform</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/solutions/gateway/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/gateway/"
                 >API Gateway</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/solutions/kubernetes-ingress/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/solutions/build-on-kubernetes/"
                 >Kubernetes</a
               >
             </li>
             <li>
               <a
-                href="https://konghq.com/products/kong-enterprise/kong-mesh/?itm_source=website&itm_medium=footer-nav"
+                href="https://konghq.com/kong-mesh/"
                 >Service Mesh</a
               >
             </li>
@@ -271,8 +283,8 @@
       <ul>
         <li>
           <span class="mashape-footer-content">
-            <a href="http://konghq.com/terms/">Terms</a><b>•</b
-            ><a href="http://konghq.com/privacy/">Privacy</a></span
+            <a href="https://konghq.com/terms/">Terms</a><b>•</b
+            ><a href="https://konghq.com/privacy/">Privacy</a></span
           >
         </li>
       </ul>


### PR DESCRIPTION
### Summary
Fixing the docs site footer.

**SEO work:**
- Updating URLs from `http` to `https`
- Removing tracking queries from URLs

**Accessibility:**
- Switching the h5 category headers to a named div

Reference: https://w3.org/WAI/tutorials/page-structure/headings/

**Consistency with marketing site:**
- Added missing links to Kong Gateway and Kong Mesh
- Updated the "Get Started" URL to go to the correct place instead of a redirect
- Updated the solution guide URLs to go to the correct pages instead of redirects

Partially fixes DOCU-2204 (mixed content links) and DOCU-2205 (tracking parameters).

### Reason
Fixes recommended based on SEO audit results, accessibility guidelines (header levels), and consistency with the konghq.com marketing site. 

### Testing
See the footer: https://deploy-preview-3693--kongdocs.netlify.app/