### PR TITLE
Update Go pdk docs

### DIFF
--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -81,8 +81,8 @@ Property | Description | Default
 
 Notes:
 
-- Usage of the legacy style is discouraged; it is deprecated as of {{site.base_gateway}} version 2.8.0, to be
-removed in {{site.base_gateway}} version 3.0.0.
+- Using the legacy style is discouraged; it is deprecated as of {{site.base_gateway}} version 2.8.0, 
+and planned to be removed in {{site.base_gateway}} version 3.0.0.
 - The legacy configuration doesn't allow multiple plugin servers.
 - Version 0.5.0 of [go-pluginserver] requires the old style configuration.
 - The new style configuration requires v0.6.0 of [go-pluginserver].

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -105,7 +105,7 @@ correspond to the embedded plugin server approach.
 
 ## Developing Go plugins
 
-{{site.base_gateway}} support for the Go language consist of the [go-pdk], a library that provides Go functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
+{{site.base_gateway}} supports the Go language with the [go-pdk], a library that provides Go functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 
 Notes:
 

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -96,8 +96,6 @@ the following steps:
 2. Ensure that properties `go_plugins_dir` and `go_pluginserver_exe` are not set
 in your Kong configuration file or environment variable.
 3. Set configuration according to [Kong Gateway plugin server configuration](#kong-gateway-plugin-server-configuration).
-Note that, in this mode, the plugin itself acts as the plugin server; as such
-the external go-pluginserver is no longer required.
 
 Check out the [go-plugins](https://github.com/Kong/go-plugins/tree/v0.5.0) repository for an example of the required updates; plugins with the `-lm` suffix correspond to the legacy method, while those without the suffix
 correspond to the embedded plugin server approach.

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -180,7 +180,7 @@ func main () {
 }
 ```
 
-Note that the `main()` function must have a `package main` line at the
+The `main()` function must have a `package main` line at the
 top of the file.
 
 Then, a standard Go build creates an executable. There is no extra `go-pluginserver`,

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -89,7 +89,7 @@ and planned to be removed in {{site.base_gateway}} version 3.0.0.
 
 #### Updating from legacy to embedded server style
 
-The update from the legacy configuration to embedded plugin server style encompasses
+Update legacy configuration to embedded plugin server style configuration with
 the following steps:
 
 1. Add a `main()` function that calls `server.StartServer(New, Version, Priority)`.

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -85,7 +85,7 @@ Notes:
 and planned to be removed in {{site.base_gateway}} version 3.0.0.
 - The legacy configuration doesn't allow multiple plugin servers.
 - Version 0.5.0 of [go-pluginserver] requires the old style configuration.
-- The new style configuration requires v0.6.0 of [go-pluginserver].
+- The new configuration style requires v0.6.0 of [go-pluginserver].
 
 #### Updating from legacy to embedded server style
 

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -89,6 +89,9 @@ and planned to be removed in {{site.base_gateway}} version 3.0.0.
 
 #### Updating from legacy to embedded server style
 
+In embedded server mode, the plugin itself acts as the plugin server, 
+so the external `go-pluginserver` is no longer required.
+
 Update legacy configuration to embedded plugin server style configuration with
 the following steps:
 

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -182,7 +182,7 @@ func main () {
 Note that the `main()` function must have a `package main` line at the
 top of the file.
 
-Then, a standard Go build creates an executable. There is no extra go-pluginserver,
+Then, a standard Go build creates an executable. There is no extra `go-pluginserver`,
 no plugin loading, and no compiler/library/environment compatibility issues.
 
 The resulting executable can be placed somewhere in your path (for example,

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -100,7 +100,7 @@ the following steps:
 in your Kong configuration file or environment variable.
 3. Set configuration according to [Kong Gateway plugin server configuration](#kong-gateway-plugin-server-configuration).
 
-Check out the [go-plugins](https://github.com/Kong/go-plugins/tree/v0.5.0) repository for an example of the required updates; plugins with the `-lm` suffix correspond to the legacy method, while those without the suffix
+Check out the [go-plugins](https://github.com/Kong/go-plugins/tree/v0.5.0) repository for an example of the required updates. Plugins with the `-lm` suffix correspond to the legacy method, while those without the suffix
 correspond to the embedded plugin server approach.
 
 ## Developing Go plugins

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -67,8 +67,9 @@ plugins = bundled, go-hello, js-hello, py-hello
 plugin server using a different configuration style. Starting with {{site.base_gateway}} version 2.3,
 the old style is recognized and internally transformed to the new style.
 
-**Note**: the legacy configuration is deprecated in {{site.base_gateway}} version 2.8.0, to be
-removed in {{site.base_gateway}} version 3.0.0.
+{:.important}
+> The legacy configuration is deprecated in {{site.base_gateway}} version 2.8.0 and 
+> planned to be removed in {{site.base_gateway}} version 3.0.0.
 
 If property `pluginserver_names` isn't defined, the legacy properties
 `go_plugins_dir` and `go_pluginserver_exe` are transparently mapped to the new style:

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -184,7 +184,7 @@ Note that the `main()` function must have a `package main` line at the
 top of the file.
 
 Then, a standard Go build creates an executable. There is no extra `go-pluginserver`,
-no plugin loading, and no compiler/library/environment compatibility issues.
+no plugin loading, and no compiler, library, or environment compatibility issues.
 
 The resulting executable can be placed somewhere in your path (for example,
 `/usr/local/bin`). The common `-h` flag shows a usage help message:


### PR DESCRIPTION
### Summary

This PR mentions the deprecation of the go-pluginserver -- aka "Legacy
Style". The External Plugins guide is updated so that it consistently advises
uses to use the embedded pluginserver option for Go.

### Reason

The external go-pluginserver is deprecated and scheduled to be removed in 2.8. As such, docs need to advise users to use the new embedded pluginserver option for Go plugins.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
