### PR TITLE
docs(mesh): fix windows installation docs

### DIFF
--- a/app/mesh/1.5.x/installation/windows.md
+++ b/app/mesh/1.5.x/installation/windows.md
@@ -16,9 +16,9 @@ Tested on Windows 10 and Windows Server 2019.
 {:.note}
 > **Note**: Transparent proxying is not supported on Windows.
 
-## 1. Download Kuma
+## 1. Download Kong Mesh
 
-To run Kuma on Windows you can choose among different installation methods:
+To run Kong Mesh on Windows you can choose among different installation methods:
 
 {% navtabs %}
 {% navtab Powershell Script %}
@@ -43,7 +43,7 @@ tar xvzf kong-mesh-{{page.kong_latest.version}}-windows-amd64.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-## 2. Run Kuma
+## 2. Run Kong Mesh
 
 Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{include.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
 
@@ -56,7 +56,7 @@ cd kong-mesh-{{include.kong_latest.version}}/bin
 Then, run the control plane with:
 
 ```sh
-$ KUMA_LICENSE_PATH=/path/to/file/license.json kuma-cp run
+$ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_

--- a/app/mesh/1.6.x/installation/windows.md
+++ b/app/mesh/1.6.x/installation/windows.md
@@ -16,9 +16,9 @@ Tested on Windows 10 and Windows Server 2019.
 {:.note}
 > **Note**: Transparent proxying is not supported on Windows.
 
-## 1. Download Kuma
+## 1. Download Kong Mesh
 
-To run Kuma on Windows you can choose among different installation methods:
+To run Kong Mesh on Windows you can choose among different installation methods:
 
 {% navtabs %}
 {% navtab Powershell Script %}
@@ -43,7 +43,7 @@ tar xvzf kong-mesh-{{page.kong_latest.version}}-windows-amd64.tar.gz
 {% endnavtab %}
 {% endnavtabs %}
 
-## 2. Run Kuma
+## 2. Run Kong Mesh
 
 Once downloaded, you will find the contents of {{site.mesh_product_name}} in the `kong-mesh-{{include.kong_latest.version}}` folder. In this folder, you will find &mdash; among other files &mdash; the bin directory that stores all the executables for {{site.mesh_product_name}}.
 
@@ -56,7 +56,7 @@ cd kong-mesh-{{include.kong_latest.version}}/bin
 Then, run the control plane with:
 
 ```sh
-$ KUMA_LICENSE_PATH=/path/to/file/license.json kuma-cp run
+$ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
@@ -69,7 +69,7 @@ We suggest adding the `kumactl` executable to your `PATH` so that it's always av
 New-Item -ItemType SymbolicLink -Path C:\Windows\kumactl.exe -Target .\kumactl.exe
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/),
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 {% include /md/mesh/install-universal-verify.md %}


### PR DESCRIPTION
### Summary

Change `Kuma` to `Kong Mesh` as well as the name of env var
from `KUMA_LICENSE_PATH` to `KMESH_LICENSE_PATH`

### Reason

Found out that the docs are wrong

### Testing

It's small PR so looking at other parts of the installation where we are using proper env var should be enough, but if not, we can always test the instructions on windows machine
