### PR TITLE
[cert-manager.md] Improve `ClusterIssuer` snippet 

### DIFF
--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -176,6 +176,10 @@ spec:
     solvers:
     - http01:
         ingress:
+          podTemplate:
+             metadata:
+               annotations:
+                 kuma.io/sidecar-injection: "false"   #in case of ingress will be running in Kuma/Kong Mesh, disable sidecar injection
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -179,7 +179,7 @@ spec:
           podTemplate:
              metadata:
                annotations:
-                 kuma.io/sidecar-injection: "false"   #in case of ingress will be running in Kuma/Kong Mesh, disable sidecar injection
+                 kuma.io/sidecar-injection: "false"   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -180,6 +180,7 @@ spec:
              metadata:
                annotations:
                  kuma.io/sidecar-injection: "false"   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
+                 sidecar.istio.io/inject: "false"  # If using Istio, disable sidecar injection
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```


### PR DESCRIPTION
added additional `podAnnotations` for `cert-manager` ingress. In situations when https ingress deployed in kuma managed namespace, we don't want to inject sidecar for `cert-manager` solver ingress.

### Summary
added `podTemplate` yaml snipped with anotations. Ref: https://github.com/cert-manager/cert-manager/pull/1749

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Users may deploy Kong ingress in the same namespace with kuma.
This snippet prevents injecting sidecar in cert-manager` solver ingress. 

### Testing

run through this instruction in GKE cluster with cert-manager installed.
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
