### PR TITLE
(chore) Copy changes from 2.7.x to 2.8.x

### DIFF
--- a/app/gateway/2.8.x/configure/auth/index.md
+++ b/app/gateway/2.8.x/configure/auth/index.md
@@ -45,7 +45,7 @@ consumer to represent anonymous users, then configure your authentication plugin
 access. Here is an example, which assumes you have already configured a Service named `example-service` and
 the corresponding Route:
 
-1. ### Create an example Service and a Route
+1. **Create an example Service and a Route**
 
     Issue the following cURL request to create `example-service` pointing to `mockbin.org`, which will echo
     the request:
@@ -67,7 +67,7 @@ the corresponding Route:
 
     The url `http://localhost:8000/auth-sample` will now echo whatever is being requested.
 
-2. ### Configure the key-auth Plugin for your Service
+2. **Configure the key-auth Plugin for your Service**
 
     Issue the following cURL request to add a plugin to a Service:
 
@@ -79,7 +79,7 @@ the corresponding Route:
 
     Be sure to note the created Plugin `id` - you'll need it in step 5.
 
-3. ### Verify that the key-auth plugin is properly configured
+3. **Verify that the key-auth plugin is properly configured**
 
     Issue the following cURL request to verify that the [key-auth][key-auth]
     plugin was properly configured on the Service:
@@ -101,7 +101,7 @@ the corresponding Route:
     }
     ```
 
-4. ### Create an anonymous Consumer
+4. **Create an anonymous Consumer**
 
     Every request proxied by Kong must be associated with a Consumer. You'll now create a Consumer
     named `anonymous_users` (that Kong will utilize when proxying anonymous access) by issuing the
@@ -129,7 +129,7 @@ the corresponding Route:
 
     Be sure to note the Consumer `id` - you'll need it in the next step.
 
-5. ### Enable anonymous access
+5. **Enable anonymous access**
 
     You'll now re-configure the key-auth plugin to permit anonymous access by issuing the following
     request (**replace the sample uuids below by the `id` values from step 2 and 4**):
@@ -146,7 +146,7 @@ the corresponding Route:
     is not currently checked when configuring anonymous access, and provisioning of a Consumer `id` that doesn't already
     exist will result in an incorrect configuration.
 
-6. ### Check anonymous access
+6. **Check anonymous access**
 
     Confirm that your Service now permits anonymous access by issuing the following request:
 

--- a/app/gateway/2.8.x/configure/auth/kong-manager/workspaces.md
+++ b/app/gateway/2.8.x/configure/auth/kong-manager/workspaces.md
@@ -52,8 +52,8 @@ color / icon for the new Workspace.
     **Workspace** "Payments" and another one "payments" will
     create two different workspaces that appear identical.
 
-    Do not name Workspaces the same as these major routes in Kong
-    Manager:
+    Do not name Workspaces the same as these major API names (paths)
+    in Admin API:
 
     ```
     • Admins

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/auth-provider-strategy.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/auth-provider-strategy.md
@@ -3,23 +3,6 @@ title: Authorization Provider Strategy for Application Registration
 badge: enterprise
 ---
 
-In the 1.5.x beta version of the Application
-Registration plugin, the feature was tightly coupled with OAuth2. Kong was the
-only available system of record (SoR) for application credentials and the OAuth
-configuration was done directly within the Application Registration plugin.
-
-In the {{site.ee_product_name}} 2.1.x version, authentication was decoupled from the
-Application Registration plugin. Support has been added for third-party OAuth2
-providers. Developers have the flexibility to choose from either
-Kong or a third-party identity provider (IdP) as the system of record for
-application credentials. With third-party (external) OAuth2 support, developers
-can centralize application credential management with the
-[supported identity provider](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#idps)
-of their choice.
-
-In the {{site.ee_product_name}} 2.2.1.x version and later, support has been added
-for the Key Authentication plugin to use with Kong as the system of record.
-
 ## Supported Authentication Plugins
 
 OAuth2 plugins for use with the Application Registration plugin:

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/azure-oidc-config.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/azure-oidc-config.md
@@ -16,15 +16,11 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 
 1. Within Azure, go to the **App registrations** service and register a new application.
 
-   ![Azure App Registrations](/assets/images/docs/dev-portal/ms-azure-app-reg.png)
-
-1. In **Certificates & secrets**, create a Client secret and save it in a
+2. In **Certificates & secrets**, create a Client secret and save it in a
    secure location. You can only view the secret once.
 
-1. Under **Manifest**, update `accessTokenAcceptedVersion=2` (default is null).
+3. Under **Manifest**, update `accessTokenAcceptedVersion=2` (default is null).
    The JSON for your application should look similar to this example:
-
-   ![Azure Manifest](/assets/images/docs/dev-portal/azure-manifest.png)
 
 ## Create a Service in Kong
 
@@ -32,7 +28,7 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 {% navtab Using cURL %}
 
 ```bash
-$ curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
+curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
   --data 'url=https://httpbin.org/anything'
 ```
 
@@ -40,7 +36,7 @@ $ curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
 {% navtab Using HTTPie %}
 
 ```bash
-$ http PUT :8001/services/httpbin-service-azure \
+http PUT :8001/services/httpbin-service-azure \
   url=https://httpbin.org/anything
 ```
 {% endnavtab %}
@@ -52,14 +48,14 @@ $ http PUT :8001/services/httpbin-service-azure \
 {% navtab Using cURL %}
 
 ```bash
-$ curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
+curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   --data 'paths=/httpbin-azure'
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}
 
 ```bash
-$ http -f PUT :8001/services/httpbin-service-azure/routes/httpbin-route-azure \
+http -f PUT :8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   paths=/httpbin-azure
 ```
 
@@ -78,7 +74,7 @@ The plugins must be applied to a Service to work properly.
 {% navtab Using cURL %}
 
  ```bash
-$ curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
   --data name=openid-connect \
   --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
   --data config.display_errors="true" \
@@ -95,7 +91,7 @@ $ curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugi
 {% navtab Using HTTPie %}
 
 ```bash
-$ http -f :8001/services/httpbin-service-azure/plugins \
+http -f :8001/services/httpbin-service-azure/plugins \
   name=openid-connect \
   config.issuer=https://login.microsoftonline.com/<your_tenant_id>/v2.0 \
   config.display_errors=true \
@@ -119,7 +115,7 @@ For more information, see [OIDC plugin](/hub/kong-inc/openid-connect/).
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
   --data "name=application-registration"  \
   --data "config.auto_approve=true" \
   --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \
@@ -131,7 +127,7 @@ $ curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugi
 {% navtab Using HTTPie %}
 
 ```bash
-$ http -f :8001/services/httpbin-service-azure/plugins \
+http -f :8001/services/httpbin-service-azure/plugins \
   name=application-registration \
   config.auto_approve=true \
   config.display_name="For Azure" \
@@ -140,7 +136,6 @@ $ http -f :8001/services/httpbin-service-azure/plugins \
 ```
 {% endnavtab %}
 {% endnavtabs %}
-
 
 ### Step 3: Get an access token from Azure
 
@@ -155,7 +150,7 @@ Get an access token from Azure:
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token \
+curl -X POST https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token \
   --data scope="<your_client_id>/.default" \
   --data grant_type="client_credentials" \
   --data client_id="<your_client_id>" \
@@ -166,7 +161,7 @@ $ curl -X POST https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/to
 {% navtab Using HTTPie %}
 
 ```bash
-$ https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
+https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
   scope=<your_client_id>/.default \
   grant_type=client_credentials \
   -a <your_client_id>:<your_client_secret>
@@ -179,9 +174,7 @@ $ https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/
 1. Paste the access token obtained from the previous step into
 [JWT](https://jwt.io).
 
-   ![JWT token converter](/assets/images/docs/dev-portal/jwt-converter.png)
-
-2. Click **Share JWT** to copy the value for the
+1. Click **Share JWT** to copy the value for the
 [aud (audience)](https://tools.ietf.org/html/rfc7519#section-4.1.3) claim to
 your clipboard. You will use the `aud` value as your **Reference ID** in the
 next procedure.
@@ -194,19 +187,11 @@ next procedure.
    3. Paste the `aud` value generated in JWT in the **Reference ID** field.
    4. (Optional) Enter a **Description**.
 
-   The Create Application form should look similar to this example:
-
-   ![Create Azure Application](/assets/images/docs/dev-portal/azure-app.png)
-
 2. Click **Create**.
 
 3. After you create your application, make sure you activate the Service. In the
    Services section of the Application Dashboard, click **Activate** on the Service
    you want to use.
-
-   The view application details page should look similar to this example:
-
-   ![Azure Example Application](/assets/images/docs/dev-portal/azure-app-details.png)
 
    Because you enabled
    [Auto-approve](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration##aa)
@@ -226,17 +211,18 @@ flows with your Azure AD implementation.
 {% navtab Using cURL %}
 
 ```bash
-$ curl -i -X POST https://<proxy-hostname>:8443/httpbin-azure/oauth2/v2.0/token \
-  --data grant_type="client_credentials" \
-  --data client_id=<your_client_id> \
-  --data client_secret=<your_client_secret>
+$ curl -X POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
+--data scope="<your_client_id>/.default" \
+--data grant_type="client_credentials" \
+--data client_id="<your_client_id>" \
+--data client_secret="<your_client_secret>"
 ```
 
 {% endnavtab %}
 {% navtab Using HTTPie %}
 
 ```bash
-$ https -f POST "https://<admin-hostname>:8443/httpbin-azure/oauth2/v2.0/token" \
+$ https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
   scope=<your_client_id>/.default \
   grant_type=client_credentials \
   -a <your_client_id>:<your_client_secret> \
@@ -251,14 +237,14 @@ $ https -f POST "https://<admin-hostname>:8443/httpbin-azure/oauth2/v2.0/token" 
 {% navtab Using cURL %}
 
 ```bash
-$ curl --header 'Authorization: bearer <token_from_above>' '<admin-hostname>:8000/httpbin-azure'
+curl --header 'Authorization: bearer <token_from_above>' '<admin-hostname>:8000/httpbin-azure'
 ```
 
 {% endnavtab %}
 {% navtab Using HTTPie %}
 
 ```bash
-$ http :8000/httpbin-azure Authorization:'bearer <token_from_above>'
+http :8000/httpbin-azure Authorization:'bearer <token_from_above>'
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -1,92 +1,137 @@
 ---
-title: Enable Application Registration
+title: Enable Key Authentication for Application Registration
 badge: enterprise
 ---
 
-Application Registration allows registered developers on the Kong Dev Portal to
-authenticate with supported Authentication plugins against a Service on Kong. Either {{site.base_gateway}} or
-external identity provider admins can selectively admit access to Services using Kong Manager.
+You can use the Key Authentication plugin for authentication in conjunction with
+the Application Registration plugin.
+
+The key auth plugin uses the same Client ID as generated for the Kong OAuth2 plugin.
+You can use the same Client ID credential for a Service that has the OAuth2 plugin enabled.
 
 ## Prerequisites
-* {{site.ee_product_name}} is installed, version 2.1.0.0 or later. If you plan to use
-key authentication, version 2.2.1.0 or later.
-* Dev Portal is enabled on the same Workspace as the Service.
-* The Service is created and enabled with HTTPS.
-* Authentication is enabled on the Dev Portal.
-* Logged in as an admin with read and write roles on applications, services, and
-  developers.
-* The `portal_app_auth` configuration option is configured for your OAuth provider
-  and strategy (`kong-oauth2` default or `external-oauth2`). See
-[Configure the Authorization Provider Strategy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy) for the Portal Application Registration plugin.
-* Authorization provider configured if using a supported third-party
-  identity provider with the OIDC plugin:
-  * For example instructions using Okta as an identity provider, refer to the
-    [Okta example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
-  * For example instructions using Azure AD as an identity provider, refer to the
-    [Azure example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
 
-## Enable Application Registration on a Service using Kong Manager {#enable-app-reg-plugin}
+* Create a Service.
+* Enable the [Application Registration plugin](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
+* Activate your application for a Service if you have not already done so. The
+Service Contract must be approved by an Admin if auto approve is not enabled.
+* [Generate a credential](#gen-client-id-cred) if you don't want to use the default credential initially created for you.
 
-To use Application Registration on a Service, the Portal Application Registration
-Plugin must be enabled on a Service.
+## Enable Key Authentication in Kong Manager
 
-In Kong Manager, access the Service for which you want to enable Application Registration:
+In Kong Manager, access the Service for which you want to enable key authentication for
+use with application registration:
 
 1. From your Workspace, in the left navigation pane, go to **API Gateway > Services**.
 2. On the Services page, select the Service and click **View**.
 3. In the Plugins pane in the Services page, click **Add a Plugin**.
 4. On the Add New Plugin page in the Authentication section, find the
-   **Portal Application Registration** Plugin and click **Enable**.
+   **Key Authentication** Plugin and click **Enable**.
 
-   ![Portal Application Registration](/assets/images/docs/dev-portal/app-reg-plugin-panel.png)
+   ![Key Authentication plugin panel](/assets/images/docs/dev-portal/key-auth-plugin-panel.png)
 
-5. Enter the configuration settings. Use the parameters in the next section,
-   [Application Registration Configuration Parameters](#application-registration-configuration-parameters),
+5. Complete the fields as appropriate for your application. In this example, the Service is already
+   prepopulated. Refer to the parameters described in the next section,
+   [Key Authentication Configuration Parameters](#key-auth-params),
    to complete the fields.
-
-   ![Create application-registration plugin](/assets/images/docs/dev-portal/create-app-reg-plugin-form.png)
-
-   **Important:** Exposing
-   the Issuer URL is essential for the
-   [Authorization Code Flow](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow)
-   workflow configured for third-party identity providers.
-
-   ![Issuer URL](/assets/images/docs/dev-portal/dev-portal-issuer-url.png)
 
 6. Click **Create**.
 
-### Application Registration Configuration Parameters {#app-reg-params}
+### Key Authentication Configuration Parameters {#key-auth-params}
 
 | Form Parameter | Description                                                                       |
 |:---------------|:----------------------------------------------------------------------------------|
 | `Service` | The Service that this plugin configuration will target. Required. |
-| `Tags` | A set of strings for grouping and filtering, separated by commas. Optional. |
-| `Auto Approve` | If enabled, all new Service contract requests are automatically approved. Otherwise, Dev Portal admins must manually approve requests. Default: `false`. |
-| `Description` | Description displayed in the information about a Service in the Dev Portal. Optional. |
-| `Display Name` | Unique name displayed in the information about a Service in the Dev Portal. Required. |
-| `Show Issuer` | Displays the Issuer URL in the Service Details page. Default: `false`. **Important:** Exposing the **Issuer URL** is essential for the [Authorization Code Flow](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow) workflow configured for third-party identity providers. |
+| `Anonymous` | An optional string (Consumer UUID) value to use as an anonymous Consumer if authentication fails. If empty (default), the request fails with an `4xx`. Note that this value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`. |
+| `Hide Credentials` | Whether to show or hide the credential from the Upstream service. If `true`, the plugin strips the credential from the request (i.e., the header, query string, or request body containing the key) before proxying it. Default: `false`. |
+| `Key in Body` | If enabled, the plugin reads the request body (if said request has one and its MIME type is supported) and tries to find the key in it. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`. Default: `false`. |
+| `Key in Header` | If enabled (default), the plugin reads the request header and tries to find the key in it. Default: true. |
+| `Key in Query` | If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it. Default: true. |
+| `Key Names` | Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen. Required. Default: `apikey`. |
+| `Run on Preflight` | Indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. Default: `true`. |
 
-## Next steps
+## Generate a Credential {#gen-client-id-cred}
 
-Kong OAuth2 strategy:
+Generate a Client ID credential to use as an API key. You can generate multiple
+credentials.
 
-* If using the Kong-managed authorization strategy
-(`kong-oauth2`) with the OAuth2 plugin, configure the Kong [OAuth2](/hub/kong-inc/oauth2/)
-plugin as appropriate for your authorization requirements. You can use either the
-Kong Manager GUI or cURL commands as documented on the [Plugin Hub](/hub/).
-The OAuth2 plugin cannot be used in hybrid mode.
-* If using the Kong-managed authorization strategy
-(`kong-oauth2`) with key authentication, configure the Kong
-[Key Auth](/hub/kong-inc/key-auth/) plugin as appropriate for your authorization
-requirements. You can use either the
-[Kong Manager GUI](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-key-auth-plugin)
-or cURL commands as documented on the Plugin Hub. The Key Auth plugin
-cannot be used in hybrid mode.
+1. In the **Dev Portal > My Apps** page, click **View** for an application.
 
-External OAuth2 strategy:
+2. In the **Authentication** pane, click **Generate Credential**.
 
-* If using the third-party authorization strategy
-(`external-oauth2`), configure the OIDC plugin. You can use the Kong Manager GUI
-or cURL commands as documented on the [Plugin Hub](/hub/kong-inc/openid-connect).
-When your deployment is hybrid mode, the OIDC plugin must be configured to handle
-authentication for the Portal Application Registration plugin.
+   ![Application Authentication Pane](/assets/images/docs/dev-portal/generate-cred-dev-portal.png)
+
+   Now you can make requests using the Client ID as an API Key.
+
+## Make Requests with an API Key (Client Identifier)
+
+The Client ID of your credentials can be used as an API key to make authenticated requests to a Service.
+
+**Tip:** You can also access key request instructions directly within the user interface from the
+information icon in the Services details area of your application. Click the **i** icon to open the Service Details page.
+
+![Services Pane](/assets/images/docs/dev-portal/portal-info-modal-key-auth.png)
+
+Scroll to view all of the available examples.
+
+![Service Details Page Embedded Key Usage Instructions](/assets/images/docs/dev-portal/service-details-key-auth-usage.png)
+
+### About API Key Locations in a Request
+
+{% include /md/plugins-hub/api-key-locations.md %}
+
+### Make a request with the key as a query string parameter
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -X POST {proxy}/{route}?apikey={CLIENT_ID}
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http {proxy}/{route}?apikey={CLIENT_ID}
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Response (will be the same for all valid requests regardless of key location):
+
+```bash
+HTTP/1.1 200 OK
+...
+```
+
+### Make a request with the key in a header
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -X POST {proxy}/{route} \
+--header "apikey: {CLIENT_ID}"
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http {proxy}/{route} apikey:{CLIENT_ID}
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+### Make a request with the key in the body
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -X POST {proxy}/{route} \
+--data "apikey:={CLIENT_ID}"
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http {proxy}/{route} apikey={CLIENT_ID}
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+**Note:** The `key_in_body` parameter must be set to `true`.

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/enable-key-auth-plugin.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/enable-key-auth-plugin.md
@@ -11,7 +11,6 @@ You can use the same Client ID credential for a Service that has the OAuth2 plug
 
 ## Prerequisites
 
-* {{site.ee_product_name}} is installed, version 2.2.1.0 or later.
 * Create a Service.
 * Enable the [Application Registration plugin](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
 * Activate your application for a Service if you have not already done so. The
@@ -60,7 +59,7 @@ credentials.
 
 2. In the **Authentication** pane, click **Generate Credential**.
 
-   ![Application Authentication Pane](/assets/images/docs/dev-portal/gen-client-id-secret.png)
+   ![Application Authentication Pane](/assets/images/docs/dev-portal/generate-cred-dev-portal.png)
 
    Now you can make requests using the Client ID as an API Key.
 
@@ -86,12 +85,12 @@ Scroll to view all of the available examples.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-$ curl -X POST {proxy}/{route}?apikey={CLIENT_ID}
+curl -X POST {proxy}/{route}?apikey={CLIENT_ID}
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-$ http {proxy}/{route}?apikey={CLIENT_ID}
+http {proxy}/{route}?apikey={CLIENT_ID}
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -108,13 +107,13 @@ HTTP/1.1 200 OK
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-$ curl -X POST {proxy}/{route} \
+curl -X POST {proxy}/{route} \
 --header "apikey: {CLIENT_ID}"
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-$ http {proxy}/{route} apikey:{CLIENT_ID}
+http {proxy}/{route} apikey:{CLIENT_ID}
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -124,13 +123,13 @@ $ http {proxy}/{route} apikey:{CLIENT_ID}
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-$ curl -X POST {proxy}/{route} \
+curl -X POST {proxy}/{route} \
 --data "apikey:={CLIENT_ID}"
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-$ http {proxy}/{route} apikey={CLIENT_ID}
+http {proxy}/{route} apikey={CLIENT_ID}
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/okta-config.md
@@ -11,9 +11,7 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 Follow these steps to set up an authorization server in Okta for all authorization types.
 
 1. Sign in to the [Developer Okta site](https://developer.okta.com/).
-2. Click **API > Authorization Servers**.
-
-   ![Okta Authorization Server](/assets/images/docs/dev-portal/okta-api-auth-server.png)
+1. Click **Security > API > Authorization Servers**.
 
    Notice that you already have an authorization server set up named `default`.
    This example uses the default auth server. You can also create as many
@@ -21,27 +19,21 @@ Follow these steps to set up an authorization server in Okta for all authorizati
    more information, refer to the
    [Okta developer documentation](https://developer.okta.com/docs/guides/customize-authz-server/overview/).
 
-3. Click **default** to view the details for the default auth server. Take note
+2. Click **default** to view the details for the default auth server. Take note
 of the `Issuer` URL, which you will use to associate Kong with your authorization server.
 
-   ![Okta Issuer URL](/assets/images/docs/dev-portal/okta-auth-server-issuer-url.png)
+1. Click the **Claims** tab.
 
-4. Click the **Claims** tab.
-
-   ![Okta Issuer URL](/assets/images/docs/dev-portal/okta-auth-server-claims.png)
-
-5. Click **Add Claim**. Add a custom claim called `application_id` that will attach any successfully authenticated application's `id` to the access token.
+2. Click **Add Claim**. Add a custom claim called `application_id` that will attach any successfully authenticated application's `id` to the access token.
     1. Enter `application_id` in the **Name** field.
     2. Ensure the `Include in token type` selection is **Access Token**.
     3. Enter `app.clientId` in the **Value** field.
     4. Click **Create**.
 
-   ![Okta Claim](/assets/images/docs/dev-portal/okta-add-claim.png)
-
     Now that you have created a custom claim, you can associate the `client_id`
     with a Service via the Application Registration plugin. Start by creating a Service in Kong Manager.
 
-7. Create a Service and a Route and instantiate an OIDC plugin on that Service.
+3. Create a Service and a Route and instantiate an OIDC plugin on that Service.
    You can allow most options to use their defaults.
 
    1. In the `Config.Issuer` field, enter the Issuer URL of the Authorization server from your identity provider.
@@ -58,7 +50,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
    The core configuration should be:
 
-   ```
+   ```json
    {
      "issuer": "<auth_server_issuer_url>",
      "verify_credentials": false,
@@ -67,7 +59,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
    ```
 
-8. Configure a Portal Application Registration plugin on the Service as well. See
+4. Configure a Portal Application Registration plugin on the Service as well. See
 [Application Registration](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration#config-app-reg-plugin).
 
 ## Register an application in Okta
@@ -76,17 +68,13 @@ Follow these steps to register an application in Okta and associate the Okta
 application with an application in the Kong Dev Portal.
 
 1. Sign in to the [Developer Okta site](https://developer.okta.com/).
-2. Click **Applications** > **+ Add Application**.
+2. Click **Applications** > **Applications**.
 3. Depending on which authentication flow you want to implement, the setup of
 your Okta application will vary:
 
-    - **Client Credentials**: Select `Machine-to-Machine` when prompted for an application type.
-
-     ![Okta Create New Application](/assets/images/docs/dev-portal/okta-client-creds-app.png)
+    - **Create a new app integration**: Select `API Services` when prompted for an application type. In the **New API Services App Integration** modal, enter your app integration name.
 
     You will need your `client_id` and `client_secret` later on when you [authenticate with the proxy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth#cc-flow).
-
-    ![Okta Client Credentials](/assets/images/docs/dev-portal/okta-client-id-secret.png)
 
     - **Implicit Grant**: Select `Single-Page App`, `Native`, or `Web` when
   prompted for an application type. Make sure `Implicit` is selected for

--- a/app/gateway/2.8.x/developer-portal/configuration/authentication/oidc.md
+++ b/app/gateway/2.8.x/developer-portal/configuration/authentication/oidc.md
@@ -15,16 +15,24 @@ In addition, a configuration object is required to enable OIDC. Refer to the
 [Sample Configuration Object](#/sample-configuration-object) section of this
 document for more information.
 
-**Note:** The Dev Portal does not automatically create developer accounts on login via OIDC.
+{:.note}
+> **Note**: The Dev Portal does not automatically create developer accounts on login via OIDC.
 A developer account matching the `consumer_claim` configuration parameter has to be
 created and approved (if auto approve is not enabled) beforehand.
+> <br><br>
+> During the registration flow, users must enter their login information in their
+IDP-redirected login page. The user is then brought to the Dev Portal
+registration page and their email is pre-populated in the registration form.
+Users cannot change their email in the registration form.
+The user may be asked for additional fields, as set by the account admin.
 
 OIDC for the Dev Portal can be enabled in one of the following ways:
 
-- [Kong Manager](#enable-oidc-using-kong-manager)
-- [Kong Admin API (command line)](#enable-oidc-using-the-command-line)
-- [The Kong configuration file](#enable-oidc-using-kongconf)
-
+- [Portal Session Plugin Config](#portal-session-plugin-config)
+- [Sample Configuration Object](#sample-configuration-object)
+- [Enable OIDC using Kong Manager](#enable-oidc-using-kong-manager)
+- [Enable OIDC using the Command Line](#enable-oidc-using-the-command-line)
+- [Enable OIDC using kong.conf](#enable-oidc-using-kongconf)
 
 ## Portal Session Plugin Config
 

--- a/app/gateway/2.8.x/developer-portal/configuration/smtp.md
+++ b/app/gateway/2.8.x/developer-portal/configuration/smtp.md
@@ -14,8 +14,7 @@ curl http://localhost:8001/workspaces/<WORKSPACE_NAME> \
 
 If they are not modified manually, the Dev Portal will use the default value defined in the Kong Configuration file.
 
-In 1.3.0.1 or greater, [Dev Portal email content and styling can be customized via template files](/gateway/{{page.kong_version}}/developer-portal/theme-customization/emails/)
-
+Dev Portal email content and styling can be customized via [template files](/gateway/{{page.kong_version}}/developer-portal/theme-customization/emails/).
 
 ## portal_invite_email
 
@@ -105,7 +104,7 @@ the link above to change your password.
 **Default:** `on`
 
 **Description:**
-When enabled, developers will receive an email after successfully reseting their Dev Portal account password.
+When enabled, developers will receive an email after successfully resetting their Dev Portal account password.
 
 When disabled, developers will still be able to reset their account passwords, but will not receive a confirmation email.
 

--- a/app/gateway/2.8.x/developer-portal/index.md
+++ b/app/gateway/2.8.x/developer-portal/index.md
@@ -9,4 +9,4 @@ documentation, streamlined developer onboarding, and role-based access control
 (RBAC), Kong’s Dev Portal provides a comprehensive solution for creating
 and customizing a unified developer experience.
 
-![Dev Portal](/assets/images/docs/dev-portal/dev-portal-homepage.png)
+![Dev Portal](/assets/images/docs/dev-portal/developer-portal-homepage.png)

--- a/app/gateway/2.8.x/developer-portal/theme-customization/adding-javascript-assets.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/adding-javascript-assets.md
@@ -11,7 +11,6 @@ webpages or load additional JavaScript.
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Portal Legacy is turned off
 * The Kong Developer Portal is enabled and running
 * The [kong-portal-cli tool](/gateway/{{page.kong_version}}/developer-portal/helpers/cli) is installed locally

--- a/app/gateway/2.8.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -7,27 +7,23 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Access to Kong Manager
 * The Developer Portal is enabled and running
 
 ## The Appearance Tab
 
+{:.note}
+> **Note**: Styling does not automatically carry over from the default Dev Portal to different Dev Portals in other workspaces. Use the [Dev Portal CLI](/gateway/latest/developer-portal/helpers/cli) to manually copy templates to workspaces where you want to duplicate the styling.
+
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
 The predefined variables refer to the following elements:
 
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
+![Appearance Tab - Variables](/assets/images/docs/dev-portal/appearance-dev-portal.png)
 
 Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/gateway/{{page.kong_version}}/developer-portal/using-the-editor) for more information on how to edit, preview, and save files in the Editor.
-
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/gateway/2.8.x/developer-portal/theme-customization/emails.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/emails.md
@@ -9,21 +9,18 @@ Email files can be managed in the same way as other files for rendering, via edi
 This feature is **not** supported on legacy portal mode.
 
 If no email templates are loaded, Kong will fall back to the same emails as {{site.base_gateway}} 1.3.0.0.
-By default on 1.3.0.1 and newer, enabling a non-legacy portal on new workspaces loads default editable email templates.
+Enabling a non-legacy portal on new workspaces loads default editable email templates.
 For existing non-legacy Portals, editable email templates must be loaded manually.
 
 Email-specific values are templated in tokens that work similarly to templating in portal layouts and partials.
 Not all tokens are supported on all emails.
 
-
 ## Prerequisites
 
-* {{site.base_gateway}} **1.3.0.1** or later
 * The Kong Developer Portal is not running in **Legacy Mode**
 * The Kong Developer Portal is enabled and running
 * [The emails you want are enabled in kong](/gateway/{{page.kong_version}}/developer-portal/configuration/smtp/#portal_invite_email)
 * If using CLI tool, kong-portal-cli tool 1.1 or later is installed locally and git installed
-
 
 ## Understanding Email Files
 
@@ -69,7 +66,6 @@ The body of the email is HTML content. You can reference the tokens allowed for 
 |emails/account-verification-pending.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}`	              |`{{portal.url}}`	                                                    |email sent to developer when portal_email_verification is on and developer has verified email and developer has yet to be approved by admin (basic-auth only)	|
 {% endraw %}
 
-
 ## Token Descriptions
 
 {% raw %}
@@ -87,7 +83,6 @@ The body of the email is HTML content. You can reference the tokens allowed for 
 |`{{email.token}}`	|Can be used in combination with `{{portal.url}}` to manually build url string for password reset and account verification/invalidation. **Not recommended for use**, unless custom path for password reset or account verification has been set.	|
 {% endraw %}
 
-
 ## Editing Email Templates
 
 The default email templates will be automatically loaded into the Kong Developer Portal's file system when the Dev Portal is activated. These templates can now be edited in Kong Manager via the **Portal Editor** or via the **Portal CLI** tool.
@@ -100,9 +95,7 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
 2. Select the **Editor** from the sidebar under **Dev Portal**.
 
-The email templates can be found under the **Emails** section in the Portal Editor sidebar:
-
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
+The email templates can be found under the **Emails** section in the Portal Editor sidebar.
 
 ### Editing via the Portal CLI Tool
 
@@ -110,7 +103,6 @@ The email templates can be found under the **Emails** section in the Portal Edit
 2. If you have any customizations or permissions changes that you want to keep:
     Run `portal fetch <workspacename>` This will pull in your modifications locally.
 3.  After making any changes, `portal deploy <workspacename>` to deploy all files.
-
 
 ## Editing Email Appearance
 
@@ -144,7 +136,6 @@ The default email layout looks like:
 ```
 {% endraw %}
 
-
 The `img` tag loads the logo that can be set in the appearance tab in the manager. If you do not want to display a logo, remove the `<img>` tag. If you want to set different sizing for your logo, you can change the inline style attribute.
 
 > Note: Logo will not render for many email clients that pre-fetch images if portal is not set to be accessible from a public url (for example if you are testing the Portal with a localhost)
@@ -152,7 +143,6 @@ The `img` tag loads the logo that can be set in the appearance tab in the manage
 By modifying the html of this file, you can change the appearance of your emails. For example if you wanted to add a footer that would show on all emails, add it under the `<p>` tag
 
 Be sure to keep in mind the html support limitations of the email clients you plan to support.
-
 
 ## Loading Email Templates on Existing Dev Portals
 

--- a/app/gateway/2.8.x/developer-portal/theme-customization/markdown-extended.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/markdown-extended.md
@@ -12,7 +12,6 @@ improves rendering significantly, especially for tables.
 
 ## Prerequisites
 
-* {{site.base_gateway}} 2.1 or later
 * Access to Kong Manager
 * The Developer Portal is enabled and running
 

--- a/app/gateway/2.8.x/developer-portal/theme-customization/single-page-app.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/single-page-app.md
@@ -9,7 +9,6 @@ To view the basic example Angular template from this guide, visit the [`example/
 
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Portal Legacy is turned off
 * The Developer Portal is enabled and running
 * kong-portal-cli tool is installed locally
@@ -77,7 +76,7 @@ For this example, place the angular build inside a `workspaces/default/themes/as
 
 ### Mounting an SPA
 
-In order to load our js we need to mount the JS, to do this let’s create a new layout page, for this example, call it `spa.html`.
+To load our JS, we need to mount it. Let's create a new layout page.
 
 Create a file called `spa.html` in `workspaces/default/themes/layouts`.
 

--- a/app/gateway/2.8.x/developer-portal/using-the-editor.md
+++ b/app/gateway/2.8.x/developer-portal/using-the-editor.md
@@ -5,11 +5,8 @@ badge: enterprise
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ## Prerequisites
 
-* {{site.base_gateway}} 1.3 or later
 * Access to Kong Manager
 * The Kong Developer Portal is **enabled** and **running**
 
@@ -19,41 +16,28 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
-
-
+This will launch the **Editor Mode**.
 ## Navigating the Editor
 
 When enabled, the Dev Portal is pre-populated with Kong's default theme. The file editor exposes these files to the UI, allowing them to be edited quickly and easily from inside the browser. When you first open the editor, you will be presented with a list of files on the left, and a blank editing form.
 
 1. Create new files for the Dev Portal right from the Editor by clicking `New File+`.
-2. List of all exposed template files in the Dev Portal, separated by Content / Spec / Themes.
-3. Code View - Select a file from the sidebar to show the code here.
-4. Portal Preview - View a live preview of the selected Dev Portal file.
-5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
+1. List of all exposed template files in the Dev Portal, separated by Content / Spec / Themes.
+1. Code View - Select a file from the sidebar to show the code here.
+1. Portal Preview - View a live preview of the selected Dev Portal file.
+1. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
+![Dev Portal with Numbers](/assets/images/docs/dev-portal/editor-mode-numbered.png)
 
 ## Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
 ## Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
 
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
-
 Once created, files will immediately be available from within the Editor.
-
 
 ## Authenticating files
 
@@ -62,11 +46,6 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
     - to restrict access to certain roles, set readable_by to an array of accepted roles (you must first create roles on the permissions page)
     - on specs, readable_by is set inside "x-headmatter" object
 
-
 ## Deleting files
 
-To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
-
-**NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)
+To _permanently_ delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.

--- a/app/gateway/2.8.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/secure-services.md
@@ -306,7 +306,7 @@ You now have a consumer with an API key provisioned to access the route.
 
 To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
 ```
-http://<admin-hostname>:8000/mock/?apikey=apikey
+http://<admin-hostname>:8000/mock?apikey=apikey
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.8.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -253,7 +253,7 @@ keys.
     ```
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for data plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     control plane will need to be accessible by all data planes it controls through
     any firewalls you may have in place.
 
@@ -299,7 +299,7 @@ keys.
 
     By setting the role of the node to `control_plane`, this node will listen on
     port `0.0.0.0:8005` by default for data plane connections, and on port
-    `0.0.0.0:8006` for Vitals telemetry data. These ports on the
+    `0.0.0.0:8006` for telemetry data. These ports on the
     control plane will need to be accessible by all data planes it controls through
     any firewalls you may have in place.
 
@@ -492,11 +492,11 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
     TLS. When not set, data plane will use `kong_clustering` as the SNI.
 
     : You can also optionally use `KONG_CLUSTER_TELEMETRY_SERVER_NAME`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `KONG_CLUSTER_SERVER_NAME`.
 
     `KONG_CLUSTER_TELEMETRY_ENDPOINT`
-    : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
+    : Optional setting, needed for telemetry gathering. Not available in open-source deployments.
 
     You can also choose to encrypt or disable the data plane configuration
     cache with some additional settings:
@@ -511,7 +511,7 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
     : An optional custom path to the config cache. Not available in open-source
     deployments.
 
-2. If needed, bring up any subsequent data planes using the same settings.
+1. If needed, bring up any subsequent data planes using the same settings.
 
 {% endnavtab %}
 {% navtab Using kong.conf %}
@@ -573,11 +573,11 @@ and follow the instructions in Steps 1 and 2 **only** to download
     not set, data plane will use `kong_clustering` as the SNI.
 
     : You can also optionally use `cluster_telemetry_server_name`
-      to set a custom SNI for Vitals telemetry data. If not set, it defaults to
+      to set a custom SNI for telemetry data. If not set, it defaults to
       `cluster_server_name`.
 
     `cluster_telemetry_endpoint`
-    : Optional setting, needed for Vitals telemetry gathering. Not available in open-source deployments.
+    : Optional setting, needed for telemetry gathering. Not available in open-source deployments.
 
     You can also choose to encrypt or disable the data plane configuration
     cache with some additional settings:
@@ -675,8 +675,8 @@ Parameter | Description | CP or DP {:width=10%:}
 [`role`](/gateway/{{page.kong_version}}/reference/configuration/#role) <br>*Required* | Determines whether the {{site.base_gateway}} instance is a control plane or a data plane. Valid values are `control_plane` or `data_plane`. | Both
 [`cluster_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_listen) <br>*Optional* <br><br>**Default:** `0.0.0.0:8005`| List of addresses and ports on which the control plane will listen for incoming data plane connections. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on data plane nodes. | CP
 [`proxy_listen`](/gateway/{{page.kong_version}}/reference/configuration/#proxy_listen) <br>*Required* | Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. Ignored on control plane nodes. | DP
-[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the control plane will listen for data plane Vitals telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on data plane nodes. | CP
-[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the data plane uses to send Vitals telemetry data to the control plane. Ignored on control plane nodes. | DP
+[`cluster_telemetry_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_listen) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `0.0.0.0:8006`| List of addresses and ports on which the control plane will listen for data plane telemetry data. This port is always protected with Mutual TLS (mTLS) encryption. Ignored on data plane nodes. | CP
+[`cluster_telemetry_endpoint`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_endpoint) <span class="badge enterprise"/> <br>*Required for Enterprise deployments* | The port that the data plane uses to send telemetry data to the control plane. Ignored on control plane nodes. | DP
 [`cluster_control_plane`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_control_plane) <br>*Required* | Address and port that the data plane nodes use to connect to the control plane. Must point to the port configured using the [`cluster_listen`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_listen) property on the control plane node. Ignored on control plane nodes. | DP
 [`cluster_mtls`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_mtls) <br>*Optional* <br><br>**Default:** `shared` | One of `shared` or `pki`. Indicates whether hybrid mode will use a shared certificate/key pair for CP/DP mTLS or if PKI mode will be used. See below sections for differences in mTLS modes. | Both
 [`data_plane_config_cache_mode`](/gateway/{{page.kong_version}}/reference/configuration/#data_plane_config_cache_mode) <span class="badge enterprise"/> <br>*Optional* <br><br>**Default:** `unencrypted` | Determines how the data plane configuration cache is stored. <br> &#8226; `unencrypted`: Stores configuration without encrypting it in `config.cache.json.gz` <br> &#8226; `encrypted`: Encrypts and stores the configuration cache in `.config.cache.jwt` (hidden file). <br> &#8226; `off`: The data plane does not cache configuration | DP
@@ -689,7 +689,7 @@ Parameter | Description | Shared Mode {:width=12%:} | PKI Mode {:width=30%:}
 [`cluster_cert`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_cert) and [`cluster_cert_key`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_cert_key) <br>*Required* | Certificate/key pair used for mTLS between CP/DP nodes. | Same between CP/DP nodes. | Unique certificate for each node, generated from the CA specified by `cluster_ca_cert`.
 [`cluster_ca_cert`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_ca_cert) <br>*Required in PKI mode* | The trusted CA certificate file in PEM format used to verify the `cluster_cert`. | *Ignored* | CA certificate used to verify `cluster_cert`, same between CP/DP nodes. *Required*
 [`cluster_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_server_name) <br>*Required in PKI mode* | The SNI presented by the DP node mTLS handshake. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_server_name` value.
-[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The Vitals telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
+[`cluster_telemetry_server_name`](/gateway/{{page.kong_version}}/reference/configuration/#cluster_telemetry_server_name) <span class="badge enterprise"/>|  The telemetry SNI presented by the DP node mTLS handshake. If not specified, falls back on SNI set in `cluster_server_name`. | *Ignored* | In PKI mode, the DP nodes will also verify that the Common Name (CN) or Subject Alternative Name (SAN) inside the certificate presented by CP matches the `cluster_telemetry_server_name` value.
 
 ## Next steps
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -624,7 +624,7 @@ Valid values to this setting are:
 - `pki`: use `cluster_ca_cert`, `cluster_server_name` and `cluster_cert` for
   verification. These are different certificates for each DP node, but issued by
   a cluster-wide common CA certificate: `cluster_ca_cert`.
-- `pki_check_cn`: similar to `pki`, but additionally
+- `pki_check_cn` <span class="badge enterprise"></span>: similar to `pki`, but additionally
    checks for the Common Name of the data plane certificate specified in
    `cluster_allowed_common_names`.
 

--- a/app/gateway/2.8.x/reference/external-plugins.md
+++ b/app/gateway/2.8.x/reference/external-plugins.md
@@ -68,7 +68,7 @@ plugin server using a different configuration style. Starting with {{site.base_g
 the old style is recognized and internally transformed to the new style.
 
 {:.important}
-> The legacy configuration is deprecated in {{site.base_gateway}} version 2.8.0 and 
+> The legacy configuration is deprecated in {{site.base_gateway}} version 2.8.0 and
 > planned to be removed in {{site.base_gateway}} version 3.0.0.
 
 If property `pluginserver_names` isn't defined, the legacy properties
@@ -81,7 +81,7 @@ Property | Description | Default
 
 Notes:
 
-- Using the legacy style is discouraged; it is deprecated as of {{site.base_gateway}} version 2.8.0, 
+- Using the legacy style is discouraged; it is deprecated as of {{site.base_gateway}} version 2.8.0,
 and planned to be removed in {{site.base_gateway}} version 3.0.0.
 - The legacy configuration doesn't allow multiple plugin servers.
 - Version 0.5.0 of [go-pluginserver] requires the old style configuration.
@@ -89,7 +89,7 @@ and planned to be removed in {{site.base_gateway}} version 3.0.0.
 
 #### Updating from legacy to embedded server style
 
-In embedded server mode, the plugin itself acts as the plugin server, 
+In embedded server mode, the plugin itself acts as the plugin server,
 so the external `go-pluginserver` is no longer required.
 
 Update legacy configuration to embedded plugin server style configuration with
@@ -444,7 +444,7 @@ functions to access {{site.base_gateway}} features of the [PDK][kong-pdk].
 [kong-python-pdk] can be installed using `pip`. To install the plugin server binary and PDK globally, use:
 
 ```
-pip install kong-pdk
+pip3 install kong-pdk
 ```
 
 Assume the plugins are stored in `/usr/local/kong/python-plugins`:
@@ -475,7 +475,7 @@ schema of plugin, it shares the same syntax as it's a Lua plugin. `version` and 
 defines the version number and priority of execution respectively.
 
 **Note**: Check out [this repository](https://github.com/Kong/kong-python-pdk/tree/master/examples)
-for example Python plugins.
+for example Python plugins and [API reference](https://kong.github.io/kong-python-pdk/py-modindex.html).
 
 #### 1. Phase Handlers
 


### PR DESCRIPTION
### Summary
Copying changes made since previous merge from Gateway 2.7.x docs to Gateway 2.8.x docs.

See merge commit for reference: https://github.com/Kong/docs.konghq.com/commit/45a647d61aca27fa82a3f481313e46dc36058849

### Reason
Chore PR. Have to manually copy content as we don't have automation for this.

### Testing
Scroll through changes and check that nothing looks out of place.