### PR TITLE
(chore) Update dependencies for 2.8

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -372,7 +372,7 @@
     cassandra: "3.x.x"
     postgres: "9.5+"
     openresty: "1.19.9.1"
-    openssl: "1.1.1l"
+    openssl: "1.1.1m"
     libyaml: "0.2.5"
     pcre: "8.45"
   lua_doc: true


### PR DESCRIPTION
### Summary
Check Gateway dependencies against wiki & changelogs and update accordingly.

### Reason

In general, I don't actually know if we use these dependencies for anything on the docs site. I'm updating it because it's there, but it might be worth taking a second look at post-2.8. One for the retro.

### Testing
N/A