### PR TITLE
(chore) Generate config reference for 2.8

### DIFF
--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -2320,8 +2320,8 @@ Example for `basic-auth`:
 If `admin_gui_auth` is set to `openid-connect`, enable or disable RBAC token
 creation when automatically creating admins with OpenID Connect.
 
-* Set to `true` to enable automatic token creation for admins
-* Set to `false` to disable automatic token creation for admins
+* Set to `true` to disable automatic token creation for admins
+* Set to `false` to enable automatic token creation for admins
 
 **Default:** `false`
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -2314,19 +2314,6 @@ Example for `basic-auth`:
 
 ---
 
-#### admin_auto_create_rbac_token_disabled
-{:.badge .enterprise}
-
-If `admin_gui_auth` is set to `openid-connect`, enable or disable RBAC token
-creation when automatically creating admins with OpenID Connect.
-
-* Set to `true` to disable automatic token creation for admins
-* Set to `false` to enable automatic token creation for admins
-
-**Default:** `false`
-
----
-
 #### admin_gui_auth_password_complexity
 {:.badge .enterprise}
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -491,6 +491,18 @@ adjusted by the `log_level` property.
 
 ---
 
+#### vaults
+
+Comma-separated list of vaults this node should load. By default, no vaults are
+enabled.
+
+The specified name(s) will be substituted as such in the Lua namespace:
+`kong.vaults.{name}.*`.
+
+**Default:** `off`
+
+---
+
 #### plugins
 
 Comma-separated list of plugins this node should load. By default, only plugins
@@ -624,9 +636,8 @@ Valid values to this setting are:
 - `pki`: use `cluster_ca_cert`, `cluster_server_name` and `cluster_cert` for
   verification. These are different certificates for each DP node, but issued by
   a cluster-wide common CA certificate: `cluster_ca_cert`.
-- `pki_check_cn`: similar to `pki`, but additionally
-   checks for the Common Name of the data plane certificate specified in
-   `cluster_allowed_common_names`.
+- `pki_check_cn`: similar as `pki` but additionally checks for Common Name of
+  data plane certificate specified in `cluster_allowed_common_names`.
 
 **Default:** `shared`
 
@@ -678,16 +689,16 @@ This field is ignored if `cluster_mtls` is set to `shared`.
 
 #### cluster_allowed_common_names
 
-The list of Common Names that are allowed to connect to the control plane.
-Multiple entries may be supplied in a comma-separated string. When not
-set, only Data Planes with the same parent domain as the
-Control Plane cert are allowed to connect.
+The list of Common Names that are allowed to connect to control plane. Multiple
+entries may be supplied in a comma-separated string. When not set, Data Plane
+with same parent domain of Control Plane cert is allowed to connect.
 
 This field is ignored if `cluster_mtls` is not set to `pki_check_cn`.
 
 **Default:** none
 
 ---
+
 
 ### Hybrid Mode Data Plane section
 
@@ -2153,7 +2164,7 @@ happens on a service, the event hook calls a URL with information about that
 event. Event hook configurations differ depending on the handler. The events
 that are triggered send associated data.
 
-See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/
+See: https://docs.konghq.com/gateway/latest/admin-api/event-hooks/reference/
 
 **Default:** `on`
 
@@ -2299,6 +2310,19 @@ Example for `basic-auth`:
 `admin_gui_auth_conf = { "hide_credentials": true }`
 
 **Default:** none
+
+---
+
+#### admin_auto_create_rbac_token_disabled
+{:.badge .enterprise}
+
+If `admin_gui_auth` is set to `openid-connect`, enable or disable RBAC token
+creation when automatically creating admins with OpenID Connect.
+
+* Set to `true` to enable automatic token creation for admins
+* Set to `false` to disable automatic token creation for admins
+
+**Default:** `false`
 
 ---
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -690,10 +690,11 @@ This field is ignored if `cluster_mtls` is set to `shared`.
 
 #### cluster_allowed_common_names
 
-The list of Common Names that are allowed to connect to control plane. Multiple
-entries may be supplied in a comma-separated string. When not set, Data Plane
-with same parent domain of Control Plane cert is allowed to connect.
-
+The list of Common Names that are allowed to connect to the control plane.
+Multiple entries may be supplied in a comma-separated string. When not
+set, only data planes with the same parent domain as the
+control plane cert are allowed to connect.
+  
 This field is ignored if `cluster_mtls` is not set to `pki_check_cn`.
 
 **Default:** none


### PR DESCRIPTION
### Summary
Generate configuration reference for Gateway 2.8 from `kong.conf.default`.

Manually document `admin_auto_create_rbac_token_disabled`, as it is missing from the source file in the kong-ee repo. This one will need tech review.

### Reason
Chore PR.

### Testing
https://deploy-preview-3717--kongdocs.netlify.app/gateway/2.8.x/reference/configuration/