### PR TITLE
Bump prometheus plugin nav version

### DIFF
--- a/app/_data/extensions/kong-inc/prometheus/versions.yml
+++ b/app/_data/extensions/kong-inc/prometheus/versions.yml
@@ -1,4 +1,4 @@
-- release: 1.5.x
+- release: 1.6.x
 - release: 1.4.x
 - release: 1.3.x
 - release: 0.9.x


### PR DESCRIPTION
### Summary
Prometheus plugin version skips 1.5 and goes directly to 1.6.

### Reason
Plugin was changed to 1.6 but the nav label wasn't. See https://github.com/Kong/docs.konghq.com/pull/3712#issuecomment-1054142647.

### Testing
Check that the dropdown contains 1.6.x and 1.4.x, but not 1.5.x: https://deploy-preview-3721--kongdocs.netlify.app/hub/kong-inc/prometheus/