### PR TITLE
Fix autodoc label name

### DIFF
--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "review:tech, review:copyedit, review:general, review:autogen"
+          labels: "review:tech, review:copyedit, review:general, review:autodoc"


### PR DESCRIPTION
### Summary
Fix label name.

### Reason
The labeler GH action looks for `review:autogen`, but the label placed on autogenerated docs is `review:autodoc`. See https://github.com/Kong/docs.konghq.com/pull/3725

### Testing
N/A