### PR TITLE
[DOCU-2214] AWS lambda plugin: deprecate proxy_scheme

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -180,14 +180,8 @@ params:
         the given proxy server URL. Include the request scheme in the URL, which
         must be `http`. For example: `http://my-proxy-server:3128`.
 
-        Although the scheme is `http`, the plugin still performs a TLS handshake
-        with AWS Lambda, therefore traffic is encrypted:
-        1. The initial connection to the proxy happens in plain text, but only
-        the upstream `host:port` value is sent to the proxy. No details about
-        the request are passed to the forward proxy server.
-        2. The proxy sends a 200 response back.
-        3. The proxy becomes a L4/TCP proxy and forwards all traffic
-        byte-for-byte.
+        Kong Gateway uses HTTP tunneling via the [CONNECT HTTP](https://httpwg.org/specs/rfc7231.html#CONNECT)
+        method so that no details of the AWS Lambda request are leaked to the proxy server.
 
     - name: proxy_scheme
       required: semi

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -174,8 +174,21 @@ params:
       required: semi
       default: null
       datatype: string
+      value_in_examples: http://my-proxy-server:3128
       description: |
-        An optional value that defines whether the plugin should connect through the given proxy server URL.
+        An optional value that defines whether the plugin should connect through
+        the given proxy server URL. Include the request scheme in the URL, which
+        must be `http`. For example: `http://my-proxy-server:3128`.
+
+        Although the scheme is `http`, the plugin still performs a TLS handshake
+        with AWS Lambda, therefore traffic is encrypted:
+        1. The initial connection to the proxy happens in plain text, but only
+        the upstream `host:port` value is sent to the proxy. No details about
+        the request are passed to the forward proxy server.
+        2. The proxy sends a 200 response back.
+        3. The proxy becomes a L4/TCP proxy and forwards all traffic
+        byte-for-byte.
+
         The `proxy_url` value is required if `proxy_scheme` is defined.
     - name: proxy_scheme
       required: semi

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -189,7 +189,6 @@ params:
         3. The proxy becomes a L4/TCP proxy and forwards all traffic
         byte-for-byte.
 
-        The `proxy_url` value is required if `proxy_scheme` is defined.
     - name: proxy_scheme
       required: semi
       default: null

--- a/app/_hub/kong-inc/aws-lambda/index.md
+++ b/app/_hub/kong-inc/aws-lambda/index.md
@@ -13,9 +13,11 @@ categories:
 kong_version_compatibility:
   community_edition:
     compatible:
+      - 2.8.x
       - 2.7.x
   enterprise_edition:
     compatible:
+      - 2.8.x
       - 2.7.x
 params:
   name: aws-lambda
@@ -180,8 +182,17 @@ params:
       default: null
       datatype: string
       description: |
+
+        {:.important}
+        > As of Kong Gateway 2.8.0.0, this parameter is deprecated and will be
+        removed in 3.x.x.
+        > <br><br>
+        > If running Kong Gateway 2.7.x or earlier, the
+        `proxy_scheme` value is required if `proxy_url` is defined. In 2.8.x or
+        later versions, `proxy_scheme` is not required.
+
         An optional value that defines which HTTP scheme to use for connecting through the proxy server. The
-        supported schemes are `http` and `https`. The `proxy_scheme` value is required if `proxy_url` is defined.
+        supported schemes are `http` and `https`.
     - name: skip_large_bodies
       required: false
       default: '`true`'
@@ -350,7 +361,15 @@ Have fun leveraging the power of AWS Lambda in Kong!
 
 ## Changelog
 
-### 3.6.0
+> See the Kong GitHub repository for the
+[full plugin changelog](https://github.com/Kong/kong/blob/master/kong/plugins/aws-lambda/CHANGELOG.md).
+
+### Kong Gateway 2.8.x (plugin version 3.6.3)
+
+* The `proxy_scheme` configuration parameter is deprecated and planned to be
+removed in 3.x.x.
+
+### Kong Gateway 2.7.x (plugin version 3.6.0)
 
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled,
  the `config.aws_key` and `config.aws_secret` parameter values will be encrypted.


### PR DESCRIPTION
### Summary
* Deprecate `proxy_scheme` parameter
* Improve description for `proxy_url` parameter: added a bit of info on using `http` and explained that it's still secure (which is definitely something users would ask about)

### Reason
Eng PR: https://github.com/Kong/kong/pull/8406 

### Testing
https://deploy-preview-3726--kongdocs.netlify.app/hub/kong-inc/aws-lambda/