### PR TITLE
[DOCU-2211] Promo banner for gateway 2.8

### DIFF
--- a/app/_assets/javascripts/promo-banner.js
+++ b/app/_assets/javascripts/promo-banner.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function () {
-  var closed = localStorage.getItem("closebanner-webinar-020822");
+  var closed = localStorage.getItem("closebanner-gateway-28");
   if (
     closed !== "closebanner"
   ) {
@@ -28,6 +28,6 @@ setInterval(function () {
 }, 10);
 $(".closebanner").on("click", function () {
   $(".navbar-v2").addClass("closed");
-  localStorage.setItem("closebanner-webinar-020822", "closebanner");
+  localStorage.setItem("closebanner-gateway-28", "closebanner");
   $("#mosaic-provider-react-aria-0-1").removeClass("banner-offset");
 });

--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -115,27 +115,27 @@ body {
       }
       // uncomment this section when adding a new promo banner
       // also uncomment the promo banner sections in /app/_includes/nav-v2.html and gulpfile.js
-      // header.navbar-v2 {
-      //   transition: transform 0.2s ease-in-out;
-      //   will-change: transform;
-      //   height: 95px;
-      // }
-      //
-      // header.navbar-v2.closed {
-      //   transition: 0s ease-in-out;
-      // }
-      //
-      // header.closed,
-      // header.compress {
-      //   transform: translateY(-35px);
-      // }
-      //
-      // header:not(.closed) ~ .landing-page {
-      //   margin-top: 35px;
-      // }
-      // header:not(.closed) ~ div.page {
-      //   margin-top: 100px;
-      // }
+      header.navbar-v2 {
+        transition: transform 0.2s ease-in-out;
+        will-change: transform;
+        height: 95px;
+      }
+
+      header.navbar-v2.closed {
+        transition: 0s ease-in-out;
+      }
+
+      header.closed,
+      header.compress {
+        transform: translateY(-35px);
+      }
+
+      header:not(.closed) ~ .landing-page {
+        margin-top: 35px;
+      }
+      header:not(.closed) ~ div.page {
+        margin-top: 100px;
+      }
     }
   }
 }

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -2,12 +2,12 @@
   <a class="skip-main" href="#main">Skip to content</a>
   <!-- uncomment the promo-banner div when adding a new promo banner
   <!--also uncomment the promo banner sections in app/assets/stylesheets/header.less and gulpfile.js-->
-  <!-- <div id="promo-banner">
+  <div id="promo-banner">
     <div class="container">
-      <div class="closebanner"></div> <strong><label>LIVE WEBINAR</label> Learn how to secure, route, and transform API requests &nbsp;&mdash;<a
-          href="https://konghq.com/webinars/scaling-high-performance-apis-microservices">Register Now! &rarr;</a></strong>
+      <div class="closebanner"></div> <strong><label>NEW</label> Kong Gateway 2.8 Increases Security and Simplifies API Management. &nbsp;&mdash;<a
+          href="https://konghq.com/blog/kong-gateway-2-8">Learn More &rarr;</a></strong>
     </div>
-  </div> -->
+  </div>
   <div class="navbar-content">
     <a href="https://konghq.com" class="navbar-brand col col-xl-auto">
       <img src="/assets/images/logos/kong-logo-blue.svg" alt="Kong Logo" id="kong-logo">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ var sources = {
     paths.assets + "javascripts/feedback-widget.js",
     // uncomment the path to promo-banner.js when adding a new promo banner
     // also uncomment the promo banner sections in app/_assets/stylesheets/header.less and /app/_includes/nav-v2.html -->
-    // paths.assets + "javascripts/promo-banner.js",
+    paths.assets + "javascripts/promo-banner.js",
     paths.assets + "javascripts/copy-code-snippet-support.js"
   ],
   images: paths.assets + "images/**/*",


### PR DESCRIPTION
### Summary
Enabling the promo banner and prepping link to 2.8 release blog.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
https://deploy-preview-3728--kongdocs.netlify.app/

Check the promo banner at the top of any docs page.
Note to reviewers: the link will be broken for now, as the blog isn't live yet.
