### PR TITLE
[DOCU-2195] Upgrade guide updates for 2.8

### DIFF
--- a/app/gateway/2.8.x/install-and-run/migrate-ce-to-ke.md
+++ b/app/gateway/2.8.x/install-and-run/migrate-ce-to-ke.md
@@ -19,16 +19,16 @@ supports the same {{site.ce_product_name}} version.
    recommended to back up your production data before migrating from
    {{site.ce_product_name}} to {{site.ee_product_name}}.
 
-* If running a version of {{site.ce_product_name}} earlier than 2.7.x,
-  [upgrade to Kong 2.7.x](/gateway/{{page.kong_version}}/install-and-run/upgrade-oss/) before migrating
-  {{site.ce_product_name}} to {{site.ee_product_name}} 2.7.x.
+* If running a version of {{site.ce_product_name}} earlier than 2.8.x,
+  [upgrade to Kong 2.8.x](/gateway/{{page.kong_version}}/install-and-run/upgrade-oss/) before migrating
+  {{site.ce_product_name}} to {{site.ee_product_name}} 2.8.x.
 
 ## Migration steps
 
 The following steps guide you through the migration process.
 
-1. Download {{site.ee_product_name}} 2.7.x and configure it to point to the
-   same datastore as your {{site.ce_product_name}} 2.7.x node. The migration
+1. Download {{site.ee_product_name}} 2.8.x and configure it to point to the
+   same datastore as your {{site.ce_product_name}} 2.8.x node. The migration
    command expects the datastore to be up-to-date on any pending migration:
 
    ```shell

--- a/app/gateway/2.8.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.8.x/install-and-run/upgrade-enterprise.md
@@ -20,14 +20,14 @@ distinction between major, minor, and patch versions. The upgrade
 path for major and minor versions differs depending on the previous version
 from which you are migrating:
 
-- If you are migrating from 2.x.x, upgrading to 2.7.x is a
+- If you are migrating from 2.x.x, upgrading to 2.8.x is a
 **minor** upgrade. You can upgrade from any 2.1.x or later version directly to
-2.7.x.
+2.8.x.
 
-- If you are migrating from 1.x.x, upgrading to 2.7.x is a **major**
+- If you are migrating from 1.x.x, upgrading to 2.8.x is a **major**
 upgrade. While you can upgrade directly to the latest version, be aware of any
-breaking changes between the 1.x and 2.x series noted in this document and in
-the Gateway changelogs.
+breaking changes between the 1.x and 2.x series noted in this document
+(both this version and prior versions) and in the Gateway changelogs.
 
     See specific breaking changes in the Kong Gateway changelogs:
     [open-source (OSS)](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md#200) and
@@ -48,14 +48,18 @@ If you are adding a new plugin to your installation, you need to run
 
 ### Kong Manager breaking changes
 
-Version 2.7.x introduced a new way to configure the OIDC plugin to map IdP roles to Kong Manager admin accounts.
-You must now specify the `admin_claim` instead of the `consumer_claim` in your OIDC config file. For more information,
-see [OIDC Authenticated Group Mapping](/gateway/{{page.kong_version}}/configure/auth/kong-manager/oidc-mapping/).
+Version 2.7.x introduced a new way to configure the OIDC plugin to map IdP roles
+to Kong Manager admin accounts.
+
+If you are upgrading from 2.6.x or earlier,
+you must now specify the `admin_claim` instead of the `consumer_claim` in your
+OIDC config file. For more information, see
+[OIDC Authenticated Group Mapping](/gateway/{{page.kong_version}}/configure/auth/kong-manager/oidc-mapping/).
 
 ### Dev Portal migrations
 
-There are no migrations necessary for the Dev Portal when upgrading from 2.6.x to
-2.7.x.
+There are no migrations necessary for the Dev Portal when upgrading from 2.7.x to
+2.8.x.
 
 If you are currently using the Dev Portal in 1.5.x or earlier,
 [manually migrate the files](/enterprise/2.1.x/developer-portal/latest-migrations)
@@ -67,7 +71,7 @@ to version 2.1.x before continuing.
 > **Important:** If you are currently running in [hybrid mode](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode/),
 upgrade the control plane first, and then the data planes.
 
-* If you are currently running 2.6.x in classic (traditional)
+* If you are currently running 2.7.x in classic (traditional)
   mode and want to run in hybrid mode instead, follow the hybrid mode
   [installation instructions](/gateway/{{page.kong_version}}/plan-and-deploy/hybrid-mode/hybrid-mode-setup/)
   after running the migration.
@@ -132,7 +136,7 @@ To handle clusters split across multiple releases, you should:
 This ensures that all instances are using the new Kong package before running
 `kong migrations finish`.
 
-## Upgrade from 1.x.x - 2.6.x to 2.7.x {#migrate-db}
+## Upgrade from 1.x.x - 2.7.x to 2.8.x {#migrate-db}
 
 {{site.ee_product_name}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two Kong clusters with different
@@ -152,15 +156,15 @@ decommission it. For this reason, the full migration is split into two commands:
 Follow the instructions for your backing data store to migrate to the new version.
 If you prefer to use a fresh data store and only migrate your `kong.conf` file,
 see the instructions to
-[install 2.7.x on a fresh datastore](#install-27x-on-a-fresh-datastore).
+[install 2.8.x on a fresh datastore](#install-28x-on-a-fresh-datastore).
 
 ### Postgres
 
-1. Download 2.7.x, and configure it to point to the same
+1. Download 2.8.x, and configure it to point to the same
    datastore as your old (1.x.x-2.x.x) cluster.
 2. Run `kong migrations up`.
-3. After that finishes running, both the old (1.x.x-2.x.x) and new (2.7.x) clusters can
-   now run simultaneously on the same datastore. Start provisioning 2.7.x nodes,
+3. After that finishes running, both the old (1.x.x-2.x.x) and new (2.8.x) clusters can
+   now run simultaneously on the same datastore. Start provisioning 2.8.x nodes,
    but do _not_ use their Admin API yet.
 
    {:.important}
@@ -170,21 +174,21 @@ see the instructions to
    cluster.
 
 4. Gradually divert traffic away from your old nodes, and redirect traffic to
-   your 2.7.x cluster. Monitor your traffic to make sure everything
+   your 2.8.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-5. When your traffic is fully migrated to the 2.7.x cluster, decommission your
+5. When your traffic is fully migrated to the 2.8.x cluster, decommission your
    old nodes.
-6. From your 2.7.x cluster, run `kong migrations finish`. From this point onward,
+6. From your 2.8.x cluster, run `kong migrations finish`. From this point onward,
    it is no longer possible to start nodes in the old cluster
    that still points to the same datastore.
 
      Run this command _only_ when you are
      confident that your migration was successful. From now on, you can safely make
-     Admin API requests to your 2.7.x nodes.
+     Admin API requests to your 2.8.x nodes.
 
 ### Cassandra
 
-Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.7.x on Cassandra
+Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.8.x on Cassandra
 are incompatible with those used by {{site.ee_product_name}} 2.1.x or lower. Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
@@ -194,11 +198,11 @@ Alternatively, to keep your previous version fully operational while the new
 one initializes, transfer the data to a new keyspace using a database dump, as
 described below:
 
-1. Download 2.7.x, and configure it to point to a new keyspace.
+1. Download 2.8.x, and configure it to point to a new keyspace.
 
 2. Run `kong migrations bootstrap`.
 
-   Once that finishes running, both the old (1.x.x-2.1.x) and new (2.7.x)
+   Once that finishes running, both the old (1.x.x-2.1.x) and new (2.8.x)
    clusters can now run simultaneously, but the new cluster does not
    have any data yet.
 3. On the old cluster, run `kong config db_export`. This will create
@@ -208,14 +212,14 @@ described below:
 5. Gradually divert traffic away from your old nodes, and into
    your 2.7.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-6. When your traffic is fully migrated to the 2.7.x cluster,
+6. When your traffic is fully migrated to the 2.8.x cluster,
    decommission your old nodes.
 
-### Install 2.7.x on a fresh datastore
+### Install 2.8.x on a fresh datastore
 
-For installing on a fresh datastore, {{site.ee_product_name}} 2.7.x has the
+For installing on a fresh datastore, {{site.ee_product_name}} 2.8.x has the
 `kong migrations bootstrap` command. Run the following commands to
-prepare a new 2.7.x cluster from a fresh datastore. By default, the `kong` CLI tool
+prepare a new 2.8.x cluster from a fresh datastore. By default, the `kong` CLI tool
 loads the configuration from `/etc/kong/kong.conf`, but you can optionally use
 the `-c` flag to indicate the path to your configuration file:
 

--- a/app/gateway/2.8.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.8.x/install-and-run/upgrade-oss.md
@@ -28,7 +28,7 @@ $ kong migrations up [-c configuration_file]
 
 If the command is successful, and no migration ran
 (no output), then you only have to
-[reload](https://docs.konghq.com/gateway-oss/2.7.x/cli/#kong-reload) Kong:
+[reload](https://docs.konghq.com/gateway-oss/2.8.x/cli/#kong-reload) Kong:
 
 ```shell
 $ kong reload [-c configuration_file]
@@ -39,17 +39,17 @@ starts new workers, which take over from old workers before those old workers
 are terminated. In this way, Kong will serve new requests via the new
 configuration, without dropping existing in-flight connections.
 
-## Upgrade to `2.7.x`
+## Upgrade to `2.8.x`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
 distinction between "major", "minor", and "patch" versions. The upgrade path
 will be different depending on which previous version from which you are migrating.
 
-If you are migrating from 2.x.x, upgrading into 2.7.x is a
+If you are migrating from 2.x.x, upgrading into 2.8.x is a
 minor upgrade, but read below for important instructions on database migration,
 especially for Cassandra users.
 
-If you are migrating from 1.x, upgrading into 2.7.x is a major upgrade,
+If you are migrating from 1.x, upgrading into 2.8.x is a major upgrade,
 so, in addition, be aware of any [breaking changes](https://github.com/Kong/kong/blob/master/UPGRADE.md#breaking-changes-2.0)
 between the 1.x and 2.x series below, further detailed in the
 [CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md#200) document.
@@ -63,7 +63,7 @@ for the gateway are bundled and you can skip this section.
 If you are building your dependencies by hand, there are changes since the
 previous release, so you will need to rebuild them with the latest patches.
 
-The required OpenResty version for kong 2.7.x is
+The required OpenResty version for kong 2.8.x is
 [1.19.9.1](https://openresty.org/en/changelog-1019003.html). This is more recent
 than the version in Kong 2.5.0 (which used `1.19.3.2`). In addition to an upgraded
 OpenResty, you will need the correct [OpenResty patches](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools/patches)
@@ -72,19 +72,27 @@ The [kong-build-tools](https://github.com/Kong/kong-build-tools)
 repository contains [openresty-build-tools](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools),
 which allows you to more easily build OpenResty with the necessary patches and modules.
 
-There is a new way to deploy Go using Plugin Servers.
-For more information, see [Developing Go plugins](https://docs.konghq.com/gateway-oss/2.6.x/external-plugins/#developing-go-plugins).
+### Deprecations
+
+The external `go-pluginserver` project is considered deprecated in favor of
+the [embedded server approach](/gateway/{{page.kong_version}}/reference/external-plugins).
+
+Starting with Kong Gateway 2.8.0.0, Kong is not building new open-source
+CentOS images. Support for running open-source Kong Gateway on CentOS on is now
+deprecated, as [CentOS has reached End of Life (OEL)](https://www.centos.org/centos-linux-eol/).
+This means that if you are running Kong Gateway on CentOS, you will need to
+migrate to another distribution to upgrade to 2.8.x
 
 ### Template changes
 
 There are **Changes in the Nginx configuration file**, between kong 2.0.x,
-2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x and 2.7.x
+2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, and 2.8.x.
 
 To view the configuration changes between versions, clone the
 [Kong repository](https://github.com/kong/kong) and run `git diff`
 on the configuration templates, using `-w` for greater readability.
 
-Here's how to see the differences between previous versions and 2.7.x:
+Here's how to see the differences between previous versions and 2.8.x:
 
 ```
 git clone https://github.com/kong/kong
@@ -93,7 +101,7 @@ git diff -w 2.0.0 2.7.0 kong/templates/nginx_kong*.lua
 ```
 
 **Note:** Adjust the starting version number
-(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x) to the version number you are currently using.
+(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 2.8.x) to the version number you are currently using.
 
 To produce a patch file, use the following command:
 
@@ -102,14 +110,14 @@ git diff 2.0.0 2.7.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
 ```
 
 **Note:** Adjust the starting version number
-(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x) to the version number you are currently using.
+(2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 2.8.x) to the version number you are currently using.
 
 
 ### Suggested upgrade path
 
-**Version prerequisites for migrating to version 2.7.x**
+**Version prerequisites for migrating to version 2.8.x**
 
-The lowest version that Kong 2.7.x supports migrating from is 1.0.x.
+The lowest version that Kong 2.8.x supports migrating from is 1.0.x.
 If you are migrating from a version lower than 0.14.1, you need to
 migrate to 0.14.1 first. Then, once you are migrating from 0.14.1,
 please migrate to 1.5.x first.
@@ -123,13 +131,13 @@ with the addition of the `kong migrations migrate-apis` command,
 which you can use to migrate legacy `apis` configurations.
 
 Once you migrated to 1.5.x, you can follow the instructions in the section
-below to migrate to 2.7.x.
+below to migrate to 2.8.x.
 
-### Upgrade from `1.0.x` - `2.2.x` to `2.7.x`
+### Upgrade from `1.0.x` - `2.7.x` to `2.8.x`
 
 **Postgres**
 
-Kong 2.7.x supports a no-downtime migration model. This means that while the
+Kong 2.8.x supports a no-downtime migration model. This means that while the
 migration is ongoing, you will have two Kong clusters running, sharing the
 same database. (This is sometimes called the Blue/Green migration model.)
 
@@ -138,27 +146,27 @@ the database as it is migrated while the old Kong cluster keeps working until
 it is time to decommission it. For this reason, the migration is split into
 two steps, performed via commands `kong migrations up` (which does
 only non-destructive operations) and `kong migrations finish` (which puts the
-database in the final expected state for Kong 2.7.x).
+database in the final expected state for Kong 2.8.x).
 
-1. Download 2.7.x, and configure it to point to the same datastore
+1. Download 2.8.x, and configure it to point to the same datastore
    as your old (1.0 to 2.0) cluster. Run `kong migrations up`.
-2. After that finishes running, both the old (2.x.x) and new (2.7.x)
-   clusters can now run simultaneously. Start provisioning 2.7.x nodes,
+2. After that finishes running, both the old (2.x.x) and new (2.8.x)
+   clusters can now run simultaneously. Start provisioning 2.8.x nodes,
    but do not use their Admin API yet. If you need to perform Admin API
    requests, these should be made to the old cluster's nodes. The reason
    is to prevent the new cluster from generating data that is not understood
    by the old cluster.
 3. Gradually divert traffic away from your old nodes, and into
-   your 2.7.x cluster. Monitor your traffic to make sure everything
+   your 2.8.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-4. When your traffic is fully migrated to the 2.7.x cluster,
+4. When your traffic is fully migrated to the 2.8.x cluster,
    decommission your old nodes.
-5. From your 2.7.x cluster, run: `kong migrations finish`.
+5. From your 2.8.x cluster, run: `kong migrations finish`.
    From this point on, it will not be possible to start
    nodes in the old cluster pointing to the same datastore anymore. Only run
    this command when you are confident that your migration
    was successful. From now on, you can safely make Admin API
-   requests to your 2.7.x nodes.
+   requests to your 2.8.x nodes.
 
 **Cassandra**
 
@@ -166,7 +174,7 @@ database in the final expected state for Kong 2.7.x).
 > **Deprecation notice:**
 > Cassandra as a backend database for Kong Gateway is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the Kong Gateway 4.0 release, and some new features might not be supported with Cassandra in the Kong Gateway 3.0 release.
 
-Due to internal changes, the table schemas used by Kong 2.7.x on Cassandra
+Due to internal changes, the table schemas used by Kong 2.8.x on Cassandra
 are incompatible with those used by Kong 2.1.x (or lower). Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
@@ -174,9 +182,9 @@ database at the same time. Alternatively, to keep your previous version fully
 operational while the new one initializes, you will need to transfer the
 data to a new keyspace via a database dump, as described below:
 
-1. Download 2.7.x, and configure it to point to a new keyspace.
+1. Download 2.8.x, and configure it to point to a new keyspace.
    Run `kong migrations bootstrap`.
-2. Once that finishes running, both the old (pre-2.1) and new (2.7.x)
+2. Once that finishes running, both the old (pre-2.1) and new (2.8.x)
    clusters can now run simultaneously, but the new cluster does not
    have any data yet.
 3. On the old cluster, run `kong config db_export`. This will create
@@ -184,14 +192,14 @@ data to a new keyspace via a database dump, as described below:
 4. Transfer the file to the new cluster and run
    `kong config db_import kong.yml`. This will load the data into the new cluster.
 5. Gradually divert traffic away from your old nodes, and into
-   your 2.7.x cluster. Monitor your traffic to make sure everything
+   your 2.8.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-6. When your traffic is fully migrated to the 2.7.x cluster,
+6. When your traffic is fully migrated to the 2.8.x cluster,
    decommission your old nodes.
 
-### Installing 2.7.x on a fresh datastore
+### Installing 2.8.x on a fresh datastore
 
-The following commands should be used to prepare a new 2.7.x cluster from a
+The following commands should be used to prepare a new 2.8.x cluster from a
 fresh datastore. By default the `kong` CLI tool will load the configuration
 from `/etc/kong/kong.conf`, but you can optionally use the flag `-c` to
 indicate the path to your configuration file:
@@ -218,7 +226,7 @@ $ kong migrations up [-c configuration_file]
 
 If the command is successful, and no migration ran
 (no output), then you only have to
-[reload](https://docs.konghq.com/gateway-oss/2.7.x/cli/#kong-reload) Kong:
+[reload](https://docs.konghq.com/gateway-oss/2.8.x/cli/#kong-reload) Kong:
 
 ```shell
 $ kong reload [-c configuration_file]


### PR DESCRIPTION
### Summary
Bump versions from 2.6.x/2.7.x to 2.7.x/2.8.x.

OSS:
* Added section on deprecations: `go-pluginserver` and CentOS support.

Enterprise: 
* There are no breaking changes or particular upgrade considerations for this release.


### Reason
Gateway 2.8 release.

### Testing

https://deploy-preview-3730--kongdocs.netlify.app/gateway/2.8.x/install-and-run/migrate-ce-to-ke/
https://deploy-preview-3730--kongdocs.netlify.app/gateway/2.8.x/install-and-run/upgrade-enterprise/
https://deploy-preview-3730--kongdocs.netlify.app/gateway/2.8.x/install-and-run/upgrade-oss/

Verified with eng.
