### PR TITLE
[DOCU-2205] Remove tracking params from URLs to konghq.com

### DIFF
--- a/app/enterprise/1.5.x/introduction/index.md
+++ b/app/enterprise/1.5.x/introduction/index.md
@@ -58,5 +58,5 @@ Kong Studio enables spec-first development for all REST and GraphQL services. Wi
 
 Here are a couple of ways to try Kong Enterprise:
 
-* Get a demonstration at [_Request Demo_](https://konghq.com/request-demo/?itm_source=website&itm_medium=nav/)
-* Get a free trial at [_Kong Free Trial_](https://konghq.com/products/kong-enterprise/free-trial?itm_source=website&itm_medium=nav)
+* Get a demonstration at [_Request Demo_](https://konghq.com/request-demo/)
+* Get a free trial at [_Kong Free Trial_](https://konghq.com/products/kong-enterprise/free-trial/)

--- a/app/enterprise/1.5.x/release-notes.md
+++ b/app/enterprise/1.5.x/release-notes.md
@@ -6,17 +6,17 @@ These release notes apply to Kong Enterprise Release 1.5.x and include an overvi
 
 ## New Features
 
-### Consumer Alerts in Kong Immunity 
+### Consumer Alerts in Kong Immunity
 Kong Immunity detects service behavior anomalies using machine learning. This release extends this functionality with detection of anomalies scoped to specific API consumers. This means all existing triggered alerts now come in two flavors:
 * endpoint alerts based on traffic belonging to a specific endpoint
-* consumer alerts based on traffic in a workspace for a specific consumer 
+* consumer alerts based on traffic in a workspace for a specific consumer
 
-With consumer alerts functionality, alerts can now be specifically traced to individuals and teams that access APIs. We’ve also made a few improvements to services and routes pages in Kong Manager to account for these alerts. See [Immunity Alerts](https://docs.konghq.com/enterprise/1.5.x/brain-immunity/alerts/). 
+With consumer alerts functionality, alerts can now be specifically traced to individuals and teams that access APIs. We’ve also made a few improvements to services and routes pages in Kong Manager to account for these alerts. See [Immunity Alerts](https://docs.konghq.com/enterprise/1.5.x/brain-immunity/alerts/).
 
 ### OpenID Connect Improvements
-The OpenID Connect plugin bundled with Kong Enterprise 1.5.x features several improvements and fixes. The biggest addition is support for assertions on client authentication. The plugin is now able to authenticate itself with the OpenID Connect Providers using `client_secret_jwt` and `private_key_jwt` authentication methods. See [OpenID Connect](https://docs.konghq.com/hub/kong-inc/openid-connect/). 
+The OpenID Connect plugin bundled with Kong Enterprise 1.5.x features several improvements and fixes. The biggest addition is support for assertions on client authentication. The plugin is now able to authenticate itself with the OpenID Connect Providers using `client_secret_jwt` and `private_key_jwt` authentication methods. See [OpenID Connect](https://docs.konghq.com/hub/kong-inc/openid-connect/).
 
-### Application Registration [Beta](https://docs.konghq.com/enterprise/latest/introduction/key-concepts/#beta) 
+### Application Registration [Beta](https://docs.konghq.com/enterprise/latest/introduction/key-concepts/#beta)
 The ability for developers to create applications that package together a set of backend services is enabled through the Developer Portal and Kong Manager. The Developer Portal includes a new tab called “My Apps” that allows developers to create new applications (and credentials) and subscribe their applications to specific services/APIs. A new “Portal Application Registration” plugin is available, and added functionality in Kong Manager to provide API owners the ability to approve application access to underlying services.
 
 This feature is currently designated as [beta](https://docs.konghq.com/enterprise/latest/introduction/key-concepts/#beta). For beta features, we provide full support only in pre-production environments. See [Application Registration](https://docs.konghq.com/enterprise/1.5.x/developer-portal/administration/application-registration/).
@@ -35,16 +35,16 @@ Apart from the highlighted features mentioned above, this version of Kong Enterp
 In addition to features listed above, changes to the user documentation include:
 
 * [Getting Started Guide](https://docs.konghq.com/gateway/latest/get-started/comprehensive//) walks you through Kong concepts and foundational API gateway features and capabilities.
-* [Introduction to Kong Enterprise](https://docs.konghq.com/enterprise/1.5.x/introduction/) gives an overview of features and architecture. 
+* [Introduction to Kong Enterprise](https://docs.konghq.com/enterprise/1.5.x/introduction/) gives an overview of features and architecture.
 * [Key Concepts and Terminology](https://docs.konghq.com/enterprise/1.5.x/introduction/key-concepts/) defines concepts and terms specific to Kong Enterprise.
-* [Default Ports](https://docs.konghq.com/enterprise/1.5.x/deployment/default-ports/) list. 
-* [Kong Security Update Process](https://docs.konghq.com/enterprise/1.5.x/kong-security-update-process/) includes information about reporting a vulnerability and fix development process. 
+* [Default Ports](https://docs.konghq.com/enterprise/1.5.x/deployment/default-ports/) list.
+* [Kong Security Update Process](https://docs.konghq.com/enterprise/1.5.x/kong-security-update-process/) includes information about reporting a vulnerability and fix development process.
 * [Resource Sizing Guidelines](https://docs.konghq.com/enterprise/1.5.x/sizing-guidelines/) is now located in the Deployment section.
-* [Upgrade and Migration Steps for 1.5](https://docs.konghq.com/enterprise/1.5.x/deployment/migrations/). 
-* Kong Brain and Kong Immunity: 
+* [Upgrade and Migration Steps for 1.5](https://docs.konghq.com/enterprise/1.5.x/deployment/migrations/).
+* Kong Brain and Kong Immunity:
   * [Overview](https://docs.konghq.com/enterprise/1.5.x/brain-immunity/install-configure/) diagram
   * [Setting Up Collector App via Helm](https://docs.konghq.com/enterprise/1.5.x/brain-immunity/install-configure/#setting-up-collector-app-via-helm)
-* [New Doc Site](https://docs.konghq.com/enterprise/?itm_source=website&itm_medium=nav&_ga=2.24477050.11964654.1589165758-132287075.1554308608) updates, including:
+* [New Doc Site](https://docs.konghq.com/enterprise/) updates, including:
   * New look and layout
   * New Introduction and Deployment sections
   * Left navigation with collapsable sections

--- a/app/enterprise/2.1.x/introduction/index.md
+++ b/app/enterprise/2.1.x/introduction/index.md
@@ -58,5 +58,5 @@ Kong Studio enables spec-first development for all REST and GraphQL services. Wi
 
 Here are a couple of ways to try Kong Enterprise:
 
-* Get a demonstration at [_Request Demo_](https://konghq.com/request-demo/?itm_source=website&itm_medium=nav/)
-* Get a free trial at [_Kong Free Trial_](https://konghq.com/products/kong-enterprise/free-trial?itm_source=website&itm_medium=nav)
+* Get a demonstration at [_Request Demo_](https://konghq.com/request-demo/)
+* Get a free trial at [_Kong Free Trial_](https://konghq.com/products/kong-enterprise/free-trial)


### PR DESCRIPTION
### Summary
Searched for `itm` and `utm` params used in URLs leading to *.konghq.com, and removed them.

Companion PR to https://github.com/Kong/docs.konghq.com/pull/3693.

### Reason
We have other means of tracking traffic to konqhq.com, so including these params creates skewed/inaccurate data and reflects poorly on our SEO.

### Testing
N/A