### PR TITLE
Review label for plugin version GH action

### DIFF
--- a/.github/workflows/add-plugin-version.yml
+++ b/.github/workflows/add-plugin-version.yml
@@ -42,3 +42,4 @@ jobs:
           title: "[Automated] Plugin version updates"
           body: |
             Automatic update with new plugin release
+          labels: review:autodoc


### PR DESCRIPTION
### Summary
Apply a `review:autodoc` label.

### Reason
Every PR needs a label. Eg https://github.com/Kong/docs.konghq.com/pull/3733. 

### Testing
Won't be able to test until we run it in a future release.