### PR TITLE
Add workflow_dispatch option for algolia indexer

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch: 
   schedule:
   - cron: '0 0 * * *'
 name: Update indices every day


### PR DESCRIPTION
### Summary
Add `workflow_dispatch` to algolia GH action so that any docs team member can manually kick off the Algolia indexer for search.

### Reason
Need this option for release days. Currently, I run the indexer manually from my local env on a release day.

### Testing
N/A, need to merge first.