### PR TITLE
Fix broken link in footer

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -216,7 +216,7 @@
             </li>
             <li>
               <a
-                href="https://konghq.com/gateway/"
+                href="https://konghq.com/kong/"
                 >API Gateway</a
               >
             </li>


### PR DESCRIPTION
### Summary
Fixing a broken link to konghq.com/gateway/. This used to be a redirect but no longer works.

### Reason
Every link check will fail until this is fixed because the footer is on every page.

### Testing
Link check passed.