### PR TITLE
[DOCU-2217] Better license info in installation guides

### DIFF
--- a/app/gateway/2.8.x/install-and-run/docker.md
+++ b/app/gateway/2.8.x/install-and-run/docker.md
@@ -130,6 +130,21 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migration
 
 {% include_cached /md/admin-listen.md desc='long' %}
 
+1. (Optional) If you have an Enterprise license for {{site.base_gateway}},
+export the license key to a variable:
+
+    The license data must contain straight quotes to be considered valid JSON
+    (`'` and `"`, not `’` or `“`).
+
+    {:.note}
+    > **Note:**
+    The following license is only an example. You must use the following format,
+    but provide your own content.
+
+    ```bash
+    export KONG_LICENSE_DATA='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
+    ```
+
 1. Run the following command to start a container with {{site.base_gateway}}:
 {% capture start_container %}
 {% navtabs codeblock %}
@@ -147,6 +162,7 @@ docker run -d --name kong-gateway \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
  -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
+ -e "KONG_LICENSE_DATA=${KONG_LICENSE_DATA}" \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 8001:8001 \
@@ -201,6 +217,8 @@ docker run -d --name kong-gateway \
     * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
     (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
+    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file, specify
+    the license to use for Enterprise subscriptions.
 
 1. Verify your installation:
 
@@ -299,6 +317,21 @@ backed up by a Redis cluster).
 
 {% include_cached /md/admin-listen.md desc='long' %}
 
+1. (Optional) If you have an Enterprise license for {{site.base_gateway}},
+export the license key to a variable:
+
+    The license data must contain straight quotes to be considered valid JSON
+    (`'` and `"`, not `’` or `“`).
+
+    {:.note}
+    > **Note:**
+    The following license is only an example. You must use the following format,
+    but provide your own content.
+
+    ```bash
+    export KONG_LICENSE_DATA='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
+    ```
+
 1. From the same directory where you just created the `kong.yml` file,
 run the following command to start a container with {{site.base_gateway}}:
 
@@ -317,6 +350,7 @@ docker run -d --name kong-dbless \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
  -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
+ -e "KONG_LICENSE_DATA=${KONG_LICENSE_DATA}" \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 8001:8001 \
@@ -371,6 +405,8 @@ docker run -d --name kong-dbless \
     * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
     (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
+    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file, specify
+    the license to use for Enterprise subscriptions.
 
 1. Verify that {{site.base_gateway}} is running:
 
@@ -412,6 +448,11 @@ docker network rm kong-net
 ```
 
 ## Troubleshooting
+
+For troubleshooting license issues, see:
+* [Deployment options for licenses](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license/)
+* [`/licenses` API reference](/gateway/{{page.kong_version}}/admin-api/licenses/reference/)
+* [`/licenses` API examples](/gateway/{{page.kong_version}}/admin-api/licenses/examples/)
 
 If you did not receive a `200 OK` status code or need assistance completing
 setup, reach out to your support contact or head over to the

--- a/app/gateway/2.8.x/install-and-run/docker.md
+++ b/app/gateway/2.8.x/install-and-run/docker.md
@@ -162,7 +162,7 @@ docker run -d --name kong-gateway \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
  -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
- -e "KONG_LICENSE_DATA=${KONG_LICENSE_DATA}" \
+ -e KONG_LICENSE_DATA \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 8001:8001 \
@@ -217,8 +217,8 @@ docker run -d --name kong-gateway \
     * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
     (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
-    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file, specify
-    the license to use for Enterprise subscriptions.
+    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it 
+    as an environment variable, this parameter pulls the license from your environment.
 
 1. Verify your installation:
 
@@ -350,7 +350,7 @@ docker run -d --name kong-dbless \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
  -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
- -e "KONG_LICENSE_DATA=${KONG_LICENSE_DATA}" \
+ -e KONG_LICENSE_DATA \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 8001:8001 \
@@ -405,8 +405,8 @@ docker run -d --name kong-dbless \
     * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
     (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
-    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file, specify
-    the license to use for Enterprise subscriptions.
+    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it 
+    as an environment variable, this parameter pulls the license from your environment.
 
 1. Verify that {{site.base_gateway}} is running:
 


### PR DESCRIPTION
### Summary
* Add license env variable to docker installation instructions.
  *  If the user wants to, they can simply exclude the variable. If they have no license and leave the setting in, the container still starts with no issues, just without a license.
  * Added links to license docs for other license application options

* Improve license step for distros + a bit of cleanup 
  * Instead of linking to the "Deploy license" topic, included the instructions on the page, so that users have a clear choice depending on their environment.
  * Removed editable placeholders; a few had editable password fields, which isn't secure, and otherwise, we're avoiding using editable placeholders until we overhaul them.
  * Short descriptions for Manager and Dev Portal sections to call out the need for a database.
There's still a lot that needs to be cleaned up in this file, but I had to draw the line somewhere.

Did not do:
* Any changes to the kubernetes/helm/openshift topics, as their license info is already complete afaik.
* Did not add a license step to the MacOS install, as we only document the steps for open-source.

### Reason
Users are struggling to find Enterprise license info.

### Testing
Tested the Docker instructions. Also tested applying a license via API, just in case.

[Docker](https://deploy-preview-3739--kongdocs.netlify.app/gateway/2.8.x/install-and-run/docker/)
[RHEL](https://deploy-preview-3739--kongdocs.netlify.app/gateway/2.8.x/install-and-run/rhel/)
All other distros (Amazon Linux, CentOS, Ubuntu, and Debian) use the same include file, so the output is the same as RHEL.