### PR TITLE
[DOCU-348] Admin API: rm del service for route

### DIFF
--- a/app/enterprise/1.3-x/admin-api/index.md
+++ b/app/enterprise/1.3-x/admin-api/index.md
@@ -1106,15 +1106,6 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
 
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/enterprise/1.5.x/admin-api/index.md
+++ b/app/enterprise/1.5.x/admin-api/index.md
@@ -1114,15 +1114,6 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
 
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/enterprise/2.1.x/admin-api/index.md
+++ b/app/enterprise/2.1.x/admin-api/index.md
@@ -1126,16 +1126,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/enterprise/2.2.x/admin-api/index.md
+++ b/app/enterprise/2.2.x/admin-api/index.md
@@ -1134,16 +1134,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/enterprise/2.3.x/admin-api/index.md
+++ b/app/enterprise/2.3.x/admin-api/index.md
@@ -1134,16 +1134,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/enterprise/2.4.x/admin-api/index.md
+++ b/app/enterprise/2.4.x/admin-api/index.md
@@ -1396,16 +1396,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/enterprise/2.5.x/admin-api/index.md
+++ b/app/enterprise/2.5.x/admin-api/index.md
@@ -1396,16 +1396,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/gateway-oss/1.3.x/admin-api.md
+++ b/app/gateway-oss/1.3.x/admin-api.md
@@ -1113,16 +1113,6 @@ Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/gateway-oss/1.4.x/admin-api.md
+++ b/app/gateway-oss/1.4.x/admin-api.md
@@ -1161,16 +1161,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/gateway-oss/1.5.x/admin-api.md
+++ b/app/gateway-oss/1.5.x/admin-api.md
@@ -1165,16 +1165,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete">/routes/{route name or id}/service</div>
-
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 *Response*
 
 ```

--- a/app/gateway-oss/2.0.x/admin-api.md
+++ b/app/gateway-oss/2.0.x/admin-api.md
@@ -1340,16 +1340,6 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
 
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway-oss/2.1.x/admin-api.md
+++ b/app/gateway-oss/2.1.x/admin-api.md
@@ -1400,17 +1400,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway-oss/2.2.x/admin-api.md
+++ b/app/gateway-oss/2.2.x/admin-api.md
@@ -1408,17 +1408,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway-oss/2.3.x/admin-api.md
+++ b/app/gateway-oss/2.3.x/admin-api.md
@@ -1417,16 +1417,6 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
 
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway-oss/2.4.x/admin-api.md
+++ b/app/gateway-oss/2.4.x/admin-api.md
@@ -1562,16 +1562,6 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
 
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway-oss/2.5.x/admin-api.md
+++ b/app/gateway-oss/2.5.x/admin-api.md
@@ -1566,16 +1566,6 @@ Attributes | Description
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
 
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway/2.6.x/admin-api/index.md
+++ b/app/gateway/2.6.x/admin-api/index.md
@@ -1618,17 +1618,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway/2.7.x/admin-api/index.md
+++ b/app/gateway/2.7.x/admin-api/index.md
@@ -1616,17 +1616,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```

--- a/app/gateway/2.8.x/admin-api/index.md
+++ b/app/gateway/2.8.x/admin-api/index.md
@@ -1661,17 +1661,6 @@ Attributes | Description
 `certificate id`<br>**required** | The unique identifier of the Certificate to delete.
 `service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
 
-
-##### Delete Service Associated to a Specific Route
-
-<div class="endpoint delete indent">/routes/{route name or id}/service</div>
-
-{:.indent}
-Attributes | Description
----:| ---
-`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be deleted.
-
-
 #### Response
 
 ```


### PR DESCRIPTION
### Summary

Remove Admin API **Delete Service Associated to a Specific Route** endpoint from versions 1.3.x onward.

### Reason

Addresses [DOCU-348](https://konghq.atlassian.net/browse/DOCU-348)

### Testing

Latest:
https://deploy-preview-3740--kongdocs.netlify.app/gateway/2.8.x/admin-api/#delete-service