### PR TITLE
[DOCU-2196] Update k8 install link

### DIFF
--- a/app/gateway/2.6.x/plan-and-deploy/kubernetes-deployment-options.md
+++ b/app/gateway/2.6.x/plan-and-deploy/kubernetes-deployment-options.md
@@ -10,7 +10,7 @@ configuration to route and control traffic.
 The [kong-gateway][enterprise-download] proxy image supports DB-less
 operation and is recommended for all deployments.
 * [DB-less installation with the Kong Ingress Controller][k4k8s-enterprise-install]
-* [Database-backed installation with or without the Kong Ingress Controller][k4k8s-with-enterprise-install]
+* [Database-backed installation with or without the Kong Ingress Controller](/gateway/{{page.kong_version}}/install-and-run/helm)
 
 ### Migrating to 2.1.x and up
 

--- a/app/gateway/2.7.x/plan-and-deploy/kubernetes-deployment-options.md
+++ b/app/gateway/2.7.x/plan-and-deploy/kubernetes-deployment-options.md
@@ -10,7 +10,7 @@ configuration to route and control traffic.
 The [kong-gateway][enterprise-download] proxy image supports DB-less
 operation and is recommended for all deployments.
 * [DB-less installation with the Kong Ingress Controller][k4k8s-enterprise-install]
-* [Database-backed installation with or without the Kong Ingress Controller][k4k8s-with-enterprise-install]
+* [Database-backed installation with or without the Kong Ingress Controller](/gateway/{{page.kong_version}}/install-and-run/helm)
 
 ### Migrating to 2.1.x and up
 

--- a/app/gateway/2.8.x/plan-and-deploy/kubernetes-deployment-options.md
+++ b/app/gateway/2.8.x/plan-and-deploy/kubernetes-deployment-options.md
@@ -10,7 +10,7 @@ configuration to route and control traffic.
 The [kong-gateway][enterprise-download] proxy image supports DB-less
 operation and is recommended for all deployments.
 * [DB-less installation with the Kong Ingress Controller][k4k8s-enterprise-install]
-* [Database-backed installation with or without the Kong Ingress Controller][k4k8s-with-enterprise-install]
+* [Database-backed installation with or without the Kong Ingress Controller](/gateway/{{page.kong_version}}/install-and-run/helm)
 
 ### Migrating to 2.1.x and up
 


### PR DESCRIPTION
### Summary

“[Database-backed installation with or without the Kong Ingress Controller](https://docs.konghq.com/gateway/2.7.x/install-and-run/kubernetes)" currently goes to [Install on Kubernetes - v2.7.x | Kong Docs](https://docs.konghq.com/gateway/2.7.x/install-and-run/kubernetes/). Updated to go to [Install on Kubernetes with Helm - v2.7.x | Kong Docs](https://docs.konghq.com/gateway/2.7.x/install-and-run/helm).

### Reason

Addresses docs domain piece of https://konghq.atlassian.net/browse/DOCU-2196

### Testing

Updated on 2.6.x and newer. Investigating whether or not we should make this change to older versions. 

@lena-larionova on older versions, I looked at the [Installing Kong for Kubernetes Enterprise](https://deploy-preview-3749--kongdocs.netlify.app/enterprise/2.5.x/deployment/installation/kong-for-kubernetes/) and see that there's a link to Helm charts in GitHub. Is this what we had previous to the Install on [Kubernetes with Helm](https://deploy-preview-3749--kongdocs.netlify.app/gateway/2.8.x/install-and-run/helm/) page?

2.8.x: https://deploy-preview-3749--kongdocs.netlify.app/gateway/2.8.x/plan-and-deploy/kubernetes-deployment-options/