### PR TITLE
[DOCU-510] Add diff: Response Transformer Advanced

### DIFF
--- a/app/_hub/kong-inc/response-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/index.md
@@ -23,6 +23,10 @@ description: |
   * The plugin will decompress and recompress Gzip-compressed payloads
     when the `Content-Encoding` header is `gzip`.
 
+  Response Transformer Advanced includes the following additional configurations: `add.if_status`, `append.if_status`,
+  `remove.if_status`, `replace.body`, `replace.if_status`, `transform.functions`, `transform.if_status`, 
+  `allow.json`, `rename.if_status`, `transform.json`, and `dots_in_keys`.
+
   <div class="alert alert-warning">
     <strong>Note on transforming bodies:</strong> Be aware of the performance of transformations on the
     response body. In order to parse and modify a JSON body, the plugin needs to retain it in memory,

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -14,7 +14,24 @@ description: |
   </div>
 
   For additional response transformation features, check out the
-  [Response Transformer Advanced plugin](/hub/kong-inc/response-transformer-advanced/).
+  [Response Transformer Advanced plugin](/hub/kong-inc/response-transformer-advanced/). Response Transformer 
+  Advanced adds the following abilities:
+  
+  * When transforming a JSON payload, transformations are applied to nested JSON objects and
+    arrays. This can be turned off and on using the `config.dots_in_keys` configuration parameter.
+    See [Response Transformed Advanced arrays and nested objects](/hub/kong-inc/response-transformer-advanced/#arrays-and-nested-objects).
+  * Transformations can be restricted to responses with specific status codes using various
+    `config.*.if_status` configuration parameters.
+  * JSON body contents can be restricted to a set of allowed properties with
+    `config.allow.json`.
+  * The entire response body can be replaced using `config.replace.body`.
+  * Arbitrary transformation functions written in Lua can be applied.
+  * The plugin will decompress and recompress Gzip-compressed payloads
+    when the `Content-Encoding` header is `gzip`.
+
+  Response Transformer Advanced includes the following additional configurations: `add.if_status`, `append.if_status`,
+  `remove.if_status`, `replace.body`, `replace.if_status`, `transform.functions`, `transform.if_status`, and 
+  `allow.json`.
 type: plugin
 categories:
   - transformations

--- a/app/_hub/kong-inc/response-transformer/index.md
+++ b/app/_hub/kong-inc/response-transformer/index.md
@@ -30,8 +30,8 @@ description: |
     when the `Content-Encoding` header is `gzip`.
 
   Response Transformer Advanced includes the following additional configurations: `add.if_status`, `append.if_status`,
-  `remove.if_status`, `replace.body`, `replace.if_status`, `transform.functions`, `transform.if_status`, and 
-  `allow.json`.
+  `remove.if_status`, `replace.body`, `replace.if_status`, `transform.functions`, `transform.if_status`, 
+  `allow.json`, `rename.if_status`, `transform.json`, and `dots_in_keys`.
 type: plugin
 categories:
   - transformations


### PR DESCRIPTION
### Summary

Add more content to differentiate Response Transformer and Response Transformer Advanced. 

Moved over the Advanced differentiator description from Advanced, and add a list of configs that Advanced only has.

### Reason

Addresses [DOCU-510](https://konghq.atlassian.net/browse/DOCU-510)

### Testing

https://deploy-preview-3750--kongdocs.netlify.app/hub/kong-inc/response-transformer-advanced/
https://deploy-preview-3750--kongdocs.netlify.app/hub/kong-inc/response-transformer/
