### PR TITLE
Konnect: Gateway 2.8 support

### DIFF
--- a/app/konnect/deployment/index.md
+++ b/app/konnect/deployment/index.md
@@ -43,6 +43,7 @@ data plane.
 
 |                                | {{site.konnect_saas}} | First supported patch version
 |--------------------------------|:---------------------:|-----------------------------
+| {{site.ee_product_name}} 2.8.x | <i class="fa fa-check"></i>    | 2.8.0.0
 | {{site.ee_product_name}} 2.7.x | <i class="fa fa-check"></i>    | 2.7.0.0
 | {{site.ee_product_name}} 2.6.x | <i class="fa fa-check"></i>    | 2.6.0.0
 | {{site.ee_product_name}} 2.5.x | <i class="fa fa-check"></i>    | 2.5.0.1

--- a/app/konnect/runtime-manager/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/gateway-runtime-docker.md
@@ -78,34 +78,6 @@ runtime instances.
 ### Generate certificates
 {% include /md/konnect/runtime-certs.md %}
 
-### Prepare the Docker image
-
-Next, pull the {{site.base_gateway}} Docker image, and configure a
-{{site.base_gateway}} runtime using the certificate, the private key, and the
-remaining configuration details on the **Configure Runtime** page.
-
-1. Using Docker, pull the following image:
-
-
-    ```bash
-    $ docker pull kong/kong-gateway:2.7.0.0-alpine
-    ```
-
-    You should now have your {{site.base_gateway}} image locally.
-
-2. Verify that it worked, and find the image ID matching your repository:
-
-    ```bash
-    $ docker images
-    ```
-
-3. Tag the image ID for easier use, replacing `{IMAGE_ID}` with the one
-matching your repository:
-
-    ```bash
-    $ docker tag {IMAGE_ID} kong-ee
-    ```
-
 ### Start Kong Gateway
 
 Use the following `docker run` command sample as a guide to compile your actual values:
@@ -127,7 +99,7 @@ $ docker run -d --name kong-dp \
   -e "KONG_CLUSTER_CERT_KEY=/{PATH_TO_FILE}/tls.key" \
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly \
   -p 8000:8000 \
-  kong/kong-gateway:2.7.0.0-alpine
+  kong/kong-gateway:2.8.0.0-alpine
 ```
 {% endnavtab %}
 {% navtab Windows PowerShell %}
@@ -146,7 +118,7 @@ docker run -d --name kong-dp `
   -e "KONG_CLUSTER_CERT_KEY=/{PATH_TO_FILE}/tls.key" `
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly `
   -p 8000:8000 `
-  kong/kong-gateway:2.7.0.0-alpine
+  kong/kong-gateway:2.8.0.0-alpine
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/gateway-runtime-kubernetes.md
@@ -90,7 +90,7 @@ like this:
     ```yaml
     image:
       repository: kong/kong-gateway
-      tag: "2.7.0.0-alpine"
+      tag: "2.8.0.0-alpine"
 
     secretVolumes:
     - kong-cluster-cert

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -8,6 +8,20 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
+## March 2022
+
+### 2021.03.07
+**{{site.base_gateway}} 2.8.0.0 support**
+: {{site.konnect_saas}} now supports {{site.base_gateway}} 2.8.0.0 runtimes.
+You can keep using existing 2.7.x runtimes, or you can upgrade to
+2.8.0.0 to take advantage of any new features, updates, and bug fixes.
+
+: For all the changes and new features in {{site.base_gateway}} 2.8.x, see the
+[changelog](/gateway/changelog/#2800).
+
+: To use any new features in the release,
+[start up a new 2.8.0.0 runtime](/konnect/runtime-manager/upgrade).
+
 ## January 2022
 
 ### 2022.01.14
@@ -28,7 +42,7 @@ You can keep using existing 2.6.x runtimes, or you can upgrade to
 2.7.0.0 to take advantage of any new features, updates, and bug fixes.
 
 : For all the changes and new features in {{site.base_gateway}} 2.7.x, see the
-[changelog](/gateway/changelog/#2600).
+[changelog](/gateway/changelog/#2700).
 
 : To use any new features in the release,
 [start up a new 2.7.0.0 runtime](/konnect/runtime-manager/upgrade).


### PR DESCRIPTION
### Summary
* Adding a release note for Kong Gateway 2.8 support
* Updating versions to 2.8
* In Docker runtime topic, removing section to pull and tag the Docker image. This section is redundant and not actually used, as we explicitly call out the version tag in the "Start Kong Gateway" section.

### Reason
Gateway 2.8 support for Konnect Cloud was introduced yesterday.

### Testing
Tested by setting up a 2.8.0.0 Docker runtime through Konnect Runtime Manager.

Release note: https://deploy-preview-3752--kongdocs.netlify.app/konnect/updates/
Docker: https://deploy-preview-3752--kongdocs.netlify.app/konnect/runtime-manager/gateway-runtime-docker/