### PR TITLE
[DOCU-1968] Add missing redis params to plugins

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/index.md
@@ -273,6 +273,36 @@ params:
       datatype: array of string elements
       description: |
         Cluster addresses to use for Redis connection when the `redis` strategy is defined. Defining this value implies using Redis cluster.
+    - name: redis.keepalive_backlog
+      required: false
+      default: null
+      value_in_examples: null
+      datatype: integer
+      description: |
+        If specified, limits the total number of opened connections for a pool. If the 
+        connection pool is full, all connection queues beyond the maximum limit go into 
+        the backlog queue. Once the backlog queue is full, subsequent connect operations 
+        will fail and return `nil`. Queued connect operations resume once the number of 
+        connections in the pool is less than `keepalive_pool_size`. Note that queued 
+        connect operations are subject to set timeouts.
+    - name: redis.keepalive_pool
+      required: false
+      default: generated from string template
+      value_in_examples: null
+      datatype: string
+      description: |
+        The custom name of the connection pool. If not specified, the connection pool
+        name is generated from the string template `"<host>:<port>"` or `"<unix-socket-path>"`.
+    - name: redis.keepalive_pool_size
+      required: false
+      default: 30
+      value_in_examples: null
+      datatype: integer
+      description: |
+        The size limit for every cosocket connection pool associated with every remote
+        server, per worker process. If no `keepalive_pool_size` is specified and no `keepalive_backlog`
+        is specified, no pool is created. If no `keepalive_pool_size` is specified and `keepalive_backlog`
+        is specified, then the pool uses the default value `30`.
     - name: window_type
       required: true
       default: sliding

--- a/app/_hub/kong-inc/proxy-cache-advanced/index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/index.md
@@ -250,6 +250,36 @@ params:
         Cluster addresses to use for Redis connection when the `redis` strategy is defined.
         Defining this value implies using Redis cluster. Each string element must
         be a hostname. The minimum length of the array is 1 element.
+    - name: redis.keepalive_backlog
+      required: false
+      default: null
+      value_in_examples: null
+      datatype: integer
+      description: |
+        If specified, limits the total number of opened connections for a pool. If the 
+        connection pool is full, all connection queues beyond the maximum limit go into 
+        the backlog queue. Once the backlog queue is full, subsequent connect operations 
+        will fail and return `nil`. Queued connect operations resume once the number of 
+        connections in the pool is less than `keepalive_pool_size`. Note that queued 
+        connect operations are subject to set timeouts.
+    - name: redis.keepalive_pool
+      required: false
+      default: generated from string template
+      value_in_examples: null
+      datatype: string
+      description: |
+        The custom name of the connection pool. If not specified, the connection pool
+        name is generated from the string template `"<host>:<port>"` or `"<unix-socket-path>"`.
+    - name: redis.keepalive_pool_size
+      required: false
+      default: 30
+      value_in_examples: null
+      datatype: integer
+      description: |
+        The size limit for every cosocket connection pool associated with every remote
+        server, per worker process. If no `keepalive_pool_size` is specified and no `keepalive_backlog`
+        is specified, no pool is created. If no `keepalive_pool_size` is specified and `keepalive_backlog`
+        is specified, then the pool uses the default value `30`.
     - name: bypass_on_err
       required: false
       default: false

--- a/app/_hub/kong-inc/rate-limiting-advanced/index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/index.md
@@ -294,6 +294,36 @@ params:
         Cluster addresses to use for Redis connections when the `redis` strategy is defined.
         Defining this value implies using Redis cluster. Each string element must
         be a hostname. The minimum length of the array is 1 element.
+    - name: redis.keepalive_backlog
+      required: false
+      default: null
+      value_in_examples: null
+      datatype: integer
+      description: |
+        If specified, limits the total number of opened connections for a pool. If the 
+        connection pool is full, all connection queues beyond the maximum limit go into 
+        the backlog queue. Once the backlog queue is full, subsequent connect operations 
+        will fail and return `nil`. Queued connect operations resume once the number of 
+        connections in the pool is less than `keepalive_pool_size`. Note that queued 
+        connect operations are subject to set timeouts.
+    - name: redis.keepalive_pool
+      required: false
+      default: generated from string template
+      value_in_examples: null
+      datatype: string
+      description: |
+        The custom name of the connection pool. If not specified, the connection pool
+        name is generated from the string template `"<host>:<port>"` or `"<unix-socket-path>"`.
+    - name: redis.keepalive_pool_size
+      required: false
+      default: 30
+      value_in_examples: null
+      datatype: integer
+      description: |
+        The size limit for every cosocket connection pool associated with every remote
+        server, per worker process. If no `keepalive_pool_size` is specified and no `keepalive_backlog`
+        is specified, no pool is created. If no `keepalive_pool_size` is specified and `keepalive_backlog`
+        is specified, then the pool uses the default value `30`.
     - name: window_type
       required: true
       default: sliding

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1572,7 +1572,7 @@ from portals created in Kong Gateway v2.5.0.1.
     `connect_timeout`, `read_timeout`, and `send_timeout`. Currently, if these options are not set, the
     value of `timeout` will be used for all (or its default value of 2000ms). The `connect_timeout`, `read_timeout`,
     and `send_timeout` fields are mutually required fields. The `timeout` field will be removed from the product in version 3.0.x.x.
-  - This release also includes new configuration options `keepalive_pool` and `keepalive_backlog`. These options
+  - This release also includes new configuration options `keepalive_pool`, `keepalive_pool_size`, and `keepalive_backlog`. These options
     relate to [Openresty’s Lua INGINX module’s](https://github.com/openresty/lua-nginx-module/#tcpsockconnect) `tcp:connect` options.
 - [ACME](/hub/kong-inc/acme) (`acme`)
   The ACME plugin now waits before signaling a challenge in hybrid mode to ensure the control plane propagates any updated


### PR DESCRIPTION
### Summary

Add missing redis params: `keepalive_pool`, `keepalive_pool_size`, and `keepalive_backlog` to GraphQL Rate Limiting Advanced, Proxy Cache Advanced, and Rate Limiting Advanced plugins.

Add `keepalive_pool_size` to changelog entry.

### Reason

Addresses [DOCU-1968](https://konghq.atlassian.net/browse/DOCU-1968).

### Testing

GraphQL Rate Limiting Advanced: https://deploy-preview-3754--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/#parameters
Rate Limiting Advanced: https://deploy-preview-3754--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/#parameters
Proxy Cache Advanced: https://deploy-preview-3754--kongdocs.netlify.app/hub/kong-inc/proxy-cache-advanced/#parameters
Changelog entry: https://deploy-preview-3754--kongdocs.netlify.app/gateway/changelog/#plugins-15 (added `keepalive_pool_size`)