### PR TITLE
[DOCU-2093] Remove breaking \ from get started

### DIFF
--- a/app/_includes/md/enterprise/turn-on-rbac.md
+++ b/app/_includes/md/enterprise/turn-on-rbac.md
@@ -25,7 +25,7 @@ If you have a Docker installation, run the following command to set the needed e
 
 **Note:** make sure to replace `<kong-container-id>` with the ID of your container.
 
-<pre><code>echo "KONG_ENFORCE_RBAC=on \<br>KONG_ADMIN_GUI_AUTH=basic-auth \<br>KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' \<br>kong reload exit" | docker exec -i <div contenteditable="true">{KONG_CONTAINER_ID}</div> /bin/sh</code></pre>
+<pre><code>echo "KONG_ENFORCE_RBAC=on <br>KONG_ADMIN_GUI_AUTH=basic-auth <br>KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' <br>kong reload exit" | docker exec -i {KONG_CONTAINER_ID}/bin/sh</code></pre>
 
 This will turn on RBAC, tell {{site.base_gateway}} to use basic authentication (username/password), and tell the Sessions Plugin how to create a session cookie.
 

--- a/app/_includes/md/enterprise/turn-on-rbac.md
+++ b/app/_includes/md/enterprise/turn-on-rbac.md
@@ -25,7 +25,12 @@ If you have a Docker installation, run the following command to set the needed e
 
 **Note:** make sure to replace `<kong-container-id>` with the ID of your container.
 
-<pre><code>echo "KONG_ENFORCE_RBAC=on <br>KONG_ADMIN_GUI_AUTH=basic-auth <br>KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}' <br>kong reload exit" | docker exec -i {KONG_CONTAINER_ID}/bin/sh</code></pre>
+```bash
+echo "KONG_ENFORCE_RBAC=on
+KONG_ADMIN_GUI_AUTH=basic-auth
+KONG_ADMIN_GUI_SESSION_CONF='{\"secret\":\"secret\",\"storage\":\"kong\",\"cookie_secure\":false}'
+kong reload exit" | docker exec -i {KONG_CONTAINER_ID} /bin/sh
+```
 
 This will turn on RBAC, tell {{site.base_gateway}} to use basic authentication (username/password), and tell the Sessions Plugin how to create a session cookie.
 


### PR DESCRIPTION
### Summary

In the Get Started Comprehensive guide, we have a broken `echo` command. I removed the `\` characters, which were breaking the command. 

### Reason

Addresses [DOCU-2093](https://konghq.atlassian.net/browse/DOCU-2093)

### Testing

The change is made in an includes file, meaning that I only had to do it in one place. 

https://deploy-preview-3755--kongdocs.netlify.app/gateway/2.8.x/get-started/comprehensive/manage-teams/#turn-on-rbac
