### PR TITLE
Add gateway 2.8 to version support policy

### DIFF
--- a/app/konnect-platform/support-policy.md
+++ b/app/konnect-platform/support-policy.md
@@ -48,6 +48,7 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  2.8.x.x |  2022-03-02   |     2022-08-24      |      2023-08-24       |
 |  2.7.x.x |  2021-12-16   |     2022-08-24      |      2023-08-24       |
 |  2.6.x.x |  2021-10-14   |     2022-08-24      |      2023-08-24       |
 |  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |


### PR DESCRIPTION
### Summary
Updating table of supported versions to include gateway 2.8. 

### Reason
Missed this update for the 2.8 release. Adding to release checklist going forward, and need to find out when the version support policy ownership is transferring to the CX team.

### Testing
Netlify preview TBA