### PR TITLE
Fix typo in allowing-multiple-authentication-methods.md

### DIFF
--- a/app/gateway/2.8.x/configure/auth/allowing-multiple-authentication-methods.md
+++ b/app/gateway/2.8.x/configure/auth/allowing-multiple-authentication-methods.md
@@ -31,7 +31,7 @@ curl -sX POST kong-admin:8001/consumers \
 
 The `anonymous` consumer does not correspond to any real user, and will only serve as a fallback.
 
-Next, we add both Key Auth and Basic Auth plugins to our consumer, and set the anonymous fallback to the consumer we created earlier.
+Next, we add both Key Auth and Basic Auth plugins to our service, and set the anonymous fallback to the consumer we created earlier.
 
 ```bash
 curl -sX POST kong-admin:8001/services/example-service/plugins/ \


### PR DESCRIPTION
### Summary
I believe that there is a typo in the docs, the following sentence
> Next, we add both Key Auth and Basic Auth plugins to our consumer, and set the anonymous fallback to the consumer we created earlier.

Should be changed for
> Next, we add both Key Auth and Basic Auth plugins to our service, and set the anonymous fallback to the consumer we created earlier.

### Reason
The documentation is saying that we are adding the plugins to the consumer, but the plugins are being added to the service.

### Testing
No need, it's just a documentation typo fix.

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
