### PR TITLE
Set nofollow rule for unsecured URLs only

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -25,7 +25,7 @@
 
     {% include_cached nav-v2.html layout=page.layout %}
 
-    {{ content | replace: '<a href="http', '<a rel="nofollow noopener noreferrer" href="http' }}
+    {{ content | replace: '<a href="http:', '<a rel="nofollow noopener noreferrer" href="http:' }}
 
     {% include_cached footer.html %} {% include_cached anchor_links.html %}
 


### PR DESCRIPTION
### Summary
Setting `nofollow noreferrer` to `http` instead of  both `http` and `https`.

### Reason
We are currently setting `nofollow noreferrer` on all absolute URLs. This means we're blocking tracking and indexing for every single absolute link, including any links to konghq.com sites. Taking SEO team's recommendation to only set it for unsecured absolute URLs.

### Testing
TBA