### PR TITLE
Adjust positioning of badges and tooltips in headers

### DIFF
--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -1,5 +1,4 @@
 .badge {
-  display: inline-flex;
   &:after {
       display: inline-block;
       font-weight: 600;
@@ -104,6 +103,7 @@
 
 span.badge {
   vertical-align: text-bottom;
+  display: inline-flex;
 }
 
 h2.badge, h3.badge, h4.badge, h5.badge {
@@ -113,7 +113,6 @@ h2.badge, h3.badge, h4.badge, h5.badge {
 
   &:hover {
     .tooltiptext {
-      top: 70%;
       left: 7px;
     }
   }
@@ -133,7 +132,33 @@ h1.badge {
   }
 }
 
+h2.badge {
+  &:hover {
+    .tooltiptext {
+      top: 3px;
+    }
+  }
+}
+
+h3.badge {
+  &:hover {
+    .tooltiptext {
+      top: 4px;
+    }
+  }
+}
+
+h4.badge, h5.badge {
+  &:hover {
+    .tooltiptext {
+      top: 5px;
+    }
+  }
+}
+
 a.badge {
+  display: inline-flex;
+
   &:hover, &:focus {
     opacity: 0.9;
     text-decoration: none;


### PR DESCRIPTION
### Summary
Adjusting badge and tooltip positioning to make it consistent. 

### Reason
Having `inline-flex` set on the base `badge` element is causing issues with badges in headers. Ran into this issue while working on Konnect docs and trying to apply badges to sections in the docs.

### Testing
Before:
<img width="500" alt="Screen Shot 2022-03-18 at 3 54 16 PM" src="https://user-images.githubusercontent.com/54370747/159094971-d2ca842b-d742-4155-aa34-cef77d65877b.png">
<img width="500" alt="Screen Shot 2022-03-18 at 3 54 28 PM" src="https://user-images.githubusercontent.com/54370747/159094973-3f60ca08-66eb-4e7e-a170-67fcaf86a7ec.png">
<img width="500" alt="Screen Shot 2022-03-18 at 3 55 00 PM" src="https://user-images.githubusercontent.com/54370747/159094974-9c3c3beb-b85f-4495-872d-baac01638eea.png">

After:
<img width="500" alt="Screen Shot 2022-03-18 at 4 01 47 PM" src="https://user-images.githubusercontent.com/54370747/159095185-b4441939-27d6-4b68-a8d8-371ebea11058.png">
<img width="500" alt="Screen Shot 2022-03-18 at 4 02 15 PM" src="https://user-images.githubusercontent.com/54370747/159095189-5e841111-ae91-4236-9fd4-85582131f100.png">


Sample pages with badges; hover over a badge to see a tooltip:
https://deploy-preview-3769--kongdocs.netlify.app/gateway/
https://deploy-preview-3769--kongdocs.netlify.app/gateway/2.8.x/reference/configuration/#default-developer-portal-authentication-section
https://deploy-preview-3769--kongdocs.netlify.app/gateway/2.8.x/install-and-run/macos/
https://deploy-preview-3769--kongdocs.netlify.app/hub/kong-inc/application-registration/