### PR TITLE
Add 'Hiring' pill

### DIFF
--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -359,3 +359,28 @@ nav {
   height: 0;
   width: 0;
 }
+
+.hiring-badge {
+  display: none;
+}
+
+.hiring-badge span {
+  font-size: 13px;
+  text-transform:uppercase;
+  color:#1456cb;
+  background:#ecf6ff;
+  border-radius:5px;
+  display:inline-block;
+  padding:5px 15px;
+}
+
+.hiring-badge span:hover {
+  background:#1456cb;
+  color:#ffffff;
+}
+
+@media (min-width: 1080px) {
+  .hiring-badge{
+    display: inline-block;
+  }
+}

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -28,6 +28,14 @@
     <div class="separator"></div>
     <div class="navbar-items" role="navigation" aria-label="Main menu">
       <ul class="navbar-items" role="menubar">
+        <li role="menuitem" class="main-menu-item hiring-badge other">
+          <a target="_blank" href="https://konghq.com/careers/" class="navbar-item">
+          <span>
+            We're Hiring!
+          </span>
+          </a>
+        </li>
+
         <li id="top-module-list" aria-haspopup="true" role="menuitem"
           class="navbar-item main-menu-item with-submenu{% if include.layout != 'landing-page' %} active{% endif %}"
           onclick="toggleSubmenuVisible(this)">


### PR DESCRIPTION
### Summary
Add "We're hiring" pill to the top nav to help the recruiting team 

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
View any page - it should be in the top bar by default. On screens <1080px it should be hidden (when the nav turns to a burger menu)