### PR TITLE
Fixing all traces of old "remote" against "zone"

### DIFF
--- a/app/mesh/1.6.x/features/kds-auth.md
+++ b/app/mesh/1.6.x/features/kds-auth.md
@@ -2,7 +2,7 @@
 title: Multi-zone authentication
 ---
 
-To add to the security of your deployments, Kong Mesh provides token generation for authenticating remote control planes to the global control plane.
+To add to the security of your deployments, Kong Mesh provides token generation for authenticating zone control planes to the global control plane.
 
 The control plane token is a JWT that contains:
 
@@ -28,11 +28,11 @@ control-plane-signing-key-0001   36m
 
 To generate the tokens you need and configure your clusters:
 
-- Generate a token for each remote control plane.
-- Add the token to the configuration for each remote zone.
+- Generate a token for each zone control plane.
+- Add the token to the configuration for each zone.
 - Enable authentication on the global control plane.
 
-### Generate token for each remote zone
+### Generate token for each zone
 
 On the global control plane, [authenticate](https://kuma.io/docs/latest/security/certificates/#user-to-control-plane-communication) and run the following command:
 
@@ -49,16 +49,16 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJab25lIjoid2VzdCIsIlRva2VuU2VyaWFsTnVtYmV
 
 For authentication to the global control plane on Kubernetes, you can port-forward port 5681 to access the API.
 
-### Add token to each remote configuration
+### Add token to each zone configuration
 
 {% navtabs %}
 {% navtab Kubernetes with kumactl %}
 
-If you install the remote control plane with `kumactl install control-plane`, pass the `--cp-token-path` argument, where the value is the path to the file where the token is stored:
+If you install the zone control plane with `kumactl install control-plane`, pass the `--cp-token-path` argument, where the value is the path to the file where the token is stored:
 
 ```
 $ kumactl install control-plane \
-  --mode=remote \
+  --mode=zone \
   --zone=<zone name> \
   --cp-token-path=/tmp/token \
   --ingress-enabled \
@@ -79,7 +79,7 @@ Add the following to `Values.yaml`:
 kuma:
   controlPlane:
     secrets:
-      - Env: "KMESH_MULTIZONE_REMOTE_KDS_AUTH_CP_TOKEN_INLINE"
+      - Env: "KMESH_MULTIZONE_ZONE_KDS_AUTH_CP_TOKEN_INLINE"
         Secret: "cp-token"
         Key: "token"
 ```
@@ -90,24 +90,24 @@ kuma:
 
 Either:
 
-- Set the token as an inline value in a `KMESH_MULTIZONE_REMOTE_KDS_AUTH_CP_TOKEN_INLINE` environment variable:
+- Set the token as an inline value in a `KMESH_MULTIZONE_ZONE_KDS_AUTH_CP_TOKEN_INLINE` environment variable:
 
 ```sh
-$ KUMA_MODE=remote \
-  KUMA_MULTIZONE_REMOTE_ZONE=<zone-name> \
-  KUMA_MULTIZONE_REMOTE_GLOBAL_ADDRESS=grpcs://<global-kds-address> \
-  KMESH_MULTIZONE_REMOTE_KDS_AUTH_CP_TOKEN_INLINE="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJab25lIjoid2VzdCIsIlRva2VuU2VyaWFsTnVtYmVyIjoxfQ.kIrS5W0CPMkEVhuRXcUxk3F_uUoeI3XK1Gw-uguWMpQ" \
+$ KUMA_MODE=zone \
+  KUMA_MULTIZONE_ZONE_NAME=<zone-name> \
+  KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS=grpcs://<global-kds-address> \
+  KMESH_MULTIZONE_ZONE_KDS_AUTH_CP_TOKEN_INLINE="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJab25lIjoid2VzdCIsIlRva2VuU2VyaWFsTnVtYmVyIjoxfQ.kIrS5W0CPMkEVhuRXcUxk3F_uUoeI3XK1Gw-uguWMpQ" \
   ./kuma-cp run
 ```
 
 OR
 
-- Store the token in a file, then set the path to the file in a `KMESH_MULTIZONE_REMOTE_KDS_AUTH_CP_TOKEN_PATH` environment variable.
+- Store the token in a file, then set the path to the file in a `KMESH_MULTIZONE_ZONE_KDS_AUTH_CP_TOKEN_INLINE` environment variable.
 ```sh
-$ KUMA_MODE=remote \
-  KUMA_MULTIZONE_REMOTE_ZONE=<zone-name> \
-  KUMA_MULTIZONE_REMOTE_GLOBAL_ADDRESS=grpcs://<global-kds-address> \
-  KMESH_MULTIZONE_REMOTE_KDS_AUTH_CP_TOKEN_PATH="/tmp/token" \
+$ KUMA_MODE=zone \
+  KUMA_MULTIZONE_ZONE_NAME=<zone-name> \
+  KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS=grpcs://<global-kds-address> \
+  KMESH_MULTIZONE_ZONE_KDS_AUTH_CP_TOKEN_PATH="/tmp/token" \
   ./kuma-cp run
 ```
 
@@ -121,7 +121,7 @@ If you are starting from scratch and not securing existing Kong Mesh deployment,
 {% navtabs %}
 {% navtab Kubernetes with kumactl %}
 
-If you install the remote control plane with `kumactl install control-plane`, pass the `--cp-auth` argument with the value `cpToken`:
+If you install the zone control plane with `kumactl install control-plane`, pass the `--cp-auth` argument with the value `cpToken`:
 
 ```sh
 $ kumactl install control-plane \
@@ -155,10 +155,10 @@ $ KUMA_MODE=global \
 {% endnavtab %}
 {% endnavtabs %}
 
-Verify the remote control plane is connected with authentication by looking at the global control plane logs:
+Verify the zone control plane is connected with authentication by looking at the global control plane logs:
 
 ```
-2021-02-24T14:30:38.596+0100	INFO	kds.auth	Remote CP successfully authenticated using Control Plane Token	{"tokenSerialNumber": 1, "zone": "cluster-2"}
+2021-02-24T14:30:38.596+0100	INFO	kds.auth	Zone CP successfully authenticated using Control Plane Token	{"tokenSerialNumber": 1, "zone": "cluster-2"}
 ```
 
 ## Revoke token
@@ -259,7 +259,7 @@ data: {{ key }}
 
 ### Regenerate control plane tokens
 
-Create and add a new token for each remote control plane. These tokens are automatically created with the signing key that's assigned the highest serial number, so they're created with the new signing key.
+Create and add a new token for each zone control plane. These tokens are automatically created with the signing key that's assigned the highest serial number, so they're created with the new signing key.
 
 Make sure the new signing key is available; otherwise old and new tokens are created with the same signing key and can both provide authentication.
 
@@ -315,4 +315,4 @@ The result looks like:
 
 ## Additional security
 
-By default, a connection from the remote control plane to the global control plane is secured with TLS. You should also configure the remote control plane to [verify the certificate authority (CA) of the global control plane](https://kuma.io/docs/latest/security/certificates/#control-plane-to-control-plane-multizone){:target="_blank"}.
+By default, a connection from the zone control plane to the global control plane is secured with TLS. You should also configure the zone control plane to [verify the certificate authority (CA) of the global control plane](https://kuma.io/docs/latest/security/certificates/#control-plane-to-control-plane-multizone){:target="_blank"}.


### PR DESCRIPTION
This document has been very outdated referencing the word "remote" when we have renamed this to "zone" a while back. This includes a long list of variable names which made all copy&paste examples fail

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
