### PR TITLE
Update Gateway 2.8.x support dates

### DIFF
--- a/app/konnect-platform/support-policy.md
+++ b/app/konnect-platform/support-policy.md
@@ -48,7 +48,7 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
-|  2.8.x.x |  2022-03-02   |     2022-08-24      |      2023-08-24       |
+|  2.8.x.x |  2022-03-02   |     2023-08-24      |      2024-08-24       |
 |  2.7.x.x |  2021-12-16   |     2022-08-24      |      2023-08-24       |
 |  2.6.x.x |  2021-10-14   |     2022-08-24      |      2023-08-24       |
 |  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |


### PR DESCRIPTION
### Summary
Update Gateway 2.8 release dates to be 12 months later

### Reason
2.8 is the last minor version before the major 3.0 release, so we're adding an additional support period

### Testing
Waiting for review app