### PR TITLE
Corrected the install URL for EE on Ubuntu

### DIFF
--- a/app/gateway/2.8.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.8.x/install-and-run/ubuntu.md
@@ -51,7 +51,7 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-ubuntu-$(lsb_release -cs)/pool/all/k/kong-enterprise-edition/kong_{{page.kong_versions[page.version-index].ee-version}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}


### PR DESCRIPTION


Please see https://kongstrong.slack.com/archives/C0DSXDXV1/p1648243358762779 for more information.

### Summary
The Enterprise tab was pointing to the OSS version of the file, and had the wrong naming convention as well. These are corrected now with this PR.

### Reason
The URLs were incorrect earlier, pointing to a 404 Not Found file instead as the URL wasn't accurate.

### Testing
Can follow the fully formed URLs to test. Was a little difficult for me to see in Preview mode as it didn't contain the full URL, but I believe the changes I made are all that's needed (1: pointing to kong-enterprise-edition in the directory structure, and 2: replacing _amd64 with _all).
