### PR TITLE
Fix install URLs for Debian

### DIFF
--- a/app/gateway/2.7.x/install-and-run/debian.md
+++ b/app/gateway/2.7.x/install-and-run/debian.md
@@ -53,7 +53,7 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong-enterprise-edition/kong_{{page.kong_versions[page.version-index].ee-version}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}

--- a/app/gateway/2.8.x/install-and-run/debian.md
+++ b/app/gateway/2.8.x/install-and-run/debian.md
@@ -53,7 +53,7 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ee-version}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-2.x-debian-$(lsb_release -cs)/pool/all/k/kong-enterprise-edition/kong_{{page.kong_versions[page.version-index].ee-version}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}


### PR DESCRIPTION
### Summary
Fixing gateway enterprise install URL.

### Reason
Companion PR to #3787 . Same error on Debian doc.

### Testing
The files are here, note the `kong-enterprise-edition` in the URL:
https://download.konghq.com/gateway-2.x-debian-jessie/pool/all/k/kong-enterprise-edition/

The previous URL pointed to OSS install files: 
https://download.konghq.com/gateway-2.x-debian-jessie/pool/all/k/kong/