### PR TITLE
Added note about a feature being PostreSQL-applicable only

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -10,7 +10,7 @@ no_version: true
 
 #### Enterprise
 
-* Improved tables in Kong Manager:
+* Improved tables in Kong Manager: (for PostgreSQL-backed instances only)
   * Click on a table row to access the entry instead of using the
   old **View** icon.
   * Search and filter tables through the **Filters** dropdown, which is located


### PR DESCRIPTION
### Summary
Added a note about a feature being PostgreSQL only (i.e. does not apply to Cassandra users).

### Reason
Seems this feature is applicable to PostgreSQL only, based on comments in https://github.com/Kong/kong-ee/pull/2839.