### PR TITLE
Fix spec_render_type typo in Portal docs

### DIFF
--- a/app/gateway/2.7.x/developer-portal/theme-customization/alternate-openapi-renderer.md
+++ b/app/gateway/2.7.x/developer-portal/theme-customization/alternate-openapi-renderer.md
@@ -13,10 +13,10 @@ To do this, add some custom code and update your config, as follows:
 
 1. In `spec.renderer.html`, replace all of the current content with the content from this [spec-renderer.html](/code-snippets/spec-renderer.html) file. Doing so adds options for [Stoplight](https://meta.stoplight.io/docs/platform/ZG9jOjIwNjk2MQ-welcome-to-the-stoplight-docs) and [Redoc](https://github.com/Redocly/redoc) layouts.
 
-1. In `theme.conf.yaml`, add the parameter `spec_renderer_type` and the value `stoplight` or `redoc`. For example:
+1. In `theme.conf.yaml`, add the parameter `spec_render_type` and the value `stoplight` or `redoc`. For example:
 
     ```yaml
-    spec_renderer_type: "stoplight"
+    spec_render_type: "stoplight"
     ```
 
 1. Refresh your Dev Portal to see that the change has taken effect.

--- a/app/gateway/2.8.x/developer-portal/theme-customization/alternate-openapi-renderer.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/alternate-openapi-renderer.md
@@ -13,10 +13,10 @@ To do this, add some custom code and update your config, as follows:
 
 1. In `spec.renderer.html`, replace all of the current content with the content from this [spec-renderer.html](/code-snippets/spec-renderer.html) file. Doing so adds options for [Stoplight](https://meta.stoplight.io/docs/platform/ZG9jOjIwNjk2MQ-welcome-to-the-stoplight-docs) and [Redoc](https://github.com/Redocly/redoc) layouts.
 
-1. In `theme.conf.yaml`, add the parameter `spec_renderer_type` and the value `stoplight` or `redoc`. For example:
+1. In `theme.conf.yaml`, add the parameter `spec_render_type` and the value `stoplight` or `redoc`. For example:
 
     ```yaml
-    spec_renderer_type: "stoplight"
+    spec_render_type: "stoplight"
     ```
 
 1. Refresh your Dev Portal to see that the change has taken effect.


### PR DESCRIPTION
### Summary
The docs currently show `spec_renderer_type` when it should be `spec_render_type`

### Reason
Customer reported issue

Validated in the spec-renderer file:
https://github.com/Kong/docs.konghq.com/blob/main/app/code-snippets/spec-renderer.html#L16

### Testing
Check the review app at /gateway/2.8.x/developer-portal/theme-customization/alternate-openapi-renderer/
