### PR TITLE
Add konnect_icon helper

### DIFF
--- a/app/_plugins/konnect_icon_tag.rb
+++ b/app/_plugins/konnect_icon_tag.rb
@@ -1,0 +1,15 @@
+module Jekyll
+  class KonnectIconTag < Liquid::Tag
+
+    def initialize(tag_name, icon, tokens)
+      super
+      @icon = icon.strip
+    end
+
+    def render(context)
+      "![#{@icon} icon](/assets/images/icons/konnect/icn-#{@icon}.svg){:.inline .konnect-icn .no-image-expand}"
+    end
+  end
+end
+
+Liquid::Template.register_tag('konnect_icon', Jekyll::KonnectIconTag)


### PR DESCRIPTION
### Summary
Adds a new helper to show inline Konnect icons

Usage: `{% konnect_icon runtimes %}`

Output:
```
![#{@icon} icon](/assets/images/icons/konnect/icn-#{@icon}.svg){:.inline .konnect-icn .no-image-expand}
```

### Reason
Add a single point of configuration for how inline icons look in the Konnect docs

### Testing
Add `{% konnect_icon runtimes %}` to a page and inspect the HTML. You'll see the `alt` text if the icon doesn't exist