### PR TITLE
Fix upstream name

### DIFF
--- a/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
@@ -22,7 +22,7 @@ In the following example, you’ll use an application deployed across two differ
 
 ## Configure Upstream Services
 
-In this section, you will create an Upstream named `upstream` and add two targets to it.
+In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
@@ -38,7 +38,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
 10. Open the **Services** page.
 11. Find your `example_service` and click **Edit**.
-12. Change the **Host** field to `upstream`, then click **Update**.
+12. Change the **Host** field to `example_upstream`, then click **Update**.
 {% endnavtab %}
 {% navtab Using the Admin API %}
 

--- a/app/gateway/2.7.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/load-balancing.md
@@ -22,7 +22,7 @@ In the following example, you’ll use an application deployed across two differ
 
 ## Configure Upstream Services
 
-In this section, you will create an Upstream named `upstream` and add two targets to it.
+In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
@@ -38,7 +38,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
 10. Open the **Services** page.
 11. Find your `example_service` and click **Edit**.
-12. Change the **Host** field to `upstream`, then click **Update**.
+12. Change the **Host** field to `example_upstream`, then click **Update**.
 {% endnavtab %}
 {% navtab Using the Admin API %}
 

--- a/app/gateway/2.8.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/load-balancing.md
@@ -22,7 +22,7 @@ In the following example, you’ll use an application deployed across two differ
 
 ## Configure Upstream Services
 
-In this section, you will create an Upstream named `upstream` and add two targets to it.
+In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
@@ -38,7 +38,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
 10. Open the **Services** page.
 11. Find your `example_service` and click **Edit**.
-12. Change the **Host** field to `upstream`, then click **Update**.
+12. Change the **Host** field to `example_upstream`, then click **Update**.
 {% endnavtab %}
 {% navtab Using the Admin API %}
 

--- a/app/getting-started-guide/2.3.x/load-balancing.md
+++ b/app/getting-started-guide/2.3.x/load-balancing.md
@@ -22,7 +22,7 @@ In the following example, you’ll use an application deployed across two differ
 
 ## Configure Upstream Services
 
-In this section, you will create an Upstream named `upstream` and add two targets to it.
+In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
@@ -42,7 +42,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 {% endnavtab %}
 {% navtab Using the Admin API %}
 
-Call the Admin API on port `8001` and create an Upstream named `upstream`:
+Call the Admin API on port `8001` and create an Upstream named `example_upstream`:
 
 <!-- codeblock tabs -->
 {% navtabs codeblock %}

--- a/app/getting-started-guide/2.4.x/load-balancing.md
+++ b/app/getting-started-guide/2.4.x/load-balancing.md
@@ -22,7 +22,7 @@ In the following example, you’ll use an application deployed across two differ
 
 ## Configure Upstream Services
 
-In this section, you will create an Upstream named `upstream` and add two targets to it.
+In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
@@ -42,7 +42,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 {% endnavtab %}
 {% navtab Using the Admin API %}
 
-Call the Admin API on port `8001` and create an Upstream named `upstream`:
+Call the Admin API on port `8001` and create an Upstream named `example_upstream`:
 
 <!-- codeblock tabs -->
 {% navtabs codeblock %}

--- a/app/getting-started-guide/2.5.x/load-balancing.md
+++ b/app/getting-started-guide/2.5.x/load-balancing.md
@@ -22,7 +22,7 @@ In the following example, you’ll use an application deployed across two differ
 
 ## Configure Upstream Services
 
-In this section, you will create an Upstream named `upstream` and add two targets to it.
+In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
 {% navtabs %}
 {% navtab Using Kong Manager %}
@@ -42,7 +42,7 @@ In this section, you will create an Upstream named `upstream` and add two target
 {% endnavtab %}
 {% navtab Using the Admin API %}
 
-Call the Admin API on port `8001` and create an Upstream named `upstream`:
+Call the Admin API on port `8001` and create an Upstream named `example_upstream`:
 
 <!-- codeblock tabs -->
 {% navtabs codeblock %}


### PR DESCRIPTION
### Summary
Fixing the upstream hostname. We changed the name to `example_upstream` some time back to avoid running into reserved entity issues, but missed a couple of instances of the old name.

Ran a search through all the getting started guides for `upstream` and replaced it with the correct name.

### Reason
Customer-reported issue: https://github.com/Kong/docs.konghq.com/issues/3795

Resolves #3795

### Testing
Netlify preview.