### PR TITLE
Fix RBAC typo

### DIFF
--- a/app/enterprise/0.31-x/plugins/rbac-api.md
+++ b/app/enterprise/0.31-x/plugins/rbac-api.md
@@ -237,7 +237,7 @@ ___
 ## Delete A Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 **Response**
 

--- a/app/enterprise/0.32-x/plugins/rbac-api.md
+++ b/app/enterprise/0.32-x/plugins/rbac-api.md
@@ -237,7 +237,7 @@ ___
 ## Delete A Role
 **Endpoint** 
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 **Response**
 

--- a/app/enterprise/0.33-x/rbac/admin-api.md
+++ b/app/enterprise/0.33-x/rbac/admin-api.md
@@ -319,7 +319,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/0.33-x/rbac/admin-api.md
+++ b/app/enterprise/0.33-x/rbac/admin-api.md
@@ -858,7 +858,7 @@ HTTP 204 No Content
 
 
 [Admin API]: /gateway-oss/latest/admin-api/
-[Admin GUI]: /enterprise/{{page.kong_version}}/api-admin-gui/overview
+[Admin GUI]: /enterprise/{{page.kong_version}}/admin-gui/overview
 ### List a User's Permissions
 **Endpoint**
 

--- a/app/enterprise/0.33-x/rbac/admin-api.md
+++ b/app/enterprise/0.33-x/rbac/admin-api.md
@@ -857,8 +857,8 @@ HTTP 204 No Content
 ---
 
 
-[Admin API]: /{{page.kong_version}}/admin-api/
-[Admin GUI]: /{{page.kong_version}}/api-admin-gui/
+[Admin API]: /gateway-oss/latest/admin-api/
+[Admin GUI]: /enterprise/{{page.kong_version}}/api-admin-gui/overview
 ### List a User's Permissions
 **Endpoint**
 

--- a/app/enterprise/0.34-x/rbac/admin-api.md
+++ b/app/enterprise/0.34-x/rbac/admin-api.md
@@ -319,7 +319,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/0.35-x/admin-api/rbac/reference.md
+++ b/app/enterprise/0.35-x/admin-api/rbac/reference.md
@@ -371,7 +371,7 @@ HTTP 200 OK
 
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute | Description         |
 | --------- | ------------------- |

--- a/app/enterprise/0.36-x/admin-api/rbac/reference.md
+++ b/app/enterprise/0.36-x/admin-api/rbac/reference.md
@@ -371,7 +371,7 @@ HTTP 200 OK
 
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute | Description         |
 | --------- | ------------------- |

--- a/app/enterprise/1.3-x/admin-api/rbac/reference.md
+++ b/app/enterprise/1.3-x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/1.5.x/admin-api/rbac/reference.md
+++ b/app/enterprise/1.5.x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/2.1.x/admin-api/rbac/reference.md
+++ b/app/enterprise/2.1.x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/2.2.x/admin-api/rbac/reference.md
+++ b/app/enterprise/2.2.x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/2.3.x/admin-api/rbac/reference.md
+++ b/app/enterprise/2.3.x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/2.4.x/admin-api/rbac/reference.md
+++ b/app/enterprise/2.4.x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/enterprise/2.5.x/admin-api/rbac/reference.md
+++ b/app/enterprise/2.5.x/admin-api/rbac/reference.md
@@ -354,7 +354,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/gateway/2.6.x/admin-api/rbac/reference.md
+++ b/app/gateway/2.6.x/admin-api/rbac/reference.md
@@ -352,7 +352,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/gateway/2.7.x/admin-api/rbac/reference.md
+++ b/app/gateway/2.7.x/admin-api/rbac/reference.md
@@ -352,7 +352,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |

--- a/app/gateway/2.8.x/admin-api/rbac/reference.md
+++ b/app/gateway/2.8.x/admin-api/rbac/reference.md
@@ -352,7 +352,7 @@ ___
 ## Delete a Role
 **Endpoint**
 
-<div class="endpoint delete">/rbac/role/{name_or_id}</div>
+<div class="endpoint delete">/rbac/roles/{name_or_id}</div>
 
 | Attribute             | Description                               |
 | ---------             | -----------                               |


### PR DESCRIPTION
### Summary
Typo in `DELETE` roles request examples in RBAC admin API docs.

### Reason
https://konghq.atlassian.net/browse/FT-2498

No doc ticket; this is a quick fix for an FT ticket that's been hanging around for a few weeks, and it has no reason to.

### Testing
Checked the API definition, it's definitely `roles`: https://github.com/Kong/kong-ee/blob/master/kong/api/routes/rbac.lua#L436-L443