### PR TITLE
Fixing small references to non-encrypted plugin

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/index.md
+++ b/app/_hub/kong-inc/key-auth-enc/index.md
@@ -170,7 +170,7 @@ service, you must add the new Consumer to the allowed group. See
 Provision new credentials by making the following HTTP request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/key-auth -d
+$ curl -X POST http://kong:8001/consumers/{consumer}/key-auth-enc -d ""
 ```
 
 Response:


### PR DESCRIPTION
There was a small issue with our docs where we were still referencing the non-encrypted plugin