### PR TITLE
doc(kic) add profiling instructions

### DIFF
--- a/app/kubernetes-ingress-controller/2.2.x/troubleshooting.md
+++ b/app/kubernetes-ingress-controller/2.2.x/troubleshooting.md
@@ -282,3 +282,14 @@ application-layer traffic. If you have acces to the server's private keys you
 can [decrypt TLS](https://wiki.wireshark.org/TLS#TLS_Decryption), though this
 does not work if the session uses an ephemeral cipher (neither the controller
 nor Kong proxy have support for dumping session secrets).
+
+## Gathering profiling data
+
+The controller provides access to [the Golang
+profiler](https://pkg.go.dev/net/http/pprof), which provides diagnostic
+information on memory and CPU consumption within the program.
+
+To enable profiling and access it, set `CONTROLLER_PROFILING=true` in the
+controller container environment (`ingressController.env.profiling: true` using
+the Helm chart), wait for the Deployment to restart, run `kubectl
+port-forward <POD_NAME> 10256:10256`, and visit http://localhost:10256/debug/pprof/


### PR DESCRIPTION
### Summary
Adds instructions for accessing the ingress controller's profiler.

### Reason
It's something we ask users to do but didn't really document.

### Testing
None.
