### PR TITLE
Typo fix

### DIFF
--- a/app/gateway/2.7.x/admin-api/index.md
+++ b/app/gateway/2.7.x/admin-api/index.md
@@ -3804,7 +3804,7 @@ Targets can be both [tagged and filtered by tags](#tags).
 {:.indent}
 Attributes | Description
 ---:| ---
-`upstream_d`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
+`upstream_id`<br>**required** | The unique identifier of the Upstream that should be associated to the newly-created Target.
 
 
 #### Request Body


### PR DESCRIPTION
### Summary
Typo fix. Should be upstream_id instead of upstream_d