### PR TITLE
Update kubernetes.md

### DIFF
--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -42,7 +42,7 @@ oc new-project kong
 
     ```sh
     ## on Kubernetes native
-    kubectl create secret generic kong-enterprise-license --from-file=./license -n kong
+    kubectl create secret generic kong-enterprise-license --from-file=<absolute-path-to>/license -n kong
     ```
 
     ```sh


### PR DESCRIPTION
### Summary

secret / license generation command incorrect?

### Reason

Trying out documented steps for k8s install I see the results below;

### Testing

first error
```➜  minikube git:(main) ✗ ## on Kubernetes native
kubectl create secret generic kong-enterprise-license --from-file=~/license -n kong
error: error reading ~/license: no such file or directory
```

second successful
```➜  minikube git:(main) ✗ ## on Kubernetes native
kubectl create secret generic kong-enterprise-license --from-file=${HOME}/license -n kong
secret/kong-enterprise-license created
```

Cannot test on `oc` that may need verification too.
