### PR TITLE
Fix consumers groups rate limiting overrides attributes

### DIFF
--- a/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
+++ b/app/gateway/2.7.x/admin-api/consumer-groups/reference.md
@@ -377,10 +377,10 @@ Attribute                             | Description
 
 Attribute     | Description  
 ---------:    | --------
-`limit`<br>*required*       | An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
-`window_size`<br>*required* | An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
-`window_type`<br>*optional* | Set the time window type to either `sliding` (default) or `fixed`.
-`retry_after_jitter_max`<br>*optional* | The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.
+`config.limit`<br>*required*       | An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+`config.window_size`<br>*required* | An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+`config.window_type`<br>*optional* | Set the time window type to either `sliding` (default) or `fixed`.
+`config.retry_after_jitter_max`<br>*optional* | The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.
 
 **Response**
 

--- a/app/gateway/2.8.x/admin-api/consumer-groups/reference.md
+++ b/app/gateway/2.8.x/admin-api/consumer-groups/reference.md
@@ -377,10 +377,10 @@ Attribute                             | Description
 
 Attribute     | Description  
 ---------:    | --------
-`limit`<br>*required*       | An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
-`window_size`<br>*required* | An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
-`window_type`<br>*optional* | Set the time window type to either `sliding` (default) or `fixed`.
-`retry_after_jitter_max`<br>*optional* | The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.
+`config.limit`<br>*required*       | An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+`config.window_size`<br>*required* | An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+`config.window_type`<br>*optional* | Set the time window type to either `sliding` (default) or `fixed`.
+`config.retry_after_jitter_max`<br>*optional* | The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.
 
 **Response**
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Fixes consumers groups rate limiting overrides body attributes.

https://docs.konghq.com/gateway/2.7.x/admin-api/consumer-groups/reference/#configure-rate-limiting-for-a-consumer-group

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
They do not mention the keys being nested in a config dict.

incorrect body payload:

```json
{
  "window_size": [60],
  "limit": [200]
}
```

correct body payload:

```json
{
  "config": {
    "window_size": [60],
    "limit": [200]
  }
}
```

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

verify by sending a PUT to the admin endpoint with both payloads mentioned above

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
