### PR TITLE
Fix a typo in request-transformer-advanced plugin

### DIFF
--- a/app/_hub/kong-inc/request-transformer-advanced/index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/index.md
@@ -244,7 +244,7 @@ Lambdas are also supported if wrapped as an expression like this:
 
     $((function() ... implementation here ... end)())
 
-A complete lambda example for pefixing a header value with "Basic " if not
+A complete lambda example for prefixing a header value with "Basic " if not
 already there:
 
     Authorization:$((function()


### PR DESCRIPTION
Fix the typo "for pefixing" in request-transformer-advanced plugin

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
