### PR TITLE
chore(mesh): make windows and ubi docs more prominent

### DIFF
--- a/app/_data/docs_nav_mesh_1.7.x.yml
+++ b/app/_data/docs_nav_mesh_1.7.x.yml
@@ -64,3 +64,5 @@
       url: /features/rbac
     - text: UBI Images
       url: /features/ubi-images
+    - text: Windows Support
+      url: /features/windows

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -456,7 +456,7 @@
   edition: "mesh"
 -
   release: "1.6.x"
-  version: "1.6.0"
+  version: "1.6.1"
   edition: "mesh"
 -
   release: "1.7.x"

--- a/app/_redirects
+++ b/app/_redirects
@@ -470,6 +470,7 @@
 # KONG MESH
 /mesh/1.0.x/features/   /mesh/1.0.x/features/vault
 /mesh/1.1.x/features/   /mesh/1.1.x/features/vault
+/mesh/1.7.x/features/windows/ /mesh/1.7.x/installation/windows/
 
 
 # ABOUT

--- a/app/mesh/1.7.x/features/windows.md
+++ b/app/mesh/1.7.x/features/windows.md
@@ -1,0 +1,6 @@
+---
+title: Windows installation
+---
+
+{{site.mesh_product_name}} can run on Windows VMs.
+To see how to do it check [Installation documentation](../installation/windows.md)

--- a/app/mesh/1.7.x/features/windows.md
+++ b/app/mesh/1.7.x/features/windows.md
@@ -1,6 +1,0 @@
----
-title: Windows installation
----
-
-{{site.mesh_product_name}} can run on Windows VMs.
-To see how to do it check [Installation documentation](../installation/windows.md)

--- a/app/mesh/1.7.x/installation/docker.md
+++ b/app/mesh/1.7.x/installation/docker.md
@@ -28,6 +28,9 @@ executables, hosted on Docker Hub:
 * **kumactl**: at [`kong/kumactl:{{page.kong_latest.version}}`](https://hub.docker.com/r/kong/kumactl)
 * **kuma-prometheus-sd**: at [`kong/kuma-prometheus-sd:{{page.kong_latest.version}}`](https://hub.docker.com/r/kong/kuma-prometheus-sd)
 
+{:.note}
+> **Note**: {{site.mesh_product_name}} also has UBI images, image names are prefixed with "ubi". For example `kong/ubi-kuma-cp` instead of `kong/kuma-cp`.
+
 `docker pull` each image that you need. For example:
 
 ```sh

--- a/app/mesh/1.7.x/installation/kubernetes.md
+++ b/app/mesh/1.7.x/installation/kubernetes.md
@@ -64,6 +64,9 @@ Then, run the control plane with:
 $ kumactl install control-plane --license-path=/path/to/license.json | kubectl apply -f -
 ```
 
+{:.note}
+> **Note**: {{site.mesh_product_name}} also has UBI images. To use these images instead checkout the [UBI documentation](../features/ubi-images.md).
+
 Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 


### PR DESCRIPTION
### Summary

Make windows and ubi docs more prominent

### Reason

Windows was not listed in the list of enterprise features and UBI images were not referenced in the different install docs.
