### PR TITLE
[DOCU-2265] Dev portal settings page relocation

### DIFF
--- a/app/_includes/md/konnect/dev-portal-access.md
+++ b/app/_includes/md/konnect/dev-portal-access.md
@@ -47,9 +47,7 @@ into the Dev Portal.
 {% endnavtab %}
 {% navtab Public Dev Portal %}
 
-1. From the [{{site.konnect_short_name}}](https://cloud.konghq.com/) menu, open
-![settings icon](/assets/images/icons/konnect/konnect-settings.svg){:.inline .no-image-expand}
-**Settings**.
+1. Open **Dev Portal** from the left side menu, then click **Settings**.
 
 1. In the **Public Portal** pane, toggle the switch to **Enabled**.
 

--- a/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
+++ b/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
@@ -18,7 +18,7 @@ You have the **Organization Admin** or **Portal Admin** role in {{site.konnect_s
 
 Auto approve is disabled by default. You can enable and disable approvals at any time. If there are any pending requests when auto approve is enabled, those requests must be manually approved.
 
-1. In Konnect, open **Dev Portal** from the left side menu, then click **Settings**.
+1. In {{site.konnect_short_name}}, open **Dev Portal** from the left side menu, then click **Settings**.
 
 1. Toggle to enable or disable auto approve for one or both options:
       * Auto Approve Developers

--- a/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
+++ b/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
@@ -11,14 +11,17 @@ If auto approve is not enabled for Developers or Applications, admins will need 
 {:.note}
 > If auto approve is enabled through the Portal for Applications, it overrides the Service setting.
 
+## Prerequisites
+You have the **Organization Admin** or **Portal Admin** role in {{site.konnect_saas}}.
+
 ## Enable or disable auto approve
 
 Auto approve is disabled by default. You can enable and disable approvals at any time. If there are any pending requests when auto approve is enabled, those requests must be manually approved.
 
-1. As an admin, from the [{{site.konnect_short_name}}](https://konnect.konghq.com/) menu, click **Settings**. Then click **Portal**.
+1. In Konnect, open **Dev Portal** from the left side menu, then click **Settings**.
 
-2. Toggle to enable or disable auto approve for one or both options:
+1. Toggle to enable or disable auto approve for one or both options:
       * Auto Approve Developers
       * Auto Approve Applications
 
-3. Click **Save**.
+1. Click **Save**.

--- a/app/konnect/dev-portal/customization/custom-domain.md
+++ b/app/konnect/dev-portal/customization/custom-domain.md
@@ -20,7 +20,7 @@ In your custom domain DNS records, direct your CNAME to your Dev Portal's defaul
 
 Add a custom Dev Portal domain through your organization's {{site.konnect_short_name}} Admin UI.
 
-1. In Konnect, open **Dev Portal** from the left side menu, then click **Settings**.
+1. In {{site.konnect_short_name}}, open **Dev Portal** from the left side menu, then click **Settings**.
 
 1. Open the **Portal URL** tab.
 

--- a/app/konnect/dev-portal/customization/custom-domain.md
+++ b/app/konnect/dev-portal/customization/custom-domain.md
@@ -7,7 +7,7 @@ All Dev Portals have an auto-generated default Dev Portal URL. To further custom
 
 ## Prerequisites
 
-* Access to your organization's {{site.konnect_short_name}} Admin UI.
+* You have the **Organization Admin** or **Portal Admin** role in {{site.konnect_saas}}.
 * A domain and access to configure that domain's CNAME. Kong does not offer any custom domains as a service.
 * An X.509 certificate, which comes with a private key.
 * Your organization's auto-generated default Dev Portal URL, which is in the {{site.konnect_short_name}} Admin UI. For example, `https://kong121212.portal.konnect.konghq.com/`.
@@ -20,7 +20,9 @@ In your custom domain DNS records, direct your CNAME to your Dev Portal's defaul
 
 Add a custom Dev Portal domain through your organization's {{site.konnect_short_name}} Admin UI.
 
-1. Click **Dev Portal**, then **Portal URL**.
+1. In Konnect, open **Dev Portal** from the left side menu, then click **Settings**.
+
+1. Open the **Portal URL** tab.
 
 1. Enter the following fields.
 

--- a/app/konnect/dev-portal/customization/public-portal.md
+++ b/app/konnect/dev-portal/customization/public-portal.md
@@ -13,7 +13,7 @@ You have the **Organization Admin** or **Portal Admin** role in {{site.konnect_s
 
 ## Enable or disable public access for a Dev Portal
 
-1. In Konnect, open **Dev Portal** from the left side menu, then click **Settings**.
+1. In {{site.konnect_short_name}}, open **Dev Portal** from the left side menu, then click **Settings**.
 
 2. In the **Public Portal** pane, toggle **Enabled** or **Disabled**.
 

--- a/app/konnect/dev-portal/customization/public-portal.md
+++ b/app/konnect/dev-portal/customization/public-portal.md
@@ -3,16 +3,17 @@ title: Enable Public Dev Portal
 no_version: true
 ---
 
-When Public Portal is enabled, anyone can access your Dev Portal without a 
+When Public Portal is enabled, anyone can access your Dev Portal without a
 login. Developers will not need to register and new Application registrations will not be possible.
 
 Note that the Register options are not available in a public-facing portal.
 
+## Prerequisites
+You have the **Organization Admin** or **Portal Admin** role in {{site.konnect_saas}}.
+
 ## Enable or disable public access for a Dev Portal
 
-1. From the [{{site.konnect_short_name}}](https://konnect.konghq.com/) menu, click the
-![settings icon](/assets/images/icons/konnect/konnect-settings.svg){:.inline .no-image-expand}
-settings icon.
+1. In Konnect, open **Dev Portal** from the left side menu, then click **Settings**.
 
 2. In the **Public Portal** pane, toggle **Enabled** or **Disabled**.
 


### PR DESCRIPTION
### Summary
Updating any instructions for accessing dev portal settings in Konnect to use new location.
Also adding role prereqs needed to be able to access the menu item.

### Reason
The settings page for the dev portal moved from `Settings` -> `Portal` to `Dev Portal` -> `Settings`. 
The `Portal URL` setting moved under that option as well.

### Testing
Ran a search for any mention of settings or of Dev Portal customization. Checked the cloud-02 site to verify.