### PR TITLE
Update kuma.io links to match new site structure

### DIFF
--- a/app/_includes/md/mesh/install-universal-run.md
+++ b/app/_includes/md/mesh/install-universal-run.md
@@ -19,7 +19,7 @@ Where `/path/to/file/license.json` is the path to a valid
 {{site.mesh_product_name}} license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always
@@ -30,5 +30,5 @@ in `/usr/local/bin/` by executing:
 $ ln -s ./kumactl /usr/local/bin/kumactl
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.

--- a/app/mesh/1.0.x/features/vault.md
+++ b/app/mesh/1.0.x/features/vault.md
@@ -48,7 +48,7 @@ Vault, you must provide the following values in the configuration for `kuma-cp`:
 
 These values can be inline (for testing purposes only), a path to a file on the
 same host as `kuma-cp`, or contained in a `secret`. See the official Kuma
-documentation to learn more about [Kuma Secrets](https://kuma.io/docs/latest/documentation/secrets/)
+documentation to learn more about [Kuma Secrets](https://kuma.io/docs/latest/security/secrets/)
 and how to create one.
 
 Here's an example of a configuration using a `vault`-backed CA:
@@ -126,7 +126,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or using the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or using the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.0.x/installation/docker.md
+++ b/app/mesh/1.0.x/installation/docker.md
@@ -61,12 +61,12 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 <div class="alert alert-ee blue">
 <strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with
-a memory <a href="https://kuma.io/docs/latest/documentation/backends/">backend</a>,
+a memory <a href="https://kuma.io/docs/latest/explore/backends/">backend</a>,
 but you can use a persistent storage like PostgreSQL by updating the
 <code>conf/kuma-cp.conf</code> file.
 </div>

--- a/app/mesh/1.0.x/installation/helm.md
+++ b/app/mesh/1.0.x/installation/helm.md
@@ -59,7 +59,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.0.x/installation/kubernetes.md
+++ b/app/mesh/1.0.x/installation/kubernetes.md
@@ -78,7 +78,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.0.x/installation/openshift.md
+++ b/app/mesh/1.0.x/installation/openshift.md
@@ -128,7 +128,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 <div class="alert alert-ee blue">

--- a/app/mesh/1.0.x/overview.md
+++ b/app/mesh/1.0.x/overview.md
@@ -137,5 +137,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.1.x/features/vault.md
+++ b/app/mesh/1.1.x/features/vault.md
@@ -48,7 +48,7 @@ Vault, you must provide the following values in the configuration for `kuma-cp`:
 
 These values can be inline (for testing purposes only), a path to a file on the
 same host as `kuma-cp`, or contained in a `secret`. See the official Kuma
-documentation to learn more about [Kuma Secrets](https://kuma.io/docs/latest/documentation/secrets/)
+documentation to learn more about [Kuma Secrets](https://kuma.io/docs/latest/security/secrets/)
 and how to create one.
 
 Here's an example of a configuration using a `vault`-backed CA:
@@ -126,7 +126,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or using the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or using the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.1.x/installation/docker.md
+++ b/app/mesh/1.1.x/installation/docker.md
@@ -61,12 +61,12 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 <div class="alert alert-ee blue">
 <strong>Note:</strong> By default, this will run {{site.mesh_product_name}} with
-a memory <a href="https://kuma.io/docs/latest/documentation/backends/">backend</a>,
+a memory <a href="https://kuma.io/docs/latest/explore/backends/">backend</a>,
 but you can use a persistent storage like PostgreSQL by updating the
 <code>conf/kuma-cp.conf</code> file.
 </div>

--- a/app/mesh/1.1.x/installation/helm.md
+++ b/app/mesh/1.1.x/installation/helm.md
@@ -59,7 +59,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.1.x/installation/kubernetes.md
+++ b/app/mesh/1.1.x/installation/kubernetes.md
@@ -78,7 +78,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.1.x/installation/openshift.md
+++ b/app/mesh/1.1.x/installation/openshift.md
@@ -128,7 +128,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 <div class="alert alert-ee blue">

--- a/app/mesh/1.1.x/overview.md
+++ b/app/mesh/1.1.x/overview.md
@@ -137,5 +137,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.2.x/features/opa.md
+++ b/app/mesh/1.2.x/features/opa.md
@@ -15,7 +15,7 @@ When `OPAPolicy` is applied, the control plane configures:
 
 ## Usage
 
-To apply a policy with OPA: 
+To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
@@ -90,28 +90,28 @@ conf:
   policies: # optional
     - inlineString: | # one of: inlineString, secret
         package envoy.authz
-  
+
         import input.attributes.request.http as http_request
-  
+
         default allow = false
-  
+
         token = {"valid": valid, "payload": payload} {
             [_, encoded] := split(http_request.headers.authorization, " ")
             [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
         }
-  
+
         allow {
             is_token_valid
             action_allowed
         }
-  
+
         is_token_valid {
           token.valid
           now := time.now_ns() / 1000000000
           token.payload.nbf <= now
           now < token.payload.exp
         }
-  
+
         action_allowed {
           http_request.method == "GET"
           token.payload.role == "admin"
@@ -123,7 +123,7 @@ conf:
 
 ### With Secrets
 
-Encoding the policy in a [Secret](https://kuma.io/docs/1.0.7/documentation/secrets/#universal) provides some security for policies that contain sensitive data.
+Encoding the policy in a [Secret](https://kuma.io/docs/latest/security/secrets) provides some security for policies that contain sensitive data.
 
 {% navtabs %}
 {% navtab Kubernetes %}
@@ -209,7 +209,7 @@ The following environment variables are available:
 
 You can customize the agent in either of the following ways:
 
-- Override variables in the data plane proxy config: 
+- Override variables in the data plane proxy config:
 {% navtabs %}
 {% navtab kumactl %}
 
@@ -261,12 +261,12 @@ The `run` command on the data plane proxy accepts the following equivalent param
 
 
 ```
---opa-addr 
---opa-config-path 
---opa-diagnostic-addr 
+--opa-addr
+--opa-config-path
+--opa-diagnostic-addr
 --opa-enabled                    
---opa-ext-authz-addr 
---opa-set strings 
+--opa-ext-authz-addr
+--opa-set strings
 ```
 
 {% endnavtab %}
@@ -316,7 +316,7 @@ spec:
             credentials:
               bearer:
                 token: "bGFza2RqZmxha3NkamZsa2Fqc2Rsa2ZqYWtsc2RqZmtramRmYWxkc2tm"
-        
+
         discovery:
           name: example
           resource: /configuration/example/discovery
@@ -377,7 +377,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     > Host: backend:3001
     > User-Agent: curl/7.67.0
     > Accept: */*
-    > 
+    >
     * Mark bundle as not supporting multiuse
     < HTTP/1.1 200 OK
     < x-powered-by: Express
@@ -395,7 +395,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     < date: Tue, 16 Mar 2021 15:33:18 GMT
     < x-envoy-upstream-service-time: 1521
     < server: envoy
-    < 
+    <
     * Connection #0 to host backend left intact
     Hello World! Marketplace with sales and reviews made with <3 by the OCTO team at Kong Inc.
     ```
@@ -403,7 +403,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 1.  Apply an OPA Policy that requires a valid JWT token:
 
     ```
-    echo " 
+    echo "
     apiVersion: kuma.io/v1alpha1
     kind: OPAPolicy
     mesh: default
@@ -497,7 +497,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     > Host: backend:3001
     > User-Agent: curl/7.67.0
     > Accept: */*
-    > 
+    >
     * Mark bundle as not supporting multiuse
     < HTTP/1.1 200 OK
     < x-powered-by: Express
@@ -515,7 +515,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     < date: Tue, 16 Mar 2021 17:26:00 GMT
     < x-envoy-upstream-service-time: 261
     < server: envoy
-    < 
+    <
     * Connection #0 to host backend left intact
     Hello World! Marketplace with sales and reviews made with <3 by the OCTO team at Kong Inc.
     ```

--- a/app/mesh/1.2.x/features/vault.md
+++ b/app/mesh/1.2.x/features/vault.md
@@ -169,7 +169,7 @@ Vault, you must provide credentials in the configuration of the `mesh` object of
 You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
 
 You can provide these values inline for testing purposes only, as a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/documentation/secrets/).
+same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/).
 
 Here's an example of a configuration with a `vault`-backed CA:
 
@@ -246,7 +246,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.2.x/index.md
+++ b/app/mesh/1.2.x/index.md
@@ -135,5 +135,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.2.x/installation/docker.md
+++ b/app/mesh/1.2.x/installation/docker.md
@@ -52,10 +52,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.2.x/installation/helm.md
+++ b/app/mesh/1.2.x/installation/helm.md
@@ -57,7 +57,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -68,7 +68,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.2.x/installation/openshift.md
+++ b/app/mesh/1.2.x/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 It may take a while for OpenShift to start the

--- a/app/mesh/1.3.x/features/opa.md
+++ b/app/mesh/1.3.x/features/opa.md
@@ -15,7 +15,7 @@ When `OPAPolicy` is applied, the control plane configures:
 
 ## Usage
 
-To apply a policy with OPA: 
+To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
@@ -90,28 +90,28 @@ conf:
   policies: # optional
     - inlineString: | # one of: inlineString, secret
         package envoy.authz
-  
+
         import input.attributes.request.http as http_request
-  
+
         default allow = false
-  
+
         token = {"valid": valid, "payload": payload} {
             [_, encoded] := split(http_request.headers.authorization, " ")
             [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
         }
-  
+
         allow {
             is_token_valid
             action_allowed
         }
-  
+
         is_token_valid {
           token.valid
           now := time.now_ns() / 1000000000
           token.payload.nbf <= now
           now < token.payload.exp
         }
-  
+
         action_allowed {
           http_request.method == "GET"
           token.payload.role == "admin"
@@ -123,7 +123,7 @@ conf:
 
 ### With Secrets
 
-Encoding the policy in a [Secret](https://kuma.io/docs/1.0.7/documentation/secrets/#universal) provides some security for policies that contain sensitive data.
+Encoding the policy in a [Secret](https://kuma.io/docs/latest/security/secrets) provides some security for policies that contain sensitive data.
 
 {% navtabs %}
 {% navtab Kubernetes %}
@@ -209,7 +209,7 @@ The following environment variables are available:
 
 You can customize the agent in either of the following ways:
 
-- Override variables in the data plane proxy config: 
+- Override variables in the data plane proxy config:
 {% navtabs %}
 {% navtab kumactl %}
 
@@ -261,12 +261,12 @@ The `run` command on the data plane proxy accepts the following equivalent param
 
 
 ```
---opa-addr 
---opa-config-path 
---opa-diagnostic-addr 
+--opa-addr
+--opa-config-path
+--opa-diagnostic-addr
 --opa-enabled                    
---opa-ext-authz-addr 
---opa-set strings 
+--opa-ext-authz-addr
+--opa-set strings
 ```
 
 {% endnavtab %}
@@ -378,7 +378,7 @@ spec:
             credentials:
               bearer:
                 token: "bGFza2RqZmxha3NkamZsa2Fqc2Rsa2ZqYWtsc2RqZmtramRmYWxkc2tm"
-        
+
         discovery:
           name: example
           resource: /configuration/example/discovery
@@ -439,7 +439,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     > Host: backend:3001
     > User-Agent: curl/7.67.0
     > Accept: */*
-    > 
+    >
     * Mark bundle as not supporting multiuse
     < HTTP/1.1 200 OK
     < x-powered-by: Express
@@ -457,7 +457,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     < date: Tue, 16 Mar 2021 15:33:18 GMT
     < x-envoy-upstream-service-time: 1521
     < server: envoy
-    < 
+    <
     * Connection #0 to host backend left intact
     Hello World! Marketplace with sales and reviews made with <3 by the OCTO team at Kong Inc.
     ```
@@ -465,7 +465,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 1.  Apply an OPA Policy that requires a valid JWT token:
 
     ```
-    echo " 
+    echo "
     apiVersion: kuma.io/v1alpha1
     kind: OPAPolicy
     mesh: default
@@ -559,7 +559,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     > Host: backend:3001
     > User-Agent: curl/7.67.0
     > Accept: */*
-    > 
+    >
     * Mark bundle as not supporting multiuse
     < HTTP/1.1 200 OK
     < x-powered-by: Express
@@ -577,7 +577,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     < date: Tue, 16 Mar 2021 17:26:00 GMT
     < x-envoy-upstream-service-time: 261
     < server: envoy
-    < 
+    <
     * Connection #0 to host backend left intact
     Hello World! Marketplace with sales and reviews made with <3 by the OCTO team at Kong Inc.
     ```

--- a/app/mesh/1.3.x/features/vault.md
+++ b/app/mesh/1.3.x/features/vault.md
@@ -168,7 +168,7 @@ Vault, you must provide credentials in the configuration of the `mesh` object of
 You can authenticate with the `token` or with client certificates by providing `clientKey` and `clientCert`.
 
 You can provide these values inline for testing purposes only, as a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/documentation/secrets/).
+same host as `kuma-cp`, or contained in a `secret`. See [the Kuma Secrets documentation](https://kuma.io/docs/latest/security/secrets/).
 
 Here's an example of a configuration with a `vault`-backed CA:
 
@@ -247,7 +247,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.3.x/index.md
+++ b/app/mesh/1.3.x/index.md
@@ -135,5 +135,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.3.x/installation/docker.md
+++ b/app/mesh/1.3.x/installation/docker.md
@@ -51,10 +51,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.3.x/installation/helm.md
+++ b/app/mesh/1.3.x/installation/helm.md
@@ -65,7 +65,7 @@ suggest `kong-mesh-system`.
       ```
    
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.3.x/installation/kubernetes.md
+++ b/app/mesh/1.3.x/installation/kubernetes.md
@@ -68,7 +68,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.3.x/installation/openshift.md
+++ b/app/mesh/1.3.x/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 It may take a while for OpenShift to start the

--- a/app/mesh/1.4.x/features/opa.md
+++ b/app/mesh/1.4.x/features/opa.md
@@ -173,7 +173,7 @@ conf:
 
 ### With Secrets
 
-Encoding the policy in a [Secret](https://kuma.io/docs/1.0.7/documentation/secrets/#universal) provides some security for policies that contain sensitive data.
+Encoding the policy in a [Secret](https://kuma.io/docs/latest/security/secrets) provides some security for policies that contain sensitive data.
 
 {% navtabs %}
 {% navtab Kubernetes %}

--- a/app/mesh/1.4.x/features/vault.md
+++ b/app/mesh/1.4.x/features/vault.md
@@ -257,7 +257,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.4.x/index.md
+++ b/app/mesh/1.4.x/index.md
@@ -135,7 +135,7 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.
 
 ## Support policy

--- a/app/mesh/1.4.x/installation/docker.md
+++ b/app/mesh/1.4.x/installation/docker.md
@@ -51,10 +51,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.4.x/installation/helm.md
+++ b/app/mesh/1.4.x/installation/helm.md
@@ -66,7 +66,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.4.x/installation/kubernetes.md
+++ b/app/mesh/1.4.x/installation/kubernetes.md
@@ -68,7 +68,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.4.x/installation/openshift.md
+++ b/app/mesh/1.4.x/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 It may take a while for OpenShift to start the

--- a/app/mesh/1.5.x/features/opa.md
+++ b/app/mesh/1.5.x/features/opa.md
@@ -173,7 +173,7 @@ conf:
 
 ### With Secrets
 
-Encoding the policy in a [Secret](https://kuma.io/docs/1.0.7/documentation/secrets/#universal) provides some security for policies that contain sensitive data.
+Encoding the policy in a [Secret](https://kuma.io/docs/latest/security/secrets) provides some security for policies that contain sensitive data.
 
 {% navtabs %}
 {% navtab Kubernetes %}

--- a/app/mesh/1.5.x/features/vault.md
+++ b/app/mesh/1.5.x/features/vault.md
@@ -274,7 +274,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.5.x/index.md
+++ b/app/mesh/1.5.x/index.md
@@ -135,5 +135,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.5.x/installation/docker.md
+++ b/app/mesh/1.5.x/installation/docker.md
@@ -51,10 +51,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.5.x/installation/helm.md
+++ b/app/mesh/1.5.x/installation/helm.md
@@ -66,7 +66,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.5.x/installation/kubernetes.md
+++ b/app/mesh/1.5.x/installation/kubernetes.md
@@ -68,7 +68,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.5.x/installation/openshift.md
+++ b/app/mesh/1.5.x/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 It may take a while for OpenShift to start the

--- a/app/mesh/1.5.x/installation/windows.md
+++ b/app/mesh/1.5.x/installation/windows.md
@@ -60,7 +60,7 @@ $ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory (Powershell as Administrator):
@@ -69,7 +69,7 @@ We suggest adding the `kumactl` executable to your `PATH` so that it's always av
 New-Item -ItemType SymbolicLink -Path C:\Windows\kumactl.exe -Target .\kumactl.exe
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 {% include /md/mesh/install-universal-verify.md %}

--- a/app/mesh/1.6.x/features/vault.md
+++ b/app/mesh/1.6.x/features/vault.md
@@ -274,7 +274,7 @@ mtls:
               file: /tmp/cert.pem # can be file, secret or inline
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.6.x/index.md
+++ b/app/mesh/1.6.x/index.md
@@ -135,5 +135,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.6.x/installation/docker.md
+++ b/app/mesh/1.6.x/installation/docker.md
@@ -51,10 +51,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.6.x/installation/ecs.md
+++ b/app/mesh/1.6.x/installation/ecs.md
@@ -35,7 +35,7 @@ join the cluster, the controller requests a new data plane token scoped to that 
 
 With Kong Mesh on ECS, each service enumerates
 other services it contacts in the mesh and
-[exposes them in `Dataplane` specification](https://kuma.io/docs/latest/documentation/dps-and-data-model/#dataplane-specification).
+[exposes them in `Dataplane` specification](https://kuma.io/docs/latest/reference/dpp-specification).
 
 ## Deployment
 
@@ -108,7 +108,7 @@ Services are bootstrapped with a `Dataplane` specification.
 
 Transparent proxy is not supported on ECS, so the `Dataplane` resource for a
 service must enumerate all other mesh services this service contacts and include them
-[in the `Dataplane` specification as `outbounds`](https://kuma.io/docs/latest/documentation/dps-and-data-model/#dataplane-specification).
+[in the `Dataplane` specification as `outbounds`](https://kuma.io/docs/latest/reference/dpp-specification).
 
 See the example repository to learn
 [how to handle the `Dataplane` template with Cloudformation](https://github.com/Kong/kong-mesh-ecs/blob/main/deploy/counter-demo/demo-app.yaml#L30-L46).

--- a/app/mesh/1.6.x/installation/helm.md
+++ b/app/mesh/1.6.x/installation/helm.md
@@ -66,7 +66,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
     You can see all possible parameters of the charts by running `helm chart values kong-mesh/kong-mesh`.

--- a/app/mesh/1.6.x/installation/kubernetes.md
+++ b/app/mesh/1.6.x/installation/kubernetes.md
@@ -68,7 +68,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.6.x/installation/openshift.md
+++ b/app/mesh/1.6.x/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 It may take a while for OpenShift to start the

--- a/app/mesh/1.6.x/installation/windows.md
+++ b/app/mesh/1.6.x/installation/windows.md
@@ -60,7 +60,7 @@ $ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory (Powershell as Administrator):
@@ -69,7 +69,7 @@ We suggest adding the `kumactl` executable to your `PATH` so that it's always av
 New-Item -ItemType SymbolicLink -Path C:\Windows\kumactl.exe -Target .\kumactl.exe
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/),
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/),
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 {% include /md/mesh/install-universal-verify.md %}

--- a/app/mesh/1.7.x/features/acmpca.md
+++ b/app/mesh/1.7.x/features/acmpca.md
@@ -130,7 +130,7 @@ mtls:
             file: /tmp/accesss_key.txt # one of file, secret or inline.
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.7.x/features/vault.md
+++ b/app/mesh/1.7.x/features/vault.md
@@ -289,7 +289,7 @@ mtls:
               iamServerIdHeader: example.com # Optional server ID header value
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/documentation/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](https://kuma.io/docs/latest/reference/http-api).
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.7.x/index.md
+++ b/app/mesh/1.7.x/index.md
@@ -241,5 +241,5 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-[Learn more](https://kuma.io/docs/latest/documentation/deployments/) about the
+[Learn more](https://kuma.io/docs/latest/introduction/deployments/) about the
 standalone and multi-zone deployment modes in the Kuma documentation.

--- a/app/mesh/1.7.x/installation/docker.md
+++ b/app/mesh/1.7.x/installation/docker.md
@@ -54,10 +54,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/), 
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation

--- a/app/mesh/1.7.x/installation/ecs.md
+++ b/app/mesh/1.7.x/installation/ecs.md
@@ -35,7 +35,7 @@ join the cluster, the controller requests a new data plane token scoped to that 
 
 With Kong Mesh on ECS, each service enumerates
 other services it contacts in the mesh and
-[exposes them in `Dataplane` specification](https://kuma.io/docs/latest/documentation/dps-and-data-model/#dataplane-specification).
+[exposes them in `Dataplane` specification](https://kuma.io/docs/latest/reference/dpp-specification).
 
 ## Deployment
 
@@ -108,7 +108,7 @@ Services are bootstrapped with a `Dataplane` specification.
 
 Transparent proxy is not supported on ECS, so the `Dataplane` resource for a
 service must enumerate all other mesh services this service contacts and include them
-[in the `Dataplane` specification as `outbounds`](https://kuma.io/docs/latest/documentation/dps-and-data-model/#dataplane-specification).
+[in the `Dataplane` specification as `outbounds`](https://kuma.io/docs/latest/reference/dpp-specification).
 
 See the example repository to learn
 [how to handle the `Dataplane` template with Cloudformation](https://github.com/Kong/kong-mesh-ecs/blob/main/deploy/counter-demo/demo-app.yaml#L30-L46).

--- a/app/mesh/1.7.x/installation/helm.md
+++ b/app/mesh/1.7.x/installation/helm.md
@@ -66,7 +66,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+    deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
     like _multi-zone_.
 
     You can see all possible parameters of the charts by running `helm chart values kong-mesh/kong-mesh`.

--- a/app/mesh/1.7.x/installation/kubernetes.md
+++ b/app/mesh/1.7.x/installation/kubernetes.md
@@ -65,13 +65,13 @@ $ kumactl install control-plane --license-path=/path/to/license.json | kubectl a
 ```
 
 {:.note}
-> **Note**: {{site.mesh_product_name}} also has UBI images. To use these images instead checkout the [UBI documentation](../features/ubi-images.md).
+> **Note**: {{site.mesh_product_name}} also has UBI images. To use these images instead checkout the [UBI documentation](../../features/ubi-images).
 
 Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always

--- a/app/mesh/1.7.x/installation/openshift.md
+++ b/app/mesh/1.7.x/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 It may take a while for OpenShift to start the

--- a/app/mesh/1.7.x/installation/windows.md
+++ b/app/mesh/1.7.x/installation/windows.md
@@ -60,7 +60,7 @@ $ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/documentation/deployments/)
+deployment, but there are more advanced [deployment modes](https://kuma.io/docs/latest/introduction/deployments/)
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory (Powershell as Administrator):
@@ -69,7 +69,7 @@ We suggest adding the `kumactl` executable to your `PATH` so that it's always av
 New-Item -ItemType SymbolicLink -Path C:\Windows\kumactl.exe -Target .\kumactl.exe
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/documentation/backends/),
+This runs {{site.mesh_product_name}} with a [memory backend](https://kuma.io/docs/latest/explore/backends/),
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 {% include /md/mesh/install-universal-verify.md %}


### PR DESCRIPTION
### Summary
Updating all old `/documentation/` links to new navigation for the Kuma site.

Ran a search for all links to the kuma.io site and updated everything that didn't match the new structure.

### Reason
Kuma site navigation was reworked in the previous version but links were never updated, and they don't have redirects on their site - so we're getting tons of 404s: https://github.com/Kong/docs.konghq.com/runs/5998975783?check_suite_focus=true

### Testing
The link checker should pass.

Edit: it passed!