### PR TITLE
Platform setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ install-prerequisites:
 
 # Installs npm packages and gems.
 install:
-  npm ci
+	npm ci
 	bundle install
 
 # Using local dependencies, starts a doc site instance on http://localhost:3000.

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,17 @@
-# Installs gulp.
 install-prerequisites:
-	npm install -g gulp
+	npm install -g gulp netlify-cli
 
 # Installs npm packages and gems.
 install:
-	-mkdir -p node_modules
-	chmod 777 node_modules
+  npm ci
 	bundle install
-	yarn --ignore-engines
-	touch install
 
 # Using local dependencies, starts a doc site instance on http://localhost:3000.
-run: install
-	-chmod -R 777 dist
-	gulp
+run:
+	./node_modules/.bin/gulp
 
-build: install
-	-chmod -R 777 dist
+build:
 	./node_modules/.bin/gulp build
-
-# Brings up a docker container and starts a doc site instance on
-# http://localhost:3000.
-develop:
-	docker-compose up
 
 # Cleans up all temp files in the build.
 # Run `make clean` locally whenever you're updating dependencies, or to help
@@ -30,18 +19,9 @@ develop:
 clean:
 	-rm -rf dist
 	-rm -rf app/.jekyll-cache
-	-rm yarn.lock
-	-rm -rf node_modules
-	-rm install
 
-# docker-clean is here for legacy purposes, in case we ever decide to fix our
-# docker-compose. These commands were previously part of `clean`.
-docker-clean:
-	-docker-compose stop
-	-docker-compose rm -f
-
-# Runs tests using the npm standard and echint linters.
-test: install
+# Runs tests
+test:
 	npm test
 
 smoke:
@@ -51,12 +31,3 @@ smoke:
 	@npm run test:smoke || true
 	@kill -TERM $$(cat netlify.PID)
 	@rm netlify.PID
-
-# Starts a docker container in the background.
-background-docker-up:
-	docker-compose up -d
-	-while [ `curl -s -o /dev/null -w ''%{http_code}'' localhost:3000` != 200 ]; do echo "waiting"; docker-compose logs --tail=10 jekyll; sleep 45; done
-
-# Starts a docker container in the background, then runs tests.
-docker-test: background-docker-up
-	docker-compose exec -T jekyll npm test

--- a/README.md
+++ b/README.md
@@ -26,63 +26,19 @@ For [Gateway Enterprise configuration reference](https://docs.konghq.com/gateway
 
 * We are currently accepting plugin submissions to our plugin hub from trusted technical partners, on a limited basis. For more information, see the [Kong Partners page](https://konghq.com/partners/).
 
-## Run local project
-***
+## Run Locally
 
-For anything other than minor changes, clone the repository onto your local machine and build locally.
-
-## Run locally with gulp
-***
-
-### Prerequisites
-
-* [gulp](https://gulpjs.com/docs/en/getting-started/quick-start/) installed globally
-
-Install dependencies:
+For anything other than minor changes, [clone the repository onto your local machine and build locally](docs/platform-install.md). Once you've installed all of the tools required, you can use our `Makefile` to build the docs:
 
 ```bash
+# Install dependencies
 make install
-```
 
-Run the project:
-
-```bash
+# Build the site and watch for changes
 make run
 ```
 
-If you have issues, run:
-
-```bash
-make clean
-```
-
-## Run locally with npm
-***
-
-### Prerequisites
-
-* [node and npm](https://www.npmjs.com/get-npm)
-* [yarn](https://classic.yarnpkg.com)
-* [gulp](https://gulpjs.com/docs/en/getting-started/quick-start/)
-* [Bundler](https://bundler.io/)
-* [Ruby](https://www.ruby-lang.org) (>= 3.1.0)
-* [Python](https://www.python.org) (>= 2.7.X, < 3)
-
-Install dependencies:
-
-```bash
-gem install bundler
-npm install
-```
-
-Run the project:
-
-```bash
-npm start
-```
-
 ## Plugin contributors
-***
 
 If you have contributed a plugin, you can add a Kong badge to your plugin README.
 
@@ -97,7 +53,6 @@ Here's how the badge looks: [![](https://img.shields.io/badge/Kong-test-blue.svg
 See [Issue #908](https://github.com/Kong/docs.konghq.com/issues/908) for more information. Note that we're not currently hosting assets for badges.
 
 ## Generate the PDK, Admin API, CLI, and Configuration documentation
-***
 
 > This section is for Kong source code maintainers. You don't need to do anything here if you're contributing to this repo!
 

--- a/docs/platform-install.md
+++ b/docs/platform-install.md
@@ -1,0 +1,42 @@
+# Running docs.konghq.com locally
+
+We currently only have installation instructions for MacOS. If you're using Windows or Linux, ensure that you have Ruby (see .ruby-version in the repo root for the current version)+ Node.js installed before running the commands in the [README](https://github.com/Kong/docs.konghq.com#run-locally)
+
+## MacOS Dependency Installation
+
+Install Homebrew + any dependencies that are required:
+
+```bash
+xcode-select --install
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install rbenv ruby-build node
+```
+
+Configure `git` and ensure that you're using `zsh`:
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "user@example.com"
+chsh -s /bin/zsh
+```
+
+Configure `rbenv`:
+
+```bash
+rbenv init
+echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Clone the repository and install dependencies:
+
+```bash
+git clone git@github.com:Kong/docs.konghq.com
+cd docs.konghq.com
+rbenv install $(cat .ruby-version)
+rbenv global $(cat .ruby-version)
+gem install bundler
+```
+
+At this point you can go [back to the README](https://github.com/Kong/docs.konghq.com#run-locally) and continue reading the `Run Locally` instructions.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "repository": "Kong/docs.konghq.com",
   "license": "proprietary",
   "scripts": {
-    "deploy": "gulp deploy",
-    "preinstall": "bundle install",
-    "prestart": "npm test",
     "start": "gulp",
     "dev": "gulp dev",
     "pdk-docs": "KONG_PATH=${KONG_PATH:=} KONG_VERSION=${KONG_VERSION:=} gulp pdk-docs",


### PR DESCRIPTION
### Summary
Clean up the `Makefile` and add detailed platform installation instructions for MacOS under the `docs` folder.

### Reason
To make it easier for people to run the docs site locally and contribute.

### Testing
I've tested these instructions in a fresh MacOS virtual machine and could build the site as expected
