### PR TITLE
PDK fix: kong.client typo

### DIFF
--- a/app/enterprise/0.35-x/pdk/kong.client.md
+++ b/app/enterprise/0.35-x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/0.36-x/pdk/kong.client.md
+++ b/app/enterprise/0.36-x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/1.3-x/pdk/kong.client.md
+++ b/app/enterprise/1.3-x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/1.5.x/pdk/kong.client.md
+++ b/app/enterprise/1.5.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/2.1.x/pdk/kong.client.md
+++ b/app/enterprise/2.1.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/2.2.x/pdk/kong.client.md
+++ b/app/enterprise/2.2.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/2.3.x/pdk/kong.client.md
+++ b/app/enterprise/2.3.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/2.4.x/pdk/kong.client.md
+++ b/app/enterprise/2.4.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/enterprise/2.5.x/pdk/kong.client.md
+++ b/app/enterprise/2.5.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/0.14.x/pdk/kong.client.md
+++ b/app/gateway-oss/0.14.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/1.0.x/pdk/kong.client.md
+++ b/app/gateway-oss/1.0.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/1.1.x/pdk/kong.client.md
+++ b/app/gateway-oss/1.1.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/1.2.x/pdk/kong.client.md
+++ b/app/gateway-oss/1.2.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/1.3.x/pdk/kong.client.md
+++ b/app/gateway-oss/1.3.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/1.4.x/pdk/kong.client.md
+++ b/app/gateway-oss/1.4.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/1.5.x/pdk/kong.client.md
+++ b/app/gateway-oss/1.5.x/pdk/kong.client.md
@@ -76,7 +76,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/2.0.x/pdk/kong.client.md
+++ b/app/gateway-oss/2.0.x/pdk/kong.client.md
@@ -82,7 +82,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/2.1.x/pdk/kong.client.md
+++ b/app/gateway-oss/2.1.x/pdk/kong.client.md
@@ -82,7 +82,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/2.2.x/pdk/kong.client.md
+++ b/app/gateway-oss/2.2.x/pdk/kong.client.md
@@ -82,7 +82,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway-oss/2.3.x/pdk/kong.client.md
+++ b/app/gateway-oss/2.3.x/pdk/kong.client.md
@@ -82,7 +82,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration
@@ -298,4 +298,3 @@ kong.client.get_protocol() -- "http"
 ```
 
 [Back to top](#kongclient)
-

--- a/app/gateway-oss/2.4.x/pdk/kong.client.md
+++ b/app/gateway-oss/2.4.x/pdk/kong.client.md
@@ -82,7 +82,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration

--- a/app/gateway/2.6.x/pdk/kong.client.md
+++ b/app/gateway/2.6.x/pdk/kong.client.md
@@ -82,7 +82,7 @@ Returns the remote address of the client making the request.  Unlike
 -- a load balancer with IP 10.0.0.1 to Kong answering the request for
 -- https://username:password@example.com:1234/v1/movies
 
-kong.request.get_forwarded_ip() -- "127.0.0.1"
+kong.client.get_forwarded_ip() -- "127.0.0.1"
 
 -- Note: assuming that 10.0.0.1 is one of the trusted IPs, and that
 -- the load balancer adds the right headers matching with the configuration


### PR DESCRIPTION
### Summary
Replace `kong.request.get_forwarded_ip()` with `kong.client.get_forwarded_ip()`. 

### Reason
Continuation of https://github.com/Kong/docs.konghq.com/pull/3829. Separate PR to avoid weird fork editing issues.
This was fixed in the docs in 2.7.x but never backported, and someone recently filed a PR to fix an older version. 

### Testing
Netlify preview (sample pages):
https://deploy-preview-3846--kongdocs.netlify.app/gateway/2.6.x/pdk/kong.client/#kongclientget_forwarded_ip
https://deploy-preview-3846--kongdocs.netlify.app/enterprise/2.5.x/pdk/kong.client/#kongclientget_forwarded_ip
https://deploy-preview-3846--kongdocs.netlify.app/gateway-oss/2.5.x/pdk/kong.client/#kongclientget_forwarded_ip