### PR TITLE
Add `version` to single sourcing

### DIFF
--- a/app/_plugins/generators/single_source_generator.rb
+++ b/app/_plugins/generators/single_source_generator.rb
@@ -3,18 +3,30 @@
 module SingleSource
   class Generator < Jekyll::Generator
     priority :highest
-    def generate(site)
+    def generate(site) # rubocop:disable Metrics/AbcSize
+      # Load versions data file
+      @kong_versions = SafeYAML.load(File.read('app/_data/kong_versions.yml'))
+
+      # Generate pages
       Dir.glob('app/_data/docs_nav_*.yml').each do |f|
         data = SafeYAML.load(File.read(f))
         next unless data.is_a?(Hash) && data['generate']
 
         # Assume that the whole file should be treated as generated
         assume_generated = data['assume_generated'].nil? ? true : data['assume_generated']
-        create_pages(data['items'], site, data['product'], data['version'], assume_generated)
+        version = version_for_release(data['product'], data['release'])
+        create_pages(data['items'], site, data['product'], data['release'], version, assume_generated)
       end
     end
 
-    def create_pages(data, site, product, version, assume_generated) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
+    def version_for_release(product, release)
+      version = @kong_versions.detect do |v|
+        v['edition'] == product && v['release'] == release
+      end
+      version['version']
+    end
+
+    def create_pages(data, site, product, release, version, assume_generated) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists
       data.each do |v, _k|
         # Enable generation of specific files as required
         next unless v['generated'] || assume_generated
@@ -30,17 +42,17 @@ module SingleSource
           # Is it an in-page link? If so, skip it
           next if v['url']&.include?('/#')
 
-          site.pages << SingleSourcePage.new(site, v['src'], v['url'], product, version)
+          site.pages << SingleSourcePage.new(site, v['src'], v['url'], product, release, version)
         end
 
         # If there are any children, generate those too
-        create_pages(v['items'], site, product, version, assume_generated) if v['items']
+        create_pages(v['items'], site, product, release, version, assume_generated) if v['items']
       end
     end
   end
 
   class SingleSourcePage < Jekyll::Page
-    def initialize(site, src, dest, product, version) # rubocop:disable Lint/MissingSuper, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
+    def initialize(site, src, dest, product, release, version) # rubocop:disable Lint/MissingSuper, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize, Metrics/ParameterLists
       # Configure variables that Jekyll depends on
       @site = site
 
@@ -51,7 +63,7 @@ module SingleSource
       src ||= dest
 
       # Remove trailing slashes if they exist
-      src.chomp!('/')
+      src = src.chomp('/')
 
       # Set self.ext and self.basename by extracting information from the page filename
       process('index.md')
@@ -61,7 +73,7 @@ module SingleSource
       output_path = '' if src == 'index'
 
       # This is the directory that we're going to write the output file to
-      @dir = "#{product}/#{version}/#{output_path}"
+      @dir = "#{product}/#{release}/#{output_path}"
 
       # If the src file doesn't start with a /, assume it's within the product folder
       # Otherwise, it's an absolute src path and we should start from /src
@@ -80,6 +92,10 @@ module SingleSource
 
       # Set the "Edit on GitHub" link url
       @data['edit_link'] = file
+
+      # Set the current release and concrete version
+      @data['release'] = release
+      @data['version'] = version
 
       # Set the layout if it's not already provided
       @data['layout'] = 'docs-v2' unless data['layout']

--- a/app/_plugins/generators/single_source_generator.rb
+++ b/app/_plugins/generators/single_source_generator.rb
@@ -29,7 +29,7 @@ module SingleSource
     def create_pages(data, site, product, release, version, assume_generated) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/ParameterLists
       data.each do |v, _k|
         # Enable generation of specific files as required
-        next unless v['generated'] || assume_generated
+        next unless v['generate'] || assume_generated
 
         # Handle when it's the root page.
         # We always want to generate this, even if

--- a/docs/single-sourced-versions.md
+++ b/docs/single-sourced-versions.md
@@ -29,21 +29,21 @@ I've added comments to the file to show what will be read, and what URL will be 
 
 ```yaml
 product: deck
-version: 1.11.x
+release: 1.11.x
 generate: true
 items:
   - title: Introduction
-    # Reads `src/deck/index.md` and writes `/deck/<version>/index.html`
+    # Reads `src/deck/index.md` and writes `/deck/<release>/index.html`
     # This is a special case as absolute_url is true, but `/deck/` is equal to `/<product>/`
     # and we always need to generate an index page
     url: /deck/
     absolute_url: true
     items:
       - text: Terminology
-        # Reads `src/deck/terminology.md` and writes `/deck/<version>/terminology/index.html`
+        # Reads `src/deck/terminology.md` and writes `/deck/<release>/terminology/index.html`
         url: /terminology
       - text: Architecture
-        # Reads `src/deck/design-architecture.md` and writes `/deck/<version>/design-architecture/index.html`
+        # Reads `src/deck/design-architecture.md` and writes `/deck/<release>/design-architecture/index.html`
         url: /design-architecture
 
   - title: Changelog
@@ -55,19 +55,19 @@ items:
   - title: Installation
     icon: /assets/images/icons/documentation/icn-deployment-color.svg
     url: /installation
-    # Reads `src/deck/installation-guide.md` and writes `/deck/<version>/installation/index.html`
+    # Reads `src/deck/installation-guide.md` and writes `/deck/<release>/installation/index.html`
     src: installation-guide
 ```
 
 ### Concept 2: Single source specific files
 
-You may not want to update an entire version at once. In this instance, single sourcing specific files might be useful. You can set `assume_generated: false` at the top level, then use `generated: true` on individual items to enable this.
+You may not want to update an entire release at once. In this instance, single sourcing specific files might be useful. You can set `assume_generated: false` at the top level, then use `generated: true` on individual items to enable this.
 
 ```yaml
 product: deck
-version: 1.11.x
+release: 1.11.x
 generate: true
-# This line will make Jekyll read `app/<product>/<version>/<file>.md` by default
+# This line will make Jekyll read `app/<product>/<release>/<file>.md` by default
 # unless `generate: true` is set on a specific item
 assume_generated: false
 items:
@@ -80,25 +80,25 @@ items:
         # Reads `app/deck/1.11.x/terminology.md` like normal
         url: /terminology
       - text: Architecture
-        # Reads `src/deck/design-architecture.md` and writes `/deck/<version>/design-architecture/index.html`
+        # Reads `src/deck/design-architecture.md` and writes `/deck/<release>/design-architecture/index.html`
         url: /design-architecture
         generate: true
 
   - title: Installation
     icon: /assets/images/icons/documentation/icn-deployment-color.svg
     url: /installation
-    # Reads `src/deck/installation-v3.md` and writes `/deck/<version>/installation/index.html`
+    # Reads `src/deck/installation-v3.md` and writes `/deck/<release>/installation/index.html`
     src: installation-v3
     generate: true
 ```
 
-### Concept 3: Multiple versions + Single Sourcing
+### Concept 3: Multiple releases + Single Sourcing
 
-We may rewrite entire pages over time, and it doesn't make sense to keep everything in a single file. In this instance, we should append the version to the filename e.g. `instructions-v3.md` and use the `src` parameter to point at a specific file:
+We may rewrite entire pages over time, and it doesn't make sense to keep everything in a single file. In this instance, we should append the major version to the filename e.g. `instructions-v3.md` and use the `src` parameter to point at a specific file:
 
 ```yaml
 product: deck
-version: 1.11.x
+release: 1.11.x
 generate: true
 items:
   - title: Introduction
@@ -106,15 +106,15 @@ items:
     absolute_url: true
     items:
       - text: Terminology
-        # Reads `src/deck/terminology-v3.md` and writes `/deck/<version>/terminology/index.html`
-        # This is how you can have multiple versions of a single source file when completely rewriting content
+        # Reads `src/deck/terminology-v3.md` and writes `/deck/<release>/terminology/index.html`
+        # This is how you can have multiple release of a single source file when completely rewriting content
         url: /terminology
         src: terminology-v3
 ```
 
 ## Conditional Rendering
 
-As we add new functionality, we'll want content to be displayed for specific versions of a product. We can use the `if_version` block for this:
+As we add new functionality, we'll want content to be displayed for specific releases of a product. We can use the `if_version` block for this:
 
 ```
 {% if_version eq:1.11.x %}

--- a/docs/single-sourced-versions.md
+++ b/docs/single-sourced-versions.md
@@ -10,7 +10,7 @@ We now use a Jekyll plugin (`single_source_generator.rb`) to dynamically generat
 - If the file does not contain `generate: true` at the top level, skip it
 - If it does, loop through all items in the navigation
   - If `assume_generated` is not set at the top level, or it is set to `true` then all items will be generated
-  - If `assume_generated` is set to `false` then each item in the navigation that should be generated will need `generated: true` to be set
+  - If `assume_generated` is set to `false` then each item in the navigation that should be generated will need `generate: true` to be set
 - Each file that should be generated goes through the following process:
   - Build up the base directory: `src/<product>` by default, but if the `src` starts with a `/` it will be treated as a full path within `src`. e.g. `/shared/license` would be `/src/shared/license` whilst `shared/license` would be `/src/<product>/shared/license`
   - If `src` is set on the item, we'll use that as the source file
@@ -61,7 +61,7 @@ items:
 
 ### Concept 2: Single source specific files
 
-You may not want to update an entire release at once. In this instance, single sourcing specific files might be useful. You can set `assume_generated: false` at the top level, then use `generated: true` on individual items to enable this.
+You may not want to update an entire release at once. In this instance, single sourcing specific files might be useful. You can set `assume_generated: false` at the top level, then use `generate: true` on individual items to enable this.
 
 ```yaml
 product: deck


### PR DESCRIPTION
### Summary
Make `page.version` and `page.release` available in single sourced content

### Reason
We need the concrete version number (e.g. `1.2.0`) rather than the release (`1.2.x`) in some places. This PR makes it available

### Testing
I've tested on #3845 and it worked as expected
