### PR TITLE
Re-add 'enable app reg' doc

### DIFF
--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/enable-application-registration.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/enable-application-registration.md
@@ -1,137 +1,91 @@
 ---
-title: Enable Key Authentication for Application Registration
+title: Enable Application Registration
 badge: enterprise
 ---
 
-You can use the Key Authentication plugin for authentication in conjunction with
-the Application Registration plugin.
-
-The key auth plugin uses the same Client ID as generated for the Kong OAuth2 plugin.
-You can use the same Client ID credential for a Service that has the OAuth2 plugin enabled.
+Application Registration allows registered developers on the Kong Dev Portal to
+authenticate with supported Authentication plugins against a Service on Kong. Either {{site.base_gateway}} or
+external identity provider admins can selectively admit access to Services using Kong Manager.
 
 ## Prerequisites
 
-* Create a Service.
-* Enable the [Application Registration plugin](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-application-registration) on a Service.
-* Activate your application for a Service if you have not already done so. The
-Service Contract must be approved by an Admin if auto approve is not enabled.
-* [Generate a credential](#gen-client-id-cred) if you don't want to use the default credential initially created for you.
+* Dev Portal is enabled on the same Workspace as the Service.
+* The Service is created and enabled with HTTPS.
+* Authentication is enabled on the Dev Portal.
+* Logged in as an admin with read and write roles on applications, services, and
+  developers.
+* The `portal_app_auth` configuration option is configured for your OAuth provider
+  and strategy (`kong-oauth2` default or `external-oauth2`). See
+[Configure the Authorization Provider Strategy](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/auth-provider-strategy) for the Portal Application Registration plugin.
+* Authorization provider configured if using a supported third-party
+  identity provider with the OIDC plugin:
+  * For example instructions using Okta as an identity provider, refer to the
+    [Okta example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/okta-config).
+  * For example instructions using Azure AD as an identity provider, refer to the
+    [Azure example](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/azure-oidc-config).
 
-## Enable Key Authentication in Kong Manager
+## Enable Application Registration on a Service using Kong Manager {#enable-app-reg-plugin}
 
-In Kong Manager, access the Service for which you want to enable key authentication for
-use with application registration:
+To use Application Registration on a Service, the Portal Application Registration
+Plugin must be enabled on a Service.
+
+In Kong Manager, access the Service for which you want to enable Application Registration:
 
 1. From your Workspace, in the left navigation pane, go to **API Gateway > Services**.
 2. On the Services page, select the Service and click **View**.
 3. In the Plugins pane in the Services page, click **Add a Plugin**.
 4. On the Add New Plugin page in the Authentication section, find the
-   **Key Authentication** Plugin and click **Enable**.
+   **Portal Application Registration** Plugin and click **Enable**.
 
-   ![Key Authentication plugin panel](/assets/images/docs/dev-portal/key-auth-plugin-panel.png)
+   ![Portal Application Registration](/assets/images/docs/dev-portal/app-reg-plugin-panel.png)
 
-5. Complete the fields as appropriate for your application. In this example, the Service is already
-   prepopulated. Refer to the parameters described in the next section,
-   [Key Authentication Configuration Parameters](#key-auth-params),
+5. Enter the configuration settings. Use the parameters in the next section,
+   [Application Registration Configuration Parameters](#application-registration-configuration-parameters),
    to complete the fields.
+
+   ![Create application-registration plugin](/assets/images/docs/dev-portal/create-app-reg-plugin-form.png)
+
+   **Important:** Exposing
+   the Issuer URL is essential for the
+   [Authorization Code Flow](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow)
+   workflow configured for third-party identity providers.
+
+   ![Issuer URL](/assets/images/docs/dev-portal/dev-portal-issuer-url.png)
 
 6. Click **Create**.
 
-### Key Authentication Configuration Parameters {#key-auth-params}
+### Application Registration Configuration Parameters {#app-reg-params}
 
 | Form Parameter | Description                                                                       |
 |:---------------|:----------------------------------------------------------------------------------|
 | `Service` | The Service that this plugin configuration will target. Required. |
-| `Anonymous` | An optional string (Consumer UUID) value to use as an anonymous Consumer if authentication fails. If empty (default), the request fails with an `4xx`. Note that this value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`. |
-| `Hide Credentials` | Whether to show or hide the credential from the Upstream service. If `true`, the plugin strips the credential from the request (i.e., the header, query string, or request body containing the key) before proxying it. Default: `false`. |
-| `Key in Body` | If enabled, the plugin reads the request body (if said request has one and its MIME type is supported) and tries to find the key in it. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`. Default: `false`. |
-| `Key in Header` | If enabled (default), the plugin reads the request header and tries to find the key in it. Default: true. |
-| `Key in Query` | If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it. Default: true. |
-| `Key Names` | Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen. Required. Default: `apikey`. |
-| `Run on Preflight` | Indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. Default: `true`. |
+| `Tags` | A set of strings for grouping and filtering, separated by commas. Optional. |
+| `Auto Approve` | If enabled, all new Service contract requests are automatically approved. Otherwise, Dev Portal admins must manually approve requests. Default: `false`. |
+| `Description` | Description displayed in the information about a Service in the Dev Portal. Optional. |
+| `Display Name` | Unique name displayed in the information about a Service in the Dev Portal. Required. |
+| `Show Issuer` | Displays the Issuer URL in the Service Details page. Default: `false`. **Important:** Exposing the **Issuer URL** is essential for the [Authorization Code Flow](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/3rd-party-oauth/#ac-flow) workflow configured for third-party identity providers. |
 
-## Generate a Credential {#gen-client-id-cred}
+## Next steps
 
-Generate a Client ID credential to use as an API key. You can generate multiple
-credentials.
+Kong OAuth2 strategy:
 
-1. In the **Dev Portal > My Apps** page, click **View** for an application.
+* If using the Kong-managed authorization strategy
+(`kong-oauth2`) with the OAuth2 plugin, configure the Kong [OAuth2](/hub/kong-inc/oauth2/)
+plugin as appropriate for your authorization requirements. You can use either the
+Kong Manager GUI or cURL commands as documented on the [Plugin Hub](/hub/).
+The OAuth2 plugin cannot be used in hybrid mode.
+* If using the Kong-managed authorization strategy
+(`kong-oauth2`) with key authentication, configure the Kong
+[Key Auth](/hub/kong-inc/key-auth/) plugin as appropriate for your authorization
+requirements. You can use either the
+[Kong Manager GUI](/gateway/{{page.kong_version}}/developer-portal/administration/application-registration/enable-key-auth-plugin)
+or cURL commands as documented on the Plugin Hub. The Key Auth plugin
+cannot be used in hybrid mode.
 
-2. In the **Authentication** pane, click **Generate Credential**.
+External OAuth2 strategy:
 
-   ![Application Authentication Pane](/assets/images/docs/dev-portal/generate-cred-dev-portal.png)
-
-   Now you can make requests using the Client ID as an API Key.
-
-## Make Requests with an API Key (Client Identifier)
-
-The Client ID of your credentials can be used as an API key to make authenticated requests to a Service.
-
-**Tip:** You can also access key request instructions directly within the user interface from the
-information icon in the Services details area of your application. Click the **i** icon to open the Service Details page.
-
-![Services Pane](/assets/images/docs/dev-portal/portal-info-modal-key-auth.png)
-
-Scroll to view all of the available examples.
-
-![Service Details Page Embedded Key Usage Instructions](/assets/images/docs/dev-portal/service-details-key-auth-usage.png)
-
-### About API Key Locations in a Request
-
-{% include /md/plugins-hub/api-key-locations.md %}
-
-### Make a request with the key as a query string parameter
-
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -X POST {proxy}/{route}?apikey={CLIENT_ID}
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http {proxy}/{route}?apikey={CLIENT_ID}
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-Response (will be the same for all valid requests regardless of key location):
-
-```bash
-HTTP/1.1 200 OK
-...
-```
-
-### Make a request with the key in a header
-
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -X POST {proxy}/{route} \
---header "apikey: {CLIENT_ID}"
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http {proxy}/{route} apikey:{CLIENT_ID}
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-### Make a request with the key in the body
-
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -X POST {proxy}/{route} \
---data "apikey:={CLIENT_ID}"
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http {proxy}/{route} apikey={CLIENT_ID}
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-**Note:** The `key_in_body` parameter must be set to `true`.
+* If using the third-party authorization strategy
+(`external-oauth2`), configure the OIDC plugin. You can use the Kong Manager GUI
+or cURL commands as documented on the [Plugin Hub](/hub/kong-inc/openid-connect).
+When your deployment is hybrid mode, the OIDC plugin must be configured to handle
+authentication for the Portal Application Registration plugin.


### PR DESCRIPTION
### Summary
Re-adding "enable application registration" doc content to fix copy-paste error from 2.8.

### Reason
Issue filed here: https://github.com/Kong/docs.konghq.com/issues/3847

Issue caused by human error (accidentally overwrote the file when copying changes from 2.7 to 2.8); this will be avoidable in the future as we switch to single-sourced docs.

### Testing
Check that 2.8.x now has the same content as 2.7.x.

https://deploy-preview-3854--kongdocs.netlify.app/gateway/2.8.x/developer-portal/administration/application-registration/enable-application-registration/
https://deploy-preview-3854--kongdocs.netlify.app/gateway/2.7.x/developer-portal/administration/application-registration/enable-application-registration/