### PR TITLE
decK v1.12: Generate cli docs

### DIFF
--- a/src/deck/reference/deck.md
+++ b/src/deck/reference/deck.md
@@ -9,49 +9,80 @@ It can be used to export, import, or sync entities to Kong.
 
 ## Flags
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
--h, --help                           help for deck
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`-h`, `--help`
+:  help for deck (Default: `false`)
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
+
 * [deck completion](/deck/{{page.kong_version}}/reference/deck_completion)	 - Generate completion script
 * [deck convert](/deck/{{page.kong_version}}/reference/deck_convert)	 - Convert files from one format into another format
 * [deck diff](/deck/{{page.kong_version}}/reference/deck_diff)	 - Diff the current entities in Kong with the one on disks
@@ -62,3 +93,4 @@ It can be used to export, import, or sync entities to Kong.
 * [deck sync](/deck/{{page.kong_version}}/reference/deck_sync)	 - Sync performs operations to get Kong's configuration to match the state file
 * [deck validate](/deck/{{page.kong_version}}/reference/deck_validate)	 - Validate the state file
 * [deck version](/deck/{{page.kong_version}}/reference/deck_version)	 - Print the decK version
+

--- a/src/deck/reference/deck.md
+++ b/src/deck/reference/deck.md
@@ -1,5 +1,6 @@
 ---
 title: deck
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The deck tool helps you manage Kong clusters with a declarative
@@ -40,6 +41,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_completion.md
+++ b/src/deck/reference/deck_completion.md
@@ -2,120 +2,131 @@
 title: deck completion
 ---
 
-Generate completion script.
+To load completions:
 
-```sh
-deck completion [bash|zsh|fish|powershell]
+Bash:
 ```
+  $ source <(deck completion bash)
 
-## Usage
-To load completions, follow the instructions for your shell below.
-
-### Bash
-
-```sh
-source <(deck completion bash)
+  # To load completions for each session, execute once:
+  # Linux:
+  $ deck completion bash > /etc/bash_completion.d/deck
+  # macOS:
+  $ deck completion bash > /usr/local/etc/bash_completion.d/deck
+  ```
+Zsh:
 ```
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
 
-To load completions for each session, execute once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
-**Linux:**
-```sh
-deck completion bash > /etc/bash_completion.d/deck
+  # To load completions for each session, execute once:
+  $ deck completion zsh > "${fpath[1]}/_yourprogram"
+
+  # You will need to start a new shell for this setup to take effect.
+  ```
+fish:
 ```
+  $ deck completion fish | source
 
-**macOS:**
-```sh
-deck completion bash > /usr/local/etc/bash_completion.d/deck
+  # To load completions for each session, execute once:
+  $ deck completion fish > ~/.config/fish/completions/deck.fish
+  ```
+PowerShell:
 ```
+  PS> deck completion powershell | Out-String | Invoke-Expression
 
-### Zsh
+  # To load completions for every new session, run:
+  PS> deck completion powershell > deck.ps1
+  # and source this file from your PowerShell profile.
+  ```
 
-If shell completion is not already enabled in your environment,
-you will need to enable it. You can execute the following once:
-```sh
-echo "autoload -U compinit; compinit" >> ~/.zshrc
+## Syntax
+
 ```
-
-To load completions for each session, execute once:
-```sh
-deck completion zsh > "${fpath[1]}/_yourprogram"
+deck completion [command-specific flags] [global flags]
 ```
-
-You will need to start a new shell for this setup to take effect.
-
-### fish
-
-```sh
-deck completion fish | source
-```
-
-To load completions for each session, execute once:
-```sh
-deck completion fish > ~/.config/fish/completions/deck.fish
-```
-
-### PowerShell
-
-```powershell
-PS> deck completion powershell | Out-String | Invoke-Expression
-```
-
-To load completions for every new session, run:
-```powershell
-PS> deck completion powershell > deck.ps1
-```
-
-Then source this file from your PowerShell profile.
 
 ## Flags
 
-```
--h, --help   help for completion
-```
+`-h`, `--help`
+:  help for completion (Default: `false`)
 
-## Flags inherited from parent commands
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
+
 
 ## See also
 
-* [deck](/deck/{{page.kong_version}}/reference/deck) - Administer your Kong clusters declaratively
+* [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_completion.md
+++ b/src/deck/reference/deck_completion.md
@@ -1,5 +1,6 @@
 ---
 title: deck completion
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 To load completions:
@@ -85,6 +86,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_convert.md
+++ b/src/deck/reference/deck_convert.md
@@ -6,63 +6,103 @@ The convert command changes configuration files from one format
 into another compatible format. For example, a configuration for 'kong-gateway'
 can be converted into a 'konnect' configuration file.
 
+## Syntax
+
 ```
-deck convert [flags]
+deck convert [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
-    --from string          format of the source file, allowed formats: [kong-gateway]
--h, --help                 help for convert
-    --input-file string    configuration file to be converted. Use '-' to read from stdin.
-    --output-file string   file to write configuration to after conversion. Use '-' to write to stdout.
-    --to string            desired format of the output, allowed formats: [konnect]
-```
+`--from`
+:  format of the source file, allowed formats: [kong-gateway]
 
-## Flags inherited from parent commands
+`-h`, `--help`
+:  help for convert (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--input-file`
+:  configuration file to be converted. Use `-` to read from stdin.
+
+`--output-file`
+:  file to write configuration to after conversion. Use `-` to write to stdout.
+
+`--to`
+:  desired format of the output, allowed formats: [konnect]
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_convert.md
+++ b/src/deck/reference/deck_convert.md
@@ -1,5 +1,6 @@
 ---
 title: deck convert
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The convert command changes configuration files from one format
@@ -61,6 +62,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_diff.md
+++ b/src/deck/reference/deck_diff.md
@@ -9,73 +9,124 @@ the entities in local files. This allows you to see the entities
 that will be created, updated, or deleted.
 
 
+## Syntax
+
 ```
-deck diff [flags]
+deck diff [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help                  help for diff
-    --non-zero-exit-code    return exit code 2 if there is a diff present,
-                            exit code 0 if no diff is found,
-                            and exit code 1 if an error occurs.
-    --parallelism int       Maximum number of concurrent operations. (default 10)
-    --rbac-resources-only   sync only the RBAC resources (Kong Enterprise only).
-    --select-tag strings    only entities matching tags specified via this flag are diffed.
-                            When this setting has multiple tag values, entities must match each of them.
-    --silence-events        disable printing events to stdout
-    --skip-consumers        do not diff consumers or any plugins associated with consumers
--s, --state strings         file(s) containing Kong's configuration.
-                            This flag can be specified multiple times for multiple files.
-                            Use '-' to read from stdin. (default [kong.yaml])
--w, --workspace string      Diff configuration with a specific workspace (Kong Enterprise only).
-                            This takes precedence over _workspace fields in state files.
-```
+`-h`, `--help`
+:  help for diff (Default: `false`)
 
-## Flags inherited from parent commands
+`--non-zero-exit-code`
+:  return exit code 2 if there is a diff present,
+exit code 0 if no diff is found,
+and exit code 1 if an error occurs. (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--parallelism`
+:  Maximum number of concurrent operations. (Default: `10`)
+
+`--rbac-resources-only`
+:  sync only the RBAC resources (Kong Enterprise only). (Default: `false`)
+
+`--select-tag`
+:  only entities matching tags specified via this flag are diffed.
+When this setting has multiple tag values, entities must match each of them.
+
+`--silence-events`
+:  disable printing events to stdout (Default: `false`)
+
+`--skip-ca-certificates`
+:  do not diff CA certificates. (Default: `false`)
+
+`--skip-consumers`
+:  do not diff consumers or any plugins associated with consumers (Default: `false`)
+
+`-s`, `--state`
+:  file(s) containing Kong's configuration.
+This flag can be specified multiple times for multiple files.
+Use `-` to read from stdin. (Default: `[kong.yaml]`)
+
+`-w`, `--workspace`
+:  Diff configuration with a specific workspace (Kong Enterprise only).
+This takes precedence over _workspace fields in state files.
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_diff.md
+++ b/src/deck/reference/deck_diff.md
@@ -1,5 +1,6 @@
 ---
 title: deck diff
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The diff command is similar to a dry run of the 'decK sync' command.
@@ -85,6 +86,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_dump.md
+++ b/src/deck/reference/deck_dump.md
@@ -8,69 +8,122 @@ and writes them to a local file.
 The file can then be read using the sync command or diff command to
 configure Kong.
 
+## Syntax
+
 ```
-deck dump [flags]
+deck dump [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
-    --all-workspaces        dump configuration of all Workspaces (Kong Enterprise only).
-    --format string         output file format: json or yaml. (default "yaml")
--h, --help                  help for dump
--o, --output-file string    file to which to write Kong's configuration.Use '-' to write to stdout. (default "kong")
-    --rbac-resources-only   export only the RBAC resources (Kong Enterprise only).
-    --select-tag strings    only entities matching tags specified with this flag are exported.
-                            When this setting has multiple tag values, entities must match every tag.
-    --skip-consumers        skip exporting consumers and any plugins associated with consumers.
-    --with-id               write ID of all entities in the output
--w, --workspace string      dump configuration of a specific Workspace(Kong Enterprise only).
-    --yes                   assume 'yes' to prompts and run non-interactively.
-```
+`--all-workspaces`
+:  dump configuration of all Workspaces (Kong Enterprise only). (Default: `false`)
 
-## Flags inherited from parent commands
+`--format`
+:  output file format: json or yaml. (Default: `"yaml"`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`-h`, `--help`
+:  help for dump (Default: `false`)
+
+`-o`, `--output-file`
+:  file to which to write Kong's configuration.Use `-` to write to stdout. (Default: `"kong"`)
+
+`--rbac-resources-only`
+:  export only the RBAC resources (Kong Enterprise only). (Default: `false`)
+
+`--select-tag`
+:  only entities matching tags specified with this flag are exported.
+When this setting has multiple tag values, entities must match every tag.
+
+`--skip-ca-certificates`
+:  do not dump CA certificates. (Default: `false`)
+
+`--skip-consumers`
+:  skip exporting consumers and any plugins associated with consumers. (Default: `false`)
+
+`--with-id`
+:  write ID of all entities in the output (Default: `false`)
+
+`-w`, `--workspace`
+:  dump configuration of a specific Workspace(Kong Enterprise only).
+
+`--yes`
+:  assume `yes` to prompts and run non-interactively. (Default: `false`)
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_dump.md
+++ b/src/deck/reference/deck_dump.md
@@ -1,5 +1,6 @@
 ---
 title: deck dump
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The dump command reads all entities present in Kong
@@ -82,6 +83,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_konnect.md
+++ b/src/deck/reference/deck_konnect.md
@@ -5,56 +5,99 @@ title: deck konnect
 The konnect command prints subcommands that can be used to
 configure Konnect.
 
-WARNING: This command is currently in alpha state. This command
-might have breaking changes in future releases.
+{:.important}
+> **Deprecation notice:** The `deck konnect` command has been deprecated as of
+v1.12. Please use `deck <cmd>` instead if you would like to declaratively
+manage your Kong Gateway config with Konnect.
 
 ## Flags
 
-```
--h, --help   help for konnect
-```
+`-h`, `--help`
+:  help for konnect (Default: `false`)
 
-## Flags inherited from parent commands
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also

--- a/src/deck/reference/deck_konnect.md
+++ b/src/deck/reference/deck_konnect.md
@@ -1,5 +1,6 @@
 ---
 title: deck konnect
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The konnect command prints subcommands that can be used to
@@ -14,18 +15,6 @@ manage your Kong Gateway config with Konnect.
 
 `-h`, `--help`
 :  help for konnect (Default: `false`)
-
-`--konnect-addr`
-:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
-
-`--konnect-email`
-:  Email address associated with your Konnect account.
-
-`--konnect-password`
-:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
-
-`--konnect-password-file`
-:  File containing the password to your Konnect account.
 
 
 
@@ -59,6 +48,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_konnect_diff.md
+++ b/src/deck/reference/deck_konnect_diff.md
@@ -8,68 +8,123 @@ It loads entities from Konnect and performs a diff with
 the entities in local files. This allows you to see the entities
 that will be created, updated, or deleted.
 
-WARNING: This command is currently in alpha state. This command
-might have breaking changes in future releases.
+{:.important}
+> **Deprecation notice:** The `deck konnect` command has been deprecated as of
+v1.12. Please use `deck <cmd>` instead if you would like to declaratively
+manage your Kong Gateway config with Konnect.
+
+## Syntax
 
 ```
-deck konnect diff [flags]
+deck konnect diff [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help                 help for diff
-    --include-consumers    export consumers, associated credentials and any plugins associated with consumers.
-    --non-zero-exit-code   return exit code 2 if there is a diff present,
-                           exit code 0 if no diff is found,
-                           and exit code 1 if an error occurs.
-    --parallelism int      Maximum number of concurrent operations. (default 100)
-    --silence-events       disable printing events to stdout
--s, --state strings        file(s) containing Konnect's configuration.
-                           This flag can be specified multiple times for multiple files. (default [konnect.yaml])
-```
+`-h`, `--help`
+:  help for diff (Default: `false`)
 
-## Flags inherited from parent commands
+`--include-consumers`
+:  export consumers, associated credentials and any plugins associated with consumers. (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--non-zero-exit-code`
+:  return exit code 2 if there is a diff present,
+exit code 0 if no diff is found,
+and exit code 1 if an error occurs. (Default: `false`)
+
+`--parallelism`
+:  Maximum number of concurrent operations. (Default: `100`)
+
+`--silence-events`
+:  disable printing events to stdout (Default: `false`)
+
+`-s`, `--state`
+:  file(s) containing Konnect's configuration.
+This flag can be specified multiple times for multiple files. (Default: `[konnect.yaml]`)
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also

--- a/src/deck/reference/deck_konnect_diff.md
+++ b/src/deck/reference/deck_konnect_diff.md
@@ -1,5 +1,6 @@
 ---
 title: deck konnect diff
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The konnect diff command is similar to a dry run of the 'deck konnect sync' command.
@@ -76,7 +77,7 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
 
 `--konnect-addr`
-:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
 
 `--konnect-email`
 :  Email address associated with your Konnect account.
@@ -86,6 +87,9 @@ You may also need to pass in as header the User-Agent that was used to create th
 
 `--konnect-password-file`
 :  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_konnect_dump.md
+++ b/src/deck/reference/deck_konnect_dump.md
@@ -8,66 +8,120 @@ and writes them to a local file.
 The file can then be read using the 'deck konnect sync' command or 'deck konnect diff' command to
 configure Konnect.
 
-WARNING: This command is currently in alpha state. This command
-might have breaking changes in future releases.
+{:.important}
+> **Deprecation notice:** The `deck konnect` command has been deprecated as of
+v1.12. Please use `deck <cmd>` instead if you would like to declaratively
+manage your Kong Gateway config with Konnect.
+
+## Syntax
 
 ```
-deck konnect dump [flags]
+deck konnect dump [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
-    --format string        output file format: json or yaml. (default "yaml")
--h, --help                 help for dump
-    --include-consumers    export consumers, associated credentials and any plugins associated with consumers.
--o, --output-file string   file to which to write Kong's configuration. (default "konnect")
-    --with-id              write ID of all entities in the output.
-    --yes                  Assume 'yes' to prompts and run non-interactively.
-```
+`--format`
+:  output file format: json or yaml. (Default: `"yaml"`)
 
-## Flags inherited from parent commands
+`-h`, `--help`
+:  help for dump (Default: `false`)
+
+`--include-consumers`
+:  export consumers, associated credentials and any plugins associated with consumers. (Default: `false`)
+
+`-o`, `--output-file`
+:  file to which to write Kong's configuration. (Default: `"konnect"`)
+
+`--with-id`
+:  write ID of all entities in the output. (Default: `false`)
+
+`--yes`
+:  Assume `yes` to prompts and run non-interactively. (Default: `false`)
 
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also

--- a/src/deck/reference/deck_konnect_dump.md
+++ b/src/deck/reference/deck_konnect_dump.md
@@ -1,5 +1,6 @@
 ---
 title: deck konnect dump
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The konnect dump command reads all entities present in Konnect
@@ -73,7 +74,7 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
 
 `--konnect-addr`
-:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
 
 `--konnect-email`
 :  Email address associated with your Konnect account.
@@ -83,6 +84,9 @@ You may also need to pass in as header the User-Agent that was used to create th
 
 `--konnect-password-file`
 :  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_konnect_ping.md
+++ b/src/deck/reference/deck_konnect_ping.md
@@ -6,60 +6,105 @@ The konnect ping command can be used to verify if decK
 can connect to Konnect's API endpoint. It also validates the supplied
 credentials.
 
-WARNING: This command is currently in alpha state. This command
-might have breaking changes in future releases.
+{:.important}
+> **Deprecation notice:** The `deck konnect` command has been deprecated as of
+v1.12. Please use `deck <cmd>` instead if you would like to declaratively
+manage your Kong Gateway config with Konnect.
+
+## Syntax
 
 ```
-deck konnect ping [flags]
+deck konnect ping [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help   help for ping
-```
+`-h`, `--help`
+:  help for ping (Default: `false`)
 
-## Flags inherited from parent commands
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also

--- a/src/deck/reference/deck_konnect_ping.md
+++ b/src/deck/reference/deck_konnect_ping.md
@@ -1,5 +1,6 @@
 ---
 title: deck konnect ping
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The konnect ping command can be used to verify if decK
@@ -56,7 +57,7 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
 
 `--konnect-addr`
-:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
 
 `--konnect-email`
 :  Email address associated with your Konnect account.
@@ -66,6 +67,9 @@ You may also need to pass in as header the User-Agent that was used to create th
 
 `--konnect-password-file`
 :  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_konnect_sync.md
+++ b/src/deck/reference/deck_konnect_sync.md
@@ -5,65 +5,118 @@ title: deck konnect sync
 The konnect sync command reads the state file and performs operations in Konnect
 to get Konnect's state in sync with the input state.
 
-WARNING: This command is currently in alpha state. This command
-might have breaking changes in future releases.
+{:.important}
+> **Deprecation notice:** The `deck konnect` command has been deprecated as of
+v1.12. Please use `deck <cmd>` instead if you would like to declaratively
+manage your Kong Gateway config with Konnect.
+
+## Syntax
 
 ```
-deck konnect sync [flags]
+deck konnect sync [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help                help for sync
-    --include-consumers   export consumers, associated credentials and any plugins associated with consumers.
-    --parallelism int     Maximum number of concurrent operations. (default 100)
-    --silence-events      disable printing events to stdout
--s, --state strings       file(s) containing Konnect's configuration.
-                          This flag can be specified multiple times for multiple files. (default [konnect.yaml])
-```
+`-h`, `--help`
+:  help for sync (Default: `false`)
 
-## Flags inherited from parent commands
+`--include-consumers`
+:  export consumers, associated credentials and any plugins associated with consumers. (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--parallelism`
+:  Maximum number of concurrent operations. (Default: `100`)
+
+`--silence-events`
+:  disable printing events to stdout (Default: `false`)
+
+`-s`, `--state`
+:  file(s) containing Konnect's configuration.
+This flag can be specified multiple times for multiple files. (Default: `[konnect.yaml]`)
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also

--- a/src/deck/reference/deck_konnect_sync.md
+++ b/src/deck/reference/deck_konnect_sync.md
@@ -1,5 +1,6 @@
 ---
 title: deck konnect sync
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The konnect sync command reads the state file and performs operations in Konnect
@@ -68,7 +69,7 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
 
 `--konnect-addr`
-:  Address of the Konnect endpoint. (Default: `"https://konnect.konghq.com"`)
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
 
 `--konnect-email`
 :  Email address associated with your Konnect account.
@@ -78,6 +79,9 @@ You may also need to pass in as header the User-Agent that was used to create th
 
 `--konnect-password-file`
 :  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_ping.md
+++ b/src/deck/reference/deck_ping.md
@@ -5,61 +5,95 @@ title: deck ping
 The ping command can be used to verify if decK
 can connect to Kong's Admin API.
 
+## Syntax
+
 ```
-deck ping [flags]
+deck ping [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help               help for ping
--w, --workspace string   Ping configuration with a specific Workspace (Kong Enterprise only).
-                         Useful when RBAC permissions are scoped to a Workspace.
-```
+`-h`, `--help`
+:  help for ping (Default: `false`)
 
-## Flags inherited from parent commands
+`-w`, `--workspace`
+:  Ping configuration with a specific Workspace (Kong Enterprise only).
+Useful when RBAC permissions are scoped to a Workspace.
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_ping.md
+++ b/src/deck/reference/deck_ping.md
@@ -1,5 +1,6 @@
 ---
 title: deck ping
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The ping command can be used to verify if decK
@@ -52,6 +53,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_reset.md
+++ b/src/deck/reference/deck_reset.md
@@ -9,66 +9,113 @@ Use this command with extreme care as it's equivalent to running
 
 By default, this command will ask for confirmation.
 
+## Syntax
+
 ```
-deck reset [flags]
+deck reset [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
-    --all-workspaces        reset configuration of all workspaces (Kong Enterprise only).
--f, --force                 Skip interactive confirmation prompt before reset.
--h, --help                  help for reset
-    --rbac-resources-only   reset only the RBAC resources (Kong Enterprise only).
-    --select-tag strings    only entities matching tags specified via this flag are deleted.
-                            When this setting has multiple tag values, entities must match every tag.
-    --skip-consumers        do not reset consumers or any plugins associated with consumers.
--w, --workspace string      reset configuration of a specific workspace(Kong Enterprise only).
-```
+`--all-workspaces`
+:  reset configuration of all workspaces (Kong Enterprise only). (Default: `false`)
 
-## Flags inherited from parent commands
+`-f`, `--force`
+:  Skip interactive confirmation prompt before reset. (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`-h`, `--help`
+:  help for reset (Default: `false`)
+
+`--rbac-resources-only`
+:  reset only the RBAC resources (Kong Enterprise only). (Default: `false`)
+
+`--select-tag`
+:  only entities matching tags specified via this flag are deleted.
+When this setting has multiple tag values, entities must match every tag.
+
+`--skip-ca-certificates`
+:  do not reset CA certificates. (Default: `false`)
+
+`--skip-consumers`
+:  do not reset consumers or any plugins associated with consumers. (Default: `false`)
+
+`-w`, `--workspace`
+:  reset configuration of a specific workspace(Kong Enterprise only).
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_reset.md
+++ b/src/deck/reference/deck_reset.md
@@ -1,5 +1,6 @@
 ---
 title: deck reset
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The reset command deletes all entities in Kong's database.string.
@@ -74,6 +75,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_sync.md
+++ b/src/deck/reference/deck_sync.md
@@ -5,73 +5,124 @@ title: deck sync
 The sync command reads the state file and performs operation on Kong
 to get Kong's state in sync with the input state.
 
+## Syntax
+
 ```
-deck sync [flags]
+deck sync [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
-    --db-update-propagation-delay int   artificial delay (in seconds) that is injected between insert operations
-                                        for related entities (usually for Cassandra deployments).
-                                        See 'db_update_propagation' in kong.conf.
--h, --help                              help for sync
-    --parallelism int                   Maximum number of concurrent operations. (default 10)
-    --rbac-resources-only               diff only the RBAC resources (Kong Enterprise only).
-    --select-tag strings                only entities matching tags specified via this flag are synced.
-                                        When this setting has multiple tag values, entities must match every tag.
-    --silence-events                    disable printing events to stdout
-    --skip-consumers                    do not sync consumers or any plugins associated with consumers.
--s, --state strings                     file(s) containing Kong's configuration.
-                                        This flag can be specified multiple times for multiple files.
-                                        Use '-' to read from stdin. (default [kong.yaml])
-    --workspace string                  Sync configuration to a specific workspace (Kong Enterprise only).
-                                        This takes precedence over _workspace fields in state files.
-```
+`--db-update-propagation-delay`
+:  artificial delay (in seconds) that is injected between insert operations 
+for related entities (usually for Cassandra deployments).
+See `db_update_propagation` in kong.conf. (Default: `0`)
 
-### Flags inherited from parent commands
+`-h`, `--help`
+:  help for sync (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--parallelism`
+:  Maximum number of concurrent operations. (Default: `10`)
+
+`--rbac-resources-only`
+:  diff only the RBAC resources (Kong Enterprise only). (Default: `false`)
+
+`--select-tag`
+:  only entities matching tags specified via this flag are synced.
+When this setting has multiple tag values, entities must match every tag.
+
+`--silence-events`
+:  disable printing events to stdout (Default: `false`)
+
+`--skip-ca-certificates`
+:  do not sync CA certificates. (Default: `false`)
+
+`--skip-consumers`
+:  do not sync consumers or any plugins associated with consumers. (Default: `false`)
+
+`-s`, `--state`
+:  file(s) containing Kong's configuration.
+This flag can be specified multiple times for multiple files.
+Use `-` to read from stdin. (Default: `[kong.yaml]`)
+
+`--workspace`
+:  Sync configuration to a specific workspace (Kong Enterprise only).
+This takes precedence over _workspace fields in state files.
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_sync.md
+++ b/src/deck/reference/deck_sync.md
@@ -1,5 +1,6 @@
 ---
 title: deck sync
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The sync command reads the state file and performs operation on Kong
@@ -81,6 +82,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_validate.md
+++ b/src/deck/reference/deck_validate.md
@@ -3,78 +3,119 @@ title: deck validate
 ---
 
 The validate command reads the state file and ensures validity.
-
 It reads all the specified state files and reports YAML/JSON
 parsing issues. It also checks for foreign relationships
 and alerts if there are broken relationships, or missing links present.
 
-No communication takes place between decK and Kong Gateway during the execution
-of this command unless the `--online` flag is used.
+No communication takes places between decK and Kong during the execution of
+this command unless --online flag is used.
 
+
+## Syntax
 
 ```
-deck validate [flags]
+deck validate [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help                  help for validate
-    --online                perform validations against Kong API. When this flag is used, validation is done
-                            via communication with Kong. This increases the time for validation but catches
-                            significant errors. No resource is created in Kong.
-    --parallelism int       Maximum number of concurrent requests to Kong. (default 10)
-    --rbac-resources-only   indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).
--s, --state strings         file(s) containing Kong's configuration.
-                            This flag can be specified multiple times for multiple files.
-                            Use '-' to read from stdin. (default [kong.yaml])
--w, --workspace string      validate configuration of a specific workspace (Kong Enterprise only).
-                            This takes precedence over _workspace fields in state files.
-```
+`-h`, `--help`
+:  help for validate (Default: `false`)
 
-## Flags inherited from parent commands
+`--online`
+:  perform validations against Kong API. When this flag is used, validation is done
+via communication with Kong. This increases the time for validation but catches 
+significant errors. No resource is created in Kong. (Default: `false`)
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+`--parallelism`
+:  Maximum number of concurrent requests to Kong. (Default: `10`)
+
+`--rbac-resources-only`
+:  indicate that the state file(s) contains RBAC resources only (Kong Enterprise only). (Default: `false`)
+
+`-s`, `--state`
+:  file(s) containing Kong's configuration.
+This flag can be specified multiple times for multiple files.
+Use '-' to read from stdin. (Default: `[kong.yaml]`)
+
+`-w`, `--workspace`
+:  validate configuration of a specific workspace (Kong Enterprise only).
+This takes precedence over _workspace fields in state files.
+
+
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_validate.md
+++ b/src/deck/reference/deck_validate.md
@@ -1,5 +1,6 @@
 ---
 title: deck validate
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The validate command reads the state file and ensures validity.
@@ -74,6 +75,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)

--- a/src/deck/reference/deck_version.md
+++ b/src/deck/reference/deck_version.md
@@ -5,59 +5,91 @@ title: deck version
 The version command prints the version of decK along with a Git short
 commit hash of the source tree.
 
+## Syntax
+
 ```
-deck version [flags]
+deck version [command-specific flags] [global flags]
 ```
 
 ## Flags
 
-```
--h, --help   help for version
-```
+`-h`, `--help`
+:  help for version (Default: `false`)
 
-## Flags inherited from parent commands
 
-```
---analytics                      Share anonymized data to help improve decK.
-                                 Use --analytics=false to disable this. (default true)
---ca-cert string                 Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT environment variable.
-                                 This takes precedence over --ca-cert-file flag.
---ca-cert-file string            Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_CA_CERT_FILE environment variable.
---config string                  Config file (default is $HOME/.deck.yaml).
---headers strings                HTTP headers (key:value) to inject in all requests to Kong's Admin API.
-                                 This flag can be specified multiple times to inject multiple headers.
---kong-addr string               HTTP address of Kong's Admin API.
-                                 This value can also be set using the environment variable DECK_KONG_ADDR
-                                  environment variable. (default "http://localhost:8001")
---kong-cookie-jar-path string    Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
-                                 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
---konnect-addr string            Address of the Konnect endpoint. (default "https://konnect.konghq.com")
---konnect-email string           Email address associated with your Konnect account.
---konnect-password string        Password associated with your Konnect account, this takes precedence over --konnect-password-file flag.
---konnect-password-file string   File containing the password to your Konnect account.
---no-color                       Disable colorized output
---skip-workspace-crud            Skip API calls related to Workspaces (Kong Enterprise only).
---timeout int                    Set a request timeout for the client to connect with Kong (in seconds). (default 10)
---tls-client-cert string         PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
---tls-client-cert-file string    Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
-                                 This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
---tls-client-key string          PEM-encoded private key for the corresponding client certificate .
-                                 This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
---tls-client-key-file string     Path to file containing the private key for the corresponding client certificate.
-                                 This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
---tls-server-name string         Name to use to verify the hostname in Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SERVER_NAME environment variable.
---tls-skip-verify                Disable verification of Kong's Admin TLS certificate.
-                                 This value can also be set using DECK_TLS_SKIP_VERIFY environment variable.
---verbose int                    Enable verbose logging levels
-                                 Setting this value to 2 outputs all HTTP requests/responses
-                                 between decK and Kong.
-```
+
+## Global flags
+
+`--analytics`
+:  Share anonymized data to help improve decK.
+Use `--analytics=false` to disable this. (Default: `true`)
+
+`--ca-cert`
+:  Custom CA certificate (raw contents) to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT environment variable.
+This takes precedence over `--ca-cert-file` flag.
+
+`--ca-cert-file`
+:  Path to a custom CA certificate to use to verify Kong's Admin TLS certificate.
+This value can also be set using DECK_CA_CERT_FILE environment variable.
+
+`--config`
+:  Config file (default is $HOME/.deck.yaml).
+
+`--headers`
+:  HTTP headers (key:value) to inject in all requests to Kong's Admin API.
+This flag can be specified multiple times to inject multiple headers.
+
+`--kong-addr`
+:  HTTP address of Kong's Admin API.
+This value can also be set using the environment variable DECK_KONG_ADDR
+ environment variable. (Default: `"http://localhost:8001"`)
+
+`--kong-cookie-jar-path`
+:  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
+You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--no-color`
+:  Disable colorized output (Default: `false`)
+
+`--skip-workspace-crud`
+:  Skip API calls related to Workspaces (Kong Enterprise only). (Default: `false`)
+
+`--timeout`
+:  Set a request timeout for the client to connect with Kong (in seconds). (Default: `10`)
+
+`--tls-client-cert`
+:  PEM-encoded TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT environment variable. Must be used in conjunction with tls-client-key
+
+`--tls-client-cert-file`
+:  Path to the file containing TLS client certificate to use for authentication with Kong's Admin API.
+This value can also be set using DECK_TLS_CLIENT_CERT_FILE environment variable. Must be used in conjunction with tls-client-key-file
+
+`--tls-client-key`
+:  PEM-encoded private key for the corresponding client certificate .
+This value can also be set using DECK_TLS_CLIENT_KEY environment variable. Must be used in conjunction with tls-client-cert
+
+`--tls-client-key-file`
+:  Path to file containing the private key for the corresponding client certificate.
+This value can also be set using DECK_TLS_CLIENT_KEY_FILE environment variable. Must be used in conjunction with tls-client-cert-file
+
+`--tls-server-name`
+:  Name to use to verify the hostname in Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SERVER_NAME environment variable.
+
+`--tls-skip-verify`
+:  Disable verification of Kong's Admin TLS certificate.
+This value can also be set using DECK_TLS_SKIP_VERIFY environment variable. (Default: `false`)
+
+`--verbose`
+:  Enable verbose logging levels
+Setting this value to 2 outputs all HTTP requests/responses
+between decK and Kong. (Default: `0`)
+
 
 
 ## See also
 
 * [deck](/deck/{{page.kong_version}}/reference/deck)	 - Administer your Kong clusters declaratively
+

--- a/src/deck/reference/deck_version.md
+++ b/src/deck/reference/deck_version.md
@@ -1,5 +1,6 @@
 ---
 title: deck version
+source_url: https://github.com/Kong/deck/tree/main/cmd
 ---
 
 The version command prints the version of decK along with a Git short
@@ -48,6 +49,21 @@ This value can also be set using the environment variable DECK_KONG_ADDR
 `--kong-cookie-jar-path`
 :  Absolute path to a cookie-jar file in the Netscape cookie format for auth with Admin Server.
 You may also need to pass in as header the User-Agent that was used to create the cookie-jar.
+
+`--konnect-addr`
+:  Address of the Konnect endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your Konnect account.
+
+`--konnect-password`
+:  Password associated with your Konnect account, this takes precedence over `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your Konnect account.
+
+`--konnect-runtime-group-name`
+:  Konnect Runtime group name.
 
 `--no-color`
 :  Disable colorized output (Default: `false`)


### PR DESCRIPTION
### Summary
* Generate decK docs using updated CLI generation script.
* Add deprecation notice to all `deck konnect` commands. 

### Reason
Upcoming v1.12 release.

### Testing

**For reviewers:** These files have been generated via script from [kong/deck](https://github.com/Kong/deck). The docs generation script was recently updated (see https://github.com/Kong/deck/pull/642) and reviewed on the code side. I'm aware that the content needs some work, but the main purpose of this change is to create more user-friendly formatting.

The deprecation notice comes from https://github.com/Kong/deck-private/commit/f687fd66fbc7d2d526360c519c5df93e73bf9698, slightly adjusted for format.

When reviewing this PR, please click through the deck > CLI Reference navigation, make sure they're all using the new formatting, and that every `deck konnect` command has a deprecation notice. You don't need to copyedit content.

Compare the new formatting (all pages under `/deck/1.12.x/reference/`):
https://deploy-preview-3856--kongdocs.netlify.app/deck/1.12.x/reference/deck/

With the old formatting:
https://docs.konghq.com/deck/latest/reference/deck/