### PR TITLE
Add missing Mesh enterprise features

### DIFF
--- a/app/mesh/1.7.x/gettingstarted.md
+++ b/app/mesh/1.7.x/gettingstarted.md
@@ -41,6 +41,9 @@ After you install, follow the Kuma getting started guide to get
   * [Multi-zone authentication](/mesh/{{page.kong_version}}/features/kds-auth)
   * [Support for FIPS](/mesh/{{page.kong_version}}/features/fips-support)
   * [Certificate Authority rotation](/mesh/{{page.kong_version}}/features/ca-rotation)
+  * [Role-Based Access Control](/mesh/{{page.kong_version}}/features/rbac)
+  * [Red Hat Universal Base Images](/mesh/{{page.kong_version}}/features/ubi-images)
+  * [Windows Support](/mesh/{{page.kong_version}}/features/windows)
 
 If you are a {{site.mesh_product_name}} customer, you can also open a support
 ticket with any questions or feedback you may have.


### PR DESCRIPTION
### Summary
Add missing Mesh enterprise features

### Reason
They're present in the sidebar but not on the Getting Started page

### Testing
Review App