### PR TITLE
Fix broken Mesh Windows link

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -471,6 +471,7 @@
 /mesh/1.0.x/features/   /mesh/1.0.x/features/vault
 /mesh/1.1.x/features/   /mesh/1.1.x/features/vault
 /mesh/1.7.x/features/windows/ /mesh/1.7.x/installation/windows/
+/mesh/latest/features/windows/ /mesh/latest/installation/windows/
 
 
 # ABOUT


### PR DESCRIPTION
### Summary
Add missing Mesh redirect after SEO changes were merged

### Reason
Fix a broken link

### Testing
Review App