### PR TITLE
Redirect for broken link to vitals

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -465,6 +465,8 @@
 /enterprise/2.6.x/vitals/overview     /gateway/2.6.x/vitals/
 /enterprise/2.7.x/vitals/overview     /gateway/2.7.x/vitals/
 /enterprise/latest/vitals/overview    /gateway/latest/vitals/
+/gateway/latest/admin-api/vitals     /gateway/latest/vitals/
+/gateway/latest/admin-api/vitals/*   /gateway/latest/vitals/
 
 
 # KONG MESH


### PR DESCRIPTION
### Summary
Adding a redirect for a broken link. The source of the broken link is in the Kong Manager code.

### Reason
Issue called out on Slack: https://kongstrong.slack.com/archives/CH14Q7DEH/p1650403771168029

Broken link in Kong Manager UI.

### Testing
https://deploy-preview-3863--kongdocs.netlify.app/gateway/latest/admin-api/vitals - this URL should redirect to https://deploy-preview-3863--kongdocs.netlify.app/gateway/latest/vitals