### PR TITLE
Fix github edit link for plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -253,7 +253,7 @@ breadcrumbs:
           <a href="/hub"><i class="fa fa-chevron-left"></i>Back to Kong Plugin Hub</a>
         </p>
         <p>
-          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{page.path}}" target="_blank">
+          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{page.path | replace: "index", "_index" }}" target="_blank">
             <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
         </p>
         <p>


### PR DESCRIPTION
### Summary
Setting link to go to _index.html instead of index.html.

### Reason
Getting broken links on plugin landing pages. Issue called out on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1650478018021109

### Testing
TBA, check preview.