### PR TITLE
Backport license doc improvements

### DIFF
--- a/app/enterprise/2.1.x/deployment/licenses/report.md
+++ b/app/enterprise/2.1.x/deployment/licenses/report.md
@@ -20,117 +20,71 @@ Run the license report module and share the output information with your Kong re
 
 To generate a license report, from an HTTP client:
 
-*   For a JSON response, send an HTTP request to the Kong node endpoint` /license/report`. For example, use this cURL command:
+{% navtabs %}
+{% navtab JSON response %}
 
-    ```
-    curl '<ADMIN_API_URL>/license/report'
-    ```
+For a JSON response, send an HTTP request to the Kong node endpoint
+`/license/report`. For example, use this cURL command:
 
-    A JSON response returns, similar to the example below.
+```bash
+curl {ADMIN_API_URL}/license/report
+```
 
-    ```
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Origin: http://localhost:8002
-    Connection: keep-alive
-    Content-Length: 262
-    Content-Type: application/json; charset=utf-8
-    Date: Wed, 19 Feb 2020 05:54:23 GMT
-    Server: kong/1.3-enterprise-edition
-    Vary: Origin
-    X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
-    {
-       "counters":{
-          "req_cnt":22
-       },
-       "db_version":"postgres 9.5.20",
-       "kong_version":"1.3-enterprise-edition",
-       "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
-       "rbac_users":0,
-       "services_count": 27,
-       "system_info":{
-          "cores":6,
-          "hostname":"264da9b95dfa",
-          "uname":"Linux x86_64"
-       },
-       "workspaces_count":1
-    }
-    ```
+A JSON response returns, similar to the example below:
 
-* For a TAR file, enter the following cURL command to make a call to Kong Admin API.
+```json
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:8002
+Connection: keep-alive
+Content-Length: 262
+Content-Type: application/json; charset=utf-8
+Date: Wed, 19 Feb 2020 05:54:23 GMT
+Server: kong/1.3-enterprise-edition
+Vary: Origin
+X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
 
-    ```
-    curl <ADMIN_API_URL>/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
-    ```
-    A license report file is generated and archives a report to *.tar file.
+{% endnavtab %}
+{% navtab TAR file %}
+
+For a TAR file, enter the following cURL command to make a call to the
+Kong Admin API:
+
+```bash
+curl {ADMIN_API_URL}/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
+```
+
+A license report file is generated and archived to a `*.tar` file.
+
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Report Structure
 
-<table>
-  <tr>
-   <td>Field
-   </td>
-   <td>Description
-   </td>
-  </tr>
-  <tr>
-   <td>kong_version
-   </td>
-   <td>Kong Enterprise version
-   </td>
-  </tr>
-  <tr>
-   <td>license_key
-   </td>
-   <td>Current license key identifier
-   </td>
-  </tr>
-  <tr>
-   <td>db_version
-   </td>
-   <td>Storage name and version of node/cluster
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.cores
-   </td>
-   <td>System CPU cores of node
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.hostname
-   </td>
-   <td>System hostname
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.uname
-   </td>
-   <td>System uname
-   </td>
-  </tr>
-  <tr>
-   <td>workspaces_count
-   </td>
-   <td>Number of workspaces
-   </td>
-  </tr>
-  <tr>
-   <td>rbac_users
-   </td>
-   <td>Number of RBAC users
-   </td>
-  </tr>
-  <tr>
-   <td>services_count
-   </td>
-   <td>Number of Kong Services
-   </td>
-  </tr>
-  <tr>
-   <td>counters.req_count
-   </td>
-   <td>Number of requests node/cluster processed
-   </td>
-  </tr>
-</table>
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.

--- a/app/enterprise/2.2.x/deployment/licenses/report.md
+++ b/app/enterprise/2.2.x/deployment/licenses/report.md
@@ -20,117 +20,71 @@ Run the license report module and share the output information with your Kong re
 
 To generate a license report, from an HTTP client:
 
-*   For a JSON response, send an HTTP request to the Kong node endpoint` /license/report`. For example, use this cURL command:
+{% navtabs %}
+{% navtab JSON response %}
 
-    ```
-    curl '<ADMIN_API_URL>/license/report'
-    ```
+For a JSON response, send an HTTP request to the Kong node endpoint
+`/license/report`. For example, use this cURL command:
 
-    A JSON response returns, similar to the example below.
+```bash
+curl {ADMIN_API_URL}/license/report
+```
 
-    ```
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Origin: http://localhost:8002
-    Connection: keep-alive
-    Content-Length: 262
-    Content-Type: application/json; charset=utf-8
-    Date: Wed, 19 Feb 2020 05:54:23 GMT
-    Server: kong/1.3-enterprise-edition
-    Vary: Origin
-    X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
-    {
-       "counters":{
-          "req_cnt":22
-       },
-       "db_version":"postgres 9.5.20",
-       "kong_version":"1.3-enterprise-edition",
-       "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
-       "rbac_users":0,
-       "services_count": 27,
-       "system_info":{
-          "cores":6,
-          "hostname":"264da9b95dfa",
-          "uname":"Linux x86_64"
-       },
-       "workspaces_count":1
-    }
-    ```
+A JSON response returns, similar to the example below:
 
-* For a TAR file, enter the following cURL command to make a call to Kong Admin API.
+```json
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:8002
+Connection: keep-alive
+Content-Length: 262
+Content-Type: application/json; charset=utf-8
+Date: Wed, 19 Feb 2020 05:54:23 GMT
+Server: kong/1.3-enterprise-edition
+Vary: Origin
+X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
 
-    ```
-    curl <ADMIN_API_URL>/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
-    ```
-    A license report file is generated and archives a report to *.tar file.
+{% endnavtab %}
+{% navtab TAR file %}
+
+For a TAR file, enter the following cURL command to make a call to the
+Kong Admin API:
+
+```bash
+curl {ADMIN_API_URL}/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
+```
+
+A license report file is generated and archived to a `*.tar` file.
+
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Report Structure
 
-<table>
-  <tr>
-   <td>Field
-   </td>
-   <td>Description
-   </td>
-  </tr>
-  <tr>
-   <td>kong_version
-   </td>
-   <td>Kong Enterprise version
-   </td>
-  </tr>
-  <tr>
-   <td>license_key
-   </td>
-   <td>Current license key identifier
-   </td>
-  </tr>
-  <tr>
-   <td>db_version
-   </td>
-   <td>Storage name and version of node/cluster
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.cores
-   </td>
-   <td>System CPU cores of node
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.hostname
-   </td>
-   <td>System hostname
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.uname
-   </td>
-   <td>System uname
-   </td>
-  </tr>
-  <tr>
-   <td>workspaces_count
-   </td>
-   <td>Number of workspaces
-   </td>
-  </tr>
-  <tr>
-   <td>rbac_users
-   </td>
-   <td>Number of RBAC users
-   </td>
-  </tr>
-  <tr>
-   <td>services_count
-   </td>
-   <td>Number of Kong Services
-   </td>
-  </tr>
-  <tr>
-   <td>counters.req_count
-   </td>
-   <td>Number of requests node/cluster processed
-   </td>
-  </tr>
-</table>
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.

--- a/app/enterprise/2.3.x/admin-api/licenses/reference.md
+++ b/app/enterprise/2.3.x/admin-api/licenses/reference.md
@@ -13,8 +13,6 @@ licenses_body: |
     `payload` | The **Kong Gateway license** in JSON format.
 ---
 
-## Introduction
-
 The {{site.base_gateway}} Licenses feature is configurable through the
 [Admin API]. This feature lets you configure a license in your
 {{site.base_gateway}} cluster, in both traditional and hybrid mode deployments.
@@ -22,7 +20,7 @@ In hybrid mode deployments, the control plane sends licenses configured
 through the `/licenses` endpoint to all data planes in the cluster. The data
 planes use the most recent `updated_at` license.
 
-### List Licenses
+## List licenses
 **Endpoint**
 
 <div class="endpoint get">/licenses/</div>
@@ -57,7 +55,7 @@ be empty.
 }
 ```
 
-### Add License
+## Add license
 
 To create a license using an auto-generated UUID:
 
@@ -90,7 +88,7 @@ HTTP 201 Created
 }
 ```
 
-### Update or Add a License
+## Update or add a license
 
 **Endpoint**
 
@@ -127,7 +125,7 @@ HTTP 200 OK
 }
 ```
 
-### Update a License
+## Update a license
 
 **Endpoint**
 
@@ -163,7 +161,7 @@ HTTP 200 OK
 }
 ```
 
-### List a License
+## List a license
 
 **Endpoint**
 
@@ -186,7 +184,7 @@ HTTP 200 OK
 }
 ```
 
-### Delete a License
+## Delete a license
 
 **Endpoint**
 
@@ -198,6 +196,76 @@ HTTP 200 OK
 
 ```
 HTTP 204 No Content
+```
+
+## Generate a report
+
+Generate a report on the Kong Gateway instance to gather usage data.
+
+<div class="endpoint get">/license/report</div>
+
+Fields available in the report:
+
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
+
+If there are no licenses stored by {{site.base_gateway}}, the report will include
+`"license_key": "UNLICENSED"`:
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
 ```
 
 [Admin API]: /enterprise/{{page.kong_version}}/admin-api/

--- a/app/enterprise/2.3.x/deployment/licenses/report.md
+++ b/app/enterprise/2.3.x/deployment/licenses/report.md
@@ -20,117 +20,71 @@ Run the license report module and share the output information with your Kong re
 
 To generate a license report, from an HTTP client:
 
-*   For a JSON response, send an HTTP request to the Kong node endpoint` /license/report`. For example, use this cURL command:
+{% navtabs %}
+{% navtab JSON response %}
 
-    ```
-    curl '<ADMIN_API_URL>/license/report'
-    ```
+For a JSON response, send an HTTP request to the Kong node endpoint
+`/license/report`. For example, use this cURL command:
 
-    A JSON response returns, similar to the example below.
+```bash
+curl {ADMIN_API_URL}/license/report
+```
 
-    ```
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Origin: http://localhost:8002
-    Connection: keep-alive
-    Content-Length: 262
-    Content-Type: application/json; charset=utf-8
-    Date: Wed, 19 Feb 2020 05:54:23 GMT
-    Server: kong/1.3-enterprise-edition
-    Vary: Origin
-    X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
-    {
-       "counters":{
-          "req_cnt":22
-       },
-       "db_version":"postgres 9.5.20",
-       "kong_version":"1.3-enterprise-edition",
-       "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
-       "rbac_users":0,
-       "services_count": 27,
-       "system_info":{
-          "cores":6,
-          "hostname":"264da9b95dfa",
-          "uname":"Linux x86_64"
-       },
-       "workspaces_count":1
-    }
-    ```
+A JSON response returns, similar to the example below:
 
-* For a TAR file, enter the following cURL command to make a call to Kong Admin API.
+```json
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:8002
+Connection: keep-alive
+Content-Length: 262
+Content-Type: application/json; charset=utf-8
+Date: Wed, 19 Feb 2020 05:54:23 GMT
+Server: kong/1.3-enterprise-edition
+Vary: Origin
+X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
 
-    ```
-    curl <ADMIN_API_URL>/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
-    ```
-    A license report file is generated and archives a report to *.tar file.
+{% endnavtab %}
+{% navtab TAR file %}
+
+For a TAR file, enter the following cURL command to make a call to the
+Kong Admin API:
+
+```bash
+curl {ADMIN_API_URL}/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
+```
+
+A license report file is generated and archived to a `*.tar` file.
+
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Report Structure
 
-<table>
-  <tr>
-   <td>Field
-   </td>
-   <td>Description
-   </td>
-  </tr>
-  <tr>
-   <td>kong_version
-   </td>
-   <td>Kong Enterprise version
-   </td>
-  </tr>
-  <tr>
-   <td>license_key
-   </td>
-   <td>Current license key identifier
-   </td>
-  </tr>
-  <tr>
-   <td>db_version
-   </td>
-   <td>Storage name and version of node/cluster
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.cores
-   </td>
-   <td>System CPU cores of node
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.hostname
-   </td>
-   <td>System hostname
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.uname
-   </td>
-   <td>System uname
-   </td>
-  </tr>
-  <tr>
-   <td>workspaces_count
-   </td>
-   <td>Number of workspaces
-   </td>
-  </tr>
-  <tr>
-   <td>rbac_users
-   </td>
-   <td>Number of RBAC users
-   </td>
-  </tr>
-  <tr>
-   <td>services_count
-   </td>
-   <td>Number of Kong Services
-   </td>
-  </tr>
-  <tr>
-   <td>counters.req_count
-   </td>
-   <td>Number of requests node/cluster processed
-   </td>
-  </tr>
-</table>
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.

--- a/app/enterprise/2.4.x/admin-api/licenses/reference.md
+++ b/app/enterprise/2.4.x/admin-api/licenses/reference.md
@@ -13,8 +13,6 @@ licenses_body: |
     `payload` | The **Kong Gateway license** in JSON format.
 ---
 
-## Introduction
-
 The {{site.base_gateway}} Licenses feature is configurable through the
 [Admin API]. This feature lets you configure a license in your
 {{site.base_gateway}} cluster, in both traditional and hybrid mode deployments.
@@ -22,7 +20,7 @@ In hybrid mode deployments, the control plane sends licenses configured
 through the `/licenses` endpoint to all data planes in the cluster. The data
 planes use the most recent `updated_at` license.
 
-### List Licenses
+## List licenses
 **Endpoint**
 
 <div class="endpoint get">/licenses/</div>
@@ -57,7 +55,7 @@ be empty.
 }
 ```
 
-### Add License
+## Add license
 
 To create a license using an auto-generated UUID:
 
@@ -90,7 +88,7 @@ HTTP 201 Created
 }
 ```
 
-### Update or Add a License
+## Update or add a license
 
 **Endpoint**
 
@@ -127,7 +125,7 @@ HTTP 200 OK
 }
 ```
 
-### Update a License
+## Update a license
 
 **Endpoint**
 
@@ -163,7 +161,7 @@ HTTP 200 OK
 }
 ```
 
-### List a License
+## List a license
 
 **Endpoint**
 
@@ -186,7 +184,7 @@ HTTP 200 OK
 }
 ```
 
-### Delete a License
+## Delete a license
 
 **Endpoint**
 
@@ -198,6 +196,76 @@ HTTP 200 OK
 
 ```
 HTTP 204 No Content
+```
+
+## Generate a report
+
+Generate a report on the Kong Gateway instance to gather usage data.
+
+<div class="endpoint get">/license/report</div>
+
+Fields available in the report:
+
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
+
+If there are no licenses stored by {{site.base_gateway}}, the report will include
+`"license_key": "UNLICENSED"`:
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
 ```
 
 [Admin API]: /enterprise/{{page.kong_version}}/admin-api/

--- a/app/enterprise/2.4.x/deployment/licenses/report.md
+++ b/app/enterprise/2.4.x/deployment/licenses/report.md
@@ -20,117 +20,71 @@ Run the license report module and share the output information with your Kong re
 
 To generate a license report, from an HTTP client:
 
-*   For a JSON response, send an HTTP request to the Kong node endpoint` /license/report`. For example, use this cURL command:
+{% navtabs %}
+{% navtab JSON response %}
 
-    ```
-    curl '<ADMIN_API_URL>/license/report'
-    ```
+For a JSON response, send an HTTP request to the Kong node endpoint
+`/license/report`. For example, use this cURL command:
 
-    A JSON response returns, similar to the example below.
+```bash
+curl {ADMIN_API_URL}/license/report
+```
 
-    ```
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Origin: http://localhost:8002
-    Connection: keep-alive
-    Content-Length: 262
-    Content-Type: application/json; charset=utf-8
-    Date: Wed, 19 Feb 2020 05:54:23 GMT
-    Server: kong/1.3-enterprise-edition
-    Vary: Origin
-    X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
-    {
-       "counters":{
-          "req_cnt":22
-       },
-       "db_version":"postgres 9.5.20",
-       "kong_version":"1.3-enterprise-edition",
-       "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
-       "rbac_users":0,
-       "services_count": 27,
-       "system_info":{
-          "cores":6,
-          "hostname":"264da9b95dfa",
-          "uname":"Linux x86_64"
-       },
-       "workspaces_count":1
-    }
-    ```
+A JSON response returns, similar to the example below:
 
-* For a TAR file, enter the following cURL command to make a call to Kong Admin API.
+```json
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:8002
+Connection: keep-alive
+Content-Length: 262
+Content-Type: application/json; charset=utf-8
+Date: Wed, 19 Feb 2020 05:54:23 GMT
+Server: kong/1.3-enterprise-edition
+Vary: Origin
+X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
 
-    ```
-    curl <ADMIN_API_URL>/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
-    ```
-    A license report file is generated and archives a report to *.tar file.
+{% endnavtab %}
+{% navtab TAR file %}
+
+For a TAR file, enter the following cURL command to make a call to the
+Kong Admin API:
+
+```bash
+curl {ADMIN_API_URL}/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
+```
+
+A license report file is generated and archived to a `*.tar` file.
+
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Report Structure
 
-<table>
-  <tr>
-   <td>Field
-   </td>
-   <td>Description
-   </td>
-  </tr>
-  <tr>
-   <td>kong_version
-   </td>
-   <td>Kong Enterprise version
-   </td>
-  </tr>
-  <tr>
-   <td>license_key
-   </td>
-   <td>Current license key identifier
-   </td>
-  </tr>
-  <tr>
-   <td>db_version
-   </td>
-   <td>Storage name and version of node/cluster
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.cores
-   </td>
-   <td>System CPU cores of node
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.hostname
-   </td>
-   <td>System hostname
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.uname
-   </td>
-   <td>System uname
-   </td>
-  </tr>
-  <tr>
-   <td>workspaces_count
-   </td>
-   <td>Number of workspaces
-   </td>
-  </tr>
-  <tr>
-   <td>rbac_users
-   </td>
-   <td>Number of RBAC users
-   </td>
-  </tr>
-  <tr>
-   <td>services_count
-   </td>
-   <td>Number of Kong Services
-   </td>
-  </tr>
-  <tr>
-   <td>counters.req_count
-   </td>
-   <td>Number of requests node/cluster processed
-   </td>
-  </tr>
-</table>
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.

--- a/app/enterprise/2.5.x/admin-api/licenses/reference.md
+++ b/app/enterprise/2.5.x/admin-api/licenses/reference.md
@@ -13,8 +13,6 @@ licenses_body: |
     `payload` | The **Kong Gateway license** in JSON format.
 ---
 
-## Introduction
-
 The {{site.base_gateway}} Licenses feature is configurable through the
 [Admin API]. This feature lets you configure a license in your
 {{site.base_gateway}} cluster, in both traditional and hybrid mode deployments.
@@ -22,7 +20,7 @@ In hybrid mode deployments, the control plane sends licenses configured
 through the `/licenses` endpoint to all data planes in the cluster. The data
 planes use the most recent `updated_at` license.
 
-### List Licenses
+## List licenses
 **Endpoint**
 
 <div class="endpoint get">/licenses/</div>
@@ -57,7 +55,7 @@ be empty.
 }
 ```
 
-### Add License
+## Add license
 
 To create a license using an auto-generated UUID:
 
@@ -90,7 +88,7 @@ HTTP 201 Created
 }
 ```
 
-### Update or Add a License
+## Update or add a license
 
 **Endpoint**
 
@@ -127,7 +125,7 @@ HTTP 200 OK
 }
 ```
 
-### Update a License
+## Update a license
 
 **Endpoint**
 
@@ -163,7 +161,7 @@ HTTP 200 OK
 }
 ```
 
-### List a License
+## List a license
 
 **Endpoint**
 
@@ -186,7 +184,7 @@ HTTP 200 OK
 }
 ```
 
-### Delete a License
+## Delete a license
 
 **Endpoint**
 
@@ -198,6 +196,76 @@ HTTP 200 OK
 
 ```
 HTTP 204 No Content
+```
+
+## Generate a report
+
+Generate a report on the Kong Gateway instance to gather usage data.
+
+<div class="endpoint get">/license/report</div>
+
+Fields available in the report:
+
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
+
+If there are no licenses stored by {{site.base_gateway}}, the report will include
+`"license_key": "UNLICENSED"`:
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
 ```
 
 [Admin API]: /enterprise/{{page.kong_version}}/admin-api/

--- a/app/enterprise/2.5.x/deployment/licenses/report.md
+++ b/app/enterprise/2.5.x/deployment/licenses/report.md
@@ -20,117 +20,71 @@ Run the license report module and share the output information with your Kong re
 
 To generate a license report, from an HTTP client:
 
-*   For a JSON response, send an HTTP request to the Kong node endpoint` /license/report`. For example, use this cURL command:
+{% navtabs %}
+{% navtab JSON response %}
 
-    ```
-    curl '<ADMIN_API_URL>/license/report'
-    ```
+For a JSON response, send an HTTP request to the Kong node endpoint
+`/license/report`. For example, use this cURL command:
 
-    A JSON response returns, similar to the example below.
+```bash
+curl {ADMIN_API_URL}/license/report
+```
 
-    ```
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Origin: http://localhost:8002
-    Connection: keep-alive
-    Content-Length: 262
-    Content-Type: application/json; charset=utf-8
-    Date: Wed, 19 Feb 2020 05:54:23 GMT
-    Server: kong/1.3-enterprise-edition
-    Vary: Origin
-    X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
-    {
-       "counters":{
-          "req_cnt":22
-       },
-       "db_version":"postgres 9.5.20",
-       "kong_version":"1.3-enterprise-edition",
-       "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
-       "rbac_users":0,
-       "services_count": 27,
-       "system_info":{
-          "cores":6,
-          "hostname":"264da9b95dfa",
-          "uname":"Linux x86_64"
-       },
-       "workspaces_count":1
-    }
-    ```
+A JSON response returns, similar to the example below:
 
-* For a TAR file, enter the following cURL command to make a call to Kong Admin API.
+```json
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:8002
+Connection: keep-alive
+Content-Length: 262
+Content-Type: application/json; charset=utf-8
+Date: Wed, 19 Feb 2020 05:54:23 GMT
+Server: kong/1.3-enterprise-edition
+Vary: Origin
+X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
 
-    ```
-    curl <ADMIN_API_URL>/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
-    ```
-    A license report file is generated and archives a report to *.tar file.
+{% endnavtab %}
+{% navtab TAR file %}
+
+For a TAR file, enter the following cURL command to make a call to the
+Kong Admin API:
+
+```bash
+curl {ADMIN_API_URL}/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
+```
+
+A license report file is generated and archived to a `*.tar` file.
+
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Report Structure
 
-<table>
-  <tr>
-   <td>Field
-   </td>
-   <td>Description
-   </td>
-  </tr>
-  <tr>
-   <td>kong_version
-   </td>
-   <td>Kong Enterprise version
-   </td>
-  </tr>
-  <tr>
-   <td>license_key
-   </td>
-   <td>Current license key identifier
-   </td>
-  </tr>
-  <tr>
-   <td>db_version
-   </td>
-   <td>Storage name and version of node/cluster
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.cores
-   </td>
-   <td>System CPU cores of node
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.hostname
-   </td>
-   <td>System hostname
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.uname
-   </td>
-   <td>System uname
-   </td>
-  </tr>
-  <tr>
-   <td>workspaces_count
-   </td>
-   <td>Number of workspaces
-   </td>
-  </tr>
-  <tr>
-   <td>rbac_users
-   </td>
-   <td>Number of RBAC users
-   </td>
-  </tr>
-  <tr>
-   <td>services_count
-   </td>
-   <td>Number of Kong Services
-   </td>
-  </tr>
-  <tr>
-   <td>counters.req_count
-   </td>
-   <td>Number of requests node/cluster processed
-   </td>
-  </tr>
-</table>
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.

--- a/app/gateway/2.6.x/admin-api/licenses/reference.md
+++ b/app/gateway/2.6.x/admin-api/licenses/reference.md
@@ -20,7 +20,7 @@ In hybrid mode deployments, the control plane sends licenses configured
 through the `/licenses` endpoint to all data planes in the cluster. The data
 planes use the most recent `updated_at` license.
 
-### List Licenses
+## List licenses
 **Endpoint**
 
 <div class="endpoint get">/licenses/</div>
@@ -55,7 +55,7 @@ be empty.
 }
 ```
 
-### Add License
+## Add license
 
 To create a license using an auto-generated UUID:
 
@@ -88,7 +88,7 @@ HTTP 201 Created
 }
 ```
 
-### Update or Add a License
+## Update or add a license
 
 **Endpoint**
 
@@ -125,7 +125,7 @@ HTTP 200 OK
 }
 ```
 
-### Update a License
+## Update a license
 
 **Endpoint**
 
@@ -161,7 +161,7 @@ HTTP 200 OK
 }
 ```
 
-### List a License
+## List a license
 
 **Endpoint**
 
@@ -184,7 +184,7 @@ HTTP 200 OK
 }
 ```
 
-### Delete a License
+## Delete a license
 
 **Endpoint**
 
@@ -196,6 +196,76 @@ HTTP 200 OK
 
 ```
 HTTP 204 No Content
+```
+
+## Generate a report
+
+Generate a report on the Kong Gateway instance to gather usage data.
+
+<div class="endpoint get">/license/report</div>
+
+Fields available in the report:
+
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
+
+If there are no licenses stored by {{site.base_gateway}}, the report will include
+`"license_key": "UNLICENSED"`:
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
 ```
 
 [Admin API]: /gateway/{{page.kong_version}}/admin-api/

--- a/app/gateway/2.6.x/plan-and-deploy/licenses/report.md
+++ b/app/gateway/2.6.x/plan-and-deploy/licenses/report.md
@@ -20,117 +20,71 @@ Run the license report module and share the output information with your Kong re
 
 To generate a license report, from an HTTP client:
 
-*   For a JSON response, send an HTTP request to the Kong node endpoint` /license/report`. For example, use this cURL command:
+{% navtabs %}
+{% navtab JSON response %}
 
-    ```
-    curl '<ADMIN_API_URL>/license/report'
-    ```
+For a JSON response, send an HTTP request to the Kong node endpoint
+`/license/report`. For example, use this cURL command:
 
-    A JSON response returns, similar to the example below.
+```bash
+curl {ADMIN_API_URL}/license/report
+```
 
-    ```
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Origin: http://localhost:8002
-    Connection: keep-alive
-    Content-Length: 262
-    Content-Type: application/json; charset=utf-8
-    Date: Wed, 19 Feb 2020 05:54:23 GMT
-    Server: kong/1.3-enterprise-edition
-    Vary: Origin
-    X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
-    {
-       "counters":{
-          "req_cnt":22
-       },
-       "db_version":"postgres 9.5.20",
-       "kong_version":"1.3-enterprise-edition",
-       "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
-       "rbac_users":0,
-       "services_count": 27,
-       "system_info":{
-          "cores":6,
-          "hostname":"264da9b95dfa",
-          "uname":"Linux x86_64"
-       },
-       "workspaces_count":1
-    }
-    ```
+A JSON response returns, similar to the example below:
 
-* For a TAR file, enter the following cURL command to make a call to Kong Admin API.
+```json
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:8002
+Connection: keep-alive
+Content-Length: 262
+Content-Type: application/json; charset=utf-8
+Date: Wed, 19 Feb 2020 05:54:23 GMT
+Server: kong/1.3-enterprise-edition
+Vary: Origin
+X-Kong-Admin-Request-ID: 6fmfr4Zl3RGmOs5oY0HvT47zt0oDq54o
+{
+   "counters":{
+      "req_cnt":22
+   },
+   "db_version":"postgres 9.5.20",
+   "kong_version":"1.3-enterprise-edition",
+   "license_key":"ASDASDASDASDASDASDASDASDASD_a1VASASD",
+   "rbac_users":0,
+   "services_count": 27,
+   "system_info":{
+      "cores":6,
+      "hostname":"264da9b95dfa",
+      "uname":"Linux x86_64"
+   },
+   "workspaces_count":1
+}
+```
 
-    ```
-    curl <ADMIN_API_URL>/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
-    ```
-    A license report file is generated and archives a report to *.tar file.
+{% endnavtab %}
+{% navtab TAR file %}
+
+For a TAR file, enter the following cURL command to make a call to the
+Kong Admin API:
+
+```bash
+curl {ADMIN_API_URL}/license/report -o response.json && tar -cf report-$(date +"%Y_%m_%d_%I_%M_%p").tar response.json
+```
+
+A license report file is generated and archived to a `*.tar` file.
+
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Report Structure
 
-<table>
-  <tr>
-   <td>Field
-   </td>
-   <td>Description
-   </td>
-  </tr>
-  <tr>
-   <td>kong_version
-   </td>
-   <td>{{site.base_gateway}} version
-   </td>
-  </tr>
-  <tr>
-   <td>license_key
-   </td>
-   <td>Current license key identifier
-   </td>
-  </tr>
-  <tr>
-   <td>db_version
-   </td>
-   <td>Storage name and version of node/cluster
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.cores
-   </td>
-   <td>System CPU cores of node
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.hostname
-   </td>
-   <td>System hostname
-   </td>
-  </tr>
-  <tr>
-   <td>system_info.uname
-   </td>
-   <td>System uname
-   </td>
-  </tr>
-  <tr>
-   <td>workspaces_count
-   </td>
-   <td>Number of workspaces
-   </td>
-  </tr>
-  <tr>
-   <td>rbac_users
-   </td>
-   <td>Number of RBAC users
-   </td>
-  </tr>
-  <tr>
-   <td>services_count
-   </td>
-   <td>Number of Kong Services
-   </td>
-  </tr>
-  <tr>
-   <td>counters.req_count
-   </td>
-   <td>Number of requests node/cluster processed
-   </td>
-  </tr>
-</table>
+Field | Description
+------|------------
+`counters.req_count` | Counts the number of requests made since the license creation date.
+`db_version` | The type and version of the datastore Kong Gateway is using.
+`kong_version` | The version of the Kong Gateway instance.
+`license_key` | An encrypted identifier for the current license key. If no license is present, the field displays as `UNLICENSED`.
+`rbac_users` | The number of users registered with through RBAC.
+`services_count` | The number of configured services in the Kong Gateway instance.
+`system_info` | Displays information about the system running Kong Gateway. <br><br> &#8226; `cores`: Number of CPU cores on the node <br> &#8226; `hostname`: Encrypted system hostname <br> &#8226; `uname`: Operating system
+`workspaces_count` | The number of workspaces configured in the Kong Gateway instance.


### PR DESCRIPTION
### Summary
Backporting improvements to the license docs and adding `/license/reports` to the Gateway admin API reference in v2.1-2.6.

Backporting through 2.1.x only, as we are going to be archiving all versions before that.

### Reason
In 2.7, we updated the Kong Gateway license doc to make it easier to follow and added the missing endpoint to 2.7 and onwards. Customers ran into this doc and tried to use it in 2.6, got a slightly different result, but had nothing to compare to and assumed the current doc was wrong. This happened because 2.6 didn't document the license info in the same way.

This came up in https://github.com/Kong/docs.konghq.com/pull/3745; see comments in the closed PR for background on how we discovered what was actually going on.

### Testing

To test, check the preview to make sure all the content appears where it needs to be. There is nothing new here for content; it's a backport of existing content from [2.7.x](https://deploy-preview-3870--kongdocs.netlify.app/gateway/2.7.x/plan-and-deploy/licenses/report/), with one edit: before 2.7.x, there were no request count buckets in the report. The rest of the info should match 2.7.x.

Monitor License Usage topic:
https://deploy-preview-3870--kongdocs.netlify.app/gateway/2.6.x/plan-and-deploy/licenses/report/
https://deploy-preview-3870--kongdocs.netlify.app/enterprise/2.5.x/deployment/licenses/report/ - goes back to 2.1.x

Admin API ref:
https://deploy-preview-3870--kongdocs.netlify.app/gateway/2.6.x/admin-api/licenses/reference/#generate-a-report 
https://deploy-preview-3870--kongdocs.netlify.app/enterprise/2.5.x/admin-api/licenses/reference/#generate-a-report - goes back to 2.3.x