### PR TITLE
Konnect: Deleting a runtime group

### DIFF
--- a/app/konnect/configure/runtime-manager/runtime-groups/manage.md
+++ b/app/konnect/configure/runtime-manager/runtime-groups/manage.md
@@ -48,7 +48,7 @@ You have the **Organization Admin** role in {{site.konnect_saas}}.
 
 1. Click the action menu icon on the far right of a row and select **Edit**.
 
-1. Edit the group details, then click **Update**.
+1. Edit the group details, then click **Update**. -->
 
 ## Delete a runtime group
 {:.badge .enterprise}
@@ -102,4 +102,4 @@ can use decK to accomplish this:
 
 1. Click the action menu icon on the far right of a row and select **Delete**.
 
-1. Enter the group name, then confirm that you want to delete it. -->
+1. Enter the group name, then confirm that you want to delete it.


### PR DESCRIPTION
### Summary
Uncommenting the runtime group deletion instructions, since it is now possible to delete one.

### Reason
You can now delete a runtime group in cloud.konghq.com.

<img width="1141" alt="Screen Shot 2022-04-21 at 11 48 04 AM" src="https://user-images.githubusercontent.com/54370747/164532191-075e07f2-c1b6-4708-b74f-3f23f8505f79.png">


### Testing
https://deploy-preview-3872--kongdocs.netlify.app/konnect/configure/runtime-manager/runtime-groups/manage/#delete-a-runtime-group.

I've tested backing up and deleting a runtime group locally.