### PR TITLE
Remove external link icon from insomnia run button

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -772,7 +772,7 @@
 
 // External icons in content body, excluding badges
 .content {
-  a:not(.badge, .install-link, .install-listing-link, .feature-cta):not([href^='https://docs.konghq.com']):not([href^='#']):not([href^='/']):not([data-filter]):after {
+  a:not(.badge, .install-link, .install-listing-link, .feature-cta):not([href^='https://docs.konghq.com']):not([href^='https://insomnia.rest/run']):not([href^='#']):not([href^='/']):not([data-filter]):after {
       font-family: 'FontAwesome';
       content: " \f35d";
       margin-left: 0.2rem;


### PR DESCRIPTION
### Summary
Adjusting external link icon so that it doesn't appear below the "Run in Insomnia" button:

<img width="169" alt="Screen Shot 2022-04-21 at 3 30 39 PM" src="https://user-images.githubusercontent.com/54370747/164562081-d01e885e-ef9f-4385-960e-2138037937b7.png">

This button shows up here: https://docs.konghq.com/konnect/reference/konnect-api/

@Guaris pinging you since you've likely already noticed this issue, since you're working on this topic.

### Testing
https://deploy-preview-3875--kongdocs.netlify.app/konnect/reference/konnect-api/