### PR TITLE
Update URL when using in-page navigation

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -22,6 +22,7 @@ jQuery(function () {
       },
       700
     );
+    history.pushState({}, '', $(this).attr("href"));
   });
 
   // Active link


### PR DESCRIPTION
### Summary
Update the address bar + add a history entry when using in-page navigation

### Reason
Fix the “click anchor link, highlight address bar, copy URL from there” muscle memory


### Testing
Try using any sidebar navigation in the review app

![image](https://user-images.githubusercontent.com/59130/165476692-010f49c4-bb66-4246-80c9-30d35c97a027.png)
