### PR TITLE
Fix proxy-cache config.memory.dictionary_name default value

### DIFF
--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_index.md
@@ -66,7 +66,7 @@ params:
 
 GraphQL Proxy Caching Advanced Plugin  is designed to support storing GraphQL proxy cache data in different backend formats.
 Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and
 elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the
 graphql-proxy-cache-advanced plugin, but it is not recommended for large-scale installations as significant usage will put pressure
 on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a

--- a/app/_hub/kong-inc/proxy-cache-advanced/0.4.x.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/0.4.x.md
@@ -85,7 +85,7 @@ params:
         The backing data store in which to hold cache entities. Accepted values are: `memory`, and `redis`.
     - name: memory.dictionary_name
       required:
-      default: kong_cache
+      default: kong_db_cache
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
@@ -164,7 +164,7 @@ params:
 ### Strategies
 
 `kong-plugin-enterprise-proxy-cache` is designed to support storing proxy cache data in different backend formats. Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache-advanced plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache-advanced plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
 - `redis`: Supports Redis and Redis Sentinel deployments.
 
 ### Cache Key

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -302,7 +302,7 @@ params:
 `kong-plugin-enterprise-proxy-cache` is designed to support storing proxy cache data in different backend formats.
 Currently, the following strategies are provided:
 
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also
 used by other plugins and elements of Kong to store unrelated database cache entities.
 Using this dictionary is an easy way to bootstrap the proxy-cache-advanced plugin, but it
 is not recommended for large-scale installations as significant usage will put pressure on

--- a/app/_hub/kong-inc/proxy-cache/0.31-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.31-x.md
@@ -71,7 +71,7 @@ params:
         The backing data store in which to hold cache entities
     - name: memory.dictionary_name
       required:
-      default: kong_cache
+      default: kong_db_cache
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
@@ -128,7 +128,7 @@ params:
 ### Strategies
 
 `kong-plugin-enterprise-proxy-cache` is designed to support storing proxy cache data in different backend formats. Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
 - `redis`: Supports Redis and Redis Sentinel deployments.
 
 ### Cache Key

--- a/app/_hub/kong-inc/proxy-cache/0.32-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.32-x.md
@@ -83,7 +83,7 @@ params:
         The backing data store in which to hold cache entities
     - name: memory.dictionary_name
       required:
-      default: kong_cache
+      default: kong_db_cache
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
@@ -140,7 +140,7 @@ params:
 ### Strategies
 
 `kong-plugin-enterprise-proxy-cache` is designed to support storing proxy cache data in different backend formats. Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
 - `redis`: Supports Redis and Redis Sentinel deployments.
 
 ### Cache Key

--- a/app/_hub/kong-inc/proxy-cache/0.33-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.33-x.md
@@ -83,7 +83,7 @@ params:
         The backing data store in which to hold cache entities
     - name: memory.dictionary_name
       required:
-      default: kong_cache
+      default: kong_db_cache
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
@@ -140,7 +140,7 @@ params:
 ### Strategies
 
 `kong-plugin-enterprise-proxy-cache` is designed to support storing proxy cache data in different backend formats. Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
 - `redis`: Supports Redis and Redis Sentinel deployments.
 
 ### Cache Key

--- a/app/_hub/kong-inc/proxy-cache/0.34-x.md
+++ b/app/_hub/kong-inc/proxy-cache/0.34-x.md
@@ -83,7 +83,7 @@ params:
         The backing data store in which to hold cache entities. Accepted values are; `memory`, and `redis`.
     - name: memory.dictionary_name
       required:
-      default: kong_cache
+      default: kong_db_cache
       value_in_examples:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
@@ -140,7 +140,7 @@ params:
 ### Strategies
 
 `kong-plugin-enterprise-proxy-cache` is designed to support storing proxy cache data in different backend formats. Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
 - `redis`: Supports Redis and Redis Sentinel deployments.
 
 ### Cache Key

--- a/app/_hub/kong-inc/proxy-cache/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/_index.md
@@ -114,7 +114,7 @@ params:
         The backing data store in which to hold cache entities. The only accepted value is `memory`.
     - name: memory.dictionary_name
       required: null
-      default: '`kong_cache`'
+      default: '`kong_db_cache`'
       value_in_examples: null
       datatype: string
       description: |
@@ -132,7 +132,7 @@ params:
 ### Strategies
 
 `kong-plugin-proxy-cache` is designed to support storing proxy cache data in different backend formats. Currently the following strategies are provided:
-- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
+- `memory`: A `lua_shared_dict`. Note that the default dictionary, `kong_db_cache`, is also used by other plugins and elements of Kong to store unrelated database cache entities. Using this dictionary is an easy way to bootstrap the proxy-cache plugin, but it is not recommended for large-scale installations as significant usage will put pressure on other facets of Kong's database caching operations. It is recommended to define a separate `lua_shared_dict` via a custom Nginx template at this time.
 
 ### Cache Key
 


### PR DESCRIPTION
### Summary
Both proxy-caching and proxy-caching-adv plugin say the default value of config.memory.dictionary_name is kong_cache. But it is not correct, please replace it with kong_db_cache in below URL

### Reason
DOCU-2286

### Testing
Review app