### PR TITLE
Don't check removed files for autogenerated content

### DIFF
--- a/check-generated-content/run.js
+++ b/check-generated-content/run.js
@@ -17,7 +17,7 @@ const argv = require("minimist")(process.argv.slice(2));
       ...github.context.repo,
       pull_number,
     },
-    (response) => response.data.filter((f) => f.filename.endsWith(".md"))
+    (response) => response.data.filter((f) => f.status != "removed" && f.filename.endsWith(".md") )
   );
 
   // Load contents for each file


### PR DESCRIPTION
### Summary
We were trying to check deleted files for autogenerated content, which failed when we couldn't read the file's frontmatter (as it was deleted)

### Reason
Fix the build!

### Testing
I've tested locally against #3890 and it's working as expected
