### PR TITLE
Update docs for latency to specify the unit

### DIFF
--- a/app/_hub/kong-inc/prometheus/_index.md
+++ b/app/_hub/kong-inc/prometheus/_index.md
@@ -61,7 +61,7 @@ dashboard: [https://grafana.com/dashboards/7424](https://grafana.com/dashboards/
 
 - **Status codes**: HTTP status codes returned by Upstream services.
   These are available per service, across all services, and per route per consumer.
-- **Latencies Histograms**: Latency as measured at Kong:
+- **Latencies Histograms**: Latency in ms, as measured at Kong:
    - **Request**: Total time taken by Kong and Upstream services to serve
      requests.
    - **Kong**: Time taken for Kong to route a request and run all configured
@@ -113,7 +113,7 @@ kong_http_consumer_status{service="s1",route="s1.route-1",code="200",consumer="<
 # HELP kong_http_status HTTP status codes per service/route in Kong
 # TYPE kong_http_status counter
 kong_http_status{code="301",service="google",route="google.route-1"} 2
-# HELP kong_latency Latency added by Kong, total request time and upstream latency for each service in Kong
+# HELP kong_latency Latency added by Kong in ms, total request time and upstream latency for each service in Kong
 # TYPE kong_latency histogram
 kong_latency_bucket{type="kong",service="google",route="google.route-1",le="00001.0"} 1
 kong_latency_bucket{type="kong",service="google",route="google.route-1",le="00002.0"} 1


### PR DESCRIPTION
### Summary
Update docs to highlight latency unit

### Reason
When working with the metrics there is no way to find out the latency unit.

### Testing
No testing is needed, please confirm the Latency shows up in milliseconds. 

Seems like Kong is using ngx variables to work with the latency.
```
latency = ctx.KONG_BALANCER_ENDED_AT - ngx.req.start_time() * 1000

function Kong.preread()
  local ctx = ngx.ctx
  if not ctx.KONG_PROCESSING_START then
    ctx.KONG_PROCESSING_START = start_time() * 1000
  end
```

Nginx resources for start_time 
- https://www.nginx.com/resources/wiki/modules/lua/#ngx-req-start-time
- https://github.com/openresty/lua-nginx-module#ngxreqstart_time  
- http://nginx.org/en/docs/http/ngx_http_log_module.html # search for $request_time

```
$request_time
    request processing time in seconds with a milliseconds resolution; time elapsed between the first bytes were read from the client and the log written after the last bytes were sent to the client 
```