### PR TITLE
[DOCU-2302] Clean out mentions of old BasePlugin module

### DIFF
--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -93,7 +93,7 @@ available when kong is initializing each worker.
 A plugin's `handler.lua` must return a table containing the functions it must
 execute on each phase.
 
-{{site.ce_product_name}} can process HTTP and stream traffic. Some phases are executed 
+{{site.ce_product_name}} can process HTTP and stream traffic. Some phases are executed
 only when processing HTTP traffic, others when processing stream,
 and some (like `init_worker` and `log`) are invoked by both kinds of traffic.
 
@@ -174,31 +174,6 @@ function CustomHandler.access(self, config)
 end
 ```
 
-### Migrating from BasePlugin module
-
-The `BasePlugin` module is deprecated and will be removed in a future version
-of {{site.ce_product_name}}.  If you have an old plugin that uses it, replace
-the initial part:
-
-```lua
---  DEPRECATED --
-local BasePlugin = require "kong.plugins.base_plugin"
-local CustomHandler = BasePlugin:extend()
-CustomHandler.VERSION  = "1.0.0"
-CustomHandler.PRIORITY = 10
-```
-
-with the current equivalent:
-```lua
-local CustomHandler = {
-  VERSION  = "1.0.0",
-  PRIORITY = 10,
-}
-```
-
-You don't need to add a `:new()` method or call any of the `CustomHandler.super.XXX:(self)`
-methods.
-
 The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
 It can be be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
@@ -239,6 +214,31 @@ end
 
 See [the source code of the Key-Auth Plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/handler.lua)
 for an example of a real-life handler code.
+
+### Migrating from BasePlugin module
+
+The `BasePlugin` module is deprecated and has been removed from
+{{site.base_gateway}}. If you have an old plugin that uses this module, replace
+the following section:
+
+```lua
+--  DEPRECATED --
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+CustomHandler.VERSION  = "1.0.0"
+CustomHandler.PRIORITY = 10
+```
+
+with the current equivalent:
+```lua
+local CustomHandler = {
+  VERSION  = "1.0.0",
+  PRIORITY = 10,
+}
+```
+
+You don't need to add a `:new()` method or call any of the `CustomHandler.super.XXX:(self)`
+methods.
 
 
 ## Plugin Development Kit

--- a/src/gateway/plugin-development/entities-cache.md
+++ b/src/gateway/plugin-development/entities-cache.md
@@ -70,16 +70,18 @@ Function name                                 | Description
 `cache:invalidate(key)`                       | Evicts a value from the node's cache **and** propagates the eviction events to all other nodes in the cluster.
 `cache:purge()`                               | Evicts **all** values from the node's cache.
 
-Bringing back our authentication plugin example, to lookup a credential with a
-specific api-key, we would write something similar to:
+Bringing back our authentication plugin example, to look up a credential with a
+specific API key, we would write something similar to:
 
 ```lua
 -- handler.lua
-local BasePlugin = require "kong.plugins.base_plugin"
 
+local CustomHandler = {
+  VERSION  = "1.0.0",
+  PRIORITY = 10,
+}
 
 local kong = kong
-
 
 local function load_credential(key)
   local credential, err = kong.db.keyauth_credentials:select_by_key(key)
@@ -90,20 +92,7 @@ local function load_credential(key)
 end
 
 
-local CustomHandler = BasePlugin:extend()
-
-
-CustomHandler.VERSION  = "1.0.0"
-CustomHandler.PRIORITY = 1010
-
-
-function CustomHandler:new()
-  CustomHandler.super.new(self, "my-custom-plugin")
-end
-
-
 function CustomHandler:access(config)
-  CustomHandler.super.access(self)
 
   -- retrieve the apikey from the request querystring
   local key = kong.request.get_query_arg("apikey")

--- a/src/gateway/plugin-development/plugin-configuration.md
+++ b/src/gateway/plugin-development/plugin-configuration.md
@@ -262,26 +262,15 @@ enabled the plugin with the default values, you'd have access to:
 
 ```lua
 -- handler.lua
-local BasePlugin = require "kong.plugins.base_plugin"
 
+local CustomHandler = {
+  VERSION  = "1.0.0",
+  PRIORITY = 10,
+}
 
 local kong = kong
 
-
-local CustomHandler = BasePlugin:extend()
-
-
-CustomHandler.VERSION  = "1.0.0"
-CustomHandler.PRIORITY = 10
-
-
-function CustomHandler:new()
-  CustomHandler.super.new(self, "my-custom-plugin")
-end
-
-
 function CustomHandler:access(config)
-  CustomHandler.super.access(self)
 
   kong.log.inspect(config.key_names)        -- { "apikey" }
   kong.log.inspect(config.hide_credentials) -- false
@@ -366,25 +355,15 @@ And the following will be available in
 
 ```lua
 -- handler.lua
-local BasePlugin = require "kong.plugins.base_plugin"
 
+local CustomHandler = {
+  VERSION  = "1.0.0",
+  PRIORITY = 10,
+}
 
 local kong = kong
 
-
-local CustomHandler = BasePlugin:extend()
-
-
-CustomHandler.VERSION  = "1.0.0"
-CustomHandler.PRIORITY = 10
-
-
-function CustomHandler:new()
-  CustomHandler.super.new(self, "my-custom-plugin")
-end
-
 function CustomHandler:access(config)
-  CustomHandler.super.access(self)
 
   kong.log.inspect(config.environment) -- "development"
   kong.log.inspect(config.server.host) -- "http://localhost"


### PR DESCRIPTION
### Summary
Based on the migration instructions in the custom logic topic, cleaned out the BasePlugin module from examples and removed deprecated methods.

Also moved the "migrating from BasePlugin" section a bit further down; the old location made it look like the rest of the text below it was part of the migration, but it is not (see https://github.com/Kong/docs.konghq.com/pull/3400/files for reference). 

### Reason
BasePlugin is deprecated and slated to be removed in 3.0.

### Testing
https://deploy-preview-3903--kongdocs.netlify.app/gateway/latest/plugin-development/custom-logic/#migrating-from-baseplugin-module
https://deploy-preview-3903--kongdocs.netlify.app/gateway/latest/plugin-development/entities-cache/
https://deploy-preview-3903--kongdocs.netlify.app/gateway/latest/plugin-development/plugin-configuration/