### PR TITLE
Move mode badges to the beginning of list items

### DIFF
--- a/app/gateway/2.8.x/index.md
+++ b/app/gateway/2.8.x/index.md
@@ -50,13 +50,13 @@ with Kong's [Admin API](#kong-admin-api) or with [declarative configuration](#de
 **Kong Gateway** (available in
 [Free, Plus, or Enterprise modes](https://konghq.com/pricing)): Kong's API gateway
 with added functionality.
-* In **Free mode** <span class="badge free"></span>,
+* <span class="badge free"></span> In **Free mode**,
   this package adds [Kong Manager](#kong-manager) to the basic open-source functionality.
-* In **Plus mode** <span class="badge plus"></span>, you have access to more
+* <span class="badge plus"></span> In **Plus mode**, you have access to more
 {{site.base_gateway}} features, but only through {{site.konnect_saas}}.
 See the [{{site.konnect_saas}} documentation](/konnect/) and the
 **Plus**-labelled plugins on the [Plugin Hub](/hub/) for more information.
-* With an **Enterprise** subscription <span class="badge enterprise"></span>,
+* <span class="badge enterprise"></span> With an **Enterprise** subscription,
   it also includes:
     * [Dev Portal](#kong-dev-portal)
     * [Vitals](#kong-vitals)


### PR DESCRIPTION
### Summary
This bulleted list explains modes and subscriptions. Since the badges for these get introduced here, it might look cleaner to put them at the beginning of the list items rather than weaving them into the sentence structure.

### Reason
Just exploring your docs and GitHub workflow. 

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
