### PR TITLE
Fix badge for new site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Netlify Status]([![Netlify Status](https://api.netlify.com/api/v1/badges/a4e2b987-f4f2-4512-a8fa-fd954a0126f8/deploy-status)](https://app.netlify.com/sites/kongdocs/deploys))](https://app.netlify.com/sites/kongdocs/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/a4e2b987-f4f2-4512-a8fa-fd954a0126f8/deploy-status)](https://app.netlify.com/sites/kongdocs/deploys)
 [![](https://img.shields.io/github/license/kong/docs.konghq.com)](https://github.com/Kong/docs.konghq.com/blob/main/LICENSE)
 [![](https://img.shields.io/github/contributors/kong/docs.konghq.com)]()
 


### PR DESCRIPTION
### Summary
Fix the netlify status badge.

### Reason
We switched sites and there's a new link the badge now. Also, I broke it with an accidental previous commit.

### Testing
Check the file in the branch: https://github.com/Kong/docs.konghq.com/blob/netlify-badge/README.md