### PR TITLE
[DOCU-2273] Troubleshoot runtime instances

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -94,6 +94,8 @@
               url: /configure/runtime-manager/runtime-instances/renew-certificates
             - text: Runtime Parameter Reference
               url: /configure/runtime-manager/runtime-instances/runtime-parameter-reference
+            - text: Troubleshoot Runtime Instance Issues
+              url: /configure/runtime-manager/runtime-instances/troubleshoot
 
 - title: Publish
   icon: /assets/images/icons/konnect/icn-dev-portal-nav.svg

--- a/app/konnect/configure/runtime-manager/runtime-instances/troubleshoot.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/troubleshoot.md
@@ -42,11 +42,11 @@ the version may be out of date.
 
 Verify that your instance versions are up to date:
 
-1. Open {% konnect_icon runtimes %} **Runtimes**, then open your runtime group.
+1. Open {% konnect_icon runtimes %} **Runtime Manager**, then open your runtime group.
 
-1. Click **+ Create new runtime**, switch to a Linux or Kubernetes tab, and
-    check the version in the codeblock. This is the version that the
-    {{site.konnect_short_name}} control plane is running.
+1. Click **+ Add runtime instance** and check the {{site.base_gateway}} version
+in the codeblock. This is the version that the {{site.konnect_short_name}} 
+control plane is running.
 
 1. Return to the runtime instances page.
 

--- a/app/konnect/configure/runtime-manager/runtime-instances/troubleshoot.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/troubleshoot.md
@@ -1,0 +1,56 @@
+---
+title: Troubleshoot Runtime Instances
+no_version: true
+---
+
+## Out of sync runtime instance
+
+Occasionally, a {{site.base_gateway}} runtime instance might get out of sync
+with the {{site.konnect_short_name}} control plane. If this happens, you would
+see the status `Out of sync` on the Runtime Instances page, meaning the control
+plane can't communicate with the instance.
+
+Troubleshoot the issue using the following steps:
+
+1. Ensure the runtime instance is running. If it's not running, start it; if it
+is running, restart it.
+
+    Check the sync status in the Runtime Manager.
+
+1. Check the logs of the runtime that's appearing as `Out of sync`.
+{{site.base_gateway}} logs can be found at `<kong-prefix-directory>/logs`,
+where the default directory is `/usr/local/kong/logs`.
+
+    If you find either of the following:
+
+    * There is a connection error, where the instance failed to connect to the
+    control plane.
+    * Sending a ping to the control plane failed, or
+    the runtime instance failed to receive a ping response from the control plane.
+
+    Diagnose the host network where the instance resides.
+
+    If you find a network issue and resolve it, restart the instance and check
+    the sync status in the Runtime Manager.
+
+1. If the logs show a license issue, contact [Kong Support](https://support.konghq.com/).
+
+## Missing functionality
+
+If you are trying to use a setting or feature in {{site.konnect_short_name}}
+and it isn't working on your runtime instance, check the runtime instance
+version. It may be out of date and doesn't support the new setting.
+
+1. Check the version of {{site.base_gateway}} that the Konnect control plane is
+currently running.
+
+    1. Open {% konnect_icon runtimes %} **Runtimes**, then open your runtime group.
+    1. Click **+ Create new runtime**, switch to a Linux or Kubernetes tab, and
+    check the version in the codeblock.
+
+1. Return to the runtime instances page.
+
+1. Check the runtime instance versions in the table. If you see
+an instance running an older version of {{site.base_gateway}}, your runtime
+instance may need
+[upgrading](/konnect/configure/runtime-manager/runtime-instances/upgrade).

--- a/app/konnect/configure/runtime-manager/runtime-instances/troubleshoot.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/troubleshoot.md
@@ -6,51 +6,53 @@ no_version: true
 ## Out of sync runtime instance
 
 Occasionally, a {{site.base_gateway}} runtime instance might get out of sync
-with the {{site.konnect_short_name}} control plane. If this happens, you would
+with the {{site.konnect_short_name}} control plane. If this happens, you will
 see the status `Out of sync` on the Runtime Instances page, meaning the control
 plane can't communicate with the instance.
 
-Troubleshoot the issue using the following steps:
+Troubleshoot the issue using the following methods:
 
-1. Ensure the runtime instance is running. If it's not running, start it; if it
+* Ensure the runtime instance is running. If it's not running, start it; if it
 is running, restart it.
 
     Check the sync status in the Runtime Manager.
 
-1. Check the logs of the runtime that's appearing as `Out of sync`.
-{{site.base_gateway}} logs can be found at `<kong-prefix-directory>/logs`,
-where the default directory is `/usr/local/kong/logs`.
+* Check the logs of the runtime that's appearing as `Out of sync`. The default
+directory for {{site.base_gateway}} logs is [`/usr/local/kong/logs`](/gateway/latest/reference/configuration/#log_level).
 
-    If you find either of the following:
+    If you find any of the following errors:
 
-    * There is a connection error, where the instance failed to connect to the
-    control plane.
-    * Sending a ping to the control plane failed, or
-    the runtime instance failed to receive a ping response from the control plane.
+    * Runtime instance failed to connect to the control plane.
+    * Runtime instance failed to ping the control plane.
+    * Runtime instance failed to receive a ping response from the control plane.
 
-    Diagnose the host network where the instance resides.
-
-    If you find a network issue and resolve it, restart the instance and check
+    You may have an issue on the host network where the instance resides.
+    Diagnose and resolve the issue, then restart the instance and check
     the sync status in the Runtime Manager.
 
-1. If the logs show a license issue, contact [Kong Support](https://support.konghq.com/).
+* If the logs show a license issue, contact [Kong Support](https://support.konghq.com/).
+
+If you are unable to resolve sync issues using the above methods, contact
+[Kong Support](https://support.konghq.com/).
 
 ## Missing functionality
 
-If you are trying to use a setting or feature in {{site.konnect_short_name}}
-and it isn't working on your runtime instance, check the runtime instance
-version. It may be out of date and doesn't support the new setting.
+If a {{site.konnect_short_name}} feature isn’t working on your runtime instance,
+the version may be out of date.
 
-1. Check the version of {{site.base_gateway}} that the Konnect control plane is
-currently running.
+Verify that your instance versions are up to date:
 
-    1. Open {% konnect_icon runtimes %} **Runtimes**, then open your runtime group.
-    1. Click **+ Create new runtime**, switch to a Linux or Kubernetes tab, and
-    check the version in the codeblock.
+1. Open {% konnect_icon runtimes %} **Runtimes**, then open your runtime group.
+
+1. Click **+ Create new runtime**, switch to a Linux or Kubernetes tab, and
+    check the version in the codeblock. This is the version that the
+    {{site.konnect_short_name}} control plane is running.
 
 1. Return to the runtime instances page.
 
 1. Check the runtime instance versions in the table. If you see
 an instance running an older version of {{site.base_gateway}}, your runtime
-instance may need
-[upgrading](/konnect/configure/runtime-manager/runtime-instances/upgrade).
+instance may need [upgrading](/konnect/configure/runtime-manager/runtime-instances/upgrade).
+
+If your version is up to date but the feature still isn't working, contact
+[Kong Support](https://support.konghq.com/).

--- a/app/konnect/deployment/license-management.md
+++ b/app/konnect/deployment/license-management.md
@@ -4,11 +4,12 @@ no_version: true
 ---
 
 When you create a {{site.konnect_saas}} account, a license is
-automatically provisioned to the Cloud service. You do not need to manage this
+automatically provisioned to the organization. You do not need to manage this
 license manually.
 
 Any runtimes configured through the [Runtime Manager](/konnect/configure/runtime-manager)
 also implicitly receive the same license from {{site.konnect_saas}}
-control plane.
+control plane. You should never have to deal with a license
+directly.
 
 For any license questions, contact your sales representative.


### PR DESCRIPTION
### Summary
* New topic for troubleshooting runtime instances in Konnect
* Some minor phrasing updates for the license topic

Info for out-of-sync runtime instances gathered from engineering; info for version compat gathered from personal testing.

Note: The process for finding a currently compatible gateway is janky and unreliable, so I've raised that issue with Ross and Hayden. Nothing else to do for this doc with that, but they're going to brainstorm a way to expose the information in the UI.

### Reason
https://konghq.atlassian.net/browse/DOCU-2273

### Testing
https://deploy-preview-3914--kongdocs.netlify.app/konnect/configure/runtime-manager/runtime-instances/troubleshoot/