### PR TITLE
Seo sitemap fixes

### DIFF
--- a/app/_plugins/generators/canonical_url_generator.rb
+++ b/app/_plugins/generators/canonical_url_generator.rb
@@ -40,7 +40,7 @@ module CanonicalUrl
         unless versioned_product?(url_segments[0])
           all_pages[page.url] = {
             'url' => page.url,
-            'sitemap' => page.data['seo_noindex'] ? false : true
+            'page' => page
           }
           next
         end
@@ -84,7 +84,7 @@ module CanonicalUrl
         all_pages[url] = {
           'version' => version,
           'url' => page.url,
-          'sitemap' => page.data['seo_noindex'] ? false : true
+          'page' => page
         }
       end
 
@@ -170,7 +170,7 @@ module CanonicalUrl
 
       # Remove any pages that should not be in the sitemap
       pages = pages.values.filter do |v|
-        next false unless v['sitemap']
+        next false if v['page'].data['seo_noindex']
         next false if blocked_from_sitemap.any? { |blocked| v['url'] == blocked }
 
         true
@@ -195,7 +195,7 @@ module CanonicalUrl
           page.data['canonical_url'] = page.url
           all_pages[page.url] = {
             'url' => page.url,
-            'sitemap' => true
+            'page' => page
           }
           next
         end
@@ -205,7 +205,7 @@ module CanonicalUrl
           url = page.url.gsub('/index', '/')
           all_pages[url] = {
             'url' => url,
-            'sitemap' => true
+            'page' => page
           }
           page.data['canonical_url'] = url
         else

--- a/app/_plugins/generators/canonical_url_generator.rb
+++ b/app/_plugins/generators/canonical_url_generator.rb
@@ -171,6 +171,7 @@ module CanonicalUrl
       # Remove any pages that should not be in the sitemap
       pages = pages.values.filter do |v|
         next false if v['page'].data['seo_noindex']
+        next false if v['page'].data['redirect_to'] # Legacy HTML based redirects from jekyll-redirect-from
         next false if blocked_from_sitemap.any? { |blocked| v['url'] == blocked }
 
         true

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -140,7 +140,7 @@ test.describe("unversioned content", () => {
   });
 });
 
-test.describe("sitemap", () => {
+test.describe("sitemap includes", () => {
   [
     "/konnect/",
     "/konnect-platform/",
@@ -161,6 +161,22 @@ test.describe("sitemap", () => {
       await page.goto("/sitemap.xml");
       const html = await page.content();
       await expect(html).toContain(`<loc>https://docs.konghq.com${t}</loc>`);
+    });
+  });
+});
+
+
+test.describe("sitemap does not include", () => {
+  [
+    "/gateway/2.6.x/configure/auth/kong-manager/oidc/",
+    "/mesh/1.6.x/",
+    "/mesh/1.1.x/overview/",
+    "/konnect-platform/compatibility/",
+  ].forEach((t) => {
+    test(t, async ({ page }) => {
+      await page.goto("/sitemap.xml");
+      const html = await page.content();
+      await expect(html).not.toContain(`<loc>https://docs.konghq.com${t}</loc>`);
     });
   });
 });


### PR DESCRIPTION
### Summary
Remove URLs that were unexpectedly present in the sitemap.xml file despite having `noindex` set

### Reason
Google's getting confused about whether it should index the pages we list (we shouldn't)

### Testing

The following URLs show up in https://docs.konghq.com/sitemap.xml but not the preview sitemap

* https://docs.konghq.com/gateway/2.6.x/configure/auth/kong-manager/oidc/
* https://docs.konghq.com/mesh/1.6.x/
* https://docs.konghq.com/mesh/1.1.x/overview/