### PR TITLE
Konnect compatibility badges and filter

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -687,4 +687,6 @@ jQuery(function () {
       .append( '<div class="tooltip"><span class="tooltiptext" >Available in Kong open-source only</span></div>' );
     $('.badge.dbless')
       .append( '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>' );
+    $('.badge.konnect')
+      .append( '<div class="tooltip"><span class="tooltiptext">Available in the Konnect Cloud app</span></div>' );
 });

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -102,7 +102,7 @@
       z-index: 10;
     }
 
-    &:hover {
+    &:hover, &:focus {
        .tooltiptext {
         display: block;
       }
@@ -119,7 +119,7 @@ h2.badge, h3.badge, h4.badge, h5.badge {
       margin-left: 7px;
     }
 
-  &:hover {
+  &:hover, &:focus {
     .tooltiptext {
       left: 7px;
     }
@@ -132,7 +132,7 @@ h1.badge {
       margin-left: 7px;
     }
 
-  &:hover {
+  &:hover, &:focus {
     .tooltiptext {
       right: 0;
       top: 0;
@@ -141,7 +141,7 @@ h1.badge {
 }
 
 h2.badge {
-  &:hover {
+  &:hover, &:focus {
     .tooltiptext {
       top: 3px;
     }
@@ -149,7 +149,7 @@ h2.badge {
 }
 
 h3.badge {
-  &:hover {
+  &:hover, &:focus {
     .tooltiptext {
       top: 4px;
     }
@@ -157,7 +157,7 @@ h3.badge {
 }
 
 h4.badge, h5.badge {
-  &:hover {
+  &:hover, &:focus {
     .tooltiptext {
       top: 5px;
     }
@@ -175,7 +175,7 @@ a.badge {
 
 .badge-container {
     a > .tooltip > .tooltiptext {
-      margin-top: 6px;
+      margin-top: 0.5em;
   }
 }
 
@@ -184,7 +184,7 @@ a.badge {
 table > tbody > tr {
   &:last-of-type {
     .badge {
-      &:hover {
+      &:hover, &:focus {
         .tooltiptext {
           left: 100%;
           bottom: 105%;

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -22,6 +22,14 @@
       background-color: @blue-500;
 
     }
+
+  &.konnect::after {
+      content: "KONNECT COMPATIBLE";
+      color: black;
+      border-color: @blue-200;
+      background-color: @blue-200;
+    }
+
   &.enterprise::after {
       content: "ENTERPRISE";
       color: white;
@@ -157,12 +165,17 @@ h4.badge, h5.badge {
 }
 
 a.badge {
-  display: inline-flex;
-  margin-top: 3px;
+  margin-top: 6px;
 
   &:hover, &:focus {
-    opacity: 0.9;
+    opacity: 0.8;
     text-decoration: none;
+  }
+}
+
+.badge-container {
+    a > .tooltip > .tooltiptext {
+      margin-top: 6px;
   }
 }
 
@@ -181,14 +194,3 @@ table > tbody > tr {
       }
     }
   }
-
-// Tooltips in the plugin hub doc sidebar
-.about-extn-table {
-  .badge {
-    &:hover {
-      .tooltiptext {
-        left: -50px;
-      }
-    }
-  }
-}

--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -397,9 +397,9 @@ ul.navbar-item-submenu {
 
   .page-header-icon {
     width: 64px;
-    vertical-align: middle;
     display: inline-block;
-    margin: 0 15px 2px 0;
+    vertical-align: top;
+    margin: 8px 15px 2px 0;
 
     img {
       max-width: 100%;

--- a/app/_hub/index.html
+++ b/app/_hub/index.html
@@ -44,6 +44,11 @@ body_id: page-hub
               </a>
             </li>
             <li class="nav-item">
+              <a class="nav-link" data-filter="konnect-cloud" role="menuitem" tabindex="0">
+                Konnect
+              </a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link" data-filter="pub-not-konghq" role="menuitem" tabindex="0">
                 Third-Party
               </a>

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -29,8 +29,9 @@
         {% endif %}
 
         <h1 id="main" tabindex="-1">{{ header_title }}</h1>
-        <div class="license-tier">
+        <div class="badge-container">
         {% if include.publisher == "Kong Inc." %}
+           {% unless include.cloud == false %}<a href="https://konnect.konghq.com" class="badge konnect" aria-label="compatible with Konnect"></a>{% endunless %}
            {% if include.plus %} <a href="https://konghq.com/pricing" class="badge plus" aria-label="available with plus subscription"></a>{% endif %}
            {% if include.enterprise %}<a href="https://konghq.com/pricing" class="badge enterprise" aria-label="available with enterprise subscription"></a>{% endif %}
            {% if include.oss %}<a href="https://konghq.com/pricing" class="badge oss" aria-label="open-source only"></a>{% endif %}

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -16,6 +16,7 @@
           unless extn.cloud == false %}plus {% endunless %}{% endif %}{%
             if extn.enterprise %}enterprise {%
               else %}open-source {% endif %}{%
+                unless extn.cloud == false %} konnect-cloud{% endunless %}{%
                 else %}pub-not-konghq pub-{{extn_publisher}}{% endif %}">
     <div class="plugin-card">
       <a href="{{ extn.url | remove: 'index.html' }}" title="{{ extn.name }}: {{ extn.desc }}">

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -31,7 +31,7 @@ id: documentation
           </p>
           <p id="oss-ee-toggle" data-current="Enterprise" style="display: none">
             <span class="oss-ee-toggle-inner">
-            <img src="/assets/images/icons/icn-enterprise-black.svg" alt="enterprise-switcher-icon"/>Switch to <span id="switch-to-version">OSS</span></a>
+            <img src="/assets/images/icons/icn-enterprise-black.svg" alt="enterprise-switcher-icon"/>Switch to <span id="switch-to-version">OSS</span>
             </span>
           </p>
         </div>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -138,11 +138,11 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
 
 <div class="page page-extension-profile">
   {% if page.header_icon or page.header_title %}
-    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon plus=page.plus enterprise=page.enterprise publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
+    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% elsif page.type == concept %}
-    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon plus=page.plus enterprise=page.enterprise publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
+    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% else %}
-    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon plus=page.plus enterprise=page.enterprise publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
+    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% endif %}
 
   <div class="container">


### PR DESCRIPTION
### Summary
Further improvements to plugin hub badges.
* "Konnect compatible" badge to make the info more prominent
* Filter for Konnect on the plugin hub landing page
* Fix a bunch of alignment issues for badges that were making pages jumpy on load
* Fixed badge tab-ability, you can use your keyboard to move through them now

### Reason
In the previous round of reviews, Hayden asked for the Konnect compatibility information to be easily visible when you first load a page, as it's currently hard to see. As well, we were asked for a Konnect filter on the Plugin Hub landing page.

### Testing
Check the "Konnect" filter on the Hub landing page: https://deploy-preview-3934--kongdocs.netlify.app/hub/

Check badges on a few plugins:
* [All three badges](https://deploy-preview-3934--kongdocs.netlify.app/hub/kong-inc/opa/)
* [Only the Konnect-compatible badge](https://deploy-preview-3934--kongdocs.netlify.app/hub/kong-inc/bot-detection/)
* [Third-party plugin, no badge](https://deploy-preview-3934--kongdocs.netlify.app/hub/cleafy/cleafy/)
* [Not compatible - no Konnect badge](https://deploy-preview-3934--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/ )

For page load jumpiness, compare a live doc page vs a preview and see how the header does or doesn't move around:
[Live doc](https://docs.konghq.com/hub/kong-inc/opa/) vs [fixed doc](https://deploy-preview-3934--kongdocs.netlify.app/hub/kong-inc/opa/)