### PR TITLE
Add Contact Sales to Enterprise tooltip

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -678,7 +678,7 @@ $("a[data-filter]").on("keypress", function(e) {
 // Tooltips for badges
 jQuery(function () {
     $('.badge.enterprise')
-      .append( '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription</span></div>' );
+      .append( '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription - <a target="_blank" style="color:white;" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>' );
     $('.badge.plus')
       .append( '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Konnect Cloud)</span></div>' );
     $('.badge.free')


### PR DESCRIPTION
### Summary
Adds a "Contact Sales" link to the Enterprise tooltip

Old:
![image](https://user-images.githubusercontent.com/59130/168276514-a84e6861-dfe4-41bd-aab6-33caf64467b3.png)


New:
![image](https://user-images.githubusercontent.com/59130/168276501-42dc6ab5-2de0-4b6a-aa73-79e9cec1ce36.png)


### Reason
Aghi requested 

### Testing
Hover over any enterprise badge on the site