### PR TITLE
Update decK version to 1.12.1

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -426,7 +426,7 @@
   edition: "deck"
 -
   release: "1.12.x"
-  version: "1.12.0"
+  version: "1.12.1"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Summary
Update the version that appears in install docs.

### Reason
https://github.com/Kong/deck/releases/tag/v1.12.1

### Testing
Check version in installation doc: https://deploy-preview-3936--kongdocs.netlify.app/deck/latest/installation/