### PR TITLE
[ENGEN-450] chore(debian) add version 8 "jessie" deprecation notice

### DIFF
--- a/app/_includes/md/deb.md
+++ b/app/_includes/md/deb.md
@@ -15,7 +15,9 @@ You can install Kong by downloading an installation package or using our apt rep
 
     {% if include.distribution == "debian" %}
 
+    {% if_version lte:2.8.x %}
 - [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
+    {% endif_version %}
 - [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
 - [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
 - [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
@@ -37,7 +39,7 @@ $ sudo dpkg -i kong.{{site.data.kong_latest.version}}.amd64.deb
 To install from the command line
 
 ```bash
-$ echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-{{ include.distribution }}-$(lsb_release -sc)/ default all" | sudo tee /etc/apt/sources.list.d/kong.list 
+$ echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-{{ include.distribution }}-$(lsb_release -sc)/ default all" | sudo tee /etc/apt/sources.list.d/kong.list
 $ sudo apt-get update
 $ sudo apt install -y kong
 ```

--- a/src/gateway/install-and-run/debian.md
+++ b/src/gateway/install-and-run/debian.md
@@ -5,7 +5,6 @@ title: Install Kong Gateway on Debian
 > Download the latest {{page.kong_version}} package for Debian:
 >
 > * **Kong Gateway**:
-> [**8 Jessie**]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
 > [**9 Stretch**]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
 > [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
 > or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link}
@@ -18,7 +17,6 @@ title: Install Kong Gateway on Debian
 >
 > <br>
 > <span class="install-subtitle">View the list of all 2.x packages for
-> [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/){:.install-listing-link},
 > [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/){:.install-listing-link},
 > [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/){:.install-listing-link}, or
 > [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}
@@ -28,6 +26,10 @@ The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 {{site.ce_product_name}} is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
+
+## Deprecation Notices
+
+* Debian 8 ("Jessie") is EOL and containers based-on, packages targetting, and packages tested on it *will not be produced* for Kong Gateway _3.0 and later_.
 
 ## Prerequisites
 

--- a/src/gateway/install-and-run/upgrade-enterprise.md
+++ b/src/gateway/install-and-run/upgrade-enterprise.md
@@ -13,6 +13,10 @@ to {{site.ee_product_name}}. See
 If you experience any issues when running migrations, contact
 [Kong Support](https://support.konghq.com/support/s/) for assistance.
 
+## Deprecation Notices
+
+* Debian 8 ("Jessie") is EOL and containers based-on, packages targetting, and packages tested on it *will not be produced* for Kong Gateway _3.0 and later_.
+
 ## Upgrade path for Kong Gateway releases
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a

--- a/src/gateway/install-and-run/upgrade-oss.md
+++ b/src/gateway/install-and-run/upgrade-oss.md
@@ -39,6 +39,10 @@ starts new workers, which take over from old workers before those old workers
 are terminated. In this way, Kong will serve new requests via the new
 configuration, without dropping existing in-flight connections.
 
+## Deprecation Notices
+
+* Debian 8 ("Jessie") is EOL and containers based-on, packages targetting, and packages tested on it *will not be produced* for Kong Gateway _3.0 and later_.
+
 ## Upgrade to 2.8.x
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -2345,7 +2345,7 @@ Supported preset rules:
 - `min_20`: minimum length of 20
 
 To write your own rules, see
-https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.
+https://manpages.debian.org/stretch/passwdqc/passwdqc.conf.5.en.html.
 
 NOTE: Only keywords "min", "max" and "passphrase" are supported.
 
@@ -2961,7 +2961,7 @@ Supported preset rules:
 - `min_20`: minimum length of 20
 
 To write your own rules, see
-https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.
+https://manpages.debian.org/stretch/passwdqc/passwdqc.conf.5.en.html.
 
 NOTE: Only keywords "min", "max" and "passphrase" are supported.
 


### PR DESCRIPTION
### Summary
This is the docs analogue to https://github.com/Kong/kong/pull/8807

Changes to the platforms being tagetted by our build/test/release infrastructure are considered a breaking change, so deprecating Debian 8 "Jessie" has been slated for Kong Gateway 3.0-- *thus this PR targets the `release/gateway-3.0` branch*.

### Reason
See also:
  - https://konghq.atlassian.net/browse/ENGEN-450
  - https://github.com/Kong/kong/pull/8807
  - https://github.com/Kong/kong-distributions/pull/766
  - https://github.com/Kong/kong-build-tools/pull/448

> July 9th, 2020
> The Debian Long Term Support (LTS) Team hereby announces that Debian 8 jessie support has reached its end-of-life on June 30, 2020, five years after its initial release on April 26, 2015.

~https://www.debian.org/News/2020/20200709