### PR TITLE
[ENGEN-450] Chore(debian 8): add deprecations of Debian 8 "Jessie"

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -38,6 +38,7 @@ jobs:
         id: waitForNetlify
         with:
           site_name: "kongdocs"
+          max_timeout: 120
       - name: Run link checker
         run: |
           cd broken-link-checker

--- a/app/_includes/md/deb.md
+++ b/app/_includes/md/deb.md
@@ -15,7 +15,9 @@ You can install Kong by downloading an installation package or using our apt rep
 
     {% if include.distribution == "debian" %}
 
+    {% if_version lte:2.8.x %}
 - [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
+    {% endif_version %}
 - [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
 - [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
 - [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
@@ -37,7 +39,7 @@ $ sudo dpkg -i kong.{{site.data.kong_latest.version}}.amd64.deb
 To install from the command line
 
 ```bash
-$ echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-{{ include.distribution }}-$(lsb_release -sc)/ default all" | sudo tee /etc/apt/sources.list.d/kong.list 
+$ echo "deb [trusted=yes] {{ site.links.download }}/gateway-2.x-{{ include.distribution }}-$(lsb_release -sc)/ default all" | sudo tee /etc/apt/sources.list.d/kong.list
 $ sudo apt-get update
 $ sudo apt install -y kong
 ```

--- a/src/gateway/install-and-run/debian.md
+++ b/src/gateway/install-and-run/debian.md
@@ -1,11 +1,21 @@
 ---
 title: Install Kong Gateway on Debian
 ---
+
+{:.important}
+> **Deprecation notice**: Support for running Kong Gateway on
+Debian 8 ("Jessie") is now deprecated, as [Debian 8 ("Jessie") has reached End of Life (EOL)](https://www.debian.org/News/2020/20200709).
+Starting with Kong Gateway 3.0.0.0, Kong is neither building new Debian 8 ("Jessie") images nor packages. Nor will Kong test package installation on Debian 8 ("Jessie").
+> If you need to install Kong Gateway on Debian 8 ("Jessie"), see the documentation for
+[previous versions](/gateway/2.8.x/install-and-run/debian/).
+> <br><br>
+> Kong Gateway Enterprise subscriptions can still use Debian 8 ("Jessie") in 2.8, but support
+for Debian 8 ("Jessie") is planned to be removed in 3.0.
+
 {:.install-banner}
 > Download the latest {{page.kong_version}} package for Debian:
 >
 > * **Kong Gateway**:
-> [**8 Jessie**]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
 > [**9 Stretch**]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
 > [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
 > or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link}
@@ -18,7 +28,6 @@ title: Install Kong Gateway on Debian
 >
 > <br>
 > <span class="install-subtitle">View the list of all 2.x packages for
-> [8 Jessie]({{ site.links.download }}/gateway-2.x-debian-jessie/pool/all/k/){:.install-listing-link},
 > [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/){:.install-listing-link},
 > [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/){:.install-listing-link}, or
 > [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}


### PR DESCRIPTION
### Summary
This is the docs analogue to https://github.com/Kong/kong/pull/8807

Changes to the platforms being tagetted by our build/test/release infrastructure are considered a breaking change, so deprecating Debian 8 "Jessie" has been slated for Kong Gateway 3.0-- *thus this PR targets the `release/gateway-3.0` branch*.

### Reason
See also:
  - https://konghq.atlassian.net/browse/ENGEN-450
  - https://github.com/Kong/kong/pull/8807
  - https://github.com/Kong/kong-distributions/pull/766
  - https://github.com/Kong/kong-build-tools/pull/448

> July 9th, 2020
> The Debian Long Term Support (LTS) Team hereby announces that Debian 8 jessie support has reached its end-of-life on June 30, 2020, five years after its initial release on April 26, 2015.

~https://www.debian.org/News/2020/20200709