### PR TITLE
Open badge links in new tab/page

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -678,7 +678,7 @@ $("a[data-filter]").on("keypress", function(e) {
 // Tooltips for badges
 jQuery(function () {
     $('.badge.enterprise')
-      .append( '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription - <a target="_blank" style="color:white;" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>' );
+      .append( '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription - <a target="_blank" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>' );
     $('.badge.plus')
       .append( '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Konnect Cloud)</span></div>' );
     $('.badge.free')

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -100,6 +100,10 @@
       border-radius: 4px;
       position: absolute;
       z-index: 10;
+
+      a {
+        color: white;
+      }
     }
 
     &:hover, &:focus {

--- a/app/_assets/stylesheets/base.less
+++ b/app/_assets/stylesheets/base.less
@@ -231,22 +231,6 @@ h1, h2, h3, h4, h5, h6, .page-header-section-title {
   color: #262e33;
 }
 
-/* Fix for anchor link h tags being hidden by nav */
-.page-content {
-  h1, h2, h3, h4, h5, h6, .page-header-section-title, a[name] {
-    @media (min-width: @navbar-collapse-point) {
-      &::before {
-        display: block;
-        content: " ";
-        margin-top: -@nav-header-height - 5;
-        height: @nav-header-height + 5;
-        visibility: hidden;
-        pointer-events: none;
-      }
-    }
-  }
-}
-
 h1, .page-header-section-title {
   font-size: 4rem;
   font-weight: 500;

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -31,10 +31,10 @@
         <h1 id="main" tabindex="-1">{{ header_title }}</h1>
         <div class="badge-container">
         {% if include.publisher == "Kong Inc." %}
-           {% unless include.cloud == false %}<a href="https://konnect.konghq.com" class="badge konnect" aria-label="compatible with Konnect"></a>{% endunless %}
-           {% if include.plus %} <a href="https://konghq.com/pricing" class="badge plus" aria-label="available with plus subscription"></a>{% endif %}
-           {% if include.enterprise %}<a href="https://konghq.com/pricing" class="badge enterprise" aria-label="available with enterprise subscription"></a>{% endif %}
-           {% if include.oss %}<a href="https://konghq.com/pricing" class="badge oss" aria-label="open-source only"></a>{% endif %}
+           {% unless include.cloud == false %}<a href="https://konnect.konghq.com" target="_blank" class="badge konnect" aria-label="compatible with Konnect"></a>{% endunless %}
+           {% if include.plus %} <a href="https://konghq.com/pricing" target="_blank" class="badge plus" aria-label="available with plus subscription"></a>{% endif %}
+           {% if include.enterprise %}<a href="https://konghq.com/pricing" target="_blank" class="badge enterprise" aria-label="available with enterprise subscription"></a>{% endif %}
+           {% if include.oss %}<a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source only"></a>{% endif %}
         {% endif %}
         </div>
       </div>

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -91,7 +91,7 @@ id: documentation
             <h1 tabindex="-1" id="main" class="page-content-title"
             >{{page.title | flatify }}
             {% if page.badge %}
-              <a href="https://konghq.com/pricing" {%
+              <a href="https://konghq.com/pricing" target="_blank" {%
                 if page.badge == 'plus' %}class="badge plus" aria-label="available with plus subscription"{% endif %}{%
                 if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with enterprise subscription"{% endif %}{%
                 if page.badge == 'free' %}class="badge free" aria-label="available in Kong Gateway free mode"{% endif %}{%

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -565,6 +565,7 @@ Badge | HTML tag | Markdown tag
 <span class="badge beta"></span> | `<span class="badge beta"></span>` | `{:.badge .beta}`
 <span class="badge alpha"></span> | `<span class="badge alpha"></span>` | `{:.badge .alpha}`
 <span class="badge oss"></span> | `<span class="badge oss"></span>` | `{:.badge .oss}`
+<span class="badge konnect"></span> | `<span class="badge konnect"></span>` | `{:.badge .konnect}`
 
 For example, you can use the Markdown tag on headers:
 


### PR DESCRIPTION
### Summary
* Setting `target=_blank` on badges to open links in a new page.
* Fixing header margin issue
* Adding badge to style guide
* Minor consistency edit for keeping style definitions in our `.less` files and not in having it directly in an HTML tag

### Reason
* Badge link targeting issue was reported by Rick.
* Have been running into a weird margin issue on headers, turned out it was due to a hacky workaround to have clickable anchor links. The workaround is no longer necessary, since the issue has long been fixed, and all we had left was this weird margin.

### Testing
https://deploy-preview-3949--kongdocs.netlify.app/hub/kong-inc/mocking/ - click on badges, links should open in new tab/window.
https://deploy-preview-3949--kongdocs.netlify.app/contributing/markdown-rules/#badges style guide entry