### PR TITLE
[DOCU-2225] Teams and roles cleanup

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -157,13 +157,15 @@
     - text: Authentication and Authorization
       url: /org-management/auth
       items:
-        - text: Manage Teams and Roles
+        - text: Teams and Roles
           url: /org-management/teams-and-roles
           items:
+            - text: Manage Teams and Roles
+              url: /org-management/teams-and-roles/manage
             - text: Teams Reference
-              url: /org-management/teams-reference
+              url: /org-management/teams-and-roles/teams-reference
             - text: Roles Reference
-              url: /org-management/roles-reference
+              url: /org-management/teams-and-roles/roles-reference
         - text: Manage Users
           url: /org-management/users
         - text: Set up SSO with Okta

--- a/app/konnect/account-management/billing.md
+++ b/app/konnect/account-management/billing.md
@@ -1,6 +1,7 @@
 ---
 title: Manage Payment Methods and Invoices
 no_version: true
+content_type: how-to
 ---
 
 Access the billing portal from the {{site.konnect_saas}}

--- a/app/konnect/account-management/billing.md
+++ b/app/konnect/account-management/billing.md
@@ -9,9 +9,6 @@ Access the billing portal from the {{site.konnect_saas}}
 From the billing portal, you can manage credit cards associated with the account,
 view and pay an invoice, and check the payment history of the account.
 
-## Prerequisites
-You have organization admin access.
-
 ## Modify a payment method
 
 1. From the **Billing and Usage** page, click **Go to billing portal**.

--- a/app/konnect/account-management/change-plan.md
+++ b/app/konnect/account-management/change-plan.md
@@ -13,9 +13,6 @@ Use the [Billing and Usage](/konnect/account-management) page in {{site.konnect_
 change your plan. The **Plan Details** section lists your current plan, along
 with options to change or cancel it.
 
-## Prerequisites
-You have organization admin access.
-
 ## Upgrade a plan
 
 ### Upgrade from Free to Plus
@@ -55,7 +52,7 @@ There is no self-serve upgrade option for Enterprise plans.
 2. Click **Confirm Downgrade** to save and return to the **Billing and Usage**
 overview.
 
-    With a downgrade, your monthly charges are prorated and you are billed 
+    With a downgrade, your monthly charges are prorated and you are billed
     on your actual usage.
 
     Your plan should now display as Konnect Free.

--- a/app/konnect/account-management/change-plan.md
+++ b/app/konnect/account-management/change-plan.md
@@ -1,6 +1,7 @@
 ---
 title: Change to a Different Plan
 no_version: true
+content_type: how-to
 ---
 
 You can change a Free or Plus subscription at any time from {{site.konnect_saas}}.

--- a/app/konnect/account-management/index.md
+++ b/app/konnect/account-management/index.md
@@ -1,6 +1,7 @@
 ---
 title: Konnect Plans, Billing, and Usage
 no_version: true
+content_type: how-to
 ---
 
 {{site.konnect_product_name}} has [three plans](/konnect-platform/plans) to

--- a/app/konnect/account-management/index.md
+++ b/app/konnect/account-management/index.md
@@ -16,9 +16,6 @@ settings page, and manage your Konnect Free or Plus plan from this page.
 There is no self-serve option for managing Enterprise plans.
 Contact your sales representative to make any changes.
 
-### Prerequisites
-You have organization admin access.
-
 ### Manage and view plan billing and usage
 
 1. From the {{site.konnect_short_name}} menu, click

--- a/app/konnect/configure/runtime-manager/runtime-groups/declarative-config.md
+++ b/app/konnect/configure/runtime-manager/runtime-groups/declarative-config.md
@@ -1,6 +1,7 @@
 ---
 title: Manage Runtime Groups with decK
 no_version: true
+content_type: how-to
 ---
 
 You can manage runtime groups in your {{site.konnect_saas}} org using configuration

--- a/app/konnect/configure/runtime-manager/runtime-groups/declarative-config.md
+++ b/app/konnect/configure/runtime-manager/runtime-groups/declarative-config.md
@@ -31,7 +31,6 @@ registration, or configure custom plugins.
 
 ## Prerequisites
 
-* [**Organization Admin**](/konnect/org-management/teams-and-roles) permissions.
 * decK v1.12.0 or later [installed](/deck/latest/installation/).
 * Optional: To test your configuration, [set up a simple runtime](/konnect/getting-started/configure-runtime).
 

--- a/app/konnect/configure/runtime-manager/runtime-groups/manage.md
+++ b/app/konnect/configure/runtime-manager/runtime-groups/manage.md
@@ -1,6 +1,7 @@
 ---
 title: Manage Runtime Groups
 no_version: true
+content_type: how-to
 ---
 
 Create, update, and delete runtime groups through the

--- a/app/konnect/configure/runtime-manager/runtime-groups/manage.md
+++ b/app/konnect/configure/runtime-manager/runtime-groups/manage.md
@@ -15,9 +15,6 @@ From a runtime group details page, you can
 and configure any [global entities](/konnect/configure/runtime-manager/runtime-groups/manage-entities)
 in the group.
 
-## Prerequisites
-You have the **Organization Admin** role in {{site.konnect_saas}}.
-
 ## Create a runtime group
 {:.badge .enterprise}
 

--- a/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-conf.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-conf.md
@@ -12,11 +12,6 @@ instances associated with the {{site.konnect_saas}} account.
 > **Note:** Kong does not host runtimes. You must install and host your own
 runtime instances.
 
-## Prerequisites
-
-* You have **Runtime Admin** or **Organization Admin** permissions in
-{{site.konnect_saas}}.
-
 ## Generate certificates
 
 {% include /md/konnect/runtime-certs.md %}

--- a/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-conf.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-conf.md
@@ -1,6 +1,7 @@
 ---
 title: Set up a Kong Gateway Runtime on Linux
 no_version: true
+content_type: how-to
 ---
 Using `kong.conf`, set up a runtime instance through the
 [{{site.konnect_short_name}} Runtime Manager](/konnect/configure/runtime-manager) and

--- a/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-docker.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-docker.md
@@ -21,14 +21,13 @@ runtime instances.
 
 ### Prerequisites
 
-* You have **Runtime Admin** or **Organization Admin** permissions in
-{{site.konnect_saas}}.
-* The quick setup script requires Docker and a Unix shell (for example, bash or
-  zshell). Platform-specific tools and permissions:
-  * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
-  * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/). If you can't set up a WSL 2 backend, see the [advanced](#advanced-setup) instructions for
-  a custom Docker setup instead.
+The quick setup script requires Docker and a Unix shell (for example, bash or
+zshell). Platform-specific tools and permissions:
+
+* **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
+* **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
+* **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/). If you can't set up a WSL 2 backend, see the [advanced](#advanced-setup) instructions for
+a custom Docker setup instead.
 
 ### Run the quick setup script
 

--- a/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-docker.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-docker.md
@@ -1,6 +1,7 @@
 ---
 title: Set up a Kong Gateway Runtime with Docker
 no_version: true
+content_type: how-to
 ---
 Set up a Docker runtime instance through the
 [{{site.konnect_short_name}} Runtime Manager](/konnect/configure/runtime-manager) and
@@ -21,13 +22,13 @@ runtime instances.
 
 ### Prerequisites
 
-The quick setup script requires Docker and a Unix shell (for example, bash or
-zshell). Platform-specific tools and permissions:
-
-* **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
-* **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-* **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/). If you can't set up a WSL 2 backend, see the [advanced](#advanced-setup) instructions for
-a custom Docker setup instead.
+* The quick setup script requires Docker and a Unix shell (for example, bash or
+zshell).
+* Platform-specific tools and permissions:
+  * **All platforms:** [Docker](https://docs.docker.com/get-docker/) and [jq](https://stedolan.github.io/jq/) installed
+  * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
+  * **Windows:** Docker Desktop [installed](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [integrated with a WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/). If you can't set up a WSL 2 backend, see the [advanced](#advanced-setup) instructions for
+  a custom Docker setup instead.
 
 ### Run the quick setup script
 
@@ -55,12 +56,10 @@ see a new entry for your instance.
 
 ### Prerequisites
 
-* You have **Runtime Admin** or **Organization Admin** permissions in
-{{site.konnect_saas}}.
-* Tools and permissions:
-  * **All platforms:** [Docker](https://docs.docker.com/get-docker/) installed
-  * **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
-  * **[Windows](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [MacOS](https://docs.docker.com/docker-for-mac/install/):** Docker Desktop installed
+Tools and permissions:
+* **All platforms:** [Docker](https://docs.docker.com/get-docker/) installed
+* **Linux:** User added to the [`docker` group](https://docs.docker.com/engine/install/linux-postinstall/)
+* **[Windows](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-on-windows) and [MacOS](https://docs.docker.com/docker-for-mac/install/):** Docker Desktop installed
 
 ### Generate certificates
 {% include /md/konnect/runtime-certs.md %}

--- a/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
@@ -14,7 +14,6 @@ runtime instances.
 
 ## Prerequisites
 
-* You have **Runtime Admin** or **Organization Admin** permissions in {{site.konnect_saas}}.
 * **Kubernetes cluster with load balancer:** {{site.konnect_short_name}} is
 compatible with all distributions of Kubernetes. You can use a Minikube, GKE,
 or OpenShift TLS.

--- a/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
+++ b/app/konnect/configure/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
@@ -1,6 +1,7 @@
 ---
 title: Set up a Kong Gateway Runtime on Kubernetes
 no_version: true
+content_type: how-to
 ---
 Set up a Kubernetes runtime instance through the
 [{{site.konnect_short_name}} Runtime Manager](/konnect/configure/runtime-manager) and

--- a/app/konnect/configure/servicehub/manage-services.md
+++ b/app/konnect/configure/servicehub/manage-services.md
@@ -39,7 +39,7 @@ Access all Konnect Service configuration through the {% konnect_icon servicehub 
 element to reveal a text box, enter the new text, then click outside of the text
 box to save.
 
-### Share a Service
+<!-- ### Share a Service
 
 If you have a Service Admin or Organization Admin role, you can share any
 Service that you have access to.
@@ -54,7 +54,7 @@ For more information, see [Manage Teams, Roles, and Users](/konnect/org-manageme
 
 1. Select a role to grant to the user or team.
 
-1. Click **Share service** to save.
+1. Click **Share service** to save. -->
 
 ### Delete a Service
 

--- a/app/konnect/deployment/import.md
+++ b/app/konnect/deployment/import.md
@@ -1,6 +1,7 @@
 ---
 title: Import Kong Gateway Entities into Konnect Cloud
 no_version: true
+content_type: how-to
 ---
 
 If you are an existing {{site.base_gateway}} user looking to use {{site.konnect_short_name}}

--- a/app/konnect/deployment/import.md
+++ b/app/konnect/deployment/import.md
@@ -18,7 +18,6 @@ You cannot import [unsupported plugins](/konnect/configure/servicehub/plugins/#p
 
 ## Prerequisites
 * {{site.konnect_saas}} [account credentials](/konnect/getting-started/access-account/).
-* [**Organization Admin**](/konnect/org-management/teams-and-roles) permissions.
 * decK v1.12 or later [installed](/deck/latest/installation/).
 
 ## Import entity configuration

--- a/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
+++ b/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
@@ -8,8 +8,6 @@ need to manually approve Developer and Application requests. You can enable auto
 
 If auto approve is not enabled for Developers or Applications, admins will need to approve new Developers and Applications manually. For more information on manual approval, see [Manage Developer Access](/konnect/dev-portal/access-and-approval/manage-devs/) and [Manage Application Registration Requests](/konnect/dev-portal/applications/manage-app-reg-requests/). 
 
-Only an **Organization Admin** or **Portal Admin** can change these settings.
-
 {:.note}
 > If auto approve is enabled through the Portal for Applications, it overrides the Service setting.
 

--- a/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
+++ b/app/konnect/dev-portal/access-and-approval/auto-approve-devs-apps.md
@@ -1,12 +1,13 @@
 ---
 title: Auto Approve Developer and Application Registrations
 no_version: true
+content_type: how-to
 ---
 
 When auto approval is enabled, {{site.konnect_short_name}} admins don't
 need to manually approve Developer and Application requests. You can enable automatic approval from the Dev Portal settings.
 
-If auto approve is not enabled for Developers or Applications, admins will need to approve new Developers and Applications manually. For more information on manual approval, see [Manage Developer Access](/konnect/dev-portal/access-and-approval/manage-devs/) and [Manage Application Registration Requests](/konnect/dev-portal/applications/manage-app-reg-requests/). 
+If auto approve is not enabled for Developers or Applications, admins will need to approve new Developers and Applications manually. For more information on manual approval, see [Manage Developer Access](/konnect/dev-portal/access-and-approval/manage-devs/) and [Manage Application Registration Requests](/konnect/dev-portal/applications/manage-app-reg-requests/).
 
 {:.note}
 > If auto approve is enabled through the Portal for Applications, it overrides the Service setting.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -17,9 +17,6 @@ This guide walks you through the two supported authentication plugins:
 
 ## Prerequisites
 
-- [**Organization Admin** or **Service Admin**](/konnect/org-management/teams-and-roles)
-permissions.
-
 - The Services have been created, versioned, and published to the
   {{site.konnect_short_name}} Dev Portal so that they appear in the catalog.
 
@@ -40,12 +37,12 @@ permissions.
 ## Enable app registration with key authentication {#konnect-key-auth-flow}
 
 1. From the {{site.konnect_short_name}} menu, click {% konnect_icon servicehub %} **Service Hub** and select a
-Service. Now, click the **Versions** button and select the desired version. 
+Service. Now, click the **Versions** button and select the desired version.
 
 2. Click **Version actions** > **Enable app registration**.
 
 3. Select `key-auth` from the **Auth Type** list.
-  Optionally, click to enable [**Auto Approve**](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps/) for application 
+  Optionally, click to enable [**Auto Approve**](/konnect/dev-portal/access-and-approval/auto-approve-devs-apps/) for application
   registrations for the selected Service.
 
 4. Click **Enable**.
@@ -56,7 +53,7 @@ Service. Now, click the **Versions** button and select the desired version.
 ## Enable App Registration with OpenID Connect {#oidc-flow}
 
 1. From the {{site.konnect_short_name}} menu, click {% konnect_icon servicehub %} **Service Hub** and select a
-Service. Now, click the **Versions** button and select the desired version. 
+Service. Now, click the **Versions** button and select the desired version.
 
 2. Click **Version actions** > **Enable app registration**.
 
@@ -102,6 +99,6 @@ at any time.
 
 1. From the **Service** menu, select **Version** to display all of the registered versions.
 
-1. Click the Version you intend to disable. 
+1. Click the Version you intend to disable.
 
 1. Click **Version actions** > **Disable app registration**.

--- a/app/konnect/dev-portal/customization/index.md
+++ b/app/konnect/dev-portal/customization/index.md
@@ -3,12 +3,12 @@ title: Customize the Konnect Dev Portal
 no_version: true
 ---
 
-The {{site.konnect_short_name}} Dev Portal currently offers three areas you can customize: 
+The {{site.konnect_short_name}} Dev Portal currently offers three areas you can customize:
 * [Appearance](#appearance)
 * [Custom URL](#add-a-custom-dev-portal-domain)
 * [Enabling Public Access](/konnect/dev-portal/publish/#access)
 
-This doc covers the details of customizing the appearance of your Developer Portal, and the steps to customize a URL. 
+This doc covers the details of customizing the appearance of your Developer Portal, and the steps to customize a URL.
 
 ## Appearance
 
@@ -29,17 +29,16 @@ For details on the requirements for each customizable option, hover over the inf
 
 ## Custom Developer Portal URL
 
-All Dev Portals have an auto-generated default Dev Portal URL. You can add a custom domain. When set up properly, users can access the Dev Portal from both the default URL and the custom URL. The {{site.konnect_short_name}} Kong Developer Portal generates an SSL certificate for your custom domain automatically. 
+All Dev Portals have an auto-generated default Dev Portal URL. You can add a custom domain. When set up properly, users can access the Dev Portal from both the default URL and the custom URL. The {{site.konnect_short_name}} Kong Developer Portal generates an SSL certificate for your custom domain automatically.
 
 ### Prerequisites
 
-* You have the **Organization Admin** or **Portal Admin** role in {{site.konnect_saas}}.
 * A domain and access to configure domain's CNAME
 * Your organization's auto-generated default Dev Portal URL. For example, `https://kong121212.portal.konnect.konghq.com/`.
 
 ### Direct your CNAME to the default Dev Portal URL
 
-From your domain registrar's DNS records settings options, point your CNAME to your Dev Portal's default URL. 
+From your domain registrar's DNS records settings options, point your CNAME to your Dev Portal's default URL.
 
 
 ## Add a custom Dev Portal domain
@@ -52,7 +51,7 @@ Add a custom Dev Portal domain through your organization's {{site.konnect_short_
 
 3. Enter the full domain, including subdomain (if applicable). Don't include a path. It's not necessary to include the URL protocol, for example, `https://` into the **Custom Portal URL** field.
 
-4. Test to see if your custom URL works. You'll see the custom URL listed in your Dev Portal under your default Dev Portal URL. Your SSL certificate will be generated automatically. 
+4. Test to see if your custom URL works. You'll see the custom URL listed in your Dev Portal under your default Dev Portal URL. Your SSL certificate will be generated automatically.
 
    {:.note}
-   > **Note:** DNS propagation can take a few hours. If after a few hours you can't access the Dev Portal from the custom URL, contact your domain registrar. 
+   > **Note:** DNS propagation can take a few hours. If after a few hours you can't access the Dev Portal from the custom URL, contact your domain registrar.

--- a/app/konnect/dev-portal/customization/index.md
+++ b/app/konnect/dev-portal/customization/index.md
@@ -1,6 +1,7 @@
 ---
 title: Customize the Konnect Dev Portal
 no_version: true
+content_type: how-to
 ---
 
 The {{site.konnect_short_name}} Dev Portal currently offers three areas you can customize:

--- a/app/konnect/org-management/auth.md
+++ b/app/konnect/org-management/auth.md
@@ -1,6 +1,7 @@
 ---
 title: Authentication and Authorization
 no_version: true
+content_type: explanation
 ---
 
 Secure your {{site.konnect_saas}} organization by setting up teams and roles,
@@ -13,12 +14,12 @@ provider.
 The default authentication option in {{site.konnect_saas}} is basic
 authentication. You don't have to do anything special to set it up.
 
-* Manage resource access in your organization
- with [teams and roles](/konnect/org-management/teams-and-roles)
+* Learn about [teams and roles](/konnect/org-management/teams-and-roles) in {{site.konnect_short_name}}
+* [Manage teams and roles](/konnect/org-management/teams-and-roles/manage)
 * [Invite users](/konnect/org-management/users) to join your
 organization
-* [Teams reference](/konnect/org-management/teams-reference)
-* [Roles reference](/konnect/org-management/roles-reference)
+* [Teams reference](/konnect/org-management/teams-and-roles/teams-reference)
+* [Roles reference](/konnect/org-management/teams-and-roles/roles-reference)
 
 ## External authentication
 {:.badge .enterprise}

--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -220,7 +220,7 @@ in Okta, locate the Okta groups you want to map.
     For example, if you have a `service_admin` group in Okta, you might map it
     to the `Service Admin` team in {{site.konnect_short_name}}. You can hover
     over the info (`i`) icon beside each field to learn more about the team, or
-    see the [teams reference](/konnect/org-management/teams-reference)
+    see the [teams reference](/konnect/org-management/teams-and-roles/teams-reference)
     for more information.
 
     You must have at least one group mapped to save configuration changes.

--- a/app/konnect/org-management/teams-and-roles.md
+++ b/app/konnect/org-management/teams-and-roles.md
@@ -24,15 +24,13 @@ automatically-created users, adjust user permissions through Okta, or
 [adjust team mapping](/konnect/org-management/okta-idp/#map-teams-to-groups).
 
 
-## Prerequisites
-
-You must be part of the **Organization Admin** team to manage users, teams, and
-roles.
-
 ## Manage teams and roles
 
 You can find a list of all teams in your organization through
 {% konnect_icon organizations %} **Organization** > **Teams** in Konnect.
+
+You must be part of the **Organization Admin** team to manage users, teams, and
+roles.
 
 * **Team:** A group of users with access to the same roles. Teams are useful
 for assigning access by functionality, as they can provide granular access to

--- a/app/konnect/org-management/teams-and-roles/index.md
+++ b/app/konnect/org-management/teams-and-roles/index.md
@@ -50,7 +50,7 @@ If two roles provide access to the same entity, the role with more access
 takes effect. For example, if you have the Service Admin and Service Deployer
 roles on the same Service, the Service Admin role takes precedence.
 
-### Entity and role sharing
+<!-- ### Entity and role sharing
 
 An Organization Admin can share any role or entity with any user in the
 organization.
@@ -67,7 +67,7 @@ level of access: creator, deployer, viewer, etc.
 You can [share any Service](/konnect/configure/servicehub/manage-services/#share-service)
 through the Service Hub, or
 [share any runtime group](/konnect/configure/runtime-manager/runtime-groups/manage/#share-runtime-group)
-through the Runtime Manager.
+through the Runtime Manager. -->
 
 ## Get started with access management
 

--- a/app/konnect/org-management/teams-and-roles/index.md
+++ b/app/konnect/org-management/teams-and-roles/index.md
@@ -1,6 +1,7 @@
 ---
-title: Manage Teams and Roles
+title: Teams and Roles
 no_version: true
+content_type: explanation
 ---
 
 Many organizations have strict security requirements. For example, organizations
@@ -13,18 +14,7 @@ predefined teams for a standard set of roles, or create custom teams with
 any roles you choose. Invite users and add them to these teams to manage user
 access.
 
-To invite users to your organization, see [Manage Users](/konnect/org-management/users).
-
-{:.note}
-> **Note:** If Okta integration is [enabled](/konnect/org-management/okta-idp),
-{{site.konnect_short_name}} users and teams become read-only. An organization
-admin can view all registered users in {{site.konnect_short_name}}, but cannot
-edit their team membership from the {{site.konnect_short_name}} side. To manage
-automatically-created users, adjust user permissions through Okta, or
-[adjust team mapping](/konnect/org-management/okta-idp/#map-teams-to-groups).
-
-
-## Manage teams and roles
+## Teams and roles
 
 You can find a list of all teams in your organization through
 {% konnect_icon organizations %} **Organization** > **Teams** in Konnect.
@@ -41,10 +31,10 @@ runtime groups and Services can be shared with teams.
 instances of a resource type (for example, a particular Service or all Services).
 
 When you create a Konnect account, you are automatically added to the Organization
-Admin team, which is one of the [predefined teams](/konnect/org-management/teams-reference)
+Admin team, which is one of the [predefined teams](/konnect/org-management/teams-and-roles/teams-reference)
 in Konnect. Predefined teams have sets of roles that can't be modified or
 deleted. You can add users to these teams, or create your own custom teams
-with any of the [supported roles](/konnect/org-management/roles-reference).
+with any of the [supported roles](/konnect/org-management/teams-and-roles/roles-reference).
 
 All users can view all teams and members of each team, but they can't view the
 team roles.
@@ -79,66 +69,11 @@ through the Service Hub, or
 [share any runtime group](/konnect/configure/runtime-manager/runtime-groups/manage/#share-runtime-group)
 through the Runtime Manager.
 
-### Create a team
+## Get started with access management
 
-1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
- **Organization** link.
-2. Click **+ New Team**.
-3. Enter a team name and description. Both fields are required.
-4. Click **Save**.
-
-By default, your new team has no roles applied. Customize the roles through the team's
-configuration page.
-
-### Edit roles for a team
-
-You can edit the roles for any custom team. Any changes made to a team's roles
-are automatically applied to all team members.
-
-1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
- **Organization** link.
-2. Choose a team from the list.
-
-    Teams with the `Predefined` label can't be edited or deleted.
-
-3. Choose an entity tab, then click **+ Add role(s)**.
-
-4. Enter the UUID of the element you want to assign, or enter `*` to target
-all entities of the selected type.
-
-5. Select one or more roles from the list.
-
-    Hover over the `i` icon next to the role to see its description,
-    or see the [roles reference](/konnect/org-management/roles-reference).
-
-6. Click **Save**.
-
-
-### Add or remove team members
-
-Edit team membership for any team, custom or predefined.
-
-1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
- **Organization** link.
-2. Choose a team from the list.
-3. On the **Members** tab, click **+ New Member**.
-4. Select a user in the organization and click **Save**.
-
-The user gains all roles attributed to the team.
-
-### Delete a team
-
-Deleting a team completely removes it and its configuration from
-{{site.konnect_short_name}}. If the team has any team members, they will be
-unassigned from the team.
-
-{:.warning}
-> **Warning:** Deleting a team is irreversible.
-
-1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
- **Organization** link.
-
-1. Choose a team from the list, open the action menu on the right of the row,
-and click **Delete**.
-
-1. Confirm deletion in the dialog.
+* Manage resource access in your organization
+ with [teams and roles](/konnect/org-management/teams-and-roles/manage)
+* [Invite users](/konnect/org-management/users) to join your
+organization
+* [View the teams reference](/konnect/org-management/teams-and-roles/teams-reference)
+* [View the roles reference](/konnect/org-management/teams-and-roles/roles-reference)

--- a/app/konnect/org-management/teams-and-roles/manage.md
+++ b/app/konnect/org-management/teams-and-roles/manage.md
@@ -1,0 +1,86 @@
+---
+title: Manage Teams and Roles
+no_version: true
+content_type: how-to
+---
+
+Manage access to your {{site.konnect_short_name}} organization and its
+resources using teams and roles.
+
+{:.note}
+> **Note:** If Okta integration is [enabled](/konnect/org-management/okta-idp),
+{{site.konnect_short_name}} users and teams become read-only. An organization
+admin can view all registered users in {{site.konnect_short_name}}, but cannot
+edit their team membership from the {{site.konnect_short_name}} side. To manage
+automatically-created users, adjust user permissions through Okta, or
+[adjust team mapping](/konnect/org-management/okta-idp/#map-teams-to-groups).
+
+### Create a team
+
+1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
+ **Organization** link.
+2. Click **+ New Team**.
+3. Enter a team name and description. Both fields are required.
+4. Click **Save**.
+
+By default, your new team has no roles applied. Customize the roles through the team's
+configuration page.
+
+### Edit roles for a team
+
+You can edit the roles for any custom team. Any changes made to a team's roles
+are automatically applied to all team members.
+
+1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
+ **Organization** link.
+2. Choose a team from the list.
+
+    Teams with the `Predefined` label can't be edited or deleted.
+
+3. Choose an entity tab, then click **+ Add role(s)**.
+
+4. Enter the UUID of the element you want to assign, or enter `*` to target
+all entities of the selected type.
+
+5. Select one or more roles from the list.
+
+    Hover over the `i` icon next to the role to see its description,
+    or see the [roles reference](/konnect/org-management/teams-and-roles/roles-reference).
+
+6. Click **Save**.
+
+
+### Add or remove team members
+
+Edit team membership for any team, custom or predefined.
+
+1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
+ **Organization** link.
+2. Choose a team from the list.
+3. On the **Members** tab, click **+ New Member**.
+4. Select a user in the organization and click **Save**.
+
+The user gains all roles attributed to the team.
+
+### Delete a team
+
+Deleting a team completely removes it and its configuration from
+{{site.konnect_short_name}}. If the team has any team members, they will be
+unassigned from the team.
+
+{:.warning}
+> **Warning:** Deleting a team is irreversible.
+
+1. From the left navigation menu in Konnect, open the {% konnect_icon organizations %}
+ **Organization** link.
+
+1. Choose a team from the list, open the action menu on the right of the row,
+and click **Delete**.
+
+1. Confirm deletion in the dialog.
+
+## See also
+
+* [Introduction to teams and roles in {{site.konnect_short_name}}](/konnect/org-management/teams-and-roles/)
+* [Teams reference](/konnect/org-management/teams-and-roles/teams-reference)
+* [Roles reference](/konnect/org-management/teams-and-roles/roles-reference)

--- a/app/konnect/org-management/teams-and-roles/roles-reference.md
+++ b/app/konnect/org-management/teams-and-roles/roles-reference.md
@@ -1,6 +1,7 @@
 ---
 title: Roles reference
 no_version: true
+content_type: reference
 ---
 
 A team can have any number of roles.

--- a/app/konnect/org-management/teams-and-roles/teams-reference.md
+++ b/app/konnect/org-management/teams-and-roles/teams-reference.md
@@ -1,6 +1,7 @@
 ---
 title: Teams Reference
 no_version: true
+content_type: reference
 ---
 
 All new and existing organizations in Konnect have predefined default teams.

--- a/app/konnect/org-management/users.md
+++ b/app/konnect/org-management/users.md
@@ -27,7 +27,7 @@ automatically-created users, adjust user permissions through Okta, or
 1. Assign the user to one or more teams.
 
     For team descriptions, hover over the information (`i`) icon next to the team name,
-    or see the [predefined teams references](/konnect/org-management/teams-reference).
+    or see the [predefined teams references](/konnect/org-management/teams-and-roles/teams-reference).
 
 1. Click **Save**.
 

--- a/app/konnect/org-management/users.md
+++ b/app/konnect/org-management/users.md
@@ -16,10 +16,6 @@ edit their team membership from the {{site.konnect_short_name}} side. To manage
 automatically-created users, adjust user permissions through Okta, or
 [adjust team mapping](/konnect/org-management/okta-idp/#map-teams-to-groups).
 
-## Prerequisites
-
-You must be part of the **Organization Admin** team to manage users.
-
 ## Add a user to the organization
 
 ### Invite a user

--- a/app/konnect/org-management/users.md
+++ b/app/konnect/org-management/users.md
@@ -1,6 +1,7 @@
 ---
 title: Manage Users
 no_version: true
+content_type: how-to
 ---
 
 You can invite users to join your Konnect organization through the **Organization**

--- a/app/konnect/vitals/analyze.md
+++ b/app/konnect/vitals/analyze.md
@@ -20,10 +20,6 @@ Service Hub.
 If you want to combine multiple Services, Routes, or Applications in one report,
 see [custom reports](/konnect/vitals/generate-reports/).
 
-## Prerequisites
-You have any [**Service** role or the **Organization Admin**](/konnect/org-management/users-and-roles/)
-role.
-
 ## Analyze Services
 
 ### View performance for a Service

--- a/app/konnect/vitals/analyze.md
+++ b/app/konnect/vitals/analyze.md
@@ -1,6 +1,7 @@
 ---
 title: Analyze Services and Routes
 no_version: true
+content_type: how-to
 ---
 
 In the Service Hub, the Service, Service version, and Route graphs provide dynamic

--- a/app/konnect/vitals/generate-reports.md
+++ b/app/konnect/vitals/generate-reports.md
@@ -2,6 +2,7 @@
 title: Generate Reports
 no_version: true
 alpha: true
+content_type: how-to
 ---
 
 Create custom reports to track API calls based on Services, Routes, or

--- a/app/konnect/vitals/generate-reports.md
+++ b/app/konnect/vitals/generate-reports.md
@@ -12,9 +12,6 @@ Applications.
 shows the sum of requests for all selected versions broken down by Service.
 It does not show data points for individual Service versions.
 
-## Prerequisites
-You have the [**Organization Admin**](/konnect/org-management/users-and-roles/) role.
-
 ## View custom reports
 
 To access all custom reports, open {% konnect_icon vitals %}


### PR DESCRIPTION
### Summary
* Remove prereqs with "required role" that we had in most tasks. 
* Split multi-purpose teams and roles doc into how-to and explanation
* Add `content_type` tag to edited topics (and a few in the roles/access section)

To do: comment out sharing feature temporarily, as it's not available yet.

Follow up task (not for this PR): create a troubleshooting entry that talks about access/roles.

### Reason
Roles and permissions within Konnect and Kong Gateway: We are not going to prescribe a specific role and permission because there are multitudes of different roles that could work for any given task. At the moment, we were nearly always saying that "You must have organization admin permissions", which helps no one.


### Testing
TBA
