### PR TITLE
[DOCU-502] Update link to workspaces

### DIFF
--- a/app/enterprise/2.1.x/property-reference.md
+++ b/app/enterprise/2.1.x/property-reference.md
@@ -3031,7 +3031,7 @@ Different strategies are available to tune how to enforce splitting traffic of
 workspaces.
 
 - `smart` is the default option and uses the algorithm described in
-  https://docs.konghq.com/enterprise/0.33-x/workspaces/examples/#important-note-conflicting-apis-or-routes-in-workspaces
+   the [workspaces example](/gateway/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces)
 - `off` disables any check
 - `path` enforces routes to comply with the pattern described in config
   enforce_route_path_pattern


### PR DESCRIPTION
### Summary
Updating a link to point to `latest`. Since this guide is autogenerated, `latest` is safer to use than any versioned URL.

Checked previous versions, link didn't exist. Checked later versions, link was already fixed. This is the only version that had the issue.

### Reason
https://konghq.atlassian.net/browse/DOCU-502

### Testing
TBA