### PR TITLE
Fix "edit this page" links

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -7,7 +7,7 @@ id: documentation
 {% assign latest_page_url = page.url | replace: page.kong_version, "latest" %}
 {% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
 
-{% assign default_edit_link = page.path | replace: "/latest/", page.kong_version %}
+{% assign default_edit_link = page.path | replace: "latest", page.kong_version %}
 
 <div class="page v2 {{ page.class }}" data-url={{ page.url }}>
 

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -7,6 +7,8 @@ id: documentation
 {% assign latest_page_url = page.url | replace: page.kong_version, "latest" %}
 {% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
 
+{% assign default_edit_link = page.path | replace: "/latest/", page.kong_version %}
+
 <div class="page v2 {{ page.class }}" data-url={{ page.url }}>
 
   <div class="container">
@@ -21,7 +23,7 @@ id: documentation
             {% if page.edit_link %}
             <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/{{ page.edit_link }}" target="_blank">
             {% else %}
-            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ page.path }}" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ default_edit_link }}" target="_blank">
             {% endif %}
               <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
           </p>


### PR DESCRIPTION
### Summary
Fixing the "edit this page" link to github from "latest" pages.

### Reason
"Latest" is an alias, so there is no "latest" directory in the source. The gh page edit links were trying to go to latest.
Eg, click "edit this page" here and notice that it take you to "latest": https://docs.konghq.com/gateway/latest/install-and-run/

### Testing
Check the "edit this page" link in the top right corner for any /latest/ URL. It should take you to the correct version. Eg:

https://deploy-preview-3956--kongdocs.netlify.app/gateway/latest/install-and-run/
https://deploy-preview-3956--kongdocs.netlify.app/mesh/latest/gettingstarted/