### PR TITLE
Ignore netlify test directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ install
 .vscode/
 yarn.lock
 
+# test directory
+.netlify/
+
 # jekyll
 dist
 .jekyll-metadata


### PR DESCRIPTION
### Summary
Set github to ignore the `.netlify` directory, which gets generated when you run smoke tests locally. 

### Reason
Was running smoke tests locally and noticed that github was seeing this dir. Don't want someone to accidentally commit it at some point.

### Testing
Pull down the branch locally, break something (eg, delete a top level nav section from Gateway) and run `make smoke`. This will generate a local `.netlify` directory.
Use `git status` to check that the directory isn't seen by github. 