### PR TITLE
Add generated path to conflict warning for single sourced documents

### DIFF
--- a/app/_plugins/generators/latest_version_generator.rb
+++ b/app/_plugins/generators/latest_version_generator.rb
@@ -19,7 +19,8 @@ module LatestVersion
 
       # Load config file
       site.pages.each do |page|
-        parts = Pathname(page.path).each_filename.to_a
+        parts = Pathname(remove_generated_prefix(page.path)).each_filename.to_a
+
         products_with_latest.each do |product|
           # Reset values for every new page
           generate_latest = false
@@ -52,6 +53,16 @@ module LatestVersion
           site.pages << page
         end
       end
+    end
+
+    def remove_generated_prefix(path)
+      # Remove the generated prefix if it's present
+      # It's in the format GENERATED:nav=nav/product_1.2.x:src=src/path/here:/output/path
+      return path unless path.start_with?('GENERATED:')
+
+      path = path.split(':')
+      path.shift(3)
+      path.join(':')
     end
   end
 

--- a/app/_plugins/generators/versions.rb
+++ b/app/_plugins/generators/versions.rb
@@ -76,7 +76,18 @@ module Jekyll
       # Add a `version` property to every versioned page
       # Also create aliases under /latest/ for all x.x.x doc pages
       site.pages.each do |page| # rubocop:disable Metrics/BlockLength
-        parts = Pathname(page.path).each_filename.to_a
+        path = page.path
+
+        # Remove the generated prefix if it's present
+        # It's in the format GENERATED:nav=nav/product_1.2.x:src=src/path/here:/output/path
+        if path.start_with?('GENERATED:')
+          path = path.split(':')
+          path.shift(3)
+          path = path.join(':')
+        end
+
+        parts = Pathname(path).each_filename.to_a
+
         page.data['has_version'] = true
         # Only apply those rules to documentation pages
         is_product = %w[


### PR DESCRIPTION
### Summary
Mark files as generated in the conflicted files output when using single sourcing generation

![image](https://user-images.githubusercontent.com/59130/169579730-99876fd4-5720-4ff6-8853-8d0050567ce6.png)


### Reason
It was hard to work out why duplicates were happening previously

### Testing
Create a file in `app/demo/one`, then create an entry in a nav file with the `url: /demo/one` and look at the error message