### PR TITLE
Fix margins when promo banner is active

### DIFF
--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -133,8 +133,11 @@ body {
       header:not(.closed) ~ .landing-page {
         margin-top: 35px;
       }
-      header:not(.closed) ~ div.page {
+      header:not(.closed) ~ div.page.v2 {
         margin-top: 100px;
+      }
+      header:not(.closed) ~ .page-extension-profile, .page-hub {
+        margin-top: 45px;
       }
     }
   }


### PR DESCRIPTION
### Summary
Fixing margins on plugin docs.

### Reason

When promo banner is active, the margins on the plugin docs are huge and they shrink when the promo banner is closed (blue banner at top of page).
![Screen Shot 2022-05-20 at 4 55 42 PM](https://user-images.githubusercontent.com/54370747/169625940-979273ed-2e20-4bd5-a191-a83219f27c3a.png)

They shrink back down to normal size when banner is closed:
![Screen Shot 2022-05-20 at 5 01 44 PM](https://user-images.githubusercontent.com/54370747/169625995-658788a2-df17-4822-bef1-d5d6c799c102.png)


### Testing
Check the plugin docs, then close the promo banner and check that the margins remain the same size.

![Screen Shot 2022-05-20 at 4 59 57 PM](https://user-images.githubusercontent.com/54370747/169626025-77888f15-f5fd-45c4-9359-ee42c8c77fb1.png)
