### PR TITLE
Fix PDF Generation for plugins + docs

### DIFF
--- a/pdf-generation/list-plugins.js
+++ b/pdf-generation/list-plugins.js
@@ -2,10 +2,10 @@ const fg = require('fast-glob')
 
 module.exports = async function (plugin, version) {
   plugin = plugin || '*'
-  version = version || 'index'
+  version = version || '_index'
   let files = await fg(`../app/_hub/kong-inc/${plugin}/${version}.md`)
   files = files.map((f) => {
-    return f.replace('../app/_hub/', '/hub/').replace(/\.md$/, '.html')
+    return f.replace('../app/_hub/', '/hub/').replace(/\.md$/, '.html').replace("_index", 'index')
   })
 
   // Prefix with URL


### PR DESCRIPTION
### Summary
PDF generation is broken in two ways:

1. The switch from `index` to `_index` for plugins prevented PDF generation for the default version of plugins
2. The addition of the OpenAPI renderer prevented that page from being printed to PDF

Some `prettier` printing also made it in to the PR, but I don't think it's a bad thing

### Reason
Fixing the existing tooling

### Testing

Run this locally:

```
cd pdf-generation
npm ci

# Build a plugin PDF
KONG_PLUGIN_NAME=basic-auth node run.js

# Build a docs PDF
KONG_DOC_VERSIONS=gateway_2.8.x node run.js
```