### PR TITLE
[DOCU-2352] Document forward proxy fallback behavior

### DIFF
--- a/app/_hub/kong-inc/forward-proxy/_index.md
+++ b/app/_hub/kong-inc/forward-proxy/_index.md
@@ -64,7 +64,7 @@ params:
         At least one of `http_proxy_host` or `https_proxy_host` must be specified.
 
         If `https_proxy_host` isn't set, the plugin falls back to the value
-        configured in `https_proxy_host`.
+        configured in `http_proxy_host`.
     - name: https_proxy_port
       required: semi
       default: null

--- a/app/_hub/kong-inc/forward-proxy/_index.md
+++ b/app/_hub/kong-inc/forward-proxy/_index.md
@@ -38,6 +38,7 @@ params:
 
         If `http_proxy_host` isn't set, the plugin falls back to the value
         configured in `https_proxy_host`.
+      # minimum_version: "2.8.x"
 
     - name: http_proxy_port
       required: semi
@@ -52,6 +53,7 @@ params:
 
         If `http_proxy_port` isn't set, the plugin falls back to the value
         configured in `https_proxy_port`.
+      # minimum_version: "2.8.x"
     - name: https_proxy_host
       required: semi
       default: null
@@ -65,6 +67,7 @@ params:
 
         If `https_proxy_host` isn't set, the plugin falls back to the value
         configured in `http_proxy_host`.
+      # minimum_version: "2.8.x"
     - name: https_proxy_port
       required: semi
       default: null
@@ -78,6 +81,7 @@ params:
 
         If `https_proxy_port` isn't set, the plugin falls back to the value
         configured in `http_proxy_port`.
+      # minimum_version: "2.8.x"
     - name: proxy_host
       required: false
       default: null
@@ -92,6 +96,7 @@ params:
         > Use `http_proxy_host` or `https_proxy_host` instead.
 
         The hostname or IP address of the forward proxy to which to connect.
+      # maximum_version: "2.8.x"
     - name: proxy_port
       required: false
       default: null
@@ -106,6 +111,7 @@ params:
         > Use `http_proxy_host` or `https_proxy_host` instead.
 
         The TCP port of the forward proxy to which to connect.
+      # maximum_version: "2.8.x"
     - name: proxy_scheme
       required: true
       default: http

--- a/app/_hub/kong-inc/forward-proxy/_index.md
+++ b/app/_hub/kong-inc/forward-proxy/_index.md
@@ -35,6 +35,10 @@ params:
         Required if `http_proxy_port` is set.
 
         At least one of `http_proxy_host` or `https_proxy_host` must be specified.
+
+        If `http_proxy_host` isn't set, the plugin falls back to the value
+        configured in `https_proxy_host`.
+
     - name: http_proxy_port
       required: semi
       default: null
@@ -45,6 +49,9 @@ params:
         Required if `http_proxy_host` is set.
 
         At least one of `http_proxy_port` or `https_proxy_port` must be specified.
+
+        If `http_proxy_port` isn't set, the plugin falls back to the value
+        configured in `https_proxy_port`.
     - name: https_proxy_host
       required: semi
       default: null
@@ -55,6 +62,9 @@ params:
         Required if `https_proxy_port` is set.
 
         At least one of `http_proxy_host` or `https_proxy_host` must be specified.
+
+        If `https_proxy_host` isn't set, the plugin falls back to the value
+        configured in `https_proxy_host`.
     - name: https_proxy_port
       required: semi
       default: null
@@ -65,6 +75,9 @@ params:
         Required if `https_proxy_host` is set.
 
         At least one of `http_proxy_port` or `https_proxy_port` must be specified.
+
+        If `https_proxy_port` isn't set, the plugin falls back to the value
+        configured in `http_proxy_port`.
     - name: proxy_host
       required: false
       default: null


### PR DESCRIPTION
### Summary
Expand descriptions for the the forward proxy plugin to include fallback behavior info.

### Reason
https://konghq.atlassian.net/browse/DOCU-2352
https://github.com/Kong/kong-ee/pull/3211/  

### Testing
https://deploy-preview-3971--kongdocs.netlify.app/hub/kong-inc/forward-proxy/