### PR TITLE
[DOCU-2353] mTLS auth plugin: proxy host and port parameters

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -113,39 +113,44 @@ params:
       value_in_examples: example
       datatype: string
       description: |
-        The HTTP hostname or IP address of a proxy. Supports CRL and OCSP.
+        The HTTP hostname or IP address of a proxy. Use this setting with
+        `http_proxy_port` to access a certificate revocation list
+        (CRL) or an OCSP server.
 
         Required if `http_proxy_port` is set.
-
+      # minimum_version: "2.8.x"
     - name: http_proxy_port
       required: semi
       default: null
       value_in_examples: 80
       datatype: string
       description: |
-        The TCP port of the HTTP proxy. Supports CRL and OCSP.
+        The TCP port of the HTTP proxy.
 
         Required if `http_proxy_host` is set.
-
+      # minimum_version: "2.8.x"
     - name: https_proxy_host
       required: semi
       default: null
       value_in_examples:
       datatype: string
       description: |
-        The HTTPS hostname or IP address of a proxy. Supports CRL and OCSP.
+        The HTTPS hostname or IP address of a proxy. Use this setting with
+        `https_proxy_port` to access a certificate revocation list
+        (CRL) or an OCSP server.
 
         Required if `https_proxy_port` is set.
-
+      # minimum_version: "2.8.x"
     - name: https_proxy_port
       required: semi
       default: null
       value_in_examples:
       datatype: string
       description: |
-        The TCP port of the HTTPS proxy. Supports CRL and OCSP.
+        The TCP port of the HTTPS proxy.
 
         Required if `https_proxy_host` is set.
+      # minimum_version: "2.8.x"
 ---
 
 ## Usage

--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -107,6 +107,45 @@ params:
       datatype: number
       description: |
         Cache expiry time in seconds.
+    - name: http_proxy_host
+      required: semi
+      default: null
+      value_in_examples: example
+      datatype: string
+      description: |
+        The HTTP hostname or IP address of a proxy. Supports CRL and OCSP.
+
+        Required if `http_proxy_port` is set.
+
+    - name: http_proxy_port
+      required: semi
+      default: null
+      value_in_examples: 80
+      datatype: string
+      description: |
+        The TCP port of the HTTP proxy. Supports CRL and OCSP.
+
+        Required if `http_proxy_host` is set.
+
+    - name: https_proxy_host
+      required: semi
+      default: null
+      value_in_examples:
+      datatype: string
+      description: |
+        The HTTPS hostname or IP address of a proxy. Supports CRL and OCSP.
+
+        Required if `https_proxy_port` is set.
+
+    - name: https_proxy_port
+      required: semi
+      default: null
+      value_in_examples:
+      datatype: string
+      description: |
+        The TCP port of the HTTPS proxy. Supports CRL and OCSP.
+
+        Required if `https_proxy_host` is set.
 ---
 
 ## Usage
@@ -171,8 +210,8 @@ curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
 {% navtab Konnect Cloud %}
 
 Go through the Konnect Manager:
-1. From the Dashboard, select **Shared Config** in the left navigation 
-2. Select **Certificates** 
+1. From the Dashboard, select **Shared Config** in the left navigation
+2. Select **Certificates**
 3. Click **New Certificate**
 4. Copy and paste your certificate information and select **Create**
 
@@ -293,3 +332,11 @@ When authentication fails, the client does not have access to any details that e
 failure. The security reason for this omission is to prevent malicious reconnaissance.
 Instead, the details are recorded inside Kong's error logs under the `[mtls-auth]`
 filter.
+
+## Changelog
+
+### Kong Gateway 2.8.1.1
+
+* Introduced certificate revocation list (CRL) and OCSP server support with the
+following parameters: `http_proxy_host`, `http_proxy_port`, `https_proxy_host`,
+and `https_proxy_port`.


### PR DESCRIPTION
### Summary
Document new proxy parameters for the mTLS auth plugin. 

### Reason
https://github.com/Kong/kong-ee/pull/3078
https://konghq.atlassian.net/browse/DOCU-2353

### Testing
https://deploy-preview-3972--kongdocs.netlify.app/hub/kong-inc/mtls-auth/

Reviewers: I drafted this doc but don't really understand how CRLs or OCSP servers work, so please validate my phrasing. 