### PR TITLE
[ENGEN-451] chore(xenial) 👋

### DIFF
--- a/app/_includes/md/deb.md
+++ b/app/_includes/md/deb.md
@@ -7,7 +7,9 @@ You can install Kong by downloading an installation package or using our apt rep
 
     {% if include.distribution == "ubuntu" %}
 
+    {% if_version lte:2.8.x %}
 - [Xenial]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
+    {% endif_version %}
 - [Bionic]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
 - [Focal]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong/kong_{{site.data.kong_latest.version}}_amd64.deb)
 

--- a/src/gateway/install-and-run/ubuntu.md
+++ b/src/gateway/install-and-run/ubuntu.md
@@ -2,6 +2,13 @@
 title: Install Kong Gateway on Ubuntu
 ---
 
+{:.important}
+> **Deprecation notice**: Support for running Kong Gateway on
+Ubuntu 16.04 ("Xenial") is now deprecated, as [Standard Support for Ubuntu 16.04 has ended as of April, 2021](https://wiki.ubuntu.com/Releases).
+Starting with Kong Gateway 3.0.0.0, Kong is neither building new Ubuntu 16.04 images nor packages. Nor will Kong test package installation on Ubuntu 16.04.
+> If you need to install Kong Gateway on Ubuntu 16.04, see the documentation for
+[previous versions](/gateway/2.8.x/install-and-run/ubuntu/).
+
 <!-- Banner with links to latest downloads -->
 <!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
 


### PR DESCRIPTION
### Summary

Companion PR to:
  - https://github.com/Kong/kong-build-tools-base-images/pull/40
  - https://github.com/Kong/kong-build-tools/pull/476
  - https://github.com/Kong/kong-build-tools-base-images/pull/40

### Reason

Ubuntu 16.04 aka "Xenial Xerus" reached "End of Standard Support" in April of 2021.