### PR TITLE
[Fix] data.lua link syntax

### DIFF
--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -143,9 +143,9 @@ As always, be mindful of your shell's quoting rules specifying values
 containing spaces.
 
 For more details on the Nginx configuration file structure and block
-directives, see the [official documentation](https://nginx.org/en/docs/beginners_guide.html#conf_structure).
+directives, see the [Nginx reference](https://nginx.org/en/docs/beginners_guide.html#conf_structure).
 
-For a list of Nginx directives, see the [official documentation](https://nginx.org/en/docs/dirindex.html).
+For a list of Nginx directives, see the [Nginx directives index](https://nginx.org/en/docs/dirindex.html).
 Note however that some directives are dependent of specific Nginx modules,
 some of which may not be included with the official builds of Kong.
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -143,9 +143,9 @@ As always, be mindful of your shell's quoting rules specifying values
 containing spaces.
 
 For more details on the Nginx configuration file structure and block
-directives, see https://nginx.org/en/docs/beginners_guide.html#conf_structure.
+directives, see the [official documentation](https://nginx.org/en/docs/beginners_guide.html#conf_structure).
 
-For a list of Nginx directives, see https://nginx.org/en/docs/dirindex.html.
+For a list of Nginx directives, see the [official documentation](https://nginx.org/en/docs/dirindex.html).
 Note however that some directives are dependent of specific Nginx modules,
 some of which may not be included with the official builds of Kong.
 

--- a/autodoc-conf-ee/data.lua
+++ b/autodoc-conf-ee/data.lua
@@ -146,9 +146,9 @@ As always, be mindful of your shell's quoting rules specifying values
 containing spaces.
 
 For more details on the Nginx configuration file structure and block
-directives, see https://nginx.org/en/docs/beginners_guide.html#conf_structure.
+directives, see the [official documentation](https://nginx.org/en/docs/beginners_guide.html#conf_structure).
 
-For a list of Nginx directives, see https://nginx.org/en/docs/dirindex.html.
+For a list of Nginx directives, see the [official documentation](https://nginx.org/en/docs/dirindex.html).
 Note however that some directives are dependent of specific Nginx modules,
 some of which may not be included with the official builds of Kong.
 

--- a/autodoc-conf-ee/data.lua
+++ b/autodoc-conf-ee/data.lua
@@ -146,9 +146,9 @@ As always, be mindful of your shell's quoting rules specifying values
 containing spaces.
 
 For more details on the Nginx configuration file structure and block
-directives, see the [official documentation](https://nginx.org/en/docs/beginners_guide.html#conf_structure).
+directives, see the [Nginx reference](https://nginx.org/en/docs/beginners_guide.html#conf_structure).
 
-For a list of Nginx directives, see the [official documentation](https://nginx.org/en/docs/dirindex.html).
+For a list of Nginx directives, see the [Nginx directives index](https://nginx.org/en/docs/dirindex.html).
 Note however that some directives are dependent of specific Nginx modules,
 some of which may not be included with the official builds of Kong.
 


### PR DESCRIPTION
### Summary
Fixes an issue with links in `reference/configuration` rendering like this. 
![image](https://user-images.githubusercontent.com/23319190/170774320-5f791d78-a5bd-4151-9e8c-60d29b98072a.png)




### Testing
[netlify](https://deploy-preview-3982--kongdocs.netlify.app/gateway/latest/reference/configuration/#injecting-individual-nginx-directives)

check links, read copy. 