### PR TITLE
Update algolia config

### DIFF
--- a/algolia/config-full-docs.json
+++ b/algolia/config-full-docs.json
@@ -5,20 +5,20 @@
       "url": "https://docs.konghq.com/konnect/"
     },
     {
-      "url": "https://docs.konghq.com/deck/1.11.x/"
+      "url": "https://docs.konghq.com/deck/latest/"
     },
     {
-      "url": "https://docs.konghq.com/kubernetes-ingress-controller/2.3.x/"
+      "url": "https://docs.konghq.com/kubernetes-ingress-controller/latest/"
     },
     {
       "url": "https://docs.konghq.com/gateway/changelog/",
       "selectors_key": "changelog"
     },
     {
-      "url": "https://docs.konghq.com/gateway/2.8.x/"
+      "url": "https://docs.konghq.com/gateway/latest/"
     },
     {
-      "url": "https://docs.konghq.com/mesh/1.6.x/"
+      "url": "https://docs.konghq.com/mesh/latest/"
     },
     {
       "url": "https://docs.konghq.com/mesh/changelog/",


### PR DESCRIPTION
### Summary
Set algolia config to index `/latest/` instead of incrementing versions with every release

### Reason
We now have evergreen URLs at `latest` for any versioned doc. Setting the index to pull from `latest` creates a more consistent experience and leaves us one less task to do at release time. 

### Testing
Tested by running the index locally. It completed successfully.

![Screen Shot 2022-05-27 at 1 56 11 PM](https://user-images.githubusercontent.com/54370747/170788452-ae10c901-6322-46ef-9730-fab4bcc0a7b9.png)

