### PR TITLE
[FTI-4021]add explanation for valid value range of key's ttl in key-auth plugin

### DIFF
--- a/app/_hub/kong-inc/key-auth/_index.md
+++ b/app/_hub/kong-inc/key-auth/_index.md
@@ -233,7 +233,7 @@ In both cases, the fields/parameters work as follows:
 field/parameter     | description
 ---                 | ---
 `{consumer}`        | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
-`ttl`<br>*optional* | The number of seconds the key is going to be valid. If missing, the `ttl` is unlimited.
+`ttl`<br>*optional* | The number of seconds the key is going to be valid. If missing or set to zero, the `ttl` of the key is unlimited. If present, the value must be an integer between 0 and 100000000.
 `key`<br>*optional* | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
 
 ### Make a Request with the Key


### PR DESCRIPTION


### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Add more explanation for the valid value range of key's `ttl` in the key-auth plugin. According to the [dao layer check function](https://github.com/Kong/kong/blob/9dfffb5d8316c5277afeb81cd46b42d47a6ac705/kong/db/dao/init.lua#L193-L199), the `ttl` type option should be within the range between 0 and 100000000.

And as for the key-auth plugin, `ttl` set to zero has the same effect as `ttl` is missing

Related bugfix: https://github.com/Kong/kong/pull/8831


### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
