### PR TITLE
[FTI-3323]add include_uri_captures_in_opa_input option to OPA plugin

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -470,6 +470,7 @@ include_credential
 include_parsed_json_body_in_opa_input
 include_route_in_opa_input
 include_service_in_opa_input
+include_uri_captures_in_opa_input
 independantly
 inject_client_cert_details
 introspect_jwt_tokens
@@ -928,6 +929,7 @@ upstream_uri
 upstream_url
 upstream_user_info_header
 upstream_user_info_jwt_header
+uri_captures
 uri_param_names
 urlencode_in_examples
 use_tcp

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -81,6 +81,13 @@ params:
       default: false
       description: |
         If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be JSON decoded and the decoded struct is included as input to OPA.
+    - name: include_uri_captures_in_opa_input
+      required: false
+      datatype: boolean
+      default: false
+      minimum_version: "3.0.x"
+      description: |
+        If set to true, the [regex capture groups](https://docs.konghq.com/gateway/latest/reference/proxy/#using-regex-in-paths) captured on the Kong Gateway Route's path field in the current request (if any) are included as input to OPA.
     - name: ssl_verify
       required: true
       datatype: boolean

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -215,6 +215,10 @@ The input to OPA has the following JSON structure:
           "accept-encoding": "gzip, deflate",
           "connection": "keep-alive",
           "accept": "*\\/*"
+        },
+        "uri_captures": {      # The regex capture groups captured on the Kong Gateway Route's path field in the current request. Injected only if `include_uri_captures_in_opa_input` is set to `true`.
+          "named": {},
+          "unnamed": []
         }
       }
     },


### PR DESCRIPTION
### Summary

Add a new option `include_uri_captures_in_opa_input` to the OPA plugin.
The new option will enable the ability to make regex capture groups included as the input to OPA

Realted PR: https://github.com/Kong/kong-ee/pull/3270
https://github.com/Kong/kong-ee/pull/3953/files

### Reason

https://konghq.atlassian.net/browse/FTI-3323

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
