### PR TITLE
Remove mention of AWS Aurora

### DIFF
--- a/app/gateway/2.8.x/reference/clustering.md
+++ b/app/gateway/2.8.x/reference/clustering.md
@@ -78,9 +78,7 @@ This makes Kong clusters **eventually consistent**.
 When using Postgres as the backend storage, you can optionally enable
 Kong to serve read queries from a separate database instance.
 
-One of the common use cases of this feature is to deploy Kong with the
-Amazon Aurora service as backend storage. Because Aurora natively supports
-read-only instances, enabling the read-only connection support in Kong
+Enabling the read-only connection support in Kong
 greatly reduces the load on the main database instance since read-only
 queries are no longer sent to it.
 


### PR DESCRIPTION
### Summary
Mentioning AWS Aurora by name implied official support. Instead, we want to highlight that read-replicas are useful for scaling Kong.

### Reason
Raised by CRE

### Testing

Check `/gateway/2.8.x/reference/clustering/#use-read-only-replicas-when-deploying-kong-clusters-with-postgres` in the review app
