### PR TITLE
Combine plugin examples into tabs for better UX

### DIFF
--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -23,7 +23,7 @@
 
                 > .navtab-title {
                   padding: 8px 16px;
-                  font-size: 15px;
+                  font-size: 14px;
                   font-weight: 600;
                   opacity: 0.7;
                   border-radius: 3px;
@@ -121,7 +121,7 @@
       position: relative;
       cursor: pointer;
       padding: 8px 16px;
-      font-size: 17px;
+      font-size: 16px;
       font-weight: 600;
       opacity: 0.7;
 

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -4,13 +4,9 @@
 
     &.parent {
       > .navtab-contents {
-          // border: 1px solid @grey-200;
-          // border-radius: 3px;
-          // padding: 15px;
-
          .navtabs {
            .navtab-contents {
-               border: 1px solid @grey-200;
+               border: 1px solid @grey-300;
                border-radius: 3px;
                padding: 15px;
              }
@@ -19,7 +15,6 @@
             border-bottom: none;
             background: @grey-100;
             border-radius: 3px;
-            // width: fit-content;
 
                 > .navtab-title {
                   padding: 8px 16px;
@@ -36,20 +31,16 @@
                     opacity: 1;
                     color: @blue-500;
                     cursor: text;
-                    background: @grey-200;
+                    background: @blue-150;
                   }
                 }
               }
             }
           }
-
-          // >.navtab-titles {
-          //   border-bottom: none;
-          // }
         }
 
     &.codeblock {
-      background-color: @grey-200;
+      background-color: @grey-300;
       border: 1px solid @grey-200;
       border-radius: 3px;
       line-height: 24px;
@@ -82,7 +73,7 @@
       }
 
       .navtab-titles {
-        background-color: @grey-200;
+        background-color: @grey-300;
         color: rgba(black, 0.6);
         opacity: 1;
         displaY: flex;
@@ -115,7 +106,7 @@
   .navtab-titles {
     display: flex;
     align-items: center;
-    border-bottom: 1px solid @gray;
+    border-bottom: 1px solid @grey-300;
 
     .navtab-title {
       position: relative;

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -2,42 +2,44 @@
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 
-    &.parent {
-      > .navtab-contents {
-         .navtabs {
-           .navtab-contents {
-               border: 1px solid @grey-300;
-               border-radius: 3px;
-               padding: 15px;
-             }
+  &.parent {
+    > .navtab-contents {
+       .navtabs {
+         .navtab-contents {
+             border: 1px solid @grey-300;
+             border-radius: 3px;
+             padding: 15px;
+           }
 
-            .navtab-titles {
-            border-bottom: none;
-            background: @grey-100;
-            border-radius: 3px;
+        .navtab-titles {
+          border-bottom: none;
+          background: @grey-100;
+          border-radius: 3px;
 
-                > .navtab-title {
-                  padding: 8px 16px;
-                  font-size: 14px;
-                  font-weight: 600;
-                  opacity: 0.7;
-                  border-radius: 3px;
+          > .navtab-title {
+            padding: 8px 16px;
+            font-size: 14px;
+            font-weight: 600;
+            opacity: 0.7;
+            border-radius: 3px 3px 0 0  ;
 
-                  &:hover {
-                    color: rgba(black, 0.4);
-                    transition: color 0.2s;
-                  }
-                  &.active {
-                    opacity: 1;
-                    color: @blue-500;
-                    cursor: text;
-                    background: @blue-150;
-                  }
-                }
-              }
+            &:hover {
+              color: @blue-500;
+              opacity: 0.8;
+              transition: color 0.2s;
+              background: @blue-150;
+            }
+            &.active {
+              opacity: 1;
+              color: @blue-500;
+              cursor: text;
+              background: @blue-150;
             }
           }
         }
+      }
+    }
+  }
 
     &.codeblock {
       background-color: @grey-300;
@@ -117,7 +119,7 @@
       opacity: 0.7;
 
       &:hover {
-        color: rgba(black, 0.4);
+        color: @blue-500;
         transition: color 0.2s;
       }
 

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -2,6 +2,17 @@
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 
+    &.parent {
+      > .navtab-contents {
+          border: 1px solid @blue-200;
+          border-radius: 3px;
+          padding: 15px;
+      }
+      >.navtab-titles {
+        border-bottom: none;
+      }
+    }
+
     &.codeblock {
       background-color: @grey-200;
       border: 1px solid @grey-200;

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -4,14 +4,49 @@
 
     &.parent {
       > .navtab-contents {
-          border: 1px solid @blue-200;
-          border-radius: 3px;
-          padding: 15px;
-      }
-      >.navtab-titles {
-        border-bottom: none;
-      }
-    }
+          // border: 1px solid @grey-200;
+          // border-radius: 3px;
+          // padding: 15px;
+
+         .navtabs {
+           .navtab-contents {
+               border: 1px solid @grey-200;
+               border-radius: 3px;
+               padding: 15px;
+             }
+
+            .navtab-titles {
+            border-bottom: none;
+            background: @grey-100;
+            border-radius: 3px;
+            // width: fit-content;
+
+                > .navtab-title {
+                  padding: 8px 16px;
+                  font-size: 15px;
+                  font-weight: 600;
+                  opacity: 0.7;
+                  border-radius: 3px;
+
+                  &:hover {
+                    color: rgba(black, 0.4);
+                    transition: color 0.2s;
+                  }
+                  &.active {
+                    opacity: 1;
+                    color: @blue-500;
+                    cursor: text;
+                    background: @grey-200;
+                  }
+                }
+              }
+            }
+          }
+
+          // >.navtab-titles {
+          //   border-bottom: none;
+          // }
+        }
 
     &.codeblock {
       background-color: @grey-200;
@@ -86,7 +121,7 @@
       position: relative;
       cursor: pointer;
       padding: 8px 16px;
-      font-size: 16px;
+      font-size: 17px;
       font-weight: 600;
       opacity: 0.7;
 

--- a/app/_assets/stylesheets/variables.less
+++ b/app/_assets/stylesheets/variables.less
@@ -124,17 +124,21 @@
 // Kongponents colors
 // -------------------------
 
-@blue-100: #f0f5ff;
-@blue-200: #d9e7ff;
-@blue-300: #a6c6ff;
-@blue-400: #5996ff;
-@blue-500: #1456cb;
-@blue-600: #083c99;
+@blue-100: #f2f6fe;
+@blue-150: #eaf0ff;
+@blue-200: #bdd3f9;
+@blue-300: #8ab3fa;
+@blue-400: #3972d5;
+@blue-500: #1155cb;
+@blue-600: #003694;
 @blue-700: #0a2b66;
+
+@petrol-100: #eaf4fb;
+@petrol-200: #03464ac;
 
 @steel-080: #fafbfd;
 @steel-090: #f3f6fb;
-@steel-100: #eff2f8;
+@steel-100: #f0f4fa;
 @steel-200: #dae3f2;
 @steel-300: #a3b6d9;
 @steel-400: #7d91b3;
@@ -142,27 +146,38 @@
 @steel-600: #395380;
 @steel-700: #273c61;
 
-@red-100: #fff7f9;
-@red-200: #ffe6ea;
-@red-300: #ffb3bf;
-@red-400: #f26d83;
-@red-500: #e6173a;
-@red-600: #bf1330;
-@red-700: #99001a;
+@red-100: #ffdede;
+@red-200: #fcc;
+@red-300: #ff9a99;
+@red-400: #ff7877;
+@red-500: #d44324;
+@red-600: #e50000;
+@red-700: #922021;
 
-@green-100: #f1fff7;
-@green-200: #ccffe1;
-@green-300: #82d9a6;
-@green-400: #19a654;
+@green-100: #e8f8f5;
+@green-200: #c0f2d5;
+@green-300: #84e5ae;
+@green-400: #42d782;
 @green-500: #008036;
+@green-600: #008871;
+@green-700: #13755e;
 
-@yellow-100: #fff9e6;
-@yellow-200: #ffedb9;
-@yellow-300: #ffdc73;
-@yellow-400: #f2a230;
-@yellow-500: #8c5200;
+@teal-100: #cdf1fe;
+@teal-200: #91e1fc;
+@teal-300: #169fcc;
+@teal-400: #0a7fae;
+@teal-500: #006e9d;
 
-@grey-100: #fafafa;
-@grey-200: #ebebeb;
-@grey-300: #e0e0e0;
-@grey-400: #d6d6d6;
+@yellow-100: #fff3d8;
+@yellow-200: #ffe6ba;
+@yellow-300: #ffd68c;
+@yellow-400: #fabe5f;
+@yellow-500: #c67c06;
+@yellow-600: #a05604;
+
+@grey-100: #f8f8fa;
+@grey-200: #f1f1f5;
+@grey-300: #e7e7ec;
+@grey-400: #b6b6bd;
+@grey-500: #6f7787;
+@grey-600: #3c4557;

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -115,7 +115,7 @@ endif %}{% endif_plugin_version %}{% endfor
 
 {% capture plugin_config_for_service %}
 
-The following examples provide some typical configuration for enabling
+The following examples provide some typical configurations for enabling
 the <code>{{include.params.name}}</code> plugin on a
 [service](/gateway/latest/admin-api/#service-object).
 
@@ -250,7 +250,7 @@ is not already prefilled.{% unless
 {% if include.params.route_id %}
 {% capture plugin_config_for_route %}
 
-The following examples provide some typical configuration for enabling
+The following examples provide some typical configurations for enabling
 the <code>{{include.params.name}}</code> plugin on a
 [route](/gateway/latest/admin-api/#route-object).
 
@@ -383,7 +383,7 @@ or sample values as needed:
 {% if include.params.consumer_id %}
 {% capture plugin_config_for_consumer %}
 
-The following examples provide some typical configuration for enabling
+The following examples provide some typical configurations for enabling
 the <code>{{include.params.name}}</code> plugin on a
 [consumer](/gateway/latest/admin-api/#consumer-object).
 
@@ -501,7 +501,7 @@ considered _global_, and will be run on every request. Read the
 [Plugin Reference](/gateway/latest/admin-api/#add-plugin) and the [Plugin Precedence](/gateway/latest/admin-api/#precedence)
 sections for more information.
 
-The following examples provide some typical configuration for enabling
+The following examples provide some typical configurations for enabling
 the <code>{{include.params.name}}</code> plugin globally.
 {% navtabs %}
 {% navtab Admin API %}

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -114,13 +114,15 @@ endif %}{% endif_plugin_version %}{% endfor
 {% if include.params.service_id %}
 
 {% capture plugin_config_for_service %}
-### Enable the plugin on a service
+
+The following examples provide some typical configuration for enabling
+the <code>{{include.params.name}}</code> plugin on a
+[service](/gateway/latest/admin-api/#service-object).
 
 {% navtabs %}
 {% navtab Admin API %}
 
-For example, configure this plugin on a [service](/gateway/latest/admin-api/#service-object) by
-making the following request:
+Make the following request:
 
 ```bash
 curl -X POST http://{HOST}:8001/services/{SERVICE}/plugins \
@@ -185,8 +187,7 @@ spec:
 {% unless include.params.yaml_examples == false %}
 {% navtab Declarative (YAML) %}
 
-For example, configure this plugin on a [service](/gateway/latest/admin-api/#service-object) by
-adding this section to your declarative configuration file:
+Add this section to your declarative configuration file:
 
 ``` yaml
 plugins:
@@ -203,7 +204,6 @@ plugins:
 {% endunless %}
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Konnect Cloud %}
-Configure this plugin on a service:
 
 1. In Konnect Cloud, select the service on the ServiceHub page.
 2. Scroll down to **Versions** and select the version.
@@ -219,7 +219,6 @@ or sample values as needed:
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Kong Manager %}
-Configure this plugin on a service:
 
 1. In Kong Manager, select the workspace.
 2. From the Dashboard, scroll down to **Services** and click **View** for the
@@ -250,12 +249,15 @@ is not already prefilled.{% unless
 
 {% if include.params.route_id %}
 {% capture plugin_config_for_route %}
-### Enable the plugin on a route
+
+The following examples provide some typical configuration for enabling
+the <code>{{include.params.name}}</code> plugin on a
+[route](/gateway/latest/admin-api/#route-object).
 
 {% navtabs %}
 {% navtab Admin API %}
 
-For example, configure this plugin on a [route](/gateway/latest/admin-api/#route-object) with:
+Make the following request:
 
 ```bash
 $ curl -X POST http://{HOST}:8001/routes/{ROUTE}/plugins \
@@ -319,8 +321,7 @@ spec:
 {% unless include.params.yaml_examples == false %}
 {% navtab Declarative (YAML) %}
 
-For example, configure this plugin on a [route](/gateway/latest/admin-api/#route-object) by
-adding this section to your declarative configuration file:
+Add this section to your declarative configuration file:
 
 ```yaml
 plugins:
@@ -336,7 +337,6 @@ plugins:
 {% endunless %}
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Konnect Cloud %}
-Configure this plugin on a route:
 
 1. In Konnect Cloud, select the service from the ServiceHub page.
 2. Scroll down to **Versions** and select the version.
@@ -352,7 +352,6 @@ or sample values as needed:
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Kong Manager %}
-Configure this plugin on a route:
 
 1. In Kong Manager, select the workspace.
 2. From the Dashboard, select **Routes** in the left navigation.
@@ -383,12 +382,15 @@ or sample values as needed:
 
 {% if include.params.consumer_id %}
 {% capture plugin_config_for_consumer %}
-### Enabling the plugin on a consumer
+
+The following examples provide some typical configuration for enabling
+the <code>{{include.params.name}}</code> plugin on a
+[consumer](/gateway/latest/admin-api/#consumer-object).
 
 {% navtabs %}
 {% navtab Admin API %}
 
-For example, configure this plugin on a [consumer](/gateway/latest/admin-api/#consumer-object) with:
+Make the following request:
 
 ```bash
 $ curl -X POST http://{HOST}:8001/consumers/{CONSUMER}/plugins \
@@ -449,8 +451,7 @@ metadata:
 {% unless include.params.yaml_examples == false %}
 {% navtab Declarative (YAML) %}
 
-For example, configure this plugin on a [consumer](/gateway/latest/admin-api/#consumer-object) by
-adding this section to your declarative configuration file:
+Add this section to your declarative configuration file:
 
 ``` yaml
 plugins:
@@ -467,7 +468,6 @@ plugins:
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Kong Manager %}
-Configure this plugin on a consumer:
 
 1. In Kong Manager, select the workspace.
 2. From the Dashboard, scroll down to **Consumers** and click **View** for the consumer row.
@@ -495,17 +495,18 @@ Configure this plugin on a consumer:
 <!-- Global config example -->
 
 {% capture plugin_global_config %}
-### Enable the plugin globally
 
 A plugin which is not associated to any service, route, or consumer is
 considered _global_, and will be run on every request. Read the
 [Plugin Reference](/gateway/latest/admin-api/#add-plugin) and the [Plugin Precedence](/gateway/latest/admin-api/#precedence)
 sections for more information.
 
+The following examples provide some typical configuration for enabling
+the <code>{{include.params.name}}</code> plugin globally.
 {% navtabs %}
 {% navtab Admin API %}
 
-For example, configure this plugin globally with:
+Make the following request:
 
 ```bash
 $ curl -X POST http://{HOST}:8001/plugins/ \
@@ -537,7 +538,8 @@ plugin: {{include.params.name}}
 {% endunless %}
 {% unless include.params.yaml_examples == false %}
 {% navtab Declarative (YAML) %}
-For example, configure this plugin using the <code>plugins:</code> entry in the declarative
+
+Add a <code>plugins</code> entry in the declarative
 configuration file:
 
 ``` yaml
@@ -550,7 +552,6 @@ plugins:
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Kong Manager %}
-Configure this plugin globally:
 
 1. In Kong Manager, select the workspace.
 2. From the Dashboard, select **Plugins** in the left navigation.
@@ -576,13 +577,32 @@ default/sample values as needed:
 {% endcapture %}
 
 <!-- Layout text -->
+
+{% if include.params.service_id or include.params.route_id or include.params.consumer_id %}
+{% navtabs parent %}
 {% if include.params.service_id %}
+  {% navtab Enable on a service %}
   {{ plugin_config_for_service | markdownify }}
+  {% endnavtab %}
 {% endif %}
+
 {% if include.params.route_id %}
+  {% navtab Enable on a route %}
   {{ plugin_config_for_route | markdownify }}
+  {% endnavtab %}
 {% endif %}
+
 {% if include.params.consumer_id %}
+  {% navtab Enable on a consumer %}
   {{ plugin_config_for_consumer | markdownify }}
+  {% endnavtab %}
 {% endif %}
-{{ plugin_global_config | markdownify }}
+
+{% navtab Enable globally %}
+  {{ plugin_global_config | markdownify }}
+{% endnavtab %}
+{% endnavtabs %}
+
+{% else %}
+  {{ plugin_global_config | markdownify }}
+{% endif %}

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -206,6 +206,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
         {% endif %}
 
         {% if page.params.examples != false %}
+        <h3 id="example-config">Example plugin configuration</h3>
           {% include_cached hub-examples.html version=page.version params=page.params publisher=page.publisher name=page.name %}
         {% endif %}
 


### PR DESCRIPTION
### Summary
An attempt at combining the plugin config examples into something that's hopefully easier to navigate/understand.

You can set the `parent` class on a group of `navtabs` to surround it with a border. This makes it clearer that the tabs contain tabs.

Previously:

![Screen Shot 2022-05-20 at 1 33 23 PM](https://user-images.githubusercontent.com/54370747/171506601-4006e520-12da-4b92-a141-f1ae0230f0b4.png)

Reworked:

https://user-images.githubusercontent.com/54370747/171506991-09cd8f27-2fcb-4394-80a8-0038d7b2cd1a.mov

### Reason
Most recently, the issue was raised by Rick. However, this issue has been called out many times in the past: we have too many similar examples and they cover a huge portion of the plugin page while being mostly the same. 

Feedback from Rick: to a new user, it looks like each section has to be done in order (enable on a service, then on a route, etc). It's not immediately clear that a) these instructions are independent from one another, and b) these are typical examples only, and not necessarily the best/only way to configure a plugin.

https://konghq.atlassian.net/browse/DOCU-2350

### Testing
Look at any kong plugin, eg https://deploy-preview-3990--kongdocs.netlify.app/hub/kong-inc/key-auth/