### PR TITLE
(chore) Bump decK version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -426,7 +426,7 @@
   edition: "deck"
 -
   release: "1.12.x"
-  version: "1.12.1"
+  version: "1.12.2"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Summary
Bumping the decK patch version.

### Reason
https://github.com/Kong/deck/releases/tag/v1.12.2

### Testing
Check the decK install guide.