### PR TITLE
docs(*): added logic that detect arch for kong-mesh

### DIFF
--- a/app/mesh/installer.sh
+++ b/app/mesh/installer.sh
@@ -21,7 +21,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 : "${VERSION:=}"
-: "${ARCH:=amd64}"
+: "${ARCH:=}"
 
 PRODUCT_NAME="Kong Mesh"
 LATEST_VERSION=https://docs.konghq.com/mesh/latest_version/
@@ -68,6 +68,18 @@ fi
 if [ -z "$DISTRO" ]; then
   printf "ERROR\tUnable to detect the operating system\n"
   exit 1
+fi
+
+DETECTED_ARCH=`uname -m`
+if [ "$ARCH" = "" ]; then
+  if [ "$DETECTED_ARCH" = "x86_64" ]; then
+    ARCH=amd64
+  elif [ "$DETECTED_ARCH" = "arm64" ] || [ "$DETECTED_ARCH" = "aarch64" ] || [ "$DETECTED_ARCH" = "armv8l" ] || [ "$DETECTED_ARCH" = "armv8b" ]; then
+    ARCH=arm64
+  else
+    printf "ERROR\tArchitecture %s not supported by $PRODUCT_NAME\n" "$DETECTED_ARCH"
+    exit 1
+  fi
 fi
 
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
### Summary

Detect arch type of the machine.

### Reason
Since `kong-mesh` 1.8 we support arm64, and we didn't detect the arch type.

### Testing
`./installer.sh | VERSION=1.8.0-rc1  sh - `
