### PR TITLE
[DOCU-2360] Portal email recipients and developer metadata

### DIFF
--- a/app/gateway/2.8.x/developer-portal/theme-customization/emails.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/emails.md
@@ -57,13 +57,13 @@ The body of the email is HTML content. You can reference the tokens allowed for 
 |--- 	|---	|---	|---	|
 |emails/invite.txt	        |  `{{portal.gui_url}}` `{{email.developer_email}}`                                          | `{{portal.gui_url}}`                                                |email sent to developer who is invited to a portal from the manager	|
 |---	|---	|---	|---	|
-|emails/request-access.txt	|`{{portal.gui_url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.admin_url}}`     	|`{{portal.gui_url}}` `{{email.developer_email}}`	                      |email sent to admin when a developer signs up for portal, in order to approve the developer	|
-|emails/approved-access.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}`	                            |`{{portal.gui_url}}`	                                                |email sent to developer when their account is approved	|
-|emails/password-reset.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.token}}` `{{email.token_exp}}` `{{email.reset_url}}`	|`{{portal.url}}` `{{email.token}}` or `{{email.reset_url}}`	|email sent to developer when a password reset  is requested (basic-auth only)	|
-|emails/password-reset-success.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}`	                    |`{{portal.url}}`	                                                    |email sent to developer when a password reset is successful (basic-auth only) 	|
-|emails/account-verification.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.token}}` `{{email.verify_url}}` `{{email.invalidate_url}}`	|`{{portal.url}}` `{{email.token}}` or  both `{{email.verify_url}}` and `{{email.invalidate_url}} `	|email sent to developer when portal_email_verification is on  to verify developer email (basic-auth only)	|
-|emails/account-verification-approved.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}`	              |`{{portal.url}}`	                                                    |email sent to developer when portal_email_verification is on and developer has verified email and developer has been approved by admin/auto-approve is on (basic-auth only)	|
-|emails/account-verification-pending.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}`	              |`{{portal.url}}`	                                                    |email sent to developer when portal_email_verification is on and developer has verified email and developer has yet to be approved by admin (basic-auth only)	|
+|emails/request-access.txt	|`{{portal.gui_url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}` `{{email.admin_url}}`     	|`{{portal.gui_url}}` `{{email.developer_email}}`	                      |email sent to admin when a developer signs up for portal, in order to approve the developer	|
+|emails/approved-access.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}`	                            |`{{portal.gui_url}}`	                                                |email sent to developer when their account is approved	|
+|emails/password-reset.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}` `{{email.token}}` `{{email.token_exp}}` `{{email.reset_url}}`	|`{{portal.url}}` `{{email.token}}` or `{{email.reset_url}}`	|email sent to developer when a password reset  is requested (basic-auth only)	|
+|emails/password-reset-success.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}`	                    |`{{portal.url}}`	                                                    |email sent to developer when a password reset is successful (basic-auth only) 	|
+|emails/account-verification.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}` `{{email.token}}` `{{email.verify_url}}` `{{email.invalidate_url}}`	|`{{portal.url}}` `{{email.token}}` or  both `{{email.verify_url}}` and `{{email.invalidate_url}} `	|email sent to developer when portal_email_verification is on  to verify developer email (basic-auth only)	|
+|emails/account-verification-approved.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}`	              |`{{portal.url}}`	                                                    |email sent to developer when portal_email_verification is on and developer has verified email and developer has been approved by admin/auto-approve is on (basic-auth only)	|
+|emails/account-verification-pending.txt	|`{{portal.url}}` `{{email.developer_email}}` `{{email.developer_name}}` `{{email.developer_meta.*}}`	              |`{{portal.url}}`	                                                    |email sent to developer when portal_email_verification is on and developer has verified email and developer has yet to be approved by admin (basic-auth only)	|
 {% endraw %}
 
 ## Token Descriptions
@@ -73,8 +73,9 @@ The body of the email is HTML content. You can reference the tokens allowed for 
 |---	|---	|
 |`{{portal.url}}`	|Dev Portal URL for the workspace	|
 |---	|---	|
-|`{{email.developer_email}}`	|Developers email	|
-|`{{email.developer_name}}`	|Developers full name, this value is collected as part of registration by default. If meta-fields are edited to not include full_name then this will fallback to email 	|
+|`{{email.developer_email}}`	|Developer's email	|
+|`{{email.developer_name}}`	|Developer's full name, this value is collected as part of registration by default. If meta-fields are edited to not include full_name then this will fallback to email 	|
+|`{{email.developer_meta.*}}`	|Developer's meta-fields, these value are collected as part of registration. They must be configured prior to registration. If the value doesn't exist or is optional and blank, it will display as an empty string. If the `developer_meta` configuration doesn't specify the field, it will appear as-is without replacement, e.g. `{{email.developer_meta.preferred_name}}`|
 |`{{email.admin_url}}`	|Kong Manger URL	|
 |`{{email.reset_url}}`	|Dev Portal full URL for resetting password (assumes default path for password reset) 	|
 |`{{email.token_exp}}`	|Human readable string for amount of time from sending of email, password reset token/url is valid.	|

--- a/app/gateway/2.8.x/developer-portal/theme-customization/emails.md
+++ b/app/gateway/2.8.x/developer-portal/theme-customization/emails.md
@@ -76,7 +76,7 @@ The body of the email is HTML content. You can reference the tokens allowed for 
 |`{{email.developer_email}}`	|Developer's email	|
 |`{{email.developer_name}}`	|Developer's full name, this value is collected as part of registration by default. If meta-fields are edited to not include full_name then this will fallback to email 	|
 |`{{email.developer_meta.*}}`	|Developer's meta-fields, these value are collected as part of registration. They must be configured prior to registration. If the value doesn't exist or is optional and blank, it will display as an empty string. If the `developer_meta` configuration doesn't specify the field, it will appear as-is without replacement, e.g. `{{email.developer_meta.preferred_name}}`|
-|`{{email.admin_url}}`	|Kong Manger URL	|
+|`{{email.admin_url}}`	|Kong Manager URL	|
 |`{{email.reset_url}}`	|Dev Portal full URL for resetting password (assumes default path for password reset) 	|
 |`{{email.token_exp}}`	|Human readable string for amount of time from sending of email, password reset token/url is valid.	|
 |`{{email.verify_url}}`	|Link to verify account (assumes default path for account verification))	|

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -3298,6 +3298,19 @@ associated with the account.
 
 ---
 
+#### portal_smtp_admin_emails
+{:.badge .enterprise}
+
+Comma separated list of admin emails to receive portal-related notifications.
+
+If none are set, the values in `smtp_admin_emails` will be used.
+
+Example `admin1@example.com, admin2@example.com`
+
+**Default:** none
+
+---
+
 
 ### Admin Smtp Configuration section
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -15,7 +15,7 @@ for the Developer Portal using the following configuration parameters:
   * [`portal_application_status_email`](/gateway/latest/reference/configuration/#portal_application_status_email): Enable to send application request status update emails to developers.
   * [`portal_application_request_email`](/gateway/latest/reference/configuration/#portal_application_request_email): Enable to send service access request emails to users specified in `smtp_admin_emails`.
   * [`portal_smtp_admin_emails`](/gateway/latest/reference/configuration/#portal_smtp_admin_emails): Specify the email addresses to send portal admin emails to, overriding values set in `smtp_admin_emails`.
-* Added the ability to use `email.developer_meta` fields in portal email templates. For example, `{{email.developer_meta.preferred_name}}`.
+* Added the ability to use `email.developer_meta` fields in portal email templates. For example, `{% raw %}{{email.developer_meta.preferred_name}}{% endraw %}`.
 
 #### Plugins
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -14,6 +14,8 @@ no_version: true
 for the Developer Portal using the following configuration parameters:
   * [`portal_application_status_email`](/gateway/latest/reference/configuration/#portal_application_status_email): Enable to send application request status update emails to developers.
   * [`portal_application_request_email`](/gateway/latest/reference/configuration/#portal_application_request_email): Enable to send service access request emails to users specified in `smtp_admin_emails`.
+  * [`portal_smtp_admin_emails`](/gateway/latest/reference/configuration/#portal_smtp_admin_emails): Specify the email addresses to send portal admin emails to, overriding values set in `smtp_admin_emails`.
+* Added the ability to use `email.developer_meta` fields in portal email templates. For example, `{{email.developer_meta.preferred_name}}`.
 
 #### Plugins
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Following up on https://github.com/Kong/docs.konghq.com/pull/3995 with a couple more additions that we snuck into 2.8.1.1.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
https://konghq.atlassian.net/browse/DOCU-2360

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->
https://deploy-preview-3999--kongdocs.netlify.app/gateway/changelog
https://deploy-preview-3999--kongdocs.netlify.app/gateway/latest/reference/configuration/#portal_smtp_admin_emails
https://deploy-preview-3999--kongdocs.netlify.app/gateway/latest/developer-portal/theme-customization/emails/
<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
