### PR TITLE
[DOCU-2329] Linux OS support and deprecation

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -26,18 +26,18 @@ items:
         url: /install-and-run/openshift
       - text: Docker
         url: /install-and-run/docker
-      - text: Amazon Linux
-        url: /install-and-run/amazon-linux
-      - text: CentOS
-        url: /install-and-run/centos
       - text: macOS
         url: /install-and-run/macos
+      - text: Amazon Linux
+        url: /install-and-run/amazon-linux
       - text: Debian
         url: /install-and-run/debian
       - text: RHEL
         url: /install-and-run/rhel
       - text: Ubuntu
         url: /install-and-run/ubuntu
+      - text: Supported Linux OSes
+        url: /install-and-run/os-support
       - text: Migrating from OSS to EE
         url: /install-and-run/migrate-ce-to-ke
       - text: Upgrade Kong Gateway

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -16,8 +16,9 @@ items:
 
   - title: Install and Run
     icon: /assets/images/icons/documentation/icn-deployment-color.svg
-    url: /install-and-run/
     items:
+      - text: Installation Options
+        url: /install-and-run/
       - text: Kubernetes
         url: /install-and-run/kubernetes
       - text: Helm
@@ -26,18 +27,20 @@ items:
         url: /install-and-run/openshift
       - text: Docker
         url: /install-and-run/docker
+      - text: Linux
+        items:
+          - text: Supported Distributions
+            url: /install-and-run/os-support
+          - text: Amazon Linux
+            url: /install-and-run/amazon-linux
+          - text: Debian
+            url: /install-and-run/debian
+          - text: RHEL
+            url: /install-and-run/rhel
+          - text: Ubuntu
+            url: /install-and-run/ubuntu
       - text: macOS
         url: /install-and-run/macos
-      - text: Amazon Linux
-        url: /install-and-run/amazon-linux
-      - text: Debian
-        url: /install-and-run/debian
-      - text: RHEL
-        url: /install-and-run/rhel
-      - text: Ubuntu
-        url: /install-and-run/ubuntu
-      - text: Supported Linux OSes
-        url: /install-and-run/os-support
       - text: Migrating from OSS to EE
         url: /install-and-run/migrate-ce-to-ke
       - text: Upgrade Kong Gateway

--- a/app/_data/tables/os_support.yml
+++ b/app/_data/tables/os_support.yml
@@ -1,0 +1,209 @@
+- os_version:
+  name: Amazon Linux 1
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: 2.8.x
+  oss: true
+  oss_versions:
+    first_version: 0.10.x
+    last_version: 2.8.x
+  status: deprecated
+  deprecation_date: December 31, 2020
+  eol_link: https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life
+
+- os_version:
+  name: Amazon Linux 2
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 2.0.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: CentOS 6
+  enterprise: true
+  enterprise_versions:
+    first_version: null
+    last_version: 2.3.x
+  oss: true
+  oss_versions:
+    first_version: 0.10.x
+    last_version: 2.3.x
+  status: deprecated
+  deprecation_date: November 30, 2020
+  eol_link: https://endoflife.software/operating-systems/linux/centos
+
+- os_version:
+  name: CentOS 7
+  enterprise: true
+  enterprise_versions:
+    first_version: 2.1.x
+    last_version: 2.8.x
+  oss: true
+  oss_versions:
+    first_version: 0.10.x
+    last_version: 2.7.x
+  status: deprecated
+  deprecation_date: December 31, 2021
+  eol_link: https://www.centos.org/centos-linux-eol/
+
+- os_version:
+  name: CentOS 8
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: 2.8.x
+  oss: true
+  oss_versions:
+    first_version: 1.4.x
+    last_version: 2.7.x
+  status: deprecated
+  deprecation_date: December 31, 2021
+  eol_link: https://www.centos.org/centos-linux-eol/
+
+- os_version:
+  name: Debian 8 (Jessie)
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: 2.8.x
+  oss: true
+  oss_versions:
+    first_version: 0.2.x
+    last_version: 2.8.x
+  status: deprecated
+  deprecation_date: June 30th, 2020
+  eol_link: https://www.debian.org/News/2020/20200709
+
+- os_version:
+  name: Debian 9 (Stretch)
+  enterprise: true
+  enterprise_versions:
+    first_version: 2.1.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 0.11.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: Debian 10 (Buster)
+  enterprise: true
+  enterprise_versions:
+    first_version: 2.7.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 1.4.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: Debian 11 (Bullseye)
+  enterprise: true
+  enterprise_versions:
+    first_version: 2.7.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 1.4.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: RHEL 6
+  enterprise: false
+  enterprise_versions:
+    first_version: null
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 0.14.x
+    last_version: 1.5.x
+  status: deprecated
+  deprecation_date: November 30, 2020
+  eol_link: https://access.redhat.com/support/policy/updates/errata
+
+- os_version:
+  name: RHEL 7
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 0.14.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: RHEL 8
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 1.4.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: Ubuntu 16.04 (Xenial)
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: 2.8.x
+  oss: true
+  oss_versions:
+    first_version: 0.10.x
+    last_version: 2.8.x
+  status: deprecated
+  deprecation_date: April 2021
+  eol_link: https://wiki.ubuntu.com/Releases
+
+- os_version:
+  name: Ubuntu 18.04 (Bionic)
+  enterprise: true
+  enterprise_versions:
+    first_version: 1.5.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 0.14.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null
+
+- os_version:
+  name: Ubuntu 20.04 (Focal)
+  enterprise: true
+  enterprise_versions:
+    first_version: 2.1.x
+    last_version: null
+  oss: true
+  oss_versions:
+    first_version: 2.1.x
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null

--- a/app/_data/tables/os_support.yml
+++ b/app/_data/tables/os_support.yml
@@ -1,4 +1,4 @@
-- os_version:
+-
   name: Amazon Linux 1
   enterprise: true
   enterprise_versions:
@@ -11,8 +11,7 @@
   status: deprecated
   deprecation_date: December 31, 2020
   eol_link: https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life
-
-- os_version:
+-
   name: Amazon Linux 2
   enterprise: true
   enterprise_versions:
@@ -25,8 +24,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: CentOS 6
   enterprise: true
   enterprise_versions:
@@ -39,8 +37,7 @@
   status: deprecated
   deprecation_date: November 30, 2020
   eol_link: https://endoflife.software/operating-systems/linux/centos
-
-- os_version:
+-
   name: CentOS 7
   enterprise: true
   enterprise_versions:
@@ -54,7 +51,7 @@
   deprecation_date: December 31, 2021
   eol_link: https://www.centos.org/centos-linux-eol/
 
-- os_version:
+-
   name: CentOS 8
   enterprise: true
   enterprise_versions:
@@ -67,8 +64,7 @@
   status: deprecated
   deprecation_date: December 31, 2021
   eol_link: https://www.centos.org/centos-linux-eol/
-
-- os_version:
+-
   name: Debian 8 (Jessie)
   enterprise: true
   enterprise_versions:
@@ -81,8 +77,7 @@
   status: deprecated
   deprecation_date: June 30th, 2020
   eol_link: https://www.debian.org/News/2020/20200709
-
-- os_version:
+-
   name: Debian 9 (Stretch)
   enterprise: true
   enterprise_versions:
@@ -95,8 +90,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: Debian 10 (Buster)
   enterprise: true
   enterprise_versions:
@@ -109,8 +103,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: Debian 11 (Bullseye)
   enterprise: true
   enterprise_versions:
@@ -123,8 +116,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: RHEL 6
   enterprise: false
   enterprise_versions:
@@ -137,8 +129,7 @@
   status: deprecated
   deprecation_date: November 30, 2020
   eol_link: https://access.redhat.com/support/policy/updates/errata
-
-- os_version:
+-
   name: RHEL 7
   enterprise: true
   enterprise_versions:
@@ -151,8 +142,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: RHEL 8
   enterprise: true
   enterprise_versions:
@@ -165,8 +155,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: Ubuntu 16.04 (Xenial)
   enterprise: true
   enterprise_versions:
@@ -179,8 +168,7 @@
   status: deprecated
   deprecation_date: April 2021
   eol_link: https://wiki.ubuntu.com/Releases
-
-- os_version:
+-
   name: Ubuntu 18.04 (Bionic)
   enterprise: true
   enterprise_versions:
@@ -193,8 +181,7 @@
   status: active
   deprecation_date: null
   eol_link: null
-
-- os_version:
+-
   name: Ubuntu 20.04 (Focal)
   enterprise: true
   enterprise_versions:

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,3 +1,7 @@
+# DEPRECATED OS
+/gateway/3.0.x/install-and-run/centos    /gateway/latest/install-and-run/os-support
+/gateway/latest/install-and-run/centos   /gateway/latest/install-and-run/os-support
+
 # FREE TRIALS, GENERAL LICENSING
 /free-trial/guide/                    https://konghq.com/install
 /konnect-platform/plans/              https://konghq.com/pricing/

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -3,6 +3,35 @@ title: Kong Gateway Changelog
 no_version: true
 ---
 
+## 3.0.0.0
+**Release Date** TBD
+
+### Deprecated
+
+* **Amazon Linux 1**: Support for running Kong Gateway on Amazon Linux 1 is now deprecated, as the
+[Amazon Linux (1) AMI has ended standard support as of December 31, 2020](https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life).
+Starting with Kong Gateway 3.0.0.0, Kong is not building new Amazon Linux 1
+images or packages, and Kong will not test package installation on Amazon Linux 1.
+
+    If you need to install Kong Gateway on Amazon Linux 1, see the documentation for
+    [previous versions](/gateway/2.8.x/install-and-run/amazon-linux/).
+
+*  **Debian 8**: Support for running Kong Gateway on Debian 8 ("Jessie") is now deprecated, as
+[Debian 8 ("Jessie") has reached End of Life (EOL)](https://www.debian.org/News/2020/20200709).
+Starting with Kong Gateway 3.0.0.0, Kong is not building new Debian 8
+("Jessie") images or packages, and Kong will not test package installation on
+Debian 8 ("Jessie").
+
+    If you need to install Kong Gateway on Debian 8 ("Jessie"), see the documentation for
+    [previous versions](/gateway/2.8.x/install-and-run/debian/).
+
+* **Ubuntu 16.04**: Support for running Kong Gateway on Ubuntu 16.04 ("Xenial") is now deprecated,
+as [Standard Support for Ubuntu 16.04 has ended as of April, 2021](https://wiki.ubuntu.com/Releases).
+Starting with Kong Gateway 3.0.0.0, Kong is not building new Ubuntu 16.04
+images or packages, and Kong will not test package installation on Ubuntu 16.04.
+
+    If you need to install Kong Gateway on Ubuntu 16.04, see the documentation for
+    [previous versions](/gateway/2.8.x/install-and-run/ubuntu/).
 
 ## 2.8.1.0
 **Release Date** 2022/04/07

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -16,7 +16,7 @@ images or packages, and Kong will not test package installation on Amazon Linux 
     If you need to install Kong Gateway on Amazon Linux 1, see the documentation for
     [previous versions](/gateway/2.8.x/install-and-run/amazon-linux/).
 
-*  **Debian 8**: Support for running Kong Gateway on Debian 8 ("Jessie") is now deprecated, as
+* **Debian 8**: Support for running Kong Gateway on Debian 8 ("Jessie") is now deprecated, as
 [Debian 8 ("Jessie") has reached End of Life (EOL)](https://www.debian.org/News/2020/20200709).
 Starting with Kong Gateway 3.0.0.0, Kong is not building new Debian 8
 ("Jessie") images or packages, and Kong will not test package installation on

--- a/src/gateway/install-and-run/amazon-linux.md
+++ b/src/gateway/install-and-run/amazon-linux.md
@@ -2,26 +2,6 @@
 title: Install Kong Gateway on Amazon Linux
 ---
 
-{:.important}
-> **Deprecation notice**: Support for running Kong Gateway on
-Amazon Linux 1 is now deprecated, as [The Amazon Linux (1) AMI has ended standard support as of December 31, 2020](https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life).
-Starting with Kong Gateway 3.0.0.0, Kong is neither building new Amazon Linux 1 images nor packages. Nor will Kong test package installation on Amazon Linux 1.
-> If you need to install Kong Gateway on Amazon Linux 1, see the documentation for
-[previous versions](/gateway/2.8.x/install-and-run/amazon-linux/).
-
-<!-- Banner with links to latest downloads -->
-<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
-
-{:.install-banner}
-> Download the latest {{page.kong_version}} packages for
-> Amazon Linux:
-> * **Kong Gateway**: [**Amazon Linux 2**]({{site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amzn2.noarch.rpm){:.install-link} (version {{page.kong_versions[page.version-index].ee-version}})
-> * **Kong Gateway (OSS)**: [**Amazon Linux 2**]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm){:.install-link} (version {{page.kong_versions[page.version-index].ce-version}})
-> <br><br>
->
-> <span class="install-subtitle">View the list of all 2.x packages for
-> [Amazon Linux 2]({{ site.links.download }}/gateway-2.x-amazonlinux-2/Packages/k/){:.install-listing-link}  </span>
-
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 Kong is licensed under an
@@ -29,7 +9,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A [supported system](/gateway/{{page.kong_version}}/install-and-run/os-support) with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong.
 
 ## Download and Install

--- a/src/gateway/install-and-run/centos.md
+++ b/src/gateway/install-and-run/centos.md
@@ -34,7 +34,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A [supported system](/gateway/{{page.kong_version}}/install-and-run/os-support) with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong.
 
 ## Download and Install

--- a/src/gateway/install-and-run/debian.md
+++ b/src/gateway/install-and-run/debian.md
@@ -2,37 +2,6 @@
 title: Install Kong Gateway on Debian
 ---
 
-{:.important}
-> **Deprecation notice**: Support for running Kong Gateway on
-Debian 8 ("Jessie") is now deprecated, as [Debian 8 ("Jessie") has reached End of Life (EOL)](https://www.debian.org/News/2020/20200709).
-Starting with Kong Gateway 3.0.0.0, Kong is neither building new Debian 8 ("Jessie") images nor packages. Nor will Kong test package installation on Debian 8 ("Jessie").
-> If you need to install Kong Gateway on Debian 8 ("Jessie"), see the documentation for
-[previous versions](/gateway/2.8.x/install-and-run/debian/).
-> <br><br>
-> Kong Gateway Enterprise subscriptions can still use Debian 8 ("Jessie") in 2.8, but support
-for Debian 8 ("Jessie") is planned to be removed in 3.0.
-
-{:.install-banner}
-> Download the latest {{page.kong_version}} package for Debian:
->
-> * **Kong Gateway**:
-> [**9 Stretch**]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
-> [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
-> or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link}
-> (latest version: {{page.kong_versions[page.version-index].ee-version}})
-> * **Kong Gateway (OSS)**:
-> [**9 Stretch**]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link},
-> [**10 Buster**]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link},
-> or [**11 Bullseye**]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
-> (latest version: {{page.kong_versions[page.version-index].ce-version}})
->
-> <br>
-> <span class="install-subtitle">View the list of all 2.x packages for
-> [9 Stretch]({{ site.links.download }}/gateway-2.x-debian-stretch/pool/all/k/){:.install-listing-link},
-> [10 Buster]({{ site.links.download }}/gateway-2.x-debian-buster/pool/all/k/){:.install-listing-link}, or
-> [11 Bullseye]({{ site.links.download }}/gateway-2.x-debian-bullseye/pool/all/k/){:.install-listing-link}
->  </span>
-
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 {{site.ce_product_name}} is licensed under an
@@ -40,7 +9,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A [supported system](/gateway/{{page.kong_version}}/install-and-run/os-support) with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * The following tools are installed:
   * [`curl`](https://curl.se/)
   * [`lsb-release`](https://packages.debian.org/lsb-release)

--- a/src/gateway/install-and-run/docker.md
+++ b/src/gateway/install-and-run/docker.md
@@ -2,16 +2,6 @@
 title: Install Kong Gateway on Docker
 ---
 
-<!-- Banner with links to latest downloads -->
-<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
-
-{:.install-banner}
-> See the list of Docker tags and pull the Docker image:
-> * [**Kong Gateway**](https://hub.docker.com/r/kong/kong-gateway/tags){:.install-listing-link}
-> * [**Kong Gateway (OSS)**](https://hub.docker.com/_/kong){:.install-listing-link}
->
-> (latest {{site.base_gateway}} version: {{page.kong_versions[page.version-index].ee-version}})
-
 {{site.base_gateway}} supports both PostgreSQL 9.5+ and Cassandra 3.11.* as its
 datastore. This guide provides steps to configure PostgreSQL.
 
@@ -217,7 +207,7 @@ docker run -d --name kong-gateway \
     * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
     (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
-    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it 
+    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it
     as an environment variable, this parameter pulls the license from your environment.
 
 1. Verify your installation:
@@ -405,7 +395,7 @@ docker run -d --name kong-dbless \
     * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
     (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
-    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it 
+    * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it
     as an environment variable, this parameter pulls the license from your environment.
 
 1. Verify that {{site.base_gateway}} is running:

--- a/src/gateway/install-and-run/index.md
+++ b/src/gateway/install-and-run/index.md
@@ -25,10 +25,12 @@ disable_image_expand: true
     <div class="install-text">OpenShift</div>
   </a>
 
+  {% if_version lte:2.8.x %}
   <a href="/gateway/{{page.kong_version}}/install-and-run/centos" class="docs-grid-install-block no-description">
     <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/centos.gif" alt="" />
     <div class="install-text">CentOS</div>
   </a>
+  {% endif_version %}
 
   <a href="/gateway/{{page.kong_version}}/install-and-run/ubuntu" class="docs-grid-install-block no-description">
     <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/ubuntu.png" alt="" />

--- a/src/gateway/install-and-run/index.md
+++ b/src/gateway/install-and-run/index.md
@@ -61,6 +61,11 @@ disable_image_expand: true
   </a>
 </div>
 
+{:.note}
+> **Note**: For installation on a Linux OS, review the list of
+[supported and deprecated OSes](/gateway/{{page.kong_version}}/install-and-run/os-support)
+before installing {{site.base_gateway}}.
+
 ## Deployment options
 
 {% include_cached /md/gateway/deployment-options.md kong_version=page.kong_version %}

--- a/src/gateway/install-and-run/macos.md
+++ b/src/gateway/install-and-run/macos.md
@@ -2,21 +2,13 @@
 title: Install Kong Gateway on macOS
 badge: oss
 ---
-<!-- Banner with links to latest downloads -->
-<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
-
-{:.install-banner}
-> See the MacOS
-> [**Homebrew formula**]({{ site.repos.homebrew }}){:.install-listing-link}
->
-> (latest version: {{page.kong_versions[page.version-index].ce-version}})
 
 {{site.ce_product_name}} is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 ## Prerequisites
 
-You have a supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+You have [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 
 ## Download and install
 

--- a/src/gateway/install-and-run/os-support.md
+++ b/src/gateway/install-and-run/os-support.md
@@ -1,0 +1,84 @@
+---
+title: Supported Operating Systems
+---
+
+{% assign os_versions = site.data.tables.os_support %}
+
+## Supported
+
+Kong Gateway currently supports the following Linux operating systems:
+
+<table>
+  <thead>
+      <th>OS version</th>
+      <th>First Enterprise version</th>
+      <th>First open-source version</th>
+  </thead>
+  <tbody>
+  {% for os_version in os_versions %}
+    {% if os_version.status == "active" %}
+      <tr>
+        <td>
+          {{ os_version.name }}
+        </td>
+        <td style="text-align: center">
+          {% if os_version.enterprise == true and os_version.enterprise_versions.first_version != null %}
+            {{ os_version.enterprise_versions.first_version }}
+          {% else %}
+          Not supported
+          {% endif %}
+        </td>
+        <td style="text-align: center">
+          {% if os_version.oss == true and os_version.oss_versions.first_version != null %}
+            {{ os_version.oss_versions.first_version }}
+          {% else %}
+          Not supported
+          {% endif %}
+        </td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+## Deprecated
+
+The following versions have reached end of life (EoL) and are no longer
+supported by Kong:
+
+<table>
+  <thead>
+      <th>OS version</th>
+      <th>End of Life</th>
+      <th>Last Enterprise version</th>
+      <th>Last open-source version</th>
+  </thead>
+  <tbody>
+  {% for os_version in os_versions %}
+    {% if os_version.status == "deprecated" %}
+      <tr>
+        <td>
+          {{ os_version.name }}
+        </td>
+        <td>
+          <a href="{{ os_version.eol_link }}">{{ os_version.deprecation_date }}</a>
+        </td>
+        <td style="text-align: center">
+          {% if os_version.enterprise == true %}
+            {{ os_version.enterprise_versions.last_version }}
+          {% else %}
+          Not applicable
+          {% endif %}
+        </td>
+        <td style="text-align: center">
+          {% if os_version.oss == true %}
+            {{ os_version.oss_versions.last_version }}
+          {% else %}
+          Not applicable
+          {% endif %}
+        </td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>

--- a/src/gateway/install-and-run/os-support.md
+++ b/src/gateway/install-and-run/os-support.md
@@ -15,22 +15,22 @@ Kong Gateway currently supports the following Linux operating systems:
       <th>First open-source version</th>
   </thead>
   <tbody>
-  {% for os_version in os_versions %}
-    {% if os_version.status == "active" %}
+  {% for item in os_versions %}
+    {% if item.status == "active" %}
       <tr>
         <td>
-          {{ os_version.name }}
+          {{ item.name }}
         </td>
         <td style="text-align: center">
-          {% if os_version.enterprise == true and os_version.enterprise_versions.first_version != null %}
-            {{ os_version.enterprise_versions.first_version }}
+          {% if item.enterprise == true and item.enterprise_versions.first_version != null %}
+            {{ item.enterprise_versions.first_version }}
           {% else %}
           Not supported
           {% endif %}
         </td>
         <td style="text-align: center">
-          {% if os_version.oss == true and os_version.oss_versions.first_version != null %}
-            {{ os_version.oss_versions.first_version }}
+          {% if item.oss == true and item.oss_versions.first_version != null %}
+            {{ item.oss_versions.first_version }}
           {% else %}
           Not supported
           {% endif %}
@@ -54,25 +54,25 @@ supported by Kong:
       <th>Last open-source version</th>
   </thead>
   <tbody>
-  {% for os_version in os_versions %}
-    {% if os_version.status == "deprecated" %}
+  {% for item in os_versions %}
+    {% if item.status == "deprecated" %}
       <tr>
         <td>
-          {{ os_version.name }}
+          {{ item.name }}
         </td>
         <td>
-          <a href="{{ os_version.eol_link }}">{{ os_version.deprecation_date }}</a>
+          <a href="{{ item.eol_link }}">{{ item.deprecation_date }}</a>
         </td>
         <td style="text-align: center">
-          {% if os_version.enterprise == true %}
-            {{ os_version.enterprise_versions.last_version }}
+          {% if item.enterprise == true %}
+            {{ item.enterprise_versions.last_version }}
           {% else %}
           Not applicable
           {% endif %}
         </td>
         <td style="text-align: center">
-          {% if os_version.oss == true %}
-            {{ os_version.oss_versions.last_version }}
+          {% if item.oss == true %}
+            {{ item.oss_versions.last_version }}
           {% else %}
           Not applicable
           {% endif %}

--- a/src/gateway/install-and-run/os-support.md
+++ b/src/gateway/install-and-run/os-support.md
@@ -11,8 +11,8 @@ Kong Gateway currently supports the following Linux operating systems:
 <table>
   <thead>
       <th>OS version</th>
-      <th>First Enterprise version</th>
-      <th>First open-source version</th>
+      <th style="text-align: center">First Enterprise Gateway version</th>
+      <th style="text-align: center">First open-source Gateway version</th>
   </thead>
   <tbody>
   {% for item in os_versions %}
@@ -50,8 +50,8 @@ supported by Kong:
   <thead>
       <th>OS version</th>
       <th>End of Life</th>
-      <th>Last Enterprise version</th>
-      <th>Last open-source version</th>
+      <th style="text-align: center">Last Enterprise Gateway version</th>
+      <th style="text-align: center">Last open-source Gateway version</th>
   </thead>
   <tbody>
   {% for item in os_versions %}

--- a/src/gateway/install-and-run/rhel.md
+++ b/src/gateway/install-and-run/rhel.md
@@ -2,26 +2,6 @@
 title: Install Kong Gateway on RHEL
 ---
 
-<!-- Banner with links to latest downloads -->
-<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
-
-{:.install-banner}
-> Download the latest {{page.kong_version}} package for RHEL:
-> * **Kong Gateway**:
-> [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel7.noarch.rpm){:.install-link} or
-> [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel8.noarch.rpm){:.install-link}
-> (latest version: {{page.kong_versions[page.version-index].ee-version}})
-> * **Kong Gateway (OSS)**:
-> [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.rhel7.amd64.rpm){:.install-link} or
-> [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.rhel8.amd64.rpm){:.install-link}
-> (latest version: {{page.kong_versions[page.version-index].ce-version}})
->
-> <br>
-> <span class="install-subtitle">View the list of all 2.x packages for
-> [**RHEL 7**]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/){:.install-listing-link} or
-> [**RHEL 8**]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/){:.install-listing-link}<span>
-
-
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 Kong is licensed under an
@@ -29,7 +9,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A [supported system](/gateway/{{page.kong_version}}/install-and-run/os-support) with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong
 
 ## Download and Install

--- a/src/gateway/install-and-run/ubuntu.md
+++ b/src/gateway/install-and-run/ubuntu.md
@@ -2,37 +2,6 @@
 title: Install Kong Gateway on Ubuntu
 ---
 
-{:.important}
-> **Deprecation notice**: Support for running Kong Gateway on
-Ubuntu 16.04 ("Xenial") is now deprecated, as [Standard Support for Ubuntu 16.04 has ended as of April, 2021](https://wiki.ubuntu.com/Releases).
-Starting with Kong Gateway 3.0.0.0, Kong is neither building new Ubuntu 16.04 images nor packages. Nor will Kong test package installation on Ubuntu 16.04.
-> If you need to install Kong Gateway on Ubuntu 16.04, see the documentation for
-[previous versions](/gateway/2.8.x/install-and-run/ubuntu/).
-
-<!-- Banner with links to latest downloads -->
-<!-- The install-link and install-listing-link classes are used for tracking, do not remove -->
-
-{:.install-banner}
-> Download the latest {{site.ee_product_name}} {{page.kong_version}} package for Ubuntu:
-> * **Kong Gateway**:
-> [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link},
-> [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link}, or
-> [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_all.deb){:.install-link}
-> (latest version: {{page.kong_versions[page.version-index].ee-version}})
-> * **Kong Gateway (OSS)**:
-> [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link},
-> [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}, or
-> [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb){:.install-link}
->(latest version: {{page.kong_versions[page.version-index].ee-version}})
->
-> <br>
-> <span class="install-subtitle">View the list of all 2.x packages for
-> [**Xenial**]({{ site.links.download }}/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/){:.install-listing-link},
-> [**Focal**]({{ site.links.download }}/gateway-2.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/){:.install-listing-link}, or
-> [**Bionic**]({{ site.links.download }}/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/){:.install-listing-link}
->  </span>
-
-
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
 Kong is licensed under an
@@ -40,7 +9,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
+* A [supported system](/gateway/{{page.kong_version}}/install-and-run/os-support) with root or [root-equivalent](/gateway/{{page.kong_version}}/plan-and-deploy/kong-user) access.
 * (Enterprise only) A `license.json` file from Kong
 
 ## Download and install

--- a/src/gateway/plan-and-deploy/kong-user.md
+++ b/src/gateway/plan-and-deploy/kong-user.md
@@ -24,7 +24,6 @@ privileged system calls in the operating system.
 
 {{site.ee_product_name}} is installed on one of the following Linux distributions:
 * [Amazon Linux 1 or 2](/gateway/{{page.kong_version}}/install-and-run/amazon-linux)
-* [CentOS](/gateway/{{page.kong_version}}/install-and-run/centos)
 * [RHEL](/gateway/{{page.kong_version}}/install-and-run/rhel)
 * [Ubuntu](/gateway/{{page.kong_version}}/install-and-run/ubuntu)
 

--- a/tests/sidebar.test.js
+++ b/tests/sidebar.test.js
@@ -127,7 +127,7 @@ test.describe("sidenav versions", () => {
     {
       title: "Root page links to /latest/",
       src: "/gateway/",
-      link_text: "Install and Run",
+      link_text: "Installation Options",
       expected_url: "/gateway/latest/install-and-run/",
     },
     {
@@ -139,7 +139,7 @@ test.describe("sidenav versions", () => {
     {
       title: "Sub page links to latest",
       src: "/gateway/latest/admin-api/",
-      link_text: "Install and Run",
+      link_text: "Installation Options",
       expected_url: "/gateway/latest/install-and-run/",
     },
     {


### PR DESCRIPTION
### Summary
Creating a central location to track supported OSes and deprecations. We’re getting more and more of them over time, and we need a way to keep track of when to remove, deprecate, and have an easily reusable templated blurb. 

Removed the warnings from installation pages. It overwhelms the installation pages in a bad way, making the whole page look deprecated. From looking around at other places, docs don't usually mention a supported OS version right on an installation page, so they also don't have to add these notices there.

Breakdown:
* One central doc with tables of supported and deprecated OSes, along with the versions they were introduced or were deprecated in, and links to EoL statements.
   * I went with a markdown file with table + separate data file, with the idea that the data file is much easier to maintain. Large complex tables in markdown are painful.
* Deprecation info added to changelog
* Linking to support tables from installation topics
* Removing blocks of install links. They have already been removed from 2.8.
* Removing CentOS from 3.0 entirely

### Reason

https://konghq.atlassian.net/browse/DOCU-2329
We have a lot of deprecations and no clean way to track them.

### Testing
OS support topic: https://deploy-preview-4000--kongdocs.netlify.app/gateway/latest/install-and-run/os-support/
Changelog: https://deploy-preview-4000--kongdocs.netlify.app/gateway/changelog/
No more CentOS: https://deploy-preview-4000--kongdocs.netlify.app/gateway/latest/install-and-run/
No more giant yellow blocks: https://deploy-preview-4000--kongdocs.netlify.app/gateway/latest/install-and-run/amazon-linux/