### PR TITLE
fix(docs) update key-auths-enc endpoint

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -291,7 +291,7 @@ Paginate through the API keys for all Consumers using the following
 request:
 
 ```bash
-$ curl -X GET http://kong:8001/key-auth-enc
+$ curl -X GET http://kong:8001/key-auths-enc
 ```
 
 Response:
@@ -356,7 +356,7 @@ Retrieve a [Consumer][consumer-object] associated with an API
 key by making the following request:
 
 ```bash
-curl -X GET http://kong:8001/key-auth-enc/{key or id}/consumer
+curl -X GET http://kong:8001/key-auths-enc/{key or id}/consumer
 ```
 
 `key or id`: The `id` or `key` property of the API key for which to get the


### PR DESCRIPTION
### Summary

The endpoint to retrieve `key-auth-enc` plugin credentials is not right.

Change `key-auth-enc` to `key-auths-enc`.

### Reason

Mislead end users.

<!-- ### Testing -->
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
