### PR TITLE
Update cert-manager.md

### DIFF
--- a/app/kubernetes-ingress-controller/2.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.3.x/guides/cert-manager.md
@@ -111,7 +111,7 @@ Next, set up a CNAME DNS record to resolve `demo.example.com` to
 `proxy.example.com`.
 
 ```bash
-$ dig +short demo.yolo2.com
+$ dig +short demo.example.com
 proxy.example.com.
 35.233.170.67
 ```


### PR DESCRIPTION
> review:general
> change incorrect cname domain in example

### Summary
Examples indicate the useage of CNAME = `demo.example.com` but show `demo.yolo2.com`

### Reason
Inconsistent example output.

### Testing
Updated Documentation Markdown.
