### PR TITLE
Clarify what each report type entitles

### DIFF
--- a/app/konnect/vitals/generate-reports.md
+++ b/app/konnect/vitals/generate-reports.md
@@ -50,7 +50,7 @@ can [export](#export-a-custom-report), [edit](#edit-a-custom-report), or [delete
 
    * **Service report**: Generate a report based on Services catalogued in Service Hub.
    * **Route report**: Generate a report based on Routes.
-   * **Application report**: Generate a report based on Applications registered against your Developer Portal.
+   * **Application report**: Generate a report based on Applications registered on your Developer Portal.
 
    Depending on the report type you choose, the available metrics and entities
    will change.

--- a/app/konnect/vitals/generate-reports.md
+++ b/app/konnect/vitals/generate-reports.md
@@ -48,9 +48,9 @@ can [export](#export-a-custom-report), [edit](#edit-a-custom-report), or [delete
 
 1. Choose a report type.
 
-   * **Service report**: Generate a report based on Services.
+   * **Service report**: Generate a report based on Services catalogued in Service Hub.
    * **Route report**: Generate a report based on Routes.
-   * **Application report**: Generate a report based on API consumers.
+   * **Application report**: Generate a report based on Applications registered against your Developer Portal.
 
    Depending on the report type you choose, the available metrics and entities
    will change.


### PR DESCRIPTION
### Summary
Since we now need to consider entities for Runtime Manager (e.g. Gateway Services or Consumer) and Service Hub/Developer Portal (e.g. Services and Applications), it is important to let the reader know what entities/data we include into the generated report based on the chosen report type.

- Services only includes Service packages that are catalogued/registered inside Service Hub. It does not include Gateway Services.
- Routes include anything across Runtime Manager and Service Hub but of course, it does only unique entities (e.g. same route can exist in Runtime Manager and attached to a Service Version in Service Hub.
- Applications only includes applications created in the Konnect Dev Portal, not the Consumer manually created inside Runtime Manager.

### Reason
Mainly because we have similar entities in Runtime Manager (e.g. Gateway Services or Consumer) and Service Hub/Developer Portal (e.g. Services and Applications).
