### PR TITLE
docs(kong-mesh) add cert-manager documentation

### DIFF
--- a/.github/styles/kong/Terms.yml
+++ b/.github/styles/kong/Terms.yml
@@ -4,6 +4,7 @@ level: error
 ignorecase: true
 swap:
 
+  datacenter: data center
   developer portal: Dev Portal
   codeblock': code block
   blacklist: denylist
@@ -16,6 +17,7 @@ swap:
   kong gateway: "{{site.base_gateway}}"
   Konnect: "{{site.konnect_short_name}}"
   Konnect Cloud: "{{site.konnect_saas}}"
+  multizone: multi-zone
   pg: PostgreSQL
   'postgres$': PostgreSQL
   'self(?:-| )hosted': self-managed

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -30,6 +30,7 @@ httpbin
 HTTPie
 https
 ini
+io
 jq
 json
 JsonPath

--- a/app/_data/docs_nav_mesh_1.6.x.yml
+++ b/app/_data/docs_nav_mesh_1.6.x.yml
@@ -1,6 +1,6 @@
 - title: Introduction
   icon: /assets/images/icons/documentation/icn-flag.svg
-  url: /mesh/
+  url: /mesh/1.6.x/
   absolute_url: true
 
 - title: Release notes

--- a/app/_data/docs_nav_mesh_1.8.x.yml
+++ b/app/_data/docs_nav_mesh_1.8.x.yml
@@ -4,7 +4,7 @@ generate: true
 items:
   - title: Introduction
     icon: /assets/images/icons/documentation/icn-flag.svg
-    url: /mesh/
+    url: /mesh/1.8.x/
     absolute_url: true
 
   - title: Release notes

--- a/app/_data/docs_nav_mesh_1.8.x.yml
+++ b/app/_data/docs_nav_mesh_1.8.x.yml
@@ -59,6 +59,8 @@ items:
         url: /features/vault
       - text: Amazon ACM Private CA
         url: /features/acmpca
+      - text: cert-manager Private CA
+        url: /features/cert-manager
       - text: OPAPolicy Support
         url: /features/opa
       - text: Multi-zone authentication

--- a/src/mesh/features/acmpca.md
+++ b/src/mesh/features/acmpca.md
@@ -21,7 +21,7 @@ server.
 * `acmpca`: {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
 
-* [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates dataplane certificates
+* [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates data plane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
 
 ## ACM Private CA mode
@@ -138,8 +138,8 @@ Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](htt
 {% endnavtab %}
 {% endnavtabs %}
 
-## Multizone and ACM Private CA
+## multi-zone and ACM Private CA
 
-In a multizone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with ACM Private CA. This is because certificates for data plane proxies are requested from ACM Private CA by the zone control plane, not the global control plane.
+In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with ACM Private CA. This is because certificates for data plane proxies are requested from ACM Private CA by the zone control plane, not the global control plane.
 
-You must also make sure the global control plane can communicate with ACM Private CA. When a new `acmpca` backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multizone environment, validation is performed on the global control plane.
+You must also make sure the global control plane can communicate with ACM Private CA. When a new `acmpca` backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multi-zone environment, validation is performed on the global control plane.

--- a/src/mesh/features/acmpca.md
+++ b/src/mesh/features/acmpca.md
@@ -21,6 +21,9 @@ server.
 * `acmpca`: {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
 
+* [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates dataplane certificates
+using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
+
 ## ACM Private CA mode
 
 In `acmpca` mTLS mode, {{site.mesh_product_name}} communicates with the Amazon Certificate Manager,

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -24,7 +24,7 @@ using Amazon Certificate Manager Private CA.
 * [`certmanager`]: {{site.mesh_product_name}} generates dataplane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
 
-## cert-manager CA mode
+## Kubernetes cert-manager CA mode
 
 In `certmanager` mTLS mode, {{site.mesh_product_name}} communicates with a locally installed cert-manager `Issuer`,
 which generates the data plane proxy certificates automatically.
@@ -42,7 +42,7 @@ and ensures data plane certificates are issued and rotated for each proxy.
 
 `certmanager` is only available for {{site.mesh_product_name}} in the Kubernetes environment.
 
-### Configure cert-manager CA
+### Configure Kubernetes cert-manager CA
 
 The `certmanager` mTLS backend requires a cert-manager `Issuer` or `ClusterIssuer` to be accessible
 from the {{site.mesh_product_name}} system namespace.
@@ -97,7 +97,7 @@ In `issuerRef`, only `name` is strictly required.
 
 Apply the configuration with `kubectl apply -f [..]`.
 
-## Multizone and cert-manager
+## Multizone and Kubernetes cert-manager
 
 In a multizone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with cert-manager using the same configuration.
 This is because certificates for data plane proxies are requested from cert-manager by the zone control plane, not the global control plane.

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -55,7 +55,7 @@ The {{site.mesh_product_name}} system namespace is `kong-mesh-system` by default
 If the cert-manager is configured outside of the {{site.mesh_product_name}} system namespace,
 and `ClusterIssuer` is not used,
 this may require cert-manager configuration and secrets to be "reflected" into the `Issuer`
-in the {{site.mesh_product_name}} system namespace. See https://cert-manager.io/docs/faq/sync-secrets/ for details.
+in the {{site.mesh_product_name}} system namespace. See [cert-manager documentation](See https://cert-manager.io/docs/faq/sync-secrets/) for details.
 
 The following steps show how to configure cert-manager for {{site.mesh_product_name}} with
 a mesh named `default`. For your environment, replace `default` with the appropriate mesh name.

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -84,7 +84,7 @@ spec:
       type: certmanager
       dpCert:
         rotation:
-          expiration: 5m
+          expiration: 24h
       conf:
         issuerRef:
           name: my-ca-issuer

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -68,7 +68,7 @@ to configure {{site.mesh_product_name}}
 
 ### Configure Mesh
 
-Here's an of mTLS configuration with `certmanager` backend
+Here's an example of mTLS configuration with `certmanager` backend
 which references an `Issuer` named `my-ca-issuer`:
 
 ```yaml

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -60,7 +60,7 @@ in the {{site.mesh_product_name}} system namespace. See https://cert-manager.io/
 The following steps show how to configure cert-manager for {{site.mesh_product_name}} with
 a mesh named `default`. For your environment, replace `default` with the appropriate mesh name.
 
-See [cert-manager.io](https://cert-manager.io) to learn how t
+See [cert-manager.io](https://cert-manager.io) to learn how to
 install and configure cert-manager.io.
 
 Once created, you will need the `IssuerRef` information of the `Issuer` or `ClusterIssuer`

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -50,6 +50,7 @@ A `ClusterIssuer` is accessible from the entire Kubernetes `cluster`.
 An `Issuer` is only accessible from within its own namespace,
 and must reside in the {{site.mesh_product_name}} system namespace
 o be available to {{site.mesh_product_name}}.
+The {{site.mesh_product_name}} system namespace is `kong-mesh-system` by default.
 
 If the cert-manager is configured outside of the {{site.mesh_product_name}} system namespace,
 and `ClusterIssuer` is not used,

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -21,7 +21,7 @@ server.
 * [`acmpca`](/mesh/{{page.kong_version}}/features/acmpca): {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
 
-* `certmanager`: {{site.mesh_product_name}} generates dataplane certificates
+* `certmanager`: {{site.mesh_product_name}} generates data plane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
 
 ## Kubernetes cert-manager CA mode
@@ -61,7 +61,7 @@ The following steps show how to configure cert-manager for {{site.mesh_product_n
 a mesh named `default`. For your environment, replace `default` with the appropriate mesh name.
 
 See [cert-manager.io](https://cert-manager.io) to learn how to
-install and configure cert-manager.io.
+install and configure cert-manager.
 
 Once created, you will need the `IssuerRef` information of the `Issuer` or `ClusterIssuer`
 to configure {{site.mesh_product_name}}
@@ -97,16 +97,16 @@ In `issuerRef`, only `name` is strictly required.
 
 Apply the configuration with `kubectl apply -f [..]`.
 
-## Multizone and Kubernetes cert-manager
+## multi-zone and Kubernetes cert-manager
 
-In a multizone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with cert-manager using the same configuration.
+In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with cert-manager using the same configuration.
 This is because certificates for data plane proxies are requested from cert-manager by the zone control plane, not the global control plane.
 
-This implies that each Kubernetes cluster in multizone must include an `Issuer` or `ClusterIssuer`
+This implies that each Kubernetes cluster in multi-zone must include an `Issuer` or `ClusterIssuer`
 resource with the `issuerRef`  specified in the `Mesh` `certmanager` backend specification.
 Also, because the backend is `Mesh` scoped configuration and `certmanager` backend is limited to the Kubernetes environment,
-Universal and Kubernetes cannot be used together in a multizone environment which includes a `certmanager` mTLS backend.
+Universal and Kubernetes cannot be used together in a multi-zone environment which includes a `certmanager` mTLS backend.
 
 You must also ensure the global control plan can access cert-manager.
 When a new `certmanager`backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate.
-In a multizone environment, validation is performed on the global control plane.
+In a multi-zone environment, validation is performed on the global control plane.

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -93,7 +93,7 @@ spec:
 ```
 
 In `issuerRef`, only `name` is strictly required.
-`group` and `kind` will default to cert-manager default values. See issuerRef in [cert-manager API](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateRequestSpec) for details.
+`group` and `kind` will default to cert-manager default values. See `issuerRef` in [cert-manager API](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateRequestSpec) for details.
 
 Apply the configuration with `kubectl apply -f [..]`.
 
@@ -103,7 +103,7 @@ In a multizone environment, the global control plane provides the `Mesh` to the 
 This is because certificates for data plane proxies are requested from cert-manager by the zone control plane, not the global control plane.
 
 This implies that each Kubernetes cluster in multizone must include an `Issuer` or `ClusterIssuer`
-resource with an `issuerRef`  specified in the `Mesh` `certmanager` backend specification.
+resource with the `issuerRef`  specified in the `Mesh` `certmanager` backend specification.
 Also, because the backend is `Mesh` scoped configuration and `certmanager` backend is limited to the Kubernetes environment,
 Universal and Kubernetes cannot be used together in a multizone environment which includes a `certmanager` mTLS backend.
 

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -21,7 +21,7 @@ server.
 * [`acmpca`](/mesh/{{page.kong_version}}/features/acmpca): {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
 
-* [`certmanager`]: {{site.mesh_product_name}} generates dataplane certificates
+* `certmanager`: {{site.mesh_product_name}} generates dataplane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
 
 ## Kubernetes cert-manager CA mode

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -1,0 +1,111 @@
+---
+title: Kong Mesh - Kubernetes cert-manager CA Policy
+---
+
+## cert-manager CA Backend
+
+The default [mTLS policy in Kuma](https://kuma.io/docs/latest/policies/mutual-tls/)
+supports the following backends:
+
+* `builtin`: {{site.mesh_product_name}} automatically generates the Certificate
+Authority (CA) root certificate and key that will be used to generate the data
+plane certificates.
+* `provided`: the CA root certificate and key can be provided by the user.
+
+{{site.mesh_product_name}} adds:
+
+* [`vault`](/mesh/{{page.kong_version}}/features/vault): {{site.mesh_product_name}} generates data plane certificates
+using a CA root certificate and key stored in a HashiCorp Vault
+server.
+
+* [`acmpca`](/mesh/{{page.kong_version}}/features/acmpca): {{site.mesh_product_name}} generates data plane certificates
+using Amazon Certificate Manager Private CA.
+
+* [`certmanager`]: {{site.mesh_product_name}} generates dataplane certificates
+using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
+
+## cert-manager CA mode
+
+In `certmanager` mTLS mode, {{site.mesh_product_name}} communicates with a locally installed cert-manager `Issuer`,
+which generates the data plane proxy certificates automatically.
+{{site.mesh_product_name}} does not retrieve any CA private keys,
+which means that the private key of the CA is secured by cert-manager itself,
+or an upstream CA,
+and not exposed to third parties.
+
+In `certmanager` mode, you provide {{site.mesh_product_name}} with a cert-manager `Issuer`
+or `ClusterIssuer` reference. {{site.mesh_product_name}} will communicate with cert-manager
+via Kubernetes resources which reference the `Issuer` or `ClusterIssuer`.
+
+When {{site.mesh_product_name}} is running in `certmanager` mode, the backend communicates with cert-manager
+and ensures data plane certificates are issued and rotated for each proxy.
+
+`certmanager` is only available for {{site.mesh_product_name}} in the Kubernetes environment.
+
+### Configure cert-manager CA
+
+The `certmanager` mTLS backend requires a cert-manager `Issuer` or `ClusterIssuer` to be accessible
+from the {{site.mesh_product_name}} system namespace.
+A `ClusterIssuer` is accessible from the entire Kubernetes `cluster`.
+An `Issuer` is only accessible from within its own namespace,
+and must reside in the {{site.mesh_product_name}} system namespace
+o be available to {{site.mesh_product_name}}.
+
+If the cert-manager is configured outside of the {{site.mesh_product_name}} system namespace,
+and `ClusterIssuer` is not used,
+this may require cert-manager configuration and secrets to be "reflected" into the `Issuer`
+in the {{site.mesh_product_name}} system namespace. See https://cert-manager.io/docs/faq/sync-secrets/ for details.
+
+The following steps show how to configure cert-manager for {{site.mesh_product_name}} with
+a mesh named `default`. For your environment, replace `default` with the appropriate mesh name.
+
+See [cert-manager.io](https://cert-manager.io) to learn how t
+install and configure cert-manager.io.
+
+Once created, you will need the `IssuerRef` information of the `Issuer` or `ClusterIssuer`
+to configure {{site.mesh_product_name}}
+
+### Configure Mesh
+
+Here's an of mTLS configuration with `certmanager` backend
+which references an `Issuer` named `my-ca-issuer`:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: certmanager-1
+    backends:
+    - name: certmanager-1
+      type: certmanager
+      dpCert:
+        rotation:
+          expiration: 5m
+      conf:
+        issuerRef:
+          name: my-ca-issuer
+          kind: Issuer
+          group: cert-manager.io
+```
+
+In `issuerRef`, only `name` is strictly required.
+`group` and `kind` will default to cert-manager default values. See issuerRef in [cert-manager API](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateRequestSpec) for details.
+
+Apply the configuration with `kubectl apply -f [..]`.
+
+## Multizone and cert-manager
+
+In a multizone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with cert-manager using the same configuration.
+This is because certificates for data plane proxies are requested from cert-manager by the zone control plane, not the global control plane.
+
+This implies that each Kubernetes cluster in multizone must include an `Issuer` or `ClusterIssuer`
+resource with an `issuerRef`  specified in the `Mesh` `certmanager` backend specification.
+Also, because the backend is `Mesh` scoped configuration and `certmanager` backend is limited to the Kubernetes environment,
+Universal and Kubernetes cannot be used together in a multizone environment which includes a `certmanager` mTLS backend.
+
+You must also ensure the global control plan can access cert-manager.
+When a new `certmanager`backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate.
+In a multizone environment, validation is performed on the global control plane.

--- a/src/mesh/features/vault.md
+++ b/src/mesh/features/vault.md
@@ -21,7 +21,7 @@ server.
 * [`acmpca`](/mesh/{{page.kong_version}}/features/acmpca) {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
 
-* [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates dataplane certificates
+* [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates data plane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
 
 ## Vault mode
@@ -297,8 +297,8 @@ Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](htt
 {% endnavtab %}
 {% endnavtabs %}
 
-## Multizone and Vault
+## Multi-zone and Vault
 
-In a multizone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane communicates with Vault over the same address. This is because certificates for data plane proxies are issued from the zone control plane, not from the global control plane.
+In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane communicates with Vault over the same address. This is because certificates for data plane proxies are issued from the zone control plane, not from the global control plane.
 
-You must also make sure the global control plane communicates with Vault. When a new Vault backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multizone environment, validation is performed on the global control plane.
+You must also make sure the global control plane communicates with Vault. When a new Vault backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multi-zone environment, validation is performed on the global control plane.

--- a/src/mesh/features/vault.md
+++ b/src/mesh/features/vault.md
@@ -21,6 +21,9 @@ server.
 * [`acmpca`](/mesh/{{page.kong_version}}/features/acmpca) {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
 
+* [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates dataplane certificates
+using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
+
 ## Vault mode
 
 In `vault` mTLS mode, {{site.mesh_product_name}} communicates with the HashiCorp Vault PKI,

--- a/src/mesh/gettingstarted.md
+++ b/src/mesh/gettingstarted.md
@@ -37,6 +37,7 @@ After you install, follow the Kuma getting started guide to get
 * Learn about enterprise features:
   * [Support for HashiCorp Vault CA](/mesh/{{page.kong_version}}/features/vault)
   * [Support for Amazon Certificate Manager Private CA](/mesh/{{page.kong_version}}/features/acmpca)
+  * [Support for Kubernetes cert-manager CA](/mesh/{{page.kong_version}}/features/cert-manager)
   * [Support for Open Policy Agent](/mesh/{{page.kong_version}}/features/opa)
   * [Multi-zone authentication](/mesh/{{page.kong_version}}/features/kds-auth)
   * [Support for FIPS](/mesh/{{page.kong_version}}/features/fips-support)

--- a/src/mesh/index.md
+++ b/src/mesh/index.md
@@ -113,6 +113,11 @@ every cloud and environment.
 <td><i class="fa fa-check"></i></td>
 </tr>
 <tr>
+<td>Kubernetes cert-manager CA</td>
+<td><i class="fa fa-times"></i></td>
+<td><i class="fa fa-check"></i></td>
+</tr>
+<tr>
 <td>GUI Dashboard for TLS and CA</td>
 <td><i class="fa fa-times"></i></td>
 <td><i class="fa fa-check"></i></td>

--- a/src/mesh/index.md
+++ b/src/mesh/index.md
@@ -103,7 +103,7 @@ every cloud and environment.
 <td><i class="fa fa-check"></i></td>
 </tr>
 <tr>
-<td>Hashicorp Vault CA</td>
+<td>HashiCorp Vault CA</td>
 <td><i class="fa fa-times"></i></td>
 <td><i class="fa fa-check"></i></td>
 </tr>
@@ -265,8 +265,8 @@ for both edge and internal API traffic.
   <img src="/assets/images/docs/mesh/gw_mesh.png" width="600px"/>
   <br>
   <i>Two different applications - "Banking" and "Trading" - run in their
-  own meshes "A" and "B" across different datacenters. In this example,
-  Kong Gateway is being used both for edge communication and for internal
+  own meshes "A" and "B" across different data centers. In this example,
+  {{site.base_gateway}} is being used both for edge communication and for internal
   communication between meshes.</i>
 </center>
 
@@ -326,7 +326,7 @@ hybrid Kubernetes/VMs:
   <img src="/assets/images/docs/mesh/multi-zone.jpg" width="600px"/>
   <br>
   <i>{{site.mesh_product_name}} can support multiple zones (like a Kubernetes
-    cluster, VPC, datacenter, etc.) together in the same distributed deployment.
+    cluster, VPC, data center, etc.) together in the same distributed deployment.
      Then, you can create multiple isolated virtual meshes with the same
      control plane in order to support every team and application in the
      organization.</i>

--- a/vale.ini
+++ b/vale.ini
@@ -15,4 +15,5 @@ BasedOnStyles = kong
 
 BlockIgnores = (\((http.*://|\.\/|\/).*?\))
 TokenIgnores = {%.*?%}, \
-{{.*?}}
+{{.*?}}, \
+({#.*?})


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

Add documentation for cert-manager in Kong Mesh.

### Reason

cert-manager added to 1.8 mesh release.

### Testing

Netlify preview