### PR TITLE
Remove old titles from breadcrumbs

### DIFF
--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -3,13 +3,7 @@
   <ul class="breadcrumbs">
       <i class="sidebar-toggle"></i>
     <li class="breadcrumb-item">
-      {% if include.edition =='enterprise' or include.edition =='konnect' or include.edition =='konnect-platform' or include.edition == 'mesh' or include.edition == 'gateway' %}
-        Kong Konnect Platform
-      {% elsif include.edition == 'contributing' %}
-        Contribute to the docs
-      {% else %}
-        Open Source
-      {% endif %}
+      <a href="/">Home</a>
     </li>
     <li class="breadcrumb-item">
       {% if include.edition == 'enterprise' %}<a href="/enterprise/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}">{{site.ee_product_name}}</a>
@@ -30,7 +24,10 @@
         {% for crumb in crumbs offset: 3 %}
           {% unless forloop.last %}
             <li class="breadcrumb-item">
-              {% assign crumb_limit = forloop.index | plus: 3 %}{{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
+              {% assign crumb_limit = forloop.index | plus: 3 %}
+              <!-- <a href="{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}"> -->
+              {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
+              <!-- </a> -->
             </li>
           {% endunless %}
         {% endfor %}
@@ -38,7 +35,10 @@
         {% for crumb in crumbs offset: 2 %}
           {% unless forloop.last %}
             <li class="breadcrumb-item">
-              {% assign crumb_limit = forloop.index | plus: 2 %}{{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
+              {% assign crumb_limit = forloop.index | plus: 2 %}
+              <!-- <a href="{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}"> -->
+                {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
+              <!-- </a> -->
             </li>
           {% endunless %}
         {% endfor %}
@@ -47,7 +47,10 @@
       {% for crumb in crumbs offset: 3 %}
         {% unless forloop.last %}
         <li class="breadcrumb-item">
-          {% assign crumb_limit = forloop.index | plus: 3 %}{{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
+          {% assign crumb_limit = forloop.index | plus: 3 %}
+          <!-- <a href="{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}"> -->
+            {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
+          <!-- </a> -->
         </li>
         {% endunless %}
       {% endfor %}

--- a/tests/breadcrumbs.test.js
+++ b/tests/breadcrumbs.test.js
@@ -4,7 +4,7 @@ test.describe("Gateway", () => {
   test("renders nested breadcrumbs correctly (EE)", async ({ page }) => {
     await page.goto("/enterprise/2.5.x/plugin-development/custom-entities/");
     await expect(page.locator(".breadcrumb-item:nth-of-type(1)")).toHaveText(
-      "Kong Konnect Platform"
+      "Home"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(2)")).toHaveText(
       "Kong Gateway"
@@ -17,7 +17,7 @@ test.describe("Gateway", () => {
   test("renders nested breadcrumbs correctly (OSS)", async ({ page }) => {
     await page.goto("/gateway-oss/2.5.x/plugin-development/custom-entities/");
     await expect(page.locator(".breadcrumb-item:nth-of-type(1)")).toHaveText(
-      "Open Source"
+      "Home"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(2)")).toHaveText(
       "Kong Gateway (OSS)"
@@ -32,7 +32,7 @@ test.describe("Gateway", () => {
   }) => {
     await page.goto("/gateway/latest/");
     await expect(page.locator(".breadcrumb-item:nth-of-type(1)")).toHaveText(
-      "Kong Konnect Platform"
+      "Home"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(2)")).toHaveText(
       "Kong Gateway"
@@ -45,7 +45,7 @@ test.describe("decK", () => {
     await page.goto("/deck/latest/");
 
     await expect(page.locator(".breadcrumb-item:nth-of-type(1)")).toHaveText(
-      "Open Source"
+      "Home"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(2)")).toHaveText(
       "decK"


### PR DESCRIPTION
### Summary
Replace 'kong konnect platform' and 'open source' in breadcrumbs with 'home'.


#### Ramblings on breadcrumb schemas and link generation

I also did some exploration to get each breadcrumb linking to the parent page, and I ran into an issue: not every directory item has a page associated with it. For example, you might have the following path:

https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/design/

The breadcrumbs would be:
Home > Kubernetes Ingress Controller > Concepts

* The final page doesn't appear in the breadcrumbs because you're already on it - this is expected.
* The "concepts" breadcrumb is the problem here: this page doesn't exist. So instead of trying to determine whether a page exists and have random unlinked pages, for now I chose to link only the first two breadcrumbs: "Home" and product name. 
  * This is a symptom of an underlying problem with our navigation/folder structure, which should match up but don't

I left the code for the links in the file, just commented out for now. It's something we could (and should) use eventually, but we need to deal with our nav structure for that.

(Overall, we actually just need a proper breadcrumb schema, but the nav structure will also interfere with being able to generate that cleanly).

### Reason
The old labels were no longer accurate.

### Testing
Test breadcrumbs on various pages:
https://deploy-preview-4019--kongdocs.netlify.app/gateway/latest/
https://deploy-preview-4019--kongdocs.netlify.app/gateway/latest/install-and-run/kubernetes/
https://deploy-preview-4019--kongdocs.netlify.app/deck/latest/guides/multi-file-state/
etc