### PR TITLE
[DOCU-2341] Improve Okta issuer URL instructions

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -185,6 +185,8 @@
           url: /org-management/okta-idp
     - text: Account and Org Deactivation
       url: /org-management/deactivation
+    - text: Troubleshoot
+      url: /org-management/troubleshoot
 
 
 - title: Legacy content

--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -163,13 +163,13 @@ values are present.
     something like this:
 
         ```
-        https://example-account.okta.com/oauth2/default
+        https://example.okta.com/oauth2/default
         ```
         Where `default` is the name or ID of the authorization server.
 
         {:.note}
         > Note: Do not use the issuer URI from your application's settings. That
-        URI is incomplete: `https://example-account.okta.com`.
+        URI is incomplete: `https://example.okta.com`.
 
 1. Paste the issuer URI from Okta into the **Issuer URI** field in {{site.konnect_short_name}}.
 1. Copy and paste the **Client ID** and **Client Secret** from your Okta

--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -83,7 +83,7 @@ claims to extract that information.
 
 1. From the left menu, select **Security > API**.
 
-1. Select the Custom Authorization Server that you want to configure.
+1. Select the authorization server that you want to configure.
 
 1. Go to the Claims tab.
 
@@ -157,8 +157,21 @@ values are present.
 
     Refer back to your Okta application to fill in the following fields.
 
-1. Copy the **Issuer URI** from your Okta custom authorization server, then paste it into
-the **Issuer URI** field in {{site.konnect_short_name}}. <!-- found in general settings in Okta app -->
+1. Locate your issuer URI in Okta.
+    1. Go to **Security** > **API**.
+    1. Copy the issuer URI for your authorization server. It should look
+    something like this:
+
+        ```
+        https://example-account.okta.com/oauth2/default
+        ```
+        Where `default` is the name or ID of the authorization server.
+
+        {:.note}
+        > Note: Do not use the issuer URI from your application's settings. That
+        URI is incomplete: `https://example-account.okta.com`.
+
+1. Paste the issuer URI from Okta into the **Issuer URI** field in {{site.konnect_short_name}}.
 1. Copy and paste the **Client ID** and **Client Secret** from your Okta
 application into {{site.konnect_saas}}.
 

--- a/app/konnect/org-management/troubleshoot.md
+++ b/app/konnect/org-management/troubleshoot.md
@@ -22,7 +22,7 @@ in CSV format, then importing the CSV file into Okta to populate the new group.
 ### Named cookie not present
 
 #### Problem
-If the issuer URL is incorrect or incomplete, you may get the following error
+If the issuer URI is incorrect or incomplete, you may get the following error
 (or similar) when trying to authenticate with Okta:
 
 ```

--- a/app/konnect/org-management/troubleshoot.md
+++ b/app/konnect/org-management/troubleshoot.md
@@ -30,14 +30,14 @@ failed to get state: http: named cookie not present
 ```
 
 This may happen if the wrong issuer URI was used, for example, the URI from
-your application's settings. That URI is incomplete: `https://example-account.okta.com`.
+your application's settings. That URI is incomplete: `https://example.okta.com`.
 
 #### Solution
 The issuer URI must be in the following format, where `default` is
 the name or ID of the authorization server:
 
 ```
-https://example-account.okta.com/oauth2/default
+https://example.okta.com/oauth2/default
 ```
 
 You can find this URI in your Okta developer account, under **Security** > **API**.

--- a/app/konnect/org-management/troubleshoot.md
+++ b/app/konnect/org-management/troubleshoot.md
@@ -1,0 +1,43 @@
+---
+title: Troubleshoot Account and Org Issues
+no_version: true
+---
+
+## Identity Provider Errors
+
+### Groups claim is empty when Okta is the IdP
+
+#### Problem
+In the token payload, the `groups` claim is configured correctly but still
+appears empty, or it includes some groups but not all.
+
+#### Solution
+This issue might happen if the authorization server is pulling in additional
+groups from third-party applications (for example, Google groups).
+
+An Okta administrator needs to duplicate the third-party groups
+and re-create them directly in Okta. They can do this by exporting the group
+in CSV format, then importing the CSV file into Okta to populate the new group.
+
+### Named cookie not present
+
+#### Problem
+If the issuer URL is incorrect or incomplete, you may get the following error
+(or similar) when trying to authenticate with Okta:
+
+```
+failed to get state: http: named cookie not present
+```
+
+This may happen if the wrong issuer URI was used, for example, the URI from
+your application's settings. That URI is incomplete: `https://example-account.okta.com`.
+
+#### Solution
+The issuer URI must be in the following format, where `default` is
+the name or ID of the authorization server:
+
+```
+https://example-account.okta.com/oauth2/default
+```
+
+You can find this URI in your Okta developer account, under **Security** > **API**.

--- a/app/konnect/org-management/troubleshoot.md
+++ b/app/konnect/org-management/troubleshoot.md
@@ -13,7 +13,7 @@ appears empty, or it includes some groups but not all.
 
 #### Solution
 This issue might happen if the authorization server is pulling in additional
-groups from third-party applications (for example, Google groups).
+groups from third-party applications, for example, Google groups.
 
 An Okta administrator needs to duplicate the third-party groups
 and re-create them directly in Okta. They can do this by exporting the group
@@ -23,7 +23,7 @@ in CSV format, then importing the CSV file into Okta to populate the new group.
 
 #### Problem
 If the issuer URI is incorrect or incomplete, you may get the following error
-(or similar) when trying to authenticate with Okta:
+when trying to authenticate with Okta:
 
 ```
 failed to get state: http: named cookie not present


### PR DESCRIPTION
### Summary
* Clarify exactly which issuer URL to use for Okta SSO configuration. 
* Create a troubleshooting topic for account/org issues - we have two pieces of Okta config advice that are buried in the config topic itself. Pulling them into a troubleshooting topic for _hopefully_ easier findability.

### Reason
https://konghq.atlassian.net/browse/DOCU-2341

### Testing
https://deploy-preview-4023--kongdocs.netlify.app/konnect/org-management/okta-idp/#set-up-konnect
https://deploy-preview-4023--kongdocs.netlify.app/konnect/org-management/troubleshoot/