### PR TITLE
[FT-2378] [ENGEN-452] Add notes for ubi-minimal usage

### DIFF
--- a/app/_includes/md/rpm.md
+++ b/app/_includes/md/rpm.md
@@ -38,12 +38,21 @@ $ sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
 - [Red Hat 7]({{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel7.amd64.rpm)
 - [Red Hat 8]({{ site.links.download }}/gateway-2.x-rhel-8/Packages/k/kong-{{site.data.kong_latest.version}}.rhel8.amd64.rpm)
 
-To install from the command line
+To install from the command line using `yum`
 
 ```bash
 $ curl -Lo kong-{{site.data.kong_latest.version}}.amd64.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel%{rhel}.amd64.rpm")
 $ sudo yum kong-{{site.data.kong_latest.version}}.amd64.rpm
 ```
+
+To install from the command line using `rpm` directly (you will need Kong's dependencies installed separately)
+
+```bash
+$ curl -Lo kong.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-7/Packages/k/kong-{{site.data.kong_latest.version}}.rhel%{rhel}.amd64.rpm")
+rpm -iv kong.rpm
+```
+
+Installing directly via `rpm` is suitable for RedHat's [UBI (Universal Build Image)](https://developers.redhat.com/blog/2020/03/24/red-hat-universal-base-images-for-docker-users) "minimal" variant (you will need Kong's dependencies installed separately via `microdnf`)
 
     {% endif %}
 

--- a/app/_includes/md/rpm.md
+++ b/app/_includes/md/rpm.md
@@ -30,7 +30,7 @@ To install from the command line
 $ curl -Lo kong-{{site.data.kong_latest.version}}.amd64.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-centos-%{centos_ver}/Packages/k/kong-{{site.data.kong_latest.version}}.el%{centos_ver}.amd64.rpm")
 $ sudo yum install kong-{{site.data.kong_latest.version}}.amd64.rpm
 ```
-        
+
     {% endif %}
 
     {% if include.distribution == "rhel" %}
@@ -63,7 +63,7 @@ $ curl {{ site.links.download }}/gateway-2.x-amazonlinux-2/config.repo | sudo te
 $ sudo yum install -y kong
 ```
 
-    {% endif %}    
+    {% endif %}
 
     {% if include.distribution == "centos" %}
 

--- a/app/_includes/md/rpm.md
+++ b/app/_includes/md/rpm.md
@@ -52,7 +52,7 @@ $ curl -Lo kong.rpm $( rpm --eval "{{ site.links.download }}/gateway-2.x-rhel-7/
 rpm -iv kong.rpm
 ```
 
-Installing directly via `rpm` is suitable for RedHat's [UBI (Universal Build Image)](https://developers.redhat.com/blog/2020/03/24/red-hat-universal-base-images-for-docker-users) "minimal" variant (you will need Kong's dependencies installed separately via `microdnf`)
+Installing directly using `rpm` is suitable for RedHat's [Universal Base Image](https://developers.redhat.com/blog/2020/03/24/red-hat-universal-base-images-for-docker-users) "minimal" variant. You will need to install Kong's dependencies separately via `microdnf`
 
     {% endif %}
 


### PR DESCRIPTION
### Summary
As part of the work to add ubi-minimal/slim images, I changed this: https://github.com/Kong/docker-kong/blob/8a361ad78d4f84b67e893588fd3a6108bea67fe7/rhel/Dockerfile#L43-L45

### Reason
So here are the adjoining docs.

Sibling PR to: https://github.com/Kong/docker-kong/pull/576