### PR TITLE
[DOCU-2308] DecK Konnect guide

### DIFF
--- a/app/_data/docs_nav_deck_1.12.x.yml
+++ b/app/_data/docs_nav_deck_1.12.x.yml
@@ -22,7 +22,7 @@ items:
   - title: Installation
     icon: /assets/images/icons/documentation/icn-deployment-color.svg
     url: /installation
-    
+
   - title: Guides
     icon: /assets/images/icons/documentation/icn-solution-guide.svg
     items:
@@ -38,6 +38,8 @@ items:
         url: /guides/best-practices
       - text: Using decK with Kong Gateway (Enterprise)
         url: /guides/kong-enterprise
+      - text: Using decK with Konnect
+        url: /guides/konnect
       - text: Using Multiple Files to Store Configuration
         url: /guides/multi-file-state
       - text: De-duplicate Plugin Configuration

--- a/src/deck/faqs.md
+++ b/src/deck/faqs.md
@@ -78,6 +78,11 @@ your use case:
 Of course, decK is designed to be compatible with open-source and enterprise
 versions of Kong.
 
+### I'm a {{site.konnect_short_name}} user, can I use decK?
+
+Yes, decK is compatible with {{site.konnect_short_name}}. We recommend
+upgrading to decK 1.12 to take advantage of the new `--konnect` CLI flags.
+
 ### I use Cassandra as a data store for Kong, can I use decK?
 
 {:.important}

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -139,16 +139,17 @@ or use a flag when running any decK command.
 In {{site.konnect_short_name}}, there are two types of services:
 * Gateway services: Managed through Runtime Manager
 * {{site.konnect_short_name}} services: Managed through Service Hub
+Each Konnect Service may contain one or more service versions. A service version represents an implementation of a Gateway service.
 
 decK manages Gateway services, which contain configurations for the Gateway proxy.
 
-Although decK doesn't _directly_ manage {{site.konnect_short_name}} services, you can use tags to associate a Gateway service to a {{site.konnect_short_name}} service:
+Although decK doesn't _directly_ manage {{site.konnect_short_name}} services or service versions, you can use tags to associate a Gateway service to a service version in a {{site.konnect_short_name}} service:
 
 ```yaml
 tags:
-- _KonnectService:example
+- _KonnectService:<Konnect-Service-Name>
 ```
-If the {{site.konnect_short_name}} service doesn't exist, setting this tag creates a {{site.konnect_short_name}} service.
+The `<Konnect-Service-Name>` identifies which {{site.konnect_short_name}} to associate the Gateway service to while the name of the Gateway service identifies which service version to associate the Gateway service to. If the {{site.konnect_short_name}} service doesn't exist, setting this tag creates a {{site.konnect_short_name}} service.
 
 For example, see the following configuration snippet, where the Gateway service named `example_service` is attached to the {{site.konnect_short_name}} service `example`:
 

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -136,7 +136,7 @@ You can see this by pushing a config file to {{site.konnect_short_name}} with `d
       host: mockbin.org
     ```
 
-2. Sync the file to Konnect:
+2. Sync the file to {{site.konnect_short_name}}:
 
     ```sh
     deck sync

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -48,43 +48,46 @@ decK looks for {{site.konnect_short_name}} credentials in the following order of
 
 For example, if you have both a decK config file and a {{site.konnect_short_name}} password file, decK uses the password in the config file.
 
-### Authenticate with CLI flags
+### Authenticate using a plaintext password
 
-There are two ways to authenticate through CLI flags. You can pass the password in `--konnect-password` directly or save it to a file and pass the filename to decK with `--konnect-password-file`.
-
-With `konnect-password`:
+You can use the `--konnect-password` flag to provide the password directly in the command:
 
 ```sh
 deck ping \
-  --konnect-email YOUR_EMAIL \
+  --konnect-email example@example.com \
   --konnect-password YOUR_PASSWORD
 ```
 
-Or, save your {{site.konnect_short_name}} password to a file, then pass the file using the `--konnect-password-file` flag:
+### Authenticate using a password file
+
+For a more secure approach, you can save your {{site.konnect_short_name}}
+password to a file, then pass the filename to decK with `--konnect-password-file`:
 
 ```sh
 deck ping \
-  --konnect-email YOUR_EMAIL \
+  --konnect-email example@example.com \
   --konnect-password-file /PATH/TO/FILE
 ```
 
-### Authenticate with a decK config file
+### Authenticate using a decK config file
 
-The default decK configuration file is `~/.deck.yaml`.
-You can store {{site.konnect_short_name}} credentials in this file to pass them more securely.
-For example:
+The default decK configuration file is `~/.deck.yaml`. You can use this file
+to set either `konnect-password` or `konnect-password-file` for all connections
+decK.
 
-```
-konnect-email: example@email.com
-konnect-password: YOUR_PASSWORD
-```
+* Use `konnect-password` to store {{site.konnect_short_name}} credentials directly in the configuration file:
 
-Alternatively, you can save your password in a separate file, then specify the password file instead of a password:
+    ```
+    konnect-email: example@email.com
+    konnect-password: YOUR_PASSWORD
+    ```
 
-```
-konnect-email: example@example.com
-konnect-password-file: PATH/TO/FILENAME
-```
+* Store your password in a separate file, then specify the path to `konnect-password-file` instead of a literal password:
+
+    ```
+    konnect-email: example@example.com
+    konnect-password-file: PATH/TO/FILENAME
+    ```
 
 decK automatically uses the credentials in `~/.deck.yaml` in any subsequent calls:
 
@@ -109,55 +112,24 @@ deck ping --konnect-addr https://konnect.konghq.com
 
 ## Runtime groups
 
-Target runtime groups in your state file with the `konnect_runtime_group` parameter:
+Each state file targets one runtime group.
+If you don't provide a group, decK targets the `default` runtime group.
 
-```yaml
-_format_version: "1.1"
-_konnect:
-  runtime_group_name: staging
-```
+If you have a custom runtime group, you can specify the group in the state file,
+or set a flag when running any decK command.
 
-You can also set this parameter using the `--konnect-runtime-group-name` flag:
-
-```sh
-deck sync --konnect-runtime-group-name default
-```
-
-A state file can only target one runtime group.
-
-If you leave this empty, don't provide a flag, or don't include a `_konnect` section at all, decK targets the `default` runtime group.
-You can see this by pushing a config file to {{site.konnect_short_name}} with `deck sync`.
-
-1. Create a basic config file:
-
-    ```yaml
-    _format_version: "1.1"
-    services:
-    - name: example_service
-      host: mockbin.org
-    ```
-
-2. Sync the file to {{site.konnect_short_name}}:
-
-    ```sh
-    deck sync
-    ```
-
-3. Pull down the configuration with `deck dump`:
-
-    ```sh
-    deck dump --konnect-runtime-group-name default
-    ```
-
-    See the newly added `_konnect` section:
+* Target a runtime group in your state file with the `konnect_runtime_group` parameter:
 
     ```yaml
     _format_version: "1.1"
     _konnect:
-      runtime_group_name: default
-    services:
-    - name: example_service
-      host: mockbin.org
+      runtime_group_name: staging
+    ```
+
+* Set a group using the `--konnect-runtime-group-name` CLI flag:
+
+    ```sh
+    deck sync --konnect-runtime-group-name staging
     ```
 
 ## {{site.konnect_short_name}} service tags

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -14,12 +14,7 @@ You _cannot_ use decK to publish content to the Dev Portal, manage application r
 
 You can use `deck` commands such as `ping`, `diff`, or `sync` with `--konnect` flags to interact with {{site.konnect_short_name}}.
 
-
 If you don't pass a {{site.konnect_short_name}} flag to decK, decK looks for a local {{site.base_gateway}} instance instead.
-
-{:.note}
-> Prior to decK 1.12, decK provided `deck konnect` commands.
-These commands are deprecated and have been replaced with flags.
 
 `--konnect-addr`
 :  Address of the {{site.konnect_short_name}} endpoint. (Default: `"https://us.api.konghq.com"`)
@@ -37,12 +32,16 @@ This takes precedence over the `--konnect-password-file` flag.
 `--konnect-runtime-group-name`
 :  {{site.konnect_short_name}} runtime group name.
 
+{:.note}
+> **Note:** Prior to decK 1.12, decK provided [`deck konnect`](/deck/1.11.x/reference/deck_konnect) commands.
+Those commands are deprecated and have been replaced with the flags in this guide.
+
 ## Authenticate with {{site.konnect_short_name}}
 
 decK looks for {{site.konnect_short_name}} credentials in the following order of precedence:
 
 1. Password set with the `--konnect-password` flag
-2. decK configuration file (default: `~/.deck.yaml`)
+2. decK configuration file, if one exists (default lookup path: `$HOME/.deck.yaml`)
 3. File passed with the `--konnect-password-file` flag
 
 For example, if you have both a decK config file and a {{site.konnect_short_name}} password file, decK uses the password in the config file.
@@ -70,9 +69,13 @@ deck ping \
 
 ### Authenticate using a decK config file
 
-The default decK configuration file is `~/.deck.yaml`. You can use this file
-to set either `konnect-password` or `konnect-password-file` for all connections
-decK.
+By default, decK looks for a configuration file named `.deck.yaml` in the `$HOME` directory.
+This file lets you specify flags to include with every decK command.
+
+You can create the file at the default location, or set a custom filename and path with [`--config`](/deck/{{page.kong_version}}/reference/deck).
+
+If you store {{site.konnect_short_name}} credentials in the file, decK uses the credentials for every command.
+Set either `konnect-password` or `konnect-password-file` in the decK config file.
 
 * Use `konnect-password` to store {{site.konnect_short_name}} credentials directly in the configuration file:
 
@@ -88,7 +91,7 @@ decK.
     konnect-password-file: PATH/TO/FILENAME
     ```
 
-decK automatically uses the credentials in `~/.deck.yaml` in any subsequent calls:
+decK automatically uses the credentials from `~/.deck.yaml` in any subsequent calls:
 
 ```
 deck ping

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -74,7 +74,7 @@ deck ping \
   --konnect-password YOUR_PASSWORD
 ```
 
-Save your {{site.konnect_short_name}} password to a file, then pass the file
+Or, save your {{site.konnect_short_name}} password to a file, then pass the file
 using the `--konnect-password-file` flag:
 
 ```sh
@@ -188,9 +188,11 @@ service named `example` with a version named `example_service` in the Service Hu
 
 ### Authentication with a {{site.konnect_short_name}} password file is not working
 
-Check that there are no conflicts with settings in the decK config file
+If you have verified that your password is correct but decK can't connect to
+your account, check for conflicts with the decK config file
 (`~/.deck.yaml`) and the {{site.konnect_short_name}} password file. There is
-likely an old decK config file conflicting with the password file.
+likely an decK config file conflicting with the password file and passing 
+another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.
 
@@ -198,14 +200,17 @@ To resolve, remove one of the duplicate sets of credentials.
 
 When migrating from {{site.base_gateway}} to {{site.konnect_short_name}},
 make sure to remove any `_workspace`tags. If you leave `_workspace` in, you
-will see the error:
+get the following error:
 
 ```
 Error: checking if workspace exists
 ```
 
-A file with no workspace or runtime group tags gets synced to the `default`
-runtime group.
+Remove the `_workspace` key to resolve this error. 
+
+You can now sync the file as-is to apply it to the 
+default runtime group, or add a key to 
+apply the configuration to a specific runtime group.
 
 To apply configuration to custom runtime groups, replace `_workspace`
 with `runtime_group_name: GroupName`.

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -23,7 +23,7 @@ instead of a self-managed {{site.base_gateway}} control plane.
 
 You can also
 [save {{site.konnect_short_name}} credentials to a decK config file](#authenticate-with-a-deck-config-file)
-to target Konnect by default.
+to target {{site.konnect_short_name}} by default.
 
 If you don't pass any {{site.konnect_short_name}} parameters
 to decK, decK looks for a local {{site.base_gateway}} instance instead.

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -1,5 +1,6 @@
 ---
 title: Using decK with Kong Konnect
+content_type: reference
 ---
 
 You can manage {{site.base_gateway}} core entity configuration in your {{site.konnect_short_name}} organization using decK.

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -8,11 +8,6 @@ You can manage {{site.base_gateway}} core entity configuration in your
 Similar to Gateway workspaces, decK can only target one runtime group at a
 time. Managing multiple runtime groups requires a separate state file per group.
 
-Use any `--konnect`-prefixed CLI flag to target `https://cloud.konghq.com` by
-default, or save {{site.konnect_short_name}} credentials to a decK config file.
-If you don't pass any {{site.konnect_short_name}} parameters
-to decK, decK looks for a local {{site.base_gateway}} instance instead.
-
 You _cannot_ use decK to publish content to the Dev Portal, manage application
 registration, or configure custom plugins.
 
@@ -25,6 +20,13 @@ This guide targets the `cloud.konghq.com` environment. For
 You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`)
 with `--konnect` flags to target {{site.konnect_short_name}}
 instead of a self-managed {{site.base_gateway}} control plane.
+
+You can also
+[save {{site.konnect_short_name}} credentials to a decK config file](#authenticate-with-a-deck-config-file)
+to target Konnect by default.
+
+If you don't pass any {{site.konnect_short_name}} parameters
+to decK, decK looks for a local {{site.base_gateway}} instance instead.
 
 {:.note}
 > Prior to decK 1.12, decK provided `deck konnect` commands. These commands are
@@ -56,7 +58,7 @@ of precedence:
 3. File passed with the `--konnect-password-file` flag
 
 For example, if you have both a decK config file and a {{site.konnect_short_name}}
- password file, decK uses the password in the config file.
+password file, decK uses the password in the config file.
 
 ### Authenticate with CLI flags
 
@@ -122,7 +124,7 @@ _konnect:
 A state file can only target one runtime group.
 
 If you leave this empty or don't include a `_konnect` section at all, decK
-targets the `default` runtime group. You can see this by pushing a simple
+targets the `default` runtime group. You can see this by pushing a
 config file to {{site.konnect_short_name}} with `deck sync`:
 
 ```yaml
@@ -165,7 +167,7 @@ If the {{site.konnect_short_name}} service doesn't exist, setting this tag
 creates a {{site.konnect_short_name}} service.
 
 For example, see the following configuration snippet, where the Gateway service
-named `MyService` is attached to the {{site.konnect_short_name}} service `example`:
+named `example_service` is attached to the {{site.konnect_short_name}} service `example`:
 
 ```yaml
 _format_version: "1.1"
@@ -180,7 +182,7 @@ services:
 
 If the {{site.konnect_short_name}} service doesn't exist, this configuration
 snippet creates a {{site.konnect_short_name}}
-service named `example` with a version named `MyService` in the Service Hub.
+service named `example` with a version named `example_service` in the Service Hub.
 
 ## Troubleshoot
 

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -2,31 +2,24 @@
 title: Using decK with Kong Konnect
 ---
 
-You can manage {{site.base_gateway}} core entity configuration in your
-{{site.konnect_short_name}} organization using decK.
+You can manage {{site.base_gateway}} core entity configuration in your {{site.konnect_short_name}} organization using decK.
 
-Similar to Gateway workspaces, decK can only target one runtime group at a
-time. Managing multiple runtime groups requires a separate state file per group.
+Similar to Gateway workspaces, decK can only target one runtime group at a time.
+Managing multiple runtime groups requires a separate state file per group.
 
-You _cannot_ use decK to publish content to the Dev Portal, manage application
-registration, or configure custom plugins.
+You _cannot_ use decK to publish content to the Dev Portal, manage application registration, or configure custom plugins.
 
 ## {{site.konnect_short_name}} flags
 
-You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`)
-with `--konnect` flags to target {{site.konnect_short_name}}
-instead of a self-managed {{site.base_gateway}} control plane.
+You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`) with `--konnect` flags to target {{site.konnect_short_name}} instead of a self-managed {{site.base_gateway}} control plane.
 
-You can also
-[save {{site.konnect_short_name}} credentials to a decK config file](#authenticate-with-a-deck-config-file)
-to target {{site.konnect_short_name}} by default.
+You can also [save {{site.konnect_short_name}} credentials to a decK config file](#authenticate-with-a-deck-config-file) to target {{site.konnect_short_name}} by default.
 
-If you don't pass any {{site.konnect_short_name}} parameters
-to decK, decK looks for a local {{site.base_gateway}} instance instead.
+If you don't pass any {{site.konnect_short_name}} parameters to decK, decK looks for a local {{site.base_gateway}} instance instead.
 
 {:.note}
-> Prior to decK 1.12, decK provided `deck konnect` commands. These commands are
-deprecated and have been replaced with flags.
+> Prior to decK 1.12, decK provided `deck konnect` commands.
+These commands are deprecated and have been replaced with flags.
 
 `--konnect-addr`
 :  Address of the {{site.konnect_short_name}} endpoint. (Default: `"https://us.api.konghq.com"`)
@@ -46,21 +39,17 @@ This takes precedence over the `--konnect-password-file` flag.
 
 ## Authenticate with {{site.konnect_short_name}}
 
-decK looks for {{site.konnect_short_name}} credentials in the following order
-of precedence:
+decK looks for {{site.konnect_short_name}} credentials in the following order of precedence:
 
 1. Password set with the `--konnect-password` flag
 2. decK configuration file (default: `~/.deck.yaml`)
 3. File passed with the `--konnect-password-file` flag
 
-For example, if you have both a decK config file and a {{site.konnect_short_name}}
-password file, decK uses the password in the config file.
+For example, if you have both a decK config file and a {{site.konnect_short_name}} password file, decK uses the password in the config file.
 
 ### Authenticate with CLI flags
 
-There are two ways to authenticate through CLI flags: by passing the password in
-`--konnect-password` directly, or by saving it to a file and passing the filename
-to decK with `--konnect-password-file`.
+There are two ways to authenticate through CLI flags: by passing the password in `--konnect-password` directly, or by saving it to a file and passing the filename to decK with `--konnect-password-file`.
 
 With `konnect-password`:
 
@@ -70,8 +59,7 @@ deck ping \
   --konnect-password YOUR_PASSWORD
 ```
 
-Or, save your {{site.konnect_short_name}} password to a file, then pass the file
-using the `--konnect-password-file` flag:
+Or, save your {{site.konnect_short_name}} password to a file, then pass the file using the `--konnect-password-file` flag:
 
 ```sh
 deck ping \
@@ -81,24 +69,23 @@ deck ping \
 
 ### Authenticate with a decK config file
 
-The default decK configuration file is `~/.deck.yaml`. You can store {{site.konnect_short_name}}
-credentials in this file to pass them more securely. For example:
+The default decK configuration file is `~/.deck.yaml`.
+You can store {{site.konnect_short_name}} credentials in this file to pass them more securely.
+For example:
 
 ```
 konnect-email: example@email.com
 konnect-password: YOUR_PASSWORD
 ```
 
-Alternatively, you can save your password in a separate file, then
-specify the password file instead of a password:
+Alternatively, you can save your password in a separate file, then specify the password file instead of a password:
 
 ```
 konnect-email: example@example.com
 konnect-password-file: PATH/TO/FILENAME
 ```
 
-decK automatically uses the credentials in `~/.deck.yaml` in any subsequent
-calls:
+decK automatically uses the credentials in `~/.deck.yaml` in any subsequent calls:
 
 ```
 deck ping
@@ -113,8 +100,7 @@ Use `--konnect-addr` to select the API to connect to.
 The default API decK uses is `https://us.api.konghq.com`, which targets the `cloud.konghq.com` environment.
 If your account is in this environment, you don't need to change anything.
 
-If your account is in the `konnect.konghq.com` environment, use this flag
-to target the relevant API:
+If your account is in the `konnect.konghq.com` environment, use this flag to target the relevant API:
 
 ```sh
 deck ping --konnect-addr https://konnect.konghq.com
@@ -122,8 +108,7 @@ deck ping --konnect-addr https://konnect.konghq.com
 
 ## Runtime groups
 
-Target runtime groups in your state file with the `konnect_runtime_group`
-parameter:
+Target runtime groups in your state file with the `konnect_runtime_group` parameter:
 
 ```yaml
 _format_version: "1.1"
@@ -139,9 +124,8 @@ deck sync --konnect-runtime-group-name default
 
 A state file can only target one runtime group.
 
-If you leave this empty, don't provide a flag, or don't include a `_konnect`
-section at all, decK targets the `default` runtime group. You can see this by
-pushing a config file to {{site.konnect_short_name}} with `deck sync`.
+If you leave this empty, don't provide a flag, or don't include a `_konnect` section at all, decK targets the `default` runtime group.
+You can see this by pushing a config file to {{site.konnect_short_name}} with `deck sync`.
 
 1. Create a basic config file:
 
@@ -181,22 +165,17 @@ In {{site.konnect_short_name}}, there are two types of services:
 * Gateway services: Managed through Runtime Manager
 * {{site.konnect_short_name}} services: Managed through Service Hub
 
-decK manages Gateway services, which contain configurations for the Gateway
-proxy.
+decK manages Gateway services, which contain configurations for the Gateway proxy.
 
-Although decK doesn't _directly_ manage {{site.konnect_short_name}} services,
-you can use tags to associate a Gateway service to a {{site.konnect_short_name}}
-service:
+Although decK doesn't _directly_ manage {{site.konnect_short_name}} services, you can use tags to associate a Gateway service to a {{site.konnect_short_name}} service:
 
 ```yaml
 tags:
 - _KonnectService:example
 ```
-If the {{site.konnect_short_name}} service doesn't exist, setting this tag
-creates a {{site.konnect_short_name}} service.
+If the {{site.konnect_short_name}} service doesn't exist, setting this tag creates a {{site.konnect_short_name}} service.
 
-For example, see the following configuration snippet, where the Gateway service
-named `example_service` is attached to the {{site.konnect_short_name}} service `example`:
+For example, see the following configuration snippet, where the Gateway service named `example_service` is attached to the {{site.konnect_short_name}} service `example`:
 
 ```yaml
 _format_version: "1.1"
@@ -209,27 +188,20 @@ services:
   - _KonnectService:example
 ```
 
-If the {{site.konnect_short_name}} service doesn't exist, this configuration
-snippet creates a {{site.konnect_short_name}}
-service named `example` with a version named `example_service` in the Service Hub.
+If the {{site.konnect_short_name}} service doesn't exist, this configuration snippet creates a {{site.konnect_short_name}} service named `example` with a version named `example_service` in the Service Hub.
 
 ## Troubleshoot
 
 ### Authentication with a {{site.konnect_short_name}} password file is not working
 
-If you have verified that your password is correct but decK can't connect to
-your account, check for conflicts with the decK config file
-(`~/.deck.yaml`) and the {{site.konnect_short_name}} password file. There is
-likely a decK config file conflicting with the password file and passing
-another set of credentials.
+If you have verified that your password is correct but decK can't connect to your account, check for conflicts with the decK config file (`~/.deck.yaml`) and the {{site.konnect_short_name}} password file.
+There is likely a decK config file conflicting with the password file and passing another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.
 
 ### Workspace connection refused
 
-When migrating from {{site.base_gateway}} to {{site.konnect_short_name}},
-make sure to remove any `_workspace`tags. If you leave `_workspace` in, you
-get the following error:
+When migrating from {{site.base_gateway}} to {{site.konnect_short_name}}, make sure to remove any `_workspace`tags. If you leave `_workspace` in, you get the following error:
 
 ```
 Error: checking if workspace exists
@@ -237,15 +209,11 @@ Error: checking if workspace exists
 
 Remove the `_workspace` key to resolve this error.
 
-You can now sync the file as-is to apply it to the
-default runtime group, or add a key to
-apply the configuration to a specific runtime group.
+You can now sync the file as-is to apply it to the default runtime group, or add a key to apply the configuration to a specific runtime group.
 
-To apply configuration to custom runtime groups, replace `_workspace`
-with `runtime_group_name: GroupName`.
+To apply configuration to custom runtime groups, replace `_workspace` with `runtime_group_name: GroupName`.
 
-For example, to export the configuration from workspace `staging` to
-runtime group `staging`, you would change:
+For example, to export the configuration from workspace `staging` to runtime group `staging`, you would change:
 
 ```
 _workspace: staging

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -5,18 +5,17 @@ content_type: reference
 
 You can manage {{site.base_gateway}} core entity configuration in your {{site.konnect_short_name}} organization using decK.
 
-Similar to Gateway workspaces, decK can only target one runtime group at a time.
+decK can only target one runtime group at a time.
 Managing multiple runtime groups requires a separate state file per group.
 
 You _cannot_ use decK to publish content to the Dev Portal, manage application registration, or configure custom plugins.
 
 ## {{site.konnect_short_name}} flags
 
-You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`) with `--konnect` flags to target {{site.konnect_short_name}} instead of a self-managed {{site.base_gateway}} control plane.
+You can use `deck` commands such as `ping`, `diff`, or `sync` with `--konnect` flags to interact with {{site.konnect_short_name}}.
 
-You can also [save {{site.konnect_short_name}} credentials to a decK config file](#authenticate-with-a-deck-config-file) to target {{site.konnect_short_name}} by default.
 
-If you don't pass any {{site.konnect_short_name}} parameters to decK, decK looks for a local {{site.base_gateway}} instance instead.
+If you don't pass a {{site.konnect_short_name}} flag to decK, decK looks for a local {{site.base_gateway}} instance instead.
 
 {:.note}
 > Prior to decK 1.12, decK provided `deck konnect` commands.
@@ -60,7 +59,7 @@ deck ping \
 
 ### Authenticate using a password file
 
-For a more secure approach, you can save your {{site.konnect_short_name}}
+You can save your {{site.konnect_short_name}}
 password to a file, then pass the filename to decK with `--konnect-password-file`:
 
 ```sh
@@ -116,7 +115,7 @@ Each state file targets one runtime group.
 If you don't provide a group, decK targets the `default` runtime group.
 
 If you have a custom runtime group, you can specify the group in the state file,
-or set a flag when running any decK command.
+or use a flag when running any decK command.
 
 * Target a runtime group in your state file with the `konnect_runtime_group` parameter:
 
@@ -126,7 +125,7 @@ or set a flag when running any decK command.
       runtime_group_name: staging
     ```
 
-* Set a group using the `--konnect-runtime-group-name` CLI flag:
+* Set a group using the `--konnect-runtime-group-name` flag:
 
     ```sh
     deck sync --konnect-runtime-group-name staging

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -11,10 +11,6 @@ time. Managing multiple runtime groups requires a separate state file per group.
 You _cannot_ use decK to publish content to the Dev Portal, manage application
 registration, or configure custom plugins.
 
-This guide targets the `cloud.konghq.com` environment. For
-`konnect.konghq.com`, see [`deck konnect` commands](/deck/1.11.x/reference/deck_konnect/)
- in decK 1.11 or earlier.
-
 ## {{site.konnect_short_name}} flags
 
 You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`)
@@ -90,15 +86,15 @@ credentials in this file to pass them more securely. For example:
 
 ```
 konnect-email: example@email.com
-konnect-password: MyPass
+konnect-password: YOUR_PASSWORD
 ```
 
 Alternatively, you can save your password in a separate file, then
 specify the password file instead of a password:
 
 ```
-konnect-email: example@email.com
-konnect-password-file: path/to/filename
+konnect-email: example@example.com
+konnect-password-file: PATH/TO/FILENAME
 ```
 
 decK automatically uses the credentials in `~/.deck.yaml` in any subsequent
@@ -108,6 +104,20 @@ calls:
 deck ping
 
 Successfully Konnected as MyName (Konnect Org)!
+```
+
+## Target a {{site.konnect_short_name}} API
+
+Use `--konnect-addr` to select the API to connect to.
+
+The default API decK uses is `https://us.api.konghq.com`, which targets the `cloud.konghq.com` environment.
+If your account is in this environment, you don't need to change anything.
+
+If your account is in the `konnect.konghq.com` environment, use this flag
+to target the relevant API:
+
+```sh
+deck ping --konnect-addr https://konnect.konghq.com
 ```
 
 ## Runtime groups
@@ -121,30 +131,49 @@ _konnect:
   runtime_group_name: staging
 ```
 
+You can also set this parameter using the `--konnect-runtime-group-name` flag:
+
+```sh
+deck sync --konnect-runtime-group-name default
+```
+
 A state file can only target one runtime group.
 
-If you leave this empty or don't include a `_konnect` section at all, decK
-targets the `default` runtime group. You can see this by pushing a
-config file to {{site.konnect_short_name}} with `deck sync`:
+If you leave this empty, don't provide a flag, or don't include a `_konnect`
+section at all, decK targets the `default` runtime group. You can see this by
+pushing a config file to {{site.konnect_short_name}} with `deck sync`.
 
-```yaml
-_format_version: "1.1"
-services:
-- name: example_service
-  host: mockbin.org
-```
+1. Create a basic config file:
 
-Then pull down the configuration with `deck dump` to see the newly added
-`_konnect` section:
+    ```yaml
+    _format_version: "1.1"
+    services:
+    - name: example_service
+      host: mockbin.org
+    ```
 
-```yaml
-_format_version: "1.1"
-_konnect:
-  runtime_group_name: default
-services:
-- name: example_service
-  host: mockbin.org
-```
+2. Sync the file to Konnect:
+
+    ```sh
+    deck sync
+    ```
+
+3. Pull down the configuration with `deck dump`:
+
+    ```sh
+    deck dump --konnect-runtime-group-name default
+    ```
+
+    See the newly added `_konnect` section:
+
+    ```yaml
+    _format_version: "1.1"
+    _konnect:
+      runtime_group_name: default
+    services:
+    - name: example_service
+      host: mockbin.org
+    ```
 
 ## {{site.konnect_short_name}} service tags
 
@@ -191,7 +220,7 @@ service named `example` with a version named `example_service` in the Service Hu
 If you have verified that your password is correct but decK can't connect to
 your account, check for conflicts with the decK config file
 (`~/.deck.yaml`) and the {{site.konnect_short_name}} password file. There is
-likely an decK config file conflicting with the password file and passing 
+likely a decK config file conflicting with the password file and passing
 another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.
@@ -206,10 +235,10 @@ get the following error:
 Error: checking if workspace exists
 ```
 
-Remove the `_workspace` key to resolve this error. 
+Remove the `_workspace` key to resolve this error.
 
-You can now sync the file as-is to apply it to the 
-default runtime group, or add a key to 
+You can now sync the file as-is to apply it to the
+default runtime group, or add a key to
 apply the configuration to a specific runtime group.
 
 To apply configuration to custom runtime groups, replace `_workspace`

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -50,7 +50,7 @@ For example, if you have both a decK config file and a {{site.konnect_short_name
 
 ### Authenticate with CLI flags
 
-There are two ways to authenticate through CLI flags: by passing the password in `--konnect-password` directly, or by saving it to a file and passing the filename to decK with `--konnect-password-file`.
+There are two ways to authenticate through CLI flags. You can pass the password in `--konnect-password` directly or save it to a file and pass the filename to decK with `--konnect-password-file`.
 
 With `konnect-password`:
 
@@ -202,7 +202,7 @@ To resolve, remove one of the duplicate sets of credentials.
 
 ### Workspace connection refused
 
-When migrating from {{site.base_gateway}} to {{site.konnect_short_name}}, make sure to remove any `_workspace`tags. If you leave `_workspace` in, you get the following error:
+When migrating from {{site.base_gateway}} to {{site.konnect_short_name}}, make sure to remove any `_workspace` tags. If you leave `_workspace` in, you get the following error:
 
 ```
 Error: checking if workspace exists
@@ -212,7 +212,7 @@ Remove the `_workspace` key to resolve this error.
 
 You can now sync the file as-is to apply it to the default runtime group, or add a key to apply the configuration to a specific runtime group.
 
-To apply configuration to custom runtime groups, replace `_workspace` with `runtime_group_name: GroupName`.
+To apply the configuration to custom runtime groups, replace `_workspace` with `runtime_group_name: GroupName`.
 
 For example, to export the configuration from workspace `staging` to runtime group `staging`, you would change:
 
@@ -220,7 +220,7 @@ For example, to export the configuration from workspace `staging` to runtime gro
 _workspace: staging
 ```
 
-Into:
+To:
 ```
 _konnect:
   runtime_group_name: staging

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -91,7 +91,7 @@ Set either `konnect-password` or `konnect-password-file` in the decK config file
     konnect-password-file: PATH/TO/FILENAME
     ```
 
-decK automatically uses the credentials from `~/.deck.yaml` in any subsequent calls:
+decK automatically uses the credentials from `$HOME/.deck.yaml` in any subsequent calls:
 
 ```
 deck ping
@@ -169,7 +169,7 @@ If the {{site.konnect_short_name}} service doesn't exist, this configuration sni
 
 ### Authentication with a {{site.konnect_short_name}} password file is not working
 
-If you have verified that your password is correct but decK can't connect to your account, check for conflicts with the decK config file (`~/.deck.yaml`) and the {{site.konnect_short_name}} password file.
+If you have verified that your password is correct but decK can't connect to your account, check for conflicts with the decK config file (`$HOME/.deck.yaml`) and the {{site.konnect_short_name}} password file.
 There is likely a decK config file conflicting with the password file and passing another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -93,7 +93,7 @@ Set either `konnect-password` or `konnect-password-file` in the decK config file
 
 decK automatically uses the credentials from `$HOME/.deck.yaml` in any subsequent calls:
 
-```
+```sh
 deck ping
 
 Successfully Konnected as MyName (Konnect Org)!
@@ -201,12 +201,12 @@ To apply the configuration to custom runtime groups, replace `_workspace` with `
 
 For example, to export the configuration from workspace `staging` to runtime group `staging`, you would change:
 
-```
+```yaml
 _workspace: staging
 ```
 
 To:
-```
+```yaml
 _konnect:
   runtime_group_name: staging
 ```

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -16,6 +16,10 @@ to decK, decK looks for a local {{site.base_gateway}} instance instead.
 You _cannot_ use decK to publish content to the Dev Portal, manage application
 registration, or configure custom plugins.
 
+This guide targets the `cloud.konghq.com` environment. For
+`konnect.konghq.com`, see [`deck konnect` commands](/deck/1.11.x/reference/deck_konnect/)
+ in decK 1.11 or earlier.
+
 ## {{site.konnect_short_name}} flags
 
 You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`)

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -114,7 +114,7 @@ deck ping --konnect-addr https://konnect.konghq.com
 
 ## Runtime groups
 
-Each state file targets one runtime group.
+Each [state file](/deck/{{page.kong_version}}/terminology/#state-files) targets one runtime group.
 If you don't provide a group, decK targets the `default` runtime group.
 
 If you have a custom runtime group, you can specify the group in the state file,

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -1,0 +1,218 @@
+---
+title: Using decK with Kong Konnect
+---
+
+You can manage {{site.base_gateway}} core entity configuration in your
+{{site.konnect_short_name}} organization using decK.
+
+Similar to Gateway workspaces, decK can only target one runtime group at a
+time. Managing multiple runtime groups requires a separate state file per group.
+
+Use any `--konnect`-prefixed CLI flag to target `https://cloud.konghq.com` by
+default, or save {{site.konnect_short_name}} credentials to a decK config file.
+If you don't pass any {{site.konnect_short_name}} parameters
+to decK, decK looks for a local {{site.base_gateway}} instance instead.
+
+You _cannot_ use decK to publish content to the Dev Portal, manage application
+registration, or configure custom plugins.
+
+## {{site.konnect_short_name}} flags
+
+You can use any regular `deck` commands (such as `ping`, `diff`, or `sync`)
+with `--konnect` flags to target {{site.konnect_short_name}}
+instead of a self-managed {{site.base_gateway}} control plane.
+
+{:.note}
+> Prior to decK 1.12, decK provided `deck konnect` commands. These commands are
+deprecated and have been replaced with flags.
+
+`--konnect-addr`
+:  Address of the {{site.konnect_short_name}} endpoint. (Default: `"https://us.api.konghq.com"`)
+
+`--konnect-email`
+:  Email address associated with your {{site.konnect_short_name}} account.
+
+`--konnect-password`
+:  Password associated with your {{site.konnect_short_name}} account.
+This takes precedence over the `--konnect-password-file` flag.
+
+`--konnect-password-file`
+:  File containing the password to your {{site.konnect_short_name}} account.
+
+`--konnect-runtime-group-name`
+:  {{site.konnect_short_name}} runtime group name.
+
+## Authenticate with {{site.konnect_short_name}}
+
+decK looks for {{site.konnect_short_name}} credentials in the following order
+of precedence:
+
+1. Password set with the `--konnect-password` flag
+2. decK configuration file (default: `~/.deck.yaml`)
+3. File passed with the `--konnect-password-file` flag
+
+For example, if you have both a decK config file and a {{site.konnect_short_name}}
+ password file, decK uses the password in the config file.
+
+### Authenticate with CLI flags
+
+There are two ways to authenticate through CLI flags: by passing the password in
+`--konnect-password` directly, or by saving it to a file and passing the filename
+to decK with `--konnect-password-file`.
+
+With `konnect-password`:
+
+```sh
+deck ping \
+  --konnect-email YOUR_EMAIL \
+  --konnect-password YOUR_PASSWORD
+```
+
+Save your {{site.konnect_short_name}} password to a file, then pass the file
+using the `--konnect-password-file` flag:
+
+```sh
+deck ping \
+  --konnect-email YOUR_EMAIL \
+  --konnect-password-file /PATH/TO/FILE
+```
+
+### Authenticate with a decK config file
+
+The default decK configuration file is `~/.deck.yaml`. You can store {{site.konnect_short_name}}
+credentials in this file to pass them more securely. For example:
+
+```
+konnect-email: example@email.com
+konnect-password: MyPass
+```
+
+Alternatively, you can save your password in a separate file, then
+specify the password file instead of a password:
+
+```
+konnect-email: example@email.com
+konnect-password-file: path/to/filename
+```
+
+decK automatically uses the credentials in `~/.deck.yaml` in any subsequent
+calls:
+
+```
+deck ping
+
+Successfully Konnected as MyName (Konnect Org)!
+```
+
+## Runtime groups
+
+Target runtime groups in your state file with the `konnect_runtime_group`
+parameter:
+
+```yaml
+_format_version: "1.1"
+_konnect:
+  runtime_group_name: staging
+```
+
+A state file can only target one runtime group.
+
+If you leave this empty or don't include a `_konnect` section at all, decK
+targets the `default` runtime group. You can see this by pushing a simple
+config file to {{site.konnect_short_name}} with `deck sync`:
+
+```yaml
+_format_version: "1.1"
+services:
+- name: example_service
+  host: mockbin.org
+```
+
+Then pull down the configuration with `deck dump` to see the newly added
+`_konnect` section:
+
+```yaml
+_format_version: "1.1"
+_konnect:
+  runtime_group_name: default
+services:
+- name: example_service
+  host: mockbin.org
+```
+
+## {{site.konnect_short_name}} service tags
+
+In {{site.konnect_short_name}}, there are two types of services:
+* Gateway services: Managed through Runtime Manager
+* {{site.konnect_short_name}} services: Managed through Service Hub
+
+decK manages Gateway services, which contain configurations for the Gateway
+proxy.
+
+Although decK doesn't _directly_ manage {{site.konnect_short_name}} services,
+you can use tags to associate a Gateway service to a {{site.konnect_short_name}}
+service:
+
+```yaml
+tags:
+- _KonnectService:example
+```
+If the {{site.konnect_short_name}} service doesn't exist, setting this tag
+creates a {{site.konnect_short_name}} service.
+
+For example, see the following configuration snippet, where the Gateway service
+named `MyService` is attached to the {{site.konnect_short_name}} service `example`:
+
+```yaml
+_format_version: "1.1"
+_konnect:
+  runtime_group_name: default
+services:
+- name: example_service
+  host: mockbin.org
+  tags:
+  - _KonnectService:example
+```
+
+If the {{site.konnect_short_name}} service doesn't exist, this configuration
+snippet creates a {{site.konnect_short_name}}
+service named `example` with a version named `MyService` in the Service Hub.
+
+## Troubleshoot
+
+### Authentication with a {{site.konnect_short_name}} password file is not working
+
+Check that there are no conflicts with settings in the decK config file
+(`~/.deck.yaml`) and the {{site.konnect_short_name}} password file. There is
+likely an old decK config file conflicting with the password file.
+
+To resolve, remove one of the duplicate sets of credentials.
+
+### Workspace connection refused
+
+When migrating from {{site.base_gateway}} to {{site.konnect_short_name}},
+make sure to remove any `_workspace`tags. If you leave `_workspace` in, you
+will see the error:
+
+```
+Error: checking if workspace exists
+```
+
+A file with no workspace or runtime group tags gets synced to the `default`
+runtime group.
+
+To apply configuration to custom runtime groups, replace `_workspace`
+with `runtime_group_name: GroupName`.
+
+For example, to export the configuration from workspace `staging` to
+runtime group `staging`, you would change:
+
+```
+_workspace: staging
+```
+
+Into:
+```
+_konnect:
+  runtime_group_name: staging
+```

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -139,17 +139,27 @@ or use a flag when running any decK command.
 In {{site.konnect_short_name}}, there are two types of services:
 * Gateway services: Managed through Runtime Manager
 * {{site.konnect_short_name}} services: Managed through Service Hub
-Each Konnect Service may contain one or more service versions. A service version represents an implementation of a Gateway service.
+
+Each {{site.konnect_short_name}} service may contain one or more service versions.
+A service version represents an implementation of a Gateway service.
 
 decK manages Gateway services, which contain configurations for the Gateway proxy.
 
 Although decK doesn't _directly_ manage {{site.konnect_short_name}} services or service versions, you can use tags to associate a Gateway service to a service version in a {{site.konnect_short_name}} service:
 
 ```yaml
-tags:
-- _KonnectService:<Konnect-Service-Name>
+services:
+- name: SERVICE_NAME
+  tags:
+  - _KonnectService:KONNECT_SERVICE_NAME
 ```
-The `<Konnect-Service-Name>` identifies which {{site.konnect_short_name}} to associate the Gateway service to while the name of the Gateway service identifies which service version to associate the Gateway service to. If the {{site.konnect_short_name}} service doesn't exist, setting this tag creates a {{site.konnect_short_name}} service.
+
+Where:
+
+* `KONNECT_SERVICE_NAME`: Identifies which {{site.konnect_short_name}} _service_ to associate the Gateway service to.
+* `SERVICE_NAME`: The name of the Gateway service. Identifies which {{site.konnect_short_name}} _service version_ to associate the Gateway service to.
+
+If the {{site.konnect_short_name}} service doesn't exist, setting a `_Konnect` tag creates a {{site.konnect_short_name}} service.
 
 For example, see the following configuration snippet, where the Gateway service named `example_service` is attached to the {{site.konnect_short_name}} service `example`:
 


### PR DESCRIPTION
### Summary

Adding a guide for using decK with Konnect with examples into the decK docs.

The only thing I couldn't figure out was the purpose of the `--konnect-addr` flag in the current environment. Users only have one API they can target, right? Or can they somehow target `konnect.konghq.com` still? I couldn't get it to do anything different - @GGabriele, is there something I'm missing, or is this flag not helpful to customers at the moment (only useful internally)?

Note that this is going into live docs, not into the `konnect` branch, because this version of decK is already out - even though Konnect is in beta.

### Reason
https://konghq.atlassian.net/browse/DOCU-2308

### Testing
Tested all the things with decK 1.12 and cloud.konghq.com; that's also how I figured out precedence for auth methods. If that's not the desired precedence, then it's something that we should know about anyway. 

Preview: https://deploy-preview-4030--kongdocs.netlify.app/deck/latest/guides/konnect/