### PR TITLE
Fix slashes in deploying to Azure command

### DIFF
--- a/app/_hub/tomkerkhove/microsoft_azure_container_instances/_index.md
+++ b/app/_hub/tomkerkhove/microsoft_azure_container_instances/_index.md
@@ -116,18 +116,18 @@ Running Kong on Azure Container Instances is super easy:
 1. **Start Kong**
 
     ```bash
-    $ az container create --name kong-gateway /
-                          --dns-name-label kong-gateway /
-                          --resource-group kong-gateway /
-                          --image kong:latest /
-                          --port 8000 8443 8001 8444 /
-                          --environment-variables KONG_PG_HOST="<instance-name>.postgres.database.azure.com" /
-                                                  KONG_PG_USER="<username>" /
-                                                  KONG_PG_PASSWORD="<password>" /
-                                                  KONG_PROXY_ACCESS_LOG="/dev/stdout" /
-                                                  KONG_ADMIN_ACCESS_LOG="/dev/stdout" /
-                                                  KONG_PROXY_ERROR_LOG="/dev/stderr" /
-                                                  KONG_ADMIN_ERROR_LOG="/dev/stderr" /
+    $ az container create --name kong-gateway \
+                          --dns-name-label kong-gateway \
+                          --resource-group kong-gateway \
+                          --image kong:latest \
+                          --port 8000 8443 8001 8444 \
+                          --environment-variables KONG_PG_HOST="<instance-name>.postgres.database.azure.com" \
+                                                  KONG_PG_USER="<username>" \
+                                                  KONG_PG_PASSWORD="<password>" \
+                                                  KONG_PROXY_ACCESS_LOG="/dev/stdout" \
+                                                  KONG_ADMIN_ACCESS_LOG="/dev/stdout" \
+                                                  KONG_PROXY_ERROR_LOG="/dev/stderr" \
+                                                  KONG_ADMIN_ERROR_LOG="/dev/stderr" \
                                                   KONG_ADMIN_LISTEN="0.0.0.0:8001, 0.0.0.0:8444 ssl"
     ```
 


### PR DESCRIPTION
### Summary
Fix the forward slashes to backward slashes for Linux commands

### Reason
The command has forward slashes, which fails while running in Linux and needs to be backward slashes for new lines.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
N/A
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
