### PR TITLE
Removed 'path' as option for admin_gui_url

### DIFF
--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -2205,13 +2205,13 @@ The lookup, or balancer, address for Kong Manager.
 
 Accepted format (items in parentheses are optional):
 
-`<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`
+`<scheme>://<IP / HOSTNAME>(:<PORT>)`
 
 Examples:
 
 - `http://127.0.0.1:8003`
 - `https://kong-admin.test`
-- `http://dev-machine/dev-285`
+- `http://dev-machine`
 
 By default, Kong Manager will use the window request host and append the
 resolved listener port depending on the requested protocol.


### PR DESCRIPTION
### Summary
Removed the path part of the schema presented for the admin_gui_url property.

### Reason
While the schema technically allows for the path to be set and won't throw errors, it doesn't appear to actually do anything other than the host and port part. I believe this is (possibly) confirmed too by FTI-976 which hasn't been implemented yet and is a feature request for allowing customers to set their own root paths for Kong Manager.

### Testing
Please consider double-checking this though in case I'm overlooking something, but I believe this change is correct based on the FTI and my own testing.

review:tech