### PR TITLE
fix: description of generation of refresh token in OAuth2 plugin documentation

### DIFF
--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -360,14 +360,14 @@ A diagram representing this flow:
   <a title="OAuth 2.0 Flow" href="/assets/images/docs/oauth2/oauth2-flow.png" target="_blank"><img src="/assets/images/docs/oauth2/oauth2-flow.png"/></a>
 </div>
 
-1. The client application will redirect the end user to the authorization page on your web application, passing `client_id`, `response_type` and `scope` (if required) as querystring parameters. This is a sample authorization page:
+1. The client application will redirect the end user to the authorization page on your web application, passing `client_id`, `response_type` and `scope` (if required) as query string parameters. This is a sample authorization page:
     <div class="alert alert-info">
       <center><img title="OAuth 2.0 Prompt" src="/assets/images/docs/oauth2/oauth2-prompt.png"/></center>
     </div>
 
 2. Before showing the actual authorization page, the web application will make sure that the user is logged in.
 
-3. The client application will send the `client_id` in the querystring, from which the web application can retrieve both the OAuth 2.0 application name, and developer name, by making the following request to Kong:
+3. The client application will send the `client_id` in the query string, from which the web application can retrieve both the OAuth 2.0 application name, and developer name, by making the following request to Kong:
 
     ```bash
     $ curl kong:8001/oauth2?client_id=XXX

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -268,7 +268,7 @@ form parameter                        | default | description
 `credential`                          |         | Contains the ID of the OAuth 2.0 application created on Kong.
 `token_type`<br>*optional*            | `bearer`| The [token type](https://tools.ietf.org/html/rfc6749#section-7.1).
 `access_token`<br>*optional*          |         | You can optionally set your own access token value, otherwise a random string will be generated.
-`refresh_token`<br>*optional*         |         | You can optionally set your own unique refresh token value, otherwise a random string will be generated.
+`refresh_token`<br>*optional*         |         | You can optionally set your own unique refresh token value, otherwise no refresh token will be generated.
 `expires_in`                          |         | The expiration time (in seconds) of the access token.
 `scope`<br>*optional*                 |         | The authorized scope associated with the token.
 `authenticated_userid`<br>*optional*  |         | The custom ID of the user who authorized the application.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

The documentation for the [Kong OAuth2 plugin](https://github.com/Kong/kong/tree/master/kong/plugins/oauth2) states that a refresh token will be generated automatically when manually creating (aka migrating) token. This is incorrect; the [DAO attribute](https://github.com/Kong/kong/blob/a02542d6dfb96073c4ef6ab5f86b350b756ae2fa/kong/plugins/oauth2/daos.lua#L103) does not define ` auto = true` and so a refresh token will not be generated automatically.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Existing documentation is currently incorrect/out-of-sync from reality.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

Attempt to creating a OAuth2 token by following the existing documentation but excluding the `refresh_token` parameter. E.g.:

```
$ curl -X POST http://localhost:8001/oauth2_tokens --data 'credential.id=962db0d1-f06e-4085-8dee-5538f213ca69' --data "token_type=bearer" --data "expires_in=3600" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   390  100   306  100    84  15300   4200 --:--:-- --:--:-- --:--:-- 19500
{
  "credential": {
    "id": "962db0d1-f06e-4085-8dee-5538f213ca69"
  },
  "ttl": null,
  "access_token": "Evav6Wu7ktqHf9QghnWbCHrY7zIQREn7",
  "refresh_token": null,
  "expires_in": 3600,
  "id": "b43105cf-ee83-46c9-8ba2-cb1faa19589b",
  "service": null,
  "token_type": "bearer",
  "created_at": 1655542732,
  "authenticated_userid": null,
  "scope": null
}
```

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
