### PR TITLE
[DOCU-2371] Konnect hostnames and ports

### DIFF
--- a/app/_includes/md/gateway-ports.md
+++ b/app/_includes/md/gateway-ports.md
@@ -1,24 +1,24 @@
-<!-- used in Konnect and Gateway docs -->
+<!-- Do not use; used in older versions of Gateway docs only -->
 
 By default, {{site.base_gateway}} listens on the following ports:
 
 | Port                                                                               | Protocol | Description |
 |:-----------------------------------------------------------------------------------|:---------|:--|
-| [`:8000`](/gateway/latest/reference/configuration/#proxy_listen)      | HTTP     | Takes incoming HTTP traffic from **Consumers**, and forwards it to upstream **Services**. |
-| [`:8443`](/gateway/latest/reference/configuration/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from **Consumers**, and forwards it to upstream **Services**. |
-| [`:8001`](/gateway/latest/reference/configuration/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. |
-| [`:8444`](/gateway/latest/reference/configuration/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. |
-| [`:8002`](/gateway/latest/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. |
-| [`:8445`](/gateway/latest/reference/configuration/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. |
-| [`:8003`](/gateway/latest/reference/configuration/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. |
-| [`:8446`](/gateway/latest/reference/configuration/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**. |
-| [`:8004`](/gateway/latest/reference/configuration/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. |
-| [`:8447`](/gateway/latest/reference/configuration/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. |
-| [`:8005`](/gateway/latest/plan-and-deploy/hybrid-mode/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. |
-| [`:8006`](/gateway/latest/plan-and-deploy/hybrid-mode/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. |
+| [`8000`](/gateway/latest/reference/configuration/#proxy_listen)      | HTTP     | Takes incoming HTTP traffic from consumers, and forwards it to upstream services. |
+| [`8443`](/gateway/latest/reference/configuration/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from consumers, and forwards it to upstream services. |
+| [`8001`](/gateway/latest/reference/configuration/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. |
+| [`8444`](/gateway/latest/reference/configuration/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. |
+| [`8002`](/gateway/latest/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. |
+| [`8445`](/gateway/latest/reference/configuration/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. |
+| [`8003`](/gateway/latest/reference/configuration/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. |
+| [`8446`](/gateway/latest/reference/configuration/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**. |
+| [`8004`](/gateway/latest/reference/configuration/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. |
+| [`8447`](/gateway/latest/reference/configuration/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. |
+| [`8005`](/gateway/latest/reference/configuration/#cluster_listen)    | HTTP     | Hybrid mode only. Control plane listens for traffic from data planes. |
+| [`8006`](/gateway/latest/reference/configuration/#cluster_telemetry_listen)  | HTTP     | Hybrid mode only. Control plane listens for Vitals telemetry data from data planes. |
 
 
-Self-managed ports can be fully customized. Set them in `kong.conf`.
+{{site.base_gateway}} ports can be fully customized. Set them in `kong.conf`.
 
 For Kubernetes or Docker deployments, map ports as needed. For example, if you
 want to expose the Admin API through port `3001`, map `3001:8001`.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -52,7 +52,8 @@ You can find them through the Runtime Manager:
 
 1. Open a runtime group.
 2. Click **Add runtime instance**.
-3. Choose the Linux or Kubernetes tab and note the hostnames in the codeblock for the following parameters:
+3. Choose the Linux or Kubernetes tab and note the hostnames in the code block
+for the following parameters:
 
     ```
     cluster_control_plane = example12345.us.cp0.konghq.com:443

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -41,14 +41,13 @@ Add the following hostnames to the allowlist to give the
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
 * `us.api.konghq.com`: The {{site.konnect_short_name}} API.
     Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
-* `<group-ID>.us.cp0.konghq.com`: Handles configuration for a runtime group.
-    Runtime instances connect to this host to receive configuration updates.
-* `<group-ID>.us.tp0.konghq.com`: Gathers telemetry data for a runtime group.
+* `RUNTIME_GROUP_ID.us.cp0.konghq.com`: Handles configuration for a runtime group.
+    Runtime instances connect to this host to receive configuration updates. 
+    This hostname is unique to each organization and runtime group.
+* `RUNTIME_GROUP_ID.us.tp0.konghq.com`: Gathers telemetry data for a runtime group.
+    This hostname is unique to each organization and runtime group.
 
-The configuration and telemetry hostnames are unique to each organization and
-runtime group.
-
-You can find them through the Runtime Manager:
+You can find the configuration and telemetry hostnames through the Runtime Manager:
 
 1. Open a runtime group.
 2. Click **Add runtime instance**.
@@ -56,8 +55,8 @@ You can find them through the Runtime Manager:
 for the following parameters:
 
     ```
-    cluster_control_plane = EXAMPLE.us.cp0.konghq.com:443
-    cluster_server_name = EXAMPLE.us.cp0.konghq.com
-    cluster_telemetry_endpoint = EXAMPLE.us.tp0.konghq.com:443
-    cluster_telemetry_server_name = EXAMPLE.us.tp0.konghq.com
+    cluster_control_plane = example.us.cp0.konghq.com:443
+    cluster_server_name = example.us.cp0.konghq.com
+    cluster_telemetry_endpoint = example.us.tp0.konghq.com:443
+    cluster_telemetry_server_name = example.us.tp0.konghq.com
     ```

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -3,32 +3,60 @@ title: Ports and Network Requirements
 no_version: true
 ---
 
-## Konnect Cloud ports
+## Control plane ports
 
 The {{site.konnect_saas}} control plane uses the following port:
 
 | Port      | Protocol  | Description |
 |:----------|:----------|:------------|
-| `:443`    | TCP <br>HTTPS | Cluster communication port for configuration and telemetry data. The {{site.konnect_saas}} control plane uses this port to listen for runtime node connections and to communicate with the runtime nodes. |
+| `443`    | TCP <br>HTTPS | Cluster communication port for configuration and telemetry data. The {{site.konnect_saas}} control plane uses this port to listen for runtime node connections and to communicate with the runtime nodes. |
 
 Kong's hosted control plane expects traffic on this port, so the cluster port
 can't be customized.
 
 The cluster communication port must be accessible by all
-the data planes within the same cluster. This port is protected by mTLS to
+the data planes within the same cluster.
+This port is protected by mTLS to
 ensure end-to-end security and integrity.
 
-## Runtime ports
+## Runtime instance ports
 
-{% include /md/gateway-ports.md %}
+By default, {{site.base_gateway}} listens on the following ports:
 
-## Hostnames to add to allow lists
+| Port                                                                               | Protocol | Description |
+|:-----------------------------------------------------------------------------------|:---------|:--|
+| [`8000`](/gateway/latest/reference/configuration/#proxy_listen)      | HTTP     | Takes incoming HTTP traffic from consumers, and forwards it to upstream services. |
+| [`8443`](/gateway/latest/reference/configuration/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from consumers, and forwards it to upstream services. |
 
-The {{site.konnect_saas}} control plane uses the following hostnames:
-* `us.cp0.konghq.com`: configuration
-* `us.tp0.konghq.com`: telemetry
+{{site.base_gateway}} ports can be fully customized. Set them in `kong.conf`.
 
+For Kubernetes or Docker deployments, map ports as needed. For example, if you
+want to use port `3001` for the proxy, map `3001:8000`.
 
-You can find your specific instance hostnames through Runtime manager.
-Start configuring a new runtime, choose the Linux or Kubernetes tab, and note
-the hostnames in the codeblock.
+## Hostnames
+
+Add the following hostnames to allowlists to give the
+{{site.konnect_short_name}} control plane access through firewalls:
+
+* `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
+* `us.api.konghq.com`: The {{site.konnect_short_name}} API.
+    Necessary if you are using decK in your workflow, as decK uses this API to access and apply configuration.
+* `<group-ID>.us.cp0.konghq.com`: Handles configuration for a runtime group.
+    Runtime instances connect to this host to receive configuration updates.
+* `<group-ID>.us.tp0.konghq.com`: Gathers telemetry for a runtime group.
+
+The configuration and telemetry hostnames are unique to each organization and
+runtime group.
+
+You can find them through the Runtime Manager:
+
+1. Open a runtime group.
+2. Click **Add runtime instance**.
+3. Choose the Linux or Kubernetes tab and note the hostnames in the codeblock for the following parameters:
+
+    ```
+    cluster_control_plane = example12345.us.cp0.konghq.com:443
+    cluster_server_name = example12345.us.cp0.konghq.com
+    cluster_telemetry_endpoint = example12345.us.tp0.konghq.com:443
+    cluster_telemetry_server_name = example12345.us.tp0.konghq.com
+    ```

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -35,15 +35,15 @@ want to use port `3001` for the proxy, map `3001:8000`.
 
 ## Hostnames
 
-Add the following hostnames to allowlists to give the
-{{site.konnect_short_name}} control plane access through firewalls:
+Add the following hostnames to the allowlist to give the
+{{site.konnect_short_name}} control plane access through the firewall:
 
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
 * `us.api.konghq.com`: The {{site.konnect_short_name}} API.
-    Necessary if you are using decK in your workflow, as decK uses this API to access and apply configuration.
+    Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
 * `<group-ID>.us.cp0.konghq.com`: Handles configuration for a runtime group.
     Runtime instances connect to this host to receive configuration updates.
-* `<group-ID>.us.tp0.konghq.com`: Gathers telemetry for a runtime group.
+* `<group-ID>.us.tp0.konghq.com`: Gathers telemetry data for a runtime group.
 
 The configuration and telemetry hostnames are unique to each organization and
 runtime group.
@@ -56,8 +56,8 @@ You can find them through the Runtime Manager:
 for the following parameters:
 
     ```
-    cluster_control_plane = example12345.us.cp0.konghq.com:443
-    cluster_server_name = example12345.us.cp0.konghq.com
-    cluster_telemetry_endpoint = example12345.us.tp0.konghq.com:443
-    cluster_telemetry_server_name = example12345.us.tp0.konghq.com
+    cluster_control_plane = EXAMPLE.us.cp0.konghq.com:443
+    cluster_server_name = EXAMPLE.us.cp0.konghq.com
+    cluster_telemetry_endpoint = EXAMPLE.us.tp0.konghq.com:443
+    cluster_telemetry_server_name = EXAMPLE.us.tp0.konghq.com
     ```


### PR DESCRIPTION
### Summary

* Updating the list of Konnect hostnames a user might need to add to their firewall's allowlist. 
  * Renamed the section from "Hostnames to add to allow lists" to simply "Hostnames" to parallel the rest of the page. The whole point of this entire doc is to provide lists of ports and hosts to add to allowlists, it's not specific to this section.

* Simplified the Kong Gateway ports table to just the proxy ports. Unless I'm missing something, none of the other ports are actually in use in Konnect or on data planes - they're all self-hosted control plane ports.

### Reason
https://konghq.atlassian.net/browse/DOCU-2371

### Testing
https://deploy-preview-4039--kongdocs.netlify.app/konnect/network/