### PR TITLE
chore(docs) PUT /vaults-beta/{} always responds with 200 OK FT-2589

### DIFF
--- a/app/gateway/2.8.x/admin-api/index.md
+++ b/app/gateway/2.8.x/admin-api/index.md
@@ -4352,7 +4352,7 @@ body is not allowed.
 #### Response
 
 ```
-HTTP 201 Created or HTTP 200 OK
+HTTP 200 OK
 ```
 
 See POST and PATCH responses.


### PR DESCRIPTION
### Summary

The documentation states that `PUT /vaults-beta/{...}` can respond with a 200 or 201 response code, but it always responds with 200.  This change corrects the documentation for the endpoint.

### Reason

https://konghq.atlassian.net/browse/FT-2589
