### PR TITLE
Remove run_on_preflight from jwt-signer

### DIFF
--- a/app/_hub/kong-inc/jwt-signer/_index.md
+++ b/app/_hub/kong-inc/jwt-signer/_index.md
@@ -63,14 +63,6 @@ params:
         the logging level on Kong nodes, which requires a reload, use this
         parameter to enable instrumentation for the request. The parameter writes
         log entries with some added information using `ngx.CRIT` (CRITICAL) level.
-    - name: run_on_preflight
-      required: false
-      default: true
-      datatype: boolean
-      description: |
-        A boolean value that indicates whether the plugin should run (and try to 
-        authenticate) on `OPTIONS` preflight requests. If set to `false`, then 
-        `OPTIONS` requests are always allowed.
     - name: access_token_issuer
       required: false
       default: kong


### PR DESCRIPTION
### Summary
Removing a parameter from the JWT signer plugin that doesn't exist in the plugin. 

Parameter was added yesterday by an external contributor as supposedly missing; seems like we both confused the JWT signer plugin with the JWT plugin, which _does_ have this parameter (and it's [already documented there](https://docs.konghq.com/hub/kong-inc/jwt-signer/)).

### Testing
TBA