### PR TITLE
doc(acme) add missing Admin API section and explain `domains` behaviour

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -68,7 +68,7 @@ Loggly
 loopback
 lua
 Luarocks
-ngrock
+ngrok
 minikube
 Mockbin
 Moesif

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -68,6 +68,7 @@ Loggly
 loopback
 lua
 Luarocks
+ngrock
 minikube
 Mockbin
 Moesif

--- a/app/_hub/kong-inc/acme/0.2.11.md
+++ b/app/_hub/kong-inc/acme/0.2.11.md
@@ -53,7 +53,7 @@ params:
       required: false
       default: "`[]`"
       description: |
-        The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`. Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name or Subject Alternative Name to create certifcates; each domain will have its own certificate.
+        The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`. Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name or Subject Alternative Name to create certifcates; each domain will have its own certificate. ACME plugin checks this configuration before the presense of certificate in `storage` when serving certificate of a request.
     - name: fail_backoff_minutes
       required: false
       default: 5
@@ -244,6 +244,48 @@ schedules a renewal in the background and returns immediately.
 ```bash
 $ curl http://localhost:8001/acme -XPATCH
 ```
+
+### Monitoring and debugging
+
+The ACME plugin exposes several endpoints through Admin API that can be used for
+debugging and monitoring certificate creation and renewal.
+
+- **POST /acme**: start applying or renewing certificate and return the result; available parameter:
+  - **host**: the domain to create certificate
+  - **test_http_challenge_flow**: when set, only check for configuration sanity.
+- **PATCH /acme**: same as POST, but runs the process at background.
+- **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
+- **GET /acme/certificates/:host**: list the certificate with specific host.
+
+Following is an example of the certificate listing API:
+
+```
+{
+  "data": [
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "A9:49:55:06:A7:B6:1D:2B:13:47:C5:58:5B:AC:DA:43:B5:25:E0:86",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain1.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "93:B8:E9:D5:C6:36:ED:B4:A8:B3:FD:C5:9E:A8:08:88"
+    },
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "26:12:A2:C4:6A:F5:A5:90:9D:03:15:CB:FE:A7:BF:32:1C:42:49:CE",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain2.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "F1:15:74:E3:E1:DD:21:72:48:C0:4F:06:25:1B:71:F7"
+    }
+  ]
+}
+```
+
 
 ### Local testing and development
 

--- a/app/_hub/kong-inc/acme/0.2.11.md
+++ b/app/_hub/kong-inc/acme/0.2.11.md
@@ -344,8 +344,8 @@ $ echo q |openssl s_client -connect localhost -port 8443 -servername $NGROK_HOST
 - In database mode, the plugin creates SNI and Certificate entity in Kong to
 serve certificate. If SNI or Certificate for current request is already set
 in database, they will be overwritten.
-- In DB-less mode, the plugin takes over certificate handling, if the SNI or
-Certificate entity is already defined in Kong, they will be overrided from
+- In DB-less mode, the plugin takes over certificate handling. If the SNI or
+Certificate entity is already defined in Kong, they will be overridden by the
 response.
 - The plugin only supports http-01 challenge, meaning user will need a public
 IP and setup resolvable DNS. Kong also needs to accept proxy traffic from port `80`.

--- a/app/_hub/kong-inc/acme/0.2.11.md
+++ b/app/_hub/kong-inc/acme/0.2.11.md
@@ -120,15 +120,15 @@ params:
 
 ### Workflow
 
-A `http-01` challenge workflow between the Kong Gateway and the ACME server is described below:
+A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
 
 1. The client sends a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Gateway sends a request to the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
-4. `mydomain.com` is publicly resolvable to the Kong Gateway that serves the challenge response.
+2. The {{site.base_gateway}} sends a request to the ACME server to start the validation process.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
+4. `mydomain.com` is publicly resolvable to the {{site.base_gateway}} that serves the challenge response.
 5. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-6. The Kong Gateway checks the challenge status and if passed, downloads the certificate from the ACME server.
-7. The Kong Gateway uses the new certificate to serve TLS requests.
+6. The {{site.base_gateway}} checks the challenge status and if passed, downloads the certificate from the ACME server.
+7. The {{site.base_gateway}} uses the new certificate to serve TLS requests.
 
 ### Using the Plugin
 

--- a/app/_hub/kong-inc/acme/0.2.13.md
+++ b/app/_hub/kong-inc/acme/0.2.13.md
@@ -57,7 +57,7 @@ params:
       required: false
       default: "`[]`"
       description: |
-        The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`. Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name or Subject Alternative Name to create certifcates; each domain will have its own certificate.
+        The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`. Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name or Subject Alternative Name to create certifcates; each domain will have its own certificate. ACME plugin checks this configuration before the presense of certificate in `storage` when serving certificate of a request.
     - name: fail_backoff_minutes
       required: false
       default: 5
@@ -263,6 +263,47 @@ schedules a renewal in the background and returns immediately.
 
 ```bash
 $ curl http://localhost:8001/acme -XPATCH
+```
+
+### Monitoring and debugging
+
+The ACME plugin exposes several endpoints through Admin API that can be used for
+debugging and monitoring certificate creation and renewal.
+
+- **POST /acme**: start applying or renewing certificate and return the result; available parameter:
+  - **host**: the domain to create certificate
+  - **test_http_challenge_flow**: when set, only check for configuration sanity.
+- **PATCH /acme**: same as POST, but runs the process at background.
+- **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
+- **GET /acme/certificates/:host**: list the certificate with specific host.
+
+Following is an example of the certificate listing API:
+
+```
+{
+  "data": [
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "A9:49:55:06:A7:B6:1D:2B:13:47:C5:58:5B:AC:DA:43:B5:25:E0:86",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain1.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "93:B8:E9:D5:C6:36:ED:B4:A8:B3:FD:C5:9E:A8:08:88"
+    },
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "26:12:A2:C4:6A:F5:A5:90:9D:03:15:CB:FE:A7:BF:32:1C:42:49:CE",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain2.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "F1:15:74:E3:E1:DD:21:72:48:C0:4F:06:25:1B:71:F7"
+    }
+  ]
+}
 ```
 
 ### Local testing and development

--- a/app/_hub/kong-inc/acme/0.2.13.md
+++ b/app/_hub/kong-inc/acme/0.2.13.md
@@ -139,15 +139,15 @@ params:
 
 ### Workflow
 
-A `http-01` challenge workflow between the Kong Gateway and the ACME server is described below:
+A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
 
 1. The client sends a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Gateway sends a request to the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
-4. `mydomain.com` is publicly resolvable to the Kong Gateway that serves the challenge response.
+2. The {{site.base_gateway}} sends a request to the ACME server to start the validation process.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
+4. `mydomain.com` is publicly resolvable to the {{site.base_gateway}} that serves the challenge response.
 5. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-6. The Kong Gateway checks the challenge status and if passed, downloads the certificate from the ACME server.
-7. The Kong Gateway uses the new certificate to serve TLS requests.
+6. The {{site.base_gateway}} checks the challenge status and if passed, downloads the certificate from the ACME server.
+7. The {{site.base_gateway}} uses the new certificate to serve TLS requests.
 
 ### Using the Plugin
 

--- a/app/_hub/kong-inc/acme/0.2.14.md
+++ b/app/_hub/kong-inc/acme/0.2.14.md
@@ -71,6 +71,7 @@ params:
         The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`.
         Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name
         or Subject Alternative Name to create certificates; each domain must have its own certificate.
+        ACME plugin checks this configuration before the presense of certificate in `storage` when serving certificate of a request.
     - name: fail_backoff_minutes
       required: false
       default: 5
@@ -289,6 +290,47 @@ schedules a renewal in the background and returns immediately.
 
 ```bash
 $ curl http://localhost:8001/acme -XPATCH
+```
+
+## Monitoring and debugging
+
+The ACME plugin exposes several endpoints through Admin API that can be used for
+debugging and monitoring certificate creation and renewal.
+
+- **POST /acme**: start applying or renewing certificate and return the result; available parameter:
+  - **host**: the domain to create certificate
+  - **test_http_challenge_flow**: when set, only check for configuration sanity.
+- **PATCH /acme**: same as POST, but runs the process at background.
+- **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
+- **GET /acme/certificates/:host**: list the certificate with specific host.
+
+Following is an example of the certificate listing API:
+
+```
+{
+  "data": [
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "A9:49:55:06:A7:B6:1D:2B:13:47:C5:58:5B:AC:DA:43:B5:25:E0:86",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain1.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "93:B8:E9:D5:C6:36:ED:B4:A8:B3:FD:C5:9E:A8:08:88"
+    },
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "26:12:A2:C4:6A:F5:A5:90:9D:03:15:CB:FE:A7:BF:32:1C:42:49:CE",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain2.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "F1:15:74:E3:E1:DD:21:72:48:C0:4F:06:25:1B:71:F7"
+    }
+  ]
+}
 ```
 
 ## Hybrid mode

--- a/app/_hub/kong-inc/acme/0.2.14.md
+++ b/app/_hub/kong-inc/acme/0.2.14.md
@@ -165,15 +165,15 @@ To configure a storage type other than `kong`, refer to [lua-resty-acme](https:/
 
 ## Workflow
 
-A `http-01` challenge workflow between the Kong Gateway and the ACME server is described below:
+A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
 
 1. The client sends a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Gateway sends a request to the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
-4. `mydomain.com` is publicly resolvable to the Kong Gateway that serves the challenge response.
+2. The {{site.base_gateway}} sends a request to the ACME server to start the validation process.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
+4. `mydomain.com` is publicly resolvable to the {{site.base_gateway}} that serves the challenge response.
 5. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-6. The Kong Gateway checks the challenge status and if passed, downloads the certificate from the ACME server.
-7. The Kong Gateway uses the new certificate to serve TLS requests.
+6. The {{site.base_gateway}} checks the challenge status and if passed, downloads the certificate from the ACME server.
+7. The {{site.base_gateway}} uses the new certificate to serve TLS requests.
 
 
 ## Using the plugin
@@ -360,7 +360,7 @@ External storage in Hybrid Mode works in following flow:
 
 1. The client send a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
 2. The Kong Control Plane or Data Plane requests the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
 4. The Kong Control Plane or Data Plane stores the challenge response detail in external storage.
 5. `mydomain.com` is publicly resolvable to the Kong Data Plane that reads and serves the challenge response from external storage.
 6. The ACME server checks if the previous challenge has a response at `mydomain.com`.

--- a/app/_hub/kong-inc/acme/0.3.x.md
+++ b/app/_hub/kong-inc/acme/0.3.x.md
@@ -60,6 +60,7 @@ params:
         The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`.
         Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name
         or Subject Alternative Name to create certificates; each domain must have its own certificate.
+        ACME plugin checks this configuration before the presense of certificate in `storage` when serving certificate of a request.
     - name: fail_backoff_minutes
       required: false
       default: 5
@@ -280,6 +281,47 @@ schedules a renewal in the background and returns immediately.
 
 ```bash
 curl http://localhost:8001/acme -XPATCH
+```
+
+## Monitoring and debugging
+
+The ACME plugin exposes several endpoints through Admin API that can be used for
+debugging and monitoring certificate creation and renewal.
+
+- **POST /acme**: start applying or renewing certificate and return the result; available parameter:
+  - **host**: the domain to create certificate
+  - **test_http_challenge_flow**: when set, only check for configuration sanity.
+- **PATCH /acme**: same as POST, but runs the process at background.
+- **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
+- **GET /acme/certificates/:host**: list the certificate with specific host.
+
+Following is an example of the certificate listing API:
+
+```
+{
+  "data": [
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "A9:49:55:06:A7:B6:1D:2B:13:47:C5:58:5B:AC:DA:43:B5:25:E0:86",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain1.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "93:B8:E9:D5:C6:36:ED:B4:A8:B3:FD:C5:9E:A8:08:88"
+    },
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "26:12:A2:C4:6A:F5:A5:90:9D:03:15:CB:FE:A7:BF:32:1C:42:49:CE",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain2.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "F1:15:74:E3:E1:DD:21:72:48:C0:4F:06:25:1B:71:F7"
+    }
+  ]
+}
 ```
 
 ## Hybrid mode

--- a/app/_hub/kong-inc/acme/0.3.x.md
+++ b/app/_hub/kong-inc/acme/0.3.x.md
@@ -156,15 +156,15 @@ To configure a storage type other than `kong`, refer to [lua-resty-acme](https:/
 
 ## Workflow
 
-A `http-01` challenge workflow between the Kong Gateway and the ACME server is described below:
+A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
 
 1. The client sends a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Gateway sends a request to the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
-4. `mydomain.com` is publicly resolvable to the Kong Gateway that serves the challenge response.
+2. The {{site.base_gateway}} sends a request to the ACME server to start the validation process.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
+4. `mydomain.com` is publicly resolvable to the {{site.base_gateway}} that serves the challenge response.
 5. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-6. The Kong Gateway checks the challenge status and if passed, downloads the certificate from the ACME server.
-7. The Kong Gateway uses the new certificate to serve TLS requests.
+6. The {{site.base_gateway}} checks the challenge status and if passed, downloads the certificate from the ACME server.
+7. The {{site.base_gateway}} uses the new certificate to serve TLS requests.
 
 
 ## Using the plugin
@@ -351,7 +351,7 @@ External storage in Hybrid Mode works in following flow:
 
 1. The client send a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
 2. The Kong Control Plane or Data Plane requests the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
 4. The Kong Control Plane or Data Plane stores the challenge response detail in external storage.
 5. `mydomain.com` is publicly resolvable to the Kong Data Plane that reads and serves the challenge response from external storage.
 6. The ACME server checks if the previous challenge has a response at `mydomain.com`.

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -60,7 +60,7 @@ params:
         The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`.
         Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name
         or Subject Alternative Name to create certificates; each domain must have its own certificate.
-        ACME plugin checks this configuration before the presense of certificate in `storage` when serving certificate of a request.
+        The ACME plugin checks this configuration before checking any certificate in `storage` when serving the certificate of a request.
     - name: fail_backoff_minutes
       required: false
       default: 5
@@ -294,16 +294,50 @@ curl http://localhost:8001/acme -XPATCH
 The ACME plugin exposes several endpoints through Admin API that can be used for
 debugging and monitoring certificate creation and renewal.
 
-- **POST /acme**: start applying or renewing certificate and return the result; available parameter:
-  - **host**: the domain to create certificate
-  - **test_http_challenge_flow**: when set, only check for configuration sanity.
-- **PATCH /acme**: same as POST, but runs the process at background.
+### Apply certificate
+
+**Endpoint**
+
+<div class="endpoint post">/acme</div>
+Applies or renews the certificate and returns the result.
+
+**Request body**
+
+Attribute | Description
+---:| ---
+`host`<br>*required* | The domain where to create the certificate.
+`test_http_challenge_flow`<br>*optional* | When set, only checks if the configuration is valid. Does not apply the certificate.
+
+### Update certificate
+
+Apply or renew the certificate and return the result. Unlike `POST`, `PATCH` runs the process in the background. 
+
+**Endpoint**
+
+<div class="endpoint patch">/acme</div>
+
+**Request body**
+
+Attribute | Description
+---:| ---
+`host`<br>*required* | The domain where to create the certificate.
+`test_http_challenge_flow`<br>*optional* | When set, only checks if the configuration is valid. Does not apply the certificate.
 - **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
-- **GET /acme/certificates/:host**: list the certificate with specific host.
 
-Following is an example of the certificate listing API:
+### Get certificate by host
 
-```
+List certificates with a specific host.
+
+**Endpoint**
+<div class="endpoint get">/acme/certificates/{HOST}</div>
+
+Attribute | Description
+---:| ---
+`HOST` | The IP or hostname of the host to target.
+
+Example response for listing certificates:
+
+```json
 {
   "data": [
     {

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -60,6 +60,7 @@ params:
         The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`.
         Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name
         or Subject Alternative Name to create certificates; each domain must have its own certificate.
+        ACME plugin checks this configuration before the presense of certificate in `storage` when serving certificate of a request.
     - name: fail_backoff_minutes
       required: false
       default: 5
@@ -286,6 +287,47 @@ schedules a renewal in the background and returns immediately.
 
 ```bash
 curl http://localhost:8001/acme -XPATCH
+```
+
+## Monitoring and debugging
+
+The ACME plugin exposes several endpoints through Admin API that can be used for
+debugging and monitoring certificate creation and renewal.
+
+- **POST /acme**: start applying or renewing certificate and return the result; available parameter:
+  - **host**: the domain to create certificate
+  - **test_http_challenge_flow**: when set, only check for configuration sanity.
+- **PATCH /acme**: same as POST, but runs the process at background.
+- **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
+- **GET /acme/certificates/:host**: list the certificate with specific host.
+
+Following is an example of the certificate listing API:
+
+```
+{
+  "data": [
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "A9:49:55:06:A7:B6:1D:2B:13:47:C5:58:5B:AC:DA:43:B5:25:E0:86",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain1.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "93:B8:E9:D5:C6:36:ED:B4:A8:B3:FD:C5:9E:A8:08:88"
+    },
+    {
+      "not_after": "2022-09-21 23:59:59",
+      "pubkey_type": "id-ecPublicKey",
+      "digest": "26:12:A2:C4:6A:F5:A5:90:9D:03:15:CB:FE:A7:BF:32:1C:42:49:CE",
+      "issuer_cn": "ZeroSSL ECC Domain Secure Site CA",
+      "valid": true,
+      "host": "subdomain2.domain.com",
+      "not_before": "2022-06-23 00:00:00",
+      "serial_number": "F1:15:74:E3:E1:DD:21:72:48:C0:4F:06:25:1B:71:F7"
+    }
+  ]
+}
 ```
 
 ## Hybrid mode

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -322,7 +322,13 @@ Attribute | Description
 ---:| ---
 `host`<br>*required* | The domain where to create the certificate.
 `test_http_challenge_flow`<br>*optional* | When set, only checks if the configuration is valid. Does not apply the certificate.
-- **GET /acme/certificates**: list the certificate being created by ACME plugin; one can use this endpoint to monitor certificate existence and expiry.
+
+### Get ACME certificates
+
+List the certificates being created by the ACME plugin. You can use this endpoint to monitor certificate existence and expiry.
+ 
+**Endpoint**
+<div class="endpoint get">/acme/certificates</div>
 
 ### Get certificate by host
 

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -162,15 +162,15 @@ To configure a storage type other than `kong`, refer to [lua-resty-acme](https:/
 
 ## Workflow
 
-A `http-01` challenge workflow between the Kong Gateway and the ACME server is described below:
+A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
 
 1. The client sends a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Gateway sends a request to the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
-4. `mydomain.com` is publicly resolvable to the Kong Gateway that serves the challenge response.
+2. The {{site.base_gateway}} sends a request to the ACME server to start the validation process.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
+4. `mydomain.com` is publicly resolvable to the {{site.base_gateway}} that serves the challenge response.
 5. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-6. The Kong Gateway checks the challenge status and if passed, downloads the certificate from the ACME server.
-7. The Kong Gateway uses the new certificate to serve TLS requests.
+6. The {{site.base_gateway}} checks the challenge status and if passed, downloads the certificate from the ACME server.
+7. The {{site.base_gateway}} uses the new certificate to serve TLS requests.
 
 
 ## Using the plugin
@@ -310,7 +310,7 @@ Attribute | Description
 
 ### Update certificate
 
-Apply or renew the certificate and return the result. Unlike `POST`, `PATCH` runs the process in the background. 
+Apply or renew the certificate and return the result. Unlike `POST`, `PATCH` runs the process in the background.
 
 **Endpoint**
 
@@ -326,7 +326,7 @@ Attribute | Description
 ### Get ACME certificates
 
 List the certificates being created by the ACME plugin. You can use this endpoint to monitor certificate existence and expiry.
- 
+
 **Endpoint**
 <div class="endpoint get">/acme/certificates</div>
 
@@ -397,7 +397,7 @@ External storage in Hybrid Mode works in following flow:
 
 1. The client send a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
 2. The Kong Control Plane or Data Plane requests the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Gateway.
+3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
 4. The Kong Control Plane or Data Plane stores the challenge response detail in external storage.
 5. `mydomain.com` is publicly resolvable to the Kong Data Plane that reads and serves the challenge response from external storage.
 6. The ACME server checks if the previous challenge has a response at `mydomain.com`.
@@ -481,11 +481,11 @@ own certificate.
 
 ## Changelog
 
-### Kong Gateway 2.8.x (plugin version 0.4.0)
+### {{site.base_gateway}} 2.8.x (plugin version 0.4.0)
 
 * Added the `rsa_key_size` configuration parameter.
 
-### Kong Gateway 2.7.x (plugin version 0.3.0)
+### {{site.base_gateway}} 2.7.x (plugin version 0.3.0)
 
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled,
  the `account_email`, `eab_kid`, and `eab_hmac_kid` parameter values will be


### PR DESCRIPTION
### Summary
Add missing Admin API section and explain `domains` behaviour

We use autodoc to generate core admin endpoints, but seems not for endpoints exposed from plugins (?)
Please let me know if it's favored, or should i move them to autodoc instead.