### PR TITLE
Update Enterprise RG count to 10 total by default

### DIFF
--- a/app/konnect/runtime-manager/runtime-groups/index.md
+++ b/app/konnect/runtime-manager/runtime-groups/index.md
@@ -17,7 +17,7 @@ group. All runtime instances in one runtime group
 must be of the same type. Currently, only Kong Gateway runtime types are supported.
 
 Every organization has one default runtime group. With an Enterprise subscription,
-you can configure nine additional custom runtime groups (a total of 10 by default) in the same Konnect
+you can configure nine additional custom runtime groups, for a total of 10 by default, in the same Konnect
 account to manage runtime instances and their configuration in any groupings
 you want.
 

--- a/app/konnect/runtime-manager/runtime-groups/index.md
+++ b/app/konnect/runtime-manager/runtime-groups/index.md
@@ -17,7 +17,7 @@ group. All runtime instances in one runtime group
 must be of the same type. Currently, only Kong Gateway runtime types are supported.
 
 Every organization has one default runtime group. With an Enterprise subscription,
-you can configure two additional custom runtime groups in the same Konnect
+you can configure nine additional custom runtime groups (a total of 10 by default) in the same Konnect
 account to manage runtime instances and their configuration in any groupings
 you want.
 


### PR DESCRIPTION
### Summary
Enterprise customers will have 10 runtime groups by default (they can purchase more if they want).

### Reason

Updating per latest pricing and packaging decisions

### Testing

