### PR TITLE
key-auth-enc plugin: Remove non-existent ttl parameter

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -204,7 +204,6 @@ In both cases, the fields/parameters work as follows:
 field/parameter     | description
 ---                 | ---
 `{consumer}`        | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
-`ttl`<br>*optional* | The number of seconds the key is going to be valid. If missing, the `ttl` is unlimited.
 `key`<br>*optional* | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
 
 ### Make a Request with the Key


### PR DESCRIPTION
### Summary
Removing a setting that isn't available in the plugin.

### Reason
Parameter doesn't exist.
 
Reported on Slack, see: https://kongstrong.slack.com/archives/C0DSXDXV1/p1655994419162749

### Testing
https://docs.konghq.com/hub/kong-inc/key-auth-enc/