### PR TITLE
Update promo banner for Kong Summit 2022

### DIFF
--- a/app/_assets/javascripts/promo-banner.js
+++ b/app/_assets/javascripts/promo-banner.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function () {
-  var closed = localStorage.getItem("closebanner-gateway-28");
+  var closed = localStorage.getItem("closebanner-summit-2022");
   if (
     closed !== "closebanner"
   ) {
@@ -28,6 +28,6 @@ setInterval(function () {
 }, 10);
 $(".closebanner").on("click", function () {
   $(".navbar-v2").addClass("closed");
-  localStorage.setItem("closebanner-gateway-28", "closebanner");
+  localStorage.setItem("closebanner-summit-2022", "closebanner");
   $("#mosaic-provider-react-aria-0-1").removeClass("banner-offset");
 });

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -4,8 +4,8 @@
   <!--also uncomment the promo banner sections in app/assets/stylesheets/header.less and gulpfile.js-->
   <div id="promo-banner">
     <div class="container">
-      <div class="closebanner"></div> <strong><label>NEW</label> Kong Gateway 2.8 Increases Security and Simplifies API Management. &nbsp;&mdash;<a
-          href="https://konghq.com/blog/kong-gateway-2-8">Learn More &rarr;</a></strong>
+      <div class="closebanner"></div> <strong>Kong Summit 2022: Where API Innovation Runs Wild &nbsp;&mdash;<a
+          href="https://konghq.com/conferences/kong-summit">Learn More &rarr;</a></strong>
     </div>
   </div>
   <div class="navbar-content">
@@ -28,7 +28,7 @@
     <div class="separator"></div>
     <div class="navbar-items" role="navigation" aria-label="Main menu">
       <ul class="navbar-items" role="menubar">
-        <li role="menuitem" class="main-menu-item hiring-badge"> 
+        <li role="menuitem" class="main-menu-item hiring-badge">
           <a target="_blank" href="https://konghq.com/careers/" class="navbar-item">
           <span>
             We're Hiring!


### PR DESCRIPTION
### Summary
Updating to Kong Summit 2022 to mimic the banner on the konghq.com site. 

### Reason
Gateway 2.8 has been in the banner for a while, and Summit is coming up.

### Testing
Check that the banner appears for you in the preview: https://deploy-preview-4052--kongdocs.netlify.app/

Check that the link works, and that when you close the banner, the `closebanner-summit-2022` cookie is set and the banner stops appearing sitewide. You can check with Chrome DevTools:

<img width="780" alt="Screen Shot 2022-06-23 at 3 04 54 PM" src="https://user-images.githubusercontent.com/54370747/175423391-0699e686-b056-442a-8d86-ab23c9663e68.png">
