### PR TITLE
Fix `layout` type in Working with Templates

### DIFF
--- a/src/gateway/developer-portal/working-with-templates.md
+++ b/src/gateway/developer-portal/working-with-templates.md
@@ -251,7 +251,7 @@ Each configuration item is made up of a few parts:
       - `:stub`: Replaces namespace with value of `headmatter.stub` in each contents headmatter.
 - `layout`
     - **required**: true
-      - **type**: `boolean`
+      - **type**: `string`
       - **description**: The `layout` attribute determines what HTML layout the collections use to render. The path root is accessed from within the current themes `layouts` directory.
 
 ### content/_posts/post1.md


### PR DESCRIPTION
Changed `layout` type from boolean to string.

### Summary
Changed `layout` type from boolean to string. Decided to only change the 3.0.x version.

### Reason
[DOCU-1428](https://konghq.atlassian.net/browse/DOCU-1428)

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
