### PR TITLE
Fix GitHub edit link for single sourced pages

### DIFF
--- a/app/_plugins/generators/latest_version_generator.rb
+++ b/app/_plugins/generators/latest_version_generator.rb
@@ -19,7 +19,8 @@ module LatestVersion
 
       # Load config file
       site.pages.each do |page|
-        parts = Pathname(remove_generated_prefix(page.path)).each_filename.to_a
+        page_path = remove_generated_prefix(page.path)
+        parts = Pathname(page_path).each_filename.to_a
 
         products_with_latest.each do |product|
           # Reset values for every new page
@@ -49,7 +50,7 @@ module LatestVersion
             page.content,
             page.data,
             @page_index["#{product_name}/#{release_path}/"],
-            page.path
+            page_path
           )
           site.pages << page
         end
@@ -80,7 +81,7 @@ module LatestVersion
       @data = data.clone
       @data['is_latest'] = true
       @data['version-index'] = page_index
-      @data['edit_link'] = "app/#{path}"
+      @data['edit_link'] = "app/#{path}" unless @data['edit_link']
 
       @data['alias'] = [@dir.sub('latest/', '')] if @dir.end_with?('/latest/')
     end

--- a/tests/edit_link.test.js
+++ b/tests/edit_link.test.js
@@ -1,0 +1,37 @@
+const { test, expect } = require("@playwright/test");
+
+test.describe("Edit this page link", () => {
+  [
+    {
+      title: "/app/ page",
+      src: "/gateway/2.8.x/install-and-run/docker/",
+      expected:
+        "https://github.com/Kong/docs.konghq.com/edit/main/app/gateway/2.8.x/install-and-run/docker.md",
+    },
+
+    {
+      title: "Single Sourced",
+      src: "/deck/1.12.x/",
+      expected:
+        "https://github.com/Kong/docs.konghq.com/edit/main/src/deck/index.md",
+    },
+    {
+      title: "/app/ page /latest/",
+      src: "/gateway/latest/",
+      expected:
+        "https://github.com/Kong/docs.konghq.com/edit/main/app/gateway/2.8.x/index.md",
+    },
+    {
+      title: "Single Sourced /latest/",
+      src: "/deck/latest/",
+      expected:
+        "https://github.com/Kong/docs.konghq.com/edit/main/src/deck/index.md",
+    },
+  ].forEach((t) => {
+    test(t.title, async ({ page }) => {
+      await page.goto(t.src);
+      const s = await page.locator(".github-links a").first();
+      await expect(await s.getAttribute("href")).toEqual(t.expected);
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fix "edit this page" link on single sourced pages and add some tests to ensure that we don't break them again.

### Reason
Reported by @lena-larionova

### Testing
Edit link is broken on https://docs.konghq.com/deck/latest/

Should be fixed on [LINK]