### PR TITLE
Tweaks KIC install

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -27,6 +27,7 @@ declaratively
 degraphql
 denylist
 dev
+etcd
 Fargate
 Github
 Goroutine

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -6,7 +6,7 @@ This page explains how to install {{site.base_gateway}} with {{site.kic_product_
 
 This page also includes the equivalent commands for OpenShift.
 
-Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native datastore. For more information see [Kubernetes Deployment Options](/gateway/{{page.kong_version}}/plan-and-deploy/kubernetes-deployment-options).
+Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native data store. For more information see [Kubernetes Deployment Options](/gateway/{{page.kong_version}}/plan-and-deploy/kubernetes-deployment-options).
 
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -92,7 +92,13 @@ oc new-project kong
     export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
     ```
 
-1.  Check that the value of $PROXY_IP is the value of the external host:
+1.  Verify that the value of `$PROXY_IP` matches the value of the external host:
+
+    ```sh
+    echo $PROXY_IP
+    ```
+
+    This should match the `EXTERNAL_IP` value of the `kong-proxy` service returned by the Kubernetes API:
 
     ```sh
     kubectl get service kong-proxy -n kong
@@ -102,6 +108,17 @@ oc new-project kong
 
     ```sh
     oc get service kong-proxy -n kong
+    ```
+
+1. Finally, invoke a test request:
+    ```sh
+    curl $PROXY_IP
+    ```
+
+    which should return a response from the Kong gateway:
+
+    ```sh
+    {"message":"no Route matched with those values"}
     ```
 
 ## Next steps

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -83,7 +83,10 @@ oc new-project kong
     oc get pods -n kong
     ```
 
-1.  To make HTTP requests, you need the IP address of the load balancer. Get the LoadBalancer address and store it in a local PROXY_IP environment variable:
+1.  To make HTTP requests, you need the IP address of the load balancer. Get the `loadBalancer` address and store it in a local `PROXY_IP` environment variable:
+
+    {:.note}
+    > **Note:** Some cluster providers provide only a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
 
     ```sh
     export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
@@ -100,9 +103,6 @@ oc new-project kong
     ```sh
     oc get service kong-proxy -n kong
     ```
-
-    {:.note}
-    > **Note:** Some cluster providers provide only a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
 
 ## Next steps
 

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -6,7 +6,7 @@ This page explains how to install {{site.base_gateway}} with {{site.kic_product_
 
 This page also includes the equivalent commands for OpenShift.
 
-Note that in DB-less mode on Kubernetes, config is stored in etcd, the Kubernetes native data store. For more information see [Kubernetes Deployment Options](/gateway/{{page.kong_version}}/plan-and-deploy/kubernetes-deployment-options).
+In DB-less mode on Kubernetes, the config is stored in etcd, the Kubernetes native data store. For more information, see [Kubernetes Deployment Options](/gateway/{{page.kong_version}}/plan-and-deploy/kubernetes-deployment-options).
 
 The {{site.base_gateway}} software is governed by the
 [Kong Software License Agreement](https://konghq.com/kongsoftwarelicense/).
@@ -86,7 +86,7 @@ oc new-project kong
 1.  To make HTTP requests, you need the IP address of the load balancer. Get the `loadBalancer` address and store it in a local `PROXY_IP` environment variable:
 
     {:.note}
-    > **Note:** Some cluster providers provide only a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
+    > **Note:** Some cluster providers only provide a DNS name for load balancers. In this case, specify `.hostname` instead of `.ip`.
 
     ```sh
     export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
@@ -110,12 +110,12 @@ oc new-project kong
     oc get service kong-proxy -n kong
     ```
 
-1. Finally, invoke a test request:
+1. Invoke a test request:
     ```sh
     curl $PROXY_IP
     ```
 
-    which should return a response from the Kong gateway:
+    This should return the following response from Gateway:
 
     ```sh
     {"message":"no Route matched with those values"}


### PR DESCRIPTION
### Summary

Moves the NOTE warning up to the proper section related to the instruction
Adds code formatting to guidance as well

### Reason
When following this guide the first time, I got tripped up by what the "NOTE" in this
docs page is telling me. But I didn't notice it because it was located at the bottom of the
doc and not in proximity to the instruction I was runnig.

### Testing
Built docs locally and verified local version of the page

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
