### PR TITLE
Vale: Adjust rules for curly brackets

### DIFF
--- a/.github/styles/kong/Terms.yml
+++ b/.github/styles/kong/Terms.yml
@@ -12,7 +12,7 @@ swap:
   dbless: DB-less
   file name: filename
   hashicorp: HashiCorp
-  kong: Kong
+  'kong(?: )': Kong
   # '(?:kubernetes|k8s)': Kubernetes
   kong gateway: "{{site.base_gateway}}"
   Konnect: "{{site.konnect_short_name}}"

--- a/.github/styles/kong/Terms.yml
+++ b/.github/styles/kong/Terms.yml
@@ -12,7 +12,6 @@ swap:
   dbless: DB-less
   file name: filename
   hashicorp: HashiCorp
-  '(?:# )kong(?: )': Kong
   # '(?:kubernetes|k8s)': Kubernetes
   kong gateway: "{{site.base_gateway}}"
   Konnect: "{{site.konnect_short_name}}"

--- a/.github/styles/kong/Terms.yml
+++ b/.github/styles/kong/Terms.yml
@@ -12,7 +12,7 @@ swap:
   dbless: DB-less
   file name: filename
   hashicorp: HashiCorp
-  'kong(?: )': Kong
+  '(?:# )kong(?: )': Kong
   # '(?:kubernetes|k8s)': Kubernetes
   kong gateway: "{{site.base_gateway}}"
   Konnect: "{{site.konnect_short_name}}"

--- a/vale.ini
+++ b/vale.ini
@@ -13,7 +13,8 @@ WordTemplate = \s(?:%s)\s
 [*.md]
 BasedOnStyles = kong
 
-BlockIgnores = (\((http.*://|\.\/|\/).*?\))
-TokenIgnores = {%.*?%}, \
-{{.*?}}, \
+BlockIgnores = (\((http.*://|\.\/|\/).*?\)), \
+{\:.*?}
+TokenIgnores = ({.*?}), \
+{%.*?%}, \
 (?:)(/[(A-Za-z0-9)(\055/)(_)]*/)

--- a/vale.ini
+++ b/vale.ini
@@ -15,6 +15,6 @@ BasedOnStyles = kong
 
 BlockIgnores = (\((http.*://|\.\/|\/).*?\)), \
 {\:.*?}
-TokenIgnores = ({.*?}), \
-{%.*?%}, \
+TokenIgnores = {%.*?%}, \
+{{.*?}}, \
 (?:)(/[(A-Za-z0-9)(\055/)(_)]*/)


### PR DESCRIPTION
### Summary
Adding rules to ignore all content in curly brackets:

Previous rules weren't ignoring the following:
* `{:.class-name}`
* `{#header-short-name}`

### Testing
Check locally.