### PR TITLE
DOCU-2377: Cleanup KIC using kongplugin resource guide

### DIFF
--- a/app/gateway/2.8.x/index.md
+++ b/app/gateway/2.8.x/index.md
@@ -3,6 +3,7 @@ title: Kong Gateway
 subtitle: API gateway built for hybrid and multi-cloud, optimized for microservices and distributed architectures
 ---
 
+Test
 {{site.base_gateway}} is a lightweight, fast, and flexible cloud-native API
 gateway. An API gateway is a reverse proxy that lets you manage, configure, and route
 requests to your APIs.

--- a/app/gateway/2.8.x/index.md
+++ b/app/gateway/2.8.x/index.md
@@ -3,7 +3,6 @@ title: Kong Gateway
 subtitle: API gateway built for hybrid and multi-cloud, optimized for microservices and distributed architectures
 ---
 
-Test
 {{site.base_gateway}} is a lightweight, fast, and flexible cloud-native API
 gateway. An API gateway is a reverse proxy that lets you manage, configure, and route
 requests to your APIs.

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -2,10 +2,9 @@
 title: Using KongPlugin resource
 ---
 
-In this guide, we will learn how to use KongPlugin resource to configure
-plugins in Kong to modify requests for a specific request path.
-The guide will cover configuring a plugin for a specific service, a set of Ingress rules
-and for a specific user of the API.
+This guide will cover how to use the {{site.kic_product_name}} 
+`KongPlugin` Custom Resource to control proxied requests, including
+restricting paths and transforming requests.
 
 ## Installation
 
@@ -565,6 +564,8 @@ X-Kong-Proxy-Latency: 1
 Via: kong/2.8.1
 ```
 
-This guide demonstrates how you can use the {{site.kic_product_name}} to
-impose restrictions and transformations
-on various levels using Kubernetes style APIs.
+There is a lot more you can do with Kong Plugins, check the [Plugin Hub](/hub) for
+more information.
+
+Next, you might want to learn more about Ingress with the 
+[KongIngress resource guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kongingress-resource/).

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -19,14 +19,14 @@ set to contain the IP address or URL pointing to Kong.
 If you've not done so, please follow one of the
 [deployment guides](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview) to configure this environment variable.
 
-If everything is setup correctly, making a request to Kong should return
+If everything is set up correctly, making a request to Kong should return
 `HTTP 404 Not Found`.
 
 ```sh
 curl -i $PROXY_IP
 ```
 
-In this document, expected output will follow each command:
+In this document, the expected output follows each command:
 
 ```sh
 HTTP/1.1 404 Not Found
@@ -43,7 +43,7 @@ This message is expected as Kong does not yet know how to proxy the request.
 
 ## Installing sample services
 
-We will start by installing two services. First an httpbin service:
+Start by installing two services. First, install an `httpbin` service:
 
 ```sh
 kubectl apply -f https://bit.ly/k8s-httpbin
@@ -54,7 +54,7 @@ service/httpbin created
 deployment.apps/httpbin created
 ```
 
-And then an echo service:
+And then an `echo` service:
 
 ```sh
 kubectl apply -f https://bit.ly/echo-service
@@ -272,7 +272,7 @@ X-Kong-Proxy-Latency: 1
 Via: kong/2.8.1
 ```
 
-Here, we have successfully setup a plugin which is executed only when a
+Here, we have successfully set up a plugin which is executed only when a
 request matches a specific `Ingress` rule.
 
 ## Configuring plugins on Service resource
@@ -391,8 +391,7 @@ Via: kong/2.8.1
 
 Instead of applying plugins to specific services or ingress routes,
 we can apply plugins to protect the entire gateway.
-To show this, we will be configuring a rate-limiting plugin, which
-will throttle requests coming from the same client.
+To test this, let's configure a rate-limiting plugin to throttle requests coming from the same client.
 
 This must be a cluster-level `KongClusterPlugin` resource, as `KongPlugin`
 resources cannot be applied globally, to preserve Kubernetes RBAC guarantees
@@ -423,7 +422,7 @@ kongclusterplugin.configuration.konghq.com/global-rate-limit created
 ```
 
 With this plugin (please note the `global` label), every request through
-the {{site.kic_product_name}} will be rate-limited:
+the {{site.kic_product_name}} is rate-limited:
 
 ```sh
 curl -I $PROXY_IP/foo -H 'apikey: my-sooper-secret-key'
@@ -519,7 +518,7 @@ kongconsumer.configuration.konghq.com/harry configured
 Note the annotation being added to the `KongConsumer` resource.
 
 Now, if the request is made as the `harry` consumer, the client
-will be rate-limited differently:
+is rate-limited differently:
 
 ```sh
 curl -I $PROXY_IP/foo -H 'apikey: my-sooper-secret-key'
@@ -544,7 +543,7 @@ X-Kong-Proxy-Latency: 1
 Via: kong/2.8.1
 ```
 
-And a regular unauthenticated request
+And a regular unauthenticated request:
 
 ```sh
 curl -I $PROXY_IP/bar

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -2,7 +2,7 @@
 title: Using KongPlugin resource
 ---
 
-This guide will cover how to use the {{site.kic_product_name}} 
+This guide walks you through using the {{site.kic_product_name}} 
 `KongPlugin` Custom Resource to control proxied requests, including
 restricting paths and transforming requests.
 

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -564,8 +564,9 @@ X-Kong-Proxy-Latency: 1
 Via: kong/2.8.1
 ```
 
-There is a lot more you can do with Kong Plugins, check the [Plugin Hub](/hub) for
-more information.
+## Next steps
+
+There's a lot more you can do with Kong plugins. Check the [Plugin Hub](/hub) to see all of the available plugins and how to use them.
 
 Next, you might want to learn more about Ingress with the 
 [KongIngress resource guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kongingress-resource/).

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -371,6 +371,7 @@ X-Kong-Proxy-Latency: 1
 Via: kong/1.2.1
 ```
 
+Then use the API key with `/foo`:
 ```sh
 curl -I $PROXY_IP/foo -H 'apikey: my-sooper-secret-key'
 ```

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -447,6 +447,8 @@ X-Kong-Proxy-Latency: 1
 Via: kong/1.2.1
 ```
 
+
+Requests to `/bar` are also rate limited:
 ```sh
 curl -I $PROXY_IP/bar
 ```

--- a/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -352,7 +352,7 @@ resource, but not for `/baz` because that request does not match.
 Follow the [Using Consumers and Credentials](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-consumer-credential-resource)
 guide to provision a user and an `apikey`.
 
-Use the API key to pass authentication:
+Use the API key to pass authentication. Try it with `/baz`:
 
 ```sh
 curl -I $PROXY_IP/baz -H 'apikey: my-sooper-secret-key'


### PR DESCRIPTION


### Summary
Removes command output from the example commands. 
This also relates to DOCU-2369 which requests the removal of shell prompt characters
from example commands.

### Reason
If the command output and shell prompt are in the example commands, the user cannot copy and paste the command to a shell and immediately execute. This add some burden to the reader.

### Testing
Built docs locally and evaluated the page manually

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
