### PR TITLE
Updated migrations `reset` command in auto docs

### DIFF
--- a/app/gateway/2.6.x/reference/cli.md
+++ b/app/gateway/2.6.x/reference/cli.md
@@ -137,7 +137,9 @@ The available commands are:
   finish                                Finish running any pending migrations
                                         after 'up'.
   list                                  List executed migrations.
-  reset                                 Reset the database.
+  reset                                 Reset the database. 
+                                        The `reset` command erases all of the data 
+                                        in Kong's database and deletes all of the schemas.
   migrate-community-to-enterprise       Migrates Kong Community entities to
                                         Kong Enterprise in the default
                                         workspace.

--- a/app/gateway/2.7.x/reference/cli.md
+++ b/app/gateway/2.7.x/reference/cli.md
@@ -134,7 +134,9 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database. The `reset` command erases all of the data in Kong's database and deletes all of the schemas.
+  reset                             Reset the database. 
+                                    The `reset` command erases all of the data 
+                                    in Kong's database and deletes all of the schemas.
 
   migrate-community-to-enterprise       Migrates Kong Community entities to
                                         Kong Enterprise in the default

--- a/app/gateway/2.7.x/reference/cli.md
+++ b/app/gateway/2.7.x/reference/cli.md
@@ -134,7 +134,7 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database.
+  reset                             Reset the database. The `reset` command erases all of the data in Kong's database and deletes all of the schemas.
 
   migrate-community-to-enterprise       Migrates Kong Community entities to
                                         Kong Enterprise in the default

--- a/app/gateway/2.8.x/reference/cli.md
+++ b/app/gateway/2.8.x/reference/cli.md
@@ -132,7 +132,7 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database.
+  reset                             Reset the database. The `reset` command erases all of the data in Kong's database and deletes all of the schemas.
 
   migrate-community-to-enterprise       Migrates Kong Community entities to
                                         Kong Enterprise in the default

--- a/app/gateway/2.8.x/reference/cli.md
+++ b/app/gateway/2.8.x/reference/cli.md
@@ -132,7 +132,9 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database. The `reset` command erases all of the data in Kong's database and deletes all of the schemas.
+  reset                             Reset the database. 
+                                    The `reset` command erases all of the data 
+                                    in Kong's database and deletes all of the schemas.
 
   migrate-community-to-enterprise       Migrates Kong Community entities to
                                         Kong Enterprise in the default


### PR DESCRIPTION
Updated `reset` command

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Updated migrations `reset` command in auto docs that were already generated. The Gateway CLI work was completed in https://github.com/Kong/kong/pull/9010. 
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
This change was requested in [DOCU-1474](https://konghq.atlassian.net/browse/DOCU-1474) because it was unclear to customers that the reset command would erase data instead of reset the migration steps.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
In the Netlify preview Kong Gateway docs, go to **Reference > CLI Reference > kong migrations** to make sure the `reset` command description is updated in versions 2.6.x-2.8.x.
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

