### PR TITLE
DOCU-2369: Removes prompts from instruction commands

### DIFF
--- a/src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/src/kubernetes-ingress-controller/guides/getting-started.md
@@ -313,5 +313,5 @@ HTTP requests with /bar -> Kong enforces rate-limit +   -> echo-server
 ## Next steps
 
 * To learn how to secure proxied routes, see the [ACL and JWT Plugins Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configure-acl-plugin/).
-* The [External Services Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-external-service/) explains how to proxy services outside of your Kubernetes cluster
+* The [External Services Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-external-service/) explains how to proxy services outside of your Kubernetes cluster.
 

--- a/src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/src/kubernetes-ingress-controller/guides/getting-started.md
@@ -15,7 +15,7 @@ If you've not done so, please follow one of the
 [deployment guides](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview) to configure this environment variable.
 
 If everything is setup correctly, making a request to Kong should return back
-a HTTP 404 Not Found.
+a HTTP `404 Not Found` status code.
 
 ```sh
 curl -i $PROXY_IP

--- a/src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/src/kubernetes-ingress-controller/guides/getting-started.md
@@ -312,6 +312,6 @@ HTTP requests with /bar -> Kong enforces rate-limit +   -> echo-server
 
 ## Next steps
 
-* To learn how to secure proxied routes, check out the [ACL and JWT Plugins Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configure-acl-plugin/)
+* To learn how to secure proxied routes, see the [ACL and JWT Plugins Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configure-acl-plugin/).
 * The [External Services Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-external-service/) explains how to proxy services outside of your Kubernetes cluster
 


### PR DESCRIPTION
Additionally:
* attempts to standardize some of the layout of command -> expected results to
match what was started in https://github.com/Kong/docs.konghq.com/pull/4064
* Adds a CTA at the bottom of the guide
* updates command expected output to more modern responses

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
Removes the command prompts from the instruction commands, allows a user to more easily copy and paste the instructions

### Testing
Locally built and viewed the changed page

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
