### PR TITLE
Add UBI install instructions to the correct doc

### DIFF
--- a/app/_includes/md/rpm.md
+++ b/app/_includes/md/rpm.md
@@ -1,3 +1,4 @@
+<!-- DO NOT UPDATE THIS FILE, IT'S FOR ARCHIVED CONTENT ONLY -->
 
 ## Installation
 

--- a/app/gateway/2.8.x/install-and-run/rhel.md
+++ b/app/gateway/2.8.x/install-and-run/rhel.md
@@ -61,18 +61,13 @@ sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
 {% endnavtabs_ee %}
 {% endnavtab %}
 {% navtab rpm %}
-{% navtabs_ee codeblock %}
-{% navtab Kong Gateway %}
-```bash
-rpm -iv kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
+
+{:.important}
+> The `rpm` method is only available for open-source packages. For the `kong-enterprise-edition` package, use `yum`.
+
 ```bash
 rpm -iv kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
 ```
-{% endnavtab %}
-{% endnavtabs_ee %}
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}

--- a/app/gateway/2.8.x/install-and-run/rhel.md
+++ b/app/gateway/2.8.x/install-and-run/rhel.md
@@ -40,9 +40,13 @@ curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --
 
 {{ download_package | indent | replace: " </code>", "</code>" }}
 
-2. Install the package:
+2. Install the package using `yum` or `rpm`.
+
+    If you use the `rpm` install method, the packages _only_ contain {{site.base_gateway}}. They don't include any dependencies.
 
 {% capture install_package %}
+{% navtabs %}
+{% navtab yum %}
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
@@ -55,9 +59,27 @@ sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
+{% endnavtab %}
+{% navtab rpm %}
+{% navtabs_ee codeblock %}
+{% navtab Kong Gateway %}
+```bash
+rpm -iv kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+rpm -iv kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
+```
+{% endnavtab %}
+{% endnavtabs_ee %}
+{% endnavtab %}
+{% endnavtabs %}
 {% endcapture %}
 
 {{ install_package | indent | replace: " </code>", "</code>" }}
+
+    Installing directly using `rpm` is suitable for RedHat's [Universal Base Image](https://developers.redhat.com/blog/2020/03/24/red-hat-universal-base-images-for-docker-users) "minimal" variant. You will need to install Kong's dependencies separately via `microdnf`.
 
 {% endnavtab %}
 {% navtab YUM repository %}
@@ -71,7 +93,7 @@ Install the YUM repository from the command line.
 
 2. Install Kong:
 {% capture install_from_repo %}
-{% navtabs codeblock %}
+{% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
 sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
@@ -82,7 +104,7 @@ sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index
 sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}
 ```
 {% endnavtab %}
-{% endnavtabs %}
+{% endnavtabs_ee %}
 {% endcapture %}
 
 {{ install_from_repo | indent | replace: " </code>", "</code>" }}

--- a/app/gateway/2.8.x/install-and-run/rhel.md
+++ b/app/gateway/2.8.x/install-and-run/rhel.md
@@ -79,7 +79,7 @@ rpm -iv kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
 
 {{ install_package | indent | replace: " </code>", "</code>" }}
 
-    Installing directly using `rpm` is suitable for RedHat's [Universal Base Image](https://developers.redhat.com/blog/2020/03/24/red-hat-universal-base-images-for-docker-users) "minimal" variant. You will need to install Kong's dependencies separately via `microdnf`.
+    Installing directly using `rpm` is suitable for Red Hat's [Universal Base Image](https://developers.redhat.com/blog/2020/03/24/red-hat-universal-base-images-for-docker-users) "minimal" variant. You will need to install Kong's dependencies separately via `microdnf`.
 
 {% endnavtab %}
 {% navtab YUM repository %}


### PR DESCRIPTION
### Summary
Original PR added changes to a doc that's not in use anymore: https://github.com/Kong/docs.konghq.com/pull/4024

Moving it into the latest documentation.

@curiositycasualty I had to split the commands out and add some placeholder values that'll pick up the correct latest version of the gateway. Let me know if it looks right.

Also - are there UBI-minimal packages for `kong-enterprise-edition`? I'm working off of the assumption that there are, but I'm not entirely sure if that's correct.

### Reason
Doc is in the wrong place.

### Testing
Tested locally. Netlify preview: https://deploy-preview-4081--kongdocs.netlify.app/gateway/latest/install-and-run/rhel/

Will need some help checking accuracy. In the preview, you can switch to the open-source version by clicking the toggle in the top right:
![Screen Shot 2022-07-01 at 2 05 59 PM](https://user-images.githubusercontent.com/54370747/176967869-9c83fb26-319c-4cfd-9436-a4195ab4375d.png)

Output looks like this:
![Screen Shot 2022-07-01 at 1 54 59 PM](https://user-images.githubusercontent.com/54370747/176967796-a65034f3-e89a-4bce-8c90-aa91731b3502.png)

