### PR TITLE
Fix broken link in https://docs.konghq.com/mesh/latest/features/cert-manager/

### DIFF
--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -55,7 +55,7 @@ The {{site.mesh_product_name}} system namespace is `kong-mesh-system` by default
 If the cert-manager is configured outside of the {{site.mesh_product_name}} system namespace,
 and `ClusterIssuer` is not used,
 this may require cert-manager configuration and secrets to be "reflected" into the `Issuer`
-in the {{site.mesh_product_name}} system namespace. See [cert-manager documentation](See https://cert-manager.io/docs/faq/sync-secrets/) for details.
+in the {{site.mesh_product_name}} system namespace. See [cert-manager documentation](https://cert-manager.io/docs/faq/sync-secrets/) for details.
 
 The following steps show how to configure cert-manager for {{site.mesh_product_name}} with
 a mesh named `default`. For your environment, replace `default` with the appropriate mesh name.


### PR DESCRIPTION
### Summary
Fix broken link in https://docs.konghq.com/mesh/latest/features/cert-manager/

### Reason
The redirection is not working properly

Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>