### PR TITLE
Fixed mixture of Kong schema and Draft 4

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -118,6 +118,7 @@ stdin
 stdout
 Bagdi
 subcommand
+substring
 sudo
 Syslog
 tbl

--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -463,12 +463,12 @@ In this example, use the plugin to validate a request's path parameter.
     }
     ```
 
-4. In these step examples, validation makes sure that `status_code` is a number and that the body contains a parameter called `name`
+4. In these step examples, validation ensures that `status_code` is a number and the body contains a parameter called `name`.
 
    A proxy request with a non-numerical status code is blocked:
 
     ```
-    curl --request POST \
+    curl -i -X POST \
     --url http://localhost:8000/status/abc \
     --header 'Content-Type: application/json' \
     --data '{ "name": "foo" }'
@@ -481,7 +481,7 @@ In this example, use the plugin to validate a request's path parameter.
     A proxy request with a numeric status code is allowed:
 
     ```
-    curl --request POST \
+    curl -i -X POST \
     --url http://localhost:8000/status/123 \
     --header 'Content-Type: application/json' \
     --data '{ "name": "foo" }'

--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -346,7 +346,7 @@ In this example, use the plugin to validate a request's path parameter.
     ```
     curl -i -X POST http://kong:8001/services \
       --data name=httpbin \
-      --data url=http://httpbin.org/anything
+      --data url=http://httpbin.org
 
     HTTP/1.1 201 Created
     ..

--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -346,7 +346,7 @@ In this example, use the plugin to validate a request's path parameter.
     ```
     curl -i -X POST http://kong:8001/services \
       --data name=httpbin \
-      --data url=http://httpbin.org
+      --data url=http://httpbin.org/anything
 
     HTTP/1.1 201 Created
     ..
@@ -416,7 +416,7 @@ In this example, use the plugin to validate a request's path parameter.
     {
       "created_at": 1563483059,
       "config": {
-        "body_schema": "{\"name\":{\"type\": \"string\", \"required\": false}}",
+        "body_schema": "{\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"]}",
         "parameter_schema": [
           {
             "style": "simple",
@@ -447,7 +447,7 @@ In this example, use the plugin to validate a request's path parameter.
     {
       "name": "request-validator",
       "config": {
-        "body_schema": "{\"name\":{\"type\": \"string\", \"required\": false}}",
+        "body_schema": "{\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"]}",
         "version": "draft4",
         "parameter_schema": [
           {
@@ -463,12 +463,15 @@ In this example, use the plugin to validate a request's path parameter.
     }
     ```
 
-4. In these step examples, validation makes sure that `status_code` is a number.
+4. In these step examples, validation makes sure that `status_code` is a number and that the body contains a parameter called `name`
 
    A proxy request with a non-numerical status code is blocked:
 
     ```
-    curl -i -X GET http://kong:8000/status/abc
+    curl --request POST \
+    --url http://localhost:8000/status/abc \
+    --header 'Content-Type: application/json' \
+    --data '{ "name": "foo" }'
     HTTP/1.1 400 Bad Request
     ...
 
@@ -478,7 +481,10 @@ In this example, use the plugin to validate a request's path parameter.
     A proxy request with a numeric status code is allowed:
 
     ```
-    curl -i -X GET http://kong:8000/status/200
+    curl --request POST \
+    --url http://localhost:8000/status/123 \
+    --header 'Content-Type: application/json' \
+    --data '{ "name": "foo" }'
     HTTP/1.1 200 OK
     X-Kong-Upstream-Latency: 163
     X-Kong-Proxy-Latency: 37


### PR DESCRIPTION
### Summary
New version has Draft 4 compatible values in both parameters and adds sending the body value

### Reason
The example at the bottom contained a Draft 4 example for the parameter validation. The also included (but not used) body validator was in Kong schema format and had no effect at all (Kong accepts it, but it has consequences at all).

Customer trying body validation to work by copy&pasting previous example failed

### Testing
Follow the instructions :)
