### PR TITLE
chore: Bump decK version to 1.12.3

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -426,7 +426,7 @@
   edition: "deck"
 -
   release: "1.12.x"
-  version: "1.12.2"
+  version: "1.12.3"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Summary
Bump decK version for latest release: https://github.com/Kong/deck/releases/tag/v1.12.3

### Reason
https://github.com/Kong/deck/releases/tag/v1.12.3 is out.

### Testing
https://deploy-preview-4092--kongdocs.netlify.app/deck/latest/installation/