### PR TITLE
Add Kong PG SSL for Azure postgres database

### DIFF
--- a/app/_hub/tomkerkhove/microsoft_azure_container_instances/_index.md
+++ b/app/_hub/tomkerkhove/microsoft_azure_container_instances/_index.md
@@ -106,6 +106,7 @@ Running Kong on Azure Container Instances is super easy:
                           --environment-variables KONG_PG_HOST="<instance-name>.postgres.database.azure.com" \
                                                   KONG_PG_USER="<username>" \
                                                   KONG_PG_PASSWORD="<password>" \
+                                                  KONG_PG_SSL="on" \
                           --command-line "kong migrations bootstrap"
     ```
     In this example, we are using a PostgreSQL database running on [Azure Database for PostgreSQL](/hub/tomkerkhove/microsoft_azure/#running-postgresql-on-azure-with-azure-database-for-postgresql){:target="_blank"}{:rel="noopener noreferrer"}.
@@ -128,6 +129,7 @@ Running Kong on Azure Container Instances is super easy:
                                                   KONG_ADMIN_ACCESS_LOG="/dev/stdout" \
                                                   KONG_PROXY_ERROR_LOG="/dev/stderr" \
                                                   KONG_ADMIN_ERROR_LOG="/dev/stderr" \
+                                                  KONG_PG_SSL="on" \
                                                   KONG_ADMIN_LISTEN="0.0.0.0:8001, 0.0.0.0:8444 ssl"
     ```
 
@@ -139,6 +141,6 @@ Running Kong on Azure Container Instances is super easy:
 
 1. **Use Kong**
 
-    That's it - You can now use Kong by browsing to `<dns-label>.westeurope.azurecontainer.io`.
+    That's it - You can now use Kong by browsing to `<dns-label>.westeurope.azurecontainer.io:8000` and the Admin API is available at `<dns-label>.westeurope.azurecontainer.io:8001`.
 
     Quickly learn how to use Kong with the [5-minute Quickstart](/gateway/latest/get-started/quickstart){:target="_blank"}{:rel="noopener noreferrer"}.

--- a/app/_hub/tomkerkhove/microsoft_azure_container_instances/_index.md
+++ b/app/_hub/tomkerkhove/microsoft_azure_container_instances/_index.md
@@ -88,9 +88,9 @@ kong_version_compatibility: # required
 
 Running Kong on Azure Container Instances is super easy:
 
-1. **Provision a datastore**
+1. **Provision a data store**
 
-    Provision the datastore that you want to use:
+    Provision the data store that you want to use:
     1. [Running Cassandra on Azure with Azure Cosmos DB](/hub/tomkerkhove/microsoft_azure/#running-cassandra-on-azure-with-azure-cosmos-db){:target="_blank"}{:rel="noopener noreferrer"}
     1. [Running PostgreSQL on Azure with Azure Database for PostgreSQL](/hub/tomkerkhove/microsoft_azure/#running-postgresql-on-azure-with-azure-database-for-postgresql){:target="_blank"}{:rel="noopener noreferrer"}
 


### PR DESCRIPTION
### Summary
Add Kong PG SSL for Azure postgres database
Mention port for Kong URL and Admin URL

### Reason
Azure Postgres databases [enforces SSL connection by default](https://docs.microsoft.com/en-us/azure/postgresql/single-server/concepts-ssl-connection-security) and hence it is necessary to add SSL connection for Kong's postgres database.
Also, mentioned the ports for the Kong Gateway and the URL for the Admin API since it is necessary to be clear and Azure Container Instances does not support different port mapping yet i.e., mapping 8080 to 80. The Gateway would run in `<dns-label>.westeurope.azurecontainer.io:8000` and not `<dns-label>.westeurope.azurecontainer.io`

### Testing
N/A

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
