### PR TITLE
Badge adjustments

### DIFF
--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -172,7 +172,7 @@ a.badge {
   margin-top: 6px;
 
   &:hover, &:focus {
-    opacity: 0.8;
+    opacity: 1;
     text-decoration: none;
   }
 }

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -108,12 +108,12 @@ id: documentation
 
             {% if page.alpha %}
             <blockquote class="warning no-icon">
-              This feature is released as a <a href="/konnect-platform/key-concepts/#tech-preview"><span class="badge alpha" role="link" aria-label="tech preview"></span></a> (alpha-quality) and should not be deployed in a production environment.
+              This feature is released as a <a href="/konnect-platform/key-concepts/#tech-preview">tech preview</a> (alpha-quality) and should not be deployed in a production environment.
             </blockquote>
             {% endif %}
             {% if page.beta %}
             <blockquote class="warning no-icon">
-              This feature is released as <a href="/konnect-platform/key-concepts/#beta"><span class="badge beta" role="link" aria-label="beta"></span></a> and should not be deployed in a production environment.
+              This feature is released as <a href="/konnect-platform/key-concepts/#beta">beta</a> and should not be deployed in a production environment.
             </blockquote>
             {% endif %}
 


### PR DESCRIPTION
### Summary
Remove badges from beta/alpha banners and setting badge link opacity to 1. With anything under 1, the tooltip becomes hard to read when there's a link involved and it overlaps with text.

### Reason
Ran into badge opacity issues in some Konnect docs. When a badge from a header overlaps with a banner, it doesn't go well. Was going to figure out a way to fix it, but it's honestly easier to read the banners when they don't have those badges.
If anything, we can adjust the banners for better beta/alpha design in the future.

### Testing

Beta banner: https://deploy-preview-4108--kongdocs.netlify.app/gateway/latest/plan-and-deploy/security/secrets-management/ 
Alpha/tech preview banner: https://deploy-preview-4108--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/using-gateway-api/ 
Badge opacity, hover over badges in the header: https://deploy-preview-4108--kongdocs.netlify.app/hub/kong-inc/jwt-signer/