### PR TITLE
Update configuring-fallback-service.md

### DIFF
--- a/src/kubernetes-ingress-controller/guides/configuring-fallback-service.md
+++ b/src/kubernetes-ingress-controller/guides/configuring-fallback-service.md
@@ -157,7 +157,7 @@ metadata:
   annotations:
 spec:
   ingressClassName: kong
-  backend:
+  defaultBackend:
     service:
       name: fallback-svc
       port:


### PR DESCRIPTION
### Summary
Changes spec.backend to spec.defaultBackend in Configuring-fallback-service/Setup a fallback service code snippet.

### Reason
Ref. https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

networking.k8s.io/v1's spec.backend is renamed to spec.defaultBackend

### Testing
Testing the existing code snippet as documented, returns the error: 

```
error: error validating "STDIN": error validating data: ValidationError(Ingress.spec): unknown field "backend" in io.k8s.api.networking.v1.IngressSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

After change (spec.backend -> spec.defaultBackend), kubectl returns:

`ingress.networking.k8s.io/fallback created` (ok)