### PR TITLE
Add support for moving URLs and setting canonical URL correctly

### DIFF
--- a/app/moved_urls.yml
+++ b/app/moved_urls.yml
@@ -1,0 +1,2 @@
+---
+/gateway-oss/VERSION/configuration/: "/gateway/VERSION/reference/configuration/"

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,28 @@
+# SEO
+
+The canonical URL for each page is automatically set by the `canonical_url_generator` plugin. It works by looking for a URL that matches the current page, but where the version is higher than the current URL. As an example:
+
+`/gateway/2.3.x/configuration` would have a canonical URL of `/gateway/2.5.x/configuration`. `2.5.x` is the last version in which this URL existed.
+
+In `2.6.x` the page moved to `/gateway/2.6.x/reference/configuration`, which means the canonical URL would be `/gateway/2.8.x/reference/configuration`.
+
+_However_, we have a special `/latest/` URL which is always the latest version, so the canonical URL for the 2.6.x link above would actually be ``/gateway/latest/reference/configuration`.
+
+## Tracking file renames
+
+It is possible to track pages through renames using the `moved_urls.yml` file. This is a key:value file that contains the old URL and the URL that it should be mapped to. e.g.
+
+```yaml
+---
+/gateway-oss/VERSION/configuration/: "/gateway/VERSION/reference/configuration/" # 2.5.x
+```
+
+It is possible for a URL to be forwarded multiple times. In this instance, the final URL will be set as canonical on all pages rather than creating a canonical chain:
+
+```yaml
+---
+/gateway-oss/VERSION/configuration/: "/foo/bar/" # 2.5.x
+/foo/bar/: "/gateway/VERSION/reference/configuration/" # 4.2.x
+```
+
+Each line ends with a comment. This is the latest version that uses the source URL. This is useful to keep track of, as it allows us to remove entries from `moved_urls.yml` when archiving old content. In this example, when `2.5.x` is archived we can remove the `/gateway-oss/VERSION/configuration/` canonical redirect.

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -2,11 +2,11 @@
 
 The canonical URL for each page is automatically set by the `canonical_url_generator` plugin. It works by looking for a URL that matches the current page, but where the version is higher than the current URL. As an example:
 
-`/gateway/2.3.x/configuration` would have a canonical URL of `/gateway/2.5.x/configuration`. `2.5.x` is the last version in which this URL existed.
+1. `/gateway/2.3.x/configuration` would have a canonical URL of `/gateway/2.5.x/configuration`. `2.5.x` is the last version in which this URL existed.
 
-In `2.6.x` the page moved to `/gateway/2.6.x/reference/configuration`, which means the canonical URL would be `/gateway/2.8.x/reference/configuration`.
+2. In `2.6.x` the page moved to `/gateway/2.6.x/reference/configuration`, which means the canonical URL would normally be `/gateway/2.8.x/reference/configuration`.
 
-_However_, we have a special `/latest/` URL which is always the latest version, so the canonical URL for the 2.6.x link above would actually be ``/gateway/latest/reference/configuration`.
+3. _However_, we have a special `/latest/` URL which is always the latest version, so the canonical URL for the 2.6.x link above would actually be `/gateway/latest/reference/configuration`.
 
 ## Tracking file renames
 

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -40,6 +40,11 @@ test.describe("Canonical links", () => {
       src: "/hub/",
       href: "/hub/",
     },
+    {
+      title: "page using moved_urls.yml to track renamed files",
+      src: "/gateway-oss/2.5.x/configuration/",
+      href: "/gateway/latest/reference/configuration/",
+    },
   ].forEach((t) => {
     test(t.title, async ({ page }) => {
       await page.goto(t.src);


### PR DESCRIPTION
### Summary
Add the ability to track canonical URLs when the URL of a page changes

### Reason
When we update the IA for 3.0 URLs will change. We don't want duplicate content penalties

### Testing
Visit /gateway-oss/2.5.x/configuration/ and view source

The canonical tag should point to `/gateway/latest/reference/configuration/` which is the new URL for that page