### PR TITLE
Kong GW quickstart remove C* config and use PG_HOST

### DIFF
--- a/app/gateway/2.8.x/get-started/quickstart/index.md
+++ b/app/gateway/2.8.x/get-started/quickstart/index.md
@@ -2,12 +2,12 @@
 title: Start Kong Gateway
 ---
 
-In this section, you'll learn how to install and manage your Kong Gateway instance. First, you'll start Kong Gateway to gain access to its Admin
+In this section, you'll learn how to install and manage your {{site.base_gateway}} instance. First, you'll start {{site.base_gateway}} to gain access to its Admin
 API, where you'll manage entities including Services, Routes, and Consumers.
 
-## Start Kong Gateway using Docker with a database
+## Start {{site.base_gateway}} using Docker with a database
 
-One quick way to get Kong Gateway up and running is by using [Docker with a PostgreSQL database](/gateway/{{page.kong_version}}/install-and-run/docker). We recommend this method to test out basic Kong Gateway functionality.
+One quick way to get {{site.base_gateway}} up and running is by using [Docker with a PostgreSQL database](/gateway/{{page.kong_version}}/install-and-run/docker). We recommend this method to test out basic {{site.base_gateway}} functionality.
 
 For a comprehensive list of installation options, see our [Install page](/gateway/{{page.kong_version}}/install-and-run/).
 
@@ -33,7 +33,7 @@ For a comprehensive list of installation options, see our [Install page](/gatewa
 {% include_cached /md/enterprise/cassandra-deprecation.md %}
 
 
-   Data sent through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
+   Data sent through the Admin API is stored in Kong's [data store][datastore-section] (Kong
    supports PostgreSQL and Cassandra).
 
 3. Prep your database:
@@ -90,19 +90,19 @@ By default, Kong listens on the following ports:
 {:.note}
 > **Note**: If you are using Docker, [`exec`](https://docs.docker.com/engine/reference/commandline/exec) into the Docker container to use these commands.
 
-Stop Kong Gateway using the [stop][CLI] command:
+Stop {{site.base_gateway}} using the [stop][CLI] command:
 
 ```bash
 kong stop
 ```
 
-Reload Kong Gateway using the [reload][CLI] command:
+Reload {{site.base_gateway}} using the [reload][CLI] command:
 
 ```bash
 kong reload
 ```
 
-Start Kong Gateway using the [start][CLI] command:
+Start {{site.base_gateway}} using the [start][CLI] command:
 
 ```bash
 kong start
@@ -110,7 +110,7 @@ kong start
 
 ## Next Steps
 
-Now that you have Kong Gateway running, you can interact with the Admin API.
+Now that you have {{site.base_gateway}} running, you can interact with the Admin API.
 
 To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
 

--- a/app/gateway/2.8.x/get-started/quickstart/index.md
+++ b/app/gateway/2.8.x/get-started/quickstart/index.md
@@ -45,7 +45,6 @@ For a comprehensive list of installation options, see our [Install page](/gatewa
      -e "KONG_PG_HOST=kong-database" \
      -e "KONG_PG_USER=kong" \
      -e "KONG_PG_PASSWORD=kong" \
-     -e "KONG_PG_HOST=kong-database" \
      kong:latest kong migrations bootstrap
    ```
 
@@ -58,7 +57,6 @@ For a comprehensive list of installation options, see our [Install page](/gatewa
         -e "KONG_PG_HOST=kong-database" \
         -e "KONG_PG_USER=kong" \
         -e "KONG_PG_PASSWORD=kong" \
-        -e "KONG_PG_HOST=kong-database" \
         -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
         -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
         -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \

--- a/app/gateway/2.8.x/get-started/quickstart/index.md
+++ b/app/gateway/2.8.x/get-started/quickstart/index.md
@@ -45,7 +45,7 @@ For a comprehensive list of installation options, see our [Install page](/gatewa
      -e "KONG_PG_HOST=kong-database" \
      -e "KONG_PG_USER=kong" \
      -e "KONG_PG_PASSWORD=kong" \
-     -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
+     -e "KONG_PG_HOST=kong-database" \
      kong:latest kong migrations bootstrap
    ```
 
@@ -58,7 +58,7 @@ For a comprehensive list of installation options, see our [Install page](/gatewa
         -e "KONG_PG_HOST=kong-database" \
         -e "KONG_PG_USER=kong" \
         -e "KONG_PG_PASSWORD=kong" \
-        -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
+        -e "KONG_PG_HOST=kong-database" \
         -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
         -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
         -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \

--- a/app/gateway/2.8.x/get-started/quickstart/index.md
+++ b/app/gateway/2.8.x/get-started/quickstart/index.md
@@ -3,7 +3,7 @@ title: Start Kong Gateway
 ---
 
 In this section, you'll learn how to install and manage your {{site.base_gateway}} instance. First, you'll start {{site.base_gateway}} to gain access to its Admin
-API, where you'll manage entities including Services, Routes, and Consumers.
+API, where you'll manage entities including services, routes, and consumers.
 
 ## Start {{site.base_gateway}} using Docker with a database
 


### PR DESCRIPTION
### Summary
Changes the Kong quickstart guide to use the `PG_HOST` value to configure the database connection instead of the deprecated C* value.

### Reason
C* is deprecated, PG values should be used

### Testing
Tested the code in a local docker environment
