### PR TITLE
Use canonical URL rather than page_exists on old versions

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -118,14 +118,9 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if include.p
   />
 
   {% assign latest_include.url = include.url | replace: include.kong_version, include.kong_latest.release %}
-  {% capture latest_page_exists %}{% page_exists {{latest_include.url}} %}{% endcapture %}
   
   {% if include.canonical_url %}
     <link rel="canonical" href="{{site.links.web}}{{ include.canonical_url }}" />
-  {% else %}
-    {% if include.kong_version == include.kong_latest.release and include.no_version != true %}<link rel="canonical" href="{{ site.links.web }}{{ include.url }}" />
-      {% elsif latest_page_exists == 'true' %}<link rel="canonical" href="{% capture latest_path %}{{ site.links.web }}{{ latest_include.url }}{% endcapture %}{{ latest_path }}" />
-    {% endif %}
   {% endif %}
 
   {% if include.seo_noindex %}

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -5,7 +5,6 @@ id: documentation
 ---
 
 {% assign latest_page_url = page.url | replace: page.kong_version, "latest" %}
-{% capture latest_page_exists %}{% page_exists {{latest_page_url}} %}{% endcapture %}
 
 {% assign default_edit_link = page.path | replace: "latest", page.kong_version %}
 
@@ -84,8 +83,7 @@ id: documentation
             {% unless page.edition == 'gateway-oss' or page.edition == 'enterprise' or page.edition == 'getting-started-guide' %}
               <blockquote class="important">
               You are browsing documentation for an outdated version. See the
-              <a href="{% if latest_page_exists == 'true' %}{{latest_page_url}}{% elsif page.edition == 'gateway' %}/gateway/{% elsif page.edition == 'mesh'%}/mesh/{% elsif page.edition == 'kubernetes-ingress-controller/'%}/kubernetes-ingress-controller/{% else %}/{% endif %}">
-                latest documentation here</a>.
+              <a href="{{ page.canonical_url }}">latest documentation here</a>.
               </blockquote>
             {% endunless %}
             {% endif %}


### PR DESCRIPTION
### Summary
Use the page's `canonical_url` rather than `page_exists` when linking to new versions of documentation.

This is functionally equivalent in most cases, but allows us to link to new versions when changing the URL thanks to #4115 

### Testing
I've tested locally by enabling the "latest version" box on gateway-oss 2.5.x (not added to this PR)

This shows the URL pointing to the new configuration guide as expected

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59130/178567371-4b3b6c6a-b7fa-4d6a-8acd-4e0c2f0aa336.png">
