### PR TITLE
feat(portal): update list of supported TLDs for Dev Portal Custom URLs [TDX-2218]

### DIFF
--- a/app/konnect/dev-portal/customization/index.md
+++ b/app/konnect/dev-portal/customization/index.md
@@ -54,10 +54,10 @@ To add a custom URL to Dev Portal, open {% konnect_icon dev-portal %} **Dev Port
 
 ### Supported TLDs
 
-The Custom URL feature currently supports domain names with the following Top Level Domains (TLDs):
+The Custom URL feature currently supports domain names with the following top-level domains (TLDs):
 `.io`, `.com`, `.tech`, `.net`, `.dev`, `.org`, `.edu`, `.gov`, `.fr`, `.se`, `.us`, `.au`, `.uk`, `.cloud`, `.site`.
 
-If you'd like to use a domain outside this list, please [contact support](https://support.konghq.com).
+If you need to use a different domain [contact support](https://support.konghq.com).
 
 {% comment %}
 ### Domain name restrictions

--- a/app/konnect/dev-portal/customization/index.md
+++ b/app/konnect/dev-portal/customization/index.md
@@ -35,9 +35,9 @@ To add a custom URL to Dev Portal, you need:
 In your DNS configuration, create a CNAME record for the domain you want to use using the automatically generated Dev Portal URL.
 The record will look like this:
 
-| Type  | Name   | Value                                                                                      |
-|:------|--------|--------------------------------------------------------------------------------------------|
-| CNAME | portal | `https://example.us.portal.konghq.com`|
+| Type  | Name   | Value                                  |
+|:------|--------|----------------------------------------|
+| CNAME | portal | `https://example.us.portal.konghq.com` |
 
 ### Update Dev Portal URL settings {#update-portal}
 
@@ -45,15 +45,21 @@ To add a custom URL to Dev Portal, open {% konnect_icon dev-portal %} **Dev Port
 
 1. Open the **Portal URL** tab.
 
-3. Enter the fully qualified domain name (FQDN) including the subdomain, if applicable,into the **Custom Portal URL** field.
+3. Enter the fully qualified domain name (FQDN) including the subdomain, if applicable, into the **Custom Portal URL** field.
    Don't include a path or protocol (e.g. `https://`).
 
 4. Click **Save Custom Domain**.
 
 5. Click **Confirm** to begin the domain verification process.
 
+### Supported TLDs
 
+The Custom URL feature currently supports domain names with the following Top Level Domains (TLDs):
+`.io`, `.com`, `.tech`, `.net`, `.dev`, `.org`, `.edu`, `.gov`, `.fr`, `.se`, `.us`, `.au`, `.uk`, `.cloud`, `.site`.
 
+If you'd like to use a domain outside this list, please [contact support](https://support.konghq.com).
+
+{% comment %}
 ### Domain name restrictions
 
 Because of SSL certificate authority restrictions, {{site.konnect_short_name}} can't generate SSL certificates
@@ -77,6 +83,7 @@ for the following domains:
   * `.zw` Zimbabwe
 
 If you have any questions, [contact Support](https://support.konghq.com).
+{% endcomment %}
 
 ### Delete a custom URL {#delete-url}
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Due to current limitations, we need to re-add the list of supported TLDs to the Customize Dev Portal page. I'm commenting out the `Domain name restrictions` section instead of removing it - we hope to extend the support to all (allowed) TLDs soon.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

TDX-2218

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
https://deploy-preview-4119--kongdocs.netlify.app/
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
