### PR TITLE
Add support for unlisted single-sourced docs

### DIFF
--- a/app/_plugins/generators/single_source_generator.rb
+++ b/app/_plugins/generators/single_source_generator.rb
@@ -15,6 +15,10 @@ module SingleSource
         # Assume that the whole file should be treated as generated
         assume_generated = data['assume_generated'].nil? ? true : data['assume_generated']
         version = version_for_release(data['product'], data['release'])
+
+        # If there is an 'unlisted' section, add that in to 'items' to be rendered
+        data['items'] = data['items'] + data['unlisted'] if data['unlisted']
+
         create_pages(data['items'], site, data['product'], data['release'], version, assume_generated)
       end
     end

--- a/docs/single-sourced-versions.md
+++ b/docs/single-sourced-versions.md
@@ -112,6 +112,31 @@ items:
         src: terminology-v3
 ```
 
+## Rendering unlisted pages
+
+In some cases you may want to render a page within a version without adding it to the side navigation. You can accomplish this by adding an `unlisted` section to the data file:
+
+```yaml
+product: deck
+release: 1.11.x
+generate: true
+items:
+  - title: Introduction
+    url: /deck/
+    absolute_url: true
+    items:
+      - text: Terminology
+        # Reads `src/deck/terminology-v3.md` and writes `/deck/<release>/terminology/index.html`
+        # This is how you can have multiple release of a single source file when completely rewriting content
+        url: /terminology
+        src: terminology-v3
+unlisted:
+  # Read from src/deck/how-to/example.md. Rendered at /deck/how-to/example/
+  # Not listed in the sidebar
+  # Options such as 'generate' and 'src' are valid here too
+  - url: /how-to/example
+```
+
 ## Conditional Rendering
 
 As we add new functionality, we'll want content to be displayed for specific releases of a product. We can use the `if_version` block for this:


### PR DESCRIPTION
### Summary
Add support for unlisted single-sourced docs

### Reason
We need it for some of the how-to guides until we decide how to expose them publicly.

### Testing
Tested locally with the following config:

```diff
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -505,3 +505,5 @@ items:

       - text: Plugins in Other Languages
         url: /reference/external-plugins
+unlisted:
+  - url: /how-to/example
```

And `example.md`:

```markdown
---
title: Example
---

This is a test
```

![image](https://user-images.githubusercontent.com/59130/178846432-c9a22e42-f3f1-4d1c-81f8-3d12caf33d08.png)

