### PR TITLE
Clean up branding and descriptions for Konnect

### DIFF
--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -1,16 +1,16 @@
 features:
   - title: Key features
     items:
-      - name: ServiceHub
-        description: Build a comprehensive catalog of services to enable discovery, consumption, and management of every service across your entire architecture.
+      - name: Service Hub
+        description: Build a comprehensive catalog of services to enable discovery, consumption, and management of every API across your entire architecture.
         icon: /assets/images/landing-page/service-hub.svg
         links:
           - text: Cloud
             icon: /assets/images/icons/icn-cloud-blue.svg
             url: /konnect/servicehub
 
-      - name: Developer Portal
-        description: Publish services to individual Developer Portals to provide a bespoke experience to developers within and outside your organization.
+      - name: Dev Portal
+        description: Streamline developer onboarding with a self-service developer experience, letting developers discover, register, and consume published services.
         icon: /assets/images/landing-page/dev-portal.svg
         links:
           - text: Cloud
@@ -21,7 +21,7 @@ features:
             url: /gateway/latest/developer-portal/
 
       - name: Vitals
-        description: View granular analytics with Vitals to monitor the health of environments, clusters, and individual services through the ServiceHub interface.
+        description: View granular analytics with Vitals to monitor the health of environments and clusters. Gain deep insights into service, route, and application usage.
         icon: /assets/images/landing-page/analytics.svg
         links:
           - text: Cloud
@@ -32,7 +32,7 @@ features:
             url: /gateway/latest/vitals/overview
 
       - name: Runtime Manager
-        description: Provision and manage Kong Gateway runtimes in your environment and platform of choice.
+        description: Provision and manage Kong Gateway runtimes and services in your environment and platform of choice.
         icon: /assets/images/landing-page/runtime.svg
         links:
           - text: Cloud

--- a/app/_hub/kong-inc/application-registration/_index.md
+++ b/app/_hub/kong-inc/application-registration/_index.md
@@ -11,14 +11,13 @@ description: |
   [Application Registration](/gateway/latest/developer-portal/administration/application-registration/enable-application-registration) plugin.
 
   {:.note}
-  > **Note**: This plugin is for application registration in self-managed Kong
+  > **Note**: This plugin is for application registration in _self-managed_ Kong
   > Gateway instances.
   > <br>
   > <br>
-  > In Konnect, the functionality is built into the ServiceHub,
-  > so you don't need to set up this plugin.
-  > See the [Konnect Application Overview](/konnect/dev-portal/applications/application-overview/)
-  > for more information.
+  > In Konnect, the functionality is built into the Service Hub, so you don't need this plugin. See the following documentation:
+  * [Learn about app registration in Konnect](/konnect/dev-portal/applications/application-overview/)
+  * [Enable app registration](/konnect/dev-portal/applications/enable-app-reg)
 
   The Application Registration plugin is used in tandem with supported Kong Gateway authorization
   plugins, depending on your configured Dev

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -20,14 +20,12 @@
     </li>
     {% if include.no_version == true %}
       {% if include.url contains '/konnect/servicehub' %}
-      <li class="breadcrumb-item">ServiceHub</li>
+      <li class="breadcrumb-item">Service Hub</li>
         {% for crumb in crumbs offset: 3 %}
           {% unless forloop.last %}
             <li class="breadcrumb-item">
               {% assign crumb_limit = forloop.index | plus: 3 %}
-              <!-- <a href="{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}"> -->
               {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
-              <!-- </a> -->
             </li>
           {% endunless %}
         {% endfor %}

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -205,8 +205,6 @@ plugins:
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Konnect Cloud %}
 
-<!-- In [{{site.konnect_short_name}}](https://cloud.konghq.com), from the Service Hub page, select a service version. -->
-
 You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
 
 From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service version, then set up the plugin:

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -208,6 +208,7 @@ plugins:
 <!-- In [{{site.konnect_short_name}}](https://cloud.konghq.com), from the Service Hub page, select a service version. -->
 
 You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
+
 From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service version, then set up the plugin:
 
 1. In the **Plugins** section, click **Add Plugin**.
@@ -343,6 +344,7 @@ plugins:
 {% navtab Konnect Cloud %}
 
 You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
+
 From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service version, then set up the plugin:
 
 1. Select a route.

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -205,15 +205,19 @@ plugins:
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Konnect Cloud %}
 
-1. In Konnect Cloud, select the service on the ServiceHub page.
-2. Scroll down to **Versions** and select the version.
-3. Scroll down to **Plugins** and click **New Plugin**.
-4. Find and select the **{{ include.name }}** plugin.{% unless
+<!-- In [{{site.konnect_short_name}}](https://cloud.konghq.com), from the Service Hub page, select a service version. -->
+
+You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
+From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service version, then set up the plugin:
+
+1. In the **Plugins** section, click **Add Plugin**.
+2. Find and select the **{{ include.name }}** plugin.{% unless
   config_required_fields_gui == empty %}
-5. Enter the following [parameters](#parameters), updating the default
-or sample values as needed:
+3. Configure the plugin's [parameters](#parameters).
+
+    You can test out the plugin with the following sample configuration:
     {{ config_required_fields_gui }}{% endunless %}
-6. Click **Create**.
+4. Click **Create**.
 
 {% endnavtab %}
 {% endunless %}
@@ -338,16 +342,19 @@ plugins:
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
 {% navtab Konnect Cloud %}
 
-1. In Konnect Cloud, select the service from the ServiceHub page.
-2. Scroll down to **Versions** and select the version.
-3. Select the route.
-4. Scroll down to **Plugins** and click **Add Plugin**.
-5. Find and select the **{{ include.name }}** plugin.{% unless
-    config_required_fields_gui == empty %}
-6. Enter the following [parameters](#parameters), updating the default
-or sample values as needed:
+You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
+From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service version, then set up the plugin:
+
+1. Select a route.
+2. In the **Plugins** section, click **Add Plugin**.
+3. Find and select the **{{ include.name }}** plugin.{% unless
+  config_required_fields_gui == empty %}
+4. Configure the plugin's [parameters](#parameters).
+
+    You can test out the plugin with the following sample configuration:
     {{ config_required_fields_gui }}{% endunless %}
-7. Click **Create**.
+5. Click **Create**.
+
 {% endnavtab %}
 {% endunless %}
 {% unless include.params.manager_examples == false or include.publisher != "Kong Inc." %}

--- a/app/_layouts/landing-page.html
+++ b/app/_layouts/landing-page.html
@@ -13,7 +13,7 @@ id: landing-page
   </div>
 
   <h1 id="main" tabindex="-1">Welcome <span>to Kong Docs</span></h1>
-  <h4>Find all the information you need to use the {{site.konnect_product_name}} platform and Kong’s projects</h4>
+  <h4>Find all the information you need to use Kong’s platforms and projects</h4>
 
   <section class="search">
     <div class="search-input-wrapper">
@@ -30,27 +30,11 @@ id: landing-page
       </h5>
       <hr>
       <div class="platform-links">
-        <a href="/konnect-platform/" class="name-link">
-          <div class="name-label">
-                <div class="link-text">
-                  <img class="icon" src="/assets/images/icons/icn-doc.svg" alt="">
-                  Konnect Platform Overview
-                </div>
-              </div>
-          </a>
           <a href="/konnect/" class="name-link">
             <div class="name-label">
               <div class="link-text">
                 <img class="icon" src="/assets/images/icons/icn-cloud-blue.svg" alt="">
-                Cloud
-              </div>
-            </div>
-          </a>
-          <a href="/gateway/" class="name-link">
-            <div class="name-label">
-              <div class="link-text">
-                <img class="icon" src="/assets/images/icons/icn-server-blue.svg" alt="">
-                Self-managed
+                Konnect Cloud documentation
               </div>
             </div>
           </a>
@@ -77,7 +61,7 @@ id: landing-page
         <div class="card">
           <img class="icon" src="/assets/images/landing-page/catalog.svg" alt=""/>
           <div class="title">2. Catalog services</div>
-          <div class="description">Catalog your services using the {{site.konnect_short_name}} ServiceHub</div>
+          <div class="description">Catalog your services using the {{site.konnect_short_name}} Service Hub</div>
           <a href="/konnect/getting-started/configure-service" class="link-text">
             Catalog
             <img src="/assets/images/icons/icn-arrow-right.svg" alt="">
@@ -91,7 +75,7 @@ id: landing-page
         <div class="card">
           <img class="icon" src="/assets/images/landing-page/services.svg" alt=""/>
           <div class="title">3. Manage services</div>
-          <div class="description">Manage your services using the {{site.konnect_short_name}} ServiceHub</div>
+          <div class="description">Manage your services using the {{site.konnect_short_name}} Service Hub</div>
           <a href="/konnect/getting-started/implement-service/" class="link-text">
             Manage
             <img src="/assets/images/icons/icn-arrow-right.svg" alt="">

--- a/app/contributing/word-choice.md
+++ b/app/contributing/word-choice.md
@@ -25,7 +25,7 @@ Kong Mesh <br><br> Mesh | Kong's service mesh. Use "Kong Mesh" for the first men
 Kuma | Kong's open-source service mesh. <br><br> ❌&nbsp; Do not use "Kong Kuma". This is an open-source project supported by the CNCF and maintained, not owned, by Kong.
 Insomnia | Kong's open-source API client.
 Dev Portal <br><br> Dev Portal, self-managed <br> Dev Portal, cloud | A module for sharing APIs and their specs with developers, and enabling the developers to create applications based on Gateway or Konnect services. <br><br> ❌&nbsp; Do not use "Developer Portal".
-ServiceHub | The service catalog in Konnect Cloud. <br><br> ❌&nbsp; Do not use "Service Hub", "Service hub", or "Servicehub".
+Service Hub | The service catalog in Konnect Cloud. <br><br> ❌&nbsp; Do not use "ServiceHub", "Service hub", or "Servicehub".
 Runtime Manager | The runtime management service in Konnect Cloud <br><br> ❌&nbsp; Do not use "Runtime manager".
 Vitals | Analytics for Gateway.
 decK | Kong's CLI tool for managing declarative configuration.<br><br> ❌&nbsp; Do not capitalize the first letter, even if the name appears at the start of a sentence.

--- a/app/konnect/servicehub/service-implementations.md
+++ b/app/konnect/servicehub/service-implementations.md
@@ -1,5 +1,5 @@
 ---
-title: Manage Services through ServiceHub
+title: Manage Services through Service Hub
 no_version: true
 ---
 


### PR DESCRIPTION
### Summary
* Cleaning up instances of ServiceHub
* Adjusting landing page to get rid of "Konnect Platform" terminology and inaccurate links
* Updating descriptions from marketing materials
* Updating Konnect UI instructions for plugin examples

### Reason
Consistent branding with Helium and accurate examples.

### Testing
TBA