### PR TITLE
doc(conf) add declarative_config_encryption_mode in kong.conf

### DIFF
--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -1729,6 +1729,18 @@ The declarative configuration as a string
 
 ---
 
+#### declarative_config_encryption_mode
+{:.badge .enterprise}
+
+Set encryption of the declarative config mapped file on filesystem. This configuration
+is valid in database-less deployment and also the Data plane in the Hybrid mode deployment.
+
+Accepted values are `off`, `aes-256-gcm`, `chacha20-poly1305`.
+
+**Default:** `off`
+
+---
+
 
 ### Datastore Cache section
 


### PR DESCRIPTION
FT-2613

### Summary
- Add the new EE option `declarative_config_encryption_mode`.

### Reason
https://github.com/Kong/kong-ee/pull/3312

### Testing