### PR TITLE
Guide `ingress-class` instead of `ingress.class` for Knative

### DIFF
--- a/app/_data/docs_nav_kic_2.2.x.yml
+++ b/app/_data/docs_nav_kic_2.2.x.yml
@@ -111,6 +111,8 @@
       url: /guides/preserve-client-ip
     - text: Using Gateway API
       url: /guides/using-gateway-api
+    - text: Using Kong with Knative
+      url: /guides/using-kong-with-knative
 - title: References
   icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
   items:

--- a/app/_data/docs_nav_kic_2.3.x.yml
+++ b/app/_data/docs_nav_kic_2.3.x.yml
@@ -115,6 +115,8 @@ items:
         url: /guides/preserve-client-ip
       - text: Using Gateway API
         url: /guides/using-gateway-api
+      - text: Using Kong with Knative
+        url: /guides/using-kong-with-knative
   - title: References
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     items:

--- a/app/_data/docs_nav_kic_2.4.x.yml
+++ b/app/_data/docs_nav_kic_2.4.x.yml
@@ -115,6 +115,8 @@ items:
         url: /guides/preserve-client-ip
       - text: Using Gateway API
         url: /guides/using-gateway-api
+      - text: Using Kong with Knative
+        url: /guides/using-kong-with-knative
   - title: References
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     items:

--- a/src/kubernetes-ingress-controller/guides/using-kong-with-knative.md
+++ b/src/kubernetes-ingress-controller/guides/using-kong-with-knative.md
@@ -64,7 +64,7 @@ Next, we will configure Knative to use `kong` as the Ingress class:
 $ kubectl patch configmap/config-network \
   --namespace knative-serving \
     --type merge \
-      --patch '{"data":{"ingress.class":"kong"}}'
+      --patch '{"data":{"ingress-class":"kong"}}'
 ```
 
 ## Setup Knative domain


### PR DESCRIPTION
### Summary

Guide `ingress-class` instead of `ingress.class` for Knative Ingress.

### Reason

https://github.com/Kong/kubernetes-ingress-controller/issues/2344 introduced to use `ingress-class` instead of `ingress.class` for Knative Ingress, however Kong document hasn't been changed.

### Testing

I tested it on K8s v1.24 + Knative v1.5.0 with Kong v2.8 + Ingress Controller v2.5 .

If we use `ingress.class` in above versions, it does not work (endpoint address is not assigned to K8s service for ksvc.)