### PR TITLE
[DOCU-2401] Add cluster_telemetry_server_name into 2.6-2.8 docs

### DIFF
--- a/app/gateway/2.6.x/reference/configuration.md
+++ b/app/gateway/2.6.x/reference/configuration.md
@@ -7,7 +7,7 @@
 title: Configuration Reference for Kong Gateway
 source_url: https://github.com/Kong/kong-ee/blob/master/kong.conf.default
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/gateway/2.6.x/reference/configuration.md
+++ b/app/gateway/2.6.x/reference/configuration.md
@@ -742,6 +742,15 @@ node to which telemetry updates will be posted in `host:port` format.
 
 ---
 
+#### cluster_telemetry_server_name
+{:.badge .enterprise}
+
+The SNI (Server Name Indication extension) to use for Vitals telemetry data.
+
+**Default:** none
+
+---
+
 
 ### Hybrid Mode Control Plane section
 

--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -757,6 +757,15 @@ node to which telemetry updates will be posted in `host:port` format.
 
 ---
 
+#### cluster_telemetry_server_name
+{:.badge .enterprise}
+
+The SNI (Server Name Indication extension) to use for Vitals telemetry data.
+
+**Default:** none
+
+---
+
 #### data_plane_config_cache_mode
 {:.badge .enterprise}
 

--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -7,7 +7,7 @@
 title: Configuration Reference for Kong Gateway
 source_url: https://github.com/Kong/kong-ee/blob/master/kong.conf.default
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -770,6 +770,15 @@ node to which telemetry updates will be posted in `host:port` format.
 
 ---
 
+#### cluster_telemetry_server_name
+{:.badge .enterprise}
+
+The SNI (Server Name Indication extension) to use for Vitals telemetry data.
+
+**Default:** none
+
+---
+
 #### data_plane_config_cache_mode
 {:.badge .enterprise}
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -7,7 +7,7 @@
 title: Configuration Reference for Kong Gateway
 source_url: https://github.com/Kong/kong-ee/blob/master/kong.conf.default
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Add cluster_telemetry_server_name into 2.6-2.8 docs
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
This issue was discovered as a result of https://github.com/Kong/docs.konghq.com/pull/4089. I made changes to the kong/kong-ee repo in https://github.com/Kong/kong-ee/pull/3464. 
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Is this technically accurate? (is it enterprise and has no defaults?)
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
