### PR TITLE
[DOCU-2402] Remove KM and decK, and HTTPie instructions from comprehensive docs.

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -94,6 +94,7 @@ opa
 outbounds
 passthrough
 PayPal
+petstore
 plaintext
 PowerShell
 prepend

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -80,7 +80,7 @@ items:
             url: /get-started/comprehensive/load-balancing
           - text: Workspaces and Teams
             url: /get-started/comprehensive/manage-teams
-          - text: Publish, Locate, and Consume Services
+          - text: Publish and Consume Services
             url: /get-started/comprehensive/dev-portal
 
   - title: Plan and Deploy

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -66,19 +66,19 @@ items:
       - text: Comprehensive Guide
         url: /get-started/comprehensive
         items:
-          - text: Prepare to Administer
+          - text: Configure Services and Routes
             url: /get-started/comprehensive/prepare
           - text: Expose your Services
             url: /get-started/comprehensive/expose-services
-          - text: Protect your Services
+          - text: Configure Rate Limiting
             url: /get-started/comprehensive/protect-services
-          - text: Improve Performance
+          - text: Configure Proxy Caching
             url: /get-started/comprehensive/improve-performance
-          - text: Secure Services
+          - text: Configure Key Authentication
             url: /get-started/comprehensive/secure-services
-          - text: Set Up Intelligent Load Balancing
+          - text: Configure Load Balancing
             url: /get-started/comprehensive/load-balancing
-          - text: Manage Administrative Teams
+          - text: Workspaces and Teams
             url: /get-started/comprehensive/manage-teams
           - text: Publish, Locate, and Consume Services
             url: /get-started/comprehensive/dev-portal

--- a/src/gateway/get-started/comprehensive/dev-portal.md
+++ b/src/gateway/get-started/comprehensive/dev-portal.md
@@ -1,5 +1,5 @@
 ---
-title: Publish, Locate, and Consume Services
+title: Publish and Consume Services
 badge: enterprise
 ---
 
@@ -11,37 +11,11 @@ Make sure the Dev Portal is on. You should have enabled it during [installation]
 
 ## Enable the Dev Portal for a Workspace
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. In Kong Manager, open the Workspaces tab and open your workspace (for example, SecureWorkspace).
-
-2. Scroll down in the sidebar, then click the **Overview** link under the Dev Portal section.
-
-3. Click **Enable Developer Portal** and refresh the browser page.
-
-{% endnavtab %}
-{% navtab Using the Admin API %}
-
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
   --data config.portal=true
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
-  config.portal=true
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
-{% endnavtab %}
-{% endnavtabs %}
 This will expose the Dev Portal at `http://<admin-hostname>:8003/SecureWorkspace.`
 
 After the Dev Portal is enabled for the Workspace, a few new links appear in the left navigation menu. It may take a few seconds for the Settings page to populate.

--- a/src/gateway/get-started/comprehensive/expose-services.md
+++ b/src/gateway/get-started/comprehensive/expose-services.md
@@ -14,7 +14,7 @@ If you are not following the Getting Started workflow, make sure you have
 ## What are Services and Routes?
 
 **Service** and **Route** objects let you expose your services to clients with
-Kong Gateway. When configuring access to your API, you’ll start by specifying a
+{{site.base_gateway}}. When configuring access to your API, you’ll start by specifying a
 Service. In {{site.base_gateway}}, a Service is an entity representing an external
 upstream API or microservice &mdash; for example, a data transformation
 microservice, a billing API, and so on.
@@ -25,7 +25,7 @@ protocol, host, port, and path individually.
 
 Before you can start making requests against the Service, you will need to add
 a Route to it. Routes determine how (and if) requests are sent to their Services
-after they reach Kong Gateway. A single Service can have many Routes.
+after they reach {{site.base_gateway}}. A single Service can have many Routes.
 
 After configuring the Service and the Route, you’ll be able to start making
 requests through {{site.base_gateway}}.
@@ -46,278 +46,44 @@ Gateway proxies API requests.
 configuration, including adding Services and Routes, is done through requests to
 the Admin API.
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. On the Workspaces tab in Kong Manager, scroll to the Workspace section and
-click the **default** workspace.
-
-    This example uses the default workspace, but you can also create a new
-    workspace, or use an existing workspace.
-
-2. Scroll down to **Services** and click **Add a Service**.
-
-3. In the **Create Service** dialog, enter the name `example_service` and the
-URL `http://mockbin.org`.
-
-4. Click **Create**.
-
-The service is created, and the page automatically redirects back to the
-`example_service` overview page.
-{% endnavtab %}
-{% navtab Using the Admin API %}
-
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X POST http://<kong-admin-host>:8001/services \
   --data name=example_service \
   --data url='http://mockbin.org'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http POST http://<kong-admin-host>:8001/services \
-  name=example_service \
-  url='http://mockbin.org'
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 If the service is created successfully, you'll get a 201 success message.
 
 Verify the service’s endpoint:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://<admin-hostname>:8001/services/example_service
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http http://<kong-admin-host>:8001/services/example_service
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-1. In the `kong.yaml` file you exported in
-[Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
-define a Service with the name `example_service` and the URL
-`http://mockbin.org`:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-    ```
-2. Save the file. From your terminal, sync the configuration to update your
-gateway instance:
-
-    ``` bash
-    deck sync
-    ```
-
-    The message should show that you’re creating a service:
-
-    ```
-    creating service example_service
-    Summary:
-    Created: 1
-    Updated: 0
-    Deleted: 0
-    ```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Add a Route
 
 For the Service to be accessible through the API gateway, you need to add a
 Route to it.
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-1. From the `example_service` overview page, scroll down to the Routes section
-and click **Add Route**.  
-
-    The Create Route dialog displays with the Service field auto-populated with
-    the Service name and ID number. This field is required.
-
-    **Note:** If the Service field is not automatically populated, click
-    **Services** in the left navigation pane. Find your Service, click the
-    clipboard icon next to the id field, then go back to the Create Route
-    page and paste it into the Service field.
-
-2. Enter a name for the Route, and at least one of the following fields: Host,
-Methods, or Paths. For this example, use the following:
-      1. For **Name**, enter `mocking`.
-      2. For **Path(s)**, click **Add Path** and enter `/mock`.
-
-3. Click **Create**.
-
-The Route is created and you are automatically redirected back to the
-`example_service` overview page. The new Route appears under the Routes section.
-
-{% endnavtab %}
-{% navtab Using the Admin API %}
-
 Define a Route (`/mock`) for the Service (`example_service`) with a specific
 path that clients need to request. Note at least one of the hosts, paths, or
 methods must be set for the Route to be matched to the service.
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/services/example_service/routes \
-  paths:='["/mock"]' \
-  name=mocking
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 A `201` message indicates the Route was created successfully.
-
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-1. Paste the following into the `kong.yaml` file, under the entry for
-`example_service`:
-
-    ``` yaml
-    routes:
-    - name: mocking
-      paths:
-      - /mock
-      strip_path: true
-    ```
-
-    Your file should now look like this:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        strip_path: true
-    ```
-
-2. Sync the configuration:
-
-    ``` bash
-    deck sync
-    ```
-
-3. (Optional) You can update your local file with the new configuration:
-
-    <div class="alert alert-warning">
-
-    <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
-    overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
-    </div>
-
-    ``` bash
-    $ deck dump
-    ```
-
-    Alternatively, you will also see this configuration in the diff that decK
-    shows when you're syncing a change to the configuration.
-
-    You'll notice that both the Service and Route now have parameters that you
-    did not explicitly set. These are default parameters that every Service and
-    Route are created with:
-
-    ``` yaml
-    services:
-    - connect_timeout: 60000
-      host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-      read_timeout: 60000
-      retries: 5
-      write_timeout: 60000
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        path_handling: v0
-        preserve_host: false
-        protocols:
-        - http
-        - https
-        regex_priority: 0
-        strip_path: true
-        https_redirect_status_code: 426
-    ```
-
-    You can do this after any `deck sync` to see {{site.base_gateway}}'s most
-    recent configuration.
-
-    The rest of this guide continues using the simplified version of the
-    configuration file without performing a `deck dump` for every step, to keep
-    it easy to follow.
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Verify the Route is forwarding requests to the Service
 
 By default, {{site.base_gateway}} handles proxy requests on port `8000`. The proxy is often referred to as the data plane.
 
-{% navtabs %}
-{% navtab Using a Web Browser %}
-
-From a web browser, navigate to `http://<kong-gateway-host>:8000/mock/request`.
-
-{% endnavtab %}
-
-{% navtab Using the Admin API %}
-
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http http://<admin-hostname>:8000/mock/request
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% endnavtabs %}
-
-
 ## Summary and next steps
 
 In this section, you:

--- a/src/gateway/get-started/comprehensive/expose-services.md
+++ b/src/gateway/get-started/comprehensive/expose-services.md
@@ -47,7 +47,7 @@ configuration, including adding Services and Routes, is done through requests to
 the Admin API.
 
 ```sh
-curl -i -X POST http://<kong-admin-host>:8001/services \
+curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
   --data url='http://mockbin.org'
 ```
@@ -57,7 +57,7 @@ If the service is created successfully, you'll get a 201 success message.
 Verify the service’s endpoint:
 
 ```sh
-curl -i http://<admin-hostname>:8001/services/example_service
+curl -i http://localhost:8001/services/example_service
 ```
 
 ## Add a Route
@@ -70,7 +70,7 @@ path that clients need to request. Note at least one of the hosts, paths, or
 methods must be set for the Route to be matched to the service.
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
+curl -i -X POST http://localhost:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
 ```
@@ -82,7 +82,7 @@ A `201` message indicates the Route was created successfully.
 By default, {{site.base_gateway}} handles proxy requests on port `8000`. The proxy is often referred to as the data plane.
 
 ```sh
-curl -i -X GET http://<admin-hostname>:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/request
 ```
 ## Summary and next steps
 

--- a/src/gateway/get-started/comprehensive/improve-performance.md
+++ b/src/gateway/get-started/comprehensive/improve-performance.md
@@ -22,7 +22,7 @@ Call the Admin API on port `8001` and configure plugins to enable in-memory cach
 
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=proxy-cache \
   --data config.content_type="application/json; charset=utf-8" \
   --data config.cache_ttl=30 \
@@ -38,7 +38,7 @@ Access the */mock* route using the Admin API and note the response headers:
 
 
 ```sh
-curl -i -X GET http://<admin-hostname>:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/request
 ```
 
 In particular, pay close attention to the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`:
@@ -73,7 +73,7 @@ To test more rapidly, the cache can be deleted by calling the Admin API:
 
 
 ```sh
-curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
+curl -i -X DELETE http://localhost:8001/proxy-cache
 ```
 
 ## Summary and Next Steps

--- a/src/gateway/get-started/comprehensive/improve-performance.md
+++ b/src/gateway/get-started/comprehensive/improve-performance.md
@@ -18,37 +18,9 @@ Use proxy caching so that Upstream services are not bogged down with repeated re
 
 ## Set up the Proxy Caching plugin
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-
-2. Go to **API Gateway** and click **Plugins**.
-
-3. Click **New Plugin**.
-
-4. Scroll down to the Traffic Control section and find the **Proxy Caching** plugin.
-
-5. Click **Enable**.
-
-6. Select to apply the plugin as **Global**. This means that proxy caching applies to all requests.
-
-7. Scroll down and complete only the following fields with the parameters listed.
-    1. config.cache_ttl: `30`
-    2. config.content_type: `application/json; charset=utf-8`
-    3. config.strategy: `memory`
-
-    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
-
-8. Click **Create**.
-{% endnavtab %}
-{% navtab Using the Admin API %}
-
 Call the Admin API on port `8001` and configure plugins to enable in-memory caching globally, with a timeout of 30 seconds for Content-Type `application/json`.
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data name=proxy-cache \
@@ -56,72 +28,6 @@ curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data config.cache_ttl=30 \
   --data config.strategy=memory
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http -f :8001/plugins \
-  name=proxy-cache \
-  config.strategy=memory \
-  config.cache_ttl=30 \
-  config.content_type="application/json; charset=utf-8"
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-1. In the `plugins` section of your `kong.yaml` file, add the `proxy-cache`
-plugin with a timeout of 30 seconds for Content-Type
-`application/json; charset=utf-8`.
-
-    ``` yaml
-    plugins:
-    - name: proxy-cache
-      config:
-        content_type:
-        - "application/json; charset=utf-8"
-        cache_ttl: 30
-        strategy: memory
-    ```
-
-    Your file should now look like this:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        strip_path: true
-    plugins:
-    - name: rate-limiting
-      config:
-        minute: 5
-        policy: local
-    - name: proxy-cache
-      config:
-        content_type:
-        - "application/json; charset=utf-8"
-        cache_ttl: 30
-        strategy: memory
-    ```
-
-2. Sync the configuration:
-
-    ```bash
-    deck sync
-    ```
-
-{% endnavtab %}
-{% endnavtabs %}
-
 
 ## Validate Proxy Caching
 
@@ -130,20 +36,10 @@ step.
 
 Access the */mock* route using the Admin API and note the response headers:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8000/mock/request
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 In particular, pay close attention to the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`:
 ```
@@ -159,9 +55,9 @@ X-Kong-Upstream-Latency: 37
 
 Next, access the */mock* route one more time.
 
-This time, notice the differences in the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`. Cache status is a `hit`, which means Kong Gateway is responding to the request directly from cache instead of proxying the request to the Upstream service.
+This time, notice the differences in the values of `X-Cache-Status`, `X-Kong-Proxy-Latency`, and `X-Kong-Upstream-Latency`. Cache status is a `hit`, which means {{site.base_gateway}} is responding to the request directly from cache instead of proxying the request to the Upstream service.
 
-Further, notice the minimal latency in the response, which allows Kong Gateway to deliver the best performance:
+Further, notice the minimal latency in the response, which allows {{site.base_gateway}} to deliver the best performance:
 
 ```
 HTTP/1.1 200 OK
@@ -175,20 +71,10 @@ X-Kong-Upstream-Latency: 1
 
 To test more rapidly, the cache can be deleted by calling the Admin API:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http delete :8001/proxy-cache
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 ## Summary and Next Steps
 

--- a/src/gateway/get-started/comprehensive/load-balancing.md
+++ b/src/gateway/get-started/comprehensive/load-balancing.md
@@ -27,13 +27,13 @@ In this section, you will create an Upstream named `example_upstream` and add tw
 Call the Admin API on port `8001` and create an Upstream named `example_upstream`:
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams \
+curl -X POST http://localhost:8001/upstreams \
   --data name=example_upstream
 ```
 Update the service you created previously to point to this upstream:
 
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/services/example_service \
+curl -X PATCH http://localhost:8001/services/example_service \
   --data host='example_upstream'
 ```
 
@@ -42,10 +42,10 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='mockbin.org:80'
 
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
 ```
 
@@ -53,7 +53,7 @@ You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and 
 
 ## Validate the Upstream Services
 
-1. With the Upstream configured, validate that it’s working by visiting the route `http://<admin-hostname>:8000/mock` using a web browser or CLI.
+1. With the Upstream configured, validate that it’s working by visiting the route `http://<localhost:8000/mock` using a web browser or CLI.
 2. Continue pinging the endpoint and the site should change from `httpbin` to `mockbin`.
 
 ## Summary and next steps

--- a/src/gateway/get-started/comprehensive/load-balancing.md
+++ b/src/gateway/get-started/comprehensive/load-balancing.md
@@ -1,5 +1,5 @@
 ---
-title: Set Up Intelligent Load Balancing
+title: Configure Load Balancing
 ---
 
 In this topic, you’ll learn about configuring upstream services, and create multiple targets for load balancing.
@@ -24,68 +24,23 @@ In the following example, you’ll use an application deployed across two differ
 
 In this section, you will create an Upstream named `example_upstream` and add two targets to it.
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-2. Go to **API Gateway** > **Upstreams**.
-3. Click **New Upstream**.
-4. For this example, enter `example_upstream` in the **Name** field.
-5. Scroll down and click **Create**.
-6. On the Upstreams page, find the new upstream service and click **View**.
-7. Scroll down and click **New Target**.
-8. In the target field, specify `httpbin.org` with port `80`, and click **Create**.
-9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
-10. Open the **Services** page.
-11. Find your `example_service` and click **Edit**.
-12. Change the **Host** field to `example_upstream`, then click **Update**.
-{% endnavtab %}
-{% navtab Using the Admin API %}
-
 Call the Admin API on port `8001` and create an Upstream named `example_upstream`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X POST http://<admin-hostname>:8001/upstreams \
   --data name=example_upstream
 ```
-{% endnavtab %}
-{% navtab HTTPie %}    
-```sh
-http POST :8001/upstreams \
-  name=example_upstream
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
 Update the service you created previously to point to this upstream:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X PATCH http://<admin-hostname>:8001/services/example_service \
   --data host='example_upstream'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}    
-```sh
-http PATCH :8001/services/example_service \
-  host='example_upstream'
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 `httpbin.org:80`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
   --data target='mockbin.org:80'
@@ -93,101 +48,13 @@ curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
 curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}    
-```sh
-http POST :8001/upstreams/example_upstream/targets \
-  target=mockbin.org:80
-http POST :8001/upstreams/example_upstream/targets \
-  target=httpbin.org:80
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
-
-{% navtab Using decK (YAML) %}
-1. In your `kong.yaml` file, create an Upstream with two targets, each with port
-80: `mockbin.org:80` and `httpbin.org:80`.
-
-    ``` yaml
-    upstreams:
-    - name: example_upstream
-      targets:
-        - target: httpbin.org:80
-          weight: 100
-        - target: mockbin.org:80
-          weight: 100
-    ```
-
-2. Update the service you created previously, pointing the `host` to this
-Upstream:
-
-    ``` yaml
-    services:
-      host: example_upstream
-      name: example_service
-      port: 80
-      protocol: http
-    ```
-
-    After these updates, your file should now look like this:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: example_upstream
-      name: example_service
-      port: 80
-      protocol: http
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        strip_path: true
-        plugins:
-        - name: key-auth
-          enabled: false
-    consumers:
-    - custom_id: consumer
-      username: consumer
-      keyauth_credentials:
-      - key: apikey
-    upstreams:
-    - name: example_upstream
-      targets:
-        - target: httpbin.org:80
-          weight: 100
-        - target: mockbin.org:80
-          weight: 100
-    plugins:
-    - name: rate-limiting
-      config:
-        minute: 5
-        policy: local
-    - name: proxy-cache
-      config:
-        content_type:
-        - "application/json; charset=utf-8"
-        cache_ttl: 30
-        strategy: memory
-    ```
-
-3. Sync the configuration:
-
-    ``` bash
-    deck sync
-    ```
-{% endnavtab %}
-{% endnavtabs %}
 
 You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that Upstream.
 
 ## Validate the Upstream Services
 
 1. With the Upstream configured, validate that it’s working by visiting the route `http://<admin-hostname>:8000/mock` using a web browser or CLI.
-2. Continue hitting the endpoint and the site should change from `httpbin` to `mockbin`.
+2. Continue pinging the endpoint and the site should change from `httpbin` to `mockbin`.
 
 ## Summary and next steps
 

--- a/src/gateway/get-started/comprehensive/manage-teams.md
+++ b/src/gateway/get-started/comprehensive/manage-teams.md
@@ -1,5 +1,5 @@
 ---
-title: Manage Administrative Teams
+title: Workspaces and Teams
 badge: enterprise
 ---
 
@@ -27,7 +27,7 @@ At a high level, securing {{site.base_gateway}} administration is a two-step pro
 1. Turn on RBAC.
 2. Create a workspace and an admin for segregated administration.
 
-At this point in the Getting Started Guide, you have been interacting with your environment as the built-in Super Admin, `kong_admin`. The password for this `kong_admin` user was “seeded” during the installation process using the KONG_PASSWORD environment variable. After RBAC is enabled, you will need to authenticate to the Kong Manager and the {{site.base_gateway}} Admin API using the proper credentials.
+At this point in the Getting Started Guide, you have been interacting with your environment as the built-in Super Admin, `kong_admin`. The password for this `kong_admin` user was “seeded” during the installation process using the KONG_PASSWORD environment variable. After RBAC is enabled, you will need to authenticate to the Admin API using the proper credentials.
 
 In the following sections, you will need the `kong_admin` account’s password to log in to {{site.base_gateway}}, and the `kong_admin_uri` needs to be configured to avoid getting CORS errors.
 
@@ -37,78 +37,14 @@ In the following sections, you will need the `kong_admin` account’s password t
 
 ## Create a workspace
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-### Log into Kong Manager
-
-1. Go to Kong Manager, or reload the page if you already have it open and you will see the following login screen.
-2. Log in to Kong Manager with the built-in Super Admin account, `kong_admin`, and its password.
-
-    Remember, this is the initial KONG_PASSWORD you used when you ran migrations during installation.
-
-3. If you have logged in successfully, then you can start administering your {{site.base_gateway}} cluster.
-
-    If this step did not work, and you know the credentials are correct, then something is likely wrong with your {{site.base_gateway}} configuration. Double-check the settings. If the cause of the problem still isn’t clear, work with your {{site.konnect_product_name}} account team and [Kong Support](https://support.konghq.com/) for assistance.
-
-#### Create the Workspace
-
-1. Access your Kong Manager instance.
-2. On the workspaces tab, click on **New Workspace**.
-3. Create a workspace named `SecureWorkspace` and select a color for the workspace avatar.
-
-    **Note:** Each workspace name should be unique, regardless of letter case. For example, naming one workspace “Payments” and another one “payments” will create two different workspaces that appear identical.
-
-    **WARNING:** Do not give a workspace the same name as any of these major routes in Kong Manager:
-
-    |---------|-----------|--------------|---------------|
-    | Admins  | APIs      | Certificates | Consumers     |
-    | Plugins | Portal    | Routes       | Services      |
-    | SNIs    | Upstreams | Vitals       | PermalinkStep |
-
-4. Click **Create New workspace**.
-5. On the new workspace, click **Teams**.
-6. From the Teams page, click the **Roles** tab to view the default roles that come with {{site.base_gateway}}.
-7. Next to SecureWorkspace, click **View** to see its assigned roles.
-8. There are different roles available for the SecureWorkspace. By default, each new workspace has the following roles and privileges:
-
-    | Role                     | Description                                                                                  |
-    |--------------------------|----------------------------------------------------------------------------------------------|
-    | *workspace-admin*        | Can administer the objects in a workspace but can’t add new administrators to the workspace. |
-    | *workspace-portal-admin* | Can manage the Dev Portal. |
-    | *workspace-read-only*    | Can view anything in the workspace, but can’t make any changes. |
-    | *workspace-super-admin*  | Can do anything inside the workspace. |
-
-**Notes:**
-
-* **Be careful:** Granting access to the **default** workspace gives access to all workspaces in the organization.
-
-* The **default** workspace only has three roles: *workspace-admin*, *workspace-super admin*, and *workspace-read-only*. Every other workspace will have the four roles mentioned above.
-
-* You can also create custom roles by clicking on the **Add Role** button and specifying the endpoints that the administrator with the role will be able to interact with.
-{% endnavtab %}
-{% navtab Using the Admin API %}
 Create a new workspace called SecureWorkspace, substituting the `kong_admin`
 account’s password in place of `<super-user-token>`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X POST http://<admin-hostname>:8001/workspaces \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=SecureWorkspace'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/workspaces \
-  name=SecureWorkspace \
-  Kong-Admin-Token:<super-user-token>
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 **Note:** Each workspace name should be unique, regardless of letter case. For example, naming one workspace “Payments” and another one “payments” will create two different workspaces that appear identical.
 
@@ -123,59 +59,9 @@ http :8001/workspaces \
 
 If you are unable to log in with `kong_admin`'s token, and you know the credentials are correct, then something is likely wrong with your {{site.base_gateway}} configuration. Double-check the settings, or, if the cause of the problem still isn’t clear, work with your {{site.konnect_product_name}} account team and Kong support for assistance.
 
-{% endnavtab %}
-{% endnavtabs %}
-
 ## Create an Admin
 
 Next, create an admin for the SecureWorkspace, granting them permissions to manage only that workspace.
-
-{% navtabs %}
-{% navtab Using Kong Manager %}
-### Invite a New Admin
-
-<div class="alert alert-warning">
-<strong>Note:</strong> If you also use the Admin API, once you've created this admin, you can find it under the <em>/admins</em> endpoint.</div>
-
-1. From the **Teams** > **Admins** tab, click **Invite Admin**.
-2. Enter the new administrator’s **Email** address, **Username**, and **Custom Id**.
-3. Ensure that **Enable RBAC Token** is enabled.
-
-    **Note:** This setting lets the admin use the Admin API as well as Kong Manager. If you don’t want this user to access the Admin API, uncheck this box.
-
-4. Click **Add/Edit Roles**.
-5. In the Workspace Access dialog, select the **SecureWorkspace**.
-6. Select the **workspace-admin** role, which makes this user the workspace administrator for the SecureWorkspace.
-
-    When you are done adding roles, you are redirected back to the Invite Admin dialog.
-
-    <div class="alert alert-warning">
-    <strong>Important:</strong> Before you move on, make sure the <strong>Enable RBAC Token</strong> checkbox is checked. The RBAC token is what allows the new admin to send a token to the Admin API to configure the system programmatically.
-    </div>
-
-7. Click **Invite Admin** to send the invite.
-
-    At this point in the getting started guide, you likely haven’t set up SMTP yet, so no email will be sent. Instead, you’ll later generate a registration link for the new administrator manually.
-
-#### Register the Admin
-
-1. Back on the **Teams** page, click **View** for the administrator you just created.
-2. Click the **Generate registration link** button.
-
-    Using this link, the new administrator can go to a web browser and paste it in to initiate his/her account and create an initial password. Again, normally, this would happen through SMTP, and the user would get this link through an email.
-
-3. Click the **copy icon** to copy the registration link, then save it.
-4. Email or SMS the registration link to the new administrator &mdash; or use it yourself to test the login in the following steps.
-5. Open a different browser or an incognito tab in the current browser so your existing login session is ignored.
-6. Enter the registration link you copied previously into the new browser to log in with the new administrator (secureworkspaceadmin).
-
-    If the registration link has expired, you can generate a new one by logging in with your `kong_admin` administrator and generating a new link.
-
-7. Enter a new password for your new administrator (save this in a secure place) and click on the **Register** button.
-
-    If everything went well, you should see an “Account Setup Success” message.
-{% endnavtab %}
-{% navtab Using the Admin API %}
 
 <div class="alert alert-warning">
 <strong>Note:</strong> The following method refers to the <em>/users</em> endpoint and creates an Admin API user that won't be visible (or manageable) through Kong Manager. If you want to later administer the admin through Kong Manager, create it under the <a href="/gateway/{{page.kong_version}}/admin-api/admins/reference/"><em>/admins</em> endpoint</a> instead.
@@ -184,54 +70,25 @@ Next, create an admin for the SecureWorkspace, granting them permissions to mana
 Create a new user named `secureworkspaceadmin` with the RBAC token
 `secureadmintoken`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=secureworkspaceadmin' \
   --data 'user_token=secureadmintoken'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/SecureWorkspace/rbac/users \
-  name=secureworkspaceadmin \
-  user_token=secureadmintoken \
-  Kong-Admin-Token:<super-user-token>
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 Create a blank role in the workspace and name it `admin`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=admin' \
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/SecureWorkspace/rbac/roles/ \
-  name=admin \
-  Kong-Admin-Token:<super-user-token>
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 Give the `admin` role permissions to do everything on all endpoints in the
 workspace:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
   -H Kong-Admin-Token:<super-user-token> \
@@ -239,67 +96,22 @@ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpo
   --data 'workspace=SecureWorkspace' \
   --data 'actions=*'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
-  endpoint='*' \
-  workspace=SecureWorkspace \
-  actions='*' \
-  Kong-Admin-Token:<super-user-token>
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 Grant the `admin` role to `secureworkspaceadmin`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'role=admin'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
-  roles=admin \
-  Kong-Admin-Token:<super-user-token>
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Verify the New Admin
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. Click the **Login** button to be taken to a new screen to log in with your new administrator.
-2. Enter the **Username** and **Password** of your new administrator and click **Login** again.
-
-    Once you log in, you’ll notice that you can only see the SecureWorkspace.
-
-3. You can also verify that this user’s administration rights are limited. As this user, if you open the Teams tab and try to add new administrators, Admin API users (RBAC users), Groups, or Roles, you won’t have the permissions to do so.
-
-{% endnavtab %}
-{% navtab Using the Admin API %}
 1. Try to access the `default` workspace using `secureworkspaceadmin`'s user token.
 
     *Using cURL:*
     ```sh
     curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
-    ```
-    *Or using HTTPie:*
-
-    ```sh
-    http :8001/default/rbac/users Kong-Admin-Token:secureadmintoken
     ```
 
     You should get a `403 Forbidden` error message:
@@ -314,49 +126,11 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
     ```sh
     curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
     ```
-    *Or using HTTPie:*
 
-    ```sh
-    http :8001/SecureWorkspace/rbac/users Kong-Admin-Token:secureadmintoken
-    ```
     This time, you should get a `200 OK` success message and a list of users.
 
-{% endnavtab %}
-{% endnavtabs %}
 
-That's it! You are now controlling access to {{site.base_gateway}} administration with RBAC.
-
-## Reference: Using decK with RBAC and Workspaces
-
-### RBAC
-
-Once RBAC is enabled, you will have to pass the `kong-admin-token` in a header
-any time you use decK:
-
-``` bash
-deck sync --headers "kong-admin-token:mytoken"   
-```
-> **Note:** You should not use an RBAC token with Super Admin
-privileges for decK. Always scope down to the exact permissions you need to
-give decK.
-
-### Workspaces
-
-When you have multiple workspaces, decK creates a file for each one. Export
-them as follows:
-
-``` bash
-deck dump --all-workspaces
-```
-
-Or, to export the configuration for only one workspace:
-
-``` bash
-deck dump --workspace SecureWorkspace
-```
-
-You can use these flags with any decK commands to update and export your
-configuration.
+You are now controlling access to {{site.base_gateway}} administration with RBAC.
 
 ## Summary and next steps
 

--- a/src/gateway/get-started/comprehensive/manage-teams.md
+++ b/src/gateway/get-started/comprehensive/manage-teams.md
@@ -27,7 +27,7 @@ At a high level, securing {{site.base_gateway}} administration is a two-step pro
 1. Turn on RBAC.
 2. Create a workspace and an admin for segregated administration.
 
-At this point in the Getting Started Guide, you have been interacting with your environment as the built-in Super Admin, `kong_admin`. The password for this `kong_admin` user was “seeded” during the installation process using the KONG_PASSWORD environment variable. After RBAC is enabled, you will need to authenticate to the Admin API using the proper credentials.
+At this point in the Getting Started Guide, you have been interacting with your environment as the built-in Super Admin, `kong_admin`. The password for this `kong_admin` user was “seeded” during the installation process using the KONG_PASSWORD environment variable. After RBAC is enabled, you must authenticate to the Admin API using the proper credentials.
 
 In the following sections, you will need the `kong_admin` account’s password to log in to {{site.base_gateway}}, and the `kong_admin_uri` needs to be configured to avoid getting CORS errors.
 
@@ -41,7 +41,7 @@ Create a new workspace called SecureWorkspace, substituting the `kong_admin`
 account’s password in place of `<super-user-token>`:
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/workspaces \
+curl -X POST http://localhost:8001/workspaces \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=SecureWorkspace'
 ```
@@ -72,7 +72,7 @@ Create a new user named `secureworkspaceadmin` with the RBAC token
 
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=secureworkspaceadmin' \
   --data 'user_token=secureadmintoken'
@@ -81,7 +81,7 @@ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
 Create a blank role in the workspace and name it `admin`:
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=admin' \
 ```
@@ -90,7 +90,7 @@ Give the `admin` role permissions to do everything on all endpoints in the
 workspace:
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'endpoint=*'
   --data 'workspace=SecureWorkspace' \
@@ -100,7 +100,7 @@ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpo
 Grant the `admin` role to `secureworkspaceadmin`:
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'role=admin'
 ```
@@ -109,9 +109,8 @@ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworks
 
 1. Try to access the `default` workspace using `secureworkspaceadmin`'s user token.
 
-    *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/default/rbac/users
     ```
 
     You should get a `403 Forbidden` error message:
@@ -124,7 +123,7 @@ curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworks
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/SecureWorkspace/rbac/users
     ```
 
     This time, you should get a `200 OK` success message and a list of users.

--- a/src/gateway/get-started/comprehensive/prepare.md
+++ b/src/gateway/get-started/comprehensive/prepare.md
@@ -15,8 +15,8 @@ appropriate port/IP/DNS settings.
 * If using declarative configuration to configure {{site.base_gateway}},
 [decK](/deck/latest/installation) is installed.
 
-In this guide, an instance of {{site.base_gateway}} is referenced via
-`<admin-hostname>`. Make sure to replace `<admin-hostname>` with the hostname
+In this guide, an instance of {{site.base_gateway}} is referenced using
+`localhost`. If you are not using `localhost`, make sure to replace `localhost` with the hostname
 of your control plane instance.
 
 ## Verify the {{site.base_gateway}} configuration

--- a/src/gateway/get-started/comprehensive/prepare.md
+++ b/src/gateway/get-started/comprehensive/prepare.md
@@ -28,7 +28,7 @@ View the current configuration by issuing the following command in a terminal
 window:
 
 ```bash
-curl -i -X GET http://<admin-hostname>:8001
+curl -i -X GET http://localhost:8001
 ```
 
 ## (Optional) Verify Control Plane and Data Plane connection
@@ -41,7 +41,7 @@ data planes using the Cluster Status CLI.
 Run the following from a control plane:
 
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 
 The output shows all of the connected data plane instances in the cluster:

--- a/src/gateway/get-started/comprehensive/prepare.md
+++ b/src/gateway/get-started/comprehensive/prepare.md
@@ -1,5 +1,5 @@
 ---
-title: Prepare to Administer Kong Gateway
+title: Configure Services and Routes
 ---
 
 Before getting started with using {{site.base_gateway}}, verify that it was
@@ -10,7 +10,7 @@ installed correctly, and that you’re ready to administer it.
 Before you start this section, make sure that:
 
 * {{site.base_gateway}} is installed and running.
-* Kong Manager (if applicable) and Kong Admin API ports are listening on the
+* Kong Admin API ports are listening on the
 appropriate port/IP/DNS settings.
 * If using declarative configuration to configure {{site.base_gateway}},
 [decK](/deck/latest/installation) is installed.
@@ -19,88 +19,17 @@ In this guide, an instance of {{site.base_gateway}} is referenced via
 `<admin-hostname>`. Make sure to replace `<admin-hostname>` with the hostname
 of your control plane instance.
 
-## Verify the Kong Gateway configuration
-{% navtabs %}
-{% navtab Using Kong Manager %}
-As a {{site.base_gateway}} user, you can use Kong Manager for environment
-administration. You’re going to use it later on in this guide, so first make 
-sure you can access Kong Manager.
+## Verify the {{site.base_gateway}} configuration
 
-Open a web browser and navigate to `http://<admin-hostname>:8002`.
-
-If {{site.base_gateway}} was installed correctly, it automatically logs you
-in and presents the Kong Manager Overview page.
-{% endnavtab %}
-{% navtab Using the Admin API %}
 Ensure that you can send requests to the gateway's Admin API using either cURL
 or HTTPie.
 
 View the current configuration by issuing the following command in a terminal
 window:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```bash
 curl -i -X GET http://<admin-hostname>:8001
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http <admin-hostname>:8001
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-The current configuration returns.
-{% endnavtab %}
-
-{% navtab Using decK (YAML) %}
-
-1. Check that decK is connected to {{site.base_gateway}}:
-
-    ``` bash
-    deck ping
-    ```
-
-    You should see a success message with the version that you're
-    connected to:
-    ```
-    Successfully connected to Kong!
-    Kong version:  2.1.0
-    ```
-
-2. Ensure that you can pull configuration from {{site.base_gateway}} by issuing
-the following command in a terminal window:
-
-    ``` bash
-    deck dump
-    ```
-
-    This command creates a `kong.yaml` file with the gateway's entire current
-    configuration, in the directory where decK is installed.
-
-    You can also use this command at any time (for example, after a `deck sync`)
-    to see the {{site.base_gateway}}'s most recent configuration.
-
-    <div class="alert alert-warning">
-
-    <strong>Be careful!</strong> Any subsequent <code>deck dump</code> will
-    overwrite the existing <code>kong.yaml</code> file. Create backups as needed.
-    </div>
-
-3. Open the file in your preferred code editor. Since you haven't configured
-anything yet, the file should only contain the decK version:
-
-    ``` yaml
-    _format_version: "1.1"
-    ```
-
-    You will use this file to configure {{site.base_gateway}}.
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## (Optional) Verify Control Plane and Data Plane connection
 
@@ -111,20 +40,10 @@ data planes using the Cluster Status CLI.
 
 Run the following from a control plane:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```bash
 curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http :8001/clustering/data-planes
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
+
 The output shows all of the connected data plane instances in the cluster:
 
 ```json

--- a/src/gateway/get-started/comprehensive/protect-services.md
+++ b/src/gateway/get-started/comprehensive/protect-services.md
@@ -23,7 +23,7 @@ Call the Admin API on port `8001` and configure plugins to enable a limit of fiv
 
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=rate-limiting \
   --data config.minute=5 \
   --data config.policy=local
@@ -39,16 +39,16 @@ To validate rate limiting, access the API six (6) times from the CLI to confirm 
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://<admin-hostname>:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/request
 ```
 {% endnavtab %}
 
 {% navtab Web Browser %}
 
-1. Enter `<admin-hostname>:8000/mock` and refresh your browser six times.
-    After the 6th request, you’ll receive an error message.
+1. Enter `localhost:8000/mock` and refresh your browser six times.
+    After the sixth request, you’ll receive an error message.
 2. Wait at least 30 seconds and try again.
-    The service will be accessible until the sixth (6th) access attempt within a 30-second window.
+    The service will be accessible until the sixth access attempt within a 30-second window.
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -68,7 +68,7 @@ After the 6th request, you should receive a 429 "API rate limit exceeded" error:
 
 In this section:
 
-* If using the Admin API or decK, you enabled the Rate Limiting plugin,
+* When you used the Admin API or decK, you enabled the Rate Limiting plugin,
 setting the rate limit to 5 times per minute.
 
 Next, head on to learn about [proxy caching](/gateway/{{page.kong_version}}/get-started/comprehensive/improve-performance).

--- a/src/gateway/get-started/comprehensive/protect-services.md
+++ b/src/gateway/get-started/comprehensive/protect-services.md
@@ -18,11 +18,9 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 ## Set up Rate Limiting
 
 {:.note}
-> **Note:** This section sets up the basic Rate Limiting plugin. If you have a {{site.base_gateway}} instance, see instructions for **Using Kong Manager** to set up Rate Limiting Advanced with sliding window support instead.
 
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.
 
-<!-- codeblock tabs -->
 
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/plugins \
@@ -31,7 +29,6 @@ curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data config.policy=local
 ```
 
-<!-- end codeblock tabs -->
 
 
 ## Validate Rate Limiting

--- a/src/gateway/get-started/comprehensive/protect-services.md
+++ b/src/gateway/get-started/comprehensive/protect-services.md
@@ -33,27 +33,18 @@ curl -i -X POST http://localhost:8001/plugins \
 
 ## Validate Rate Limiting
 
-To validate rate limiting, access the API six (6) times from the CLI to confirm the requests are rate limited.
+To validate rate limiting, send a request to the API six (6) times from the CLI to confirm the requests are rate limited.
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X GET http://localhost:8000/mock/request
 ```
-{% endnavtab %}
 
-{% navtab Web Browser %}
+Or with follow these instructions from your web browser:
 
 1. Enter `localhost:8000/mock` and refresh your browser six times.
     After the sixth request, you’ll receive an error message.
 2. Wait at least 30 seconds and try again.
     The service will be accessible until the sixth access attempt within a 30-second window.
-
-{% endnavtab %}
-{% endnavtabs %}
-
-<!-- end codeblock tabs -->
 
 
 After the 6th request, you should receive a 429 "API rate limit exceeded" error:

--- a/src/gateway/get-started/comprehensive/protect-services.md
+++ b/src/gateway/get-started/comprehensive/protect-services.md
@@ -15,36 +15,7 @@ Kong's [Rate Limiting plugin](/hub/kong-inc/rate-limiting) lets you restrict how
 ## Why Use Rate Limiting?
 
 Rate limiting protects the APIs from accidental or malicious overuse. Without rate limiting, each user may request as often as they like, which can lead to spikes of requests that starve other consumers. After rate limiting is enabled, API calls are limited to a fixed number of requests per second.
-
 ## Set up Rate Limiting
-
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-
-2. Go to **API Gateway** > **Plugins**.
-
-3. Click **New Plugin**.
-
-4. Scroll down to **Traffic Control** and find the **Rate Limiting Advanced** plugin. Click **Enable**.
-
-5. Apply the plugin as **Global**, which means the rate limiting applies to all requests, including every Service and Route in the Workspace.
-
-    If you switched it to **Scoped**, the rate limiting would apply the plugin to only one Service, Route, or Consumer.
-
-    > **Note**: By default, the plugin is automatically enabled when the form is submitted. You can also toggle the **This plugin is Enabled** button at the top of the form to configure the plugin without enabling it. For this example, keep the plugin enabled.
-
-6. Scroll down and complete only the following fields with the following parameters.
-    1. config.limit: `5`
-    2. config.sync_rate: `-1`
-    3. config.window_size: `30`
-
-    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
-
-7. Click **Create**.
-{% endnavtab %}
-{% navtab Using the Admin API %}
 
 {:.note}
 > **Note:** This section sets up the basic Rate Limiting plugin. If you have a {{site.base_gateway}} instance, see instructions for **Using Kong Manager** to set up Rate Limiting Advanced with sliding window support instead.
@@ -52,97 +23,18 @@ Rate limiting protects the APIs from accidental or malicious overuse. Without ra
 Call the Admin API on port `8001` and configure plugins to enable a limit of five (5) requests per minute, stored locally and in-memory, on the node.
 
 <!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data name=rate-limiting \
   --data config.minute=5 \
   --data config.policy=local
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http -f post :8001/plugins \
-  name=rate-limiting \
-  config.minute=5 \
-  config.policy=local
-```
-{% endnavtab %}
-{% endnavtabs %}
+
 <!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-{:.note}
-> **Note:** This section sets up the basic Rate Limiting plugin. If you have a {{site.base_gateway}} instance, see instructions for **Using Kong Manager** to set up Rate Limiting Advanced with sliding window support instead.
-
-1. Add a new `plugins` section to the bottom of your `kong.yaml` file. Enable
-`rate-limiting` with a limit of five (5) requests per minute, stored locally
-and in-memory, on the node:
-
-    ``` yaml
-    plugins:
-    - name: rate-limiting
-      config:
-        minute: 5
-        policy: local
-    ```
-
-    Your file should now look like this:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        strip_path: true
-    plugins:
-    - name: rate-limiting
-      config:
-        minute: 5
-        policy: local
-    ```
-
-    This plugin will be applied globally, which means the rate limiting
-    applies to all requests, including every Service and Route in the Workspace.
-
-    If you pasted the plugin section under an existing Service, Route, or
-    Consumer, the rate limiting would only apply to that specific
-    entity.
-
-    >**Note**: By default, `enabled` is set to `true` for the plugin. You can
-    disable the plugin at any time by setting `enabled: false`.
-
-2. Sync the configuration:
-
-    ``` bash
-    deck sync
-    ```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 
 ## Validate Rate Limiting
-
-{% navtabs %}
-{% navtab Using a Web Browser %}
-
-1. Enter `<admin-hostname>:8000/mock` and refresh your browser six times.
-    After the 6th request, you’ll receive an error message.
-2. Wait at least 30 seconds and try again.
-    The service will be accessible until the sixth (6th) access attempt within a 30-second window.
-
-{% endnavtab %}
-{% navtab Using the Admin API %}
 
 To validate rate limiting, access the API six (6) times from the CLI to confirm the requests are rate limited.
 
@@ -153,12 +45,17 @@ To validate rate limiting, access the API six (6) times from the CLI to confirm 
 curl -i -X GET http://<admin-hostname>:8000/mock/request
 ```
 {% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8000/mock/request
-```
+
+{% navtab Web Browser %}
+
+1. Enter `<admin-hostname>:8000/mock` and refresh your browser six times.
+    After the 6th request, you’ll receive an error message.
+2. Wait at least 30 seconds and try again.
+    The service will be accessible until the sixth (6th) access attempt within a 30-second window.
+
 {% endnavtab %}
 {% endnavtabs %}
+
 <!-- end codeblock tabs -->
 
 
@@ -168,8 +65,6 @@ After the 6th request, you should receive a 429 "API rate limit exceeded" error:
 "message": "API rate limit exceeded"
 }
 ```
-{% endnavtab %}
-{% endnavtabs %}
 
 
 ## Summary and next steps
@@ -178,7 +73,5 @@ In this section:
 
 * If using the Admin API or decK, you enabled the Rate Limiting plugin,
 setting the rate limit to 5 times per minute.
-* If using Kong Manager, you enabled the Rate Limiting Advanced plugin,
-setting the rate limit to 5 times for every 30 seconds.
 
 Next, head on to learn about [proxy caching](/gateway/{{page.kong_version}}/get-started/comprehensive/improve-performance).

--- a/src/gateway/get-started/comprehensive/secure-services.md
+++ b/src/gateway/get-started/comprehensive/secure-services.md
@@ -37,14 +37,14 @@ created:
 
 
 ```sh
-curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
+curl -X POST http://localhost:8001/routes/mocking/plugins \
   --data name=key-auth
 ```
 
 Try to access the service again:
 
 ```sh
-curl -i http://<admin-hostname>:8000/mock
+curl -i http://localhost:8000/mock
 ```
 
 
@@ -73,7 +73,7 @@ The following creates a new consumer called **consumer**:
 
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username=consumer \
   --data custom_id=consumer
 ```
@@ -85,7 +85,7 @@ created above. For this example, set the key to `apikey`.
 
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
+curl -i -X POST http://localhost:8001/consumers/consumer/key-auth \
   --data key=apikey
 ```
 
@@ -114,7 +114,7 @@ You now have a consumer with an API key provisioned to access the route.
 To validate the Key Authentication plugin, access the *mocking* route again, using the header `apikey` with a key value of `apikey`.
 
 ```sh
-curl -i http://<admin-hostname>:8000/mock/request \
+curl -i http://localhost:8000/mock/request \
   -H 'apikey:apikey'
 ```
 You should get an `HTTP/1.1 200 OK` message in response.
@@ -126,7 +126,7 @@ If you are following this getting started guide topic by topic, you will need to
 Find the plugin ID and copy it:
 
 ```sh
-curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
+curl -X GET http://localhost:8001/routes/mocking/plugins/
 ```
 
 
@@ -138,7 +138,7 @@ Output:
 Disable the plugin:
 
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
+curl -X PATCH http://localhost:8001/routes/mocking/plugins/{<plugin-id>} \
   --data enabled=false
 ```
 

--- a/src/gateway/get-started/comprehensive/secure-services.md
+++ b/src/gateway/get-started/comprehensive/secure-services.md
@@ -142,10 +142,6 @@ curl -X PATCH http://localhost:8001/routes/mocking/plugins/{<plugin-id>} \
   --data enabled=false
 ```
 
-```sh
-http -f patch :8001/routes/mocking/plugins/{<plugin-id>} \
-  enabled=false
-```
 ## Summary and next steps
 
 In this topic, you:

--- a/src/gateway/get-started/comprehensive/secure-services.md
+++ b/src/gateway/get-started/comprehensive/secure-services.md
@@ -1,5 +1,5 @@
 ---
-title: Secure your Services Using Authentication
+title: Configure key authentication
 ---
 In this topic, you’ll learn about API Gateway authentication, set up the Key Authentication plugin, and add a consumer.  
 
@@ -31,65 +31,23 @@ For more information, see [What is API Gateway Authentication?](https://konghq.c
 
 ## Set up the Key Authentication Plugin
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. Access your Kong Manager instance and your **default** workspace.
-2. Go to the **Routes** page and select the **mocking** route you created.
-3. Click **View**.
-4. On the Scroll down and select the **Plugins** tab, then click **Add a Plugin**.
-5. In the Authentication section, find the **Key Authentication** plugin and click **Enable**.
-6. In the **Create new key-auth plugin** dialog, the plugin fields are automatically scoped to the route because the plugin is selected from the mocking Routes page.
-
-    For this example, this means that you can use all of the default values.
-
-7. Click **Create**.
-
-    Once the plugin is enabled on the route, **key-auth** displays under the Plugins section on the route’s overview page.
-
-Now, if you try to access the route without providing an API key, the request will fail, and you’ll see the message `"No API key found in request".`
-
-Before Kong proxies requests for this route, it needs an API key. For this example, since you installed the Key Authentication plugin, you need to create a consumer with an associated key first.
-{% endnavtab %}
-{% navtab Using the Admin API %}
-
 Call the Admin API on port `8001` and configure plugins to enable key
 authentication. For this example, apply the plugin to the */mock* route you
 created:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```sh
 curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
   --data name=key-auth
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/routes/mocking/plugins \
-  name=key-auth
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 Try to access the service again:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://<admin-hostname>:8000/mock
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8000/mock
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
+
+
 
 Since you added key authentication, you should be unable to access it:
 
@@ -105,122 +63,32 @@ Before Kong proxies requests for this route, it needs an API key. For this
 example, since you installed the Key Authentication plugin, you need to create
 a consumer with an associated key first.
 
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-1. Under the `mocking` route in the `routes` section of the `kong.yaml` file,
-add a plugin section and enable the `key-auth` plugin:
-
-    ``` yaml
-    plugins:
-    - name: key-auth
-    ```
-
-    Your file should now look like this:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        strip_path: true
-        plugins:
-        - name: key-auth
-    plugins:
-    - name: rate-limiting
-      config:
-        minute: 5
-        policy: local
-    - name: proxy-cache
-      config:
-        content_type:
-        - "application/json; charset=utf-8"
-        cache_ttl: 30
-        strategy: memory
-    ```
-
-2. Sync the configuration:
-
-    ``` bash
-    deck sync
-    ```
-
-Now, if you try to access the route at `http://<admin-hostname>:8000/mock`
-without providing an API key, the request will fail, and you’ll see the message
-`"No API key found in request".`
-
-Before Kong proxies requests for this route, it needs an API key. For this
-example, since you installed the Key Authentication plugin, you need to create
-a consumer with an associated key first.
-
-{% endnavtab %}
-{% endnavtabs %}
-
 
 ## Set up Consumers and Credentials
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-
-1. In Kong Manager, go to **API Gateway** > **Consumers**.
-2. Click **New Consumer**.
-3. Enter the **Username** and **Custom ID**. For this example, use `consumer` for each field.
-4. Click **Create**.
-5. On the Consumers page, find your new consumer and click **View**.
-6. Scroll down the page and click the **Credentials** tab.
-7. Click **New Key Auth Credential**.
-8. Set the key to **apikey** and click **Create**.
-
-  The new Key Authentication ID displays on the **Consumers** page under the **Credentials** tab.
-{% endnavtab %}
-{% navtab Using the Admin API %}
 
 To create a consumer, call the Admin API and the consumer’s endpoint.
 The following creates a new consumer called **consumer**:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
+
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/consumers/ \
   --data username=consumer \
   --data custom_id=consumer
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/consumers \
-  username=consumer \
-  custom_id=consumer
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
+
 
 Once provisioned, call the Admin API to provision a key for the consumer
 created above. For this example, set the key to `apikey`.
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
+
+
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
   --data key=apikey
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/consumers/consumer/key-auth \
-  key=apikey
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
+
 
 If no key is entered, Kong automatically generates the key.
 
@@ -241,125 +109,26 @@ HTTP/1.1 201 Created
 
 You now have a consumer with an API key provisioned to access the route.
 
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-1. Add a `consumers` section to your `kong.yaml` file and create a new consumer:
-
-    ``` yaml
-    consumers:
-    - custom_id: consumer
-      username: consumer
-      keyauth_credentials:
-      - key: apikey
-    ```
-
-    Your file should now look like this:
-
-    ``` yaml
-    _format_version: "1.1"
-    services:
-    - host: mockbin.org
-      name: example_service
-      port: 80
-      protocol: http
-      routes:
-      - name: mocking
-        paths:
-        - /mock
-        strip_path: true
-        plugins:
-        - name: key-auth
-    consumers:
-    - custom_id: consumer
-      username: consumer
-      keyauth_credentials:
-      - key: apikey
-    plugins:
-    - name: rate-limiting
-      config:
-        minute: 5
-        policy: local
-    - name: proxy-cache
-      config:
-        content_type:
-        - "application/json; charset=utf-8"
-        cache_ttl: 30
-        strategy: memory
-    ```
-
-2. Sync the configuration:
-
-    ``` bash
-    deck sync
-    ```
-
-You now have a consumer with an API key provisioned to access the route.
-
-{% endnavtab %}
-{% endnavtabs %}
-
-
 ## Validate Key Authentication
 
-{% navtabs %}
-{% navtab Using a Web Browser %}
-
-To validate the Key Authentication plugin, access your route through your browser by appending `?apikey=apikey` to the url:
-```
-http://<admin-hostname>:8000/mock?apikey=apikey
-```
-
-{% endnavtab %}
-{% navtab Using the Admin API %}
 To validate the Key Authentication plugin, access the *mocking* route again, using the header `apikey` with a key value of `apikey`.
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://<admin-hostname>:8000/mock/request \
   -H 'apikey:apikey'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8000/mock/request apikey:apikey
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
 You should get an `HTTP/1.1 200 OK` message in response.
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## (Optional) Disable the plugin
 If you are following this getting started guide topic by topic, you will need to use this API key in any requests going forward. If you don’t want to keep specifying the key, disable the plugin before moving on.
 
-{% navtabs %}
-{% navtab Using Kong Manager %}
-1. Go to the Plugins page and click on **View** for the key-auth row.
-2. Use the toggle at the top of the page to switch the plugin from **Enabled** to **Disabled**.
-{% endnavtab %}
-{% navtab Using the Admin API %}
 
 Find the plugin ID and copy it:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/routes/mocking/plugins
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
+
 
 Output:
 ```sh
@@ -368,44 +137,15 @@ Output:
 
 Disable the plugin:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
   --data enabled=false
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
+
 ```sh
 http -f patch :8001/routes/mocking/plugins/{<plugin-id>} \
   enabled=false
 ```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
-
-{% endnavtab %}
-{% navtab Using decK (YAML) %}
-
-1. Disable the key-auth plugin in the `kong.yaml` file by setting
-`enabled` to `false`:
-
-    ``` yaml
-    plugins:
-    - name: key-auth
-      enabled: false
-    ```
-
-2. Sync the configuration:
-
-    ``` bash
-    $ deck sync
-    ```
-
-{% endnavtab %}
-{% endnavtabs %}
-
 ## Summary and next steps
 
 In this topic, you:


### PR DESCRIPTION
### Summary
remove KM, Deck, and HTTPIE instructions from comprehensive docs. 
This also includes renaming according to the IA sheet. 
This PR does not contain new KM docs or new decK docs. Those will be added in a later PR. 
This PR does not contain major updates to these docs. That will be added in a later PR. 


### Reason
[[DOCU-2402]](https://konghq.atlassian.net/browse/DOCU-2402)

### Testing
soon

[DOCU-2402]: https://konghq.atlassian.net/browse/DOCU-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ