### PR TITLE
cert-manager kic guide fixes/enhancements

### DIFF
--- a/src/kubernetes-ingress-controller/guides/cert-manager.md
+++ b/src/kubernetes-ingress-controller/guides/cert-manager.md
@@ -168,7 +168,7 @@ metadata:
   name: letsencrypt-prod
 spec:
   acme:
-    email: user@example.com #please change this
+    email: user@example.com #please change this/this is an optional, but recommended setting
     privateKeySecretRef:
       name: letsencrypt-prod
     server: https://acme-v02.api.letsencrypt.org/directory

--- a/src/kubernetes-ingress-controller/guides/cert-manager.md
+++ b/src/kubernetes-ingress-controller/guides/cert-manager.md
@@ -202,7 +202,6 @@ kind: Ingress
 metadata:
   name: demo-example-com
   annotations:
-    kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   ingressClassName: kong
@@ -227,9 +226,6 @@ ingress.extensions/demo-example-com configured
 
 Things to note here:
 
-- The annotation `kubernetes.io/tls-acme`  is set to `true`, informing
-  cert-manager that it should provision a certificate for hosts in this
-  Ingress using ACME protocol.
 - `certmanager.k8s.io/cluster-issuer` is set to `letsencrypt-prod`, directing
   cert-manager to use Let's Encrypt's production server to provision a TLS
   certificate.

--- a/src/kubernetes-ingress-controller/guides/cert-manager.md
+++ b/src/kubernetes-ingress-controller/guides/cert-manager.md
@@ -166,7 +166,6 @@ $ echo "apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
-  namespace: cert-manager
 spec:
   acme:
     email: user@example.com #please change this


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
1. `ClusterIssuer`'s are not namespaced
2. Removing an unnecessary cert-manager annotation
3. Denoting that the `email` setting in a `ClusterIssuer` is an optional key


### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Noticed some minor issues when deploying and reading the cert-manager API docs

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

1. Deploy cert-manager via helm
2. Deploy the ClusterIssuer config in the guide
3. Follow remainder of guide

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
