### PR TITLE
[DOCU-2400] Release: Gateway 2.8.1.3

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -1,4 +1,3 @@
-AgeNet
 Alertmanager
 allowlist
 anonymized
@@ -106,6 +105,8 @@ outbounds
 passthrough
 PayPal
 plaintext
+Postgres
+PostgreSQL
 PowerShell
 prepend
 prepends

--- a/app/_data/docs_nav_gateway_2.8.x.yml
+++ b/app/_data/docs_nav_gateway_2.8.x.yml
@@ -130,6 +130,8 @@
                 url: /plan-and-deploy/security/secrets-management/backends/env
               - text: AWS Secrets Manager
                 url: /plan-and-deploy/security/secrets-management/backends/aws-sm
+              - text: GCP Secrets Manager
+                url: /plan-and-deploy/security/secrets-management/backends/gcp-sm
               - text: Hashicorp Vault
                 url: /plan-and-deploy/security/secrets-management/backends/hashicorp-vault
           - text: Reference Format

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -362,7 +362,7 @@
   lua_doc: true
 -
   release: "2.8.x"
-  ee-version: "2.8.1.2"
+  ee-version: "2.8.1.3"
   ce-version: "2.8.1"
   edition: "gateway"
   luarocks_version: "2.5.1-0"

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -58,9 +58,13 @@ params:
       datatype: array of string elements
       description: |
         The list of domains to create certificate for. To match subdomains under `example.com`, use `*.example.com`.
-        Regex pattern is not supported. Note this config is only used to match domains, not to specify the Common Name
-        or Subject Alternative Name to create certificates; each domain must have its own certificate.
+        Regex pattern is not supported.
+
+        This parameter is only used to match domains, not to specify the Common Name
+        or Subject Alternative Name to create certificates. Each domain must have its own certificate.
         The ACME plugin checks this configuration before checking any certificate in `storage` when serving the certificate of a request.
+
+        If this field is left empty, all top-level domains (TLDs) are allowed.
     - name: fail_backoff_minutes
       required: false
       default: 5

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -2,7 +2,6 @@
 name: ACME
 publisher: Kong Inc.
 version: 0.4.x
-source_url: 'https://github.com/Kong/kong-plugin-acme'
 desc: Let's Encrypt and ACMEv2 integration with Kong
 description: |
   This plugin allows Kong to apply certificates from Let's Encrypt or any other ACMEv2 service and serve them dynamically.

--- a/app/_hub/kong-inc/vault-auth/0.4.0.md
+++ b/app/_hub/kong-inc/vault-auth/0.4.0.md
@@ -1,7 +1,7 @@
 ---
 name: Vault Authentication
 publisher: Kong Inc.
-version: 0.4.1
+version: 0.4.0
 desc: Add Vault authentication to your Services
 description: |
   Add authentication to a Service or Route with an access token and secret token. Credential tokens are stored securely via Vault. Credential lifecyles can be managed through the Kong Admin API, or independently via Vault.
@@ -105,9 +105,6 @@ service, you must add the new consumer to an allowed group. See
 
 ### Create a Vault
 
-{:.note}
-> Vault Auth plugin only works with HashiCorp Vault KV Secrets Engine - Version 1.
-
 A Vault object represents the connection between Kong and a Vault server. It defines the connection and authentication information used to communicate with the Vault API. This allows different instances of the `vault-auth` plugin to communicate with different Vault servers, providing a flexible deployment and consumption model.
 
 Vault objects require setting a `vault_token` attribute. This attribute is _referenceable_, which means it can be securely stored as a
@@ -117,7 +114,7 @@ in a vault. References must follow a [specific format](/gateway/latest/plan-and-
 Vault objects can be created via the following HTTP request:
 
 ```bash
-$ curl -X POST http://localhost:8001/vault-auth \
+$ curl -X POST http://localhost:8001/vaults \
   --header 'Content-Type: multipart/form-data' \
   --form name=kong-auth \
   --form mount=kong-auth \
@@ -152,7 +149,7 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 Token pairs can be managed either via the Kong Admin API, or independently via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/vault-auth/{vault}/credentials/{consumer}
+$ curl -X POST http://kong:8001/vaults/{vault}/credentials/{consumer}
 HTTP/1.1 201 Created
 
 {
@@ -227,7 +224,7 @@ $ curl http://kong:8000/{proxy path} \
 Existing Vault credentials can be removed from the Vault server via the following API:
 
 ```bash
-$ curl -X DELETE http://kong:8001/vault-auth/{vault}/credentials/token/{access token}
+$ curl -X DELETE http://kong:8001/vaults/{vault}/credentials/token/{access token}
 
 HTTP/1.1 204 No Content
 ```
@@ -272,10 +269,6 @@ EOF
 
 
 ## Changelog
-
-### {{site.base_gateway}} 2.8.1.3 (plugin version 0.4.1)
-
-* The endpoints of Vault Auth plugin will be moved from `/vaults` to `/vault-auth` with `vaults_use_new_style_api=on` set in `kong.conf`.
 
 ### {{site.base_gateway}} 2.8.x (plugin version 0.4.0)
 

--- a/app/_hub/kong-inc/vault-auth/versions.yml
+++ b/app/_hub/kong-inc/vault-auth/versions.yml
@@ -1,3 +1,4 @@
+- release: 0.4.1
 - release: 0.4.0
 - release: 0.3.0
 - release: 0.2.2

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
@@ -1,6 +1,5 @@
 ---
 title: Advanced Secrets Configuration
-beta: true
 ---
 
 
@@ -23,7 +22,7 @@ refer to respective [vault backend documentation](/gateway/{{page.kong_version}}
 
 You can configure your vault backend with `KONG_VAULT_<vault-backend>_<config_opt>` environment variables.
 
-For example, Kong Gateway might look for an environment variable that matches `KONG_VAULT_ENV_PREFIX`:
+For example, {{site.base_gateway}} might look for an environment variable that matches `KONG_VAULT_ENV_PREFIX`:
 
 ```bash
 export KONG_VAULT_ENV_PREFIX=SECURE_
@@ -33,14 +32,11 @@ export KONG_VAULT_ENV_PREFIX=SECURE_
 
 You can configure your vault backend using the `vaults` entity.
 
-For the beta release of this feature, the endpoint is `/vaults-beta`.
-
 ```bash
-http PUT :8001/vaults-beta/my-env-vault \
+http -f PUT :8001/vaults/my-env-vault \
   name=env \
   description="ENV vault for secrets" \
-  config.prefix=SECURE_ \
-  -f
+  config.prefix=SECURE_
 ```
 
 This lets you drop the configuration from environment variables and query arguments and use the entity name in the reference.
@@ -53,13 +49,10 @@ For more information, see the section on the [Vaults entity](#vaults-entity).
 
 ## Vaults CLI
 
-{:.warning}
-> **Beta warning:** In the beta release, only the `kong vault get` command is supported.
-
 ```text
 Usage: kong vault COMMAND [OPTIONS]
 
-Vault utilities for Kong.
+Vault utilities for {{site.base_gateway}}.
 
 Example usage:
  TEST=hello kong vault get env/test
@@ -75,10 +68,7 @@ Options:
 ## Vaults Entity
 
 {:.warning}
-> **Beta warning:**
-> <br>
-> The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This will be
-> changed in the future. Kong Manager has currently no supports for configuring vault entities.
+> Kong Manager currently doesn't support configuring vault entities.
 
 The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
 
@@ -88,7 +78,7 @@ Create a Vault entity:
 {% navtab cURL %}
 
 ```bash
-$ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault-1  \
+$ curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault-1  \
         --data name=env \
         --data description='ENV vault for secrets' \
         --data config.prefix=SECRET_
@@ -98,11 +88,10 @@ $ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault-1  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-env-vault-1 \
+http -f PUT :8001/vaults/my-env-vault-1 \
   name=env \
   description="ENV vault for secrets" \
-  config.prefix=SECRET_  \
-  -f
+  config.prefix=SECRET_
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -1,12 +1,11 @@
 ---
 title: AWS Secrets Manager
-beta: true
 badge: enterprise
 ---
 
 ## Configuration
 
-[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation only supports
+[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be configured in multiple ways. The current version of {{site.base_gateway}} implementation only supports
 configuring via environment variables.
 
 ```bash
@@ -32,7 +31,7 @@ Access these secrets from `my-secret-name` like this:
 
 ```bash
 {vault://aws/my-secret-name/foo}
-{vault://aws/my-secret-name/snap}
+{vault://aws/my-secret-name/snip}
 ```
 
 ## Entity
@@ -43,7 +42,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-aws-sm-vault  \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-aws-sm-vault  \
   --data name=aws \
   --data description="Storing secrets in AWS Secrets Manager" \
   --data config.region="us-east-1"
@@ -53,10 +52,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-aws-sm-vault  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-aws-sm-vault name="aws" \
+http -f PUT :8001/vaults/my-aws-sm-vault name="aws" \
   description="Storing secrets in AWS Secrets Manager" \
-  config.region="us-east-1" \
-  -f 
+  config.region="us-east-1"
 ```
 
 {% endnavtab %}
@@ -84,7 +82,7 @@ environment variable.
 
 ```bash
 {vault://my-aws-sm-vault/my-secret-name/foo}
-{vault://my-aws-sm-vault/my-secret-name/snap}
+{vault://my-aws-sm-vault/my-secret-name/snip}
 ```
 
 ## Advanced Examples
@@ -92,13 +90,13 @@ environment variable.
 You can create multiple entities, which lets you have secrets in different regions:
 
 ```bash
-http PUT :8001/vaults-beta/aws-eu-central-vault name=aws config.region="eu-central-1" -f 
-http PUT :8001/vaults-beta/aws-us-west-vault name=aws config.region="us-west-1" -f 
+http -f PUT :8001/vaults/aws-eu-central-vault name=aws config.region="eu-central-1"
+http -f PUT :8001/vaults/aws-us-west-vault name=aws config.region="us-west-1"
 ```
 
 This lets you source secrets from different regions:
 
 ```bash
 {vault://aws-eu-central-vault/my-secret-name/foo}
-{vault://aws-us-west-vault/my-secret-name/snap}
+{vault://aws-us-west-vault/my-secret-name/snip}
 ```

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -38,6 +38,12 @@ Access these secrets from `my-secret-name` like this:
 
 The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
 
+{:.important}
+> **API Endpoint update**
+>
+> If you're using 2.8.2 or below, or have not set `vaults_use_new_style_api=on` in `kong.conf` you will need to replace `/vaults/` with `/vaults-beta/` in the examples below.
+
+
 {% navtabs codeblock %}
 {% navtab cURL %}
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
@@ -1,7 +1,7 @@
 ---
 title: Environment Variables Vault
-beta: true
 badge: free
+content-type: how-to
 ---
 
 ## Configuration
@@ -14,7 +14,7 @@ There is no prior configuration needed.
 Define a secret in a environment variable:
 
 ```bash
-export MY_SECRET_VALUE=opensesame
+export MY_SECRET_VALUE=EXAMPLE_VALUE
 ```
 
 We can now reference this secret
@@ -46,7 +46,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault \
         --data name=env \
         --data description="Store secrets in environment variables"
 ```
@@ -55,10 +55,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-env-vault \
+http -f PUT :8001/vaults/my-env-vault \
   name="env" \
-  description="Store secrets in environment variables" \
-  -f 
+  description="Store secrets in environment variables"
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -1,0 +1,115 @@
+---
+title: GCP Secrets Manager
+badge: enterprise
+content-type: how-to
+---
+
+## Configuration
+
+The current version of {{site.base_gateway}}'s implementation supports
+configuring
+[GCP Secrets Manager](https://cloud.google.com/secret-manager/) in two
+ways:
+
+* Environment variables
+* Workload Identity
+
+To configure GCP Secrets Manager, the `GCP_SERVICE_ACCOUNT`
+environment variable must be set to the JSON document referring to the
+[credentials for your service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys):
+
+```bash
+export GCP_SERVICE_ACCOUNT=$(cat gcp-my-project-c61f2411f321.json)
+```
+
+{{site.base_gateway}} uses the key to automatically authenticate
+with the GCP API and grant you access.
+
+To use GCP Secrets Manager with
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+on a GKE cluster, update your pod spec so that the service account is
+attached to the pod. For configuration information, read the [Workload
+Identity configuration
+documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
+
+{:.note}
+> With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
+
+## Examples
+
+To use a GCP Secret Manager
+[secret](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets)
+with the name `my-secret-name`, create a JSON object in GCP that
+contains one or more properties:
+
+```json
+{
+  "foo": "bar",
+  "snip": "snap"
+}
+```
+
+You can now reference the secret's individual resources like this:
+
+```bash
+{vault://gcp/my-secret-name/foo?project_id=my_project_id}
+{vault://gcp/my-secret-name/snip?project_id=my_project_id}
+```
+
+Note that both the provider (`gcp`) as well as the GCP project ID
+(`my_project_id`) need to be specified.
+
+## Entity
+
+Once the database is initialized, a Vault entity can be created
+that encapsulates the provider and the GCP project ID:
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
+  --data name=gcp \
+  --data description="Storing secrets in GCP Secrets Manager" \
+  --data config.project_id="my_project_id"
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http -f PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
+  name="gcp" \
+  description="Storing secrets in GCP Secrets Manager" \
+  config.project_id="my_project_id"
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+```json
+{
+    "config": {
+        "project_id": "my_project_id"
+    },
+    "created_at": 1657874961,
+    "description": "Storing secrets in GCP Secrets Manager",
+    "id": "90e200be-cf84-4ce9-a1d6-a41c75c79f31",
+    "name": "gcp",
+    "prefix": "my-gcp-sm-vault",
+    "tags": null,
+    "updated_at": 1657874961
+}
+```
+
+With the Vault entity in place, you can reference the GCP secrets
+through it:
+
+```bash
+{vault://my-gcp-sm-vault/my-secret-name/foo}
+{vault://my-gcp-sm-vault/my-secret-name/snip}
+```
+
+When you use the Vault entity, you no longer need to specify the GCP project ID to access the secrets.

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -64,6 +64,11 @@ Note that both the provider (`gcp`) as well as the GCP project ID
 Once the database is initialized, a Vault entity can be created
 that encapsulates the provider and the GCP project ID:
 
+{:.important}
+> **API Endpoint update**
+>
+> If you're using 2.8.2 or below, or have not set `vaults_use_new_style_api=on` in `kong.conf` you will need to replace `/vaults/` with `/vaults-beta/` in the examples below.
+
 {% navtabs codeblock %}
 {% navtab cURL %}
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
@@ -29,7 +29,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-hashicorp-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-hashicorp-vault \
   --data name="hcv" \
   --data description="Storing secrets in Hashicorp Vault" \
   --data config.protocol="https" \
@@ -44,7 +44,7 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-hashicorp-vault \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-hashicorp-vault \
+http -f PUT :8001/vaults/my-hashicorp-vault \
   name="hcv" \
   description="Storing secrets in Hashicorp Vault" \
   config.protocol="https" \
@@ -52,8 +52,7 @@ http PUT :8001/vaults-beta/my-hashicorp-vault \
   config.port="8200" \
   config.mount="secret" \
   config.kv="v2" \
-  config.token="<mytoken>" \
-  -f 
+  config.token="<mytoken>"
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
@@ -25,6 +25,11 @@ You can also store this information in an entity.
 {:.note}
 The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
 
+{:.important}
+> **API Endpoint update**
+>
+> If you're using 2.8.2 or below, or have not set `vaults_use_new_style_api=on` in `kong.conf` you will need to replace `/vaults/` with `/vaults-beta/` in the examples below.
+
 {% navtabs codeblock %}
 {% navtab cURL %}
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
@@ -1,14 +1,12 @@
 ---
 title: Supported Vault Backends
-beta: true
 ---
-
-Secrets rotation is not supported for the beta version.
 
 The following Vault implementations are supported:
 
 |                                                                                                                        | Rotation Support             | Get                          | Tier       |
 |------------------------------------------------------------------------------------------------------------------------|------------------------------|------------------------------|------------|
 | [AWS Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/aws-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
-| [Hashicorp Vault](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [GCP Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/gcp-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [HashiCorp Vault](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
 | [Environment Variable](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/env)        |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Free       |

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -1,21 +1,19 @@
 ---
 title: Get Started with Secrets Management
-beta: true
 ---
 
-This feature is currently in beta state and isn't fully supported. APIs are subject to change.
-
-
 Secrets are generally confidential values that should not appear in plain text in the application. There are several products that help you
-store, retrieve, and rotate these secrets securely. Kong Gateway offers a mechanism to set up references to these secrets which makes your Kong Gateway
+store, retrieve, and rotate these secrets securely. {{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your {{site.base_gateway}}
 installation more secure.
 
 ## Getting started
 
 {:.note}
-> This feature isn't enabled by default in this version of Kong.
+> This feature isn't enabled by default in this version of {{site.base_gateway}}.
 ><br>
-> Start Kong Gateway with `KONG_VAULTS=bundled`.
+> Start {{site.base_gateway}} with `KONG_VAULTS=bundled KONG_VAULTS_USE_NEW_STYLE_API=on`.
+><br>
+> When running {{site.base_gateway}} in hybrid or DB-less mode, secrets management is only supported in {{site.base_gateway}} 2.8.1.3 or later.
 
 The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
 
@@ -31,7 +29,7 @@ Define your environment variable and assign a secret value to it:
 export MY_SECRET_POSTGRES_PASSWORD="opensesame"
 ```
 
-Next, set up a `reference` to this environment variable so that Kong Gateway can find this secret. We use a Uniform Resource Locator (URL) format for this.
+Next, set up a `reference` to this environment variable so that {{site.base_gateway}} can find this secret. We use a Uniform Resource Locator (URL) format for this.
 
 In this case, the reference would look like this:
 
@@ -65,7 +63,7 @@ the kong.conf has a key called "pg_password". Replace the original value with
 pg_password={vault://env/my-secret-postgres-password}
 ```
 
-Upon startup, Kong will try to detect and transparently resolve references.
+Upon startup, {{site.base_gateway}} will try to detect and transparently resolve references.
 
 {:.note}
 >For quick debug/testing you can use the new [CLI for vaults](/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli)

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -1,6 +1,5 @@
 ---
 title: Secrets Management
-beta: true
 ---
 
 A secret is any sensitive piece of information required for API gateway
@@ -10,7 +9,7 @@ with APIs serviced by the gateway.
 
 Some of the most common types of secrets used by {{site.base_gateway}} include:
 
-* Datastore usernames and passwords, used with PostgreSQL and Redis
+* Data store usernames and passwords, used with PostgreSQL and Redis
 * Private X.509 certificates
 * API keys
 * Sensitive plugin configuration fields, generally used for authentication
@@ -51,29 +50,24 @@ documentation for each plugin to identify the referenceable fields:
 {{site.base_gateway}} supports the following vault backends:
 * Environment variables
 * AWS Secrets Manager
-* Hashicorp Vault
+* GCP Secrets Manager
+* HashiCorp Vault
 
 See the [backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
 for more information about each option.
 
-## Beta limitations
+## Notes on the GA release of the Secrets Management feature
 
-This feature is currently in beta. This means it has limited support from
-Kong and the functionality may change in the future.
-
-**Do not** implement this feature in a product environment.
-
-* The beta of this feature only supports `get`. There is no `set` or secrets
-rotation support in the beta.
-* In this version, this feature isn't enabled by default. To test it out, start
-{{site.base_gateway}} with `KONG_VAULTS=bundled` if running Kong in a container,
-or with `vaults=bundled` set in `kong.conf`.
-* The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This
-endpoint will change once the beta is over.
+In the GA release of the Secrets Management feature in
+{{site.base_gateway}}, this feature is enabled by default.
+Due to conflicts with previous releases of {{site.base_gateway}},
+the endpoints for secrets management in the
+Admin API will be moved from the previous `/vaults-beta` prefix to
+`/vaults` with `vaults_use_new_style_api=on` set in `kong.conf`.
 
 ## Get started
 
-To test out secrets management, see the following topics:
+For further information on secrets management, see the following topics:
 * [Get started with secrets management](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/getting-started/)
 * [Backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
 * [Reference format](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/reference-format/)

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
@@ -1,6 +1,5 @@
 ---
 title: Reference Format
-beta: true
 ---
 
 ## Reference Format
@@ -49,7 +48,8 @@ or using a vault entity
 
 #### Secret ID
 
-The `secret-id` is used as an identifier in case the vault uses a nested datastructure.
+The `secret-id` is used as an identifier in case the vault uses a
+nested data structure.
 
 #### Secret Key
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -6,7 +6,7 @@ no_version: true
 <!-- vale off -->
 
 ## 2.8.1.3
-**Release Date** 2022/07/25
+**Release Date** 2022/08/05
 
 ### Features
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -6,7 +6,7 @@ no_version: true
 <!-- vale off -->
 
 ## 2.8.1.3
-**Release Date** TBD
+**Release Date** 2022/07/25
 
 ### Features
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -5,6 +5,49 @@ no_version: true
 
 <!-- vale off -->
 
+## 2.8.1.3
+**Release Date** TBD
+
+### Features
+
+#### Enterprise
+
+* Added GCP integration support for the secrets manager. GCP is now available as a vault backend.
+
+#### Plugins
+
+* [AWS Lambda](/hub/kong-inc/aws-lambda/) (`aws-lambda`)
+   * Added support for cross-account lambda function invocation based on AWS roles.
+
+### Fixes
+
+#### Enterprise
+* Fixed an issue with excessive log file disk utilization on control planes.
+* Fixed an issue with keyring encryption, where keyring was not decrypting keys after a soft reload.
+* The router now detects static route collisions inside the current workspace, as well as with other workspaces.
+* When using a custom plugin in a hybrid mode deployment, the control plane now detects compatibility issues and stops sending the plugin configuration to data planes that can't use it. The control plane continues sending the custom plugin configuration to compatible data planes.
+* Optimized the Kong PDK function `kong.response.get_source()`.
+
+#### Kong Manager
+* Fixed an issue with admin creation.
+Previously, when an admin was created with no roles, the admin would have access to the first workspace listed alphabetically.
+
+#### Plugins
+
+* [Mocking](/hub/kong-inc/mocking) (`mocking`)
+  * Fixed an issue where the plugin didn't accept empty values in examples.
+
+* [ACME](/hub/kong-inc/acme) (`acme`)
+  * The `domains` plugin parameter can now be left empty.
+  When `domains` is empty, all TLDs are allowed.
+  Previously, the parameter was labelled as optional, but leaving it empty meant that the plugin retrieved no certificates at all.
+
+* [Response Transformer Advanced](/hub/kong-inc/response-transformer-advanced/) (`response-transformer-advanced`)
+  * Fixed an issue with nested array parsing.
+
+* [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
+  * Fixed an issue with `cluster` strategy timestamp precision in Cassandra.
+
 ## 2.8.1.2
 **Release Date** 2022/07/15
 


### PR DESCRIPTION
### Summary
Changelog and any doc updates for the Gateway 2.8.1.3 patch release.

⚠ **Important:** ⚠  We have two potential issues here, both listed under "Features" in the changelog:

- [x] * I couldn't find the [AWS Lambda plugin update](https://konghq.atlassian.net/browse/FTI-3291) in the kong-ee `next/2.8.x.x` branch. The change was originally made in open-source Kong and was merged there, with plans to GA in 3.0. Is this change _actually_ going into 2.8.1.3? I see that Fel's last question on the ticket was also not answered. 

- [x]   * If the answer is yes, it goes into 2.8.1.3, we will need to make sure the changes in this doc PR get pulled into `main`:  https://github.com/Kong/docs.konghq.com/pull/3996

- [x] * GCP integration support for the secrets manager: this is undocumented, and first we are aware of it. It will need to be added to the secrets manager doc:  https://docs.konghq.com/gateway/latest/plan-and-deploy/security/secrets-management/backends/ 

Dev checklist for remaining work (mostly docs): https://github.com/Kong/kong-ee/pull/3554

### Reason

Upcoming patch release. 
https://konghq.atlassian.net/browse/DOCU-2400

### Testing
https://deploy-preview-4142--kongdocs.netlify.app/gateway/changelog/

I set a release date, but need to verify that this is actually when the release comes out.