### PR TITLE
Further improve the plugin template

### DIFF
--- a/app/_hub/_init/my-extension/_index.md
+++ b/app/_hub/_init/my-extension/_index.md
@@ -14,7 +14,7 @@
 # releases: # Fill in the Gateway version that this plugin is being added in.
 #   - 3.0.x
 #
-# 3. Add an icon for the plugin to app/_assets/images/icons/hub.
+# 3. Add a 64x64px icon for the plugin to app/_assets/images/icons/hub.
 # The name of the file must be in the following format: <publisher>_<plugin-directory-name>.png
 # For example, for the rate limiting plugin the icon name is kong-inc_rate-limiting.png
 # If your plugin doesn't have an icon yet, you can duplicate the default_icon.png file.

--- a/app/_hub/_init/my-extension/_index.md
+++ b/app/_hub/_init/my-extension/_index.md
@@ -1,8 +1,25 @@
 ---
 # This file is for documenting an individual Kong plugin.
-# Duplicate this file in your own *publisher path* on your own branch.
+#
+# 1. Duplicate this file in your own *publisher path* on your own branch.
 # Your publisher path is relative to app/_hub/.
 # The path must consist only of alphanumeric characters and hyphens (-).
+#
+# 2. Create a versions.yml file in your new plugin directory.
+# Set the Kong Gateway version that the plugin is being added to.
+# Use the following format in that file (see docs/single-sourced-plugins.md for more info):
+#
+# strategy: gateway
+#
+# releases: # Fill in the Gateway version that this plugin is being added in.
+#   - 3.0.x
+#
+# 3. Add an icon for the plugin to app/_assets/images/icons/hub.
+# The name of the file must be in the following format: <publisher>_<plugin-directory-name>.png
+# For example, for the rate limiting plugin the icon name is kong-inc_rate-limiting.png
+# If your plugin doesn't have an icon yet, you can duplicate the default_icon.png file.
+#
+# 4. Fill in the template in this file.
 #
 # The following YAML data must be filled out as prescribed by the comments
 # on individual parameters. Also see documentation at:

--- a/app/_plugins/generators/plugin_single_source_generator.rb
+++ b/app/_plugins/generators/plugin_single_source_generator.rb
@@ -59,6 +59,9 @@ module PluginSingleSource
         name = f.gsub('app/_hub/', '').gsub('/_index.md', '')
         next if seen.include?(name)
 
+        # Don't generate the sample file
+        next if name == '_init/my-extension'
+
         create_pages(
           {
             'strategy' => 'matrix',


### PR DESCRIPTION
### Summary
Adding full steps for creating a new plugin doc (icon, versions.yml) to the template.

### Reason
The info is hard to track down and scattered (it exists in some internal docs that aren't kept up-to-date). It's simpler to add this info to the template instead, which is what new plugin authors are already looking at. Often, we will have new plugin submissions where the person fully followed the template instructions and didn't bother looking anywhere else, so the icon and versions file are missing.

Need this for doc team as well.

### Testing

On branch, shouldn't be published to live site.

@mheap I ran into an issue with this template, caused by single-sourcing. The plugin doc generator actually creates a published/live doc for the template as well, under [/hub/_init/my-extension/](https://deploy-preview-4143--kongdocs.netlify.app/hub/_init/my-extension/). Can we add an ignore rule for the `app/_hub/_init/` directory? If we do that, we can also add a sample `versions.yml` which users can similarly duplicate.