### PR TITLE
Add GCP vault in 2.8.1.3

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -98,6 +98,8 @@ outbounds
 passthrough
 PayPal
 plaintext
+Postgres
+PostgreSQL
 PowerShell
 prepend
 prepends

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -1,4 +1,3 @@
-AgeNet
 Alertmanager
 allowlist
 anonymized

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -109,6 +109,7 @@ Prometheus
 Protobuf
 proxied
 proxying
+querystring
 redis
 reentrant
 referenceable

--- a/app/_data/docs_nav_gateway_2.8.x.yml
+++ b/app/_data/docs_nav_gateway_2.8.x.yml
@@ -130,6 +130,8 @@
                 url: /plan-and-deploy/security/secrets-management/backends/env
               - text: AWS Secrets Manager
                 url: /plan-and-deploy/security/secrets-management/backends/aws-sm
+              - text: GCP Secrets Manager
+                url: /plan-and-deploy/security/secrets-management/backends/gcp-sm
               - text: Hashicorp Vault
                 url: /plan-and-deploy/security/secrets-management/backends/hashicorp-vault
           - text: Reference Format

--- a/app/_hub/kong-inc/vault-auth/0.4.0.md
+++ b/app/_hub/kong-inc/vault-auth/0.4.0.md
@@ -61,7 +61,7 @@ params:
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
 
-        **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+        **Note:** This value must refer to the Consumer `id` attribute that is internal to {{site.base_gateway}}, and **not** its `custom_id`.
     - name: run_on_preflight
       required: true
       default: '`true`'
@@ -146,7 +146,7 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 
 `vault-auth` credentials are defined as a pair of tokens: an `access` token that identifies the owner of the credential, and a `secret` token that is used to authenticate ownership of the `access` token.
 
-Token pairs can be managed either via the Kong Admin API, or independantly via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
+Token pairs can be managed either via the Kong Admin API, or independently via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
 $ curl -X POST http://kong:8001/vaults/{vault}/credentials/{consumer}
@@ -270,7 +270,7 @@ EOF
 
 ## Changelog
 
-### Kong Gateway 2.8.x (plugin version 0.4.0)
+### {{site.base_gateway}} 2.8.x (plugin version 0.4.0)
 
 * The `vaults.vault_token` form field is now marked as
 referenceable, which means it can be securely stored as a
@@ -282,7 +282,7 @@ were labelled as `2.7.x`, `2.1.x`, `1.5.x`, `1.3-x`, `0.36-x`, and `0.35-x`.
 They are now updated to align with the plugin's actual versions, `0.3.0`, `0.2.2`,
 `0.2.1`, `0.2.0`, `0.1.2`, and `0.1.0` respectively.
 
-### Kong Gateway 2.7.x (plugin version 0.3.0)
+### {{site.base_gateway}} 2.7.x (plugin version 0.3.0)
 
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled
 and you are using Vault, the `vaults.vault_token` and `vault_credentials.secret_token` fields will be encrypted.

--- a/app/_hub/kong-inc/vault-auth/0.4.0.md
+++ b/app/_hub/kong-inc/vault-auth/0.4.0.md
@@ -61,7 +61,7 @@ params:
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
 
-        **Note:** This value must refer to the Consumer `id` attribute that is internal to {{site.base_gateway}}, and **not** its `custom_id`.
+        **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/vault-auth/0.4.0.md
+++ b/app/_hub/kong-inc/vault-auth/0.4.0.md
@@ -1,7 +1,7 @@
 ---
 name: Vault Authentication
 publisher: Kong Inc.
-version: 0.4.1
+version: 0.4.0
 desc: Add Vault authentication to your Services
 description: |
   Add authentication to a Service or Route with an access token and secret token. Credential tokens are stored securely via Vault. Credential lifecyles can be managed through the Kong Admin API, or independently via Vault.
@@ -114,7 +114,7 @@ in a vault. References must follow a [specific format](/gateway/latest/plan-and-
 Vault objects can be created via the following HTTP request:
 
 ```bash
-$ curl -X POST http://localhost:8001/vault-auth \
+$ curl -X POST http://localhost:8001/vaults \
   --header 'Content-Type: multipart/form-data' \
   --form name=kong-auth \
   --form mount=kong-auth \
@@ -149,7 +149,7 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 Token pairs can be managed either via the Kong Admin API, or independantly via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/vault-auth/{vault}/credentials/{consumer}
+$ curl -X POST http://kong:8001/vaults/{vault}/credentials/{consumer}
 HTTP/1.1 201 Created
 
 {
@@ -224,7 +224,7 @@ $ curl http://kong:8000/{proxy path} \
 Existing Vault credentials can be removed from the Vault server via the following API:
 
 ```bash
-$ curl -X DELETE http://kong:8001/vault-auth/{vault}/credentials/token/{access token}
+$ curl -X DELETE http://kong:8001/vaults/{vault}/credentials/token/{access token}
 
 HTTP/1.1 204 No Content
 ```
@@ -269,10 +269,6 @@ EOF
 
 
 ## Changelog
-
-### Kong Gateway 2.8.1.3 (plugin version 0.4.1)
-
-* The endpoints of Vault Auth plugin will be moved from `/vaults` to `/vault-auth` with `vaults_use_new_style_api=on` set in `kong.conf`.
 
 ### Kong Gateway 2.8.x (plugin version 0.4.0)
 

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -61,7 +61,7 @@ params:
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
 
-        **Note:** This value must refer to the Consumer `id` attribute that is internal to {{site.base_gateway}}, and **not** its `custom_id`.
+        **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -105,6 +105,9 @@ service, you must add the new consumer to an allowed group. See
 
 ### Create a Vault
 
+{:.note}
+> Vault Auth plugin only works with HashiCorp Vault KV Secrets Engine - Version 1.
+
 A Vault object represents the connection between Kong and a Vault server. It defines the connection and authentication information used to communicate with the Vault API. This allows different instances of the `vault-auth` plugin to communicate with different Vault servers, providing a flexible deployment and consumption model.
 
 Vault objects require setting a `vault_token` attribute. This attribute is _referenceable_, which means it can be securely stored as a

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -61,7 +61,7 @@ params:
       description: |
         An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
 
-        **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+        **Note:** This value must refer to the Consumer `id` attribute that is internal to {{site.base_gateway}}, and **not** its `custom_id`.
     - name: run_on_preflight
       required: true
       default: '`true`'
@@ -146,7 +146,7 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 
 `vault-auth` credentials are defined as a pair of tokens: an `access` token that identifies the owner of the credential, and a `secret` token that is used to authenticate ownership of the `access` token.
 
-Token pairs can be managed either via the Kong Admin API, or independantly via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
+Token pairs can be managed either via the Kong Admin API, or independently via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
 $ curl -X POST http://kong:8001/vault-auth/{vault}/credentials/{consumer}
@@ -270,11 +270,11 @@ EOF
 
 ## Changelog
 
-### Kong Gateway 2.8.1.3 (plugin version 0.4.1)
+### {{site.base_gateway}} 2.8.1.3 (plugin version 0.4.1)
 
 * The endpoints of Vault Auth plugin will be moved from `/vaults` to `/vault-auth` with `vaults_use_new_style_api=on` set in `kong.conf`.
 
-### Kong Gateway 2.8.x (plugin version 0.4.0)
+### {{site.base_gateway}} 2.8.x (plugin version 0.4.0)
 
 * The `vaults.vault_token` form field is now marked as
 referenceable, which means it can be securely stored as a
@@ -286,7 +286,7 @@ were labelled as `2.7.x`, `2.1.x`, `1.5.x`, `1.3-x`, `0.36-x`, and `0.35-x`.
 They are now updated to align with the plugin's actual versions, `0.3.0`, `0.2.2`,
 `0.2.1`, `0.2.0`, `0.1.2`, and `0.1.0` respectively.
 
-### Kong Gateway 2.7.x (plugin version 0.3.0)
+### {{site.base_gateway}} 2.7.x (plugin version 0.3.0)
 
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled
 and you are using Vault, the `vaults.vault_token` and `vault_credentials.secret_token` fields will be encrypted.

--- a/app/_hub/kong-inc/vault-auth/versions.yml
+++ b/app/_hub/kong-inc/vault-auth/versions.yml
@@ -1,3 +1,4 @@
+- release: 0.4.1
 - release: 0.4.0
 - release: 0.3.0
 - release: 0.2.2

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
@@ -22,7 +22,7 @@ refer to respective [vault backend documentation](/gateway/{{page.kong_version}}
 
 You can configure your vault backend with `KONG_VAULT_<vault-backend>_<config_opt>` environment variables.
 
-For example, Kong Gateway might look for an environment variable that matches `KONG_VAULT_ENV_PREFIX`:
+For example, {{site.base_gateway}} might look for an environment variable that matches `KONG_VAULT_ENV_PREFIX`:
 
 ```bash
 export KONG_VAULT_ENV_PREFIX=SECURE_
@@ -52,7 +52,7 @@ For more information, see the section on the [Vaults entity](#vaults-entity).
 ```text
 Usage: kong vault COMMAND [OPTIONS]
 
-Vault utilities for Kong.
+Vault utilities for {{site.base_gateway}}.
 
 Example usage:
  TEST=hello kong vault get env/test

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
@@ -68,7 +68,7 @@ Options:
 ## Vaults Entity
 
 {:.warning}
-> Kong Manager has currently no supports for configuring vault entities.
+> Kong Manager currently doesn't support configuring vault entities.
 
 The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
@@ -1,6 +1,5 @@
 ---
 title: Advanced Secrets Configuration
-beta: true
 ---
 
 
@@ -33,14 +32,11 @@ export KONG_VAULT_ENV_PREFIX=SECURE_
 
 You can configure your vault backend using the `vaults` entity.
 
-For the beta release of this feature, the endpoint is `/vaults-beta`.
-
 ```bash
-http PUT :8001/vaults-beta/my-env-vault \
+http -f PUT :8001/vaults/my-env-vault \
   name=env \
   description="ENV vault for secrets" \
-  config.prefix=SECURE_ \
-  -f
+  config.prefix=SECURE_
 ```
 
 This lets you drop the configuration from environment variables and query arguments and use the entity name in the reference.
@@ -52,9 +48,6 @@ This lets you drop the configuration from environment variables and query argume
 For more information, see the section on the [Vaults entity](#vaults-entity).
 
 ## Vaults CLI
-
-{:.warning}
-> **Beta warning:** In the beta release, only the `kong vault get` command is supported.
 
 ```text
 Usage: kong vault COMMAND [OPTIONS]
@@ -75,10 +68,7 @@ Options:
 ## Vaults Entity
 
 {:.warning}
-> **Beta warning:**
-> <br>
-> The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This will be
-> changed in the future. Kong Manager has currently no supports for configuring vault entities.
+> Kong Manager has currently no supports for configuring vault entities.
 
 The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
 
@@ -88,7 +78,7 @@ Create a Vault entity:
 {% navtab cURL %}
 
 ```bash
-$ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault-1  \
+$ curl -i -X PUT http://<hostname>:8001/vaults/my-env-vault-1  \
         --data name=env \
         --data description='ENV vault for secrets' \
         --data config.prefix=SECRET_
@@ -98,11 +88,10 @@ $ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault-1  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-env-vault-1 \
+http -f PUT :8001/vaults/my-env-vault-1 \
   name=env \
   description="ENV vault for secrets" \
-  config.prefix=SECRET_  \
-  -f
+  config.prefix=SECRET_
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
@@ -78,7 +78,7 @@ Create a Vault entity:
 {% navtab cURL %}
 
 ```bash
-$ curl -i -X PUT http://<hostname>:8001/vaults/my-env-vault-1  \
+$ curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault-1  \
         --data name=env \
         --data description='ENV vault for secrets' \
         --data config.prefix=SECRET_

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -31,7 +31,7 @@ Access these secrets from `my-secret-name` like this:
 
 ```bash
 {vault://aws/my-secret-name/foo}
-{vault://aws/my-secret-name/snap}
+{vault://aws/my-secret-name/snip}
 ```
 
 ## Entity
@@ -82,7 +82,7 @@ environment variable.
 
 ```bash
 {vault://my-aws-sm-vault/my-secret-name/foo}
-{vault://my-aws-sm-vault/my-secret-name/snap}
+{vault://my-aws-sm-vault/my-secret-name/snip}
 ```
 
 ## Advanced Examples
@@ -98,5 +98,5 @@ This lets you source secrets from different regions:
 
 ```bash
 {vault://aws-eu-central-vault/my-secret-name/foo}
-{vault://aws-us-west-vault/my-secret-name/snap}
+{vault://aws-us-west-vault/my-secret-name/snip}
 ```

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -42,7 +42,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults/my-aws-sm-vault  \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-aws-sm-vault  \
   --data name=aws \
   --data description="Storing secrets in AWS Secrets Manager" \
   --data config.region="us-east-1"

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -1,6 +1,5 @@
 ---
 title: AWS Secrets Manager
-beta: true
 badge: enterprise
 ---
 
@@ -43,7 +42,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-aws-sm-vault  \
+curl -i -X PUT http://<hostname>:8001/vaults/my-aws-sm-vault  \
   --data name=aws \
   --data description="Storing secrets in AWS Secrets Manager" \
   --data config.region="us-east-1"
@@ -53,10 +52,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-aws-sm-vault  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-aws-sm-vault name="aws" \
+http -f PUT :8001/vaults/my-aws-sm-vault name="aws" \
   description="Storing secrets in AWS Secrets Manager" \
-  config.region="us-east-1" \
-  -f 
+  config.region="us-east-1"
 ```
 
 {% endnavtab %}
@@ -92,8 +90,8 @@ environment variable.
 You can create multiple entities, which lets you have secrets in different regions:
 
 ```bash
-http PUT :8001/vaults-beta/aws-eu-central-vault name=aws config.region="eu-central-1" -f 
-http PUT :8001/vaults-beta/aws-us-west-vault name=aws config.region="us-west-1" -f 
+http -f PUT :8001/vaults/aws-eu-central-vault name=aws config.region="eu-central-1"
+http -f PUT :8001/vaults/aws-us-west-vault name=aws config.region="us-west-1"
 ```
 
 This lets you source secrets from different regions:

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -5,7 +5,7 @@ badge: enterprise
 
 ## Configuration
 
-[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation only supports
+[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be configured in multiple ways. The current version of {{site.base_gateway}} implementation only supports
 configuring via environment variables.
 
 ```bash

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
@@ -45,7 +45,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults/my-env-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault \
         --data name=env \
         --data description="Store secrets in environment variables"
 ```

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
@@ -1,6 +1,5 @@
 ---
 title: Environment Variables Vault
-beta: true
 badge: free
 ---
 
@@ -46,7 +45,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault \
+curl -i -X PUT http://<hostname>:8001/vaults/my-env-vault \
         --data name=env \
         --data description="Store secrets in environment variables"
 ```
@@ -55,10 +54,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-env-vault \
+http -f PUT :8001/vaults/my-env-vault \
   name="env" \
-  description="Store secrets in environment variables" \
-  -f 
+  description="Store secrets in environment variables"
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/env.md
@@ -1,6 +1,7 @@
 ---
 title: Environment Variables Vault
 badge: free
+content-type: how-to
 ---
 
 ## Configuration
@@ -13,7 +14,7 @@ There is no prior configuration needed.
 Define a secret in a environment variable:
 
 ```bash
-export MY_SECRET_VALUE=opensesame
+export MY_SECRET_VALUE=EXAMPLE_VALUE
 ```
 
 We can now reference this secret

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -1,0 +1,91 @@
+---
+title: GCP Secrets Manager
+beta: true
+badge: enterprise
+---
+
+## Configuration
+
+[GCP Secrets Manager](https://cloud.google.com/secret-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation only supports
+configuring via environment variables.
+
+```bash
+export GCP_SERVICE_ACCOUNT=<service_account>
+```
+
+## Examples
+
+For example, let's use an GCP Secrets Manager Secret with the name `my-secret-name`.
+
+In this object, you have multiple key=value pairs.
+
+```json
+{
+  "foo": "bar",
+  "snip": "snap",
+}
+```
+
+Access these secrets from `my-secret-name` like this:
+
+```bash
+{vault://gcp/my-secret-name/foo}
+{vault://gcp/my-secret-name/snap}
+```
+
+## Entity
+
+The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X PUT http://<hostname>:8001/vaults-beta/my-gcp-sm-vault  \
+  --data name=gcp \
+  --data description="Storing secrets in GCP Secrets Manager" \
+  --data config.project_id="my_project_id"
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http PUT :8001/vaults-beta/my-gco-sm-vault name="gcp" \
+  description="Storing secrets in GCP Secrets Manager" \
+  config.region="my_project_id" \
+  -f 
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+```json
+
+{
+    "config": {
+        "project_id": "project-last-hope"
+    },
+    "created_at": 1657874961,
+    "description": "Storing secrets in GCP Secrets Manager",
+    "id": "90e200be-cf84-4ce9-a1d6-a41c75c79f31",
+    "name": "gcp",
+    "prefix": "my-gcp-sm-vault",
+    "tags": null,
+    "updated_at": 1657874961
+}
+```
+
+With the Vault entity in place, you can now reference the secrets. This allows you to drop the `KONG_VAULT_GCP_PROJECT_ID`
+environment variable.
+
+```bash
+{vault://my-gcp-sm-vault/my-secret-name/foo}
+{vault://my-gcp-sm-vault/my-secret-name/snap}
+```
+
+## Advanced Examples
+
+## TODO : Add WI details

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -6,22 +6,22 @@ badge: enterprise
 
 ## Configuration
 
-[GCP Secrets Manager](https://cloud.google.com/secret-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation supports
+[GCP Secrets Manager](https://cloud.google.com/secret-manager/) can be configured in multiple ways. The current version of {{site.base_gateway}}'s implementation supports
 configuring via environment variables. 
 
 ```bash
-export GCP_SERVICE_ACCOUNT=<service_account>
+export GCP_SERVICE_ACCOUNT=SERVICE_ACCOUNT
 ```
 
 {:.note}
-> **Note**: This vault also works with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on your GKE clusters. 
-> For that the service account should be attached to pod,
-> above environment variable ie. `GCP_SERVICE_ACCOUNT` does need in that case.
+> **Note**: The GCP Secrets Manager vault also works with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on your GKE clusters. 
+> To use that, the service account should be attached to the pod,
+> above the environment variable. `GCP_SERVICE_ACCOUNT` is not needed in this case. 
 
 
 ## Examples
 
-For example, let's use an GCP Secrets Manager Secret with the name `my-secret-name`.
+To use a GCP Secret manager secret with the name `my-secret-name`.
 
 In this object, you have multiple key=value pairs.
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -6,12 +6,18 @@ badge: enterprise
 
 ## Configuration
 
-[GCP Secrets Manager](https://cloud.google.com/secret-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation only supports
-configuring via environment variables.
+[GCP Secrets Manager](https://cloud.google.com/secret-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation supports
+configuring via environment variables. 
 
 ```bash
 export GCP_SERVICE_ACCOUNT=<service_account>
 ```
+
+{:.note}
+> **Note**: This vault also works with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on your GKE clusters. 
+> For that the service account should be attached to pod,
+> above environment variable ie. `GCP_SERVICE_ACCOUNT` does need in that case.
+
 
 ## Examples
 
@@ -85,7 +91,3 @@ environment variable.
 {vault://my-gcp-sm-vault/my-secret-name/foo}
 {vault://my-gcp-sm-vault/my-secret-name/snap}
 ```
-
-## Advanced Examples
-
-## TODO : Add WI details

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -1,6 +1,7 @@
 ---
 title: GCP Secrets Manager
 badge: enterprise
+content-type: how-to
 ---
 
 ## Configuration

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -13,7 +13,7 @@ ways:
 * Environment variables
 * Workload Identity
 
-To configure GCP secrets manager, the `GCP_SERVICE_ACCOUNT`
+To configure GCP Secrets Manager, the `GCP_SERVICE_ACCOUNT`
 environment variable must be set to the JSON document referring to the
 [credentials for your service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys):
 
@@ -21,18 +21,18 @@ environment variable must be set to the JSON document referring to the
 export GCP_SERVICE_ACCOUNT=$(cat gcp-my-project-c61f2411f321.json)
 ```
 
-{{site.base_gateway}} will use the key to automatically authenticate
+{{site.base_gateway}} uses the key to automatically authenticate
 with the GCP API and grant you access.
 
 To use GCP Secrets Manager with
 [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
 on a GKE cluster, update your pod spec so that the service account is
-attached to the pod. For configuration information, read the Workload
+attached to the pod. For configuration information, read the [Workload
 Identity configuration
-[documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
+documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
 
 {:.note}
-> With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` is not necessary.
+> With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
 
 ## Examples
 
@@ -60,14 +60,14 @@ Note that both the provider (`gcp`) as well as the GCP project ID
 
 ## Entity
 
-Once the database has been initialized, a Vault entity can be created
+Once the database is initialized, a Vault entity can be created
 that encapsulates the provider and the GCP project ID:
 
 {% navtabs codeblock %}
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults/my-gcp-sm-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
   --data name=gcp \
   --data description="Storing secrets in GCP Secrets Manager" \
   --data config.project_id="my_project_id"
@@ -77,7 +77,7 @@ curl -i -X PUT http://<hostname>:8001/vaults/my-gcp-sm-vault \
 {% navtab HTTPie %}
 
 ```bash
-http -f PUT http://<hostname>:8001/vaults/my-gcp-sm-vault \
+http -f PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
   name="gcp" \
   description="Storing secrets in GCP Secrets Manager" \
   config.project_id="my_project_id"
@@ -112,5 +112,4 @@ through it:
 {vault://my-gcp-sm-vault/my-secret-name/snip}
 ```
 
-When using the Vault entity, the GCP project ID no longer needs to be
-specified to access the secrets.
+When you use the Vault entity, you no longer need to specify the GCP project ID to access the secrets.

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -49,7 +49,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-gcp-sm-vault  \
+curl -i -X PUT http://HOSTNAME:8001/vaultsa/my-gcp-sm-vault  \
   --data name=gcp \
   --data description="Storing secrets in GCP Secrets Manager" \
   --data config.project_id="my_project_id"
@@ -59,9 +59,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-gcp-sm-vault  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-gco-sm-vault name="gcp" \
+http PUT :8001/vaults-beta/my-gcp-sm-vault name="gcp" \
   description="Storing secrets in GCP Secrets Manager" \
-  config.region="my_project_id" \
+  config.project_id="my_project_id" \
   -f 
 ```
 
@@ -93,3 +93,4 @@ environment variable.
 {vault://my-gcp-sm-vault/my-secret-name/foo}
 {vault://my-gcp-sm-vault/my-secret-name/snap}
 ```
+

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -5,25 +5,27 @@ badge: enterprise
 ---
 
 ## Configuration
+The current version of {{site.base_gateway}}'s implementation supports configuring [GCP Secrets Manager](https://cloud.google.com/secret-manager/) in two ways: 
 
-[GCP Secrets Manager](https://cloud.google.com/secret-manager/) can be configured in multiple ways. The current version of {{site.base_gateway}}'s implementation supports
-configuring via environment variables. 
+* Environment variables
+* Workload Identity 
+
+To configure using environment export the GCP service account variable: 
 
 ```bash
 export GCP_SERVICE_ACCOUNT=SERVICE_ACCOUNT
 ```
+{{site.base_gateway}} will automatically authenticate with the GCP API and grant you access. 
+
+To use GCP Secrets Manager with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on a GKE cluster, update your pod spec so that the service account is attached to the pod. For configuration information, read the Workload Identity configuration [documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
 
 {:.note}
-> **Note**: The GCP Secrets Manager vault also works with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on your GKE clusters. 
-> To use that, the service account should be attached to the pod,
-> above the environment variable. `GCP_SERVICE_ACCOUNT` is not needed in this case. 
-
+> With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` is not necessary. 
 
 ## Examples
 
-To use a GCP Secret manager secret with the name `my-secret-name`.
+To use a GCP Secret Manager [secret](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets) with the name `my-secret-name`. Create a JSON object in GCP that contains multiple key:value pairs:
 
-In this object, you have multiple key=value pairs.
 
 ```json
 {
@@ -32,7 +34,7 @@ In this object, you have multiple key=value pairs.
 }
 ```
 
-Access these secrets from `my-secret-name` like this:
+You can now reference the secret's individual resources like this: 
 
 ```bash
 {vault://gcp/my-secret-name/foo}
@@ -41,7 +43,7 @@ Access these secrets from `my-secret-name` like this:
 
 ## Entity
 
-The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
+The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity. You will need to provide {{site.base_gateway}} with the GCP Secrets Manager `project_id` in the request: 
 
 {% navtabs codeblock %}
 {% navtab cURL %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -90,7 +90,6 @@ http -f PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
 Result:
 
 ```json
-
 {
     "config": {
         "project_id": "my_project_id"

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/gcp-sm.md
@@ -112,5 +112,5 @@ through it:
 {vault://my-gcp-sm-vault/my-secret-name/snip}
 ```
 
-The `GCP_PROJECT_ID` environment variable is no longer needed once the
-Vault entity has been created.
+When using the Vault entity, the GCP project ID no longer needs to be
+specified to access the secrets.

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
@@ -29,7 +29,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-hashicorp-vault \
+curl -i -X PUT http://<hostname>:8001/vaults/my-hashicorp-vault \
   --data name="hcv" \
   --data description="Storing secrets in Hashicorp Vault" \
   --data config.protocol="https" \
@@ -44,7 +44,7 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-hashicorp-vault \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-hashicorp-vault \
+http -f PUT :8001/vaults/my-hashicorp-vault \
   name="hcv" \
   description="Storing secrets in Hashicorp Vault" \
   config.protocol="https" \
@@ -52,8 +52,7 @@ http PUT :8001/vaults-beta/my-hashicorp-vault \
   config.port="8200" \
   config.mount="secret" \
   config.kv="v2" \
-  config.token="<mytoken>" \
-  -f 
+  config.token="<mytoken>"
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
@@ -29,7 +29,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults/my-hashicorp-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-hashicorp-vault \
   --data name="hcv" \
   --data description="Storing secrets in Hashicorp Vault" \
   --data config.protocol="https" \

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
@@ -11,5 +11,5 @@ The following Vault implementations are supported:
 |------------------------------------------------------------------------------------------------------------------------|------------------------------|------------------------------|------------|
 | [AWS Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/aws-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
 | [GCP Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/gcp-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
-| [Hashicorp Vault](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [HashiCorp Vault](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
 | [Environment Variable](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/env)        |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Free       |

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
@@ -10,5 +10,6 @@ The following Vault implementations are supported:
 |                                                                                                                        | Rotation Support             | Get                          | Tier       |
 |------------------------------------------------------------------------------------------------------------------------|------------------------------|------------------------------|------------|
 | [AWS Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/aws-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [GCP Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/gcp-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
 | [Hashicorp Vault](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
 | [Environment Variable](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/env)        |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Free       |

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/index.md
@@ -1,9 +1,6 @@
 ---
 title: Supported Vault Backends
-beta: true
 ---
-
-Secrets rotation is not supported for the beta version.
 
 The following Vault implementations are supported:
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -12,6 +12,8 @@ installation more secure.
 > This feature isn't enabled by default in this version of {{site.base_gateway}}.
 ><br>
 > Start {{site.base_gateway}} with `KONG_VAULTS=bundled KONG_VAULTS_USE_NEW_STYLE_API=on`.
+><br>
+> When running in Hybrid or DBLess mode, Secrets Management is only supported in {{site.base_gateway}} version 2.8.1.3 and greater.
 
 The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -3,7 +3,7 @@ title: Get Started with Secrets Management
 ---
 
 Secrets are generally confidential values that should not appear in plain text in the application. There are several products that help you
-store, retrieve, and rotate these secrets securely. Kong Gateway offers a mechanism to set up references to these secrets which makes your Kong Gateway
+store, retrieve, and rotate these secrets securely. {{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your Kong Gateway
 installation more secure.
 
 ## Getting started
@@ -27,7 +27,7 @@ Define your environment variable and assign a secret value to it:
 export MY_SECRET_POSTGRES_PASSWORD="opensesame"
 ```
 
-Next, set up a `reference` to this environment variable so that Kong Gateway can find this secret. We use a Uniform Resource Locator (URL) format for this.
+Next, set up a `reference` to this environment variable so that {{site.base_gateway}} can find this secret. We use a Uniform Resource Locator (URL) format for this.
 
 In this case, the reference would look like this:
 
@@ -61,7 +61,7 @@ the kong.conf has a key called "pg_password". Replace the original value with
 pg_password={vault://env/my-secret-postgres-password}
 ```
 
-Upon startup, Kong will try to detect and transparently resolve references.
+Upon startup, {{site.base_gateway}} will try to detect and transparently resolve references.
 
 {:.note}
 >For quick debug/testing you can use the new [CLI for vaults](/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli)

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -1,10 +1,6 @@
 ---
 title: Get Started with Secrets Management
-beta: true
 ---
-
-This feature is currently in beta state and isn't fully supported. APIs are subject to change.
-
 
 Secrets are generally confidential values that should not appear in plain text in the application. There are several products that help you
 store, retrieve, and rotate these secrets securely. Kong Gateway offers a mechanism to set up references to these secrets which makes your Kong Gateway
@@ -13,9 +9,9 @@ installation more secure.
 ## Getting started
 
 {:.note}
-> This feature isn't enabled by default in this version of Kong.
+> This feature isn't enabled by default in this version of {{site.base_gateway}}.
 ><br>
-> Start Kong Gateway with `KONG_VAULTS=bundled`.
+> Start {{site.base_gateway}} with `KONG_VAULTS=bundled KONG_VAULTS_USE_NEW_STYLE_API=on`.
 
 The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -13,7 +13,7 @@ installation more secure.
 ><br>
 > Start {{site.base_gateway}} with `KONG_VAULTS=bundled KONG_VAULTS_USE_NEW_STYLE_API=on`.
 ><br>
-> When running in Hybrid or DBLess mode, Secrets Management is only supported in {{site.base_gateway}} version 2.8.1.3 and greater.
+> When running {{site.base_gateway}} in hybrid or DB-less mode, secrets management is only supported in {{site.base_gateway}} 2.8.1.3 or later.
 
 The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -3,7 +3,7 @@ title: Get Started with Secrets Management
 ---
 
 Secrets are generally confidential values that should not appear in plain text in the application. There are several products that help you
-store, retrieve, and rotate these secrets securely. {{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your Kong Gateway
+store, retrieve, and rotate these secrets securely. {{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your {{site.base_gateway}}
 installation more secure.
 
 ## Getting started

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -10,7 +10,7 @@ with APIs serviced by the gateway.
 
 Some of the most common types of secrets used by {{site.base_gateway}} include:
 
-* Datastore usernames and passwords, used with PostgreSQL and Redis
+* Data store usernames and passwords, used with PostgreSQL and Redis
 * Private X.509 certificates
 * API keys
 * Sensitive plugin configuration fields, generally used for authentication
@@ -52,7 +52,7 @@ documentation for each plugin to identify the referenceable fields:
 * Environment variables
 * AWS Secrets Manager
 * GCP Secrets Manager
-* Hashicorp Vault
+* HashiCorp Vault
 
 See the [backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
 for more information about each option.

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -1,6 +1,5 @@
 ---
 title: Secrets Management
-beta: true
 ---
 
 A secret is any sensitive piece of information required for API gateway
@@ -57,24 +56,22 @@ documentation for each plugin to identify the referenceable fields:
 See the [backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
 for more information about each option.
 
-## Beta limitations
+## Notes on the GA release of the Secrets Management feature
 
-This feature is currently in beta. This means it has limited support from
-Kong and the functionality may change in the future.
+With the GA release of the Secrets Management feature in
+{{site.base_gateway}}, the endpoints for secrets management in the
+Admin API have been moved from the previous `/vaults-beta` prefix to
+`/vaults`.
 
-**Do not** implement this feature in a product environment.
-
-* The beta of this feature only supports `get`. There is no `set` or secrets
-rotation support in the beta.
-* In this version, this feature isn't enabled by default. To test it out, start
-{{site.base_gateway}} with `KONG_VAULTS=bundled` if running Kong in a container,
-or with `vaults=bundled` set in `kong.conf`.
-* The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This
-endpoint will change once the beta is over.
+In this version, this feature isn't enabled by default due to
+conflicts with previous releases of {{site.base_gateway}}.  To enable
+it, start {{site.base_gateway}} with `KONG_VAULTS=bundled
+KONG_VAULTS_USE_NEW_STYLE_API=on` if running Kong in a container, or with
+`vaults=bundled` and `vaults_use_new_style_api=on`set in `kong.conf`.
 
 ## Get started
 
-To test out secrets management, see the following topics:
+For further information on secrets management, see the following topics:
 * [Get started with secrets management](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/getting-started/)
 * [Backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
 * [Reference format](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/reference-format/)

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -51,6 +51,7 @@ documentation for each plugin to identify the referenceable fields:
 {{site.base_gateway}} supports the following vault backends:
 * Environment variables
 * AWS Secrets Manager
+* GCP Secrets Manager
 * Hashicorp Vault
 
 See the [backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -58,16 +58,12 @@ for more information about each option.
 
 ## Notes on the GA release of the Secrets Management feature
 
-With the GA release of the Secrets Management feature in
-{{site.base_gateway}}, the endpoints for secrets management in the
-Admin API have been moved from the previous `/vaults-beta` prefix to
-`/vaults`.
-
-In this version, this feature isn't enabled by default due to
-conflicts with previous releases of {{site.base_gateway}}.  To enable
-it, start {{site.base_gateway}} with `KONG_VAULTS=bundled
-KONG_VAULTS_USE_NEW_STYLE_API=on` if running Kong in a container, or with
-`vaults=bundled` and `vaults_use_new_style_api=on`set in `kong.conf`.
+In the GA release of the Secrets Management feature in
+{{site.base_gateway}}, this feature is enabled by default.
+Due to conflicts with previous releases of {{site.base_gateway}},
+the endpoints for secrets management in the
+Admin API will be moved from the previous `/vaults-beta` prefix to
+`/vaults` with `vaults_use_new_style_api=on` set in `kong.conf`.
 
 ## Get started
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
@@ -48,7 +48,7 @@ or using a vault entity
 
 #### Secret ID
 
-The `secret-id` is used as an identifier in case the vault uses a nested datasructure.
+The `secret-id` is used as an identifier in case the vault uses a nested datastructure.
 
 #### Secret Key
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
@@ -1,6 +1,5 @@
 ---
 title: Reference Format
-beta: true
 ---
 
 ## Reference Format

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
@@ -48,7 +48,8 @@ or using a vault entity
 
 #### Secret ID
 
-The `secret-id` is used as an identifier in case the vault uses a nested datastructure.
+The `secret-id` is used as an identifier in case the vault uses a
+nested data structure.
 
 #### Secret Key
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/reference-format.md
@@ -48,7 +48,7 @@ or using a vault entity
 
 #### Secret ID
 
-The `secret-id` is used as an identifier in case the vault uses a nested datastructure.
+The `secret-id` is used as an identifier in case the vault uses a nested datasructure.
 
 #### Secret Key
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Added documentation for GCP Vault to Secret Management section in Kong Gateway 

### Reason
[FTI-4100](https://konghq.atlassian.net/browse/FTI-4100). In discussion with the product engineering team to ship this feature as part of gateway release v2.8.1.3. 

Slack discussion: https://kongstrong.slack.com/archives/C0223LNEQCB/p1658393569090289?thread_ts=1658213496.854579&cid=C0223LNEQCB

### Testing
Minor document update.

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
