### PR TITLE
Fix response typo in request-transformer page

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -107,6 +107,7 @@ Prometheus
 Protobuf
 proxied
 proxying
+querystring
 redis
 reentrant
 referenceable
@@ -116,6 +117,7 @@ runtime
 runtimes
 deduplication
 deduplicate
+sandboxed
 sandboxing
 serializer
 serverless

--- a/app/_hub/kong-inc/request-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/_index.md
@@ -202,10 +202,10 @@ params:
 
 ## Template as Value
 
-You can use any of the the current request headers, query params, and captured
+You can use any of the the current request headers, query parameters, and captured
 URI groups as templates to populate supported config fields.
 
-| Request Param | Template
+| Request Parameter | Template
 | ------------- | -----------
 | header        | `$(headers.<header-name>)` or `$(headers["<header-name>"])`)
 | querystring   | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`)
@@ -220,8 +220,8 @@ $('$(something_that_needs_to_escaped)')
 
 {:.note}
 > **Note**: The plugin creates a non-mutable table of request headers,
-querystrings, and captured URIs before transformation. So any update or removal
- of params used in the template does not affect the rendered value of template.
+query strings, and captured URIs before transformation. So any update or removal
+ of parameters used in the template does not affect the rendered value of template.
 
 ### Advanced templates
 
@@ -353,7 +353,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 | --------- | -----------
 | h1: v1 | h1: v1, h2: v1
 
-Add a querystring and a header:
+Add a query string and a header:
 
 ```bash
 curl -X POST http://localhost:8001/services/mockbin/plugins \
@@ -368,7 +368,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 | h1: v1 | h1: v1, h2: v1
 | h3: v1 | h1: v1, h2: v1, h3: v1
 
-| Incoming Request Querystring | Upstream Proxied Querystring
+| Incoming Request Query String | Upstream Proxied Query String
 | --------- | -----------
 | ?q1=v1 | ?q1=v1&q2=v1
 |        | ?q1=v2&q2=v1
@@ -391,7 +391,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 | p1=v1&p2=v1 | p2=v1
 | p2=v1 | p2=v1
 
-Add multiple headers and querystring parameters if not already set:
+Add multiple headers and query string parameters if not already set:
 
 ```bash
 curl -X POST http://localhost:8001/services/mockbin/plugins \
@@ -405,7 +405,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 | h1: v1 | h1: v1, h2: v1
 | h3: v1 |  h1: v1, h2: v1, h3: v1
 
-| Incoming Request Querystring | Upstream Proxied Querystring
+| Incoming Request Query String | Upstream Proxied Query String
 | --------- | -----------
 | ?q1=v1 | ?q1=v1&q2=v1
 |        | ?q1=v2&q2=v1

--- a/app/_hub/kong-inc/request-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/_index.md
@@ -306,7 +306,7 @@ Now send a request with a user id in the route path:
 curl -i -X GET localhost:8000/requests/user/foo
 ```
 
-You should notice in the reponse that the `x-user-id` header has been added with a value of `foo`.
+You should notice in the response that the `x-user-id` header has been added with a value of `foo`.
 
 ## Order of Execution
 

--- a/app/_hub/kong-inc/request-transformer/_index.md
+++ b/app/_hub/kong-inc/request-transformer/_index.md
@@ -290,7 +290,7 @@ Now send a request with a user id in the route path:
 curl -i -X GET localhost:8000/requests/user/foo
 ```
 
-You should notice in the reponse that the `x-user-id` header has been added with a value of `foo`.
+You should notice in the response that the `x-user-id` header has been added with a value of `foo`.
 
 ## Order of execution
 

--- a/app/_hub/kong-inc/request-transformer/_index.md
+++ b/app/_hub/kong-inc/request-transformer/_index.md
@@ -186,10 +186,10 @@ params:
 
 ## Template as a Value
 
-You can use any of the current request headers, query params, and captured URI
+You can use any of the current request headers, query parameters, and captured URI
 groups as templates to populate supported configuration fields.
 
-| Request Param | Template
+| Request Parameter | Template
 | ------------- | -----------
 | header        | `$(headers.<header_name>)`, `$(headers["<Header-Name>"])` or `$(headers["<header-name>"])`)
 | querystring   | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`)
@@ -203,8 +203,8 @@ $('$(something_that_needs_to_escaped)')
 ```
 
 {:.note}
-> **Note:** The plugin creates a non-mutable table of request headers, querystrings, and captured URIs
-before transformation. Therefore, any update or removal of params used in a template
+> **Note:** The plugin creates a non-mutable table of request headers, query strings, and captured URIs
+before transformation. Therefore, any update or removal of parameters used in a template
 does not affect the rendered value of a template.
 
 ### Advanced templates


### PR DESCRIPTION
### Summary
This PR fixes a typo in the `request-transformer` documentation page.
- https://docs.konghq.com/hub/kong-inc/request-transformer/

![image](https://user-images.githubusercontent.com/8079021/182031343-e41a4789-72a8-4c93-85d8-ed694f56d872.png)
