### PR TITLE
kong.cache function parameters precision

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -31,6 +31,8 @@ declaratively
 degraphql
 denylist
 deployer
+deserialize
+deserialized
 dev
 etcd
 Fargate
@@ -50,6 +52,8 @@ HTTPie
 https
 inbounds
 ini
+invalidation
+invalidations
 io
 iptables
 Istio
@@ -73,6 +77,8 @@ kumactl
 kustomization
 Kustomize
 Loggly
+lookup
+lookups
 loopback
 lua
 Luarocks
@@ -119,6 +125,7 @@ deduplication
 deduplicate
 sandboxed
 sandboxing
+schema's
 serializer
 serverless
 snis
@@ -158,6 +165,7 @@ uuid
 Valero
 validator
 validators
+vararg
 websocket
 websockets
 wireframe

--- a/app/gateway/2.8.x/plugin-development/entities-cache.md
+++ b/app/gateway/2.8.x/plugin-development/entities-cache.md
@@ -64,7 +64,7 @@ This module exposes the following functions:
 
 Function name                                 | Description
 ----------------------------------------------|---------------------------
-`value, err = cache:get(key, opts?, cb, ...)` | Retrieves the value from the cache. If the cache does not have value (miss), invokes `cb` in protected mode. `cb` must return one (and only one) value that will be cached. It *can* throw errors, as those will be caught and properly logged by Kong, at the `ngx.ERR` level. This function **does** cache negative results (`nil`). As such, one must rely on its second argument `err` when checking for errors.
+`value, err = cache:get(key, opts?, cb, ...)` | Retrieves the value from the cache. If the cache does not have value (miss), invokes `cb` in protected mode. `cb` must return one (and only one) value that will be cached. It *can* throw errors, as those will be caught and properly logged by Kong, at the `ngx.ERR` level. This function **does** cache negative results (`nil`). As such, one must rely on its second argument `err` when checking for errors. `...` being the vararg to pass to the `cb` function.
 `ttl, err, value = cache:probe(key)`          | Checks if a value is cached. If it is, returns its remaining ttl. It not, returns `nil`. The value being cached can also be a negative caching. The third return value is the value being cached itself.
 `cache:invalidate_local(key)`                 | Evicts a value from the node's cache.
 `cache:invalidate(key)`                       | Evicts a value from the node's cache **and** propagates the eviction events to all other nodes in the cluster.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Adding explicit definition of `...` parameter in of the `kong.cache` function.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Reading at the `kong` code i was a bit confused on the use of `kong.cache`. I'd have prefer to have to kind of precision to help me developing my own plugin.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
