### PR TITLE
fix(portal) remove examples of portal_gui_host with a path

### DIFF
--- a/app/enterprise/2.1.x/property-reference.md
+++ b/app/enterprise/2.1.x/property-reference.md
@@ -2238,7 +2238,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/enterprise/2.1.x/property-reference.md
+++ b/app/enterprise/2.1.x/property-reference.md
@@ -6,7 +6,7 @@
 #
 title: Configuration Property Reference for Kong Enterprise
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/enterprise/2.2.x/property-reference.md
+++ b/app/enterprise/2.2.x/property-reference.md
@@ -6,7 +6,7 @@
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/enterprise/2.2.x/property-reference.md
+++ b/app/enterprise/2.2.x/property-reference.md
@@ -2258,7 +2258,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/enterprise/2.3.x/property-reference.md
+++ b/app/enterprise/2.3.x/property-reference.md
@@ -6,7 +6,7 @@
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/enterprise/2.3.x/property-reference.md
+++ b/app/enterprise/2.3.x/property-reference.md
@@ -833,7 +833,7 @@ Some suffixes can be specified for each pair:
   necessary to raise `net.core.somaxconn` at the same time to match or exceed
   the `backlog` number set.
 
-  
+
 **Note:** The `ssl` suffix is not supported, and each address/port will accept
 TCP with or without TLS enabled.
 
@@ -2168,7 +2168,7 @@ Sets text for Kong Manager Header Banner. Header Banner is not shown if this con
 
 #### admin_gui_header_bg_color
 
-Kong Manager Header Background Color 
+Kong Manager Header Background Color
 Sets background color for Kong Manager Header Banner.
 Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager.
 
@@ -2410,7 +2410,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/enterprise/2.4.x/property-reference.md
+++ b/app/enterprise/2.4.x/property-reference.md
@@ -2503,7 +2503,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/enterprise/2.4.x/property-reference.md
+++ b/app/enterprise/2.4.x/property-reference.md
@@ -6,7 +6,7 @@
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/enterprise/2.5.x/property-reference.md
+++ b/app/enterprise/2.5.x/property-reference.md
@@ -2540,7 +2540,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/enterprise/2.5.x/property-reference.md
+++ b/app/enterprise/2.5.x/property-reference.md
@@ -6,7 +6,7 @@
 #
 title: Configuration Reference for Kong Gateway (Enterprise)
 ---
-
+<!-- vale off -->
 ## Configuration loading
 
 Kong comes with a default configuration file that can be found at

--- a/app/gateway/2.6.x/reference/configuration.md
+++ b/app/gateway/2.6.x/reference/configuration.md
@@ -722,7 +722,7 @@ If `cluster_mtls` is set to `shared`, this setting is ignored and
 **Default:** none
 
 ---
-
+<!-- vale off -->
 #### cluster_control_plane
 
 To be used by data plane nodes only: address of the control plane node from

--- a/app/gateway/2.6.x/reference/configuration.md
+++ b/app/gateway/2.6.x/reference/configuration.md
@@ -97,7 +97,7 @@ Nginx directives to this file directly via your Kong configuration.
 
 ### Injecting individual Nginx directives
 
-Any entry added to your `kong.conf` file that is prefixed by the following 
+Any entry added to your `kong.conf` file that is prefixed by the following
 supported namespaces will be converted into an equivalent Nginx
 directive by removing the prefix and added to the appropriate section of the
 Nginx configuration:
@@ -2626,7 +2626,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -97,7 +97,7 @@ Nginx directives to this file directly via your Kong configuration.
 
 ### Injecting individual Nginx directives
 
-Any entry added to your `kong.conf` file that is prefixed by the following 
+Any entry added to your `kong.conf` file that is prefixed by the following
 supported namespaces will be converted into an equivalent Nginx
 directive by removing the prefix and added to the appropriate section of the
 Nginx configuration:
@@ -2698,7 +2698,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/gateway/2.7.x/reference/configuration.md
+++ b/app/gateway/2.7.x/reference/configuration.md
@@ -746,7 +746,7 @@ which configuration updates will be fetched, in `host:port` format.
 **Default:** none
 
 ---
-
+<!-- vale off -->
 #### cluster_telemetry_endpoint
 {:.badge .enterprise}
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -97,7 +97,7 @@ Nginx directives to this file directly via your Kong configuration.
 
 ### Injecting individual Nginx directives
 
-Any entry added to your `kong.conf` file that is prefixed by the following 
+Any entry added to your `kong.conf` file that is prefixed by the following
 supported namespaces will be converted into an equivalent Nginx
 directive by removing the prefix and added to the appropriate section of the
 Nginx configuration:
@@ -2711,7 +2711,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 


### PR DESCRIPTION
### Summary
Removes examples of adding a path when configuring `portal_gui_host`

### Reason
Adding a path to `portal_gui_host` is not supported

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
