### PR TITLE
[DOCU-2418] Kong.conf config 

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -138,6 +138,8 @@ items:
             url: /kong-production/networking/network
       - text: Kong Configuration File
         url: /kong-production/kong-conf
+      - text: Configuration Environment Variables
+        url: /kong-production/environment-variables
       - text: Embedding Kong in Open Resty
         url: /kong-production/kong-openresty
       - text: Serving a website and API's from Kong

--- a/src/gateway/kong-production/environment-variables.md
+++ b/src/gateway/kong-production/environment-variables.md
@@ -5,7 +5,7 @@ content-type: how-to
 
 ## Environment variables
 
-Kong can be fully configured with environment variables. When loading properties from `kong.conf`, Kong will check existing
+{{site.base_gateway}} can be fully configured with environment variables. When loading properties from `kong.conf`, {{site.base_gateway}} will check existing
 environment variables. 
 
 To override a setting using an environment variable, declare an environment

--- a/src/gateway/kong-production/environment-variables.md
+++ b/src/gateway/kong-production/environment-variables.md
@@ -1,0 +1,24 @@
+---
+title: Kong Configuration Environment Variables
+content-type: how-to
+---
+
+## Environment variables
+
+Kong can be fully configured with environment variables. When loading properties from `kong.conf`, Kong will check existing
+environment variables. 
+
+To override a setting using an environment variable, declare an environment
+variable with the name of the setting, prefixed with `KONG_`.
+
+To override the `log_level` parameter:
+
+```
+log_level = debug # in kong.conf
+```
+
+set `KONG_LOG_LEVEL` as an environment variable:
+
+```bash
+export KONG_LOG_LEVEL=error
+```

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -47,7 +47,7 @@ Boolean values can be specified as `on`/`off` or `true`/`false`:
 ```
 
 {:.note}
-> Kong will use the default settings for any value in `kong.conf` that is commented out.
+> {{site.base_gateway}} will use the default settings for any value in `kong.conf` that is commented out.
 
 ## Verify configuration
 To verify that your configuration is usable, use the `check` command. The `check` command will evaluate the [environment variables](/gateway/latest/kong-production/environment-variables) you have
@@ -81,7 +81,7 @@ kong start --conf /path/to/kong.conf
 
 ### Debug mode
 
-You can use the [Kong CLI](/gateway/latest/reference/cli/) in debug-mode to output configuration properties in the shell:
+You can use the [{{site.base_gateway}} CLI](/gateway/latest/reference/cli/) in debug-mode to output configuration properties in the shell:
 
 ```bash
 kong start -c /etc/kong.conf --vv

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -4,8 +4,8 @@ content-type: how-to
 ---
 
 
-Kong comes with a default configuration file `kong.conf`. If you installed Kong using an official package, this file can be found at:
-`/etc/kong/kong.conf.default`. The Kong configuration file is a YAML file that can be used to configure individual properties of your Kong instance. This guide will explain how to configure Kong using the `kong.conf` file.
+{{site.base_gateway}} comes with a default configuration file `kong.conf`. If you installed {{site.base_gateway}} using an official package, this file can be found at:
+`/etc/kong/kong.conf.default`. The {{site.base_gateway}} configuration file is a YAML file that can be used to configure individual properties of your Kong instance. This guide will explain how to configure {{site.base_gateway}} using the `kong.conf` file.
 
 
 ## Configure Kong

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -64,7 +64,7 @@ configuration at /etc/kong/kong.conf is valid
 
 ## Set custom path
 
-By default, Kong looks for `kong.conf` in two
+By default, {{site.base_gateway}} looks for `kong.conf` in two
 default locations:
 
 ```

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -1,6 +1,95 @@
 ---
-title: Kong Configuration File 
-
+title: Kong Configuration File
+content-type: how-to
 ---
 
-## PLACEHOLDER kong.conf config file
+
+Kong comes with a default configuration file `kong.conf`. If you installed Kong using an official package, this file can be found at:
+`/etc/kong/kong.conf.default`. The Kong configuration file is a YAML file that can be used to configure individual properties of your Kong instance. This guide will explain how to configure Kong using the `kong.conf` file.
+
+
+## Configure Kong
+
+To configure Kong, make a copy of the default configuration file: 
+
+```bash
+cp /etc/kong/kong.conf.default /etc/kong/kong.conf
+```
+
+The file contains configuration properties and documentation: 
+
+```bash
+#upstream_keepalive_pool_size = 60  # Sets the default size of the upstream
+                                    # keepalive connection pools.
+                                    # Upstream keepalive connection pools
+                                    # are segmented by the `dst ip/dst
+                                    # port/SNI` attributes of a connection.
+                                    # A value of `0` will disable upstream
+                                    # keepalive connections by default, forcing
+                                    # each upstream request to open a new
+                                    # connection.
+```
+
+To configure a property, uncomment it and modify the value:
+
+```bash
+upstream_keepalive_pool_size = 40
+```
+
+Boolean values can be specified as `on`/`off` or `true`/`false`:
+
+```bash
+#dns_no_sync = off               # If enabled, then upon a cache-miss every
+                                 # request will trigger its own dns query.
+                                 # When disabled multiple requests for the
+                                 # same name/type will be synchronised to a
+                                 # single query.
+```
+
+{:.note}
+> Kong will use the default settings for any value in `kong.conf` that is commented out.
+
+## Verify configuration
+To verify that your configuration is usable, use the `check` command. The `check` command will evaluate the [environment variables](/gateway/latest/kong-production/environment-variables) you have
+currently set, and will output an error if your settings are invalid. 
+
+```bash
+kong check /etc/kong/kong.conf
+```
+If your configuration is valid the shell will output:
+
+```bash
+configuration at /etc/kong/kong.conf is valid
+```
+
+## Set custom path
+
+By default, Kong looks for `kong.conf` in two
+default locations:
+
+```
+/etc/kong/kong.conf
+/etc/kong.conf
+```
+
+You can override this behavior by specifying a custom path for your
+configuration file using the `-c / --conf` argument in the CLI:
+
+```bash
+kong start --conf /path/to/kong.conf
+```
+
+### Debug mode
+
+You can use the [Kong CLI](/gateway/latest/reference/cli/) in debug-mode to output configuration properties in the shell:
+
+```bash
+kong start -c /etc/kong.conf --vv
+
+2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
+2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
+2016/08/11 14:53:36 [debug] admin_listen = "0.0.0.0:8001"
+2016/08/11 14:53:36 [debug] database = "postgres"
+2016/08/11 14:53:36 [debug] log_level = "notice"
+[...]
+```

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -8,9 +8,9 @@ content-type: how-to
 `/etc/kong/kong.conf.default`. The {{site.base_gateway}} configuration file is a YAML file that can be used to configure individual properties of your Kong instance. This guide will explain how to configure {{site.base_gateway}} using the `kong.conf` file.
 
 
-## Configure Kong
+## Configure {{site.base_gateway}}
 
-To configure Kong, make a copy of the default configuration file: 
+To configure {{site.base_gateway}}, make a copy of the default configuration file: 
 
 ```bash
 cp /etc/kong/kong.conf.default /etc/kong/kong.conf


### PR DESCRIPTION
### Summary
This PR adds two docs: 

A how-to for `kong.conf` and a small how-to on setting environment variables. The info for these docs was pulled out of existing documentation. 

I'm sort of stuck on the title of the kong.conf file. Any thoughts? 

### Reason
[2418](https://konghq.atlassian.net/browse/DOCU-2418)

### Testing
soon