### PR TITLE
[DOCU-2419] Open Resty 

### DIFF
--- a/src/gateway/kong-production/kong-openresty.md
+++ b/src/gateway/kong-production/kong-openresty.md
@@ -1,6 +1,32 @@
 ---
-title: Kong Open Resty
-
+title: Embedding Kong in OpenResty
+content-type: how-to
 ---
 
-## PLACEHOLDER Kong Open Resty
+## Embedding Kong in OpenResty
+
+If you are running your own OpenResty servers, you can embed Kong
+by including the Kong Nginx sub-configuration using the `include` directive.
+If you have an existing Nginx configuration, you can include the
+Kong-specific portion of the configuration which is output by Kong in a separate
+`nginx-kong.conf` file:
+
+```
+# my_nginx.conf
+
+# ...your nginx settings...
+
+http {
+    include 'nginx-kong.conf';
+
+    # ...your nginx settings...
+}
+```
+
+Then start your Nginx instance:
+
+```bash
+nginx -p /usr/local/openresty -c my_nginx.conf
+```
+
+Kong will be running in that instance as configured in `nginx-kong.conf`.

--- a/src/gateway/kong-production/kong-openresty.md
+++ b/src/gateway/kong-production/kong-openresty.md
@@ -1,9 +1,9 @@
 ---
-title: Embedding Kong in OpenResty
+title: Embed Kong in OpenResty
 content-type: how-to
 ---
 
-## Embedding Kong in OpenResty
+## Embed Kong in OpenResty
 
 If you are running your own OpenResty servers, you can embed Kong
 by including the Kong Nginx sub-configuration using the `include` directive.

--- a/src/gateway/kong-production/kong-openresty.md
+++ b/src/gateway/kong-production/kong-openresty.md
@@ -5,10 +5,10 @@ content-type: how-to
 
 ## Embed Kong in OpenResty
 
-If you are running your own OpenResty servers, you can embed Kong
-by including the Kong Nginx sub-configuration using the `include` directive.
+If you are running your own OpenResty servers, you can embed {{site.base_gateway}}
+by including the {{site.base_gateway}} Nginx sub-configuration using the `include` directive.
 If you have an existing Nginx configuration, you can include the
-Kong-specific portion of the configuration which is output by Kong in a separate
+{{site.base_gateway}}-specific portion of the configuration which is output by {{site.base_gateway}} in a separate
 `nginx-kong.conf` file:
 
 ```

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -291,34 +291,6 @@ You can then start Kong with:
 kong start -c kong.conf --nginx-conf custom_nginx.template
 ```
 
-## Embedding Kong in OpenResty
-
-If you are running your own OpenResty servers, you can also easily embed Kong
-by including the Kong Nginx sub-configuration using the `include` directive.
-If you have an existing Nginx configuration, you can simply include the
-Kong-specific portion of the configuration which is output by Kong in a separate
-`nginx-kong.conf` file:
-
-```
-# my_nginx.conf
-
-# ...your nginx settings...
-
-http {
-    include 'nginx-kong.conf';
-
-    # ...your nginx settings...
-}
-```
-
-You can then start your Nginx instance like so:
-
-```bash
-nginx -p /usr/local/openresty -c my_nginx.conf
-```
-
-and Kong will be running in that instance (as configured in `nginx-kong.conf`).
-
 ## Serving both a website and your APIs from Kong
 
 A common use case for API providers is to make Kong serve both a website


### PR DESCRIPTION
### Summary
This PR pulls the Open Resty section out of the reference configuration file and into its own file. 

### Reason
[DOCU-2419](https://konghq.atlassian.net/browse/DOCU-2419)
