### PR TITLE
Fix db-less rendering in plugin hub

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -187,7 +187,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
       {% if page.type == "plugin" and page.params %}
         <h2 id="configuration">Configuration Reference</h2>
 
-        {% if page.params.dbless_compatible == "yes" %}
+        {% if page.params.dbless_compatible == "yes" or page.params.dbless_compatible == true %}
           <p>This plugin is <strong>compatible</strong> with DB-less mode.</p>
         {% elsif page.params.dbless_compatible == "partially" %}
           <p>This plugin is <strong>partially compatible</strong> with DB-less mode.</p>


### PR DESCRIPTION
### Summary
Resolves #4161
Resolves #4094

Plugin hub was reporting that a plugin is db-less incompatible in the body, but that it's compatible in the sidebar.

### Reason
The word `yes` is a boolean true in YAML, and the plugin specified `yes` rather than `"yes"` in the frontmatter. This PR adds a check for `dbless_compatible == true` in addition to the existing `dbless_compatible == "yes"`

### Testing
[/hub/smartparkingtechnology/google-logging/](https://deploy-preview-4190--kongdocs.netlify.app/hub/smartparkingtechnology/google-logging/)

Old:
![image](https://user-images.githubusercontent.com/59130/183056887-b314e56d-7ae3-4882-875a-600682834792.png)

New:
![image](https://user-images.githubusercontent.com/59130/183056894-6250a655-e4aa-4783-a632-3dc38ebd4cd4.png)

