### PR TITLE
Add link to arm Mesh downloads

### DIFF
--- a/src/mesh/installation/macos.md
+++ b/src/mesh/installation/macos.md
@@ -36,8 +36,8 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
-the distribution manually.
+You can also download the [amd64]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-amd64.tar.gz)
+or [arm64]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.kong_latest.version}}-darwin-arm64.tar.gz) distribution manually.
 
 Then, extract the archive with:
 


### PR DESCRIPTION
### Summary
Resolves #4057

### Reason
We provide Mesh as an arm64 binary but did not link to it

### Testing

[/mesh/1.8.x/installation/macos/](https://deploy-preview-4191--kongdocs.netlify.app/mesh/1.8.x/installation/macos/)