### PR TITLE
Add minimum version for custom_fields_by_lua

### DIFF
--- a/app/_hub/kong-inc/file-log/_index.md
+++ b/app/_hub/kong-inc/file-log/_index.md
@@ -93,7 +93,7 @@ params:
       description: |
         A list of key-value pairs, where the key is the name of a log field and
         the value is a chunk of Lua code, whose return value sets or replaces
-        the log field value.
+        the log field value. Requires Kong 2.4.x or above.
 ---
 
 ## Log format


### PR DESCRIPTION
### Summary
Resolves #3182

### Reason
Adding the minimum version required to the parameter description. Once this plugin is single sourced + delegated to gateway releases, we could use `minimum_version` to conditionally render this field. Until then, we need to use the description

### Testing
[/hub/kong-inc/file-log/](https://deploy-preview-4193--kongdocs.netlify.app/hub/kong-inc/file-log/)