### PR TITLE
Add status enum docs to Admin endpoint

### DIFF
--- a/app/gateway/2.8.x/admin-api/admins/reference.md
+++ b/app/gateway/2.8.x/admin-api/admins/reference.md
@@ -36,6 +36,17 @@ HTTP 200 OK
 }
 ```
 
+The `status` field in the response indicates if the admin has accepted their invitation:
+
+| Code | Status     |
+|------|------------|
+| 0    | Approved   |
+| 1    | Pending    |
+| 2    | Rejected   |
+| 3    | Revoked    |
+| 4    | Invited    |
+| 5    | Unverified |
+
 ## Invite an Admin
 **Endpoint**
 


### PR DESCRIPTION
### Summary
Resolves #3862

This will likely need porting in to 3.0 too

### Reason
Help users understand the available statuses in the admin list endpoint. Values taken from https://github.com/Kong/kong-ee/blob/master/kong/enterprise_edition/dao/enums.lua#L12-L19

### Testing
[/gateway/2.8.x/admin-api/admins/reference/#list-admins](https://deploy-preview-4194--kongdocs.netlify.app/gateway/2.8.x/admin-api/admins/reference/#list-admins)