### PR TITLE
Add params.global entry to plugins

### DIFF
--- a/app/_hub/kong-inc/application-registration/_index.md
+++ b/app/_hub/kong-inc/application-registration/_index.md
@@ -56,6 +56,7 @@ kong_version_compatibility:
       - 2.1.x
 params:
   name: application-registration
+  global: false
   service_id: true
   consumer_id: false
   route_id: false

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -490,7 +490,10 @@ You can configure this plugin through the Kong Manager UI.
 <!-- Global config example -->
 
 {% capture plugin_global_config %}
-
+{% if include.params.global == false %}
+{:.important}
+> This plugin cannot be enabled globally. Please select another tab.
+{% else %}
 A plugin which is not associated to any service, route, or consumer is
 considered _global_, and will be run on every request. Read the
 [Plugin Reference](/gateway/latest/admin-api/#add-plugin) and the [Plugin Precedence](/gateway/latest/admin-api/#precedence)
@@ -570,7 +573,7 @@ You can configure this plugin through the Kong Manager UI.
 {% endnavtab %}
 {% endunless %}
 {% endnavtabs %}
-
+{% endif %}
 {% endcapture %}
 
 <!-- Layout text -->

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -35,6 +35,9 @@ breadcrumbs:
     {% if page.params.service_id %}
       <tr>
         <td><code>service.name</code> or <code>service.id</code>
+        {% if page.params.global == false %}
+        <br><i>required</i>
+        {% endif %}
           <br><br><strong>Type: </strong>string</td>
         <td>The name or ID of the service the plugin targets.
           <br><br>Set one of these parameters if adding the plugin to a service through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>


### PR DESCRIPTION
### Summary
Adds a new `params.global` entry to plugin configuration that can be set to `false` if a plugin is not available globally (e.g. application registration).

I chose to keep the `Enable globally` tab and show a warning in there to make it obvious that the plugin is not available globally. This is unusual for plugins, and I think the explicit warning is more helpful than a missing tab.

### Reason
Resolves #3867

### Testing
[/hub/kong-inc/application-registration/](https://deploy-preview-4195--kongdocs.netlify.app/hub/kong-inc/application-registration/)

![image](https://user-images.githubusercontent.com/59130/183070330-3154f0e9-8af7-4cf1-8462-df7e23cc7a70.png)

![image](https://user-images.githubusercontent.com/59130/183070349-442709d3-af5a-44f4-a8f6-8e48f9796c8e.png)
