### PR TITLE
Remove grpc from mocking plugin protocols

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -83,6 +83,7 @@ loopback
 lua
 Luarocks
 ngrok
+npm
 md
 minifier
 minikube

--- a/app/_hub/kong-inc/mocking/0.1.x.md
+++ b/app/_hub/kong-inc/mocking/0.1.x.md
@@ -906,5 +906,5 @@ ensure you set the actual URL for your service so that the response can be recei
  ![Set Real Service URL](/assets/images/docs/dev-portal/km-service-url.png)
 
 ## See also
-* [Inso CLI documentation](https://support.insomnia.rest/collection/105-inso-cli)
+* [`inso` CLI documentation](https://support.insomnia.rest/collection/105-inso-cli)
 * [OpenAPI2Kong npm package](https://www.npmjs.com/package/openapi-2-kong)

--- a/app/_hub/kong-inc/mocking/0.1.x.md
+++ b/app/_hub/kong-inc/mocking/0.1.x.md
@@ -43,7 +43,7 @@ params:
   service_id: true
   consumer_id: true
   route_id: true
-  protocols: ["http", "https", "grpc", "grpcs"]
+  protocols: ["http", "https"]
   dbless_compatible: yes
   dbless_explanation: |
     Use the `api_specification` config for DB-less or hybrid mode. Attach the spec contents directly

--- a/app/_hub/kong-inc/mocking/_index.md
+++ b/app/_hub/kong-inc/mocking/_index.md
@@ -45,8 +45,6 @@ params:
   protocols:
     - http
     - https
-    - grpc
-    - grpcs
   dbless_compatible: 'yes'
   dbless_explanation: |
     Use the `api_specification` config for DB-less or hybrid mode. Attach the spec contents directly

--- a/app/_hub/kong-inc/mocking/_index.md
+++ b/app/_hub/kong-inc/mocking/_index.md
@@ -910,5 +910,5 @@ ensure you set the actual URL for your service so that the response can be recei
  ![Set Real Service URL](/assets/images/docs/dev-portal/km-service-url.png)
 
 ## See also
-* [Inso CLI documentation](https://support.insomnia.rest/collection/105-inso-cli)
+* [`inso` CLI documentation](https://support.insomnia.rest/collection/105-inso-cli)
 * [OpenAPI2Kong npm package](https://www.npmjs.com/package/openapi-2-kong)


### PR DESCRIPTION
### Summary
The mocking plugin does not support grpc endpoints

### Reason
Resolves #4048

### Testing
[/hub/kong-inc/mocking/](https://deploy-preview-4196--kongdocs.netlify.app/hub/kong-inc/mocking/)

![image](https://user-images.githubusercontent.com/59130/183071347-0742b287-819b-448c-b573-1c9f2eef29fc.png)
