### PR TITLE
[docu-2420] Website and API in the same Kong Gateway instance

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -98,6 +98,7 @@ Okta
 onboard
 onboarding
 opa
+openresty
 outbounds
 passthrough
 PayPal

--- a/src/gateway/kong-production/environment-variables.md
+++ b/src/gateway/kong-production/environment-variables.md
@@ -22,3 +22,10 @@ set `KONG_LOG_LEVEL` as an environment variable:
 ```bash
 export KONG_LOG_LEVEL=error
 ```
+
+
+## More Information
+
+* [Embedding Kong in Open resty](/gateway/latest/kong-production/kong-openresty)
+* [How to use `kong.conf`](/gateway/latest/kong-production/kong-conf)
+* [How to serve an API and a website with Kong](/gateway/latest/kong-production/website-api-serving)

--- a/src/gateway/kong-production/environment-variables.md
+++ b/src/gateway/kong-production/environment-variables.md
@@ -26,6 +26,6 @@ export KONG_LOG_LEVEL=error
 
 ## More Information
 
-* [Embedding Kong in Open resty](/gateway/latest/kong-production/kong-openresty)
+* [Embedding Kong in OpenResty](/gateway/latest/kong-production/kong-openresty)
 * [How to use `kong.conf`](/gateway/latest/kong-production/kong-conf)
 * [How to serve an API and a website with Kong](/gateway/latest/kong-production/website-api-serving)

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -93,3 +93,10 @@ kong start -c /etc/kong.conf --vv
 2016/08/11 14:53:36 [debug] log_level = "notice"
 [...]
 ```
+
+
+## More Information
+
+* [Embedding Kong in Open resty](/gateway/latest/kong-production/kong-openresty)
+* [Setting environment variables](/gateway/latest/kong-production/environment-variables)
+* [How to serve an API and a website with Kong](/gateway/latest/kong-production/website-api-serving)

--- a/src/gateway/kong-production/kong-conf.md
+++ b/src/gateway/kong-production/kong-conf.md
@@ -97,6 +97,6 @@ kong start -c /etc/kong.conf --vv
 
 ## More Information
 
-* [Embedding Kong in Open resty](/gateway/latest/kong-production/kong-openresty)
+* [Embedding Kong in OpenResty](/gateway/latest/kong-production/kong-openresty)
 * [Setting environment variables](/gateway/latest/kong-production/environment-variables)
 * [How to serve an API and a website with Kong](/gateway/latest/kong-production/website-api-serving)

--- a/src/gateway/kong-production/kong-openresty.md
+++ b/src/gateway/kong-production/kong-openresty.md
@@ -30,3 +30,10 @@ nginx -p /usr/local/openresty -c my_nginx.conf
 ```
 
 Kong will be running in that instance as configured in `nginx-kong.conf`.
+
+
+## More Information
+
+* [Setting environment variables](/gateway/latest/kong-production/environment-variables)
+* [How to use `kong.conf`](/gateway/latest/kong-production/kong-conf)
+* [How to serve an API and a website with Kong](/gateway/latest/kong-production/website-api-serving)

--- a/src/gateway/kong-production/website-api-serving.md
+++ b/src/gateway/kong-production/website-api-serving.md
@@ -5,7 +5,7 @@ content-type: how-to
 
 ## How to serve both a website and APIs using {{site.base_gateway}}
 
-A common use case for API providers is to make Kong serve both a website
+A common use case for API providers is to make {{site.base_gateway}} serve both a website
 and the APIs over port: `80` or `443` in
 production. For example, `https://example.net` (Website) and
 `https://example.net/api/v1` (API).
@@ -72,6 +72,6 @@ Then start Nginx:
 
 ## More Information
 
-* [Embedding Kong in Open resty](/gateway/latest/kong-production/kong-openresty)
+* [Embedding Kong in OpenResty](/gateway/latest/kong-production/kong-openresty)
 * [Setting environment variables](/gateway/latest/kong-production/environment-variables)
 * [How to use `kong.conf`](/gateway/latest/kong-production/kong-conf)

--- a/src/gateway/kong-production/website-api-serving.md
+++ b/src/gateway/kong-production/website-api-serving.md
@@ -1,6 +1,77 @@
 ---
-title: Serving a website and API from Kong
-
+title: Serving a website and API with Kong Gateway
+content-type: how-to
 ---
 
-## PLACEHOLDER Serving a website and API from Kong
+## How to serve both a website and APIs using {{site.base_gateway}}
+
+A common use case for API providers is to make Kong serve both a website
+and the APIs over port: `80` or `443` in
+production. For example, `https://example.net` (Website) and
+`https://example.net/api/v1` (API).
+
+You can do this using a custom
+Nginx configuration template that calls `nginx_kong.lua` in-line, and adds a new
+`location` block that serves website alongside the Kong proxy `location`
+block:
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{ "{{NGINX_WORKER_PROCESSES" }}}}; # can be set by kong.conf
+daemon ${{ "{{NGINX_DAEMON" }}}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log logs/error.log ${{ "{{LOG_LEVEL" }}}}; # can be set by kong.conf
+events {}
+
+http {
+  # here, we inline the contents of nginx_kong.lua
+  charset UTF-8;
+
+  # any contents until Kong's Proxy server block
+  ...
+
+  # Kong's Proxy server block
+  server {
+    server_name kong;
+
+    # any contents until the location / block
+    ...
+
+    # here, we declare our custom location serving our website
+    # (or API portal) which we can optimize for serving static assets
+    location / {
+      root /var/www/example.net;
+      index index.htm index.html;
+      ...
+    }
+
+    # Kong's Proxy location / has been changed to /api/v1
+    location /api/v1 {
+      set $upstream_host nil;
+      set $upstream_scheme nil;
+      set $upstream_uri nil;
+
+      # Any remaining configuration for the Proxy location
+      ...
+    }
+  }
+
+  # Kong's Admin server block goes below
+  # ...
+}
+```
+
+Then start Nginx:
+
+`nginx -p /usr/local/openresty -c my_nginx.conf`
+
+
+## More Information
+
+* [Embedding Kong in Open resty](/gateway/latest/kong-production/kong-openresty)
+* [Setting environment variables](/gateway/latest/kong-production/environment-variables)
+* [How to use `kong.conf`](/gateway/latest/kong-production/kong-conf)


### PR DESCRIPTION
### Summary
Infrastructure architecture PR. Take a section from the configuration reference doc and pulls it into its own doc. 

### Reason
[[2420]](https://konghq.atlassian.net/browse/DOCU-2420)

