### PR TITLE
[FT-2788]fix opa documents undefined return

### DIFF
--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -79,6 +79,18 @@ params:
       default: false
       description: |
         If set to true, the Kong Gateway Consumer object in use for the current request (if any) is included as input to OPA.
+    - name: include_body_in_opa_input
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        If set to true, the plain request body in the current request is included as input to OPA.
+    - name: include_parsed_json_body_in_opa_input
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be json decoded and the decoded struct is included as input to OPA.
 ---
 
 ## Usage

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -84,13 +84,13 @@ params:
       datatype: boolean
       default: false
       description: |
-        If set to true, the plain request body in the current request is included as input to OPA.
+        If set to true, the current requests' request body is included as input to OPA.
     - name: include_parsed_json_body_in_opa_input
       required: false
       datatype: boolean
       default: false
       description: |
-        If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be json decoded and the decoded struct is included as input to OPA.
+        If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be JSON decoded and the decoded struct is included as input to OPA.
 ---
 
 ## Usage
@@ -154,7 +154,7 @@ curl -XPUT localhost:8181/v1/policies/example --data-binary @example.rego
 The above command uses OPA's default port 8181. It could be different for your
 setup.
 
-### Set up Kong Gateway
+### Set up {{site.base_gateway}}
 
 Set up a Route and Service in {{site.base_gateway}} and then enable the plugin:
 

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -95,7 +95,9 @@ Create an `example.rego` file with the following content:
 ```rego
 package example
 
-default allow = false
+default allowBoolean = false
+default allowDetailed = false
+
 
 allowBoolean {
   header_present


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
- Fix the example rego file in the OPA plugin documentation. Currently, the `allowBoolean` document does not have a default value, which means that if not evaluated the returned value will be undefined and the OPA decision response will be a `{}`, which will eventually cause a 500 error on Kong side. Can be reproduced by following the current version of document, https://docs.konghq.com/hub/kong-inc/opa/#usage. When [trying request on the first time](https://docs.konghq.com/hub/kong-inc/opa/#make-a-request), the 500 error will occur.
- Add two missing config params, `include_body_in_opa_input` and `include_parsed_json_body_in_opa_input`

### Reason

Fix https://konghq.atlassian.net/browse/FT-2788

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
