### PR TITLE
[chore] OPA documents undefined return 3.0

### DIFF
--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -90,7 +90,9 @@ Create an `example.rego` file with the following content:
 ```rego
 package example
 
-default allow = false
+default allowBoolean = false
+default allowDetailed = false
+
 
 allowBoolean {
   header_present

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -79,13 +79,13 @@ params:
       datatype: boolean
       default: false
       description: |
-        If set to true, the plain request body in the current request is included as input to OPA.
+        If set to true, the current requests' request body is included as input to OPA.
     - name: include_parsed_json_body_in_opa_input
       required: false
       datatype: boolean
       default: false
       description: |
-        If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be json decoded and the decoded struct is included as input to OPA.
+        If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be JSON decoded and the decoded struct is included as input to OPA.
 ---
 
 ## Usage

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -74,6 +74,18 @@ params:
       default: false
       description: |
         If set to true, the Kong Gateway Consumer object in use for the current request (if any) is included as input to OPA.
+    - name: include_body_in_opa_input
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        If set to true, the plain request body in the current request is included as input to OPA.
+    - name: include_parsed_json_body_in_opa_input
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be json decoded and the decoded struct is included as input to OPA.
 ---
 
 ## Usage


### PR DESCRIPTION
### Summary
Mirrors https://github.com/Kong/docs.konghq.com/pull/4211 on 3.0
### Reason
The fix in that doc also affects the 3.0 release. 

