### PR TITLE
[fix] Vaults bundled

### DIFF
--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -531,7 +531,7 @@ enabled.
 The specified name(s) will be substituted as such in the Lua namespace:
 `kong.vaults.{name}.*`.
 
-**Default:** `off`
+**Default:** `bundled`
 
 ---
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -525,8 +525,7 @@ adjusted by the `log_level` property.
 
 #### vaults
 
-Comma-separated list of vaults this node should load. By default, no vaults are
-enabled.
+Comma-separated list of vaults this node should load. Vaults are `bundled` by default.
 
 The specified name(s) will be substituted as such in the Lua namespace:
 `kong.vaults.{name}.*`.


### PR DESCRIPTION
Quick fix set vaults from `off` to `bundled` until we run the autodocs. 