### PR TITLE
Port vaults doc updates into 3.0

### DIFF
--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -13,9 +13,7 @@ installation more secure.
 ## Getting started
 
 {:.note}
-> This feature isn't enabled by default in this version of Kong.
-><br>
-> Start Kong Gateway with `KONG_VAULTS=bundled`.
+> When running {{site.base_gateway}} in hybrid or DB-less mode, secrets management is only supported in {{site.base_gateway}} 2.8.1.3 or later.
 
 The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
 
@@ -31,7 +29,7 @@ Define your environment variable and assign a secret value to it:
 export MY_SECRET_POSTGRES_PASSWORD="opensesame"
 ```
 
-Next, set up a `reference` to this environment variable so that Kong Gateway can find this secret. We use a Uniform Resource Locator (URL) format for this.
+Next, set up a reference to this environment variable so that {{site.base_gateway}} can find this secret. We use a Uniform Resource Locator (URL) format for this.
 
 In this case, the reference would look like this:
 
@@ -51,23 +49,26 @@ Note that the reference is wrapped in curly braces.
 
 You can specify configuration options using environment variables or by directly updating the `kong.conf` configuration file.
 
-* Environment variable
+#### Environment variable
+
+Set the `KONG_PG_PASSWORD` environment variable to the following, adjusting `my-secret-postgres-password` to your own password object name:
 
 ```bash
 KONG_PG_PASSWORD={vault://env/my-secret-postgres-password}
 ```
 
-* Configuration file
+#### Configuration file
 
-the kong.conf has a key called "pg_password". Replace the original value with
+The `kong.conf` file contains the property `pg_password`.
+Replace the original value with the following, adjusting `my-secret-postgres-password` to your own password object name:
 
 ```bash
 pg_password={vault://env/my-secret-postgres-password}
 ```
 
-Upon startup, Kong will try to detect and transparently resolve references.
+Upon startup, {{site.base_gateway}} tries to detect and transparently resolve references.
 
 {:.note}
->For quick debug/testing you can use the new [CLI for vaults](/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli)
+> For quick debugging or testing, you can use the [CLI for vaults](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli).
 
 See the [Advanced Usage](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/advanced-usage) documentation for more information on the configuration options for each vault backend.

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/getting-started.md
@@ -6,20 +6,20 @@ beta: true
 This feature is currently in beta state and isn't fully supported. APIs are subject to change.
 
 
-Secrets are generally confidential values that should not appear in plain text in the application. There are several products that help you
-store, retrieve, and rotate these secrets securely. Kong Gateway offers a mechanism to set up references to these secrets which makes your Kong Gateway
-installation more secure.
+Secrets are generally confidential values that should not appear in plain text in the application.
+There are several products that help you store, retrieve, and rotate these secrets securely.
+{{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your {{site.base_gateway}} installation more secure.
 
 ## Getting started
 
 {:.note}
 > When running {{site.base_gateway}} in hybrid or DB-less mode, secrets management is only supported in {{site.base_gateway}} 2.8.1.3 or later.
 
-The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
+The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your PostgreSQL database with a reference to an environment variable.
 
 You can also store secrets in a secure vault backend. For a list of supported vault backend implementations, see the [Backends Overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends).
 
-In this example we'll replace our plaintext password to our Postgres database with a reference. To do so, please define your environment variable and assign a secret value to it.
+In this example we'll replace our plaintext password to our PostgreSQL database with a reference. To do so, please define your environment variable and assign a secret value to it.
 
 ### Define a reference
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -56,20 +56,17 @@ documentation for each plugin to identify the referenceable fields:
 See the [backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
 for more information about each option.
 
-## Beta limitations
+## Beta and general availability phases
 
-This feature is currently in beta. This means it has limited support from
-Kong and the functionality may change in the future.
+As of 2.8.1.3, this feature is enabled by default.
+Due to conflicts with previous releases of {{site.base_gateway}},
+the endpoints for secrets management in the
+Admin API have changed from the previous `/vaults-beta` prefix to
+`/vaults` with `vaults_use_new_style_api=on` set in `kong.conf`.
 
-**Do not** implement this feature in a product environment.
-
-* The beta of this feature only supports `get`. There is no `set` or secrets
-rotation support in the beta.
-* In this version, this feature isn't enabled by default. To test it out, start
-{{site.base_gateway}} with `KONG_VAULTS=bundled` if running Kong in a container,
-or with `vaults=bundled` set in `kong.conf`.
-* The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This
-endpoint will change once the beta is over.
+If you are running a {{site.base_gateway}} 2.8.x version before 2.8.1.3:
+* Set `vaults=bundled` in your `kong-conf` file to enable secrets management
+* Use the `/vaults-beta` Admin API endpoints
 
 ## Get started
 

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/index.md
@@ -10,7 +10,7 @@ with APIs serviced by the gateway.
 
 Some of the most common types of secrets used by {{site.base_gateway}} include:
 
-* Datastore usernames and passwords, used with PostgreSQL and Redis
+* Data store usernames and passwords, used with PostgreSQL and Redis
 * Private X.509 certificates
 * API keys
 * Sensitive plugin configuration fields, generally used for authentication

--- a/src/gateway/kong-enterprise/secrets-management/getting-started.md
+++ b/src/gateway/kong-enterprise/secrets-management/getting-started.md
@@ -6,17 +6,18 @@ beta: true
 This feature is currently in beta state and isn't fully supported. APIs are subject to change.
 
 
-Secrets are generally confidential values that should not appear in plain text in the application. There are several products that help you
-store, retrieve, and rotate these secrets securely. Kong Gateway offers a mechanism to set up references to these secrets which makes your Kong Gateway
-installation more secure.
+Secrets are generally confidential values that should not appear in plain text in the application. 
+There are several products that help you store, retrieve, and rotate these secrets securely.
+{{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your {{site.base_gateway}} installation more secure.
 
 ## Getting started
 
-The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
+The following example uses the most basic form of secrets management: storing secrets in environment variables.
+In this example, you will replace a plaintext password to your PostgreSQL database with a reference to an environment variable.
 
 You can also store secrets in a secure vault backend. For a list of supported vault backend implementations, see the [Backends Overview](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends).
 
-In this example we'll replace our plaintext password to our Postgres database with a reference. To do so, please define your environment variable and assign a secret value to it.
+In this example we'll replace our plaintext password to our PostgreSQL database with a reference. To do so, define your environment variable and assign a secret value to it.
 
 ### Define a reference
 

--- a/src/gateway/kong-enterprise/secrets-management/getting-started.md
+++ b/src/gateway/kong-enterprise/secrets-management/getting-started.md
@@ -12,14 +12,9 @@ installation more secure.
 
 ## Getting started
 
-{:.note}
-> This feature isn't enabled by default in this version of Kong.
-><br>
-> Start Kong Gateway with `KONG_VAULTS=bundled`.
-
 The following example uses the most basic form of secrets management: storing secrets in environment variables. In this example, you will replace a plaintext password to your Postgres database with a reference to an environment variable.
 
-You can also store secrets in a secure vault backend. For a list of supported vault backend implementations, see the [Backends Overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends).
+You can also store secrets in a secure vault backend. For a list of supported vault backend implementations, see the [Backends Overview](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends).
 
 In this example we'll replace our plaintext password to our Postgres database with a reference. To do so, please define your environment variable and assign a secret value to it.
 
@@ -31,7 +26,7 @@ Define your environment variable and assign a secret value to it:
 export MY_SECRET_POSTGRES_PASSWORD="opensesame"
 ```
 
-Next, set up a `reference` to this environment variable so that Kong Gateway can find this secret. We use a Uniform Resource Locator (URL) format for this.
+Next, set up a reference to this environment variable so that {{site.base_gateway}} can find this secret. We use a Uniform Resource Locator (URL) format for this.
 
 In this case, the reference would look like this:
 
@@ -42,7 +37,7 @@ In this case, the reference would look like this:
 Where:
 
 * `vault` is the scheme (protocol) that we use to indicate that this is a secret.
-* `env` is the name of the backend [(Environment Variables)](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/env), since we're storing the secret in a ENV variable.
+* `env` is the name of the backend [(Environment Variables)](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/env), since we're storing the secret in a ENV variable.
 * `my_secret_postgres_password` corresponds to the environment variable that you just defined.
 
 Note that the reference is wrapped in curly braces.
@@ -51,23 +46,26 @@ Note that the reference is wrapped in curly braces.
 
 You can specify configuration options using environment variables or by directly updating the `kong.conf` configuration file.
 
-* Environment variable
+#### Environment variable
+
+Set the `KONG_PG_PASSWORD` environment variable to the following, adjusting `my-secret-postgres-password` to your own password object name:
 
 ```bash
 KONG_PG_PASSWORD={vault://env/my-secret-postgres-password}
 ```
 
-* Configuration file
+#### Configuration file
 
-the kong.conf has a key called "pg_password". Replace the original value with
+The `kong.conf` file contains the property `pg_password`.
+Replace the original value with the following, adjusting `my-secret-postgres-password` to your own password object name:
 
 ```bash
 pg_password={vault://env/my-secret-postgres-password}
 ```
 
-Upon startup, Kong will try to detect and transparently resolve references.
+Upon startup, {{site.base_gateway}} tries to detect and transparently resolve references.
 
 {:.note}
->For quick debug/testing you can use the new [CLI for vaults](/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli)
+> For quick debugging or testing, you can use the [CLI for vaults](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli).
 
-See the [Advanced Usage](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/advanced-usage) documentation for more information on the configuration options for each vault backend.
+See the [Advanced Usage](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/advanced-usage) documentation for more information on the configuration options for each vault backend.

--- a/src/gateway/kong-enterprise/secrets-management/index.md
+++ b/src/gateway/kong-enterprise/secrets-management/index.md
@@ -27,6 +27,12 @@ you can reference each secret with a `vault` reference. For example:
 
 In this way, secrets management becomes centralized.
 
+This feature is enabled by default.
+Due to conflicts with previous releases of {{site.base_gateway}},
+the endpoints for secrets management in the
+Admin API have changed from the previous `/vaults-beta` prefix to
+`/vaults` with `vaults_use_new_style_api=on` set in `kong.conf`.
+
 ## Referenceable values
 
 The Kong Admin API [certificate object](/gateway/{{page.kong_version}}/admin-api/#certificate-object)
@@ -53,28 +59,13 @@ documentation for each plugin to identify the referenceable fields:
 * AWS Secrets Manager
 * Hashicorp Vault
 
-See the [backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
+See the [backends overview](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/)
 for more information about each option.
-
-## Beta limitations
-
-This feature is currently in beta. This means it has limited support from
-Kong and the functionality may change in the future.
-
-**Do not** implement this feature in a product environment.
-
-* The beta of this feature only supports `get`. There is no `set` or secrets
-rotation support in the beta.
-* In this version, this feature isn't enabled by default. To test it out, start
-{{site.base_gateway}} with `KONG_VAULTS=bundled` if running Kong in a container,
-or with `vaults=bundled` set in `kong.conf`.
-* The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This
-endpoint will change once the beta is over.
 
 ## Get started
 
 To test out secrets management, see the following topics:
-* [Get started with secrets management](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/getting-started/)
-* [Backends overview](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/)
-* [Reference format](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/reference-format/)
-* [Advanced usage](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/advanced-usage/)
+* [Get started with secrets management](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/getting-started/)
+* [Backends overview](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/)
+* [Reference format](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/reference-format/)
+* [Advanced usage](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/advanced-usage/)

--- a/src/gateway/kong-enterprise/secrets-management/index.md
+++ b/src/gateway/kong-enterprise/secrets-management/index.md
@@ -10,7 +10,7 @@ with APIs serviced by the gateway.
 
 Some of the most common types of secrets used by {{site.base_gateway}} include:
 
-* Datastore usernames and passwords, used with PostgreSQL and Redis
+* Data store usernames and passwords, used with PostgreSQL and Redis
 * Private X.509 certificates
 * API keys
 * Sensitive plugin configuration fields, generally used for authentication


### PR DESCRIPTION
### Summary
Copy changes made in https://github.com/Kong/docs.konghq.com/pull/4226 into 3.0.

Slight adjustment to the content, as the main reason for the notes in 2.8 was because the feature changed in a patch version. In 3.0, we don't have that issue anymore.

### Testing
Netlify