### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Team Docs own all the things, should be tagged in PRs
-*    @Kong/team-docs
+*    @Kong/docs-maintainers


### PR DESCRIPTION
### Summary
Switch to `docs-maintainers` as people that can approve PRs

