### PR TITLE
[DOCS] upsert of targets now require the `PUT` HTTP method

### DIFF
--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -3995,7 +3995,7 @@ of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
 status is propagated to the whole Kong cluster.
 
 
-<div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/{address}/healthy</div>
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/{address}/healthy</div>
 
 {:.indent}
 Attributes | Description
@@ -4039,7 +4039,7 @@ To permanently remove a target from the balancer, you should [delete a
 target](#delete-target) instead.
 
 
-<div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
 
 {:.indent}
 Attributes | Description
@@ -4074,7 +4074,7 @@ of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
 status is propagated to the whole Kong cluster.
 
 
-<div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
 
 {:.indent}
 Attributes | Description
@@ -4114,7 +4114,7 @@ To permanently remove a target from the balancer, you should [delete a
 target](#delete-target) instead.
 
 
-<div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
 
 {:.indent}
 Attributes | Description


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
According to the PR commit [fix(api) upsert of targets now require the PUT HTTP method ](https://github.com/Kong/kong-ee/pull/3096/commits/b4dd9093cbc77c04546c8c8161da889957eaa7f8)
Change set targets healthy/unhealthy endpoints the POST HTTP method to the PUT HTTP method

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
