### PR TITLE
[docu-2457] Router Reference, Router Route creation

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -26,6 +26,7 @@ items:
               - text: Securing the Database with AWS Secrets Manager
                 url: /understanding-kong/how-to/aws-secrets-manager
               - text: How to create routes with the ATC
+              - text: Configure Routes with Expressions
                 url: /understanding-kong/how-to/router-atc
           - text: Key Concepts
             items:

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -561,3 +561,5 @@ items:
         url: /reference/rate-limit
       - text: Performance Testing Framework Reference
         url: /reference/performance-testing-framework
+      - text: Router Operators
+        url: /reference/router-operators

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -25,7 +25,6 @@ items:
                 url: /understanding-kong/how-to/request-transformations
               - text: Securing the Database with AWS Secrets Manager
                 url: /understanding-kong/how-to/aws-secrets-manager
-              - text: How to create routes with the ATC
               - text: Configure Routes with Expressions
                 url: /understanding-kong/how-to/router-atc
           - text: Key Concepts

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -25,6 +25,8 @@ items:
                 url: /understanding-kong/how-to/request-transformations
               - text: Securing the Database with AWS Secrets Manager
                 url: /understanding-kong/how-to/aws-secrets-manager
+              - text: How to create routes with the ATC
+                url: /understanding-kong/how-to/router-atc
           - text: Key Concepts
             items:
               - text: Services

--- a/src/gateway/get-started/configure-services-and-routes.md
+++ b/src/gateway/get-started/configure-services-and-routes.md
@@ -149,11 +149,26 @@ The response body displays the updated change:
 You can configure a route to point to an active service. The router helps {{site.base_gateway}} forward requests to upstream services. Now, you will configure the `/mock` route for the `example_service` service. This route has a specific path that users will use to send requests. 
 A route is configured by sending a **POST** request to the [route object](/gateway/latest/admin-api/#route-object):
 
+{% if_version eq:3.0.x %}
 ```sh
 curl -i -X POST http://localhost:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
 ```
+{% endif_version %}
+
+
+{% if_version gte:3.1.x %}
+```sh
+curl --request POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --header 'Content-Type: multipart/form-data' \
+  --form 'atc=http.path == "/mock"'
+  --data name=mocking
+```
+{% endif_version %}
+
+
 
 If the route was successfully created, the API returns a `201` response code and a response body like this:
 

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -6,6 +6,20 @@ content-type: reference
 With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
 
 
+## Available Fields
+
+| Field | Description |
+| --- | ----------- | 
+| net.protocol | The protocol used to communicate with the upstream application.  |
+| tls.sni  | Server name indication. | 
+| http.method | HTTP methods that match a route. |
+| tls.sni  | Server name indication. | 
+| http.method | HTTP methods that match a route. | 
+| http.host  | Lists of domains that match a route. | 
+| http.path | Returns or sets the path. | 
+| http.raw_path| Returns or sets the escaped path. | 
+| http.headers.* |  Lists of values that are expected in the header of a request. | 
+
 ## String
 
 | Operator | Name | Return Type | 
@@ -21,6 +35,8 @@ With the release of version 3.0, {{site.base_gateway}} now ships with a new rout
 
 ## Integer
 
+| Operator | Name | Return Type | 
+| --- | ----------- | --- | 
 | == | Equals | Boolean|
 | != | Not equals| Boolean|
 | > | Greater than | Boolean|
@@ -30,23 +46,23 @@ With the release of version 3.0, {{site.base_gateway}} now ships with a new rout
 
 ## IP 
 
+| Operator | Name | Return Type | 
+| --- | ----------- | --- | 
 | == | Equals | Boolean|
 | != | Not equals | Boolean|
 | in | Contains | Boolean|
 
 ## Boolean
 
+| Operator | Name | Return Type | 
+| --- | ----------- | --- | 
 | && | And | Boolean|
 | `||` | Or | Boolean|
 | ! | Not | Boolean|
 
-## Available Fields
 
 
-* net.protocol - The protocol used to communicate with the upstream application. 
-* tls.sni - Server name indication.
-* http.method -  HTTP methods that match a route.
-* http.host -  Lists of domains that match a route.
-* http.path - Returns or sets the path.
-* http.raw_path - Returns or sets the escaped path.
-* http.headers.* - Lists of values that are expected in the header of a request.
+## More Information
+
+[Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
+[How to configure routes with Expressions](gateway/latest/understanding-kong/how-to/router-atc/)

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -3,20 +3,20 @@ title: Router Operator Reference for Kong Gateway
 content-type: reference
 ---
 
-With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific language called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
+With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific language called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators. If you want to learn how to configure routes using Expressions read [How to configure routes using Expressions](gateway/latest/understanding-kong/how-to/router-atc/).
 
 
 ## Available fields
 
 | Field | Description |
 | --- | ----------- | 
-| net.protocol | The protocol used to communicate with the upstream application.  |
-| tls.sni  | Server name indication. | 
-| http.method | HTTP methods that match a route. |
-| http.host  | Lists of domains that match a route. | 
-| http.path | Returns or sets the path. | 
-| http.raw_path | Returns or sets the escaped path. | 
-| http.headers.* |  Lists of values that are expected in the header of a request. | 
+| `net.protocol` | The protocol used to communicate with the upstream application.  |
+| `tls.sni`  | Server name indication. | 
+| `http.method` | HTTP methods that match a route. |
+| `http.host`  | Lists of domains that match a route. | 
+| `http.path` | Returns or sets the path. | 
+| `http.raw_path` | Returns or sets the escaped path. | 
+| `http.headers.*` |  Lists of values that are expected in the header of a request. | 
 
 ## String
 
@@ -63,4 +63,4 @@ With the release of version 3.0, {{site.base_gateway}} now ships with a new rout
 ## More information
 
 * [Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
-* [How to configure routes with Expressions](gateway/latest/understanding-kong/how-to/router-atc/)
+* [How to configure routes using Expressions](gateway/latest/understanding-kong/how-to/router-atc/)

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -1,23 +1,21 @@
 ---
-title: Configuration Reference for Kong Gateway
+title: Router Operator Reference for Kong Gateway
 content-type: reference
 ---
 
 With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific language called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
 
 
-## Available Fields
+## Available fields
 
 | Field | Description |
 | --- | ----------- | 
 | net.protocol | The protocol used to communicate with the upstream application.  |
 | tls.sni  | Server name indication. | 
 | http.method | HTTP methods that match a route. |
-| tls.sni  | Server name indication. | 
-| http.method | HTTP methods that match a route. | 
 | http.host  | Lists of domains that match a route. | 
 | http.path | Returns or sets the path. | 
-| http.raw_path| Returns or sets the escaped path. | 
+| http.raw_path | Returns or sets the escaped path. | 
 | http.headers.* |  Lists of values that are expected in the header of a request. | 
 
 ## String
@@ -62,7 +60,7 @@ With the release of version 3.0, {{site.base_gateway}} now ships with a new rout
 
 
 
-## More Information
+## More information
 
-[Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
-[How to configure routes with Expressions](gateway/latest/understanding-kong/how-to/router-atc/)
+* [Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
+* [How to configure routes with Expressions](gateway/latest/understanding-kong/how-to/router-atc/)

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -3,10 +3,11 @@ title: Configuration Reference for Kong Gateway
 content-type: reference
 ---
 
-With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called ATC. ATC can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
+With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
 
 
 ## String
+
 | Operator | Name | Return Type | 
 | --- | ----------- | --- | 
 | == | Equals | Boolean|
@@ -39,9 +40,13 @@ With the release of version 3.0, {{site.base_gateway}} now ships with a new rout
 | `||` | Or | Boolean|
 | ! | Not | Boolean|
 
-"protocols": ["http", "https"],
-"methods": ["GET", "POST"],
-"hosts": ["example.com", "foo.test"],
-"paths": ["/foo", "/bar"],
-"headers": {"x-another-header":["bla"], "x-my-header":["foo", "bar"]},
+## Available Fields
 
+
+* net.protocol - The protocol used to communicate with the upstream application. 
+* tls.sni - Server name indication.
+* http.method -  HTTP methods that match a route.
+* http.host -  Lists of domains that match a route.
+* http.path - Returns or sets the path.
+* http.raw_path - Returns or sets the escaped path.
+* http.headers.* - Lists of values that are expected in the header of a request.

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -1,0 +1,47 @@
+---
+title: Configuration Reference for Kong Gateway
+content-type: reference
+---
+
+With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called ATC. ATC can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
+
+
+## String
+| Operator | Name | Return Type | 
+| --- | ----------- | --- | 
+| == | Equals | Boolean|
+| != | Not equals | Boolean|
+| ~ | Regex matching | Boolean|
+| ^= | Prefix matching | Boolean|
+| =^ | Suffix matching | Boolean|
+| in | Contains | Boolean|
+| not in | Does not contain | Boolean|
+| lower() | Lowercase | String|
+
+## Integer
+
+| == | Equals | Boolean|
+| != | Not equals| Boolean|
+| > | Greater than | Boolean|
+| >= | Greater than or equal | Boolean|
+| < | Less than | Boolean|
+| <= | Less than or equal | Boolean|
+
+## IP 
+
+| == | Equals | Boolean|
+| != | Not equals | Boolean|
+| in | Contains | Boolean|
+
+## Boolean
+
+| && | And | Boolean|
+| `||` | Or | Boolean|
+| ! | Not | Boolean|
+
+"protocols": ["http", "https"],
+"methods": ["GET", "POST"],
+"hosts": ["example.com", "foo.test"],
+"paths": ["/foo", "/bar"],
+"headers": {"x-another-header":["bla"], "x-my-header":["foo", "bar"]},
+

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -3,7 +3,7 @@ title: Configuration Reference for Kong Gateway
 content-type: reference
 ---
 
-With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
+With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific language called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This document serves as a reference for all of the available operators: 
 
 
 ## Available Fields

--- a/src/gateway/understanding-kong/how-to/router-atc.md
+++ b/src/gateway/understanding-kong/how-to/router-atc.md
@@ -1,14 +1,14 @@
 ---
-title: Configure Routes with Expressions
+title: How to Configure Routes using Expressions
 content-type: how-to
 ---
 
 
-With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific language called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This how-to guide will walk through switching to the new router, and configuring routes with the new expressive domain specific language, expressions. For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-operators).
+Expressions can describe routes or paths as patterns using regular expressions. This how-to guide will walk through switching to the new router, and configuring routes with the new expressive domain specific language, expressions. For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-operators).
 
 ## Prerequisite
 
-Edit [kong.conf](/gateway/latest/kong-production/kong-conf) to contain the line `router_flavor = atc` and restart {{site.base_gateway}}.
+Edit [kong.conf](/gateway/latest/kong-production/kong-conf) to contain the line `router_flavor = expressions` and restart {{site.base_gateway}}.
 
 ## Create routes with Expressions
 
@@ -19,9 +19,7 @@ curl --request POST \
   --form  atc='http.path == "/mock"
 ```
 
-In this example, you associated a new route object with the path `/mock` to the existing service `example-service`. 
-
-The expressions DSL allows you to create complex router objects using operators and fields. 
+In this example, you associated a new route object with the path `/mock` to the existing service `example-service`. The Expressions DSL also allows you to create complex router objects using operators.  
 
 ```sh
 curl --request POST \

--- a/src/gateway/understanding-kong/how-to/router-atc.md
+++ b/src/gateway/understanding-kong/how-to/router-atc.md
@@ -1,0 +1,166 @@
+---
+title: Configure Routes with expressions
+content-type: how-to
+---
+
+
+With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This how-to guide will walk through switching to the new router, and configuring routes with the new expressive domain specific language, expressions. For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-operators).
+
+
+Kong’s Route object has carried its legacy from the early days. Over the years we have added a lot of new capability and fields to the existing router which makes the router interface quite complex and relations between different fields hard to understand. With the requirement of incremental rebuilds and more efficient runtime behavior, it is clear the existing Lua based router implementation will not be enough. With 3.0 approaching, now is the best time to address both problems at once with a new implementation.
+
+Compatibility with existing Router interface and config
+The intention is for the new router implementation to be fully compatible with existing Route objects. To achieve this, the following will be done:
+The existing Route schema will be mostly left alone
+A new field matchers will be added to the Route schema, that is mutually exclusive with all existing matching conditions
+When building the Router, Kong can convert any Route object not using the matchers field to the appropriate ATC DSL representation automatically
+
+
+## Prerequisite
+
+* Edit [kong.conf](/gateway/latest/kong-production/kong-conf) to contain the line `router_flavor = atc` and restart {{site.base_gateway}}.
+
+
+## Route creation
+
+In previous versions of Kong Gateway, creating a route was done by sending a `POST` request to the Admin API and describing a route: 
+
+
+```sh
+curl -i -X POST http://localhost:8001/services/example_service/routes \
+  --data 'paths[]=/mock' \
+  --data name=mocking
+```
+
+With the introduction of Expressions, the same route request can be written like 
+
+
+To create a new router object using expressions send a `POST` request to the [services endpoint](/gateway/latest/admin-api/#update-route) like this: 
+
+```sh
+curl --request POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --form  atc='http.path == "/mock"
+```
+
+This example creates a route to the service `example-service` with the `http.path` `/mock`. In this example, `http.path` is an available [router configuration field](/gateway/latest/reference/router-operators). 
+
+Before the introduction of this router, the same expression would have 
+
+
+
+
+
+
+
+```
+curl --location --request POST 'https://localhost:8444/services/:serviceNameOrId/routes' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+	"name": "httpbin-api",
+	"url": "https://httpbin.org/"
+}'
+
+```
+```
+
+curl --location -g --request POST '{{gateway}}/routes' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+	"name": "my-route",
+	"protocols": [
+		"http",
+		"https"
+	],
+	"methods": [
+		"GET",
+		"POST"
+	],
+	"hosts": [
+		"example.com",
+		"foo.test"
+	],
+	"paths": [
+		"/foo",
+		"/bar"
+	],
+	"headers": {
+		"x-another-header": [
+			"bla"
+		],
+		"x-my-header": [
+			"foo",
+			"bar"
+		]
+	},
+	"https_redirect_status_code": 426,
+	"regex_priority": 0,
+	"strip_path": true,
+	"path_handling": "v0",
+	"preserve_host": false,
+	"tags": [
+		"user-level",
+		"low-priority"
+	],
+	"service": {
+		"id": "c8b8f724-7e73-4df6-b1a8-8df19642d388"
+	}
+}'
+
+```
+
+
+```sh
+
+atc='http.path == "/" && http.host == "mockbin.org"
+```
+
+```sh
+
+curl --request POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --form 'atc=(http.path == "/mock" || net.protocol == "https") && (http.method == "GET" || http.method == "POST") '
+
+```
+
+In this example, the `||` and `&&` operators are used to create an expression that will 
+
+
+src/gateway/kong-production/kong-conf.md
+"protocols": ["http", "https"],
+"methods": ["GET", "POST"],
+"hosts": ["example.com", "foo.test"],
+"paths": ["/foo", "/bar"],
+"headers": {"x-another-header":["bla"], "x-my-header":["foo", "bar"]},
+
+
+3.0 
+
+(net.protocol == "http" || net.protocol == "https") &&
+
+(http.method == "GET" || http.method == "POST") &&
+
+(http.host == "example.com" || http.host == "foo.test") &&
+
+(http.path ^= "/foo" || http.path ^= "/bar") &&
+
+http.headers.x_another_header == "bla" && (http.headers.x_my_header == "foo" || http.headers.x_my_header == "bar")
+i might be reading it wrong, but it seems like an iterative feature where we just describe paths as patterns rather than creating some crazy new feature
+
+path based routing is normal, this just looks like a semantic evolution to enable regex pattern paths (edited) 
+
+
+The new router supports strict matching for paths without Regex. But it is not compatiable with the existing config interface. They will have to use the DSL directly.
+
+
+
+```
+curl http://localhost:8001/services/mock/routes -d atc='http.path == "/mock" && http.method == "GET"'
+{"name":"schema violation","message":"schema violation ( http: unknown field)","code":2,"fields":{" http":"unknown field"}}
+```
+
+
+curl http://localhost:8001/services/mock/routes -d atc='http.method == "GET" || http.method == "POST"'
+
+
+http :8001/services/6a81044e-9524-4316-b6fc-b3dbbacce7d1/routes atc='http.path == "/mock" && http.method == "GET"'

--- a/src/gateway/understanding-kong/how-to/router-atc.md
+++ b/src/gateway/understanding-kong/how-to/router-atc.md
@@ -8,18 +8,20 @@ With the release of version 3.0, {{site.base_gateway}} now ships with a new rout
 
 ## Prerequisite
 
-* Edit [kong.conf](/gateway/latest/kong-production/kong-conf) to contain the line `router_flavor = atc` and restart {{site.base_gateway}}.
+Edit [kong.conf](/gateway/latest/kong-production/kong-conf) to contain the line `router_flavor = atc` and restart {{site.base_gateway}}.
 
 ## Create routes with Expressions
 
-To create a new router object using expressions send a `POST` request to the [services endpoint](/gateway/latest/admin-api/#update-route) like this: 
+To create a new router object using expressions, send a `POST` request to the [services endpoint](/gateway/latest/admin-api/#update-route) like this: 
 ```sh
 curl --request POST \
   --url http://localhost:8001/services/example-service/routes \
   --form  atc='http.path == "/mock"
 ```
 
-In this example you associated a new route object with the path `/mock` to the existing service `example-service`. The expressions DSL allows you to create complex router objects using operators and fields. 
+In this example, you associated a new route object with the path `/mock` to the existing service `example-service`. 
+
+The expressions DSL allows you to create complex router objects using operators and fields. 
 
 ```sh
 curl --request POST \
@@ -35,7 +37,7 @@ AND
 "paths": ["/mock"]
 ```
 
-You can use non-expressions related attributes within the same `POST` request:
+You can use attributes that are unrelated to expressions within the same `POST` request:
 
 ```sh
 curl --request POST \
@@ -53,7 +55,7 @@ This would define a router object with the following attributes:
 "name": "mocking",
 
 ```
-The list of available attributes is available in the [reference documentation](/gateway/latest/admin-api/#request-body). 
+You can view the list of available attributes in the [reference documentation](/gateway/latest/admin-api/#request-body). 
 
 
 
@@ -74,7 +76,7 @@ curl --request POST \
          http.headers.x_another_header == "example_header" && (http.headers.x_my_header == "example" || http.headers.x_my_header == "example2")'
 ```
 
-This request returns a `200` with the following values: 
+This request returns a `200` status code with the following values: 
 
 ```sh
 "protocols": ["http", "https"],
@@ -84,10 +86,10 @@ This request returns a `200` with the following values:
 "headers": {"x-another-header":["example_header"], "x-my-header":["example", "example2"]},
 ```
 
-For a list of all available operators refer to the [reference documentation](/gateway/latest/reference/router-operators.
+For a list of all available operators, see the [reference documentation](/gateway/latest/reference/router-operators/).
 
 
 ## More information
 
-[Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
-[Expressions Reference](/gateway/latest/reference/router-operators)
+* [Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
+* [Expressions Reference](/gateway/latest/reference/router-operators)

--- a/src/gateway/understanding-kong/how-to/router-atc.md
+++ b/src/gateway/understanding-kong/how-to/router-atc.md
@@ -1,166 +1,93 @@
 ---
-title: Configure Routes with expressions
+title: Configure Routes with Expressions
 content-type: how-to
 ---
 
 
-With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific languaged called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This how-to guide will walk through switching to the new router, and configuring routes with the new expressive domain specific language, expressions. For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-operators).
-
-
-Kong’s Route object has carried its legacy from the early days. Over the years we have added a lot of new capability and fields to the existing router which makes the router interface quite complex and relations between different fields hard to understand. With the requirement of incremental rebuilds and more efficient runtime behavior, it is clear the existing Lua based router implementation will not be enough. With 3.0 approaching, now is the best time to address both problems at once with a new implementation.
-
-Compatibility with existing Router interface and config
-The intention is for the new router implementation to be fully compatible with existing Route objects. To achieve this, the following will be done:
-The existing Route schema will be mostly left alone
-A new field matchers will be added to the Route schema, that is mutually exclusive with all existing matching conditions
-When building the Router, Kong can convert any Route object not using the matchers field to the appropriate ATC DSL representation automatically
-
+With the release of version 3.0, {{site.base_gateway}} now ships with a new router. The new router can describe routes using a domain-specific language called Expressions. Expressions can describe routes or paths as patterns using regular expressions. This how-to guide will walk through switching to the new router, and configuring routes with the new expressive domain specific language, expressions. For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-operators).
 
 ## Prerequisite
 
 * Edit [kong.conf](/gateway/latest/kong-production/kong-conf) to contain the line `router_flavor = atc` and restart {{site.base_gateway}}.
 
-
-## Route creation
-
-In previous versions of Kong Gateway, creating a route was done by sending a `POST` request to the Admin API and describing a route: 
-
-
-```sh
-curl -i -X POST http://localhost:8001/services/example_service/routes \
-  --data 'paths[]=/mock' \
-  --data name=mocking
-```
-
-With the introduction of Expressions, the same route request can be written like 
-
+## Create routes with Expressions
 
 To create a new router object using expressions send a `POST` request to the [services endpoint](/gateway/latest/admin-api/#update-route) like this: 
-
 ```sh
 curl --request POST \
   --url http://localhost:8001/services/example-service/routes \
   --form  atc='http.path == "/mock"
 ```
 
-This example creates a route to the service `example-service` with the `http.path` `/mock`. In this example, `http.path` is an available [router configuration field](/gateway/latest/reference/router-operators). 
-
-Before the introduction of this router, the same expression would have 
-
-
-
-
-
-
-
-```
-curl --location --request POST 'https://localhost:8444/services/:serviceNameOrId/routes' \
---header 'Content-Type: application/json' \
---data-raw '{
-	"name": "httpbin-api",
-	"url": "https://httpbin.org/"
-}'
-
-```
-```
-
-curl --location -g --request POST '{{gateway}}/routes' \
---header 'Content-Type: application/json' \
---data-raw '{
-	"name": "my-route",
-	"protocols": [
-		"http",
-		"https"
-	],
-	"methods": [
-		"GET",
-		"POST"
-	],
-	"hosts": [
-		"example.com",
-		"foo.test"
-	],
-	"paths": [
-		"/foo",
-		"/bar"
-	],
-	"headers": {
-		"x-another-header": [
-			"bla"
-		],
-		"x-my-header": [
-			"foo",
-			"bar"
-		]
-	},
-	"https_redirect_status_code": 426,
-	"regex_priority": 0,
-	"strip_path": true,
-	"path_handling": "v0",
-	"preserve_host": false,
-	"tags": [
-		"user-level",
-		"low-priority"
-	],
-	"service": {
-		"id": "c8b8f724-7e73-4df6-b1a8-8df19642d388"
-	}
-}'
-
-```
-
+In this example you associated a new route object with the path `/mock` to the existing service `example-service`. The expressions DSL allows you to create complex router objects using operators and fields. 
 
 ```sh
-
-atc='http.path == "/" && http.host == "mockbin.org"
+curl --request POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --header 'Content-Type: multipart/form-data' \
+  --form 'atc=(http.path == "/mock" || net.protocol == "https")'
 ```
+In this example the || operator created an expression that set variables for the following fields: 
+
+```
+"protocols": ["http", "https"]
+AND
+"paths": ["/mock"]
+```
+
+You can use non-expressions related attributes within the same `POST` request:
+
+```sh
+curl --request POST \
+  --url http://localhost:8001/services/example-service/routes \
+  --header 'Content-Type: multipart/form-data' \
+  --form 'atc=(http.path == "/mock" || net.protocol == "https") \
+  --form name=mocking
+```
+
+This would define a router object with the following attributes:
+
+
+```
+"atc": "(http.path == \"\/mock\" || net.protocol == \"https\"),
+"name": "mocking",
+
+```
+The list of available attributes is available in the [reference documentation](/gateway/latest/admin-api/#request-body). 
+
+
+
+### Create complex routes with Expressions
+
+You can describe complex route objects using operators within a `POST` request. 
 
 ```sh
 
 curl --request POST \
   --url http://localhost:8001/services/example-service/routes \
-  --form 'atc=(http.path == "/mock" || net.protocol == "https") && (http.method == "GET" || http.method == "POST") '
-
+  --header 'Content-Type: multipart/form-data' \
+  --form name=complex_object \
+  --form 'atc=(net.protocol == "http" || net.protocol == "https") &&
+         (http.method == "GET" || http.method == "POST") &&
+         (http.host == "example.com" || http.host == "example.test") &&
+         (http.path ^= "/mock" || http.path ^= "/mocking") &&
+         http.headers.x_another_header == "example_header" && (http.headers.x_my_header == "example" || http.headers.x_my_header == "example2")'
 ```
 
-In this example, the `||` and `&&` operators are used to create an expression that will 
+This request returns a `200` with the following values: 
 
-
-src/gateway/kong-production/kong-conf.md
+```sh
 "protocols": ["http", "https"],
 "methods": ["GET", "POST"],
-"hosts": ["example.com", "foo.test"],
-"paths": ["/foo", "/bar"],
-"headers": {"x-another-header":["bla"], "x-my-header":["foo", "bar"]},
-
-
-3.0 
-
-(net.protocol == "http" || net.protocol == "https") &&
-
-(http.method == "GET" || http.method == "POST") &&
-
-(http.host == "example.com" || http.host == "foo.test") &&
-
-(http.path ^= "/foo" || http.path ^= "/bar") &&
-
-http.headers.x_another_header == "bla" && (http.headers.x_my_header == "foo" || http.headers.x_my_header == "bar")
-i might be reading it wrong, but it seems like an iterative feature where we just describe paths as patterns rather than creating some crazy new feature
-
-path based routing is normal, this just looks like a semantic evolution to enable regex pattern paths (edited) 
-
-
-The new router supports strict matching for paths without Regex. But it is not compatiable with the existing config interface. They will have to use the DSL directly.
-
-
-
-```
-curl http://localhost:8001/services/mock/routes -d atc='http.path == "/mock" && http.method == "GET"'
-{"name":"schema violation","message":"schema violation ( http: unknown field)","code":2,"fields":{" http":"unknown field"}}
+"hosts": ["example.com", "example.test"],
+"paths": ["/mock", "/mocking"],
+"headers": {"x-another-header":["example_header"], "x-my-header":["example", "example2"]},
 ```
 
+For a list of all available operators refer to the [reference documentation](/gateway/latest/reference/router-operators.
 
-curl http://localhost:8001/services/mock/routes -d atc='http.method == "GET" || http.method == "POST"'
 
+## More information
 
-http :8001/services/6a81044e-9524-4316-b6fc-b3dbbacce7d1/routes atc='http.path == "/mock" && http.method == "GET"'
+[Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
+[Expressions Reference](/gateway/latest/reference/router-operators)


### PR DESCRIPTION
### Summary
Two new docs: 
Reference for operators and fields.
Quick how-to create routes with the new router. 
Added a set of  if version tags for the comprehensive guide for 3.1 

### Reason
[docu-2457](https://konghq.atlassian.net/browse/DOCU-2457)
[docu-2458](https://konghq.atlassian.net/browse/DOCU-2458)
[docu-2388](https://konghq.atlassian.net/browse/DOCU-2388)

