### PR TITLE
DOCU-2423: Adds StatsD monitoring page under Kong in Production

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -114,6 +114,7 @@ namespace
 namespaces
 namespaced
 navtabs
+Netcat
 Netlify
 Nginx
 nginx

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -9,35 +9,22 @@ text based statistics data published by applications.
 
 This guide will help you setup a test {{site.base_gateway}} and
 StatsD service. Then you will generate sample requests to {{site.base_gateway}} and
-observe the collected monitoring data.
+observe the collected monitoring data. 
 
 ### Prerequisites
-This guide assumes the following tools are installed locally:
-* [Docker](https://docs.docker.com/get-docker/) is used to run {{site.base_gateway}}, the supporting database, and StatsD locally. 
-* [curl](https://curl.se/) is used to send requests to {{site.base_gateway}}. `curl` is pre-installed on most systems.
-* [Netcat](http://netcat.sourceforge.net/) installed as `nc` on the `PATH`. `nc` is used to send requests 
-  to the StatsD management interface. `nc` is pre-installed on many systems.
-
-### Configure StatsD monitoring
-
-1. Run the following command to start {{site.base_gateway}} using Docker:
-
+* A test {{site.base_gateway}} instance is installed using the following script:
    ```sh
    curl -Ls get.konghq.com/quickstart | sh -s
    ```
+   This script installs the test instance and a mock service that is used in this guide. 
+   {:.note}
+   > **Note:** This guide's instructions use a test {{site.base_gateway}} instance to demonstrate how the StatsD plugin can be used to collect metrics. If you want to use an existing {{site.base_gateway}} instance for this guide, you must modify the connection information in the commands.
+* [Docker](https://docs.docker.com/get-docker/) is installed locally. It is used to run {{site.base_gateway}}, the supporting database, and StatsD locally. 
+* [curl](https://curl.se/) is installed locally. It is used to send requests to {{site.base_gateway}}. `curl` is pre-installed on most systems.
+* [Netcat](http://netcat.sourceforge.net/) is installed locally as `nc` on the `PATH`. `nc` is used to send requests 
+  to the StatsD management interface. `nc` is pre-installed on many systems.
 
-   You should see the following message when {{site.base_gateway}} is ready:
-
-   ```text
-   ✔ Kong is ready!
-   ```
-
-   The script also installs a mock service to make testing easier. You will use this 
-   service later to generate metrics data. You can send a sample request with:
-
-   ```sh
-   curl localhost:8000/mock/requests
-   ```
+### Configure StatsD monitoring
 
 1. Run a StatsD container to capture monitoring data:
 

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -23,7 +23,7 @@ observe the collected monitoring data.
 
    {:.note}
       > This step is optional if you wish to use an existing {{site.base_gateway}} installation. When using an existing
-        {{site.base_gateway}}, you will need to modify the remaining commands as appropriate to account for network
+        {{site.base_gateway}}, you will need to modify the commands to account for network
         connectivity and installed {{site.base_gateway}} services and routes.
 
    ```sh

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -12,13 +12,13 @@ StatsD service. Then you will generate sample requests to {{site.base_gateway}} 
 observe the collected monitoring data.
 
 ### Prerequisites
-This guide assumes each of the following tools are installed locally. 
-* [Docker](https://docs.docker.com/get-docker/) is used to run Kong, the supporting database, and StatsD locally. 
-* [curl](https://curl.se/) is used to send requests to the gateway. Most systems come with `curl` pre-installed.
+This guide assumes the following tools are installed locally:
+* [Docker](https://docs.docker.com/get-docker/) is used to run {{site.base_gateway}}, the supporting database, and StatsD locally. 
+* [curl](https://curl.se/) is used to send requests to {{site.base_gateway}}. `curl` is pre-installed on most systems.
 * [Netcat](http://netcat.sourceforge.net/) installed as `nc` on the `PATH`. `nc` is used to send requests 
-  to the StatsD management interface. Many systems come with `nc` pre-installed.
+  to the StatsD management interface. `nc` is pre-installed on many systems.
 
-### Guide
+### Configure StatsD monitoring
 
 1. Run the following command to start {{site.base_gateway}} using Docker:
 
@@ -32,7 +32,7 @@ This guide assumes each of the following tools are installed locally.
    ✔ Kong is ready!
    ```
 
-   The script has also installed a mock service to make testing easier. You will use this 
+   The script also installs a mock service to make testing easier. You will use this 
    service later to generate metrics data. You can send a sample request with:
 
    ```sh
@@ -59,9 +59,9 @@ This guide assumes each of the following tools are installed locally.
 
    You should receive a JSON response with the details of the installed plugin.
 
-1. Generate sample traffic to the mock service. This will allow you to observe 
-   metrics generated from the StatsD plugin. The following command will generate 60 
-   requests over 1 minute. Run the following in a new terminal:
+1. Generate sample traffic to the mock service. This allows you to observe 
+   metrics generated from the StatsD plugin. The following command generates 60 
+   requests over one minute. Run the following in a new terminal:
 
    ```sh
    for _ in {1..60}; do {curl localhost:8000/mock/request; sleep 1; } done
@@ -87,12 +87,12 @@ This guide assumes each of the following tools are installed locally.
    END
    ```
 
-The [Kong Hub StatsD Plugin](/hub/kong-inc/statsd/) 
-contains the full documentation on the plugin usage and configuration
+See the [StatsD plugin](/hub/kong-inc/statsd/) 
+documentation for more information about how to use and configure the plugin.
 
-### Cleanup
+### Remove the test StatsD service 
 
-Once you are done experimenting with StatsD and {{site.base_gateway}}, use the following
+Once you are done experimenting with StatsD and {{site.base_gateway}}, you can use the following
 commands to stop and remove the services created in this guide:
 
 ```sh
@@ -100,9 +100,9 @@ docker stop kong-quickstart-statsd
 curl -Ls get.konghq.com/quickstart | sh -s -- -d
 ```
 
-### More Information
-* [How to monitor with Prometheus](/gateway/{{page.gateway_version}}/kong-production/monitoring/prometheus/) 
-provides a guide to using [Prometheus](https://prometheus.io/docs/introduction/overview/) for monitoring with the 
-[{{site.base_gateway}} Plugin](/hub/kong-inc/prometheus/)
+### More information
+* [How to monitor with Prometheus](/gateway/{{page.kong_version}}/kong-production/monitoring/prometheus/) 
+describes how to use [Prometheus](https://prometheus.io/docs/introduction/overview/) to monitor {{site.base_gateway}} using the  
+[Prometheus plugin](/hub/kong-inc/prometheus/).
 * See the [Tracing API Reference](/gateway/{{page.kong_version}}/kong-production/tracing/api/) for information
-on {{site.base_gateway}}'s tracing capabilites
+about {{site.base_gateway}}'s tracing capabilities.

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -12,19 +12,23 @@ StatsD service. Then you will generate sample requests to {{site.base_gateway}} 
 observe the collected monitoring data. 
 
 ### Prerequisites
-* A test {{site.base_gateway}} instance is installed using the following script:
-   ```sh
-   curl -Ls get.konghq.com/quickstart | sh -s -- -m
-   ```
-   The `-m` flag instructs the script to install a mock service that is used in this guide to generate sample metrics.
-   {:.note}
-   > **Note:** This guide's instructions use a test {{site.base_gateway}} instance to demonstrate how the StatsD plugin can be used to collect metrics. If you want to use an existing {{site.base_gateway}} instance for this guide, you must modify the connection information in the commands.
 * [Docker](https://docs.docker.com/get-docker/) is installed locally. It is used to run {{site.base_gateway}}, the supporting database, and StatsD locally. 
+
+   If you will be using an existing {{site.base_gateway}} instance instead of the test instance, you may need configure Docker to ensure features like network connectivity function correctly.  
 * [curl](https://curl.se/) is installed locally. It is used to send requests to {{site.base_gateway}}. `curl` is pre-installed on most systems.
 * [Netcat](http://netcat.sourceforge.net/) is installed locally as `nc` on the `PATH`. `nc` is used to send requests 
   to the StatsD management interface. `nc` is pre-installed on many systems.
 
 ### Configure StatsD monitoring
+
+{:.note}
+   > **Note:** This guide's instructions use a test {{site.base_gateway}} instance to demonstrate how the StatsD plugin can be used to collect metrics. If you want to use an existing {{site.base_gateway}} instance for this guide, you must modify the connection information in the commands.
+
+1. Optional: Install {{site.base_gateway}} using the following script:
+   ```sh
+   curl -Ls get.konghq.com/quickstart | sh -s -- -m
+   ```
+   The `-m` flag instructs the script to install a mock service that is used in this guide to generate sample metrics.
 
 1. Run a StatsD container to capture monitoring data:
 
@@ -77,7 +81,7 @@ observe the collected monitoring data.
 See the [StatsD plugin](/hub/kong-inc/statsd/) 
 documentation for more information about how to use and configure the plugin.
 
-### Remove the test StatsD service 
+### Clean up the test instance 
 
 Once you are done experimenting with StatsD and {{site.base_gateway}}, you can use the following
 commands to stop and remove the services created in this guide:

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -4,7 +4,7 @@ content_type: how-to
 ---
 
 [StatsD](https://github.com/statsd/statsd) is a network daemon that collects
-and aggreates performance metrics by listening on the network for simple 
+and aggreates performance metrics by listening on the network for 
 text based statistics data, published by applications. 
 
 This guide will help you setup a test {{site.base_gateway}} and
@@ -55,7 +55,7 @@ observe the collected monitoring data.
        --data "config.port=8125"
    ```
 
-   You should receive a JSON response with the details of the installed plugin.
+   You should receive a JSON response with details about the installed plugin.
 
 1. Generate sample traffic to the mock service. This allows you to observe 
    metrics generated from the StatsD plugin. The following command generates 60 
@@ -88,7 +88,7 @@ observe the collected monitoring data.
 See the [StatsD plugin](/hub/kong-inc/statsd/) 
 documentation for more information about how to use and configure the plugin.
 
-### Clean up running software
+### Clean up
 
 Once you are done experimenting with StatsD and {{site.base_gateway}}, you can use the following
 commands to stop and remove the software ran in this guide:

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -19,7 +19,7 @@ observe the collected monitoring data.
 
 ### Configure StatsD monitoring
 
-1. Install a test {{site.base_gateway}}:
+1. Install {{site.base_gateway}}:
 
    {:.note}
       > This step is optional if you wish to use an existing {{site.base_gateway}} installation. When using an existing

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -4,7 +4,7 @@ content_type: how-to
 ---
 
 [StatsD](https://github.com/statsd/statsd) is a network daemon that collects
-and aggreates performance metrics by listening on the network for 
+and aggregates performance metrics by listening on the network for 
 text based statistics data, published by applications. 
 
 This guide will help you setup a test {{site.base_gateway}} and

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -1,6 +1,108 @@
 ---
-title: Monitoring with Statsd
-
+title: Monitoring with StatsD
+content_type: how-to
 ---
 
-## PLACEHOLDER How to Monitor with Statsd
+[StatsD](https://github.com/statsd/statsd) is a network daemon that collects
+and aggreates performance metrics by listening on the network for simple 
+text based statistics data published by applications. 
+
+This guide will help you setup a test {[site.base_gateway} and
+StatsD service. Then you will generate sample requests to {{site.base_gateway}} and
+observe the collected monitoring data.
+
+### Prerequisites
+This guide assumes each of the following tools are installed locally. 
+* [Docker](https://docs.docker.com/get-docker/) is used to run Kong and the supporting database locally. 
+* [curl](https://curl.se/) is used to send requests to the gateway. Most systems come with `curl` pre-installed.
+* [Netcat](http://netcat.sourceforge.net/) installed as `nc` on the `PATH`. `nc` is used to send requests 
+  to the StatsD management interface. Many systems come with `nc` pre-installed.
+
+### Guide
+
+1. Run the following command to start {{site.base_gateway}} using Docker:
+
+   ```sh
+   curl -Ls get.konghq.com/quickstart | sh -s
+   ```
+
+   You should see the following message when {{site.base_gateway}} is ready:
+
+   ```text
+   ✔ Kong is ready!
+   ```
+
+   The script has also installed a mock service to make testing easier. You will use this 
+   service later to generate monitoring data. You can send a sample request with:
+
+   ```sh
+   curl localhost:8000/mock/requests
+   ```
+
+1. Run a StatsD container to capture monitoring data:
+
+   ```sh
+   docker run -d --rm -p 8126:8126 \
+     --name kong-quickstart-statsd --network=kong-quickstart-net \
+     statsd/statsd:latest
+   ```
+
+1. Install the [StatsD {{site.base_gateway}} plugin](/hub/kong-inc/statsd/), 
+   configuring the hostname and port of the listening StatsD service:
+
+   ```sh
+   curl -X POST http://localhost:8001/plugins/ \
+       --data "name=statsd"  \
+       --data "config.host=kong-quickstart-statsd" \
+       --data "config.port=8125"
+   ```
+
+   You should receive a JSON response with the details of the installed plugin.
+
+1. Generate sample traffic to the mock service. This will allow you to observe 
+   metrics generated from the StatsD plugin. The following command will generate 60 
+   requests over 1 minute. Run the following in a new terminal:
+
+   ```sh
+   for _ in {1..60}; do {curl localhost:8000/mock/request; sleep 1; } done
+   ```
+
+1. Query the StatsD management interface to see the collected metrics from {{site.base_gateway}}:
+
+   ```sh
+   echo "counters" | nc localhost 8126
+   ```
+
+   You should see a response similar to the following:
+
+   ```text
+   {
+     'statsd.bad_lines_seen': 0,
+     'statsd.packets_received': 56,
+     'statsd.metrics_received': 56,
+     'kong.mock.request.count': 7,
+     'kong.mock.request.status.200': 7,
+     'kong.mock.request.status.total': 7
+   }
+   END
+   ```
+
+The [Kong Hub StatsD Plugin](/hub/kong-inc/statsd/) 
+contains the full documentation on the plugin usage and configuration
+
+### Cleanup
+
+Once you are done experimenting with StatsD and {{site.base_gateway}}, use the following
+commands to stop and remove the services created in this guide:
+
+```sh
+docker stop kong-quickstart-statsd
+curl -Ls get.konghq.com/quickstart | sh -s -- -d
+```
+
+### More Information
+* [How to monitor with Prometheus](/gateway/{{page.gateway_version}}/kong-production/monitoring/prometheus/) 
+provides a guide to using [Prometheus](https://prometheus.io/docs/introduction/overview/) for monitoring with the 
+[{{site.base_gateway}} Plugin](/hub/kong-inc/prometheus/)
+* See the [Tracing API Reference](/gateway/{{page.kong_version}}/kong-production/tracing/api/) for information
+on {{site.base_gateway}}'s tracing capabilites

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -7,13 +7,13 @@ content_type: how-to
 and aggreates performance metrics by listening on the network for simple 
 text based statistics data published by applications. 
 
-This guide will help you setup a test {[site.base_gateway} and
+This guide will help you setup a test {{site.base_gateway}} and
 StatsD service. Then you will generate sample requests to {{site.base_gateway}} and
 observe the collected monitoring data.
 
 ### Prerequisites
 This guide assumes each of the following tools are installed locally. 
-* [Docker](https://docs.docker.com/get-docker/) is used to run Kong and the supporting database locally. 
+* [Docker](https://docs.docker.com/get-docker/) is used to run Kong, the supporting database, and StatsD locally. 
 * [curl](https://curl.se/) is used to send requests to the gateway. Most systems come with `curl` pre-installed.
 * [Netcat](http://netcat.sourceforge.net/) installed as `nc` on the `PATH`. `nc` is used to send requests 
   to the StatsD management interface. Many systems come with `nc` pre-installed.
@@ -33,7 +33,7 @@ This guide assumes each of the following tools are installed locally.
    ```
 
    The script has also installed a mock service to make testing easier. You will use this 
-   service later to generate monitoring data. You can send a sample request with:
+   service later to generate metrics data. You can send a sample request with:
 
    ```sh
    curl localhost:8000/mock/requests

--- a/src/gateway/kong-production/monitoring/statsd.md
+++ b/src/gateway/kong-production/monitoring/statsd.md
@@ -5,30 +5,37 @@ content_type: how-to
 
 [StatsD](https://github.com/statsd/statsd) is a network daemon that collects
 and aggreates performance metrics by listening on the network for simple 
-text based statistics data published by applications. 
+text based statistics data, published by applications. 
 
 This guide will help you setup a test {{site.base_gateway}} and
 StatsD service. Then you will generate sample requests to {{site.base_gateway}} and
 observe the collected monitoring data. 
 
 ### Prerequisites
-* [Docker](https://docs.docker.com/get-docker/) is installed locally. It is used to run {{site.base_gateway}}, the supporting database, and StatsD locally. 
-
-   If you will be using an existing {{site.base_gateway}} instance instead of the test instance, you may need configure Docker to ensure features like network connectivity function correctly.  
-* [curl](https://curl.se/) is installed locally. It is used to send requests to {{site.base_gateway}}. `curl` is pre-installed on most systems.
-* [Netcat](http://netcat.sourceforge.net/) is installed locally as `nc` on the `PATH`. `nc` is used to send requests 
+* [Docker](https://docs.docker.com/get-docker/) is used to run StatsD and supporting services locally. 
+* [curl](https://curl.se/) is used to send requests to {{site.base_gateway}}. `curl` is pre-installed on most systems.
+* [Netcat](http://netcat.sourceforge.net/) is installed as `nc` on the system `PATH`. `nc` is used to send requests 
   to the StatsD management interface. `nc` is pre-installed on many systems.
 
 ### Configure StatsD monitoring
 
-{:.note}
-   > **Note:** This guide's instructions use a test {{site.base_gateway}} instance to demonstrate how the StatsD plugin can be used to collect metrics. If you want to use an existing {{site.base_gateway}} instance for this guide, you must modify the connection information in the commands.
+1. Install a test {{site.base_gateway}}:
 
-1. Optional: Install {{site.base_gateway}} using the following script:
+   {:.note}
+      > This step is optional if you wish to use an existing {{site.base_gateway}} installation. When using an existing
+        {{site.base_gateway}}, you will need to modify the remaining commands as appropriate to account for network
+        connectivity and installed {{site.base_gateway}} services and routes.
+
    ```sh
    curl -Ls get.konghq.com/quickstart | sh -s -- -m
    ```
    The `-m` flag instructs the script to install a mock service that is used in this guide to generate sample metrics.
+
+   Once the {{site.base_gateway}} is ready, you will see the following message:
+
+   ```text
+   ✔ Kong is ready!
+   ```
 
 1. Run a StatsD container to capture monitoring data:
 
@@ -81,10 +88,10 @@ observe the collected monitoring data.
 See the [StatsD plugin](/hub/kong-inc/statsd/) 
 documentation for more information about how to use and configure the plugin.
 
-### Clean up the test instance 
+### Clean up running software
 
 Once you are done experimenting with StatsD and {{site.base_gateway}}, you can use the following
-commands to stop and remove the services created in this guide:
+commands to stop and remove the software ran in this guide:
 
 ```sh
 docker stop kong-quickstart-statsd


### PR DESCRIPTION
### Summary
Adds StatsD monitoring page under Kong in Production

### Reason
Helps the user with a how-to guide to quickly run Kong GW, StatsD, and StatsD plugin
https://konghq.atlassian.net/browse/DOCU-2423

### Testing
built and viewed docs locally

