### PR TITLE
Fix vault bundles description

### DIFF
--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -530,7 +530,7 @@ Comma-separated list of vaults this node should load. Vaults are `bundled` by de
 The specified name(s) will be substituted as such in the Lua namespace:
 `kong.vaults.{name}.*`.
 
-To disable vault bundles, set `vaults` to `off`.
+In version 2.8.1.3, enabling vaults can result in increased memory usage. To conserve memory usage, you can disable vault bundles by setting `vaults` to `off`.
 
 **Default:** `bundled`
 

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -530,6 +530,8 @@ Comma-separated list of vaults this node should load. Vaults are `bundled` by de
 The specified name(s) will be substituted as such in the Lua namespace:
 `kong.vaults.{name}.*`.
 
+To disable vault bundles, set `vaults` to `off`.
+
 **Default:** `bundled`
 
 ---


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Updated vaults description based on the following feedback:

> In 2.8.1.3 vault bundles are turned on by default and the out of the box memory consumption increase is immediately visible. I think we should update our docs to point this out and show how to turn off vault bundles if customer is not using secrets-mgmt.

I also updated the kong.conf file in kong/kong-ee: https://github.com/Kong/kong-ee/pull/3635 

I didn't think we'd also need to update [this page](https://docs.konghq.com/gateway/latest/plan-and-deploy/security/secrets-management/#beta-and-general-availability-phases), but let me know if you think we should. 
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
