### PR TITLE
[DOCU-2291] Copy vaults GA edits to 3.0

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -214,14 +214,16 @@ items:
             url: /kong-enterprise/secrets-management/advanced-usage
           - text: Backends
             items:
+              - text: Overview
+                url: /kong-enterprise/secrets-management/backends
               - text: Environment Variables
                 url: /kong-enterprise/secrets-management/backends/env
               - text: AWS Secrets Manager
                 url: /kong-enterprise/secrets-management/backends/aws-sm
+              - text: Google Secrets Manager
+                url: /kong-enterprise/secrets-management/backends/gcp-sm
               - text: Hashicorp Vault
                 url: /kong-enterprise/secrets-management/backends/hashicorp-vault
-              - text: Google Secrets Manager
-                url: /kong-enterprise/secrets-management/backends/google-sm
           - text: Reference Format
             url: /kong-enterprise/secrets-management/reference-format
       - text: Dynamic Plugin Ordering

--- a/src/gateway/kong-enterprise/secrets-management/advanced-usage.md
+++ b/src/gateway/kong-enterprise/secrets-management/advanced-usage.md
@@ -1,6 +1,5 @@
 ---
 title: Advanced Secrets Configuration
-beta: true
 ---
 
 
@@ -17,13 +16,13 @@ For example, the following query uses an option called `prefix` with the value `
 ```
 
 For more information on available configuration options,
-refer to respective [vault backend documentation](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends).
+refer to respective [vault backend documentation](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends).
 
 ## Environment Variables
 
 You can configure your vault backend with `KONG_VAULT_<vault-backend>_<config_opt>` environment variables.
 
-For example, Kong Gateway might look for an environment variable that matches `KONG_VAULT_ENV_PREFIX`:
+For example, {{site.base_gateway}} might look for an environment variable that matches `KONG_VAULT_ENV_PREFIX`:
 
 ```bash
 export KONG_VAULT_ENV_PREFIX=SECURE_
@@ -33,14 +32,11 @@ export KONG_VAULT_ENV_PREFIX=SECURE_
 
 You can configure your vault backend using the `vaults` entity.
 
-For the beta release of this feature, the endpoint is `/vaults-beta`.
-
 ```bash
-http PUT :8001/vaults-beta/my-env-vault \
+http -f PUT :8001/vaults/my-env-vault \
   name=env \
   description="ENV vault for secrets" \
-  config.prefix=SECURE_ \
-  -f
+  config.prefix=SECURE_
 ```
 
 This lets you drop the configuration from environment variables and query arguments and use the entity name in the reference.
@@ -53,13 +49,10 @@ For more information, see the section on the [Vaults entity](#vaults-entity).
 
 ## Vaults CLI
 
-{:.warning}
-> **Beta warning:** In the beta release, only the `kong vault get` command is supported.
-
 ```text
 Usage: kong vault COMMAND [OPTIONS]
 
-Vault utilities for Kong.
+Vault utilities for {{site.base_gateway}}.
 
 Example usage:
  TEST=hello kong vault get env/test
@@ -75,10 +68,7 @@ Options:
 ## Vaults Entity
 
 {:.warning}
-> **Beta warning:**
-> <br>
-> The API endpoint is suffixed with `-beta` to avoid any possible conflicts. This will be
-> changed in the future. Kong Manager has currently no supports for configuring vault entities.
+> Kong Manager currently doesn't support configuring vault entities.
 
 The Vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the Vaults entity.
 
@@ -88,7 +78,7 @@ Create a Vault entity:
 {% navtab cURL %}
 
 ```bash
-$ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault-1  \
+$ curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault-1  \
         --data name=env \
         --data description='ENV vault for secrets' \
         --data config.prefix=SECRET_
@@ -98,11 +88,10 @@ $ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault-1  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-env-vault-1 \
+http -f PUT :8001/vaults/my-env-vault-1 \
   name=env \
   description="ENV vault for secrets" \
-  config.prefix=SECRET_  \
-  -f
+  config.prefix=SECRET_
 ```
 
 {% endnavtab %}
@@ -125,4 +114,4 @@ Result:
 }
 ```
 
-Config options depend on the associated [backend](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends) used.
+Config options depend on the associated [backend](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends) used.

--- a/src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -1,12 +1,11 @@
 ---
 title: AWS Secrets Manager
-beta: true
 badge: enterprise
 ---
 
 ## Configuration
 
-[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be configured in multiple ways. The current version of Kong Gateway's implementation only supports
+[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be configured in multiple ways. The current version of {{site.base_gateway}} implementation only supports
 configuring via environment variables.
 
 ```bash
@@ -32,7 +31,7 @@ Access these secrets from `my-secret-name` like this:
 
 ```bash
 {vault://aws/my-secret-name/foo}
-{vault://aws/my-secret-name/snap}
+{vault://aws/my-secret-name/snip}
 ```
 
 ## Entity
@@ -43,7 +42,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-aws-sm-vault  \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-aws-sm-vault  \
   --data name=aws \
   --data description="Storing secrets in AWS Secrets Manager" \
   --data config.region="us-east-1"
@@ -53,10 +52,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-aws-sm-vault  \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-aws-sm-vault name="aws" \
+http -f PUT :8001/vaults/my-aws-sm-vault name="aws" \
   description="Storing secrets in AWS Secrets Manager" \
-  config.region="us-east-1" \
-  -f 
+  config.region="us-east-1"
 ```
 
 {% endnavtab %}
@@ -84,7 +82,7 @@ environment variable.
 
 ```bash
 {vault://my-aws-sm-vault/my-secret-name/foo}
-{vault://my-aws-sm-vault/my-secret-name/snap}
+{vault://my-aws-sm-vault/my-secret-name/snip}
 ```
 
 ## Advanced Examples
@@ -92,13 +90,13 @@ environment variable.
 You can create multiple entities, which lets you have secrets in different regions:
 
 ```bash
-http PUT :8001/vaults-beta/aws-eu-central-vault name=aws config.region="eu-central-1" -f 
-http PUT :8001/vaults-beta/aws-us-west-vault name=aws config.region="us-west-1" -f 
+http -f PUT :8001/vaults/aws-eu-central-vault name=aws config.region="eu-central-1"
+http -f PUT :8001/vaults/aws-us-west-vault name=aws config.region="us-west-1"
 ```
 
 This lets you source secrets from different regions:
 
 ```bash
 {vault://aws-eu-central-vault/my-secret-name/foo}
-{vault://aws-us-west-vault/my-secret-name/snap}
+{vault://aws-us-west-vault/my-secret-name/snip}
 ```

--- a/src/gateway/kong-enterprise/secrets-management/backends/env.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/env.md
@@ -1,7 +1,7 @@
 ---
 title: Environment Variables Vault
-beta: true
 badge: free
+content-type: how-to
 ---
 
 ## Configuration
@@ -14,7 +14,7 @@ There is no prior configuration needed.
 Define a secret in a environment variable:
 
 ```bash
-export MY_SECRET_VALUE=opensesame
+export MY_SECRET_VALUE=EXAMPLE_VALUE
 ```
 
 We can now reference this secret
@@ -46,7 +46,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault \
         --data name=env \
         --data description="Store secrets in environment variables"
 ```
@@ -55,10 +55,9 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-env-vault \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-env-vault \
+http -f PUT :8001/vaults/my-env-vault \
   name="env" \
-  description="Store secrets in environment variables" \
-  -f 
+  description="Store secrets in environment variables"
 ```
 
 {% endnavtab %}

--- a/src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
@@ -1,0 +1,115 @@
+---
+title: GCP Secrets Manager
+badge: enterprise
+content-type: how-to
+---
+
+## Configuration
+
+The current version of {{site.base_gateway}}'s implementation supports
+configuring
+[GCP Secrets Manager](https://cloud.google.com/secret-manager/) in two
+ways:
+
+* Environment variables
+* Workload Identity
+
+To configure GCP Secrets Manager, the `GCP_SERVICE_ACCOUNT`
+environment variable must be set to the JSON document referring to the
+[credentials for your service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys):
+
+```bash
+export GCP_SERVICE_ACCOUNT=$(cat gcp-my-project-c61f2411f321.json)
+```
+
+{{site.base_gateway}} uses the key to automatically authenticate
+with the GCP API and grant you access.
+
+To use GCP Secrets Manager with
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+on a GKE cluster, update your pod spec so that the service account is
+attached to the pod. For configuration information, read the [Workload
+Identity configuration
+documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
+
+{:.note}
+> With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
+
+## Examples
+
+To use a GCP Secret Manager
+[secret](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets)
+with the name `my-secret-name`, create a JSON object in GCP that
+contains one or more properties:
+
+```json
+{
+  "foo": "bar",
+  "snip": "snap"
+}
+```
+
+You can now reference the secret's individual resources like this:
+
+```bash
+{vault://gcp/my-secret-name/foo?project_id=my_project_id}
+{vault://gcp/my-secret-name/snip?project_id=my_project_id}
+```
+
+Note that both the provider (`gcp`) as well as the GCP project ID
+(`my_project_id`) need to be specified.
+
+## Entity
+
+Once the database is initialized, a Vault entity can be created
+that encapsulates the provider and the GCP project ID:
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
+  --data name=gcp \
+  --data description="Storing secrets in GCP Secrets Manager" \
+  --data config.project_id="my_project_id"
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http -f PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
+  name="gcp" \
+  description="Storing secrets in GCP Secrets Manager" \
+  config.project_id="my_project_id"
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+```json
+{
+    "config": {
+        "project_id": "my_project_id"
+    },
+    "created_at": 1657874961,
+    "description": "Storing secrets in GCP Secrets Manager",
+    "id": "90e200be-cf84-4ce9-a1d6-a41c75c79f31",
+    "name": "gcp",
+    "prefix": "my-gcp-sm-vault",
+    "tags": null,
+    "updated_at": 1657874961
+}
+```
+
+With the Vault entity in place, you can reference the GCP secrets
+through it:
+
+```bash
+{vault://my-gcp-sm-vault/my-secret-name/foo}
+{vault://my-gcp-sm-vault/my-secret-name/snip}
+```
+
+When you use the Vault entity, you no longer need to specify the GCP project ID to access the secrets.

--- a/src/gateway/kong-enterprise/secrets-management/backends/google-sm.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/google-sm.md
@@ -1,7 +1,0 @@
----
-title: Google Secrets Management
-beta: true
-badge: free
----
-
-## Configuration

--- a/src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -5,17 +5,17 @@ badge: enterprise
 
 ## Configuration
 
-[Hashicorp Vault](https://www.vaultproject.io/) can be configured with environment variables or with a Vault entity.
+[HashiCorp Vault](https://www.vaultproject.io/) can be configured with environment variables or with a Vault entity.
 
 ## Environment variables
 
 ```bash
-export KONG_VAULTS_HCV_PROTOCOL=<protocol(http|https)>
-export KONG_VAULTS_HCV_HOST=<hostname>
-export KONG_VAULTS_HCV_PORT=<portnumber>
-export KONG_VAULTS_HCV_MOUNT=<mountpoint>
-export KONG_VAULTS_HCV_KV=<v1|v2>
-export KONG_VAULTS_HCV_TOKEN=<tokenstring>
+export KONG_VAULT_HCV_PROTOCOL=<protocol(http|https)>
+export KONG_VAULT_HCV_HOST=<hostname>
+export KONG_VAULT_HCV_PORT=<portnumber>
+export KONG_VAULT_HCV_MOUNT=<mountpoint>
+export KONG_VAULT_HCV_KV=<v1|v2>
+export KONG_VAULT_HCV_TOKEN=<tokenstring>
 ```
 
 You can also store this information in an entity.
@@ -29,7 +29,7 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtab cURL %}
 
 ```bash
-curl -i -X PUT http://<hostname>:8001/vaults-beta/my-hashicorp-vault \
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-hashicorp-vault \
   --data name="hcv" \
   --data description="Storing secrets in Hashicorp Vault" \
   --data config.protocol="https" \
@@ -44,7 +44,7 @@ curl -i -X PUT http://<hostname>:8001/vaults-beta/my-hashicorp-vault \
 {% navtab HTTPie %}
 
 ```bash
-http PUT :8001/vaults-beta/my-hashicorp-vault \
+http -f PUT :8001/vaults/my-hashicorp-vault \
   name="hcv" \
   description="Storing secrets in Hashicorp Vault" \
   config.protocol="https" \
@@ -52,8 +52,7 @@ http PUT :8001/vaults-beta/my-hashicorp-vault \
   config.port="8200" \
   config.mount="secret" \
   config.kv="v2" \
-  config.token="<mytoken>" \
-  -f 
+  config.token="<mytoken>"
 ```
 
 {% endnavtab %}
@@ -83,7 +82,7 @@ Result:
 
 ## Examples
 
-For example, let's say you've configured a Hashicorp Vault with a path of `secret/hello` and a key=value pair of `foo=world`:
+For example, let's say you've configured a HashiCorp Vault with a path of `secret/hello` and a key=value pair of `foo=world`:
 
 ```text
 vault kv put secret/hello foo=world

--- a/src/gateway/kong-enterprise/secrets-management/backends/index.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/index.md
@@ -1,14 +1,12 @@
 ---
 title: Supported Vault Backends
-beta: true
 ---
-
-Secrets rotation is not supported for the beta version.
 
 The following Vault implementations are supported:
 
 |                                                                                                                        | Rotation Support             | Get                          | Tier       |
 |------------------------------------------------------------------------------------------------------------------------|------------------------------|------------------------------|------------|
-| [AWS Secrets Manager](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/aws-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
-| [Hashicorp Vault](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
-| [Environment Variable](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/backends/env)        |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Free       |
+| [AWS Secrets Manager](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/aws-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [GCP Secrets Manager](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/gcp-sm)      |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [HashiCorp Vault](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/hashicorp-vault) |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Enterprise |
+| [Environment Variable](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/env)        |  <i class="fa fa-times"></i> |  <i class="fa fa-check"></i> | Free       |

--- a/src/gateway/kong-enterprise/secrets-management/getting-started.md
+++ b/src/gateway/kong-enterprise/secrets-management/getting-started.md
@@ -1,12 +1,8 @@
 ---
 title: Get Started with Secrets Management
-beta: true
 ---
 
-This feature is currently in beta state and isn't fully supported. APIs are subject to change.
-
-
-Secrets are generally confidential values that should not appear in plain text in the application. 
+Secrets are generally confidential values that should not appear in plain text in the application.
 There are several products that help you store, retrieve, and rotate these secrets securely.
 {{site.base_gateway}} offers a mechanism to set up references to these secrets which makes your {{site.base_gateway}} installation more secure.
 
@@ -67,6 +63,6 @@ pg_password={vault://env/my-secret-postgres-password}
 Upon startup, {{site.base_gateway}} tries to detect and transparently resolve references.
 
 {:.note}
-> For quick debugging or testing, you can use the [CLI for vaults](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/advanced-usage/#vaults-cli).
+> For quick debugging or testing, you can use the [CLI for vaults](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/advanced-usage/#vaults-cli).
 
 See the [Advanced Usage](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/advanced-usage) documentation for more information on the configuration options for each vault backend.

--- a/src/gateway/kong-enterprise/secrets-management/index.md
+++ b/src/gateway/kong-enterprise/secrets-management/index.md
@@ -1,6 +1,5 @@
 ---
 title: Secrets Management
-beta: true
 ---
 
 A secret is any sensitive piece of information required for API gateway
@@ -31,7 +30,7 @@ This feature is enabled by default.
 Due to conflicts with previous releases of {{site.base_gateway}},
 the endpoints for secrets management in the
 Admin API have changed from the previous `/vaults-beta` prefix to
-`/vaults` with `vaults_use_new_style_api=on` set in `kong.conf`.
+`/vaults`.
 
 ## Referenceable values
 
@@ -57,14 +56,15 @@ documentation for each plugin to identify the referenceable fields:
 {{site.base_gateway}} supports the following vault backends:
 * Environment variables
 * AWS Secrets Manager
-* Hashicorp Vault
+* GCP Secrets Manager
+* HashiCorp Vault
 
 See the [backends overview](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/)
 for more information about each option.
 
 ## Get started
 
-To test out secrets management, see the following topics:
+For further information on secrets management, see the following topics:
 * [Get started with secrets management](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/getting-started/)
 * [Backends overview](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/)
 * [Reference format](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/reference-format/)

--- a/src/gateway/kong-enterprise/secrets-management/reference-format.md
+++ b/src/gateway/kong-enterprise/secrets-management/reference-format.md
@@ -1,6 +1,5 @@
 ---
 title: Reference Format
-beta: true
 ---
 
 ## Reference Format
@@ -49,7 +48,8 @@ or using a vault entity
 
 #### Secret ID
 
-The `secret-id` is used as an identifier in case the vault uses a nested datastructure.
+The `secret-id` is used as an identifier in case the vault uses a
+nested data structure.
 
 #### Secret Key
 
@@ -57,4 +57,4 @@ The `secret-key` is used to identify the secret within the `secret-id` object.
 
 ### Query
 
-Query arguments are used to denote configuration options in a `key=value` format to the [Vault Prefix](/gateway/{{page.kong_version}}/plan-and-deploy/security/secrets-management/reference-format/#vault-prefix)
+Query arguments are used to denote configuration options in a `key=value` format to the [Vault Prefix](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/reference-format/#vault-prefix)


### PR DESCRIPTION
### Summary
 Secrets management went into a soft GA in a 2.8 patch version, copying those edits into 3.0. I'm not writing anything new here.

* Updating links for new nav structure
* Updating nav
* Some cleanup of beta and 2.8 mentions. 

### Reason
Parity with changes made in 2.8.

https://konghq.atlassian.net/browse/DOCU-2291

### Testing
Netlify preview