### PR TITLE
[DOCU-2459] Gateway icons

### DIFF
--- a/app/_assets/images/icons/documentation/icn-flag.svg
+++ b/app/_assets/images/icons/documentation/icn-flag.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="19" height="24" viewBox="0 0 19 24">
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="24" viewBox="0 0 20 24">
     <path fill="#0070bf" fill-rule="evenodd" d="M2 0c.552 0 1 .448 1 1v1h10v2h6l-2 5 2 5h-8v-2H3v10c.552 0 1 .448 1 1v1H0v-1c0-.552.448-1 1-1V1c0-.552.448-1 1-1zm11 10v2h3l-.667-2H13zm-2-2H3v2h8V8zm0-4H3v2h8V4zm2 4h2.333L16 6h-3v2z"/>
 </svg>

--- a/app/_assets/images/icons/documentation/icn-learning.svg
+++ b/app/_assets/images/icons/documentation/icn-learning.svg
@@ -1,9 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="50" height="42" viewBox="0 0 50 42">
-    <g fill="none" fill-rule="evenodd" stroke-width="2">
-        <path stroke="#004B80" d="M8.792 16v8.968c0 .212.09.412.246.543 4.17 3.54 9.41 5.489 14.754 5.489 3.603 0 7.16-.888 10.373-2.55l1.314-.736c1.07-.646 2.098-1.38 3.066-2.203.156-.131.247-.331.247-.543V16" transform="translate(1 2)"/>
-        <path stroke="#C2D6FF" d="M0.792 9L23.941 18 47.792 9" transform="translate(1 2)"/>
-        <path stroke="#004B80" d="M0.792 8.516L23.941 0 47.792 8.516 47.792 12.774 23.941 22 0.792 12.774z" transform="translate(1 2)"/>
-        <path stroke="#3A8FE6" d="M25.792 8L35.792 12.911 35.792 34" transform="translate(1 2)"/>
-        <path fill="#FFF" fill-rule="nonzero" stroke="#3A8FE6" d="M36.292 39c1.38 0 2.5-1.12 2.5-2.5s-1.12-2.5-2.5-2.5c-1.381 0-2.5 1.12-2.5 2.5s1.119 2.5 2.5 2.5z" transform="translate(1 2)"/>
-    </g>
+<svg width="20" height="19" viewBox="0 0 20 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1101_2)">
+<path d="M3.83331 8.43333V12.1002C3.83331 12.1869 3.87011 12.2687 3.9339 12.3223C5.63897 13.7697 7.78154 14.5667 9.96665 14.5667C11.4399 14.5667 12.8943 14.2036 14.2081 13.524L14.7453 13.2231C15.1828 12.9589 15.6032 12.6588 15.999 12.3223C16.0628 12.2687 16.1 12.1869 16.1 12.1002V8.43333" stroke="#0070BF" stroke-width="1.5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0.716797 4.84019L9.91073 0.87619L19.3835 4.84019V6.82218L9.91073 11.1167L0.716797 6.82218V4.84019Z" stroke="#0070BF" stroke-width="1.5"/>
+<path d="M9.70319 5.87778L12.9299 7.8086V16.1" stroke="#0070BF" stroke-width="1.5"/>
+<path d="M13.4167 17.6333C14.0515 17.6333 14.5667 17.1181 14.5667 16.4833C14.5667 15.8485 14.0515 15.3333 13.4167 15.3333C12.7814 15.3333 12.2667 15.8485 12.2667 16.4833C12.2667 17.1181 12.7814 17.6333 13.4167 17.6333Z" fill="white" stroke="#0070BF" stroke-width="1.5"/>
+</g>
+<defs>
+<clipPath id="clip0_1101_2">
+<rect width="20" height="18.4" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -52,7 +52,7 @@ items:
             url: /understanding-kong/glossary
 
   - title: Get Started with Kong
-    icon: /assets/images/icons/documentation/icn-quickstart-color.svg
+    icon: /assets/images/icons/documentation/icn-learning.svg
     items:
       - text: Overview
         url: /get-started/

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -52,7 +52,7 @@ items:
             url: /understanding-kong/glossary
 
   - title: Get Started with Kong
-    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    icon: /assets/images/icons/documentation/icn-quickstart-color.svg
     items:
       - text: Overview
         url: /get-started/
@@ -71,7 +71,7 @@ items:
       - text: Workspaces and Teams
         url: /get-started/manage-teams
   - title: Kong in Production
-    icon: /assets/images/icons/documentation/icn-quickstart-color.svg
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
     items:
       - text: Deployment Topologies
         items:
@@ -186,7 +186,7 @@ items:
       - text: Migrate from OSS to EE
         url: /kong-production/migrate-ce-to-ke
   - title: Kong Enterprise
-    icon: /assets/images/icons/documentation/icn-references-color.svg
+    icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
     items:
       - text: Overview
         url: /kong-enterprise/
@@ -375,7 +375,7 @@ items:
         url: /kong-manager/configuring-to-send-email
 
   - title: Develop Custom Plugins
-    icon: /assets/images/icons/documentation/icn-references-color.svg
+    icon: /assets/images/icons/documentation/icn-dev-portal-color.svg
     items:
       - text: Overview
         url: /plugin-development/
@@ -446,7 +446,7 @@ items:
           - text: Running Plugins in Containers
             url: /plugin-development/other/plugins-kubernetes
   - title: Kong Plugins
-    icon: /assets/images/icons/documentation/icn-references-color.svg
+    icon: /assets/images/icons/documentation/icn-api-plugins-color.svg
     items:
       - text: Overview
         url: /kong-plugins/
@@ -488,7 +488,7 @@ items:
       - text: gRPC
         url: /kong-plugins/grpc
   - title: Admin API
-    icon: /assets/images/icons/documentation/icn-references-color.svg
+    icon: /assets/images/icons/documentation/icn-admin-api-color.svg
     items:
       - text: Introduction to the Kong Admin API
         url: /admin-api/


### PR DESCRIPTION
### Summary
Updating the icons in the new nav to be unique for each section.
* I used the icon we used to use for Dev Portal for the "Develop Custom Plugins" section. It's not an official dev portal icon, it just signifies development - so I think that should be alright.
* Used icons that we already have for most things, had to adjust the learning icon to work for the nav (it's not in use anywhere else). 
* The previous icon used for getting started was a timer, which is supposed to denote getting started quickly. I'm not sure that it really applies (or ever did). The alternative is the learning icon. What do we think?

  <img width="293" alt="Screen Shot 2022-08-18 at 10 13 23 AM" src="https://user-images.githubusercontent.com/54370747/185455906-d0591707-d78f-495d-9f9b-2a85bb422dd0.png" float="left"> <img width="289" alt="Screen Shot 2022-08-18 at 10 14 41 AM" src="https://user-images.githubusercontent.com/54370747/185455910-7528ebae-d410-402a-95a8-421e59570446.png" float="left">

* Fixed flag icon so it doesn't get blurry (img width is set to 20px, but icon width was 19px, so it was getting a tiny bit stretched).

### Reason
https://konghq.atlassian.net/browse/DOCU-2459

### Testing
https://deploy-preview-4268--kongdocs.netlify.app/gateway/latest/