### PR TITLE
Fix breadcrumb links

### DIFF
--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -49,14 +49,16 @@
       <a href="{{ product_url }}">{{ product_title }}</a>
     </li>
 
+    {% assign breadcrumb_url = product_url %}
     {% for crumb in crumbs offset: offset %}
       {% assign title = crumb | replace:'-',' ' | remove:'.md' | capitalize | strip %}
 
       {% if title == "Servicehub" %}{% assign title = "Service Hub" %}{% endif %}
 
       {% unless forloop.last %}
-      {% capture breadcrumb_url %}{{ product_url }}{{ crumb }}/{% endcapture %}
+      {% capture breadcrumb_url %}{{ breadcrumb_url }}{{ crumb }}/{% endcapture %}
       {% capture breadcrumb_exists %}{% page_exists {{breadcrumb_url}} %}{% endcapture %}
+
         <li class="breadcrumb-item">
           {% if breadcrumb_exists == 'true' %}
           <a href="{{ breadcrumb_url }}">{{ title }}</a>

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,56 +1,59 @@
+{% assign crumbs = include.url | split : '/' %}
+
+{% assign offset = 3 %}
+{% if include.no_version == true %}
+  {% assign offset = 2 %}
+{% endif %}
+
+{% if include.edition == 'enterprise' %}
+  {% capture product_url %}/enterprise/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}{% endcapture %}
+  {% capture product_title %}{{site.ee_product_name}}{% endcapture %}
+{% elsif include.edition == 'konnect' %}
+  {% capture product_url %}/konnect/{% endcapture %}
+  {% capture product_title %}{{site.konnect_saas}}{% endcapture %}
+{% elsif include.edition == 'mesh' %}
+  {% capture product_url %}/mesh/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}{% endcapture %}
+  {% capture product_title %}{{site.mesh_product_name}}{% endcapture %}
+{% elsif include.edition == 'deck' %}
+  {% capture product_url %}/deck/{% endcapture %}
+  {% capture product_title %}decK{% endcapture %}
+{% elsif include.edition == 'kubernetes-ingress-controller' %}
+  {% capture product_url %}/kubernetes-ingress-controller/{{include.kong_version}}/{% endcapture %}
+  {% capture product_title %}{{site.kic_product_name}}{% endcapture %}
+{% elsif include.edition == 'gateway-oss' %}
+  {% capture product_url %}/gateway-oss/{{include.kong_version}}/{% endcapture %}
+  {% capture product_title %}{{ site.ce_product_name }}{% endcapture %}
+{% elsif include.edition == 'gateway' %}
+  {% capture product_url %}/gateway/{{include.kong_version}}/{% endcapture %}
+  {% capture product_title %}{{ site.base_gateway }}{% endcapture %}
+{% elsif include.edition == 'getting-started-guide' %}
+  {% capture product_url %}/getting-started-guide/{{include.kong_version}}/overview{% endcapture %}
+  {% capture product_title %}Get Started with Kong Gateway{% endcapture %}
+{% elsif include.edition == 'contributing' %}
+  {% capture product_url %}/contributing/{% endcapture %}
+  {% capture product_title %}Style guide and contribution guidelines{% endcapture %}
+{% endif %}
+
 <div id="breadcrumbs">
-  {% assign crumbs = include.dir | split: '/' %}
   <ul class="breadcrumbs">
-      <i class="sidebar-toggle"></i>
+    <i class="sidebar-toggle"></i>
     <li class="breadcrumb-item">
       <a href="/">Home</a>
     </li>
     <li class="breadcrumb-item">
-      {% if include.edition == 'enterprise' %}<a href="/enterprise/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}">{{site.ee_product_name}}</a>
-      {% elsif include.edition == 'konnect' %}<a href="/konnect/">{{site.konnect_saas}}</a>
-      {% elsif include.edition == 'mesh' %}<a href="/mesh/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}">{{site.mesh_product_name}}</a>
-      {% elsif include.edition == 'deck' %}<a href="/deck/">decK</a>
-      {% elsif include.edition == 'kubernetes-ingress-controller' %}<a href="/kubernetes-ingress-controller/{{include.kong_version}}/">{{site.kic_product_name}}</a>
-      {% elsif include.edition == 'gateway-oss' %}<a href="/gateway-oss/{{include.kong_version}}/">{{site.ce_product_name}}</a>
-      {% elsif include.edition == 'gateway' %}<a href="/gateway/{{include.kong_version}}/">{{site.base_gateway}}</a>
-      {% elsif include.edition == 'getting-started-guide' %}<a href="/getting-started-guide/{{include.kong_version}}/overview">Get Started with Kong Gateway</a>
-      {% elsif include.edition == 'contributing' %}<a href="/contributing/">Style guide and contribution guidelines</a>
-      {% endif %}
+      <a href="{{ product_url }}">{{ product_title }}</a>
     </li>
-    {% if include.no_version == true %}
-      {% if include.url contains '/konnect/servicehub' %}
-      <li class="breadcrumb-item">Service Hub</li>
-        {% for crumb in crumbs offset: 3 %}
-          {% unless forloop.last %}
-            <li class="breadcrumb-item">
-              {% assign crumb_limit = forloop.index | plus: 3 %}
-              {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
-            </li>
-          {% endunless %}
-        {% endfor %}
-      {% else %}
-        {% for crumb in crumbs offset: 2 %}
-          {% unless forloop.last %}
-            <li class="breadcrumb-item">
-              {% assign crumb_limit = forloop.index | plus: 2 %}
-              <!-- <a href="{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}"> -->
-                {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
-              <!-- </a> -->
-            </li>
-          {% endunless %}
-        {% endfor %}
-      {% endif %}
-    {% else %}
-      {% for crumb in crumbs offset: 3 %}
-        {% unless forloop.last %}
+
+    {% for crumb in crumbs offset: offset %}
+      {% assign title = crumb | replace:'-',' ' | remove:'.md' | capitalize | strip %}
+
+      {% if title == "Servicehub" %}{% assign title = "Service Hub" %}{% endif %}
+
+      {% unless forloop.last %}
         <li class="breadcrumb-item">
-          {% assign crumb_limit = forloop.index | plus: 3 %}
-          <!-- <a href="{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}"> -->
-            {{ crumb | replace:'-',' ' | remove:'.md' | capitalize }}
-          <!-- </a> -->
+          <a href="{{ product_url }}{{ crumb }}">{{ title }}</a>
         </li>
-        {% endunless %}
-      {% endfor %}
-    {% endif %}
+      {% endunless %}
+    {% endfor %}
   </ul>
 </div>

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -50,8 +50,14 @@
       {% if title == "Servicehub" %}{% assign title = "Service Hub" %}{% endif %}
 
       {% unless forloop.last %}
+      {% capture breadcrumb_url %}{{ product_url }}{{ crumb }}/{% endcapture %}
+      {% capture breadcrumb_exists %}{% page_exists {{breadcrumb_url}} %}{% endcapture %}
         <li class="breadcrumb-item">
-          <a href="{{ product_url }}{{ crumb }}">{{ title }}</a>
+          {% if breadcrumb_exists == 'true' %}
+          <a href="{{ breadcrumb_url }}">{{ title }}</a>
+          {% else %}
+          {{ title }}
+          {% endif %}
         </li>
       {% endunless %}
     {% endfor %}

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,33 +1,38 @@
 {% assign crumbs = include.url | split : '/' %}
 
+{% assign version = include.kong_version %}
+{% if include.is_latest %}
+  {% assign version = "latest" %}
+{% endif %}
+
 {% assign offset = 3 %}
 {% if include.no_version == true %}
   {% assign offset = 2 %}
 {% endif %}
 
 {% if include.edition == 'enterprise' %}
-  {% capture product_url %}/enterprise/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}{% endcapture %}
+  {% capture product_url %}/enterprise/{% unless include.no_version == true %}{{version}}/{% endunless %}{% endcapture %}
   {% capture product_title %}{{site.ee_product_name}}{% endcapture %}
 {% elsif include.edition == 'konnect' %}
   {% capture product_url %}/konnect/{% endcapture %}
   {% capture product_title %}{{site.konnect_saas}}{% endcapture %}
 {% elsif include.edition == 'mesh' %}
-  {% capture product_url %}/mesh/{% unless include.no_version == true %}{{include.kong_version}}/{% endunless %}{% endcapture %}
+  {% capture product_url %}/mesh/{% unless include.no_version == true %}{{version}}/{% endunless %}{% endcapture %}
   {% capture product_title %}{{site.mesh_product_name}}{% endcapture %}
 {% elsif include.edition == 'deck' %}
   {% capture product_url %}/deck/{% endcapture %}
   {% capture product_title %}decK{% endcapture %}
 {% elsif include.edition == 'kubernetes-ingress-controller' %}
-  {% capture product_url %}/kubernetes-ingress-controller/{{include.kong_version}}/{% endcapture %}
+  {% capture product_url %}/kubernetes-ingress-controller/{{version}}/{% endcapture %}
   {% capture product_title %}{{site.kic_product_name}}{% endcapture %}
 {% elsif include.edition == 'gateway-oss' %}
-  {% capture product_url %}/gateway-oss/{{include.kong_version}}/{% endcapture %}
+  {% capture product_url %}/gateway-oss/{{version}}/{% endcapture %}
   {% capture product_title %}{{ site.ce_product_name }}{% endcapture %}
 {% elsif include.edition == 'gateway' %}
-  {% capture product_url %}/gateway/{{include.kong_version}}/{% endcapture %}
+  {% capture product_url %}/gateway/{{version}}/{% endcapture %}
   {% capture product_title %}{{ site.base_gateway }}{% endcapture %}
 {% elsif include.edition == 'getting-started-guide' %}
-  {% capture product_url %}/getting-started-guide/{{include.kong_version}}/overview{% endcapture %}
+  {% capture product_url %}/getting-started-guide/{{version}}/overview{% endcapture %}
   {% capture product_title %}Get Started with Kong Gateway{% endcapture %}
 {% elsif include.edition == 'contributing' %}
   {% capture product_url %}/contributing/{% endcapture %}

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -70,7 +70,7 @@ id: documentation
               </div>
             {% endunless %}
             {% unless page.no_breadcrumbs %}
-              {% include_cached breadcrumbs.html edition=page.edition no_version=page.no_version has_version=page.has_version kong_version=page.kong_version url=page.url dir=page.dir%}
+              {% include_cached breadcrumbs.html is_latest=page.is_latest edition=page.edition no_version=page.no_version has_version=page.has_version kong_version=page.kong_version url=page.url dir=page.dir%}
             {% endunless %}
           </div>
           {% if page.edition == 'gateway-oss' or page.edition == 'enterprise' or page.edition == 'getting-started-guide' %}


### PR DESCRIPTION
### Summary
Link all segments in the breadcrumbs to the overview page for that section. The segment is only linked in the URL exists, and is presented without a link if it would lead to a 404.

The breadcrumbs expect the overview page to be named `index.md` within a folder (e.g. /gateway/3.0.x/kong-enterprise/). It does NOT work if the file is named `overview.md` (e.g. /gateway/3.0.x/kong-production/deployment-topologies/overview/). We should standardise on our overview URLs, and I'd vote for not having `/overview/` explicitly in the URL

### Reason
The new IA work has created nested subdirectories. This highlights that breadcrumb links are working incorrectly:

### Testing
Try any nested URLs in the review app