### PR TITLE
Fix duplicate page generation in KIC

### DIFF
--- a/app/_data/docs_nav_kic_2.3.x.yml
+++ b/app/_data/docs_nav_kic_2.3.x.yml
@@ -101,8 +101,10 @@ items:
         url: /guides/upstream-mtls
       - text: Exposing a TCP-based Service
         url: /guides/using-tcpingress
+        generate: false # Generated in the CustomResources section above
       - text: Exposing a UDP-based Service
         url: /guides/using-udpingress
+        generate: false # Generated in the CustomResources section above
       - text: Using the mTLS Auth Plugin
         url: /guides/using-mtls-auth-plugin
       - text: Configuring Custom Entities

--- a/app/_data/docs_nav_kic_2.4.x.yml
+++ b/app/_data/docs_nav_kic_2.4.x.yml
@@ -101,8 +101,10 @@ items:
         url: /guides/upstream-mtls
       - text: Exposing a TCP-based Service
         url: /guides/using-tcpingress
+        generate: false # Generated in the CustomResources section above
       - text: Exposing a UDP-based Service
         url: /guides/using-udpingress
+        generate: false # Generated in the CustomResources section above
       - text: Using the mTLS Auth Plugin
         url: /guides/using-mtls-auth-plugin
       - text: Configuring Custom Entities

--- a/app/_data/docs_nav_kic_2.5.x.yml
+++ b/app/_data/docs_nav_kic_2.5.x.yml
@@ -101,8 +101,10 @@ items:
         url: /guides/upstream-mtls
       - text: Exposing a TCP-based Service
         url: /guides/using-tcpingress
+        generate: false # Generated in the CustomResources section above
       - text: Exposing a UDP-based Service
         url: /guides/using-udpingress
+        generate: false # Generated in the CustomResources section above
       - text: Using the mTLS Auth Plugin
         url: /guides/using-mtls-auth-plugin
       - text: Configuring Custom Entities


### PR DESCRIPTION
### Summary
Mark duplicated KIC navigation entries as `generate: false` to remove duplicate generation warning

### Testing
Run locally, watch as these errors no longer show up:

![image](https://user-images.githubusercontent.com/59130/185595418-44b6acda-37b9-4478-95d3-3f8ccd136f56.png)
