### PR TITLE
Adds required flag to get.konghq.com/quickstart script for adding a s…

### DIFF
--- a/src/gateway/understanding-kong/how-to/kong-gateway.md
+++ b/src/gateway/understanding-kong/how-to/kong-gateway.md
@@ -21,7 +21,7 @@ Then you'll interact with the gateway using `curl` to ensure it has been started
 Run the following command to start {{site.base_gateway}} using Docker:
 
 ```sh
-curl -Ls get.konghq.com/quickstart | sh -s
+curl -Ls get.konghq.com/quickstart | sh -s -- -m
 ```
 
 {:.note}


### PR DESCRIPTION
### Summary
Touches up the understanding-kong/how-to/kong-gateway.md document with a new required flag to install a mock service by default.

### Reason
The script behavior was changed, and this document required the new flag.

See DOCU-2414 for discussion

