### PR TITLE
add missing single quote

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -154,6 +154,7 @@ reachability
 redis
 reentrant
 referenceable
+regexes
 repo
 requery
 Resty

--- a/src/gateway/understanding-kong/how-to/router-atc.md
+++ b/src/gateway/understanding-kong/how-to/router-atc.md
@@ -20,7 +20,7 @@ To create a new router object using expressions, send a `POST` request to the [s
 ```sh
 curl --request POST \
   --url http://localhost:8001/services/example-service/routes \
-  --form  atc='http.path == "/mock"
+  --form  atc='http.path == "/mock"'
 ```
 
 In this example, you associated a new route object with the path `/mock` to the existing service `example-service`. The Expressions DSL also allows you to create complex router match conditions.


### PR DESCRIPTION
### Summary
This PR contains a fix for `acl` route creation command by adding a single quote at the end of the curl command

### Reason
I have noticed that the current example is not working with a missing single quote.

### Testing
With the fix in this PR, the curl works as expected and I am able to create the route.
