### PR TITLE
Fix PDF generation for single sourced content

### DIFF
--- a/pdf-generation/build-urls.js
+++ b/pdf-generation/build-urls.js
@@ -11,7 +11,13 @@ function extractUrls (input) {
 }
 
 module.exports = function (input) {
-  const nav = yaml.load(fs.readFileSync(input.path, 'utf8'))
+  let nav = yaml.load(fs.readFileSync(input.path, 'utf8'))
+
+  // If it's single sourced, the nav is under nav.items
+  if (nav.product && nav.items) {
+    nav = nav.items;
+  }
+
   let urls = extractUrls(nav)
   const urlVersion = input.version ? `/${input.version}` : ''
 


### PR DESCRIPTION
### Summary
PDF generation is broken for single sourced content

### Reason
To be able to build Mesh PDFs

### Testing

```
cd pdf-generation
npm ci
KONG_DOC_VERSIONS=mesh_1.8.x node run.js
```