### PR TITLE
fix the service name in graphql quickstart

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -84,6 +84,7 @@ Luarocks
 ngrok
 npm
 md
+middleware
 minifier
 minikube
 Mockbin

--- a/app/enterprise/1.3-x/plugins/graphql-quickstart.md
+++ b/app/enterprise/1.3-x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/enterprise/1.5.x/plugins/graphql-quickstart.md
+++ b/app/enterprise/1.5.x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/enterprise/2.1.x/plugins/graphql-quickstart.md
+++ b/app/enterprise/2.1.x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/enterprise/2.2.x/plugins/graphql-quickstart.md
+++ b/app/enterprise/2.2.x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/enterprise/2.3.x/plugins/graphql-quickstart.md
+++ b/app/enterprise/2.3.x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/enterprise/2.4.x/plugins/graphql-quickstart.md
+++ b/app/enterprise/2.4.x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/enterprise/2.5.x/plugins/graphql-quickstart.md
+++ b/app/enterprise/2.5.x/plugins/graphql-quickstart.md
@@ -25,7 +25,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -35,7 +35,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -43,7 +43,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/gateway/2.6.x/configure/graphql-quickstart.md
+++ b/app/gateway/2.6.x/configure/graphql-quickstart.md
@@ -26,7 +26,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -36,7 +36,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -44,7 +44,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/gateway/2.7.x/configure/graphql-quickstart.md
+++ b/app/gateway/2.7.x/configure/graphql-quickstart.md
@@ -26,7 +26,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -36,7 +36,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -44,7 +44,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/gateway/2.8.x/configure/graphql-quickstart.md
+++ b/app/gateway/2.8.x/configure/graphql-quickstart.md
@@ -26,7 +26,7 @@ $ curl -i -X POST \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/routes \
+  --url http://localhost:8001/services/graphql-service/routes \
   --data 'hosts[]=example.com' \
 ```  
 
@@ -36,7 +36,7 @@ Proxy caching for GraphQL provides advanced caching over queries.
 
 ```
 $ curl -i -X POST \
-  --url http://localhost:8001/services/example-service/plugins/ \
+  --url http://localhost:8001/services/graphql-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
 ```
@@ -44,7 +44,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \


### PR DESCRIPTION
### Summary
The service name was first defined as `graphql-service` but then referred to as `example-service` in the rest of the guide.

