### PR TITLE
doc(openid-connet) session_compressor default to 'none'

### DIFF
--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -2894,7 +2894,7 @@ In this case you would probably want to use `config.groups_claim` to point to `g
 is not a top-level claim, so you need to traverse there:
 
 1. Find the `user` claim and under it.
-2. Find the the `groups` claim, and read the value:
+2. Find the `groups` claim, and read the value:
 
 ```json
 {

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -1026,7 +1026,7 @@ params:
         - `regenerate`: generates a new session identifier on each modification and does not use expiry for signature verification (useful in single-page applications or SPAs)
     - name: session_compressor
       required: false
-      default: '"default"'
+      default: '"none"'
       datatype: string
       description: |
         The session strategy:


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
doc(openid-connet) session_compressor default to 'none'.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Misleading customers.

<!-- ### Testing -->
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
