### PR TITLE
Switch AWS Secrets Manager examples to use curl

### DIFF
--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/aws-sm.md
@@ -96,8 +96,8 @@ environment variable.
 You can create multiple entities, which lets you have secrets in different regions:
 
 ```bash
-http -f PUT :8001/vaults/aws-eu-central-vault name=aws config.region="eu-central-1"
-http -f PUT :8001/vaults/aws-us-west-vault name=aws config.region="us-west-1"
+curl -X PUT http://HOSTNAME:8001/vaults/aws-eu-central-vault -d name=aws -d config.region="eu-central-1"
+curl -X PUT http://HOSTNAME:8001/vaults/aws-us-west-vault -d name=aws -d config.region="us-west-1"
 ```
 
 This lets you source secrets from different regions:

--- a/src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -90,8 +90,8 @@ environment variable.
 You can create multiple entities, which lets you have secrets in different regions:
 
 ```bash
-http -f PUT :8001/vaults/aws-eu-central-vault name=aws config.region="eu-central-1"
-http -f PUT :8001/vaults/aws-us-west-vault name=aws config.region="us-west-1"
+curl -X PUT http://HOSTNAME:8001/vaults/aws-eu-central-vault -d name=aws -d config.region="eu-central-1"
+curl -X PUT http://HOSTNAME:8001/vaults/aws-us-west-vault -d name=aws -d config.region="us-west-1"
 ```
 
 This lets you source secrets from different regions:


### PR DESCRIPTION
### Summary
Switch from `httpie` to `curl` for AWS SM examples

### Reason
Add consistency to the docs

### Testing
Try out the curl requests