### PR TITLE
fix(graphql-rate-limiting-advanced) remove unsupported config

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -79,11 +79,6 @@ params:
       datatype: string
       description: |
         How to define the rate limit key. Can be `ip`, `credential`, `consumer`.
-    - name: header_name
-      required: semi
-      datatype: string
-      description: |
-        Header name to use as the rate limit key when the `header` identifier is defined.
     - name: dictionary_name
       required: true
       default: kong_rate_limiting_counters


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Plugin `graphql-rate-limiting-advanced` does not support `config.header_name`.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Misleading customers.
<!-- ### Testing -->
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
