### PR TITLE
Fix Docker logo on Runtime Manager overview

### DIFF
--- a/app/konnect/runtime-manager/index.md
+++ b/app/konnect/runtime-manager/index.md
@@ -52,7 +52,7 @@ Choose an installation type below:
 <div class="docs-grid-install">
 
   <a href="/konnect/runtime-manager/runtime-instances/gateway-runtime-docker" class="docs-grid-install-block no-description">
-    <img class="install-icon no-image-expand" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="Docker" />
+    <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/docker.png" alt="Docker" />
     <div class="install-text">Docker</div>
   </a>
 


### PR DESCRIPTION
### Summary
Fix broken image for Docker logo

### Testing
/konnect/runtime-manager/
