### PR TITLE
Config reference for 3.0

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -567,7 +567,7 @@ items:
   - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
     items:
-      - text: Configuration Reference
+      - text: Configuration
         url: /reference/configuration
       - text: Kong Gateway Nginx Directives
         url: /reference/nginx-directives

--- a/autodoc-conf-ee/data.lua
+++ b/autodoc-conf-ee/data.lua
@@ -11,7 +11,9 @@ title: Configuration Reference for Kong Gateway
 source_url: https://github.com/Kong/kong-ee/blob/master/kong.conf.default
 ---
 
-## Properties reference
+Reference for {{site.base_gateway}} configuration parameters. Set these parameters in `kong.conf`.
+
+To learn more about the `kong.conf` file, see the guide on the [Kong Configuration File](/gateway/{{page.kong_version}}/kong-production/kong-conf).
 ]]
 
 

--- a/autodoc-conf-ee/run.lua
+++ b/autodoc-conf-ee/run.lua
@@ -153,13 +153,13 @@ end
 
 
 for _, section in ipairs(parsed) do
+  write("---")
   write("")
   write("## " .. titleize(section.name) .. " section")
   write("")
   if #section.description > 0 then
     write(format_description(section.description))
     write("")
-    write("---")
     write("")
   end
 
@@ -244,7 +244,6 @@ for _, section in ipairs(parsed) do
       write("")
       write("**Default:** " .. format_default(var.default))
       write("")
-      write("---")
       write("")
     end
   end

--- a/autodoc-conf-ee/run.lua
+++ b/autodoc-conf-ee/run.lua
@@ -140,7 +140,7 @@ infd:close()
 
 local parsed = assert(parser.parse(lines))
 
-local outpath = "app/gateway/" .. KONG_VERSION .. "/reference/configuration.md"
+local outpath = "src/gateway/reference/configuration.md"
 local outfd = assert(io.open(outpath, "w+"))
 
 outfd:write(data.header)
@@ -209,7 +209,7 @@ for _, section in ipairs(parsed) do
       elseif string.match(var.name, "admin_gui_session") then
         write("{:.badge .enterprise}")
 
-      elseif string.match(var.name, "telemetry") then
+      elseif string.match(var.name, "cluster_telemetry") then
         write("{:.badge .enterprise}")
 
       elseif string.match(var.name, "rbac") then
@@ -218,7 +218,7 @@ for _, section in ipairs(parsed) do
       elseif string.match(var.name, "event_hooks") then
         write("{:.badge .enterprise}")
 
-      elseif string.match(var.name, "data_plane_config_cache") then
+      elseif string.match(var.name, "keyring") then
         write("{:.badge .enterprise}")
 
       elseif string.match(section.name, "PORTAL") then
@@ -237,9 +237,6 @@ for _, section in ipairs(parsed) do
         write("{:.badge .enterprise}")
 
       elseif string.match(section.name, "ROUTE COLLISION") then
-        write("{:.badge .enterprise}")
-
-      elseif string.match(section.name, "DATABASE ENCRYPTION") then
         write("{:.badge .enterprise}")
       end
       write("")

--- a/autodoc-conf-ee/run.lua
+++ b/autodoc-conf-ee/run.lua
@@ -154,7 +154,7 @@ end
 
 for _, section in ipairs(parsed) do
   write("")
-  write("### " .. titleize(section.name) .. " section")
+  write("## " .. titleize(section.name) .. " section")
   write("")
   if #section.description > 0 then
     write(format_description(section.description))
@@ -174,7 +174,7 @@ for _, section in ipairs(parsed) do
       if not pg_found then
         pg_found = true
         write("")
-        write("#### Postgres settings")
+        write("### Postgres settings")
         write("")
         write(table_header)
       end
@@ -184,7 +184,7 @@ for _, section in ipairs(parsed) do
       if not cassandra_found then
         cassandra_found = true
         write("")
-        write("#### Cassandra settings")
+        write("### Cassandra settings")
         write("")
         write(table_header)
       end
@@ -202,7 +202,7 @@ for _, section in ipairs(parsed) do
               " | " .. format_default(var.default))
 
     else
-      write("#### " .. var.name)
+      write("### " .. var.name)
       if string.match(var.name, "admin_gui_auth") then
         write("{:.badge .enterprise}")
 

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -13,9 +13,9 @@ Reference for {{site.base_gateway}} configuration parameters. Set these paramete
 
 To learn more about the `kong.conf` file, see the guide on the [Kong Configuration File](/gateway/{{page.kong_version}}/kong-production/kong-conf).
 
-### General section
+## General section
 
-#### prefix
+### prefix
 
 Working directory. Equivalent to Nginx's prefix path, containing temporary
 files and logs.
@@ -26,7 +26,7 @@ Each Kong process must have a separate working directory.
 
 ---
 
-#### log_level
+### log_level
 
 Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`.
 
@@ -37,7 +37,7 @@ accepted values.
 
 ---
 
-#### proxy_access_log
+### proxy_access_log
 
 Path for proxy port request access logs. Set this value to `off` to disable
 logging proxy requests.
@@ -49,7 +49,7 @@ location.
 
 ---
 
-#### proxy_error_log
+### proxy_error_log
 
 Path for proxy port request error logs. The granularity of these logs is
 adjusted by the `log_level` property.
@@ -58,7 +58,7 @@ adjusted by the `log_level` property.
 
 ---
 
-#### proxy_stream_access_log
+### proxy_stream_access_log
 
 Path for tcp streams proxy port access logs. Set this value to `off` to disable
 logging proxy requests.
@@ -73,7 +73,7 @@ $bytes_sent $bytes_received ' '$session_time'`
 
 ---
 
-#### proxy_stream_error_log
+### proxy_stream_error_log
 
 Path for tcp streams proxy port request error logs. The granularity of these
 logs is adjusted by the `log_level` property.
@@ -82,7 +82,7 @@ logs is adjusted by the `log_level` property.
 
 ---
 
-#### admin_access_log
+### admin_access_log
 
 Path for Admin API request access logs. If Hybrid Mode is enabled and the
 current node is set to be the Control Plane, then the connection requests from
@@ -98,7 +98,7 @@ location.
 
 ---
 
-#### admin_error_log
+### admin_error_log
 
 Path for Admin API request error logs. The granularity of these logs is
 adjusted by the `log_level` property.
@@ -107,7 +107,7 @@ adjusted by the `log_level` property.
 
 ---
 
-#### status_access_log
+### status_access_log
 
 Path for Status API request access logs. The default value of `off` implies
 that logging for this API is disabled by default.
@@ -119,7 +119,7 @@ location.
 
 ---
 
-#### status_error_log
+### status_error_log
 
 Path for Status API request error logs. The granularity of these logs is
 adjusted by the `log_level` property.
@@ -128,7 +128,7 @@ adjusted by the `log_level` property.
 
 ---
 
-#### vaults
+### vaults
 
 Comma-separated list of vaults this node should load. By default, all the
 bundled vaults are enabled.
@@ -140,7 +140,7 @@ The specified name(s) will be substituted as such in the Lua namespace:
 
 ---
 
-#### opentelemetry_tracing
+### opentelemetry_tracing
 
 Comma-separated list of tracing instrumentations this node should load. By
 default, no instrumentations are enabled.
@@ -167,7 +167,7 @@ enabled in stream mode.
 
 ---
 
-#### opentelemetry_tracing_sampling_rate
+### opentelemetry_tracing_sampling_rate
 
 Tracing instrumentation sampling rate.
 
@@ -179,7 +179,7 @@ Example: `0.25`, this should account for 25% of all traces.
 
 ---
 
-#### plugins
+### plugins
 
 Comma-separated list of plugins this node should load. By default, only plugins
 bundled in official distributions are loaded via the `bundled` keyword.
@@ -216,7 +216,7 @@ experiencing LRU churning in the database cache (i.e. when the configured
 
 ---
 
-#### pluginserver_names
+### pluginserver_names
 
 Comma-separated list of names for pluginserver processes. The actual names are
 used for log messages and to relate the actual settings.
@@ -225,7 +225,7 @@ used for log messages and to relate the actual settings.
 
 ---
 
-#### pluginserver_XXX_socket
+### pluginserver_XXX_socket
 
 Path to the unix socket used by the <XXX> pluginserver.
 
@@ -233,7 +233,7 @@ Path to the unix socket used by the <XXX> pluginserver.
 
 ---
 
-#### pluginserver_XXX_start_cmd
+### pluginserver_XXX_start_cmd
 
 Full command (including any needed arguments) to start the <XXX> pluginserver
 
@@ -241,7 +241,7 @@ Full command (including any needed arguments) to start the <XXX> pluginserver
 
 ---
 
-#### pluginserver_XXX_query_cmd
+### pluginserver_XXX_query_cmd
 
 Full command to "query" the <XXX> pluginserver. Should produce a JSON with the
 dump info of all plugins it manages
@@ -250,7 +250,7 @@ dump info of all plugins it manages
 
 ---
 
-#### port_maps
+### port_maps
 
 With this configuration parameter, you can let the Kong to know about the port
 from which the packets are forwarded to it. This is fairly common when running
@@ -271,7 +271,7 @@ of reporting the port Kong is listening to.
 
 ---
 
-#### anonymous_reports
+### anonymous_reports
 
 Send anonymous usage data such as error stack traces to help improve Kong.
 
@@ -280,9 +280,9 @@ Send anonymous usage data such as error stack traces to help improve Kong.
 ---
 
 
-### Hybrid Mode section
+## Hybrid Mode section
 
-#### role
+### role
 
 Use this setting to enable Hybrid Mode, This allows running some Kong nodes in
 a control plane role with a database and have them deliver configuration updates
@@ -300,7 +300,7 @@ Valid values to this setting are:
 
 ---
 
-#### cluster_mtls
+### cluster_mtls
 
 Sets the verification between nodes of the cluster.
 
@@ -320,7 +320,7 @@ Valid values to this setting are:
 
 ---
 
-#### cluster_cert
+### cluster_cert
 
 Filename of the cluster certificate to use when establishing secure
 communication between control and data plane nodes.
@@ -334,7 +334,7 @@ should be a different certificate for each DP node.
 
 ---
 
-#### cluster_cert_key
+### cluster_cert_key
 
 Filename of the cluster certificate key to use when establishing secure
 communication between control and data plane nodes.
@@ -348,7 +348,7 @@ should be a different certificate for each DP node.
 
 ---
 
-#### cluster_ca_cert
+### cluster_ca_cert
 
 The trusted CA certificate file in PEM format used for Control Plane to verify
 Data Plane's certificate and Data Plane to verify Control Plane's certificate.
@@ -364,7 +364,7 @@ This field is ignored if `cluster_mtls` is set to `shared`.
 
 ---
 
-#### cluster_allowed_common_names
+### cluster_allowed_common_names
 
 The list of Common Names that are allowed to connect to the control plane.
 Multiple entries may be supplied in a comma-separated string. When not
@@ -378,9 +378,9 @@ This field is ignored if `cluster_mtls` is not set to `pki_check_cn`.
 ---
 
 
-### Hybrid Mode Data Plane section
+## Hybrid Mode Data Plane section
 
-#### cluster_server_name
+### cluster_server_name
 
 The server name used in the SNI of the TLS connection from a DP node to a CP
 node.
@@ -395,7 +395,7 @@ If `cluster_mtls` is set to `shared`, this setting is ignored and
 
 ---
 
-#### cluster_control_plane
+### cluster_control_plane
 
 To be used by data plane nodes only: address of the control plane node from
 which configuration updates will be fetched, in `host:port` format.
@@ -404,7 +404,7 @@ which configuration updates will be fetched, in `host:port` format.
 
 ---
 
-#### cluster_telemetry_endpoint
+### cluster_telemetry_endpoint
 {:.badge .enterprise}
 
 To be used by data plane nodes only: telemetry address of the control plane
@@ -415,9 +415,9 @@ node to which telemetry updates will be posted in `host:port` format.
 ---
 
 
-### Hybrid Mode Control Plane section
+## Hybrid Mode Control Plane section
 
-#### cluster_listen
+### cluster_listen
 
 Comma-separated list of addresses and ports on which the cluster control plane
 server should listen for data plane connections.
@@ -437,7 +437,7 @@ See `admin_access_log` config description for more information.
 
 ---
 
-#### cluster_telemetry_listen
+### cluster_telemetry_listen
 {:.badge .enterprise}
 
 Comma-separated list of addresses and ports on which the cluster control plane
@@ -452,7 +452,7 @@ This setting has no effect if `role` is not set to `control_plane`.
 
 ---
 
-#### cluster_data_plane_purge_delay
+### cluster_data_plane_purge_delay
 
 How many seconds must pass from the time a DP node becomes offline to the time
 its entry gets removed from the database, as returned by the
@@ -466,7 +466,7 @@ its entry will be removed.
 
 ---
 
-#### cluster_ocsp
+### cluster_ocsp
 
 Whether to check for revocation status of DP certificates using OCSP (Online
 Certificate Status Protocol).
@@ -490,7 +490,7 @@ Valid values to this setting are:
 
 ---
 
-#### cluster_max_payload
+### cluster_max_payload
 
 This sets the maximum payload size allowed to be sent across from CP to DP in
 Hybrid mode.
@@ -502,9 +502,9 @@ Default is 4Mb - 4 * 1024 * 1024 due to historical reasons.
 ---
 
 
-### NGINX section
+## NGINX section
 
-#### proxy_listen
+### proxy_listen
 
 Comma-separated list of addresses and ports on which the proxy server should
 listen for HTTP/HTTPS traffic.
@@ -559,7 +559,7 @@ documentation.
 
 ---
 
-#### proxy_url
+### proxy_url
 
 Kong Proxy URL
 
@@ -585,7 +585,7 @@ append the resolved listener port depending on the requested protocol.
 
 ---
 
-#### stream_listen
+### stream_listen
 
 Comma-separated list of addresses and ports on which the stream mode should
 listen.
@@ -629,7 +629,7 @@ description of the formats that Kong might accept in stream_listen.
 
 ---
 
-#### admin_api_uri
+### admin_api_uri
 
 Hierarchical part of a URI which is composed optionally of a host, port, and
 path at which the Admin API accepts HTTP or HTTPS traffic. When this config is
@@ -640,7 +640,7 @@ resolved admin_listen HTTP/HTTPS port.
 
 ---
 
-#### admin_listen
+### admin_listen
 
 Comma-separated list of addresses and ports on which the Admin interface should
 listen.
@@ -683,7 +683,7 @@ Example: `admin_listen = 127.0.0.1:8444 http2 ssl`
 
 ---
 
-#### status_listen
+### status_listen
 
 Comma-separated list of addresses and ports on which the Status API should
 listen.
@@ -705,7 +705,7 @@ Example: `status_listen = 0.0.0.0:8100`
 
 ---
 
-#### nginx_user
+### nginx_user
 
 Defines user and group credentials used by worker processes. If group is
 omitted, a group whose name equals that of user is used.
@@ -719,7 +719,7 @@ default user and group credentials will be `nobody nobody`.
 
 ---
 
-#### nginx_worker_processes
+### nginx_worker_processes
 
 Determines the number of worker processes spawned by Nginx.
 
@@ -730,7 +730,7 @@ usage of the equivalent Nginx directive and a description of accepted values.
 
 ---
 
-#### nginx_daemon
+### nginx_daemon
 
 Determines whether Nginx will run as a daemon or as a foreground process.
 Mainly useful for development or when running Kong inside a Docker environment.
@@ -741,7 +741,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#daemon.
 
 ---
 
-#### mem_cache_size
+### mem_cache_size
 
 Size of each of the two in-memory caches for database entities. The accepted
 units are `k` and `m`, with a minimum recommended value of a few MBs.
@@ -753,7 +753,7 @@ total memory Kong uses to cache entities might be double this value.
 
 ---
 
-#### ssl_cipher_suite
+### ssl_cipher_suite
 
 Defines the TLS ciphers served by Nginx.
 
@@ -767,7 +767,7 @@ https://wiki.openssl.org/index.php/FIPS_mode_and_TLS.
 
 ---
 
-#### ssl_ciphers
+### ssl_ciphers
 
 Defines a custom list of TLS ciphers to be served by Nginx. This list must
 conform to the pattern defined by `openssl ciphers`.
@@ -778,7 +778,7 @@ This value is ignored if `ssl_cipher_suite` is not `custom`.
 
 ---
 
-#### ssl_protocols
+### ssl_protocols
 
 Enables the specified protocols for client-side connections. The set of
 supported protocol versions also depends on the version of OpenSSL Kong was
@@ -790,7 +790,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
 
 ---
 
-#### ssl_prefer_server_ciphers
+### ssl_prefer_server_ciphers
 
 Specifies that server ciphers should be preferred over client ciphers when
 using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite`
@@ -803,7 +803,7 @@ http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers
 
 ---
 
-#### ssl_dhparam
+### ssl_dhparam
 
 Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`,
 `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, or from the absolute path to
@@ -819,7 +819,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
 
 ---
 
-#### ssl_session_tickets
+### ssl_session_tickets
 
 Enables or disables session resumption through TLS session tickets. This has no
 impact when used with TLSv1.3.
@@ -833,7 +833,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets
 
 ---
 
-#### ssl_session_timeout
+### ssl_session_timeout
 
 Specifies a time during which a client may reuse the session parameters. See
 the rationale: https://github.com/mozilla/server-side-tls/issues/198
@@ -844,7 +844,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
 
 ---
 
-#### ssl_cert
+### ssl_cert
 
 Comma-separated list of the absolute path to the certificates for
 `proxy_listen` values with TLS enabled.
@@ -862,7 +862,7 @@ requests.
 
 ---
 
-#### ssl_cert_key
+### ssl_cert_key
 
 Comma-separated list of the absolute path to the keys for `proxy_listen` values
 with TLS enabled.
@@ -879,7 +879,7 @@ requests.
 
 ---
 
-#### client_ssl
+### client_ssl
 
 Determines if Nginx should attempt to send client-side TLS certificates and
 perform Mutual TLS Authentication with upstream service when proxying requests.
@@ -888,7 +888,7 @@ perform Mutual TLS Authentication with upstream service when proxying requests.
 
 ---
 
-#### client_ssl_cert
+### client_ssl_cert
 
 If `client_ssl` is enabled, the absolute path to the client certificate for the
 `proxy_ssl_certificate` directive.
@@ -900,7 +900,7 @@ attribute of the `Service` object.
 
 ---
 
-#### client_ssl_cert_key
+### client_ssl_cert_key
 
 If `client_ssl` is enabled, the absolute path to the client TLS key for the
 `proxy_ssl_certificate_key` directive.
@@ -912,7 +912,7 @@ attribute of the `Service` object.
 
 ---
 
-#### admin_ssl_cert
+### admin_ssl_cert
 
 Comma-separated list of the absolute path to the certificates for
 `admin_listen` values with TLS enabled.
@@ -923,7 +923,7 @@ See docs for `ssl_cert` for detailed usage.
 
 ---
 
-#### admin_ssl_cert_key
+### admin_ssl_cert_key
 
 Comma-separated list of the absolute path to the keys for `admin_listen` values
 with TLS enabled.
@@ -934,7 +934,7 @@ See docs for `ssl_cert_key` for detailed usage.
 
 ---
 
-#### status_ssl_cert
+### status_ssl_cert
 
 Comma-separated list of the absolute path to the certificates for
 `status_listen` values with TLS enabled.
@@ -945,7 +945,7 @@ See docs for `ssl_cert` for detailed usage.
 
 ---
 
-#### status_ssl_cert_key
+### status_ssl_cert_key
 
 Comma-separated list of the absolute path to the keys for `status_listen`
 values with TLS enabled.
@@ -956,7 +956,7 @@ See docs for `ssl_cert_key` for detailed usage.
 
 ---
 
-#### headers
+### headers
 
 Comma-separated list of headers Kong should inject in client responses.
 
@@ -992,7 +992,7 @@ Example: `headers = via, latency_tokens`
 
 ---
 
-#### trusted_ips
+### trusted_ips
 
 Defines trusted IP addresses blocks that are known to send correct
 `X-Forwarded-*` headers.
@@ -1018,7 +1018,7 @@ for examples of accepted values.
 
 ---
 
-#### real_ip_header
+### real_ip_header
 
 Defines the request header field whose value will be used to replace the client
 address.
@@ -1040,7 +1040,7 @@ for a description of this directive.
 
 ---
 
-#### real_ip_recursive
+### real_ip_recursive
 
 This value sets the `ngx_http_realip_module` directive of the same name in the
 Nginx configuration.
@@ -1052,7 +1052,7 @@ for a description of this directive.
 
 ---
 
-#### error_default_type
+### error_default_type
 
 Default MIME type to use when the request `Accept` header is missing and Nginx
 is returning an error for the request.
@@ -1064,7 +1064,7 @@ Accepted values are `text/plain`, `text/html`, `application/json`, and
 
 ---
 
-#### upstream_keepalive_pool_size
+### upstream_keepalive_pool_size
 
 Sets the default size of the upstream keepalive connection pools.
 
@@ -1078,7 +1078,7 @@ each upstream request to open a new connection.
 
 ---
 
-#### upstream_keepalive_max_requests
+### upstream_keepalive_max_requests
 
 Sets the default maximum number of requests than can be proxied upstream
 through one keepalive connection.
@@ -1092,7 +1092,7 @@ used to proxy an indefinite number of requests.
 
 ---
 
-#### upstream_keepalive_idle_timeout
+### upstream_keepalive_idle_timeout
 
 Sets the default timeout (in seconds) for which an upstream keepalive
 connection should be kept open. When the timeout is reached while the connection
@@ -1106,7 +1106,7 @@ be kept open indefinitely.
 ---
 
 
-### NGINX Injected Directives section
+## NGINX Injected Directives section
 
 Nginx directives can be dynamically injected in the runtime nginx.conf file
 without requiring a custom Nginx configuration template.
@@ -1159,7 +1159,7 @@ block.
 
 ---
 
-#### nginx_main_worker_rlimit_nofile
+### nginx_main_worker_rlimit_nofile
 
 Changes the limit on the maximum number of open files for worker processes.
 
@@ -1172,7 +1172,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
 
 ---
 
-#### nginx_events_worker_connections
+### nginx_events_worker_connections
 
 Sets the maximum number of simultaneous connections that can be opened by a
 worker process.
@@ -1186,7 +1186,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#worker_connections
 
 ---
 
-#### nginx_http_client_header_buffer_size
+### nginx_http_client_header_buffer_size
 
 Sets buffer size for reading the client request headers.
 
@@ -1197,7 +1197,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_siz
 
 ---
 
-#### nginx_http_large_client_header_buffers
+### nginx_http_large_client_header_buffers
 
 Sets the maximum number and size of buffers used for reading large clients
 requests headers.
@@ -1209,7 +1209,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buff
 
 ---
 
-#### nginx_http_client_max_body_size
+### nginx_http_client_max_body_size
 
 Defines the maximum request body size allowed by requests proxied by Kong,
 specified in the Content-Length request header. If a request exceeds this limit,
@@ -1223,7 +1223,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 
 ---
 
-#### nginx_admin_client_max_body_size
+### nginx_admin_client_max_body_size
 
 Defines the maximum request body size for Admin API.
 
@@ -1231,7 +1231,7 @@ Defines the maximum request body size for Admin API.
 
 ---
 
-#### nginx_http_client_body_buffer_size
+### nginx_http_client_body_buffer_size
 
 Defines the buffer size for reading the request body. If the client request
 body is larger than this value, the body will be buffered to disk. Note that
@@ -1248,7 +1248,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
 
 ---
 
-#### nginx_admin_client_body_buffer_size
+### nginx_admin_client_body_buffer_size
 
 Defines the buffer size for reading the request body on Admin API.
 
@@ -1256,7 +1256,7 @@ Defines the buffer size for reading the request body on Admin API.
 
 ---
 
-#### nginx_http_lua_regex_match_limit
+### nginx_http_lua_regex_match_limit
 
 Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should
 ensure at worst any regex Kong executes could finish within roughly 2 seconds.
@@ -1266,7 +1266,7 @@ ensure at worst any regex Kong executes could finish within roughly 2 seconds.
 ---
 
 
-### Datastore section
+## Datastore section
 
 Kong can run with a database to store coordinated data between Kong nodes in a
 cluster, or without a database, where each node stores its information
@@ -1303,7 +1303,7 @@ be optionally overwritten explicitly using the `pg_ro_*` config below.
 
 ---
 
-#### database
+### database
 
 Determines which of PostgreSQL or Cassandra this node will use as its
 datastore.
@@ -1315,7 +1315,7 @@ Accepted values are `postgres`, `cassandra`, and `off`.
 ---
 
 
-#### Postgres settings
+### Postgres settings
 
 name   | description  | default
 -------|--------------|----------
@@ -1350,7 +1350,7 @@ name   | description  | default
 **pg_ro_semaphore_timeout** | Same as `pg_semaphore_timeout`, but for the read-only connection. | `<pg_semaphore_timeout>`
 **pg_ro_keepalive_timeout** | Same as `pg_keepalive_timeout`, but for the read-only connection. | `<pg_keepalive_timeout>`
 
-#### Cassandra settings
+### Cassandra settings
 
 
 {% include_cached /md/enterprise/cassandra-deprecation.md %}
@@ -1376,7 +1376,7 @@ name   | description  | default
 **cassandra_data_centers** | When migrating for the first time, will use this setting when using the `NetworkTopologyStrategy`. The format is a comma-separated list made of `<dc_name>:<repl_factor>`. | `dc1:2,dc2:3`
 **cassandra_schema_consensus_timeout** | Defines the timeout (in ms) for the waiting period to reach a schema consensus between your Cassandra nodes. This value is only used during migrations. | `10000`
 
-#### declarative_config
+### declarative_config
 
 The path to the declarative configuration file which holds the specification of
 all entities (Routes, Services, Consumers, etc.) to be used when the `database`
@@ -1395,7 +1395,7 @@ node as a user-controlled fallback.
 
 ---
 
-#### declarative_config_string
+### declarative_config_string
 
 The declarative configuration as a string
 
@@ -1403,7 +1403,7 @@ The declarative configuration as a string
 
 ---
 
-#### declarative_config_encryption_mode
+### declarative_config_encryption_mode
 
 Set encryption of the declarative config mapped file on filesystem.
 
@@ -1415,7 +1415,7 @@ chacha20-poly1305 to encrypt `off` = does not encrypt
 ---
 
 
-### Datastore Cache section
+## Datastore Cache section
 
 In order to avoid unnecessary communication with the datastore, Kong caches
 entities (such as APIs, Consumers, Credentials...) for a configurable period of
@@ -1426,7 +1426,7 @@ of such configuration entities.
 
 ---
 
-#### db_update_frequency
+### db_update_frequency
 
 Frequency (in seconds) at which to check for updated entities with the
 datastore.
@@ -1439,7 +1439,7 @@ purge the old cached entity and start using the new one.
 
 ---
 
-#### db_update_propagation
+### db_update_propagation
 
 Time (in seconds) taken for an entity in the datastore to be propagated to
 replica nodes of another datacenter.
@@ -1458,7 +1458,7 @@ and this value can be safely set to 0.
 
 ---
 
-#### db_cache_ttl
+### db_cache_ttl
 
 Time-to-live (in seconds) of an entity from the datastore when cached by this
 node.
@@ -1472,7 +1472,7 @@ If set to 0 (default), such cached entities or misses never expire.
 
 ---
 
-#### db_cache_neg_ttl
+### db_cache_neg_ttl
 
 Time-to-live (in seconds) of a datastore miss (no entity).
 
@@ -1484,7 +1484,7 @@ If set to 0, misses will never expire.
 
 ---
 
-#### db_resurrect_ttl
+### db_resurrect_ttl
 
 Time (in seconds) for which stale entities from the datastore should be
 resurrected for when they cannot be refreshed (e.g., the datastore is
@@ -1495,7 +1495,7 @@ will be made.
 
 ---
 
-#### db_cache_warmup_entities
+### db_cache_warmup_entities
 
 Entities to be pre-loaded from the datastore into the in-memory cache at Kong
 start-up.
@@ -1515,7 +1515,7 @@ If the size is insufficient, Kong will log a warning.
 ---
 
 
-### DNS Resolver section
+## DNS Resolver section
 
 By default, the DNS resolver will use the standard configuration files
 `/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be
@@ -1540,7 +1540,7 @@ field entries in the record.
 
 ---
 
-#### dns_resolver
+### dns_resolver
 
 Comma separated list of nameservers, each entry in `ip[:port]` format to be
 used by Kong. If not specified the nameservers in the local `resolv.conf` file
@@ -1552,7 +1552,7 @@ Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses.
 
 ---
 
-#### dns_hostsfile
+### dns_hostsfile
 
 The hosts file to use. This file is read once and its content is static in
 memory.
@@ -1563,7 +1563,7 @@ To read the file again after modifying it, Kong must be reloaded.
 
 ---
 
-#### dns_order
+### dns_order
 
 The order in which to resolve different record types. The `LAST` type means the
 type of the last successful lookup (for the specified name). The format is a
@@ -1573,7 +1573,7 @@ type of the last successful lookup (for the specified name). The format is a
 
 ---
 
-#### dns_valid_ttl
+### dns_valid_ttl
 
 By default, DNS records are cached using the TTL value of a response. If this
 property receives a value (in seconds), it will override the TTL for all
@@ -1583,7 +1583,7 @@ records.
 
 ---
 
-#### dns_stale_ttl
+### dns_stale_ttl
 
 Defines, in seconds, how long a record will remain in cache past its TTL. This
 value will be used while the new DNS record is fetched in the background.
@@ -1595,7 +1595,7 @@ completes, or the `dns_stale_ttl` number of seconds have passed.
 
 ---
 
-#### dns_cache_size
+### dns_cache_size
 
 Defines the maximum allowed number of DNS records stored in memory cache.
 
@@ -1607,7 +1607,7 @@ errors and data are cached, therefore a single name query can easily take up
 
 ---
 
-#### dns_not_found_ttl
+### dns_not_found_ttl
 
 TTL in seconds for empty DNS responses and "(3) name error" responses.
 
@@ -1615,7 +1615,7 @@ TTL in seconds for empty DNS responses and "(3) name error" responses.
 
 ---
 
-#### dns_error_ttl
+### dns_error_ttl
 
 TTL in seconds for error responses.
 
@@ -1623,7 +1623,7 @@ TTL in seconds for error responses.
 
 ---
 
-#### dns_no_sync
+### dns_no_sync
 
 If enabled, then upon a cache-miss every request will trigger its own dns
 query.
@@ -1636,9 +1636,9 @@ a single query.
 ---
 
 
-### Tuning & Behavior section
+## Tuning & Behavior section
 
-#### worker_consistency
+### worker_consistency
 
 Defines whether this node should rebuild its state synchronously or
 asynchronously (the balancers and the router are rebuilt on updates that affects
@@ -1666,7 +1666,7 @@ after Routes and Services updates.
 
 ---
 
-#### worker_state_update_frequency
+### worker_state_update_frequency
 
 Defines how often the worker state changes are checked with a background job.
 When a change is detected, a new router or balancer will be built, as needed.
@@ -1679,7 +1679,7 @@ each individual worker.
 ---
 
 
-### Miscellaneous section
+## Miscellaneous section
 
 Additional settings inherited from lua-nginx-module allowing for more
 flexibility and advanced usage.
@@ -1689,7 +1689,7 @@ https://github.com/openresty/lua-nginx-module
 
 ---
 
-#### lua_ssl_trusted_certificate
+### lua_ssl_trusted_certificate
 
 Comma-separated list of paths to certificate authority files for Lua cosockets
 in PEM format.
@@ -1717,7 +1717,7 @@ See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate
 
 ---
 
-#### lua_ssl_verify_depth
+### lua_ssl_verify_depth
 
 Sets the verification depth in the server certificates chain used by Lua
 cosockets, set by `lua_ssl_trusted_certificate`.
@@ -1733,7 +1733,7 @@ See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth
 
 ---
 
-#### lua_ssl_protocols
+### lua_ssl_protocols
 
 Defines the TLS versions supported when handshaking with OpenResty's TCP
 cosocket APIs.
@@ -1746,7 +1746,7 @@ connections made to the upstream Service or from downstream clients.
 
 ---
 
-#### lua_package_path
+### lua_package_path
 
 Sets the Lua module search path (LUA_PATH). Useful when developing or using
 custom plugins not stored in the default search path.
@@ -1757,7 +1757,7 @@ See https://github.com/openresty/lua-nginx-module#lua_package_path
 
 ---
 
-#### lua_package_cpath
+### lua_package_cpath
 
 Sets the Lua C module search path (LUA_CPATH).
 
@@ -1767,7 +1767,7 @@ See https://github.com/openresty/lua-nginx-module#lua_package_cpath
 
 ---
 
-#### lua_socket_pool_size
+### lua_socket_pool_size
 
 Specifies the size limit for every cosocket connection pool associated with
 every remote server.
@@ -1778,7 +1778,7 @@ See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
 
 ---
 
-#### enforce_rbac
+### enforce_rbac
 {:.badge .enterprise}
 
 Specifies whether Admin API RBAC is enforced.
@@ -1799,7 +1799,7 @@ resource.
 
 ---
 
-#### rbac_auth_header
+### rbac_auth_header
 {:.badge .enterprise}
 
 Defines the name of the HTTP request header from which the Admin API will
@@ -1809,7 +1809,7 @@ attempt to authenticate the RBAC user.
 
 ---
 
-#### event_hooks_enabled
+### event_hooks_enabled
 {:.badge .enterprise}
 
 When enabled, event hook entities represent a relationship between an event
@@ -1825,7 +1825,7 @@ See: https://docs.konghq.com/gateway/latest/admin-api/event-hooks/reference/
 
 ---
 
-#### fips
+### fips
 
 Turn on FIPS mode; this mode is only available on a FIPS build.
 
@@ -1834,13 +1834,13 @@ Turn on FIPS mode; this mode is only available on a FIPS build.
 ---
 
 
-### Kong Manager section
+## Kong Manager section
 
 The Admin GUI for Kong Enterprise.
 
 ---
 
-#### admin_gui_listen
+### admin_gui_listen
 {:.badge .free}
 
 Kong Manager Listeners
@@ -1856,7 +1856,7 @@ directive.
 
 ---
 
-#### admin_gui_url
+### admin_gui_url
 {:.badge .free}
 
 Kong Manager URL
@@ -1880,7 +1880,7 @@ resolved listener port depending on the requested protocol.
 
 ---
 
-#### admin_gui_ssl_cert
+### admin_gui_ssl_cert
 {:.badge .free}
 
 The absolute path to the SSL certificate for `admin_gui_listen` values with SSL
@@ -1890,7 +1890,7 @@ enabled.
 
 ---
 
-#### admin_gui_ssl_cert_key
+### admin_gui_ssl_cert_key
 {:.badge .free}
 
 The absolute path to the SSL key for `admin_gui_listen` values with SSL
@@ -1900,7 +1900,7 @@ enabled.
 
 ---
 
-#### admin_gui_flags
+### admin_gui_flags
 {:.badge .free}
 
 Alters the layout Admin GUI (JSON) The only supported value is `{
@@ -1910,7 +1910,7 @@ Alters the layout Admin GUI (JSON) The only supported value is `{
 
 ---
 
-#### admin_gui_access_log
+### admin_gui_access_log
 {:.badge .free}
 
 Kong Manager Access Logs
@@ -1924,7 +1924,7 @@ Setting this value to `off` disables access logs for Kong Manager.
 
 ---
 
-#### admin_gui_error_log
+### admin_gui_error_log
 {:.badge .free}
 
 Kong Manager Error Logs
@@ -1940,7 +1940,7 @@ Granularity can be adjusted through the `log_level` directive.
 
 ---
 
-#### admin_gui_auth
+### admin_gui_auth
 {:.badge .enterprise}
 
 Kong Manager Authentication Plugin Name
@@ -1957,7 +1957,7 @@ Supported Plugins:
 
 ---
 
-#### admin_gui_auth_conf
+### admin_gui_auth_conf
 {:.badge .enterprise}
 
 Kong Manager Authentication Plugin Config (JSON)
@@ -1976,7 +1976,7 @@ Example for `basic-auth`:
 
 ---
 
-#### admin_gui_auth_password_complexity
+### admin_gui_auth_password_complexity
 {:.badge .enterprise}
 
 Kong Manager Authentication Password Complexity (JSON)
@@ -2018,7 +2018,7 @@ Example:
 
 ---
 
-#### admin_gui_session_conf
+### admin_gui_session_conf
 {:.badge .enterprise}
 
 Kong Manager Session Config (JSON)
@@ -2039,7 +2039,7 @@ admin_gui_session_conf = { "cookie_name": "kookie", \
 
 ---
 
-#### admin_gui_auth_header
+### admin_gui_auth_header
 {:.badge .enterprise}
 
 Defines the name of the HTTP request header from which the Admin API will
@@ -2049,7 +2049,7 @@ attempt to identify the Kong Admin user.
 
 ---
 
-#### admin_gui_auth_login_attempts
+### admin_gui_auth_login_attempts
 {:.badge .enterprise}
 
 Number of times a user can attempt to login to Kong Manager. 0 means infinite
@@ -2059,7 +2059,7 @@ attempts allowed.
 
 ---
 
-#### admin_gui_header_txt
+### admin_gui_header_txt
 {:.badge .free}
 
 Kong Manager Header Text Sets text for Kong Manager Header Banner. Header
@@ -2069,7 +2069,7 @@ Banner is not shown if this config is empty.
 
 ---
 
-#### admin_gui_header_bg_color
+### admin_gui_header_bg_color
 {:.badge .free}
 
 Kong Manager Header Background Color Sets background color for Kong Manager
@@ -2080,7 +2080,7 @@ values are ignored by Manager.
 
 ---
 
-#### admin_gui_header_txt_color
+### admin_gui_header_txt_color
 {:.badge .free}
 
 Kong Manager Header Text Color Sets text color for Kong Manager Header Banner.
@@ -2092,7 +2092,7 @@ ignored by Kong Manager.
 
 ---
 
-#### admin_gui_footer_txt
+### admin_gui_footer_txt
 {:.badge .free}
 
 Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer
@@ -2102,7 +2102,7 @@ Banner is not shown if this config is empty
 
 ---
 
-#### admin_gui_footer_bg_color
+### admin_gui_footer_bg_color
 {:.badge .free}
 
 Kong Manager Footer Background Color Sets background color for Kong Manager
@@ -2115,7 +2115,7 @@ ignored by Manager.
 
 ---
 
-#### admin_gui_footer_txt_color
+### admin_gui_footer_txt_color
 {:.badge .free}
 
 Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner.
@@ -2127,7 +2127,7 @@ ignored by Kong Manager.
 
 ---
 
-#### admin_gui_login_banner_title
+### admin_gui_login_banner_title
 {:.badge .free}
 
 Kong Manager Login Banner Title Text Sets title text for Kong Manager Login
@@ -2140,7 +2140,7 @@ Login Banner is not shown if both `admin_gui_login_banner_title` and
 
 ---
 
-#### admin_gui_login_banner_body
+### admin_gui_login_banner_body
 {:.badge .free}
 
 Kong Manager Login Banner Body Text Sets body text for Kong Manager Login
@@ -2154,9 +2154,9 @@ Login Banner is not shown if both `admin_gui_login_banner_title` and
 ---
 
 
-### Vitals section
+## Vitals section
 
-#### vitals
+### vitals
 {:.badge .enterprise}
 
 When enabled, Kong will store and report metrics about its performance.
@@ -2173,7 +2173,7 @@ and visualizations on the dashboard.
 
 ---
 
-#### vitals_strategy
+### vitals_strategy
 {:.badge .enterprise}
 
 Determines whether to use the Kong database (either PostgreSQL or Cassandra, as
@@ -2186,7 +2186,7 @@ Accepted values are `database`, `prometheus`, or `influxdb`.
 
 ---
 
-#### vitals_tsdb_address
+### vitals_tsdb_address
 {:.badge .enterprise}
 
 Defines the host and port of the TSDB server to which Vitals data is written
@@ -2204,7 +2204,7 @@ Vitals data.
 
 ---
 
-#### vitals_tsdb_user
+### vitals_tsdb_user
 {:.badge .enterprise}
 
 Influxdb user
@@ -2213,7 +2213,7 @@ Influxdb user
 
 ---
 
-#### vitals_tsdb_password
+### vitals_tsdb_password
 {:.badge .enterprise}
 
 Influxdb password
@@ -2222,7 +2222,7 @@ Influxdb password
 
 ---
 
-#### vitals_statsd_address
+### vitals_statsd_address
 {:.badge .enterprise}
 
 Defines the host and port (and an optional protocol) of the StatsD server to
@@ -2235,7 +2235,7 @@ in Kong sending StatsD metrics via TCP instead of the UDP (default).
 
 ---
 
-#### vitals_statsd_prefix
+### vitals_statsd_prefix
 {:.badge .enterprise}
 
 Defines the prefix value attached to all Vitals StatsD events. This prefix is
@@ -2245,7 +2245,7 @@ useful when writing metrics to a multi-tenant StatsD exporter or server.
 
 ---
 
-#### vitals_statsd_udp_packet_size
+### vitals_statsd_udp_packet_size
 {:.badge .enterprise}
 
 Defines the maximum buffer size in which Vitals statsd metrics will be held and
@@ -2257,7 +2257,7 @@ This value is defined in bytes.
 
 ---
 
-#### vitals_prometheus_scrape_interval
+### vitals_prometheus_scrape_interval
 {:.badge .enterprise}
 
 Defines the scrape_interval query parameter sent to the Prometheus server when
@@ -2271,9 +2271,9 @@ server.
 ---
 
 
-### Konnect section
+## Konnect section
 
-#### konnect_mode
+### konnect_mode
 
 When enabled, the dataplane is connected to Konnect
 
@@ -2282,9 +2282,9 @@ When enabled, the dataplane is connected to Konnect
 ---
 
 
-### Analytics For Konnect section
+## Analytics For Konnect section
 
-#### analytics_flush_interval
+### analytics_flush_interval
 
 Determine the frequency of flushing local data to Konnect in seconds.
 
@@ -2292,7 +2292,7 @@ Determine the frequency of flushing local data to Konnect in seconds.
 
 ---
 
-#### analytics_buffer_size_limit
+### analytics_buffer_size_limit
 
 Max number of messages can be buffered locally before dropping data in case
 there is no network connection to Konnect.
@@ -2302,9 +2302,9 @@ there is no network connection to Konnect.
 ---
 
 
-### Developer Portal section
+## Developer Portal section
 
-#### portal
+### portal
 {:.badge .enterprise}
 
 Developer Portal Switch
@@ -2323,7 +2323,7 @@ and the Dev Portal API.
 
 ---
 
-#### portal_gui_listen
+### portal_gui_listen
 {:.badge .enterprise}
 
 Developer Portal GUI Listeners
@@ -2336,7 +2336,7 @@ Portal GUI. Suffixes can be specified for each pair, similarly to the
 
 ---
 
-#### portal_gui_protocol
+### portal_gui_protocol
 {:.badge .enterprise}
 
 Developer Portal GUI protocol
@@ -2350,7 +2350,7 @@ Examples: `http`,`https`
 
 ---
 
-#### portal_gui_host
+### portal_gui_host
 {:.badge .enterprise}
 
 Developer Portal GUI host
@@ -2368,7 +2368,7 @@ Examples:
 
 ---
 
-#### portal_cors_origins
+### portal_cors_origins
 {:.badge .enterprise}
 
 Developer Portal CORS Origins
@@ -2393,7 +2393,7 @@ and can remain unset.
 
 ---
 
-#### portal_gui_use_subdomains
+### portal_gui_use_subdomains
 {:.badge .enterprise}
 
 Developer Portal GUI subdomain toggle
@@ -2412,7 +2412,7 @@ Example (on): - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->
 
 ---
 
-#### portal_gui_ssl_cert
+### portal_gui_ssl_cert
 {:.badge .enterprise}
 
 Developer Portal GUI SSL Certificate
@@ -2424,7 +2424,7 @@ SSL enabled.
 
 ---
 
-#### portal_gui_ssl_cert_key
+### portal_gui_ssl_cert_key
 {:.badge .enterprise}
 
 Developer Portal GUI SSL Certificate Key
@@ -2436,7 +2436,7 @@ enabled.
 
 ---
 
-#### portal_gui_access_log
+### portal_gui_access_log
 {:.badge .enterprise}
 
 Developer Portal GUI Access Log location
@@ -2451,7 +2451,7 @@ When using relative pathing, logs will be placed under the `prefix` location.
 
 ---
 
-#### portal_gui_error_log
+### portal_gui_error_log
 {:.badge .enterprise}
 
 Developer Portal GUI Error Log location
@@ -2468,7 +2468,7 @@ Granularity can be adjusted through the `log_level` directive.
 
 ---
 
-#### portal_api_listen
+### portal_api_listen
 {:.badge .enterprise}
 
 Developer Portal API Listeners
@@ -2481,7 +2481,7 @@ Portal API. Suffixes can be specified for each pair, similarly to the
 
 ---
 
-#### portal_api_url
+### portal_api_url
 {:.badge .enterprise}
 
 Developer Portal API URL
@@ -2515,7 +2515,7 @@ By default this value points to the local interface:
 
 ---
 
-#### portal_api_ssl_cert
+### portal_api_ssl_cert
 {:.badge .enterprise}
 
 Developer Portal API SSL Certificate
@@ -2527,7 +2527,7 @@ SSL enabled.
 
 ---
 
-#### portal_api_ssl_cert_key
+### portal_api_ssl_cert_key
 {:.badge .enterprise}
 
 Developer Portal API SSL Certificate Key
@@ -2539,7 +2539,7 @@ enabled.
 
 ---
 
-#### portal_api_access_log
+### portal_api_access_log
 {:.badge .enterprise}
 
 Developer Portal API Access Log location
@@ -2554,7 +2554,7 @@ When using relative pathing, logs will be placed under the `prefix` location.
 
 ---
 
-#### portal_api_error_log
+### portal_api_error_log
 {:.badge .enterprise}
 
 Developer Portal API Error Log location
@@ -2571,7 +2571,7 @@ Granularity can be adjusted through the `log_level` directive.
 
 ---
 
-#### portal_is_legacy
+### portal_is_legacy
 {:.badge .enterprise}
 
 Developer Portal legacy support
@@ -2586,7 +2586,7 @@ current rendering system.
 
 ---
 
-#### portal_app_auth
+### portal_app_auth
 {:.badge .enterprise}
 
 Developer Portal application registration auth provider and strategy. Must be
@@ -2598,14 +2598,14 @@ external-oauth2
 ---
 
 
-### Default Developer Portal Authentication section
+## Default Developer Portal Authentication section
 
 Referenced on workspace creation to set Dev Portal authentication defaults in
 the database for that particular workspace.
 
 ---
 
-#### portal_auth
+### portal_auth
 {:.badge .enterprise}
 
 Developer Portal Authentication Plugin Name
@@ -2623,7 +2623,7 @@ Supported Plugins:
 
 ---
 
-#### portal_auth_password_complexity
+### portal_auth_password_complexity
 {:.badge .enterprise}
 
 Kong Portal Authentication Password Complexity (JSON)
@@ -2665,7 +2665,7 @@ Example:
 
 ---
 
-#### portal_auth_conf
+### portal_auth_conf
 {:.badge .enterprise}
 
 Developer Portal Authentication Plugin Config (JSON)
@@ -2684,7 +2684,7 @@ Example for `basic-auth`:
 
 ---
 
-#### portal_auth_login_attempts
+### portal_auth_login_attempts
 {:.badge .enterprise}
 
 Number of times a user can attempt to login to the Dev Portal before password
@@ -2699,7 +2699,7 @@ basic-auth.
 
 ---
 
-#### portal_session_conf
+### portal_session_conf
 {:.badge .enterprise}
 
 Portal Session Config (JSON)
@@ -2721,7 +2721,7 @@ portal_session_conf = { "cookie_name": "portal_session", \
 
 ---
 
-#### portal_auto_approve
+### portal_auto_approve
 {:.badge .enterprise}
 
 Developer Portal Auto Approve Access
@@ -2737,7 +2737,7 @@ using Kong Manager or the Admin API.
 
 ---
 
-#### portal_token_exp
+### portal_token_exp
 {:.badge .enterprise}
 
 Duration in seconds for the expiration of the Dev Portal reset password token.
@@ -2747,7 +2747,7 @@ Default is `21600` (six hours).
 
 ---
 
-#### portal_email_verification
+### portal_email_verification
 {:.badge .enterprise}
 
 Portal Developer Email Verification.
@@ -2763,14 +2763,14 @@ Note: SMTP must be turned on in order to use this feature.
 ---
 
 
-### Default Portal Smtp Configuration section
+## Default Portal Smtp Configuration section
 
 Referenced on workspace creation to set SMTP defaults in the database for that
 particular workspace.
 
 ---
 
-#### portal_invite_email
+### portal_invite_email
 {:.badge .enterprise}
 
 When enabled, Kong admins can invite developers to a Dev Portal by using the
@@ -2792,7 +2792,7 @@ Please visit `<DEV_PORTAL_URL/register>` to create your account.
 
 ---
 
-#### portal_access_request_email
+### portal_access_request_email
 {:.badge .enterprise}
 
 When enabled, Kong admins specified by `smtp_admin_emails` will receive an
@@ -2817,7 +2817,7 @@ Please visit <KONG_MANAGER_URL/developers/requested> to review this request.
 
 ---
 
-#### portal_approved_email
+### portal_approved_email
 {:.badge .enterprise}
 
 When enabled, developers will receive an email when access to a Dev Portal has
@@ -2842,7 +2842,7 @@ Please visit <DEV PORTAL URL/login> to login.
 
 ---
 
-#### portal_reset_email
+### portal_reset_email
 {:.badge .enterprise}
 
 When enabled, developers will be able to use the Reset Password flow on a Dev
@@ -2874,7 +2874,7 @@ above to change your password.
 
 ---
 
-#### portal_reset_success_email
+### portal_reset_success_email
 {:.badge .enterprise}
 
 When enabled, developers will receive an email after successfully resetting
@@ -2901,7 +2901,7 @@ Click the link below to sign in with your new credentials.
 
 ---
 
-#### portal_application_status_email
+### portal_application_status_email
 {:.badge .enterprise}
 
 When enabled, developers will receive an email when the status changes for
@@ -2929,7 +2929,7 @@ You will receive another email when your access has been approved.
 
 ---
 
-#### portal_application_request_email
+### portal_application_request_email
 {:.badge .enterprise}
 
 When enabled, Kong admins specified by `smtp_admin_emails` will receive an
@@ -2966,7 +2966,7 @@ review this request.
 
 ---
 
-#### portal_emails_from
+### portal_emails_from
 {:.badge .enterprise}
 
 The name and email address for the `From` header included in all Dev Portal
@@ -2981,7 +2981,7 @@ and name associated with the account.
 
 ---
 
-#### portal_emails_reply_to
+### portal_emails_reply_to
 {:.badge .enterprise}
 
 Email address for the `Reply-To` header for portal emails
@@ -2995,7 +2995,7 @@ associated with the account.
 
 ---
 
-#### portal_smtp_admin_emails
+### portal_smtp_admin_emails
 {:.badge .enterprise}
 
 Comma separated list of admin emails to receive
@@ -3011,9 +3011,9 @@ Example `admin1@example.com, admin2@example.com`
 ---
 
 
-### Admin Smtp Configuration section
+## Admin Smtp Configuration section
 
-#### admin_emails_from
+### admin_emails_from
 {:.badge .enterprise}
 
 The email address for the `From` header for admin emails.
@@ -3022,7 +3022,7 @@ The email address for the `From` header for admin emails.
 
 ---
 
-#### admin_emails_reply_to
+### admin_emails_reply_to
 {:.badge .enterprise}
 
 Email address for the `Reply-To` header for admin emails.
@@ -3031,7 +3031,7 @@ Email address for the `Reply-To` header for admin emails.
 
 ---
 
-#### admin_invitation_expiry
+### admin_invitation_expiry
 {:.badge .enterprise}
 
 Expiration time for the admin invitation link (in seconds). 0 means no
@@ -3044,9 +3044,9 @@ Example, 72 hours: `72 * 60 * 60 = 259200`
 ---
 
 
-### General Smtp Configuration section
+## General Smtp Configuration section
 
-#### smtp_mock
+### smtp_mock
 {:.badge .enterprise}
 
 This flag will mock the sending of emails. This can be used for testing before
@@ -3056,7 +3056,7 @@ the SMTP client is fully configured.
 
 ---
 
-#### smtp_host
+### smtp_host
 {:.badge .enterprise}
 
 The hostname of the SMTP server to connect to.
@@ -3065,7 +3065,7 @@ The hostname of the SMTP server to connect to.
 
 ---
 
-#### smtp_port
+### smtp_port
 {:.badge .enterprise}
 
 The port number on the SMTP server to connect to.
@@ -3074,7 +3074,7 @@ The port number on the SMTP server to connect to.
 
 ---
 
-#### smtp_starttls
+### smtp_starttls
 {:.badge .enterprise}
 
 When set to `on`, STARTTLS is used to encrypt communication with the SMTP
@@ -3084,7 +3084,7 @@ server. This is normally used in conjunction with port 587.
 
 ---
 
-#### smtp_username
+### smtp_username
 {:.badge .enterprise}
 
 Username used for authentication with SMTP server
@@ -3093,7 +3093,7 @@ Username used for authentication with SMTP server
 
 ---
 
-#### smtp_password
+### smtp_password
 {:.badge .enterprise}
 
 Password used for authentication with SMTP server
@@ -3102,7 +3102,7 @@ Password used for authentication with SMTP server
 
 ---
 
-#### smtp_ssl
+### smtp_ssl
 {:.badge .enterprise}
 
 When set to `on`, SMTPS is used to encrypt communication with the SMTP server.
@@ -3112,7 +3112,7 @@ This is normally used in conjunction with port 465.
 
 ---
 
-#### smtp_auth_type
+### smtp_auth_type
 {:.badge .enterprise}
 
 The method used to authenticate with the SMTP server Valid options are `plain`,
@@ -3122,7 +3122,7 @@ The method used to authenticate with the SMTP server Valid options are `plain`,
 
 ---
 
-#### smtp_domain
+### smtp_domain
 {:.badge .enterprise}
 
 The domain used in the `EHLO` connection and part of the `Message-ID` header
@@ -3131,7 +3131,7 @@ The domain used in the `EHLO` connection and part of the `Message-ID` header
 
 ---
 
-#### smtp_timeout_connect
+### smtp_timeout_connect
 {:.badge .enterprise}
 
 The timeout (in milliseconds) for connecting to the SMTP server.
@@ -3140,7 +3140,7 @@ The timeout (in milliseconds) for connecting to the SMTP server.
 
 ---
 
-#### smtp_timeout_send
+### smtp_timeout_send
 {:.badge .enterprise}
 
 The timeout (in milliseconds) for sending data to the SMTP server.
@@ -3149,7 +3149,7 @@ The timeout (in milliseconds) for sending data to the SMTP server.
 
 ---
 
-#### smtp_timeout_read
+### smtp_timeout_read
 {:.badge .enterprise}
 
 The timeout (in milliseconds) for reading data from the SMTP server.
@@ -3158,7 +3158,7 @@ The timeout (in milliseconds) for reading data from the SMTP server.
 
 ---
 
-#### smtp_admin_emails
+### smtp_admin_emails
 {:.badge .enterprise}
 
 Comma separated list of admin emails to receive notifications.
@@ -3170,7 +3170,7 @@ Example `admin1@example.com, admin2@example.com`
 ---
 
 
-### Data & Admin Audit section
+## Data & Admin Audit section
 
 When enabled, Kong will store detailed audit data regarding Admin API and
 database access. In most cases, updates to the database are associated with
@@ -3180,7 +3180,7 @@ database traffic.
 
 ---
 
-#### audit_log
+### audit_log
 
 When enabled, Kong will log information about Admin API access and database row
 insertions, updates, and deletes.
@@ -3189,7 +3189,7 @@ insertions, updates, and deletes.
 
 ---
 
-#### audit_log_ignore_methods
+### audit_log_ignore_methods
 
 Comma-separated list of HTTP methods that will not generate audit log entries.
 By default, all HTTP requests will be logged.
@@ -3198,7 +3198,7 @@ By default, all HTTP requests will be logged.
 
 ---
 
-#### audit_log_ignore_paths
+### audit_log_ignore_paths
 
 Comma-separated list of request paths that will not generate audit log entries.
 By default, all HTTP requests will be logged.
@@ -3207,7 +3207,7 @@ By default, all HTTP requests will be logged.
 
 ---
 
-#### audit_log_ignore_tables
+### audit_log_ignore_tables
 
 Comma-separated list of database tables that will not generate audit log
 entries. By default, updates to all database tables will be logged (the term
@@ -3217,7 +3217,7 @@ entries. By default, updates to all database tables will be logged (the term
 
 ---
 
-#### audit_log_payload_exclude
+### audit_log_payload_exclude
 
 Comma-separated list of keys that will be filtered out of the payload. Keys
 that were filtered will be recorded in the audit log.
@@ -3226,7 +3226,7 @@ that were filtered will be recorded in the audit log.
 
 ---
 
-#### audit_log_record_ttl
+### audit_log_record_ttl
 
 Length, in seconds, of the TTL for audit log records. Records in the database
 older than their TTL are automatically purged.
@@ -3237,7 +3237,7 @@ Example, 30 days: `30 * 24 * 60 * 60 = 2592000`
 
 ---
 
-#### audit_log_signing_key
+### audit_log_signing_key
 
 Defines the path to a private RSA signing key that can be used to insert a
 signature of audit records, adjacent to the record. The corresponding public key
@@ -3249,11 +3249,11 @@ future. If this value is undefined, no signature will be generated.
 ---
 
 
-### Granular Tracing section
+## Granular Tracing section
 
-{:.warning} > **Deprecation warning**: Granular tracing is deprecated. This
+{:.warning}
+> **Deprecation warning**: Granular tracing is deprecated. This
 means the feature will eventually be removed.
-
 Our target for Granular tracing removal is the Kong Gateway 4.0 release.
 
 Granular tracing offers a mechanism to expose metrics and detailed debug data
@@ -3261,7 +3261,7 @@ about the lifecycle of Kong in a human- or machine-consumable format.
 
 ---
 
-#### tracing
+### tracing
 {:.badge .enterprise}
 
 When enabled, Kong will generate granular debug data about various portions of
@@ -3272,7 +3272,7 @@ timing, etc.
 
 ---
 
-#### tracing_write_strategy
+### tracing_write_strategy
 {:.badge .enterprise}
 
 Defines how Kong will write tracing data at the conclusion of the request. The
@@ -3285,7 +3285,7 @@ option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`.
 
 ---
 
-#### tracing_write_endpoint
+### tracing_write_endpoint
 {:.badge .enterprise}
 
 Defines the endpoint to which tracing data will be written.
@@ -3304,7 +3304,7 @@ Content-Type.
 
 ---
 
-#### tracing_time_threshold
+### tracing_time_threshold
 {:.badge .enterprise}
 
 The minimum time, in microseconds, over which a trace must execute in order to
@@ -3317,7 +3317,7 @@ limitation, causing traces of any duration to be written.
 
 ---
 
-#### tracing_types
+### tracing_types
 {:.badge .enterprise}
 
 Defines the types of traces that are written.
@@ -3347,7 +3347,7 @@ The following trace types are included:
 
 ---
 
-#### tracing_debug_header
+### tracing_debug_header
 {:.badge .enterprise}
 
 Defines the name of the HTTP request header that must be present in order to
@@ -3362,7 +3362,7 @@ certificate handling phases is not logged when this setting is enabled.
 
 ---
 
-#### generate_trace_details
+### generate_trace_details
 {:.badge .enterprise}
 
 When enabled, Kong will write context- specific details into traces. Trace
@@ -3376,9 +3376,9 @@ to store traces properly when this option is enabled.
 ---
 
 
-### Route Collision Detection/Prevention section
+## Route Collision Detection/Prevention section
 
-#### route_validation_strategy
+### route_validation_strategy
 {:.badge .enterprise}
 
 The strategy used to validate routes when creating or updating them.
@@ -3396,7 +3396,7 @@ workspaces.
 
 ---
 
-#### enforce_route_path_pattern
+### enforce_route_path_pattern
 {:.badge .enterprise}
 
 Specifies the Lua pattern which will be enforced on the `paths` attribute of a
@@ -3417,7 +3417,7 @@ Example For Pattern `/$(workspace)/v%d/.*` valid paths are:
 ---
 
 
-### Database Encryption & Keyring Management section
+## Database Encryption & Keyring Management section
 
 When enabled, Kong will transparently encrypt sensitive fields, such as
 Consumer credentials, TLS private keys, and RBAC user tokens, among others. A
@@ -3434,7 +3434,7 @@ note that mis-management of keyring data may result in irrecoverable data loss.
 
 ---
 
-#### keyring_enabled
+### keyring_enabled
 {:.badge .enterprise}
 
 When enabled, Kong will encrypt sensitive field values before writing them to
@@ -3446,7 +3446,7 @@ managed based on the strategy defined below.
 
 ---
 
-#### keyring_strategy
+### keyring_strategy
 {:.badge .enterprise}
 
 Defines the strategy implementation by which Kong nodes will manage symmetric
@@ -3458,7 +3458,7 @@ and 'vault'.
 
 ---
 
-#### keyring_public_key
+### keyring_public_key
 {:.badge .enterprise}
 
 Defines the filesystem path at which the public key of an RSA keypair resides.
@@ -3469,7 +3469,7 @@ recovery and optional bootstrapping.
 
 ---
 
-#### keyring_private_key
+### keyring_private_key
 {:.badge .enterprise}
 
 Defines the filesystem path at which the private key of an RSA keypair resides.
@@ -3480,7 +3480,7 @@ recovery and optional bootstrapping.
 
 ---
 
-#### keyring_recovery_public_key
+### keyring_recovery_public_key
 {:.badge .enterprise}
 
 Defines the filesystem path at which the public
@@ -3490,7 +3490,7 @@ key to optionally encrypt all keyring materials and backup in the database.
 
 ---
 
-#### keyring_blob_path
+### keyring_blob_path
 {:.badge .enterprise}
 
 Defines the filesystem path at which Kong will backup the initial keyring
@@ -3502,7 +3502,7 @@ This option is useful largely for development purposes.
 
 ---
 
-#### keyring_vault_host
+### keyring_vault_host
 {:.badge .enterprise}
 
 Defines the Vault host at which Kong will fetch the encryption material. This
@@ -3514,7 +3514,7 @@ value should be defined in the format:
 
 ---
 
-#### keyring_vault_mount
+### keyring_vault_mount
 {:.badge .enterprise}
 
 Defines the name of the Vault v2 KV secrets engine at which symmetric keys are
@@ -3524,7 +3524,7 @@ found.
 
 ---
 
-#### keyring_vault_path
+### keyring_vault_path
 {:.badge .enterprise}
 
 Defines the names of the Vault v2 KV path at which symmetric keys are found.
@@ -3533,7 +3533,7 @@ Defines the names of the Vault v2 KV path at which symmetric keys are found.
 
 ---
 
-#### keyring_vault_token
+### keyring_vault_token
 {:.badge .enterprise}
 
 Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
@@ -3542,7 +3542,7 @@ Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
 
 ---
 
-#### untrusted_lua
+### untrusted_lua
 
 Controls loading of Lua functions from admin-supplied sources such as the Admin
 API. LuaJIT bytecode loading is always disabled.
@@ -3589,7 +3589,7 @@ and `untrusted_lua_sandbox_environment` parameters below.
 
 ---
 
-#### untrusted_lua_sandbox_requires
+### untrusted_lua_sandbox_requires
 
 Comma-separated list of modules allowed to be loaded with `require` inside the
 sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
@@ -3615,7 +3615,7 @@ sandbox. For example, allowing `os` or `luaposix` may be unsafe.
 
 ---
 
-#### untrusted_lua_sandbox_environment
+### untrusted_lua_sandbox_environment
 
 Comma-separated list of global Lua variables that should be made available
 inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.
@@ -3627,7 +3627,7 @@ to escape the sandbox.
 
 ---
 
-#### openresty_path
+### openresty_path
 
 Path to the OpenResty installation that Kong will use. When this is empty (the
 default), Kong determines the OpenResty installation by searching for a

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -13,6 +13,8 @@ Reference for {{site.base_gateway}} configuration parameters. Set these paramete
 
 To learn more about the `kong.conf` file, see the guide on the [Kong Configuration File](/gateway/{{page.kong_version}}/kong-production/kong-conf).
 
+---
+
 ## General section
 
 ### prefix
@@ -24,7 +26,7 @@ Each Kong process must have a separate working directory.
 
 **Default:** `/usr/local/kong/`
 
----
+
 
 ### log_level
 
@@ -35,7 +37,7 @@ accepted values.
 
 **Default:** `notice`
 
----
+
 
 ### proxy_access_log
 
@@ -47,7 +49,7 @@ location.
 
 **Default:** `logs/access.log`
 
----
+
 
 ### proxy_error_log
 
@@ -56,7 +58,7 @@ adjusted by the `log_level` property.
 
 **Default:** `logs/error.log`
 
----
+
 
 ### proxy_stream_access_log
 
@@ -71,7 +73,7 @@ $bytes_sent $bytes_received ' '$session_time'`
 
 **Default:** `logs/access.log basic`
 
----
+
 
 ### proxy_stream_error_log
 
@@ -80,7 +82,7 @@ logs is adjusted by the `log_level` property.
 
 **Default:** `logs/error.log`
 
----
+
 
 ### admin_access_log
 
@@ -96,7 +98,7 @@ location.
 
 **Default:** `logs/admin_access.log`
 
----
+
 
 ### admin_error_log
 
@@ -105,7 +107,7 @@ adjusted by the `log_level` property.
 
 **Default:** `logs/error.log`
 
----
+
 
 ### status_access_log
 
@@ -117,7 +119,7 @@ location.
 
 **Default:** `off`
 
----
+
 
 ### status_error_log
 
@@ -126,7 +128,7 @@ adjusted by the `log_level` property.
 
 **Default:** `logs/status_error.log`
 
----
+
 
 ### vaults
 
@@ -138,7 +140,7 @@ The specified name(s) will be substituted as such in the Lua namespace:
 
 **Default:** `bundled`
 
----
+
 
 ### opentelemetry_tracing
 
@@ -165,7 +167,7 @@ enabled in stream mode.
 
 **Default:** `off`
 
----
+
 
 ### opentelemetry_tracing_sampling_rate
 
@@ -177,7 +179,7 @@ Example: `0.25`, this should account for 25% of all traces.
 
 **Default:** `1.0`
 
----
+
 
 ### plugins
 
@@ -214,7 +216,7 @@ experiencing LRU churning in the database cache (i.e. when the configured
 
 **Default:** `bundled`
 
----
+
 
 ### pluginserver_names
 
@@ -223,7 +225,7 @@ used for log messages and to relate the actual settings.
 
 **Default:** none
 
----
+
 
 ### pluginserver_XXX_socket
 
@@ -231,7 +233,7 @@ Path to the unix socket used by the <XXX> pluginserver.
 
 **Default:** `<prefix>/<XXX>.socket`
 
----
+
 
 ### pluginserver_XXX_start_cmd
 
@@ -239,7 +241,7 @@ Full command (including any needed arguments) to start the <XXX> pluginserver
 
 **Default:** `/usr/local/bin/<XXX>`
 
----
+
 
 ### pluginserver_XXX_query_cmd
 
@@ -248,7 +250,7 @@ dump info of all plugins it manages
 
 **Default:** `/usr/local/bin/query_<XXX>`
 
----
+
 
 ### port_maps
 
@@ -269,7 +271,7 @@ of reporting the port Kong is listening to.
 
 **Default:** none
 
----
+
 
 ### anonymous_reports
 
@@ -277,8 +279,8 @@ Send anonymous usage data such as error stack traces to help improve Kong.
 
 **Default:** `on`
 
----
 
+---
 
 ## Hybrid Mode section
 
@@ -298,7 +300,7 @@ Valid values to this setting are:
 
 **Default:** `traditional`
 
----
+
 
 ### cluster_mtls
 
@@ -318,7 +320,7 @@ Valid values to this setting are:
 
 **Default:** `shared`
 
----
+
 
 ### cluster_cert
 
@@ -332,7 +334,7 @@ should be a different certificate for each DP node.
 
 **Default:** none
 
----
+
 
 ### cluster_cert_key
 
@@ -346,7 +348,7 @@ should be a different certificate for each DP node.
 
 **Default:** none
 
----
+
 
 ### cluster_ca_cert
 
@@ -362,7 +364,7 @@ This field is ignored if `cluster_mtls` is set to `shared`.
 
 **Default:** none
 
----
+
 
 ### cluster_allowed_common_names
 
@@ -375,8 +377,8 @@ This field is ignored if `cluster_mtls` is not set to `pki_check_cn`.
 
 **Default:** none
 
----
 
+---
 
 ## Hybrid Mode Data Plane section
 
@@ -393,7 +395,7 @@ If `cluster_mtls` is set to `shared`, this setting is ignored and
 
 **Default:** none
 
----
+
 
 ### cluster_control_plane
 
@@ -402,7 +404,7 @@ which configuration updates will be fetched, in `host:port` format.
 
 **Default:** none
 
----
+
 
 ### cluster_telemetry_endpoint
 {:.badge .enterprise}
@@ -412,8 +414,8 @@ node to which telemetry updates will be posted in `host:port` format.
 
 **Default:** none
 
----
 
+---
 
 ## Hybrid Mode Control Plane section
 
@@ -435,7 +437,7 @@ See `admin_access_log` config description for more information.
 
 **Default:** `0.0.0.0:8005`
 
----
+
 
 ### cluster_telemetry_listen
 {:.badge .enterprise}
@@ -450,7 +452,7 @@ This setting has no effect if `role` is not set to `control_plane`.
 
 **Default:** `0.0.0.0:8006`
 
----
+
 
 ### cluster_data_plane_purge_delay
 
@@ -464,7 +466,7 @@ its entry will be removed.
 
 **Default:** `1209600`
 
----
+
 
 ### cluster_ocsp
 
@@ -488,7 +490,7 @@ Valid values to this setting are:
 
 **Default:** `off`
 
----
+
 
 ### cluster_max_payload
 
@@ -499,8 +501,8 @@ Default is 4Mb - 4 * 1024 * 1024 due to historical reasons.
 
 **Default:** `4194304`
 
----
 
+---
 
 ## NGINX section
 
@@ -557,7 +559,7 @@ documentation.
 
 **Default:** `0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384`
 
----
+
 
 ### proxy_url
 
@@ -583,7 +585,7 @@ append the resolved listener port depending on the requested protocol.
 
 **Default:** none
 
----
+
 
 ### stream_listen
 
@@ -627,7 +629,7 @@ description of the formats that Kong might accept in stream_listen.
 
 **Default:** `off`
 
----
+
 
 ### admin_api_uri
 
@@ -638,7 +640,7 @@ resolved admin_listen HTTP/HTTPS port.
 
 **Default:** none
 
----
+
 
 ### admin_listen
 
@@ -681,7 +683,7 @@ Example: `admin_listen = 127.0.0.1:8444 http2 ssl`
 
 **Default:** `127.0.0.1:8001 reuseport backlog=16384, 127.0.0.1:8444 http2 ssl reuseport backlog=16384`
 
----
+
 
 ### status_listen
 
@@ -703,7 +705,7 @@ Example: `status_listen = 0.0.0.0:8100`
 
 **Default:** `off`
 
----
+
 
 ### nginx_user
 
@@ -717,7 +719,7 @@ default user and group credentials will be `nobody nobody`.
 
 **Default:** `kong kong`
 
----
+
 
 ### nginx_worker_processes
 
@@ -728,7 +730,7 @@ usage of the equivalent Nginx directive and a description of accepted values.
 
 **Default:** `auto`
 
----
+
 
 ### nginx_daemon
 
@@ -739,7 +741,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#daemon.
 
 **Default:** `on`
 
----
+
 
 ### mem_cache_size
 
@@ -751,7 +753,7 @@ total memory Kong uses to cache entities might be double this value.
 
 **Default:** `128m`
 
----
+
 
 ### ssl_cipher_suite
 
@@ -765,7 +767,7 @@ https://wiki.openssl.org/index.php/FIPS_mode_and_TLS.
 
 **Default:** `intermediate`
 
----
+
 
 ### ssl_ciphers
 
@@ -776,7 +778,7 @@ This value is ignored if `ssl_cipher_suite` is not `custom`.
 
 **Default:** none
 
----
+
 
 ### ssl_protocols
 
@@ -788,7 +790,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
 
 **Default:** `TLSv1.1 TLSv1.2 TLSv1.3`
 
----
+
 
 ### ssl_prefer_server_ciphers
 
@@ -801,7 +803,7 @@ http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers
 
 **Default:** `on`
 
----
+
 
 ### ssl_dhparam
 
@@ -817,7 +819,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
 
 **Default:** none
 
----
+
 
 ### ssl_session_tickets
 
@@ -831,7 +833,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets
 
 **Default:** `on`
 
----
+
 
 ### ssl_session_timeout
 
@@ -842,7 +844,7 @@ See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
 
 **Default:** `1d`
 
----
+
 
 ### ssl_cert
 
@@ -860,7 +862,7 @@ requests.
 
 **Default:** none
 
----
+
 
 ### ssl_cert_key
 
@@ -877,7 +879,7 @@ requests.
 
 **Default:** none
 
----
+
 
 ### client_ssl
 
@@ -886,7 +888,7 @@ perform Mutual TLS Authentication with upstream service when proxying requests.
 
 **Default:** `off`
 
----
+
 
 ### client_ssl_cert
 
@@ -898,7 +900,7 @@ attribute of the `Service` object.
 
 **Default:** none
 
----
+
 
 ### client_ssl_cert_key
 
@@ -910,7 +912,7 @@ attribute of the `Service` object.
 
 **Default:** none
 
----
+
 
 ### admin_ssl_cert
 
@@ -921,7 +923,7 @@ See docs for `ssl_cert` for detailed usage.
 
 **Default:** none
 
----
+
 
 ### admin_ssl_cert_key
 
@@ -932,7 +934,7 @@ See docs for `ssl_cert_key` for detailed usage.
 
 **Default:** none
 
----
+
 
 ### status_ssl_cert
 
@@ -943,7 +945,7 @@ See docs for `ssl_cert` for detailed usage.
 
 **Default:** none
 
----
+
 
 ### status_ssl_cert_key
 
@@ -954,7 +956,7 @@ See docs for `ssl_cert_key` for detailed usage.
 
 **Default:** none
 
----
+
 
 ### headers
 
@@ -990,7 +992,7 @@ Example: `headers = via, latency_tokens`
 
 **Default:** `server_tokens, latency_tokens`
 
----
+
 
 ### trusted_ips
 
@@ -1016,7 +1018,7 @@ for examples of accepted values.
 
 **Default:** none
 
----
+
 
 ### real_ip_header
 
@@ -1038,7 +1040,7 @@ for a description of this directive.
 
 **Default:** `X-Real-IP`
 
----
+
 
 ### real_ip_recursive
 
@@ -1050,7 +1052,7 @@ for a description of this directive.
 
 **Default:** `off`
 
----
+
 
 ### error_default_type
 
@@ -1062,7 +1064,7 @@ Accepted values are `text/plain`, `text/html`, `application/json`, and
 
 **Default:** `text/plain`
 
----
+
 
 ### upstream_keepalive_pool_size
 
@@ -1076,7 +1078,7 @@ each upstream request to open a new connection.
 
 **Default:** `60`
 
----
+
 
 ### upstream_keepalive_max_requests
 
@@ -1090,7 +1092,7 @@ used to proxy an indefinite number of requests.
 
 **Default:** `100`
 
----
+
 
 ### upstream_keepalive_idle_timeout
 
@@ -1103,8 +1105,8 @@ be kept open indefinitely.
 
 **Default:** `60`
 
----
 
+---
 
 ## NGINX Injected Directives section
 
@@ -1157,7 +1159,7 @@ server, you may specify `nginx_proxy_ssl_protocols` and/or
 `nginx_admin_ssl_protocols`, both of which taking precedence over the `http {}`
 block.
 
----
+
 
 ### nginx_main_worker_rlimit_nofile
 
@@ -1170,7 +1172,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
 
 **Default:** `auto`
 
----
+
 
 ### nginx_events_worker_connections
 
@@ -1184,7 +1186,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#worker_connections
 
 **Default:** `auto`
 
----
+
 
 ### nginx_http_client_header_buffer_size
 
@@ -1195,7 +1197,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_siz
 
 **Default:** `1k`
 
----
+
 
 ### nginx_http_large_client_header_buffers
 
@@ -1207,7 +1209,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buff
 
 **Default:** `4 8k`
 
----
+
 
 ### nginx_http_client_max_body_size
 
@@ -1221,7 +1223,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 
 **Default:** `0`
 
----
+
 
 ### nginx_admin_client_max_body_size
 
@@ -1229,7 +1231,7 @@ Defines the maximum request body size for Admin API.
 
 **Default:** `10m`
 
----
+
 
 ### nginx_http_client_body_buffer_size
 
@@ -1246,7 +1248,7 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
 
 **Default:** `8k`
 
----
+
 
 ### nginx_admin_client_body_buffer_size
 
@@ -1254,7 +1256,7 @@ Defines the buffer size for reading the request body on Admin API.
 
 **Default:** `10m`
 
----
+
 
 ### nginx_http_lua_regex_match_limit
 
@@ -1263,8 +1265,8 @@ ensure at worst any regex Kong executes could finish within roughly 2 seconds.
 
 **Default:** `100000`
 
----
 
+---
 
 ## Datastore section
 
@@ -1301,7 +1303,7 @@ By default, all other database config for the read-only connection are
 inherited from the corresponding main connection config described above but may
 be optionally overwritten explicitly using the `pg_ro_*` config below.
 
----
+
 
 ### database
 
@@ -1312,13 +1314,13 @@ Accepted values are `postgres`, `cassandra`, and `off`.
 
 **Default:** `postgres`
 
----
+
 
 
 ### Postgres settings
 
 name   | description  | default
--------|--------------|----------
+-|--|-
 **pg_host** | Host of the Postgres server. | `127.0.0.1`
 **pg_port** | Port of the Postgres server. | `5432`
 **pg_timeout** | Defines the timeout (in ms), for connecting, reading and writing. | `5000`
@@ -1357,7 +1359,7 @@ name   | description  | default
 
 
 name   | description  | default
--------|--------------|----------
+-|--|-
 **cassandra_contact_points** | A comma-separated list of contact points to your cluster. You may specify IP addresses or hostnames. Note that the port component of SRV records will be ignored in favor of `cassandra_port`. When connecting to a multi-DC cluster, ensure that contact points from the local datacenter are specified first in this list. | `127.0.0.1`
 **cassandra_port** | The port on which your nodes are listening on. All your nodes and contact points must listen on the same port. Will be created if it doesn't exist. | `9042`
 **cassandra_keyspace** | The keyspace to use in your cluster. | `kong`
@@ -1393,7 +1395,7 @@ node as a user-controlled fallback.
 
 **Default:** none
 
----
+
 
 ### declarative_config_string
 
@@ -1401,7 +1403,7 @@ The declarative configuration as a string
 
 **Default:** none
 
----
+
 
 ### declarative_config_encryption_mode
 
@@ -1412,8 +1414,8 @@ chacha20-poly1305 to encrypt `off` = does not encrypt
 
 **Default:** none
 
----
 
+---
 
 ## Datastore Cache section
 
@@ -1424,7 +1426,7 @@ time. It also handles invalidations if such an entity is updated.
 This section allows for configuring the behavior of Kong regarding the caching
 of such configuration entities.
 
----
+
 
 ### db_update_frequency
 
@@ -1437,7 +1439,7 @@ purge the old cached entity and start using the new one.
 
 **Default:** `5`
 
----
+
 
 ### db_update_propagation
 
@@ -1456,7 +1458,7 @@ and this value can be safely set to 0.
 
 **Default:** `0`
 
----
+
 
 ### db_cache_ttl
 
@@ -1470,7 +1472,7 @@ If set to 0 (default), such cached entities or misses never expire.
 
 **Default:** `0`
 
----
+
 
 ### db_cache_neg_ttl
 
@@ -1482,7 +1484,7 @@ If set to 0, misses will never expire.
 
 **Default:** none
 
----
+
 
 ### db_resurrect_ttl
 
@@ -1493,7 +1495,7 @@ will be made.
 
 **Default:** `30`
 
----
+
 
 ### db_cache_warmup_entities
 
@@ -1512,8 +1514,8 @@ If the size is insufficient, Kong will log a warning.
 
 **Default:** `services`
 
----
 
+---
 
 ## DNS Resolver section
 
@@ -1538,7 +1540,7 @@ request it gets over the entries in the DNS record. For `SRV` records the
 `weight` fields will be honored, but it will only use the lowest `priority`
 field entries in the record.
 
----
+
 
 ### dns_resolver
 
@@ -1550,7 +1552,7 @@ Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses.
 
 **Default:** none
 
----
+
 
 ### dns_hostsfile
 
@@ -1561,7 +1563,7 @@ To read the file again after modifying it, Kong must be reloaded.
 
 **Default:** `/etc/hosts`
 
----
+
 
 ### dns_order
 
@@ -1571,7 +1573,7 @@ type of the last successful lookup (for the specified name). The format is a
 
 **Default:** `LAST,SRV,A,CNAME`
 
----
+
 
 ### dns_valid_ttl
 
@@ -1581,7 +1583,7 @@ records.
 
 **Default:** none
 
----
+
 
 ### dns_stale_ttl
 
@@ -1593,7 +1595,7 @@ completes, or the `dns_stale_ttl` number of seconds have passed.
 
 **Default:** `4`
 
----
+
 
 ### dns_cache_size
 
@@ -1605,7 +1607,7 @@ errors and data are cached, therefore a single name query can easily take up
 
 **Default:** `10000`
 
----
+
 
 ### dns_not_found_ttl
 
@@ -1613,7 +1615,7 @@ TTL in seconds for empty DNS responses and "(3) name error" responses.
 
 **Default:** `30`
 
----
+
 
 ### dns_error_ttl
 
@@ -1621,7 +1623,7 @@ TTL in seconds for error responses.
 
 **Default:** `1`
 
----
+
 
 ### dns_no_sync
 
@@ -1633,8 +1635,8 @@ a single query.
 
 **Default:** `off`
 
----
 
+---
 
 ## Tuning & Behavior section
 
@@ -1664,7 +1666,7 @@ after Routes and Services updates.
 
 **Default:** `eventual`
 
----
+
 
 ### worker_state_update_frequency
 
@@ -1676,8 +1678,8 @@ each individual worker.
 
 **Default:** `5`
 
----
 
+---
 
 ## Miscellaneous section
 
@@ -1687,7 +1689,7 @@ flexibility and advanced usage.
 See the lua-nginx-module documentation for more information:
 https://github.com/openresty/lua-nginx-module
 
----
+
 
 ### lua_ssl_trusted_certificate
 
@@ -1715,7 +1717,7 @@ See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate
 
 **Default:** `system`
 
----
+
 
 ### lua_ssl_verify_depth
 
@@ -1731,7 +1733,7 @@ See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth
 
 **Default:** `1`
 
----
+
 
 ### lua_ssl_protocols
 
@@ -1744,7 +1746,7 @@ connections made to the upstream Service or from downstream clients.
 
 **Default:** `TLSv1.1 TLSv1.2 TLSv1.3`
 
----
+
 
 ### lua_package_path
 
@@ -1755,7 +1757,7 @@ See https://github.com/openresty/lua-nginx-module#lua_package_path
 
 **Default:** `./?.lua;./?/init.lua;`
 
----
+
 
 ### lua_package_cpath
 
@@ -1765,7 +1767,7 @@ See https://github.com/openresty/lua-nginx-module#lua_package_cpath
 
 **Default:** none
 
----
+
 
 ### lua_socket_pool_size
 
@@ -1776,7 +1778,7 @@ See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
 
 **Default:** `30`
 
----
+
 
 ### enforce_rbac
 {:.badge .enterprise}
@@ -1797,7 +1799,7 @@ resource.
 
 **Default:** `off`
 
----
+
 
 ### rbac_auth_header
 {:.badge .enterprise}
@@ -1807,7 +1809,7 @@ attempt to authenticate the RBAC user.
 
 **Default:** `Kong-Admin-Token`
 
----
+
 
 ### event_hooks_enabled
 {:.badge .enterprise}
@@ -1823,7 +1825,7 @@ See: https://docs.konghq.com/gateway/latest/admin-api/event-hooks/reference/
 
 **Default:** `on`
 
----
+
 
 ### fips
 
@@ -1831,14 +1833,14 @@ Turn on FIPS mode; this mode is only available on a FIPS build.
 
 **Default:** `off`
 
----
 
+---
 
 ## Kong Manager section
 
 The Admin GUI for Kong Enterprise.
 
----
+
 
 ### admin_gui_listen
 {:.badge .free}
@@ -1854,7 +1856,7 @@ directive.
 
 **Default:** `0.0.0.0:8002, 0.0.0.0:8445 ssl`
 
----
+
 
 ### admin_gui_url
 {:.badge .free}
@@ -1878,7 +1880,7 @@ resolved listener port depending on the requested protocol.
 
 **Default:** none
 
----
+
 
 ### admin_gui_ssl_cert
 {:.badge .free}
@@ -1888,7 +1890,7 @@ enabled.
 
 **Default:** none
 
----
+
 
 ### admin_gui_ssl_cert_key
 {:.badge .free}
@@ -1898,7 +1900,7 @@ enabled.
 
 **Default:** none
 
----
+
 
 ### admin_gui_flags
 {:.badge .free}
@@ -1908,7 +1910,7 @@ Alters the layout Admin GUI (JSON) The only supported value is `{
 
 **Default:** `{}`
 
----
+
 
 ### admin_gui_access_log
 {:.badge .free}
@@ -1922,7 +1924,7 @@ Setting this value to `off` disables access logs for Kong Manager.
 
 **Default:** `logs/admin_gui_access.log`
 
----
+
 
 ### admin_gui_error_log
 {:.badge .free}
@@ -1938,7 +1940,7 @@ Granularity can be adjusted through the `log_level` directive.
 
 **Default:** `logs/admin_gui_error.log`
 
----
+
 
 ### admin_gui_auth
 {:.badge .enterprise}
@@ -1955,7 +1957,7 @@ Supported Plugins:
 
 **Default:** none
 
----
+
 
 ### admin_gui_auth_conf
 {:.badge .enterprise}
@@ -1974,7 +1976,7 @@ Example for `basic-auth`:
 
 **Default:** none
 
----
+
 
 ### admin_gui_auth_password_complexity
 {:.badge .enterprise}
@@ -2016,7 +2018,7 @@ Example:
 
 **Default:** none
 
----
+
 
 ### admin_gui_session_conf
 {:.badge .enterprise}
@@ -2037,7 +2039,7 @@ admin_gui_session_conf = { "cookie_name": "kookie", \
 
 **Default:** none
 
----
+
 
 ### admin_gui_auth_header
 {:.badge .enterprise}
@@ -2047,7 +2049,7 @@ attempt to identify the Kong Admin user.
 
 **Default:** `Kong-Admin-User`
 
----
+
 
 ### admin_gui_auth_login_attempts
 {:.badge .enterprise}
@@ -2057,7 +2059,7 @@ attempts allowed.
 
 **Default:** `0`
 
----
+
 
 ### admin_gui_header_txt
 {:.badge .free}
@@ -2067,7 +2069,7 @@ Banner is not shown if this config is empty.
 
 **Default:** none
 
----
+
 
 ### admin_gui_header_bg_color
 {:.badge .free}
@@ -2078,7 +2080,7 @@ values are ignored by Manager.
 
 **Default:** none
 
----
+
 
 ### admin_gui_header_txt_color
 {:.badge .free}
@@ -2090,7 +2092,7 @@ ignored by Kong Manager.
 
 **Default:** none
 
----
+
 
 ### admin_gui_footer_txt
 {:.badge .free}
@@ -2100,7 +2102,7 @@ Banner is not shown if this config is empty
 
 **Default:** none
 
----
+
 
 ### admin_gui_footer_bg_color
 {:.badge .free}
@@ -2113,7 +2115,7 @@ ignored by Manager.
 
 **Default:** none
 
----
+
 
 ### admin_gui_footer_txt_color
 {:.badge .free}
@@ -2125,7 +2127,7 @@ ignored by Kong Manager.
 
 **Default:** none
 
----
+
 
 ### admin_gui_login_banner_title
 {:.badge .free}
@@ -2138,7 +2140,7 @@ Login Banner is not shown if both `admin_gui_login_banner_title` and
 
 **Default:** none
 
----
+
 
 ### admin_gui_login_banner_body
 {:.badge .free}
@@ -2151,8 +2153,8 @@ Login Banner is not shown if both `admin_gui_login_banner_title` and
 
 **Default:** none
 
----
 
+---
 
 ## Vitals section
 
@@ -2171,7 +2173,7 @@ and visualizations on the dashboard.
 
 **Default:** `on`
 
----
+
 
 ### vitals_strategy
 {:.badge .enterprise}
@@ -2184,7 +2186,7 @@ Accepted values are `database`, `prometheus`, or `influxdb`.
 
 **Default:** `database`
 
----
+
 
 ### vitals_tsdb_address
 {:.badge .enterprise}
@@ -2202,7 +2204,7 @@ Vitals data.
 
 **Default:** none
 
----
+
 
 ### vitals_tsdb_user
 {:.badge .enterprise}
@@ -2211,7 +2213,7 @@ Influxdb user
 
 **Default:** none
 
----
+
 
 ### vitals_tsdb_password
 {:.badge .enterprise}
@@ -2220,7 +2222,7 @@ Influxdb password
 
 **Default:** none
 
----
+
 
 ### vitals_statsd_address
 {:.badge .enterprise}
@@ -2233,7 +2235,7 @@ in Kong sending StatsD metrics via TCP instead of the UDP (default).
 
 **Default:** none
 
----
+
 
 ### vitals_statsd_prefix
 {:.badge .enterprise}
@@ -2243,7 +2245,7 @@ useful when writing metrics to a multi-tenant StatsD exporter or server.
 
 **Default:** `kong`
 
----
+
 
 ### vitals_statsd_udp_packet_size
 {:.badge .enterprise}
@@ -2255,7 +2257,7 @@ This value is defined in bytes.
 
 **Default:** `1024`
 
----
+
 
 ### vitals_prometheus_scrape_interval
 {:.badge .enterprise}
@@ -2268,8 +2270,8 @@ server.
 
 **Default:** `5`
 
----
 
+---
 
 ## Konnect section
 
@@ -2279,8 +2281,8 @@ When enabled, the dataplane is connected to Konnect
 
 **Default:** `off`
 
----
 
+---
 
 ## Analytics For Konnect section
 
@@ -2290,7 +2292,7 @@ Determine the frequency of flushing local data to Konnect in seconds.
 
 **Default:** `1`
 
----
+
 
 ### analytics_buffer_size_limit
 
@@ -2299,8 +2301,8 @@ there is no network connection to Konnect.
 
 **Default:** `100000`
 
----
 
+---
 
 ## Developer Portal section
 
@@ -2321,7 +2323,7 @@ and the Dev Portal API.
 
 **Default:** `off`
 
----
+
 
 ### portal_gui_listen
 {:.badge .enterprise}
@@ -2334,7 +2336,7 @@ Portal GUI. Suffixes can be specified for each pair, similarly to the
 
 **Default:** `0.0.0.0:8003, 0.0.0.0:8446 ssl`
 
----
+
 
 ### portal_gui_protocol
 {:.badge .enterprise}
@@ -2348,7 +2350,7 @@ Examples: `http`,`https`
 
 **Default:** `http`
 
----
+
 
 ### portal_gui_host
 {:.badge .enterprise}
@@ -2366,7 +2368,7 @@ Examples:
 
 **Default:** `127.0.0.1:8003`
 
----
+
 
 ### portal_cors_origins
 {:.badge .enterprise}
@@ -2391,7 +2393,7 @@ and can remain unset.
 
 **Default:** none
 
----
+
 
 ### portal_gui_use_subdomains
 {:.badge .enterprise}
@@ -2410,7 +2412,7 @@ Example (on): - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->
 
 **Default:** `off`
 
----
+
 
 ### portal_gui_ssl_cert
 {:.badge .enterprise}
@@ -2422,7 +2424,7 @@ SSL enabled.
 
 **Default:** none
 
----
+
 
 ### portal_gui_ssl_cert_key
 {:.badge .enterprise}
@@ -2434,7 +2436,7 @@ enabled.
 
 **Default:** none
 
----
+
 
 ### portal_gui_access_log
 {:.badge .enterprise}
@@ -2449,7 +2451,7 @@ When using relative pathing, logs will be placed under the `prefix` location.
 
 **Default:** `logs/portal_gui_access.log`
 
----
+
 
 ### portal_gui_error_log
 {:.badge .enterprise}
@@ -2466,7 +2468,7 @@ Granularity can be adjusted through the `log_level` directive.
 
 **Default:** `logs/portal_gui_error.log`
 
----
+
 
 ### portal_api_listen
 {:.badge .enterprise}
@@ -2479,7 +2481,7 @@ Portal API. Suffixes can be specified for each pair, similarly to the
 
 **Default:** `0.0.0.0:8004, 0.0.0.0:8447 ssl`
 
----
+
 
 ### portal_api_url
 {:.badge .enterprise}
@@ -2513,7 +2515,7 @@ By default this value points to the local interface:
 
 **Default:** none
 
----
+
 
 ### portal_api_ssl_cert
 {:.badge .enterprise}
@@ -2525,7 +2527,7 @@ SSL enabled.
 
 **Default:** none
 
----
+
 
 ### portal_api_ssl_cert_key
 {:.badge .enterprise}
@@ -2537,7 +2539,7 @@ enabled.
 
 **Default:** none
 
----
+
 
 ### portal_api_access_log
 {:.badge .enterprise}
@@ -2552,7 +2554,7 @@ When using relative pathing, logs will be placed under the `prefix` location.
 
 **Default:** `logs/portal_api_access.log`
 
----
+
 
 ### portal_api_error_log
 {:.badge .enterprise}
@@ -2569,7 +2571,7 @@ Granularity can be adjusted through the `log_level` directive.
 
 **Default:** `logs/portal_api_error.log`
 
----
+
 
 ### portal_is_legacy
 {:.badge .enterprise}
@@ -2584,7 +2586,7 @@ current rendering system.
 
 **Default:** `off`
 
----
+
 
 ### portal_app_auth
 {:.badge .enterprise}
@@ -2595,15 +2597,15 @@ external-oauth2
 
 **Default:** `kong-oauth2`
 
----
 
+---
 
 ## Default Developer Portal Authentication section
 
 Referenced on workspace creation to set Dev Portal authentication defaults in
 the database for that particular workspace.
 
----
+
 
 ### portal_auth
 {:.badge .enterprise}
@@ -2621,7 +2623,7 @@ Supported Plugins:
 
 **Default:** none
 
----
+
 
 ### portal_auth_password_complexity
 {:.badge .enterprise}
@@ -2663,7 +2665,7 @@ Example:
 
 **Default:** none
 
----
+
 
 ### portal_auth_conf
 {:.badge .enterprise}
@@ -2682,7 +2684,7 @@ Example for `basic-auth`:
 
 **Default:** none
 
----
+
 
 ### portal_auth_login_attempts
 {:.badge .enterprise}
@@ -2697,7 +2699,7 @@ basic-auth.
 
 **Default:** `0`
 
----
+
 
 ### portal_session_conf
 {:.badge .enterprise}
@@ -2719,7 +2721,7 @@ portal_session_conf = { "cookie_name": "portal_session", \
 
 **Default:** none
 
----
+
 
 ### portal_auto_approve
 {:.badge .enterprise}
@@ -2735,7 +2737,7 @@ using Kong Manager or the Admin API.
 
 **Default:** `off`
 
----
+
 
 ### portal_token_exp
 {:.badge .enterprise}
@@ -2745,7 +2747,7 @@ Default is `21600` (six hours).
 
 **Default:** `21600`
 
----
+
 
 ### portal_email_verification
 {:.badge .enterprise}
@@ -2760,15 +2762,15 @@ Note: SMTP must be turned on in order to use this feature.
 
 **Default:** `off`
 
----
 
+---
 
 ## Default Portal Smtp Configuration section
 
 Referenced on workspace creation to set SMTP defaults in the database for that
 particular workspace.
 
----
+
 
 ### portal_invite_email
 {:.badge .enterprise}
@@ -2790,7 +2792,7 @@ Please visit `<DEV_PORTAL_URL/register>` to create your account.
 **Default:** `on`
 ```
 
----
+
 
 ### portal_access_request_email
 {:.badge .enterprise}
@@ -2815,7 +2817,7 @@ Please visit <KONG_MANAGER_URL/developers/requested> to review this request.
 **Default:** `on`
 ```
 
----
+
 
 ### portal_approved_email
 {:.badge .enterprise}
@@ -2840,7 +2842,7 @@ Please visit <DEV PORTAL URL/login> to login.
 
 **Default:** `on`
 
----
+
 
 ### portal_reset_email
 {:.badge .enterprise}
@@ -2872,7 +2874,7 @@ above to change your password.
 
 **Default:** `on`
 
----
+
 
 ### portal_reset_success_email
 {:.badge .enterprise}
@@ -2899,7 +2901,7 @@ Click the link below to sign in with your new credentials.
 
 **Default:** `on`
 
----
+
 
 ### portal_application_status_email
 {:.badge .enterprise}
@@ -2927,7 +2929,7 @@ You will receive another email when your access has been approved.
 
 **Default:** `off`
 
----
+
 
 ### portal_application_request_email
 {:.badge .enterprise}
@@ -2964,7 +2966,7 @@ review this request.
 
 **Default:** `off`
 
----
+
 
 ### portal_emails_from
 {:.badge .enterprise}
@@ -2979,7 +2981,7 @@ and name associated with the account.
 
 **Default:** none
 
----
+
 
 ### portal_emails_reply_to
 {:.badge .enterprise}
@@ -2993,7 +2995,7 @@ associated with the account.
 
 **Default:** none
 
----
+
 
 ### portal_smtp_admin_emails
 {:.badge .enterprise}
@@ -3008,8 +3010,8 @@ Example `admin1@example.com, admin2@example.com`
 
 **Default:** none
 
----
 
+---
 
 ## Admin Smtp Configuration section
 
@@ -3020,7 +3022,7 @@ The email address for the `From` header for admin emails.
 
 **Default:** `""`
 
----
+
 
 ### admin_emails_reply_to
 {:.badge .enterprise}
@@ -3029,7 +3031,7 @@ Email address for the `Reply-To` header for admin emails.
 
 **Default:** none
 
----
+
 
 ### admin_invitation_expiry
 {:.badge .enterprise}
@@ -3041,8 +3043,8 @@ Example, 72 hours: `72 * 60 * 60 = 259200`
 
 **Default:** `259200`
 
----
 
+---
 
 ## General Smtp Configuration section
 
@@ -3054,7 +3056,7 @@ the SMTP client is fully configured.
 
 **Default:** `on`
 
----
+
 
 ### smtp_host
 {:.badge .enterprise}
@@ -3063,7 +3065,7 @@ The hostname of the SMTP server to connect to.
 
 **Default:** `localhost`
 
----
+
 
 ### smtp_port
 {:.badge .enterprise}
@@ -3072,7 +3074,7 @@ The port number on the SMTP server to connect to.
 
 **Default:** `25`
 
----
+
 
 ### smtp_starttls
 {:.badge .enterprise}
@@ -3082,7 +3084,7 @@ server. This is normally used in conjunction with port 587.
 
 **Default:** `off`
 
----
+
 
 ### smtp_username
 {:.badge .enterprise}
@@ -3091,7 +3093,7 @@ Username used for authentication with SMTP server
 
 **Default:** none
 
----
+
 
 ### smtp_password
 {:.badge .enterprise}
@@ -3100,7 +3102,7 @@ Password used for authentication with SMTP server
 
 **Default:** none
 
----
+
 
 ### smtp_ssl
 {:.badge .enterprise}
@@ -3110,7 +3112,7 @@ This is normally used in conjunction with port 465.
 
 **Default:** `off`
 
----
+
 
 ### smtp_auth_type
 {:.badge .enterprise}
@@ -3120,7 +3122,7 @@ The method used to authenticate with the SMTP server Valid options are `plain`,
 
 **Default:** none
 
----
+
 
 ### smtp_domain
 {:.badge .enterprise}
@@ -3129,7 +3131,7 @@ The domain used in the `EHLO` connection and part of the `Message-ID` header
 
 **Default:** `localhost.localdomain`
 
----
+
 
 ### smtp_timeout_connect
 {:.badge .enterprise}
@@ -3138,7 +3140,7 @@ The timeout (in milliseconds) for connecting to the SMTP server.
 
 **Default:** `60000`
 
----
+
 
 ### smtp_timeout_send
 {:.badge .enterprise}
@@ -3147,7 +3149,7 @@ The timeout (in milliseconds) for sending data to the SMTP server.
 
 **Default:** `60000`
 
----
+
 
 ### smtp_timeout_read
 {:.badge .enterprise}
@@ -3156,7 +3158,7 @@ The timeout (in milliseconds) for reading data from the SMTP server.
 
 **Default:** `60000`
 
----
+
 
 ### smtp_admin_emails
 {:.badge .enterprise}
@@ -3167,8 +3169,8 @@ Example `admin1@example.com, admin2@example.com`
 
 **Default:** none
 
----
 
+---
 
 ## Data & Admin Audit section
 
@@ -3178,7 +3180,7 @@ Admin API requests. As such, database object audit log data is tied to a given
 HTTP via a unique identifier, providing built-in association of Admin API and
 database traffic.
 
----
+
 
 ### audit_log
 
@@ -3187,7 +3189,7 @@ insertions, updates, and deletes.
 
 **Default:** `off`
 
----
+
 
 ### audit_log_ignore_methods
 
@@ -3196,7 +3198,7 @@ By default, all HTTP requests will be logged.
 
 **Default:** none
 
----
+
 
 ### audit_log_ignore_paths
 
@@ -3205,7 +3207,7 @@ By default, all HTTP requests will be logged.
 
 **Default:** none
 
----
+
 
 ### audit_log_ignore_tables
 
@@ -3215,7 +3217,7 @@ entries. By default, updates to all database tables will be logged (the term
 
 **Default:** none
 
----
+
 
 ### audit_log_payload_exclude
 
@@ -3224,7 +3226,7 @@ that were filtered will be recorded in the audit log.
 
 **Default:** `token, secret, password`
 
----
+
 
 ### audit_log_record_ttl
 
@@ -3235,7 +3237,7 @@ Example, 30 days: `30 * 24 * 60 * 60 = 2592000`
 
 **Default:** `2592000`
 
----
+
 
 ### audit_log_signing_key
 
@@ -3246,8 +3248,8 @@ future. If this value is undefined, no signature will be generated.
 
 **Default:** none
 
----
 
+---
 
 ## Granular Tracing section
 
@@ -3259,7 +3261,7 @@ Our target for Granular tracing removal is the Kong Gateway 4.0 release.
 Granular tracing offers a mechanism to expose metrics and detailed debug data
 about the lifecycle of Kong in a human- or machine-consumable format.
 
----
+
 
 ### tracing
 {:.badge .enterprise}
@@ -3270,7 +3272,7 @@ timing, etc.
 
 **Default:** `off`
 
----
+
 
 ### tracing_write_strategy
 {:.badge .enterprise}
@@ -3283,7 +3285,7 @@ option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`.
 
 **Default:** `file`
 
----
+
 
 ### tracing_write_endpoint
 {:.badge .enterprise}
@@ -3302,7 +3304,7 @@ Content-Type.
 
 **Default:** none
 
----
+
 
 ### tracing_time_threshold
 {:.badge .enterprise}
@@ -3315,7 +3317,7 @@ limitation, causing traces of any duration to be written.
 
 **Default:** `0`
 
----
+
 
 ### tracing_types
 {:.badge .enterprise}
@@ -3345,7 +3347,7 @@ The following trace types are included:
 
 **Default:** `all`
 
----
+
 
 ### tracing_debug_header
 {:.badge .enterprise}
@@ -3360,7 +3362,7 @@ certificate handling phases is not logged when this setting is enabled.
 
 **Default:** none
 
----
+
 
 ### generate_trace_details
 {:.badge .enterprise}
@@ -3373,8 +3375,8 @@ to store traces properly when this option is enabled.
 
 **Default:** `off`
 
----
 
+---
 
 ## Route Collision Detection/Prevention section
 
@@ -3394,7 +3396,7 @@ workspaces.
 
 **Default:** `smart`
 
----
+
 
 ### enforce_route_path_pattern
 {:.badge .enterprise}
@@ -3414,8 +3416,8 @@ Example For Pattern `/$(workspace)/v%d/.*` valid paths are:
 
 **Default:** none
 
----
 
+---
 
 ## Database Encryption & Keyring Management section
 
@@ -3432,7 +3434,7 @@ semantic versioning compatibility guarantees on the keyring feature's APIs in
 that Kong may make a breaking change to the feature in a minor version. Also
 note that mis-management of keyring data may result in irrecoverable data loss.
 
----
+
 
 ### keyring_enabled
 {:.badge .enterprise}
@@ -3444,7 +3446,7 @@ managed based on the strategy defined below.
 
 **Default:** `off`
 
----
+
 
 ### keyring_strategy
 {:.badge .enterprise}
@@ -3456,7 +3458,7 @@ and 'vault'.
 
 **Default:** `cluster`
 
----
+
 
 ### keyring_public_key
 {:.badge .enterprise}
@@ -3467,7 +3469,7 @@ recovery and optional bootstrapping.
 
 **Default:** none
 
----
+
 
 ### keyring_private_key
 {:.badge .enterprise}
@@ -3478,7 +3480,7 @@ recovery and optional bootstrapping.
 
 **Default:** none
 
----
+
 
 ### keyring_recovery_public_key
 {:.badge .enterprise}
@@ -3488,7 +3490,7 @@ key to optionally encrypt all keyring materials and backup in the database.
 
 **Default:** none
 
----
+
 
 ### keyring_blob_path
 {:.badge .enterprise}
@@ -3500,7 +3502,7 @@ This option is useful largely for development purposes.
 
 **Default:** none
 
----
+
 
 ### keyring_vault_host
 {:.badge .enterprise}
@@ -3512,7 +3514,7 @@ value should be defined in the format:
 
 **Default:** none
 
----
+
 
 ### keyring_vault_mount
 {:.badge .enterprise}
@@ -3522,7 +3524,7 @@ found.
 
 **Default:** none
 
----
+
 
 ### keyring_vault_path
 {:.badge .enterprise}
@@ -3531,7 +3533,7 @@ Defines the names of the Vault v2 KV path at which symmetric keys are found.
 
 **Default:** none
 
----
+
 
 ### keyring_vault_token
 {:.badge .enterprise}
@@ -3540,7 +3542,7 @@ Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
 
 **Default:** none
 
----
+
 
 ### untrusted_lua
 
@@ -3587,7 +3589,7 @@ and `untrusted_lua_sandbox_environment` parameters below.
 
 **Default:** `sandbox`
 
----
+
 
 ### untrusted_lua_sandbox_requires
 
@@ -3613,7 +3615,7 @@ sandbox. For example, allowing `os` or `luaposix` may be unsafe.
 
 **Default:** none
 
----
+
 
 ### untrusted_lua_sandbox_environment
 
@@ -3625,7 +3627,7 @@ to escape the sandbox.
 
 **Default:** none
 
----
+
 
 ### openresty_path
 
@@ -3639,7 +3641,7 @@ Kong which OpenResty installation to use.
 
 **Default:** none
 
----
+
 
 
 


### PR DESCRIPTION
### Summary
* Manually diffed the version of the file on the branch with the generated doc from https://github.com/Kong/kong-ee/blob/master/kong.conf.default  and cleaned up the changes.
* Added a two-sentence description for what this reference is for and linked to kong.conf guide
* Script updates:
  * Adjusted header levels for the new format
  * Moved the horizontal lines (`---`) from around params to around sections. Previous formatting was confusing, made it look like a section only had one parameter in it.
  * new path - this might change in the future. I considered building autodocs newly for each version and sourcing that file (eg build to `configuration_3.0.x.md`), but I'm not sure if that's the best approach. Will address when we fix autodocs post-3.0. 
  * Adjustments for enterprise badges on various sections

### Reason
Chore task for 3.0. Normally, this is just generated with the script without manual edits, but in this case, we've had too many manual changes and need to reconcile them.

https://konghq.atlassian.net/browse/DOCU-2295

### Testing
https://deploy-preview-4302--kongdocs.netlify.app/gateway/latest/reference/configuration/

You can test the script updates locally by cloning [`kong-ee`](https://github.com/Kong/kong-ee), then running `KONG_PATH=<path-to-clone>/kong-ee KONG_VERSION=3.0.x luajit autodoc-conf-ee/run.lua` from your local copy of the **docs repo**. 
For all the info about the dependencies to install, see https://konghq.atlassian.net/wiki/spaces/KD/pages/1716748315/Autogenerated+docs