### PR TITLE
docs(rate-limiting-advanced) disallow cluster strategy in DB-less or …

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -114,8 +114,10 @@ params:
         - `local`: Counters are stored locally in-memory on the node (same effect
            as setting `sync_rate` to `-1`).
 
-        In DB-less and hybrid modes, the `cluster` config strategy is not
-        supported.
+        In DB-less and hybrid modes, the `cluster` config strategy
+        is not supported. From `3.0.0.0` onwards, Kong disallows
+        the plugin enablement if `cluster` strategy is set with DB-less
+        or hybrid mode.
 
         In Konnect Cloud, the default strategy is `redis`.
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
In DB-less and hybrid modes, the `cluster` config strategy is not supported. From `3.0.0.0` onwards, Kong disallows the plugin enablement if `cluster` strategy is set with DB-less or hybrid mode.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Provide detailed doc.

### Ticket

1. [FTI-4154](https://konghq.atlassian.net/browse/FTI-4154)

<!-- ### Testing -->
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
