### PR TITLE
docs on path handling algorithm in Kong 3.0

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -45,6 +45,7 @@ Fargate
 favicon
 flamegraph
 gevent
+gibibytes
 Github
 gojira
 Goroutine
@@ -68,6 +69,7 @@ init_worker
 inso
 instrumentations
 io
+ip
 iptables
 Istio
 jq
@@ -78,6 +80,7 @@ jwks
 jwt
 Keycloak
 kiali
+kibibytes
 Knative
 kong
 Kong/kong
@@ -102,6 +105,7 @@ Luarocks
 ngrok
 npm
 md
+mebibytes
 middleware
 minifier
 minikube
@@ -170,6 +174,7 @@ sandboxing
 schema's
 serializer
 serverless
+sni
 snis
 Splunk
 ssl
@@ -185,6 +190,8 @@ Styra
 subtree
 Bagdi
 subcommand
+submodule
+submodule's
 substring
 sudo
 syslog
@@ -211,6 +218,7 @@ unregistering
 upsert
 upstream
 upstreams
+upstream's
 upvalue
 upvalues
 use_daily_image

--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -862,7 +862,7 @@ HTTP 200 OK
   different `node_id` each time it is restarted.
 * `available_on_server`: Names of plugins that are installed on the node.
 * `enabled_in_cluster`: Names of plugins that are enabled/configured.
-  That is, the plugins configurations currently in the datastore shared
+  That is, the plugins configurations currently in the data store shared
   by all Kong nodes.
 
 
@@ -1703,10 +1703,10 @@ A route can't have both `tls` and `tls_passthrough` protocols at same time.
 
 {:.note}
 > **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
-> is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
+> is set to `expressions`, `route.path_handling` will be not be configurable and the path handling behavior
 > will be `"v0"`; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
 > will be `"v0"` regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
-> will support path_handling `"v1'` behavior.
+> will support `path_handling` `"v1'` behavior.
 
 `"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as
 *segments* of a URL. It will always join them via slashes. Given a service path `/s`, route path `/r`
@@ -2035,9 +2035,9 @@ HTTP 204 No Content
 ## Consumer Object
 
 The Consumer object represents a consumer - or a user - of a Service. You can
-either rely on Kong as the primary datastore, or you can map the consumer list
+either rely on Kong as the primary data store, or you can map the consumer list
 with your database to keep consistency between Kong and your existing primary
-datastore.
+data store.
 
 Consumers can be both [tagged and filtered by tags](#tags).
 
@@ -3477,7 +3477,7 @@ HTTP 204 No Content
 
 ## Upstream Object
 
-The upstream object represents a virtual hostname and can be used to loadbalance
+The upstream object represents a virtual hostname and can be used to load balance
 incoming requests over multiple services (targets). So for example an upstream
 named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`.
 Requests for this Service would be proxied to the targets defined within the upstream.

--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -1703,7 +1703,7 @@ A route can't have both `tls` and `tls_passthrough` protocols at same time.
 
 {:.note}
 > **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
-> is set to `expression`, `route.path_handling` will be unconfigurable and the path handling behavior
+> is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
 > will be v0; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
 > will be v0 whether the value of `route.path_handling` is v0 or v1. Only `traditional` `router_flavor`
 > will support path_handling v1 behavior.

--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -1704,9 +1704,9 @@ A route can't have both `tls` and `tls_passthrough` protocols at same time.
 {:.note}
 > **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
 > is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
-> will be v0; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
-> will be v0 whether the value of `route.path_handling` is v0 or v1. Only `traditional` `router_flavor`
-> will support path_handling v1 behavior.
+> will be `"v0"`; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
+> will be `"v0"` regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
+> will support path_handling `"v1'` behavior.
 
 `"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as
 *segments* of a URL. It will always join them via slashes. Given a service path `/s`, route path `/r`

--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -1701,7 +1701,14 @@ A route can't have both `tls` and `tls_passthrough` protocols at same time.
 
 #### Path handling algorithms
 
-`"v0"` is the behavior used in Kong 0.x and 2.x. It treats `service.path`, `route.path` and request path as
+{:.note}
+> **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
+> is set to `expression`, `route.path_handling` will be unconfigurable and the path handling behavior
+> will be v0; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
+> will be v0 whether the value of `route.path_handling` is v0 or v1. Only `traditional` `router_flavor`
+> will support path_handling v1 behavior.
+
+`"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as
 *segments* of a URL. It will always join them via slashes. Given a service path `/s`, route path `/r`
 and request path `/re`, the concatenated path will be `/s/re`. If the resulting path is a single slash,
 no further transformation is done to it. If it's longer, then the trailing slash is removed.


### PR DESCRIPTION
### Summary

From Kong 3.0, path handling v1 will be deprecated and when `router_flavor` == `expressions`, the field will be unconfigurable.
