### PR TITLE
Add apt-mark hold instructions to Ubuntu/Debian

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -228,6 +228,7 @@ wireframe
 wireframes
 worker-ip
 workspace
+xenial
 yaml
 yml
 zipkin

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -574,7 +574,7 @@ function pluginFilter(target){
     // Toggle all nav tabs that match this title
     const text = navtabTitle.text();
     const search = $(".navtab-title").filter(function () {
-      return $(this).text().toLowerCase().indexOf(text.toLowerCase()) >= 0;
+      return $(this).text().trim().toLowerCase() == text.trim().toLowerCase()
     }).each(function(k,v){
       activateSingleNavTab($(v));
     });

--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -41,6 +41,25 @@
     }
   }
 
+
+  .external-trigger {
+    .navtab-titles {
+      display: none !important;
+    }
+
+    .navtab-contents {
+      margin-top: -22px !important;
+    }
+
+    .copy-action {
+      margin-top: 0 !important;
+    }
+
+    pre.highlight {
+      padding: 20px 12px !important;
+    }
+  }
+
     &.codeblock {
       background-color: @grey-300;
       border: 1px solid @grey-200;
@@ -53,24 +72,6 @@
 
         code {
           padding: 0;
-        }
-      }
-
-      &.external-trigger {
-        .navtab-titles {
-          display: none;
-        }
-
-        .navtab-contents {
-          margin-top: -22px;
-        }
-
-        .copy-action {
-          margin-top: 0 !important;
-        }
-
-        pre.highlight {
-          padding: 20px 12px;
         }
       }
 

--- a/app/gateway/2.8.x/install-and-run/debian.md
+++ b/app/gateway/2.8.x/install-and-run/debian.md
@@ -95,6 +95,17 @@ apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
 
 {{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
+{% navtabs_ee %}
+{% navtab Kong Gateway %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong-enterprise-edition`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% endnavtabs_ee %}
+
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/gateway/2.8.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.8.x/install-and-run/ubuntu.md
@@ -90,16 +90,30 @@ Install the APT repository from the command line.
 ```bash
 sudo apt install -y kong-enterprise-edition={{page.kong_versions[page.version-index].ee-version}}
 ```
+
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
+sudo apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
 ```
+
+
 {% endnavtab %}
 {% endnavtabs_ee %}
 {% endcapture %}
 
 {{ install_from_repo | indent | replace: " </code>", "</code>" }}
+
+{% navtabs_ee %}
+{% navtab Kong Gateway %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong-enterprise-edition`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% endnavtabs_ee %}
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.8.x/install-and-run/ubuntu.md
@@ -14,10 +14,10 @@ Kong is licensed under an
 
 ## Download and install
 
-You can install {{site.base_gateway}} by downloading an installation package or using our APT repository. We currently package Kong Gateway for Ubuntu Bionic, Focal, and Xenial. 
+You can install {{site.base_gateway}} by downloading an installation package or using our APT repository. We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal, and Xenial.
 
 {:.note .no-icon}
-> We currently package Kong Gateway for Ubuntu Bionic, Focal and Xenial.
+> We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal and Xenial.
 > If you are using a different release, replace `$(lsb_release -sc)` with `xenial` in the commands below.
 > <br /><br />
 > To check your release name run `lsb_release -sc`.

--- a/src/gateway/kong-production/install-options/linux/debian.md
+++ b/src/gateway/kong-production/install-options/linux/debian.md
@@ -63,6 +63,17 @@ sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.de
 
 {{ install_package | indent | replace: " </code>", "</code>" }}
 
+{% navtabs_ee %}
+{% navtab Kong Gateway %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong-enterprise-edition`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% endnavtabs_ee %}
+
 {% endnavtab %}
 {% navtab APT repository %}
 

--- a/src/gateway/kong-production/install-options/linux/ubuntu.md
+++ b/src/gateway/kong-production/install-options/linux/ubuntu.md
@@ -14,10 +14,10 @@ Kong is licensed under an
 
 ## Download and install
 
-You can install {{site.base_gateway}} by downloading an installation package or using our APT repository. We currently package Kong Gateway for Ubuntu Bionic, Focal, and Xenial.
+You can install {{site.base_gateway}} by downloading an installation package or using our APT repository. We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal, and Xenial.
 
 {:.note .no-icon}
-> We currently package Kong Gateway for Ubuntu Bionic, Focal and Xenial.
+> We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal and Xenial.
 > If you are using a different release, replace `$(lsb_release -sc)` with `xenial` in the commands below.
 > <br /><br />
 > To check your release name run `lsb_release -sc`.

--- a/src/gateway/kong-production/install-options/linux/ubuntu.md
+++ b/src/gateway/kong-production/install-options/linux/ubuntu.md
@@ -66,6 +66,17 @@ sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.de
 
 {{ install_package | indent | replace: " </code>", "</code>" }}
 
+{% navtabs_ee %}
+{% navtab Kong Gateway %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong-enterprise-edition`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+{:.note .no-icon}
+> Once {{ site.base_gateway }} is installed, you may want to run `sudo apt-mark hold kong`. This will prevent an accidental upgrade to a new version.
+{% endnavtab %}
+{% endnavtabs_ee %}
+
 {% endnavtab %}
 {% navtab APT repository %}
 


### PR DESCRIPTION
### Summary
Add `apt-mark hold` instructions to prevent accidental Gateway upgrades

cc @hutchic 

### Reason
Customers accidentally upgrade to newer versions when running `apt upgrade`. This note will help them avoid doing so

### Testing

![image](https://user-images.githubusercontent.com/59130/186413844-fef48ddf-3ccc-40b4-b00f-aad442571c27.png)

