### PR TITLE
Fix smoke tests for newly linked breadcrumbs

### DIFF
--- a/tests/breadcrumbs.test.js
+++ b/tests/breadcrumbs.test.js
@@ -10,7 +10,7 @@ test.describe("Gateway", () => {
       "Kong Gateway"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(3)")).toHaveText(
-      "Plugin development"
+      /\s*Plugin Development\s*/m
     );
   });
 
@@ -23,7 +23,7 @@ test.describe("Gateway", () => {
       "Kong Gateway (OSS)"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(3)")).toHaveText(
-      "Plugin development"
+      /\s*Plugin Development\s*/m
     );
   });
 


### PR DESCRIPTION
### Summary
Adding autolinked breadcrumbs changed the format of the text to add whitespace (non-visible), which made the smoke test fail. This updates the tests to be more flexible

### Reason
Failing build

### Testing
Smoke tests should pass