### PR TITLE
Traditional / Clustering Topology

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -175,8 +175,6 @@ items:
         url: /kong-production/blue-green
       - text: Canary Deployments
         url: /kong-production/canary
-      - text: Clustering Reference
-        url: /kong-production/clustering
       - text: Logging Reference
         url: /kong-production/logging
       - text: Upgrade Kong Gateway

--- a/src/gateway/kong-production/deployment-topologies/traditional.md
+++ b/src/gateway/kong-production/deployment-topologies/traditional.md
@@ -1,6 +1,0 @@
----
-title: traditional
-
----
-
-## PLACEHOLDER traditional

--- a/src/gateway/kong-production/deployment-topologies/traditional/index.md
+++ b/src/gateway/kong-production/deployment-topologies/traditional/index.md
@@ -1,5 +1,5 @@
 ---
-title: Clustering Reference
+title: Traditional Deployment
 ---
 
 A Kong cluster allows you to scale the system horizontally by adding more


### PR DESCRIPTION
### Summary
Move old Clustering Reference to Topologies -> Traditional

### Reason
The doc already talks about a traditional topology. This makes it more discoverable

### Testing
/gateway/latest/kong-production/deployment-topologies/traditional/