### PR TITLE
Fix Gateway 2.8.x Overview nav link

### DIFF
--- a/app/_data/docs_nav_gateway_2.8.x.yml
+++ b/app/_data/docs_nav_gateway_2.8.x.yml
@@ -2,7 +2,7 @@
   icon: /assets/images/icons/documentation/icn-flag.svg
   items:
     - text: Overview of Kong Gateway
-      url: /gateway/
+      url: /gateway/2.8.x/
       absolute_url: true
     - text: Version Support Policy
       url: /support-policy


### PR DESCRIPTION
### Summary
Add missing `2.8.x` to URL

### Reason
2.8 overview link was pointing to 3.0 docs

### Testing
Test in review app