### PR TITLE
fix: sets access-control-allow-* headers

### DIFF
--- a/app/_headers
+++ b/app/_headers
@@ -1,3 +1,5 @@
 /mesh/latest_version
     Access-Control-Allow-Origin: *
+    Access-Control-Allow-Method: GET
+    Access-Control-Allow-Headers: Content-Type
     Content-Type: text/plain


### PR DESCRIPTION
### Summary

Adds the Access-Control-Allow-Method and Access-Control-Allow-Headers headers to the `latest_version` endpoint so that GET requests using a `Content-Type` header work in CORS scenarios.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

### Reason

Some requests to the `/mesh/latest_version` endpoint are made using a `Content-Type` header. These are rejected by the browser because the CORS preflight request doesn’t include this header.

### Testing

Using the Netlify deployment preview and the following test call:

```sh
# Live version:
curl -i -X OPTIONS https://docs.konghq.com/mesh/latest_version/ | grep 'access-control-allow-'

# Deployment preview:
curl -i -X OPTIONS https://deploy-preview-4333--kongdocs.netlify.app/mesh/latest_version/ | grep 'access-control-allow-'
```

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
