### PR TITLE
Add missing config options

### DIFF
--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -628,10 +628,10 @@ Some suffixes can be specified for each pair:
   `TCP keepalive` behavior for the listening socket. If this parameter is
   omitted then the operating system’s settings will be in effect for the socket.
   If it is set to the value `on`, the `SO_KEEPALIVE` option is turned
-  on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
+  on for the socket. If it is set to the value `off`, the `SO_KEEPALIVE` option
   is turned off for the socket. Some operating systems support setting of
   TCP keepalive parameters on a per-socket basis using the `TCP_KEEPIDLE`,
-  TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
+  `TCP_KEEPINTVL`, and `TCP_KEEPCNT` socket options.
 
 Examples:
 
@@ -702,7 +702,7 @@ Some suffixes can be specified for each pair:
   If it is set to the value `on`, the `SO_KEEPALIVE` option is turned
   on for the socket. If it is set to the value `off`, the `SO_KEEPALIVE` option
   is turned off for the socket. Some operating systems support setting of
-  TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
+  TCP keepalive parameters on a per-socket basis using the `TCP_KEEPIDLE`,
   `TCP_KEEPINTVL`, and `TCP_KEEPCNT` socket options.
 
 This value can be set to `off`, thus disabling the Admin interface for this

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -537,6 +537,16 @@ Some suffixes can be specified for each pair:
   parameter. In order for the larger `backlog` set here to take effect it is
   necessary to raise `net.core.somaxconn` at the same time to match or exceed
   the `backlog` number set.
+- `ipv6only=on|off` whether an IPv6 socket listening on a wildcard address [::]
+  will accept only IPv6 connections or both IPv6 and IPv4 connections.
+- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]` configures the
+  “TCP keepalive” behavior for the listening socket. If this parameter is
+  omitted then the operating system’s settings will be in effect for the socket.
+  If it is set to the value “on”, the SO_KEEPALIVE option is turned
+  on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
+  is turned off for the socket. Some operating systems support setting of
+  TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
+  TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
 
 This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for
 this node.
@@ -612,6 +622,16 @@ Some suffixes can be specified for each pair:
   parameter. In order for the larger `backlog` set here to take effect it is
   necessary to raise `net.core.somaxconn` at the same time to match or exceed
   the `backlog` number set.
+- `ipv6only=on|off` whether an IPv6 socket listening on a wildcard address [::]
+  will accept only IPv6 connections or both IPv6 and IPv4 connections.
+- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]` configures the
+  “TCP keepalive” behavior for the listening socket. If this parameter is
+  omitted then the operating system’s settings will be in effect for the socket.
+  If it is set to the value “on”, the SO_KEEPALIVE option is turned
+  on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
+  is turned off for the socket. Some operating systems support setting of
+  TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
+  TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
 
 Examples:
 
@@ -674,6 +694,16 @@ Some suffixes can be specified for each pair:
   parameter. In order for the larger `backlog` set here to take effect it is
   necessary to raise `net.core.somaxconn` at the same time to match or exceed
   the `backlog` number set.
+- `ipv6only=on|off` whether an IPv6 socket listening on a wildcard address [::]
+  will accept only IPv6 connections or both IPv6 and IPv4 connections.
+- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]` configures the
+  “TCP keepalive” behavior for the listening socket. If this parameter is
+  omitted then the operating system’s settings will be in effect for the socket.
+  If it is set to the value “on”, the SO_KEEPALIVE option is turned
+  on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
+  is turned off for the socket. Some operating systems support setting of
+  TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
+  TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
 
 This value can be set to `off`, thus disabling the Admin interface for this
 node, enabling a 'data-plane' mode (without configuration capabilities) pulling

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -1196,7 +1196,8 @@ block.
 Changes the limit on the maximum number of open files for worker processes.
 
 The special and default value of `auto` sets this value to `ulimit -n` with the
-upper bound limited to 16384 as a measure to protect against excess memory use.
+upper bound limited to 16384 as a measure to protect against excess memory use,
+and the lower bound of 1024 as a good default.
 
 See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
 
@@ -1210,7 +1211,8 @@ Sets the maximum number of simultaneous connections that can be opened by a
 worker process.
 
 The special and default value of `auto` sets this value to `ulimit -n` with the
-upper bound limited to 16384 as a measure to protect against excess memory use.
+upper bound limited to 16384 as a measure to protect against excess memory use,
+and the lower bound of 1024 as a good default.
 
 See http://nginx.org/en/docs/ngx_core_module.html#worker_connections
 

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -542,11 +542,11 @@ Some suffixes can be specified for each pair:
 - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]` configures the
   “TCP keepalive” behavior for the listening socket. If this parameter is
   omitted then the operating system’s settings will be in effect for the socket.
-  If it is set to the value “on”, the SO_KEEPALIVE option is turned
-  on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
+  If it is set to the value `on`, the `SO_KEEPALIVE` option is turned
+  on for the socket. If it is set to the value `off`, the `SO_KEEPALIVE` option
   is turned off for the socket. Some operating systems support setting of
-  TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
-  TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
+  TCP keepalive parameters on a per-socket basis using the `TCP_KEEPIDLE`,
+  `TCP_KEEPINTVL`, and `TCP_KEEPCNT` socket options.
 
 This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for
 this node.
@@ -625,12 +625,12 @@ Some suffixes can be specified for each pair:
 - `ipv6only=on|off` whether an IPv6 socket listening on a wildcard address [::]
   will accept only IPv6 connections or both IPv6 and IPv4 connections.
 - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]` configures the
-  “TCP keepalive” behavior for the listening socket. If this parameter is
+  `TCP keepalive` behavior for the listening socket. If this parameter is
   omitted then the operating system’s settings will be in effect for the socket.
-  If it is set to the value “on”, the SO_KEEPALIVE option is turned
+  If it is set to the value `on`, the `SO_KEEPALIVE` option is turned
   on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
   is turned off for the socket. Some operating systems support setting of
-  TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
+  TCP keepalive parameters on a per-socket basis using the `TCP_KEEPIDLE`,
   TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
 
 Examples:
@@ -699,11 +699,11 @@ Some suffixes can be specified for each pair:
 - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]` configures the
   “TCP keepalive” behavior for the listening socket. If this parameter is
   omitted then the operating system’s settings will be in effect for the socket.
-  If it is set to the value “on”, the SO_KEEPALIVE option is turned
-  on for the socket. If it is set to the value “off”, the SO_KEEPALIVE option
+  If it is set to the value `on`, the `SO_KEEPALIVE` option is turned
+  on for the socket. If it is set to the value `off`, the `SO_KEEPALIVE` option
   is turned off for the socket. Some operating systems support setting of
   TCP keepalive parameters on a per-socket basis using the TCP_KEEPIDLE,
-  TCP_KEEPINTVL, and TCP_KEEPCNT socket options.
+  `TCP_KEEPINTVL`, and `TCP_KEEPCNT` socket options.
 
 This value can be set to `off`, thus disabling the Admin interface for this
 node, enabling a 'data-plane' mode (without configuration capabilities) pulling


### PR DESCRIPTION
### Summary
Adding `ipv6only`, `so_keepalive`, and lower bounds for nginx worker params. 

### Reason
Came across a few missing updates in the configuration reference while working on the changelog.

### Testing
Please don't copyedit. This is coming directly from https://github.com/Kong/kong/blob/master/kong.conf.default and will have to be fixed up there first.

Netlify preview