### PR TITLE
Remove PDK legacy attribute

### DIFF
--- a/src/gateway/plugin-development/configuration.md
+++ b/src/gateway/plugin-development/configuration.md
@@ -234,7 +234,6 @@ return {
             anonymous = {
               type = "string",
               uuid = true,
-              legacy = true,
             },
           },
           {


### PR DESCRIPTION
### Summary
Removing the one and only use of the `legacy` plugin attribute.

### Reason
Based on changes made in https://github.com/Kong/kong/pull/8958.

### Testing
Netlify