### PR TITLE
Get started fix route name

### DIFF
--- a/src/gateway/get-started/proxy-caching.md
+++ b/src/gateway/get-started/proxy-caching.md
@@ -132,7 +132,7 @@ curl -X POST http://localhost:8001/services/example_service/plugins \
 The Proxy Caching plugin can be enabled for specific routes. The request is the same as above, but the request is sent to the route URL:
 
 ```sh
-$ curl -X POST http://localhost:8001/routes/mock/plugins \
+$ curl -X POST http://localhost:8001/routes/example_route/plugins \
    --data "name=proxy-cache" \
    --data "config.request_method=GET" \
    --data "config.response_code=200" \

--- a/src/gateway/get-started/rate-limiting.md
+++ b/src/gateway/get-started/rate-limiting.md
@@ -124,7 +124,7 @@ The Rate Limiting plugin can be enabled for specific routes. The request is the 
 but posted to the route URL:
 
 ```sh
-curl -X POST http://localhost:8001/routes/mock/plugins \
+curl -X POST http://localhost:8001/routes/example_route/plugins \
    --data "name=rate-limiting" \
    --data config.minute=5 \
    --data config.policy=local

--- a/src/gateway/get-started/services-and-routes.md
+++ b/src/gateway/get-started/services-and-routes.md
@@ -197,7 +197,7 @@ the full service update specification.
    ```sh
    curl -i -X POST http://localhost:8001/services/example_service/routes \
      --data 'paths[]=/mock' \
-     --data name=mocking
+     --data name=example_route
    ```
 
    If the route was successfully created, the API returns a `201` response code and a response body like this:
@@ -210,7 +210,7 @@ the full service update specification.
      "methods": null,
      "sources": null,
      "destinations": null,
-     "name": "mocking",
+     "name": "example_route",
      "headers": null,
      "hosts": null,
      "preserve_host": false,
@@ -245,10 +245,10 @@ the full service update specification.
    * `/services/{service name or id}/routes/{route name or id}`
    * `/routes/{route name or id}`
 
-   To view the current state of the `mocking` route, make a `GET` request to the route URL:
+   To view the current state of the `example_route` route, make a `GET` request to the route URL:
 
    ```sh
-   curl -X GET http://localhost:8001/services/example_service/routes/mocking
+   curl -X GET http://localhost:8001/services/example_service/routes/example_route
    ``` 
 
    The response body contains the current configuration of your route:
@@ -261,7 +261,7 @@ the full service update specification.
      "methods": null,
      "sources": null,
      "destinations": null,
-     "name": "mocking",
+     "name": "example_route",
      "headers": null,
      "hosts": null,
      "preserve_host": false,
@@ -299,7 +299,7 @@ the full service update specification.
    
    ```
    curl --request PATCH \
-     --url localhost:8001/services/example_service/routes/mocking \
+     --url localhost:8001/services/example_service/routes/example_route \
      --data tags="tutorial"
    ```
    
@@ -335,7 +335,7 @@ the full service update specification.
          "methods": null,
          "sources": null,
          "destinations": null,
-         "name": "mocking",
+         "name": "example_route",
          "headers": null,
          "hosts": null,
          "preserve_host": false,


### PR DESCRIPTION
### Summary
Makes the example route name match the example service name. Fixes up referring sections of the guide as well

### Reason
The guides were not accurate with the route name, this fixes that and makes the name consistent with the example service name

### Testing
built locally

