### PR TITLE
Plugin Development title cleanup

### DIFF
--- a/src/gateway/plugin-development/access-the-datastore.md
+++ b/src/gateway/plugin-development/access-the-datastore.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Accessing the Datastore
+title: Accessing the Datastore
 book: plugin_dev
 chapter: 5
 ---

--- a/src/gateway/plugin-development/admin-api.md
+++ b/src/gateway/plugin-development/admin-api.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Extending the Admin API
+title: Extending the Admin API
 book: plugin_dev
 chapter: 8
 ---

--- a/src/gateway/plugin-development/configuration.md
+++ b/src/gateway/plugin-development/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Plugin Configuration
+title: Plugin Configuration
 book: plugin_dev
 chapter: 4
 ---

--- a/src/gateway/plugin-development/custom-entities.md
+++ b/src/gateway/plugin-development/custom-entities.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Storing Custom Entities
+title: Storing Custom Entities
 book: plugin_dev
 chapter: 6
 ---

--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Implementing Custom Logic
+title: Implementing Custom Logic
 book: plugin_dev
 chapter: 3
 ---

--- a/src/gateway/plugin-development/distribution.md
+++ b/src/gateway/plugin-development/distribution.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - (un)Installing your plugin
+title: (un)Installing your plugin
 book: plugin_dev
 chapter: 10
 ---

--- a/src/gateway/plugin-development/entities-cache.md
+++ b/src/gateway/plugin-development/entities-cache.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Caching Custom Entities
+title: Caching Custom Entities
 book: plugin_dev
 chapter: 7
 ---

--- a/src/gateway/plugin-development/file-structure.md
+++ b/src/gateway/plugin-development/file-structure.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - File Structure
+title: File Structure
 book: plugin_dev
 chapter: 2
 ---

--- a/src/gateway/plugin-development/index.md
+++ b/src/gateway/plugin-development/index.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Introduction
+title: Introduction
 book: plugin_dev
 chapter: 1
 ---

--- a/src/gateway/plugin-development/tests.md
+++ b/src/gateway/plugin-development/tests.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin Development - Writing tests
+title: Writing tests
 book: plugin_dev
 chapter: 9
 ---


### PR DESCRIPTION
### Summary
The `Plugin Development` prefix was repeated on every page. This PR removes them