### PR TITLE
Update plugin priorities

### DIFF
--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -363,7 +363,11 @@ basic-auth                  | 1100
 openid-connect              | 1050
 jwt-signer                  | 1020
 request-validator           | 999
+websocket-size-limit        | 999
+websocket-validator         | 999
 grpc-gateway                | 998
+tls-handshake-modifier      | 997
+tls-metadata-headers        | 996
 application-registration    | 995
 ip-restriction              | 990
 request-size-limiting       | 951
@@ -388,6 +392,7 @@ proxy-cache                 | 100
 graphql-proxy-cache-advanced | 99
 forward-proxy               | 50
 canary                      | 20
+opentelemetry               | 14
 prometheus                  | 13
 http-log                    | 12
 statsd                      | 11

--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -295,18 +295,19 @@ The current order of execution for the bundled plugins is:
 
 Plugin                      | Priority
 ----------------------------|----------
-pre-function                | `+inf`
+pre-function                | 1000000
 correlation-id <span class="badge free"></span> | 100001
 zipkin                      | 100000
 bot-detection               | 2500
 cors                        | 2000
 session                     | 1900
+acme                        | 1705
 jwt                         | 1450
 oauth2                      | 1400
-hmac-auth                   | 1300
 key-auth                    | 1250
 ldap-auth                   | 1200
 basic-auth                  | 1100
+hmac-auth                   | 1030
 grpc-gateway                | 998
 ip-restriction              | 990
 request-size-limiting       | 951
@@ -317,6 +318,7 @@ request-transformer         | 801
 response-transformer        | 800
 aws-lambda                  | 750
 azure-functions             | 749
+opentelemetry               | 14
 prometheus                  | 13
 http-log                    | 12
 statsd                      | 11
@@ -340,7 +342,7 @@ The current order of execution for the bundled plugins is:
 
 Plugin                      | Priority
 ----------------------------|----------
-pre-function                | `+inf`
+pre-function                | 1000000
 correlation-id              | 100001 <!--  CE priority is 1, EE priority is 100001 -->
 zipkin                      | 100000
 exit-transformer            | 9999
@@ -348,19 +350,19 @@ bot-detection               | 2500
 cors                        | 2000
 session                     | 1900
 oauth2-introspection        | 1700
-acme                        | 1750
+acme                        | 1705
 mtls-auth                   | 1600
 jwt                         | 1450
 degraphql                   | 1500
 oauth2                      | 1400
 vault-auth                  | 1350
-hmac-auth                   | 1300
 key-auth                    | 1250
 key-auth-enc                | 1250
 ldap-auth                   | 1200
 ldap-auth-advanced          | 1200
 basic-auth                  | 1100
 openid-connect              | 1050
+hmac-auth                   | 1030
 jwt-signer                  | 1020
 request-validator           | 999
 websocket-size-limit        | 999


### PR DESCRIPTION
### Summary
Updating priority tables:
* Adding new plugins: opentelemetry, tls plugins, and websocket plugins
* Fixing typos for previously updated plugin priorities
* Updated `pre-function` plugin based on changelog entry
* Added missing ACME plugin to OSS table

Priorities pulled from plugin handler files in source code. ([enterprise](https://github.com/Kong/kong-ee/tree/master/plugins-ee) and [oss](https://github.com/Kong/kong/tree/master/kong/plugins))

### Reason
Plugin priority doc had some oversights.

### Testing
Netlify