### PR TITLE
Update support policy table for 3.0.x.x

### DIFF
--- a/src/gateway/support-policy.md
+++ b/src/gateway/support-policy.md
@@ -12,6 +12,7 @@ The support for {{site.ee_product_name}} software versions is explained in this 
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.0.x.x |  2022-08-31   |     2024-08-30      |      2025-08-30       |
 |  2.8.x.x |  2022-03-02   |     2023-08-24      |      2024-08-24       |
 |  2.7.x.x |  2021-12-16   |     2022-08-24      |      2023-08-24       |
 |  2.6.x.x |  2021-10-14   |     2022-08-24      |      2023-08-24       |


### PR DESCRIPTION
### Summary
Added an entry for 3.0 in the support policy table.
Followed the 24 month period for support, then another 12 months for end of sunset support, based on the standard set with 2.1.x.

### Reason
Needs updating with release.

### Testing
Netlify