### PR TITLE
Remove duplicate page titles

### DIFF
--- a/src/gateway/kong-enterprise/secrets-management/reference-format.md
+++ b/src/gateway/kong-enterprise/secrets-management/reference-format.md
@@ -2,8 +2,6 @@
 title: Reference Format
 ---
 
-## Reference Format
-
 We use the [URL syntax](https://en.wikipedia.org/wiki/URL) to describe references to a secret store.
 
 ```text

--- a/src/gateway/production/kong-openresty.md
+++ b/src/gateway/production/kong-openresty.md
@@ -3,8 +3,6 @@ title: Embed Kong in OpenResty
 content-type: how-to
 ---
 
-## Embed Kong in OpenResty
-
 If you are running your own OpenResty servers, you can embed {{site.base_gateway}}
 by including the {{site.base_gateway}} Nginx sub-configuration using the `include` directive.
 If you have an existing Nginx configuration, you can include the


### PR DESCRIPTION
### Summary
Remove titles when they duplicate the page title

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
/gateway/latest/kong-enterprise/secrets-management/reference-format
/gateway/latest/production/kong-openresty/