### PR TITLE
Add tracing pdk to nav

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -449,6 +449,8 @@ items:
           url: /plugin-development/pdk/kong.service.response
         - text: kong.table
           url: /plugin-development/pdk/kong.table
+        - text: kong.tracing
+          url: /plugin-development/pdk/kong.tracing
         - text: kong.vault
           url: /plugin-development/pdk/kong.vault
 


### PR DESCRIPTION
### Summary
Adding missing nav entry for `kong.tracing` pdk.

### Reason
It's missing.

### Testing
Netlify