### PR TITLE
Broken links, continued

### DIFF
--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -5,8 +5,8 @@
    > <br>
    > If you need to expose the `admin_listen` port to the internet in a production environment,
    > {% if_version lte:2.8.x
-   %}[secure it with authentication](/gateway/{{ include.kong_version }}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
-   %}[secure it with authentication](/gateway/{{ include.kong_version }}/production/running-kong/secure-admin-api).{% endif_version %}
+   %}[secure it with authentication](/gateway/{{page.kong_version}}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
+   %}[secure it with authentication](/gateway/{{page.kong_version}}/production/running-kong/secure-admin-api).{% endif_version %}
 
 
 {% endif %}
@@ -14,7 +14,7 @@
    {:.important}
    > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment,
   > {% if_version lte:2.8.x
-    %}[secure it with authentication](/gateway/{{ include.kong_version }}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
-    %}[secure it with authentication](/gateway/{{ include.kong_version }}/production/running-kong/secure-admin-api).{% endif_version %}
+    %}[secure it with authentication](/gateway/{{page.kong_version}}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
+    %}[secure it with authentication](/gateway/{{page.kong_version}}/production/running-kong/secure-admin-api).{% endif_version %}
 
 {% endif %}

--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -5,8 +5,8 @@
    > <br>
    > If you need to expose the `admin_listen` port to the internet in a production environment,
    > {% if_version lte:2.8.x
-   %}[secure it with authentication](/gateway/{{page.kong_version}}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
-   %}[secure it with authentication](/gateway/{{page.kong_version}}/production/running-kong/secure-admin-api).{% endif_version %}
+   %}[secure it with authentication](/gateway/{{include.kong_version}}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
+   %}[secure it with authentication](/gateway/{{include.kong_version}}/production/running-kong/secure-admin-api).{% endif_version %}
 
 
 {% endif %}
@@ -14,7 +14,7 @@
    {:.important}
    > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment,
   > {% if_version lte:2.8.x
-    %}[secure it with authentication](/gateway/{{page.kong_version}}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
-    %}[secure it with authentication](/gateway/{{page.kong_version}}/production/running-kong/secure-admin-api).{% endif_version %}
+    %}[secure it with authentication](/gateway/{{include.kong_version}}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
+    %}[secure it with authentication](/gateway/{{include.kong_version}}/production/running-kong/secure-admin-api).{% endif_version %}
 
 {% endif %}

--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -3,11 +3,18 @@
    > **Important:** The settings below are intended for non-production use **only**, as they override the default `admin_listen` setting to listen for requests from any source. **Do not** use these settings in environments directly exposed to the internet.
    >
    > <br>
-   > If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway/{{ include.kong_version }}/production/running-kong/secure-admin-api).
+   > If you need to expose the `admin_listen` port to the internet in a production environment,
+   > {% if_version lte:2.8.x
+   %}[secure it with authentication](/gateway/{{ include.kong_version }}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
+   %}[secure it with authentication](/gateway/{{ include.kong_version }}/production/running-kong/secure-admin-api).{% endif_version %}
+
 
 {% endif %}
 {% if include.desc == "short" %}
    {:.important}
-   > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment, [secure it with authentication](/gateway/{{ include.kong_version }}/production/running-kong/secure-admin-api).
+   > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment,
+  > {% if_version lte:2.8.x
+    %}[secure it with authentication](/gateway/{{ include.kong_version }}/admin-api/secure-admin-api).{% endif_version %}{% if_version gte:3.0.x
+    %}[secure it with authentication](/gateway/{{ include.kong_version }}/production/running-kong/secure-admin-api).{% endif_version %}
 
 {% endif %}

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -121,9 +121,18 @@ substituting your own license key.
 
 1. Include the license as part of the `docker run` command when starting a {{site.base_gateway}} container:
 
+    {% if_version lte:2.8.x %}
+    {:.note}
+    > **Note:** This is only a snippet. For a full working example, see the instructions to
+    [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install-and-run/docker).
+
+    {% endif_version %}
+    {% if_version gte:3.0.x %}
     {:.note}
     > **Note:** This is only a snippet. For a full working example, see the instructions to
     [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install/docker).
+
+    {% endif_version %}
 
     ```bash
     docker run -d --name kong-gateway \
@@ -142,12 +151,21 @@ on each node manually.
 
 Include the license as part of the `docker run` command when starting a
 {{site.base_gateway}} container. Mount the path to the file on your
-local filesystem to a directory in the Docker container, making the file visible 
+local filesystem to a directory in the Docker container, making the file visible
 from the container:
 
+{% if_version lte:2.8.x %}
+{:.note}
+> **Note:** This is only a snippet. For a full working example, see the instructions to
+[Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install-and-run/docker).
+
+{% endif_version %}
+{% if_version gte:3.0.x %}
 {:.note}
 > **Note:** This is only a snippet. For a full working example, see the instructions to
 [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install/docker).
+
+{% endif_version %}
 
 ```bash
 docker run -d --name kong-gateway \

--- a/app/_includes/md/enterprise/turn-on-rbac.md
+++ b/app/_includes/md/enterprise/turn-on-rbac.md
@@ -51,7 +51,7 @@ The cookie is used for all subsequent requests to authenticate the user, until i
 {% endnavtabs %}
 
 {% if_version lte:2.8.x %}
-Outside of this guide, you will likely want to modify these settings differently, depending on your installation. You can read more about these settings here: [Basic Auth for Kong Manager](/gateway/latest/kong-manager/auth//basic/).
+Outside of this guide, you will likely want to modify these settings differently, depending on your installation. You can read more about these settings here: [Basic Auth for Kong Manager](/gateway/latest/kong-manager/auth/basic/).
 {% endif_version %}
 
 {% if_version gte:3.0.x %}

--- a/app/_includes/md/gateway/deployment-options.md
+++ b/app/_includes/md/gateway/deployment-options.md
@@ -1,4 +1,9 @@
 <!-- Deployment Options section; used in all Enterprise installation topics - except k8s -->
 The installation instructions explain how to deploy {{site.base_gateway}} in its entirety on a single node -- with or without a database.
 
+{% if_version lte:2.8.x %}
+The instructions are the same for setting up a Control Plane instance in Hybrid mode. After you set up the Control Plane, you set up additional Gateway instances for the Data Planes. See [Hybrid Mode Setup](/gateway/{{include.kong_version}}/plan-and-deploy/hybrid-mode/hybrid-mode-setup) for details.
+{% endif_version %}
+{% if_version gte:3.0.x %}
 The instructions are the same for setting up a Control Plane instance in Hybrid mode. After you set up the Control Plane, you set up additional Gateway instances for the Data Planes. See [Hybrid Mode Setup](/gateway/{{include.kong_version}}/production/deployment-topologies/hybrid-mode/setup) for details.
+{% endif_version %}

--- a/app/_includes/md/gateway/root-user-note.md
+++ b/app/_includes/md/gateway/root-user-note.md
@@ -1,13 +1,23 @@
-<!-- Shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL 
+<!-- Shared between all Linux installation topics: Amazon Linux, CentOS, Ubuntu, and RHEL
 located in the app/gateway/{version}/install folder.
 
 Included in the setup.md include located in this folder - in two sections - Using a yaml declarative config file
 and Seed Super Admin.
 -->
 
+{% if_version lte:2.8.x %}
 {:.note}
 > **Note:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see
+[Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/plan-and-deploy/kong-user).
+
+{% endif_version %}
+{% if_version gte:3.0.x %}
+> **Note:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
+run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
+to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
+For more information, see
 [Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/production/running-kong/kong-user).
+{% endif_version %}

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -273,6 +273,8 @@ or hybrid mode), you can enable the [Dev Portal](/gateway/{{page.kong_version}}/
 ## Troubleshooting and support
 {:.badge .enterprise}
 
+{% if_version gte:3.0.x %}
+
 For troubleshooting license issues, see:
 * [Deployment options for licenses](/gateway/{{page.kong_version}}/licenses/deploy)
 * [`/licenses` API reference](/gateway/{{page.kong_version}}/admin-api/licenses/reference/)
@@ -287,3 +289,23 @@ your setup, reach out to your Kong Support contact or go to the
 Check out {{site.base_gateway}}'s series of
 [Getting Started](/gateway/{{include.kong_version}}/get-started/) guides to get the most
 out of {{site.base_gateway}}.
+
+{% endif_version %}
+{% if_version lte:2.8.x %}
+
+For troubleshooting license issues, see:
+* [Deployment options for licenses](/gateway/{{page.kong_version}}/plan-and-deploy/licenses/deploy-license)
+* [`/licenses` API reference](/gateway/{{page.kong_version}}/admin-api/licenses/reference/)
+* [`/licenses` API examples](/gateway/{{page.kong_version}}/admin-api/licenses/examples)
+
+If you did not receive an `HTTP/1.1 200 OK` message or need assistance completing
+your setup, reach out to your Kong Support contact or go to the
+[Support Portal](https://support.konghq.com/support/s/).
+
+## Next steps
+
+Check out {{site.base_gateway}}'s series of
+[Getting Started](/gateway/{{include.kong_version}}/get-started/comprehensive/) guides to get the most
+out of {{site.base_gateway}}.
+
+{% endif_version %}

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -210,7 +210,7 @@ See the [Kong Manager setup guide](/gateway/{{page.kong_version}}/kong-manager/e
 2. Update the Admin API setting in the `kong.conf` file to listen on the needed network interfaces on the OS host.
    A setting of `0.0.0.0:8001` will listen on port `8001` on all available network interfaces.
 
-    {% include_cached /md/admin-listen.md desc='long' %}
+    {% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
     Example configuration:
 

--- a/app/enterprise/2.1.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.1.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/enterprise/2.1.x/plugin-development/tests.md
+++ b/app/enterprise/2.1.x/plugin-development/tests.md
@@ -14,7 +14,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/enterprise/2.2.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.2.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/enterprise/2.2.x/plugin-development/tests.md
+++ b/app/enterprise/2.2.x/plugin-development/tests.md
@@ -14,7 +14,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/enterprise/2.3.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.3.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/enterprise/2.3.x/plugin-development/tests.md
+++ b/app/enterprise/2.3.x/plugin-development/tests.md
@@ -14,7 +14,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/enterprise/2.4.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.4.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/enterprise/2.4.x/plugin-development/tests.md
+++ b/app/enterprise/2.4.x/plugin-development/tests.md
@@ -14,7 +14,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/enterprise/2.5.x/plugin-development/custom-entities.md
+++ b/app/enterprise/2.5.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/enterprise/2.5.x/plugin-development/tests.md
+++ b/app/enterprise/2.5.x/plugin-development/tests.md
@@ -14,7 +14,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway-oss/2.0.x/plugin-development/admin-api.md
+++ b/app/gateway-oss/2.0.x/plugin-development/admin-api.md
@@ -95,10 +95,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway-oss/2.0.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.0.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/gateway-oss/2.0.x/plugin-development/tests.md
+++ b/app/gateway-oss/2.0.x/plugin-development/tests.md
@@ -15,7 +15,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway-oss/2.1.x/plugin-development/admin-api.md
+++ b/app/gateway-oss/2.1.x/plugin-development/admin-api.md
@@ -95,10 +95,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway-oss/2.1.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.1.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/gateway-oss/2.1.x/plugin-development/tests.md
+++ b/app/gateway-oss/2.1.x/plugin-development/tests.md
@@ -15,7 +15,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway-oss/2.2.x/plugin-development/admin-api.md
+++ b/app/gateway-oss/2.2.x/plugin-development/admin-api.md
@@ -11,7 +11,7 @@ chapter: 8
 
 <div class="alert alert-warning">
   <strong>Note:</strong> The Admin API extensions are available only
-  for HTTP plugins, not Stream plugins. 
+  for HTTP plugins, not Stream plugins.
 </div>
 
 ## Introduction
@@ -100,10 +100,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway-oss/2.2.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.2.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/gateway-oss/2.2.x/plugin-development/tests.md
+++ b/app/gateway-oss/2.2.x/plugin-development/tests.md
@@ -15,7 +15,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway-oss/2.3.x/plugin-development/admin-api.md
+++ b/app/gateway-oss/2.3.x/plugin-development/admin-api.md
@@ -11,7 +11,7 @@ chapter: 8
 
 <div class="alert alert-warning">
   <strong>Note:</strong> The Admin API extensions are available only
-  for HTTP plugins, not Stream plugins. 
+  for HTTP plugins, not Stream plugins.
 </div>
 
 ## Introduction
@@ -100,10 +100,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway-oss/2.3.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.3.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/gateway-oss/2.3.x/plugin-development/tests.md
+++ b/app/gateway-oss/2.3.x/plugin-development/tests.md
@@ -15,7 +15,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway-oss/2.4.x/plugin-development/admin-api.md
+++ b/app/gateway-oss/2.4.x/plugin-development/admin-api.md
@@ -11,7 +11,7 @@ chapter: 8
 
 <div class="alert alert-warning">
   <strong>Note:</strong> The Admin API extensions are available only
-  for HTTP plugins, not Stream plugins. 
+  for HTTP plugins, not Stream plugins.
 </div>
 
 ## Introduction
@@ -100,10 +100,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway-oss/2.4.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.4.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/gateway-oss/2.4.x/plugin-development/tests.md
+++ b/app/gateway-oss/2.4.x/plugin-development/tests.md
@@ -15,7 +15,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway-oss/2.5.x/plugin-development/admin-api.md
+++ b/app/gateway-oss/2.5.x/plugin-development/admin-api.md
@@ -11,7 +11,7 @@ chapter: 8
 
 <div class="alert alert-warning">
   <strong>Note:</strong> The Admin API extensions are available only
-  for HTTP plugins, not Stream plugins. 
+  for HTTP plugins, not Stream plugins.
 </div>
 
 ## Introduction
@@ -100,10 +100,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway-oss/2.5.x/plugin-development/custom-entities.md
+++ b/app/gateway-oss/2.5.x/plugin-development/custom-entities.md
@@ -188,7 +188,7 @@ for one that works with Cassandra too.
 enforce it for Cassandra, but for Postgres you must set this constraint in
 the migrations.
 
-To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/{{page.kong_version}}/kong/plugins/key-auth/migrations).
+To see a real-life example, give a look at the [Key-Auth plugin migrations](https://github.com/Kong/kong/tree/master/kong/plugins/key-auth/migrations).
 
 ---
 

--- a/app/gateway-oss/2.5.x/plugin-development/tests.md
+++ b/app/gateway-oss/2.5.x/plugin-development/tests.md
@@ -15,7 +15,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use another one if you wish. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
+++ b/app/gateway/2.6.x/configure/auth/kong-manager/networking.md
@@ -28,7 +28,7 @@ Common configurations to enable are
   8444 on localhost. Change [`admin_listen`] if necessary, or set
   [`admin_api_uri`].
 
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 
 * Securing Kong Manager and serving it from a dedicated node
 

--- a/app/gateway/2.6.x/configure/auth/oidc-cognito.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-cognito.md
@@ -155,7 +155,7 @@ You can verify the confirmed user from the Cognito page under “General setting
 
 ## Dev Portal Integration
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 Since AWS Cognito only supports the HTTPS protocol, when you start {{site.base_gateway}}, ensure that HTTPS protocol for Dev Portal is enabled. For example:
 

--- a/app/gateway/2.6.x/configure/auth/oidc-cognito.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-cognito.md
@@ -12,27 +12,15 @@ In this configuration, we use User Pools.
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
 
 1. Click the **Create a user pool** button on the right-hand side.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
 
 1. Click **Step Through Settings**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
-
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
 
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
@@ -43,12 +31,8 @@ In this configuration, we use User Pools.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
@@ -56,40 +40,22 @@ You need to add an OAuth2 application definition to the User Pool we just create
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
-1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
+1. Enter an App client name. This demo is using “kong-api”.
 
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
-
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
 
 1. Click the “Set attribute read and write permissions” button.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
-
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-
-1. Click “Create app client”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
+1. Click “Create app client”.
 
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
 
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
@@ -103,21 +69,13 @@ You need to add an OAuth2 application definition to the User Pool we just create
     Note that AWS Cognito doesn’t support HTTP callback URLs. This field should
     include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
-
 1. Click the “Save changes” button.
 
 Now that you have created an Amazon Cognito User Pool and Application Definition, we can configure the OpenID Connect plugin in Kong. We can then test integration between Dev Portal and Amazon Cognito.

--- a/app/gateway/2.6.x/configure/network.md
+++ b/app/gateway/2.6.x/configure/network.md
@@ -34,7 +34,7 @@ it from unauthorized access.
 
 * `8001` provides Kong's **Admin API** that you can use to operate Kong with HTTP. See [admin_listen].
 
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 
 * `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
 

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -126,7 +126,7 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migration
 
 ### Start Kong Gateway
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 1. Run the following command to start a container with {{site.base_gateway}}:
 {% capture start_container %}
@@ -295,7 +295,7 @@ backed up by a Redis cluster).
 
 ### Start Kong Gateway in DB-less mode
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 1. From the same directory where you just created the `kong.yml` file,
 run the following command to start a container with {{site.base_gateway}}:

--- a/app/gateway/2.6.x/plan-and-deploy/security/start-kong-securely.md
+++ b/app/gateway/2.6.x/plan-and-deploy/security/start-kong-securely.md
@@ -32,7 +32,7 @@ of authentication.
 For a simple configuration to use for the subsequent Getting
 Started guides:
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 ```
 enforce_rbac = on

--- a/app/gateway/2.6.x/plugin-development/admin-api.md
+++ b/app/gateway/2.6.x/plugin-development/admin-api.md
@@ -95,10 +95,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway/2.6.x/plugin-development/tests.md
+++ b/app/gateway/2.6.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use a different one. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway/2.6.x/reference/proxy.md
+++ b/app/gateway/2.6.x/reference/proxy.md
@@ -14,7 +14,7 @@ properties:
 - `admin_listen`, which also defines a list of addresses and ports, but those
   should be restricted to only be accessed by administrators, as they expose
   Kong's configuration capabilities: the **Admin API** (`8001` by default).
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 - `stream_listen`, which is similar to `proxy_listen` but for Layer 4 (TCP, TLS)
   generic proxy. This is turned off by default.
 

--- a/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.6.x/vitals/vitals-influx-strategy.md
@@ -79,7 +79,7 @@ with each other.
 
 1. Start the gateway with Kong Manager:
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
     <pre><code>docker run -d --name kong-ee --network=kong-ee-net \
       -e "KONG_DATABASE=postgres" \

--- a/app/gateway/2.7.x/configure/auth/kong-manager/networking.md
+++ b/app/gateway/2.7.x/configure/auth/kong-manager/networking.md
@@ -28,7 +28,7 @@ Common configurations to enable are
   8444 on localhost. Change [`admin_listen`] if necessary, or set
   [`admin_api_uri`].
 
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 
 * Securing Kong Manager and serving it from a dedicated node
 

--- a/app/gateway/2.7.x/configure/auth/oidc-cognito.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-cognito.md
@@ -155,7 +155,7 @@ You can verify the confirmed user from the Cognito page under “General setting
 
 ## Dev Portal Integration
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 Since AWS Cognito only supports the HTTPS protocol, when you start {{site.base_gateway}}, ensure that HTTPS protocol for Dev Portal is enabled. For example:
 

--- a/app/gateway/2.7.x/configure/auth/oidc-cognito.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-cognito.md
@@ -12,27 +12,15 @@ In this configuration, we use User Pools.
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
 
 1. Click the **Create a user pool** button on the right-hand side.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
 
 1. Click **Step Through Settings**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
-
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
 
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
@@ -43,12 +31,8 @@ In this configuration, we use User Pools.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
@@ -56,40 +40,22 @@ You need to add an OAuth2 application definition to the User Pool we just create
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
-1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
+1. Enter an App client name. This demo is using “kong-api”.
 
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
-
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
 
 1. Click the “Set attribute read and write permissions” button.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
-
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-
-1. Click “Create app client”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
+1. Click “Create app client”.
 
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
 
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
@@ -103,21 +69,13 @@ You need to add an OAuth2 application definition to the User Pool we just create
     Note that AWS Cognito doesn’t support HTTP callback URLs. This field should
     include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
-
 1. Click the “Save changes” button.
 
 Now that you have created an Amazon Cognito User Pool and Application Definition, we can configure the OpenID Connect plugin in Kong. We can then test integration between Dev Portal and Amazon Cognito.

--- a/app/gateway/2.7.x/configure/network.md
+++ b/app/gateway/2.7.x/configure/network.md
@@ -34,7 +34,7 @@ it from unauthorized access.
 
 * `8001` provides Kong's **Admin API** that you can use to operate Kong with HTTP. See [admin_listen].
 
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 
 * `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
 

--- a/app/gateway/2.7.x/install-and-run/docker.md
+++ b/app/gateway/2.7.x/install-and-run/docker.md
@@ -128,7 +128,7 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migration
 
 ### Start Kong Gateway
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 1. Run the following command to start a container with {{site.base_gateway}}:
 {% capture start_container %}
@@ -297,7 +297,7 @@ backed up by a Redis cluster).
 
 ### Start Kong Gateway in DB-less mode
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 1. From the same directory where you just created the `kong.yml` file,
 run the following command to start a container with {{site.base_gateway}}:

--- a/app/gateway/2.7.x/plan-and-deploy/security/start-kong-securely.md
+++ b/app/gateway/2.7.x/plan-and-deploy/security/start-kong-securely.md
@@ -32,7 +32,7 @@ of authentication.
 For a simple configuration to use for the subsequent Getting
 Started guides:
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 ```
 enforce_rbac = on

--- a/app/gateway/2.7.x/plugin-development/admin-api.md
+++ b/app/gateway/2.7.x/plugin-development/admin-api.md
@@ -95,10 +95,8 @@ return {
 ```
 
 This code will create two Admin API endpoints in `/consumers/:consumers/key-auth`, to
-obtain (`GET`) and create (`POST`) credentials associated to a given consumer. On this example
-the functions are provided by the `kong.api.endpoints` library. If you want to see a more
-complete example, with custom code in functions, see
-[the `api.lua` file from the key-auth plugin](https://github.com/Kong/kong/blob/master/kong/plugins/key-auth/api.lua).
+obtain (`GET`) and create (`POST`) credentials associated to a given consumer. In this example,
+the functions are provided by the `kong.api.endpoints` library.
 
 The `endpoints` module currently contains the default implementation for the most usual CRUD
 operations used in Kong. This module provides you with helpers for any insert, retrieve,

--- a/app/gateway/2.7.x/plugin-development/tests.md
+++ b/app/gateway/2.7.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use a different one. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway/2.7.x/reference/proxy.md
+++ b/app/gateway/2.7.x/reference/proxy.md
@@ -14,7 +14,7 @@ properties:
 - `admin_listen`, which also defines a list of addresses and ports, but those
   should be restricted to only be accessed by administrators, as they expose
   Kong's configuration capabilities: the **Admin API** (`8001` by default).
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 - `stream_listen`, which is similar to `proxy_listen` but for Layer 4 (TCP, TLS)
   generic proxy. This is turned off by default.
 

--- a/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.7.x/vitals/vitals-influx-strategy.md
@@ -78,7 +78,7 @@ with each other.
 
 1. Start the gateway with Kong Manager:
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
     <pre><code>docker run -d --name kong-ee --network=kong-ee-net \
       -e "KONG_DATABASE=postgres" \

--- a/app/gateway/2.8.x/configure/auth/kong-manager/networking.md
+++ b/app/gateway/2.8.x/configure/auth/kong-manager/networking.md
@@ -28,7 +28,7 @@ Common configurations to enable are
   8444 on localhost. Change [`admin_listen`] if necessary, or set
   [`admin_api_uri`].
 
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 
 * Securing Kong Manager and serving it from a dedicated node
 

--- a/app/gateway/2.8.x/configure/auth/oidc-cognito.md
+++ b/app/gateway/2.8.x/configure/auth/oidc-cognito.md
@@ -155,7 +155,7 @@ You can verify the confirmed user from the Cognito page under “General setting
 
 ## Dev Portal Integration
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 Since AWS Cognito only supports the HTTPS protocol, when you start {{site.base_gateway}}, ensure that HTTPS protocol for Dev Portal is enabled. For example:
 

--- a/app/gateway/2.8.x/configure/auth/oidc-cognito.md
+++ b/app/gateway/2.8.x/configure/auth/oidc-cognito.md
@@ -12,27 +12,15 @@ In this configuration, we use User Pools.
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
 
 1. Click the **Create a user pool** button on the right-hand side.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
 
 1. Click **Step Through Settings**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
-
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
 
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
@@ -43,12 +31,8 @@ In this configuration, we use User Pools.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
@@ -56,40 +40,22 @@ You need to add an OAuth2 application definition to the User Pool we just create
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
-1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
+1. Enter an App client name. This demo is using “kong-api”.
 
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
-
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
 
 1. Click the “Set attribute read and write permissions” button.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
-
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-
-1. Click “Create app client”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
+1. Click “Create app client”.
 
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
 
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
@@ -103,21 +69,13 @@ You need to add an OAuth2 application definition to the User Pool we just create
     Note that AWS Cognito doesn’t support HTTP callback URLs. This field should
     include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
-
 1. Click the “Save changes” button.
 
 Now that you have created an Amazon Cognito User Pool and Application Definition, we can configure the OpenID Connect plugin in Kong. We can then test integration between Dev Portal and Amazon Cognito.

--- a/app/gateway/2.8.x/configure/network.md
+++ b/app/gateway/2.8.x/configure/network.md
@@ -34,7 +34,7 @@ it from unauthorized access.
 
 * `8001` provides Kong's **Admin API** that you can use to operate Kong with HTTP. See [admin_listen].
 
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 
 * `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
 

--- a/app/gateway/2.8.x/install-and-run/docker.md
+++ b/app/gateway/2.8.x/install-and-run/docker.md
@@ -118,7 +118,7 @@ kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migration
 
 ### Start Kong Gateway
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 1. (Optional) If you have an Enterprise license for {{site.base_gateway}},
 export the license key to a variable:
@@ -305,7 +305,7 @@ backed up by a Redis cluster).
 
 ### Start Kong Gateway in DB-less mode
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 1. (Optional) If you have an Enterprise license for {{site.base_gateway}},
 export the license key to a variable:

--- a/app/gateway/2.8.x/plan-and-deploy/security/start-kong-securely.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/start-kong-securely.md
@@ -32,7 +32,7 @@ of authentication.
 For a simple configuration to use for the subsequent Getting
 Started guides:
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
 ```
 enforce_rbac = on

--- a/app/gateway/2.8.x/plugin-development/tests.md
+++ b/app/gateway/2.8.x/plugin-development/tests.md
@@ -12,7 +12,7 @@ might also want to write integration tests. Again, Kong has your back.
 ## Write integration tests
 
 The preferred testing framework for Kong is
-[busted](http://olivinelabs.com/busted/) running with the
+[busted](https://github.com/lunarmodules/busted/) running with the
 [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are
 free to use a different one. In the Kong repository, the busted
 executable can be found at `bin/busted`.

--- a/app/gateway/2.8.x/reference/proxy.md
+++ b/app/gateway/2.8.x/reference/proxy.md
@@ -14,7 +14,7 @@ properties:
 - `admin_listen`, which also defines a list of addresses and ports, but those
   should be restricted to only be accessed by administrators, as they expose
   Kong's configuration capabilities: the **Admin API** (`8001` by default).
-{% include_cached /md/admin-listen.md desc='short' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='short' %}
 - `stream_listen`, which is similar to `proxy_listen` but for Layer 4 (TCP, TLS)
   generic proxy. This is turned off by default.
 

--- a/app/gateway/2.8.x/vitals/vitals-influx-strategy.md
+++ b/app/gateway/2.8.x/vitals/vitals-influx-strategy.md
@@ -78,7 +78,7 @@ with each other.
 
 1. Start the gateway with Kong Manager:
 
-{% include_cached /md/admin-listen.md desc='long' %}
+{% include_cached /md/admin-listen.md kong_version=page.kong_version desc='long' %}
 
     <pre><code>docker run -d --name kong-ee --network=kong-ee-net \
       -e "KONG_DATABASE=postgres" \


### PR DESCRIPTION
### Summary
Fixing broken links. We had a bunch of links changed in includes without specifying version, so everything before 3.0.x broke.

### Reason
Broken links: https://github.com/Kong/docs.konghq.com/runs/8123641467?check_suite_focus=true

### Testing
Netlify