### PR TITLE
Add new per-product broken link checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,19 +187,20 @@ At least one of these labels must be applied to a PR or the build will fail.
 
 We check the documentation for broken links using [broken-link-checker](https://github.com/stevenvachon/broken-link-checker) and some custom logic to build a list of excluded URLs.
 
-The link checker runs in two different ways:
+The link checker runs in three different ways:
 
+1. Run a check against a specific `app/_data/docs_nav*.yml` file, checking each URL in the file (this is preferred)
 1. When a pull request is opened, any changed files are detected and those URLs are checked for broken links. This allows us to fix pages incrementally and ensure that we don't break any new links.
 1. A full site scan, against the latest version of each product only. This allows us to check all pages for broken links. Once all broken links are fixed, we can retire this job in favour of the CI check.
 
-To run a full site scan locally, you'll need to have the [`netlify` CLI](https://docs.netlify.com/cli/get-started/) installed.
+To run a scan locally, you'll need to have the [`netlify` CLI](https://docs.netlify.com/cli/get-started/) installed.
 
 Do **NOT** run the link checker against production.
 
 To run the link checker, build the site locally and start a local Netlify dev environment. From your clone of the doc repo, run:
 
 ```bash
-./node_modules/.bin/gulp build
+make build
 cd dist
 netlify dev
 ```
@@ -209,7 +210,50 @@ Then in another terminal, from the root of your clone of the docs repo:
 ```bash
 cd broken-link-checker
 npm ci
+```
+
+### Running a per-product scan
+
+To scan a specific product, run the following (editing the `nav` and `ignore` options as needed):
+
+```bash
+node product.js --nav gateway_2.8.x --ignore github.com
+```
+
+The `--ignore` option can be provided multiple times, and should be used to ignore false positives e.g. when running on a non-main branch you'll want to provide `--ignore docs.konghq.com/edit` to prevent the "Edit this page" URL from returning an error.
+
+When running a scan, you may want to limit the number of pages scanned as you address any broken links. The `--page` and `--perPage` options can help with this. Here's how you scan 5 pages at a time:
+
+```bash
+# Scan the first five pages
+node product.js --nav gateway_2.8.x --page 0 --perPage 5
+
+# Scan the next five pages
+node product.js --nav gateway_2.8.x --page 1 --perPage 5
+
+# Continue until the script responds with "No URLs detected to test"
+# Then run `node product.js --nav gateway_2.8.x` as a complete check to
+# ensure that you've caught all the broken links
+```
+
+The available flags are:
+
+| Flag      | Description                                                                            | Default                                     |
+|-----------|----------------------------------------------------------------------------------------|---------------------------------------------|
+| --host    | Set the URL to run the checks against                                                  | `http://localhost:8888`                     |
+| --nav     | The name of the nav file to load e.g. `gateway_2.8.x`                                   |                                             |
+| --page    | The number of pages to skip when scanning                                              | N/A. Runs against all pages if not provided |
+| --perPage | How many URLs to scan at one time                                                      | 10                                          |
+| --ignore  | A URL pattern to ignore when checking for broken links. May be provided multiple times |                                             |
+
+### Running a full-site scan
+
+The final option available is to run a full site scan. This will follow any links it detects and check links on those pages too.
+
+In general, running a per-product scan is the better choice, but if you _really_ want to scan the whole site, use the following:
+
+```bash
 node full.js --host http://localhost:8888
 ```
 
-Finally, be patient. The run will take at least 5 minutes, and up to 30 minutes to complete.
+Finally, be patient. The run will take at least 10 minutes, and up to 60 minutes to complete.

--- a/broken-link-checker/excluded.json
+++ b/broken-link-checker/excluded.json
@@ -10,6 +10,7 @@
   "http://localhost:8002/*",
   "http://localhost:8003/*",
   "http://localhost:8004/*",
+  "http://localhost:9090/*",
   "insomnia://*",
   "insomniad://",
   "*/hub/*",

--- a/broken-link-checker/package-lock.json
+++ b/broken-link-checker/package-lock.json
@@ -13,6 +13,7 @@
         "@octokit/rest": "^19.0.0",
         "broken-link-checker": "^0.7.8",
         "fast-glob": "^3.2.11",
+        "js-yaml": "^4.1.0",
         "minimist": "^1.2.5"
       }
     },
@@ -327,6 +328,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
@@ -793,6 +799,17 @@
       "integrity": "sha512-8P+oGrRDvuCpDdovK9oD4skHmSXu56bsK17K2ovXrkW7Ic4H9Y4AqnUUqlXqZxcqQ2358kid9Rb+fbLH5yeeUw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/limited-request-queue": {
@@ -1735,6 +1752,11 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -2102,6 +2124,14 @@
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-2.5.7.tgz",
       "integrity": "sha512-8P+oGrRDvuCpDdovK9oD4skHmSXu56bsK17K2ovXrkW7Ic4H9Y4AqnUUqlXqZxcqQ2358kid9Rb+fbLH5yeeUw=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
     },
     "limited-request-queue": {
       "version": "2.0.0",

--- a/broken-link-checker/package.json
+++ b/broken-link-checker/package.json
@@ -14,6 +14,7 @@
     "@octokit/rest": "^19.0.0",
     "broken-link-checker": "^0.7.8",
     "fast-glob": "^3.2.11",
+    "js-yaml": "^4.1.0",
     "minimist": "^1.2.5"
   }
 }

--- a/broken-link-checker/product.js
+++ b/broken-link-checker/product.js
@@ -1,0 +1,150 @@
+const { HtmlUrlChecker } = require("broken-link-checker");
+const argv = require('minimist')(process.argv.slice(2));
+
+const yaml = require('js-yaml');
+const fs   = require('fs');
+
+(async function () {
+  let host = argv.host || "http://localhost:8888";
+  if (host[host.length -1] == "/"){
+    host = host.substring(0, host.length-1)
+  }
+
+  if (
+    host.includes("https://docs.konghq.com") ||
+    host.includes("http://docs.konghq.com")
+  ) {
+    console.log("This tool can not be run against production");
+    process.exit(1);
+  }
+
+  const perPage = argv.perPage || 10;
+  const page = argv.page;
+
+  const nav = argv.nav;
+  if (!nav){
+    console.log("Provide a nav file e.g. 'gateway_3.0.x' using --nav");
+    process.exit(1);
+  }
+
+  let items = yaml.load(fs.readFileSync(`../app/_data/docs_nav_${nav}.yml`, 'utf8'));
+
+  // If it's a single sourced doc, extract the items directly
+  if (items.items) {
+    items = items.items;
+  }
+
+  const prefix = `/${nav.replace('_','/')}`;
+  let urls = extractNav(items, prefix);
+
+  if (page !== undefined){
+    const offset = page * perPage;
+    urls = urls.slice(offset, offset + perPage);
+  }
+
+  const blockList = [/.*\/changelog\/?/];
+  const ignoredUrls = [];
+
+  for (let item of blockList) {
+    urls = urls.filter((u) => {
+      const shouldIgnore = u.match(item);
+      if (shouldIgnore) {
+        ignoredUrls.push(`${u} (${item})`);
+      }
+      return !shouldIgnore;
+    });
+  }
+
+  if (ignoredUrls.length) {
+    console.log(`IGNORING the following URLs:\n\n${ignoredUrls.join("\n")}\n`);
+  }
+
+  urls = urls.map(u => `${host}${u}`)
+
+  if (urls.length) {
+    console.log(`Checking the following URLs:\n\n${urls.join("\n")}\n`);
+
+    // Are there any patterns to ignore failures on?
+    let ignore = argv.ignore || [];
+    if (typeof ignore === "string") {
+      ignore = [ignore];
+    }
+    const ignoreFailures = ignore.map(i => new RegExp(i))
+
+    // Check all the URLs provided
+    const r = await checkUrls(urls, ignoreFailures);
+
+    // Output report
+    if (r.length) {
+      console.log("Broken links:");
+      console.log(JSON.stringify(r, null, 2));
+      process.exit(1);
+    }
+
+    console.log("No broken links detected");
+  } else {
+    console.log("No URLs detected to test");
+  }
+})();
+
+function checkUrls(urls, ignoreFailures) {
+  return new Promise((resolve, reject) => {
+    const exclusions = require("./excluded.json");
+    const brokenLinks = new Set();
+    const htmlUrlChecker = new HtmlUrlChecker(
+      {
+        honorRobotExclusions: false,
+        excludedKeywords: exclusions,
+        maxSocketsPerHost: 64,
+        requestMethod: 'get'
+      },
+      {
+        link: (result) => {
+          if (result.broken) {
+            // Handle HTTP 308 which is a valid response
+            if (result.brokenReason === "HTTP_308") {
+              return;
+            }
+
+            // Ignore any broken links in the --ignore list
+            for (b of ignoreFailures){
+              if (result.url.resolved.match(b)){
+                return;
+              }
+            }
+
+            brokenLinks.add({
+              page: result.base.resolved,
+              text: result.html.text,
+              target: result.url.resolved,
+              reason: result.brokenReason,
+            });
+          }
+        },
+        end: () => {
+          resolve(Array.from(brokenLinks));
+        },
+      }
+    );
+
+    for (const u of urls) {
+      htmlUrlChecker.enqueue(u);
+    }
+  });
+}
+
+function extractNav(items, base){
+  let urls = [];
+  for (let u of items){
+    if (u.items){
+      urls = urls.concat(extractNav(u.items, base))
+    } else {
+      if (u.absolute_url){
+        urls.push(u.url)
+      } else {
+      urls.push(`${base}${u.url}`)
+      }
+    }
+  }
+  return urls;
+}


### PR DESCRIPTION
### Summary
Add new per-product broken link checker

### Reason
Helps track down broken links in a smaller section of the site to make fixing them accessible

### Testing

```bash
node product.js --nav gateway_2.8.x --perPage 1 --page 177
# This should return a broken link
# [
#   {
#     "page": "http://localhost:8888/gateway/2.8.x/plugin-development/tests",
#     "text": "busted",
#     "target": "http://olivinelabs.com/busted/",
#     "reason": "HTTP_404"
#   }
# ]

node product.js --nav gateway_2.8.x --perPage 1 --page 177 --ignore olivine
#  No broken links detected
```