### PR TITLE
Open external links in new tab

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -25,7 +25,7 @@
 
     {% include_cached nav-v2.html layout=page.layout %}
 
-    {{ content | replace: '<a href="http:', '<a rel="nofollow noopener noreferrer" href="http:' }}
+    {{ content | replace: '<a href="http:', '<a rel="nofollow noopener noreferrer" target="_blank" href="http:' | replace: '<a href="https:', '<a target="_blank" href="https:' }}
 
     {% include_cached footer.html %} {% include_cached anchor_links.html %}
 

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -20,14 +20,14 @@ id: documentation
         <div class="github-links">
           <p>
             {% if page.edit_link %}
-            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/{{ page.edit_link }}" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/{{ page.edit_link }}">
             {% else %}
-            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ default_edit_link }}" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ default_edit_link }}">
             {% endif %}
               <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
           </p>
           <p>
-            <a href="https://github.com/Kong/docs.konghq.com/issues" target="_blank">
+            <a href="https://github.com/Kong/docs.konghq.com/issues">
               <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue"/>Report an issue</a>
           </p>
           <p id="oss-ee-toggle" data-current="Enterprise" style="display: none">
@@ -91,7 +91,7 @@ id: documentation
             <h1 tabindex="-1" id="main" class="page-content-title"
             >{{page.title | flatify }}
             {% if page.badge %}
-              <a href="https://konghq.com/pricing" target="_blank" {%
+              <a href="https://konghq.com/pricing" {%
                 if page.badge == 'plus' %}class="badge plus" aria-label="available with plus subscription"{% endif %}{%
                 if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with enterprise subscription"{% endif %}{%
                 if page.badge == 'free' %}class="badge free" aria-label="available in Kong Gateway free mode"{% endif %}{%

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -278,11 +278,11 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
           <a href="/hub"><i class="fa fa-chevron-left"></i>Back to Kong Plugin Hub</a>
         </p>
         <p>
-          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{page.path | replace: "index", "_index" }}" target="_blank">
+          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{page.path | replace: "index", "_index" }}">
             <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
         </p>
         <p>
-          <a href="https://github.com/Kong/docs.konghq.com/issues" target="_blank">
+          <a href="https://github.com/Kong/docs.konghq.com/issues">
             <img src="/assets/images/icons/documentation/icn-monitoring-black.svg" alt="report-issue"/>Report an issue</a>
         </p>
       </div>


### PR DESCRIPTION
### Summary
Add `target="_blank"` to external links to open them in a new tab.

### Reason
We have an external link icon to warn people, but the links don't open in a new tab, as would be expected.

### Testing
Netlify. Check some external links.