### PR TITLE
update beta status for websockets

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -20,16 +20,17 @@ This lets you run plugins such as `rate-limiting` before authentication plugins.
   To enable FIPS mode, set [`fips`](/gateway/3.0.x/reference/configuration/#fips) to `on`.
   FIPS mode is only supported in Ubuntu 20.04.
 
-* **Beta feature**: Kong Gateway now includes WebSocket validation functionality. Websockets are a type of persistent connection that works on top of HTTP.
+* Kong Gateway now includes WebSocket validation functionality. Websockets are a type of persistent connection that works on top of HTTP.
 
   Previously, Kong Gateway 2.x supported limited WebSocket connections, where plugins only ran during the initial connection phase instead of for each frame.
   Now, Kong Gateway provides more control over WebSocket traffic by implementing plugins that target WebSocket frames.
 
   This release includes:
   * [Service](/gateway/3.0.x/admin-api/#service-object) and [route](/gateway/3.0.x/admin-api/#route-object) support for `ws` and `wss` protocols
-  * WebSocket PDK modules: [kong.websocket.client](/gateway/3.0.x/plugin-development/pdk/kong.websocket.client) and [kong.websocket.upstream](/gateway/3.0.x/plugin-development/pdk/kong.websocket.upstream).
-  * [New plugin handlers](/gateway/3.0.x/plugin-development/custom-logic/#websocket-plugin-development)
-  * Two new plugins: [WebSocket Size Limit](/hub/kong-inc/websocket-size-limit/)  and [WebSocket Validator](/hub/kong-inc/websocket-validator/)
+  * Two new plugins: [WebSocket Size Limit](/hub/kong-inc/websocket-size-limit/) and [WebSocket Validator](/hub/kong-inc/websocket-validator/)
+  * WebSocket plugin development capabilities (**Beta feature**)
+    * PDK modules: [kong.websocket.client](/gateway/3.0.x/plugin-development/pdk/kong.websocket.client) and [kong.websocket.upstream](/gateway/3.0.x/plugin-development/pdk/kong.websocket.upstream)
+    * [New plugin handlers](/gateway/3.0.x/plugin-development/custom-logic/#websocket-plugin-development)
 
   Learn how to develop WebSocket plugins with our [plugin development guide](/gateway/3.0.x/plugin-development/custom-logic/#websocket-plugin-development).
 


### PR DESCRIPTION
This includes some nuanced updates to the changelog re: WebSockets.

WebSocket services and routes are stable/GA, as are any of the WebSocket plugins that ship with Kong. What _should_ have a beta/unstable label is the lua-level API (PDK, plugin interface, etc).

The intended message to get across is:
1. The new WebSocket services and routes are ready to use, including our bundled WebSocket plugins.
2. There's also a new WebSocket PDK. It is not stable (yet), so be prepared to roll with any breaking changes if you write your own WebSocket plugin today.

Following these changes, I reordered the list items to emphasize the non-beta features and group the beta ones under a single element.