### PR TITLE
Changelog: Blue-green deployment fixes + missing info

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -307,13 +307,12 @@ Kong Gateway version.
 
 ### Breaking changes and deprecations
 
+#### Enterprise
+
+* Blue-green deployments from Kong Gateway Enterprise versions before 2.1.0.0 are not supported with 3.0.0.0.
+Upgrade to 2.1.0.0 or later before upgrading to 3.0.0.0 to use blue-green deployment.
+
 #### Deployment
-
-* Blue-green deployments from Kong Gateway versions before 2.1.0 are not supported with 3.0.
-Upgrade to 2.1.0 or later before upgrading to 3.0.x to use blue-green deployment.
-
-  Thanks, [@marc-charpentier](https://github.com/charpentier)!
-  [#8896](https://github.com/Kong/kong/pull/8896)
 
 * Deprecated and stopped producing Amazon Linux 1 containers and packages.
 Amazon Linux 1 [reached end-of-life on December 31, 2020](https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life).
@@ -758,6 +757,8 @@ openid-connect
   * Secrets management
   * Plugin ordering
   * Expression-based routing
+
+* Blue-green deployments for Kong Gateway (OSS) are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.
 
 ### Dependencies
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -231,6 +231,8 @@ Kong Gateway version.
   The new configuration parameter, `groups_required`, is an array of string
   elements that indicates the groups that users must belong to for the request
   to be authorized.
+  * The character `.` is now allowed in group attributes.
+  * The character `:` is now allowed in the password field.
 
 * [mTLS Authentication](/hub/kong-inc/mtls-auth) (`mtls-auth`)
   * Introduced certificate revocation list (CRL) and OCSP server support with the
@@ -308,9 +310,6 @@ Kong Gateway version.
 ### Breaking changes and deprecations
 
 #### Enterprise
-
-* Blue-green deployments from Kong Gateway Enterprise versions before 2.1.0.0 are not supported with 3.0.0.0.
-Upgrade to 2.1.0.0 or later before upgrading to 3.0.0.0 to use blue-green deployment.
 
 #### Deployment
 
@@ -758,7 +757,11 @@ openid-connect
   * Plugin ordering
   * Expression-based routing
 
-* Blue-green deployments for Kong Gateway (OSS) are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.
+* Blue-green deployments:
+  * **Kong Gateway (OSS)**: Upgrades with blue-green deloyments are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.
+  * **Kong Enterprise**: You can perform blue-green upgrades from versions 2.1.x.x-2.7.x.x to 3.0.0.0.
+    * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is known issue planned to be fixed in the next 2.8.x.x release.
+    * Upgrades from versions before 2.1.0.0 are not supported with 3.0.0.0.
 
 ### Dependencies
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -758,7 +758,7 @@ openid-connect
 * Blue-green deployments:
   * **Kong Gateway (OSS)**: Upgrades with blue-green deloyments are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.
   * **Kong Enterprise**: You can perform blue-green upgrades from versions 2.1.x.x-2.7.x.x to 3.0.0.0.
-    * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is known issue planned to be fixed in the next 2.8.x.x release.
+    * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is a known issue planned to be fixed in the next 2.8.x.x release.
     * Upgrades from versions before 2.1.0.0 are not supported with 3.0.0.0.
 
 ### Dependencies

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -309,8 +309,6 @@ Kong Gateway version.
 
 ### Breaking changes and deprecations
 
-#### Enterprise
-
 #### Deployment
 
 * Deprecated and stopped producing Amazon Linux 1 containers and packages.

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -176,7 +176,7 @@ defaults:
       layout: "docs-v2"
 
 # product name vars
-ee_product_name: Kong Gateway # This is a legacy variable that used to differentiate the Enterprise package from the Gateway product. Leaving this in case of further rebranding.
+ee_product_name: Kong Enterprise
 ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
 mesh_product_name: Kong Mesh
@@ -186,8 +186,3 @@ konnect_short_name: Konnect
 konnect_saas: Konnect Cloud
 package_name: Kong Konnect
 company_name: Kong Inc.
-
-# Konnect tier vars
-free_tier: Kong Gateway
-plus_tier: Kong Konnect Plus
-enterprise_tier: Kong Konnect Enterprise

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -177,7 +177,7 @@ defaults:
       layout: "docs-v2"
 
 # product name vars
-ee_product_name: Kong Gateway # This is a legacy variable that used to differentiate the Enterprise package from the Gateway product. Leaving this in case of further rebranding.
+ee_product_name: Kong Enterprise
 ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
 mesh_product_name: Kong Mesh
@@ -187,8 +187,3 @@ konnect_short_name: Konnect
 konnect_saas: Konnect Cloud
 package_name: Kong Konnect
 company_name: Kong Inc.
-
-# Konnect tier vars
-free_tier: Kong Gateway
-plus_tier: Kong Konnect Plus
-enterprise_tier: Kong Konnect Enterprise

--- a/src/gateway/upgrade.md
+++ b/src/gateway/upgrade.md
@@ -44,7 +44,7 @@ Amazon Linux 1 and Debian 8 (Jessie) containers and packages are deprecated and 
 
 Blue-green deployments:
 * **{{site.ee_product_name}}**: You can perform blue-green upgrades from versions 2.1.x.x-2.7.x.x to 3.0.0.0.
-  * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is known issue planned to be fixed in the next 2.8.x.x release.
+  * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is a known issue planned to be fixed in the next 2.8.x.x release.
   * Upgrades from versions before 2.1.0.0 are not supported with 3.0.0.0.
   Upgrade to a supported version before upgrading to 3.0.0.0 to use blue-green deployment.
 * **{{site.ce_product_name}}**: Blue-green deployments are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.

--- a/src/gateway/upgrade.md
+++ b/src/gateway/upgrade.md
@@ -42,8 +42,10 @@ affect your current installation.
 
 Amazon Linux 1 and Debian 8 (Jessie) containers and packages are deprecated and are no longer produced for new versions of {{site.base_gateway}}.
 
-Blue-green deployments from {{site.base_gateway}} versions before 2.1.0 are not supported with 3.0.0.
-Upgrade to 2.1.0 or later before upgrading to 3.0.x to use blue-green deployment.
+Blue-green deployments:
+* **{{site.ee_product_name}}**: Upgrade from versions before 2.1.0.0 is not supported with 3.0.0.0.
+Upgrade to 2.1.0.0 or later before upgrading to 3.0.0.0 to use blue-green deployment.
+* **{{site.ce_product_name}}**: Blue-green deployments are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.
 
 ### Dependencies
 
@@ -383,22 +385,27 @@ diff the files to identify any changes, and apply them as needed.
 {% endnavtabs %}
 
 
-## Upgrade from 2.1.x - 2.8.x to 3.0.x {#migrate-db}
+## Upgrade from 2.1.x - 2.8.x to 3.0.x with blue-green {#migrate-db}
 
-{{site.ee_product_name}} supports the zero downtime migration model. This means
+{{site.base_gateway}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two {{site.base_gateway}} clusters with different
 versions running that are sharing the same database. This is sometimes referred
 to as the
 [blue-green migration model](https://en.wikipedia.org/wiki/Blue-green_deployment).
 
+{:.important}
+> **Important**: For 3.0.x, the blue-green migration option is only available for {{site.ee_product_name}} users.
+Blue-green migration between major versions is not available in open-source Gateway environments.
+For {{site.ce_product_name}}, [install 3.0.x on a fresh data store](#install-30x-on-a-fresh-data-store).
+
 The migrations are designed so that there is no need to fully copy
-the data. The new version of {{site.ee_product_name}} is able to use the data as it
+the data. The new version of {{site.base_gateway}} is able to use the data as it
 is migrated, and the old {{site.base_gateway}} cluster keeps working until it is finally time to
 decommission it. For this reason, the full migration is split into two commands:
 
 - `kong migrations up`: performs only non-destructive operations
 - `kong migrations finish`: puts the database in the final expected state (DB-less
-  mode is not supported in {{site.ee_product_name}})
+  mode is not supported in {{site.base_gateway}})
 
 Follow the instructions for your backing data store to migrate to the new version.
 If you prefer to use a fresh data store and only migrate your `kong.conf` file,
@@ -439,8 +446,8 @@ see the instructions to
 > **Deprecation notice:**
 > Cassandra as a backend database for {{site.base_gateway}} is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the {{site.base_gateway}} 4.0 release, and some new features might not be supported with Cassandra in the {{site.base_gateway}} 3.0 release.
 
-Due to internal changes, the table schemas used by {{site.ee_product_name}} 2.8.x on Cassandra
-are incompatible with those used by {{site.ee_product_name}} 2.1.x or lower. Migrating using the usual commands
+Due to internal changes, the table schemas used by {{site.base_gateway}} 2.8.x on Cassandra
+are incompatible with those used by {{site.base_gateway}} 2.1.x or lower. Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
 database at the same time.
@@ -466,9 +473,9 @@ described below:
 6. When your traffic is fully migrated to the 3.0.x cluster,
    decommission your old nodes.
 
-### Install 3.0.x on a fresh data store
+## Install 3.0.x on a fresh data store
 
-For installing on a fresh data store, {{site.ee_product_name}} 3.0.x has the
+For installing on a fresh data store, {{site.base_gateway}} 3.0.x has the
 `kong migrations bootstrap` command. Run the following commands to
 prepare a new 3.0.x cluster from a fresh data store.
 

--- a/src/gateway/upgrade.md
+++ b/src/gateway/upgrade.md
@@ -43,8 +43,10 @@ affect your current installation.
 Amazon Linux 1 and Debian 8 (Jessie) containers and packages are deprecated and are no longer produced for new versions of {{site.base_gateway}}.
 
 Blue-green deployments:
-* **{{site.ee_product_name}}**: Upgrade from versions before 2.1.0.0 is not supported with 3.0.0.0.
-Upgrade to 2.1.0.0 or later before upgrading to 3.0.0.0 to use blue-green deployment.
+* **{{site.ee_product_name}}**: You can perform blue-green upgrades from versions 2.1.x.x-2.7.x.x to 3.0.0.0.
+  * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is known issue planned to be fixed in the next 2.8.x.x release.
+  * Upgrades from versions before 2.1.0.0 are not supported with 3.0.0.0.
+  Upgrade to a supported version before upgrading to 3.0.0.0 to use blue-green deployment.
 * **{{site.ce_product_name}}**: Blue-green deployments are not supported for major versions, therefore they are not supported with upgrades from 2.x.x to 3.0.x.
 
 ### Dependencies
@@ -385,7 +387,7 @@ diff the files to identify any changes, and apply them as needed.
 {% endnavtabs %}
 
 
-## Upgrade from 2.1.x - 2.8.x to 3.0.x with blue-green {#migrate-db}
+## Upgrade from 2.1.x - 2.8.x to 3.0.x {#migrate-db}
 
 {{site.base_gateway}} supports the zero downtime migration model. This means
 that while the migration is in process, you have two {{site.base_gateway}} clusters with different
@@ -394,9 +396,12 @@ to as the
 [blue-green migration model](https://en.wikipedia.org/wiki/Blue-green_deployment).
 
 {:.important}
-> **Important**: For 3.0.x, the blue-green migration option is only available for {{site.ee_product_name}} users.
+> **Important**:
+* For 3.0.x, the blue-green migration option is only available for {{site.ee_product_name}} users.
 Blue-green migration between major versions is not available in open-source Gateway environments.
 For {{site.ce_product_name}}, [install 3.0.x on a fresh data store](#install-30x-on-a-fresh-data-store).
+* There is a known issue with migrating 2.8.x.x to 3.0.0.0. It is planned to be fixed in the next 2.8.x release.
+If you need to upgrade to 3.0.0.0, either wait for the fix release, or [install 3.0.x on a fresh data store](#install-30x-on-a-fresh-data-store).
 
 The migrations are designed so that there is no need to fully copy
 the data. The new version of {{site.base_gateway}} is able to use the data as it
@@ -415,9 +420,9 @@ see the instructions to
 ### PostgreSQL
 
 1. Download 3.0.x, and configure it to point to the same
-   data store as your old (2.1.x-2.8.x) cluster.
+   data store as your old (2.1.x-2.7.x) cluster.
 2. Run `kong migrations up`.
-3. After that finishes running, both the old (2.1.x-2.8.x) and new (3.0.x) clusters can
+3. After that finishes running, both the old (2.1.x-2.7.x) and new (3.0.x) clusters can
    now run simultaneously on the same data store. Start provisioning 3.0.x nodes,
    but do _not_ use their Admin API yet.
 
@@ -446,7 +451,7 @@ see the instructions to
 > **Deprecation notice:**
 > Cassandra as a backend database for {{site.base_gateway}} is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the {{site.base_gateway}} 4.0 release, and some new features might not be supported with Cassandra in the {{site.base_gateway}} 3.0 release.
 
-Due to internal changes, the table schemas used by {{site.base_gateway}} 2.8.x on Cassandra
+Due to internal changes, the table schemas used by {{site.base_gateway}} 2.7.x on Cassandra
 are incompatible with those used by {{site.base_gateway}} 2.1.x or lower. Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
@@ -460,7 +465,7 @@ described below:
 
 2. Run `kong migrations bootstrap`.
 
-   Once that finishes running, both the old (2.1.x-2.8.x) and new (3.0.x)
+   Once that finishes running, both the old (2.1.x-2.7.x) and new (3.0.x)
    clusters can now run simultaneously, but the new cluster does not
    have any data yet.
 3. On the old cluster, run `kong config db_export`. This will create

--- a/tests/breadcrumbs.test.js
+++ b/tests/breadcrumbs.test.js
@@ -7,7 +7,7 @@ test.describe("Gateway", () => {
       "Home"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(2)")).toHaveText(
-      "Kong Gateway"
+      "Kong Enterprise"
     );
     await expect(page.locator(".breadcrumb-item:nth-of-type(3)")).toHaveText(
       /\s*Plugin Development\s*/m


### PR DESCRIPTION
### Summary
* Adjust info about blue-green deployments and what versions+Gateway packages they're available for
  * removed attribution to community contributor. The change they made + asked for isn't directly related, though it affects blue-green.
* Add missing entry for ldap auth advanced plugin
* Updating our product name variables, which are out of date

### Reason
A couple of conversations in Slack:
https://kongstrong.slack.com/archives/CDSTDSG9J/p1662459895450809
https://kongstrong.slack.com/archives/C02GZ0CGJNT/p1662489559237329

### Testing
Netlify