### PR TITLE
[DOCU-2453] Documentation for Konnect Personal Access Tokens

### DIFF
--- a/app/konnect/getting-started/import.md
+++ b/app/konnect/getting-started/import.md
@@ -36,8 +36,7 @@ If you want to target the `konnect.konghq.com` environment instead, use the [`--
     ```sh
     deck ping \
       --konnect-runtime-group-name default \
-      --konnect-email {YOUR_EMAIL} \
-      --konnect-password {YOUR_PASSWORD}
+      --konnect-token {YOUR_PERSONAL_ACCESS_TOKEN}
     ```
 
     If the connection is successful, the terminal displays the full name of the
@@ -48,12 +47,12 @@ If you want to target the `konnect.konghq.com` environment instead, use the [`--
     ```
 
     You can also use decK with {{site.konnect_short_name}} more securely by storing
-    your password in a file, then either calling it with
-    `--konnect-password-file /path/{FILENAME}.txt`, or adding it to your decK configuration
-    file under the `konnect-password` option along with your email:
+    your personal access token in a file, then either calling it with
+    `--konnect-token-file /path/{FILENAME}.txt`, or adding it to your decK configuration
+    file under the `konnect-token` option along with your email:
 
     ```yaml
-    konnect-password: {YOUR_PASSWORD}
+    konnect-token: {YOUR_PERSONAL_ACCESS_TOKEN}
     konnect-email: {YOUR_EMAIL}
     ```
 
@@ -84,7 +83,7 @@ Run [`deck dump`](/deck/latest/reference/deck_dump) and point decK at the `konne
 deck dump \
   --konnect-addr https://konnect.konghq.com \
   --konnect-email {YOUR_EMAIL} \
-  --konnect-password {YOUR_PASSWORD}
+  --konnect-token {YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/konnect/getting-started/import.md
+++ b/app/konnect/getting-started/import.md
@@ -49,11 +49,10 @@ If you want to target the `konnect.konghq.com` environment instead, use the [`--
     You can also use decK with {{site.konnect_short_name}} more securely by storing
     your personal access token in a file, then either calling it with
     `--konnect-token-file /path/{FILENAME}.txt`, or adding it to your decK configuration
-    file under the `konnect-token` option along with your email:
+    file under the `konnect-token` option:
 
     ```yaml
     konnect-token: {YOUR_PERSONAL_ACCESS_TOKEN}
-    konnect-email: {YOUR_EMAIL}
     ```
 
     The default location for this file is `$HOME/.deck.yaml`. You can target a
@@ -82,7 +81,6 @@ Run [`deck dump`](/deck/latest/reference/deck_dump) and point decK at the `konne
 ```sh
 deck dump \
   --konnect-addr https://konnect.konghq.com \
-  --konnect-email {YOUR_EMAIL} \
   --konnect-token {YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 {% endnavtab %}

--- a/app/konnect/runtime-manager/runtime-groups/declarative-config.md
+++ b/app/konnect/runtime-manager/runtime-groups/declarative-config.md
@@ -40,7 +40,6 @@ recognizes your account credentials:
 ```sh
 deck ping \
   --konnect-runtime-group-name default \
-  --konnect-email {YOUR_EMAIL} \
   --konnect-token {YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 
@@ -54,11 +53,10 @@ Successfully Konnected as Some Name (Org Name)!
 You can also use decK with {{site.konnect_short_name}} more securely by storing
 your personal access token in a file, then either calling it with
 `--konnect-token-file /path/{FILENAME}.txt`, or adding it to your decK configuration
-file under the `konnect-token` option along with your email:
+file under the `konnect-token` option:
 
 ```yaml
 konnect-token: {YOUR_PERSONAL_ACCESS_TOKEN}
-konnect-email: {YOUR_EMAIL}
 ```
 
 The default location for this file is `$HOME/.deck.yaml`. You can target a

--- a/app/konnect/runtime-manager/runtime-groups/declarative-config.md
+++ b/app/konnect/runtime-manager/runtime-groups/declarative-config.md
@@ -41,7 +41,7 @@ recognizes your account credentials:
 deck ping \
   --konnect-runtime-group-name default \
   --konnect-email {YOUR_EMAIL} \
-  --konnect-password {YOUR_PASSWORD}
+  --konnect-token {YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 
 If the connection is successful, the terminal displays the full name of the user
@@ -52,12 +52,12 @@ Successfully Konnected as Some Name (Org Name)!
 ```
 
 You can also use decK with {{site.konnect_short_name}} more securely by storing
-your password in a file, then either calling it with
-`--konnect-password-file /path/{FILENAME}.txt`, or adding it to your decK configuration
-file under the `konnect-password` option along with your email:
+your personal access token in a file, then either calling it with
+`--konnect-token-file /path/{FILENAME}.txt`, or adding it to your decK configuration
+file under the `konnect-token` option along with your email:
 
 ```yaml
-konnect-password: {YOUR_PASSWORD}
+konnect-token: {YOUR_PERSONAL_ACCESS_TOKEN}
 konnect-email: {YOUR_EMAIL}
 ```
 

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -114,7 +114,22 @@ You can generate a personal access token (PAT) in {{site.konnect_short_name}} to
 
 To generate a PAT in {{site.konnect_short_name}}, go to your name > **Personal access tokens** and click **+ Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 
 
-You can then use the `--konnect-token` and `--konnect-token-file` flags to use the PAT.
+You can use the `--konnect-token` flag to provide the PAT directly in the command:
+
+```sh
+deck ping \
+  --konnect-email example@example.com \
+  --konnect-token YOUR_PERSONAL_ACCESS_TOKEN
+```
+
+You can save your {{site.konnect_short_name}}
+PAT to a file, then pass the filename to decK with `--konnect-token-file`:
+
+```sh
+deck ping \
+  --konnect-email example@example.com \
+  --konnect-token-file /PATH/TO/FILE
+```
 {% endif_version %}
 
 ## Target a {{site.konnect_short_name}} API

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -119,9 +119,10 @@ Before you generate a PAT, keep the following in mind:
 * There is a limit of 10 personal access tokens per user.
 * Unused tokens are deleted/revoked after 12 months of inactivity.
 
-To generate a PAT in {{site.konnect_short_name}}, go to your name > **Personal access tokens** and click **+ Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 
+To generate a PAT in {{site.konnect_short_name}}, select your name to open the context menu 
+ and click **Personal access tokens**, then click **Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 
 
-You can use the `--konnect-token` flag to provide the PAT directly in the command:
+You can use the `--konnect-token` flag to pass the PAT directly in the command:
 
 ```sh
 deck ping \

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -110,14 +110,14 @@ Successfully Konnected as MyName (Konnect Org)!
 {% if_version gte:1.14.x %}
 ### Authenticate using a personal access token
 
-You can generate a personal access token (PAT) in {{site.konnect_short_name}} to use to authenticate with decK commands. This can be useful for organizations with CI pipelines that can't use the standard username and password authentication. 
+You can generate a personal access token (PAT) in {{site.konnect_short_name}} for authentication with decK commands. This is more secure than basic authentication, and can be useful for organizations with CI pipelines that can't use the standard username and password authentication. 
 
 Before you generate a PAT, keep the following in mind:
 
 * A PAT is granted all of the permissions that the user has access to via their most up-to-date role assignment.
-* The PAT has a maximum duration of up to 12 months.
+* The PAT has a maximum duration of 12 months.
 * There is a limit of 10 personal access tokens per user.
-* Unused tokens are deleted/revoked after 12 months of inactivity.
+* Unused tokens are deleted and revoked after 12 months of inactivity.
 
 To generate a PAT in {{site.konnect_short_name}}, select your name to open the context menu 
  and click **Personal access tokens**, then click **Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -112,13 +112,19 @@ Successfully Konnected as MyName (Konnect Org)!
 
 You can generate a personal access token (PAT) in {{site.konnect_short_name}} to use to authenticate with decK commands. This can be useful for organizations with CI pipelines that can't use the standard username and password authentication. 
 
+Before you generate a PAT, keep the following in mind:
+
+* A PAT is granted all of the permissions that the user has access to via their most up-to-date role assignment.
+* The PAT has a maximum duration of up to 12 months.
+* There is a limit of 10 personal access tokens per user.
+* Unused tokens are deleted/revoked after 12 months of inactivity.
+
 To generate a PAT in {{site.konnect_short_name}}, go to your name > **Personal access tokens** and click **+ Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 
 
 You can use the `--konnect-token` flag to provide the PAT directly in the command:
 
 ```sh
 deck ping \
-  --konnect-email example@example.com \
   --konnect-token YOUR_PERSONAL_ACCESS_TOKEN
 ```
 
@@ -127,7 +133,6 @@ PAT to a file, then pass the filename to decK with `--konnect-token-file`:
 
 ```sh
 deck ping \
-  --konnect-email example@example.com \
   --konnect-token-file /PATH/TO/FILE
 ```
 {% endif_version %}

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -107,6 +107,15 @@ deck ping
 
 Successfully Konnected as MyName (Konnect Org)!
 ```
+{% if_version gte:1.14.x %}
+### Authenticate using a personal access token
+
+You can generate a personal access token (PAT) in {{site.konnect_short_name}} to use to authenticate with decK commands. This can be useful for organizations with CI pipelines that can't use the standard username and password authentication. 
+
+To generate a PAT in {{site.konnect_short_name}}, go to your name > **Personal access tokens** and click **+ Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 
+
+You can then use the `--konnect-token` and `--konnect-token-file` flags to use the PAT.
+{% endif_version %}
 
 ## Target a {{site.konnect_short_name}} API
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Docs for the new personal access tokens feature. 
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
[DOCU-2353](https://konghq.atlassian.net/browse/DOCU-2453)
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
* /deck/latest/guides/konnect/#authenticate-using-a-personal-access-token : This is the only section that explains how to obtain a PAT. Is this sufficient or should we create a separate page in the Konnect guide about this as well? My thinking was that this is related to decK/Konnect API auth workflows, so the content should exist alongside those workflows instead of a separate page, but I'd like to know what you think.
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
