### PR TITLE
Bump deck format version to 3.0

### DIFF
--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -223,7 +223,7 @@ users can set this config to `system` to auto pick CA-bundle from OS.
 Here's a sample declarative configuration with `redis` as storage:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 # this section is not necessary if there's already a route that matches
 # /.well-known/acme-challenge path with http protocol
 services:

--- a/app/_hub/kong-inc/grpc-gateway/_index.md
+++ b/app/_hub/kong-inc/grpc-gateway/_index.md
@@ -50,7 +50,7 @@ but proxies to a `Service` with the `grpc(s)` protocol.
 Sample configuration via declarative (YAML):
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 services:
 - protocol: grpc
   host: localhost

--- a/app/_hub/kong-inc/grpc-web/_index.md
+++ b/app/_hub/kong-inc/grpc-web/_index.md
@@ -70,7 +70,7 @@ but proxies to a Service with the `grpc(s)` protocol.
 Sample configuration via declarative (YAML):
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 services:
 - protocol: grpc
   host: localhost
@@ -140,7 +140,7 @@ message HelloResponse {
 The declarative configuration becomes:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 services:
 - protocol: grpc
   host: localhost

--- a/app/_hub/kong-inc/openid-connect/1.5.x.md
+++ b/app/_hub/kong-inc/openid-connect/1.5.x.md
@@ -896,7 +896,7 @@ with declarative configuration.
 Here is example of such configuration in declarative using RS256:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 
 services:
 - name: bin

--- a/app/_hub/kong-inc/openid-connect/1.5.x.md
+++ b/app/_hub/kong-inc/openid-connect/1.5.x.md
@@ -896,7 +896,7 @@ with declarative configuration.
 Here is example of such configuration in declarative using RS256:
 
 ```yaml
-_format_version: "3.0"
+_format_version: "1.1"
 
 services:
 - name: bin

--- a/src/deck/guides/defaults-v2.md
+++ b/src/deck/guides/defaults-v2.md
@@ -58,7 +58,7 @@ want to use, skip to [setting defaults](#set-defaults).
 2. Add the following sample service and route to the file:
 
     ```yaml
-    _format_version: "0.1"
+    _format_version: "3.0"
     services:
       - host: mockbin.org
         name: example_service
@@ -163,7 +163,7 @@ Summary:
 `defaults`:
 
     ```yaml
-    _format_version: "0.1"
+    _format_version: "3.0"
     _info:
       defaults:
     services:
@@ -189,7 +189,7 @@ Summary:
     For example:
 
     ```yaml
-    _format_version: "0.1"
+    _format_version: "3.0"
     _info:
       defaults:
         route:

--- a/src/deck/guides/defaults.md
+++ b/src/deck/guides/defaults.md
@@ -43,7 +43,7 @@ again to see how decK interprets default values.
 1. Add the following sample service, route, and plugin to the file:
 
    ```yaml
-   _format_version: "0.1"
+   _format_version: "3.0"
    services:
      - host: mockbin.org
        name: example_service
@@ -127,7 +127,7 @@ overwriting your current state file, specify a different filename:
     default values populated for the service, route, and Basic Auth plugin:
 
    ```yaml
-   _format_version: "1.1"
+   _format_version: "3.0"
    plugins:
    - config:
        anonymous: null
@@ -196,7 +196,7 @@ configuration would overwrite the value in your environment.
 `defaults`:
 
    ```yaml
-   _format_version: "0.1"
+   _format_version: "3.0"
    _info:
      defaults:
    services:
@@ -223,7 +223,7 @@ configuration would overwrite the value in your environment.
     Service object:
 
    ```yaml
-   _format_version: "0.1"
+   _format_version: "3.0"
    _info:
      defaults:
        service:
@@ -242,7 +242,7 @@ configuration would overwrite the value in your environment.
     Or you could define custom default values for all available fields:
 
    ```yaml
-   _format_version: "0.1"
+   _format_version: "3.0"
    _info:
      defaults:
        route:

--- a/src/deck/guides/environment-variables.md
+++ b/src/deck/guides/environment-variables.md
@@ -21,7 +21,7 @@ You can use this method for any sensitive content.
 2. Save the following snippet into a `env-demo.yaml` file:
 
     ```yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     consumers:
     - keyauth_credentials:
       - key: {%raw%}${{ env "DECK_API_KEY" }}{%endraw%}

--- a/src/deck/guides/getting-started.md
+++ b/src/deck/guides/getting-started.md
@@ -124,7 +124,7 @@ If you already have {{site.base_gateway}} set up with the configuration of your 
 configuration in this guide, the file should look like this:
 
     ```yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     services:
     - connect_timeout: 60000
       host: example.com
@@ -168,7 +168,7 @@ Edit the `kong.yaml` file, making the following changes:
 Your `kong.yaml` file should now look like this:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 services:
 - connect_timeout: 60000
   host: example.com

--- a/src/deck/guides/kong-enterprise.md
+++ b/src/deck/guides/kong-enterprise.md
@@ -66,7 +66,7 @@ To set a workspace directly in the state file, use the `_workspace` parameter.
 For example:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 _workspace: default
 services:
 - name: example_service

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -140,7 +140,7 @@ or use a flag when running any decK command.
 * Target a runtime group in your state file with the `konnect_runtime_group` parameter:
 
     ```yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     _konnect:
       runtime_group_name: staging
     ```
@@ -181,7 +181,7 @@ If the {{site.konnect_short_name}} service doesn't exist, setting a `_Konnect` t
 For example, see the following configuration snippet, where the Gateway service named `example_service` is attached to the {{site.konnect_short_name}} service `example`:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 _konnect:
   runtime_group_name: default
 services:

--- a/src/deck/guides/multi-file-state.md
+++ b/src/deck/guides/multi-file-state.md
@@ -46,7 +46,7 @@ deck dump --select-tag team-svc1 -o svc1.yaml
 
 ```sh
 $ cat svc1.yaml
-_format_version: "1.1"
+_format_version: "3.0"
 _info:
   defaults: {}
   select_tags:
@@ -70,7 +70,7 @@ deck dump --select-tag team-svc2 -o svc2.yaml
 
 ```sh
 $ cat svc2.yaml
-_format_version: "1.1"
+_format_version: "3.0"
 _info:
   defaults: {}
   select_tags:

--- a/src/gateway/install/docker/index.md
+++ b/src/gateway/install/docker/index.md
@@ -232,7 +232,7 @@ using the URL specified in `KONG_ADMIN_GUI_URL`:
 Now that you have a running Gateway instance, Kong provides a series of
 [getting started guides](/gateway/{{page.kong_version}}/get-started/services-and-routes/)
  to help you set up and enhance your first Service.
- 
+
 
 In particular, right after installation you might want to:
 * [Create a service and a route](/gateway/{{page.kong_version}}/get-started/services-and-routes)
@@ -284,7 +284,7 @@ backed up by a Redis cluster).
     could look something like this:
 
     ```yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     _transform: true
 
     services:

--- a/src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -69,7 +69,7 @@ http -f post :8001/plugins \
     Your file should now look like this:
 
     ``` yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     services:
     - host: mockbin.org
       name: example_service
@@ -167,7 +167,7 @@ http -f post :8001/plugins \
     Your file should now look like this:
 
     ``` yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     services:
     - host: mockbin.org
       name: example_service

--- a/src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -143,7 +143,7 @@ entities and their attributes. This is a small yet complete
 example that illustrates a number of features:
 
 ```yaml
-_format_version: "2.1"
+_format_version: "3.0"
 _transform: true
 
 services:
@@ -162,7 +162,7 @@ consumers:
   - key: my-key
 ```
 
-The only mandatory piece of metadata is `_format_version: "2.1"`, which
+The only mandatory piece of metadata is `_format_version: "3.0"`, which
 specifies the version number of the declarative configuration syntax format.
 This also matches the minimum version of Kong required to parse the file.
 
@@ -238,13 +238,13 @@ http :8001/config config=@kong.yml
 The `/config` endpoint replaces the entire set of entities in memory
 with the ones specified in the given file.
 
-Or another way you can start Kong in DB-less mode is with a 
+Or another way you can start Kong in DB-less mode is with a
 declarative configuration in a string using the `KONG_DECLARATIVE_CONFIG_STRING`
-environment variable. 
+environment variable.
 
 ```
-export KONG_DATABASE=off 
-export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"mockbin.com","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}' 
+export KONG_DATABASE=off
+export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"mockbin.com","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}'
 kong start
 ```
 

--- a/src/gateway/production/running-kong/secure-admin-api.md
+++ b/src/gateway/production/running-kong/secure-admin-api.md
@@ -115,7 +115,7 @@ normally to any other Kong API.
 If you are using Docker to host {{site.ee_product_name}}, you can accomplish a similar task using a declarative configuration such as this one:
 
 ``` yaml
-_format_version: "1.1"
+_format_version: "3.0"
 
 services:
 - name: admin-api


### PR DESCRIPTION
### Summary
Bumping `_format_version` in declarative config examples to 3.0.
Didn't bump the version in `/konnect/` topics yet. Leaving that for the Konnect 3.0 support update, will be in a separate PR.

### Reason
decK `_format_version` was bumped to 3.0 for the route path changes. 
See [changelog entry](https://release-gateway-3-0--kongdocs.netlify.app/gateway/changelog/#:~:text=Bumped%20the%20version%20number%20(_format_version)%20of%20declarative%20configuration%20to%203.0%20for%20changes%20on%20route.path.%20Declarative%20configurations%20with%20older%20versions%20are%20upgraded%20to%203.0%20automatically).

### Testing
Netlify