### PR TITLE
Clean up command prompt marker

### DIFF
--- a/app/_hub/kong-inc/azure-functions/_index.md
+++ b/app/_hub/kong-inc/azure-functions/_index.md
@@ -1,7 +1,6 @@
 ---
 name: Azure Functions
 publisher: Kong Inc.
-source_url: 'https://github.com/Kong/kong-plugin-azure-functions'
 desc: Invoke and manage Azure functions from Kong
 description: |
   This plugin invokes

--- a/app/_hub/kong-inc/exit-transformer/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/_index.md
@@ -219,7 +219,7 @@ end
    {% navtab Using cURL %}
 
    ```bash
-   $ curl -i -X POST http://<admin-hostname>:8001/services \
+   curl -i -X POST http://<admin-hostname>:8001/services \
      --data name=example.com \
      --data url='http://mockbin.org'
    ```
@@ -228,7 +228,7 @@ end
    {% navtab Using HTTPie %}
 
    ```bash
-   $ http :8001/services name=example.com host=mockbin.org
+   http :8001/services name=example.com host=mockbin.org
    ```
 
    {% endnavtab %}
@@ -240,7 +240,7 @@ end
    {% navtab Using cURL %}
 
 ```bash
-$ curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
+curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
   --data 'hosts[]=example.com'
 ```
 
@@ -248,7 +248,7 @@ $ curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
    {% navtab Using HTTPie %}
 
 ```bash
-$ http -f :8001/services/example.com/routes hosts=example.com
+http -f :8001/services/example.com/routes hosts=example.com
 ```
 
    {% endnavtab %}
@@ -286,7 +286,7 @@ Configure the `exit-transformer` plugin with `transform.lua`.
    {% navtab Using cURL %}
 
    ```bash
-   $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+   curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
      -F "name=exit-transformer"  \
      -F "config.functions=@transform.lua"
    ```
@@ -294,7 +294,7 @@ Configure the `exit-transformer` plugin with `transform.lua`.
    {% navtab Using HTTPie %}
 
    ```bash
-   $ http -f :8001/services/example.com/plugins \
+   http -f :8001/services/example.com/plugins \
      name=exit-transformer \
      config.functions=@transform.lua
    ```
@@ -311,7 +311,7 @@ response in [step 6](#testy-exit):
    {% navtab Using cURL %}
 
    ```bash
-   $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+   curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
      --data "name=key-auth"
    ```
 
@@ -319,7 +319,7 @@ response in [step 6](#testy-exit):
    {% navtab Using HTTPie %}
 
    ```bash
-   $ http :8001/services/example.com/plugins name=key-auth
+   http :8001/services/example.com/plugins name=key-auth
    ```
 
    {% endnavtab %}
@@ -335,14 +335,14 @@ in the message body.
 {% navtab Using cURL %}
 
 ```bash
-$ curl --header 'Host: example.com' 'localhost:8000'
+curl --header 'Host: example.com' 'localhost:8000'
 ```
 
 {% endnavtab %}
 {% navtab Using HTTPie %}
 
 ```bash
-$ http :8000 Host:example.com
+http :8000 Host:example.com
 ```
 
 {% endnavtab %}
@@ -372,24 +372,24 @@ The plugin can also be applied globally:
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/plugins/ \
+curl -X POST http://<admin-hostname>:8001/plugins/ \
   -F "name=exit-transformer"  \
   -F "config.handle_unknown=true" \
   -F "config.functions=@transform.lua"
 ...
-$ curl --header 'Host: non-existent.com' 'localhost:8000'
+curl --header 'Host: non-existent.com' 'localhost:8000'
 ```
 
 {% endnavtab %}
 {% navtab Using HTTPie %}
 
 ```bash
-$ http :8001/plugins \
+http :8001/plugins \
   name=exit-transformer \
   config.handle_unknown=true \
   config.functions=@transform.lua
 
-$ http :8000 Host:non-existent.com
+http :8000 Host:non-existent.com
 ```
 
 {% endnavtab %}
@@ -489,7 +489,7 @@ Configure the `exit-transformer` plugin with `custom-errors-by-mimetype.lua`.
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
   -F "name=exit-transformer"  \
   -F "config.handle_unknown=true" \
   -F "config.handle_unexpected=true" \
@@ -500,7 +500,7 @@ $ curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
 {% navtab Using HTTPie %}
 
 ```bash
-$ http -f :8001/plugins name=exit-transformer \
+http -f :8001/plugins name=exit-transformer \
   config.handle_unknown=true \
   config.handle_unexpected=true \
   config.functions=@examples/custom-errors-by-mimetype.lua

--- a/app/_hub/kong-inc/grpc-gateway/_index.md
+++ b/app/_hub/kong-inc/grpc-gateway/_index.md
@@ -68,24 +68,28 @@ services:
 
 Sample configuration via the Admin API:
 
-```bash
-$ # add the gRPC service
-$ curl -X POST localhost:8001/services \
-  --data name=grpc \
-  --data protocol=grpc \
-  --data host=localhost \
-  --data port=9000
+1. Add the gRPC service:
+  ```sh
+  curl -X POST localhost:8001/services \
+    --data name=grpc \
+    --data protocol=grpc \
+    --data host=localhost \
+    --data port=9000
+  ```
 
-$ # add an http route
-$ curl -X POST localhost:8001/services/grpc/routes \
-  --data protocols=http \
-  --data name=web-service \
-  --data paths[]=/
+2. Add an `http` route:
+  ```sh
+  curl -X POST localhost:8001/services/grpc/routes \
+    --data protocols=http \
+    --data name=web-service \
+    --data paths[]=/
+  ```
 
-$ # add the plugin to the route
-$ curl -X POST localhost:8001/routes/web-service/plugins \
-  --data name=grpc-gateway
-```
+3. Add the plugin to the route:
+  ```sh
+  curl -X POST localhost:8001/routes/web-service/plugins \
+    --data name=grpc-gateway
+  ```
 
 The proto file must contain the
 [HTTP REST to gRPC mapping rule](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto).

--- a/app/_hub/kong-inc/grpc-web/_index.md
+++ b/app/_hub/kong-inc/grpc-web/_index.md
@@ -86,24 +86,28 @@ services:
 
 Same thing via the Admin API:
 
-```bash
-$ # add the gRPC service
-$ curl -X POST localhost:8001/services \
-  --data name=grpc \
-  --data protocol=grpc \
-  --data host=localhost \
-  --data port=9000
+1. Add the gRPC service:
+  ```sh
+  curl -X POST localhost:8001/services \
+    --data name=grpc \
+    --data protocol=grpc \
+    --data host=localhost \
+    --data port=9000
+  ```
 
-$ # add an http route
-$ curl -X POST localhost:8001/services/grpc/routes \
-  --data protocols=http \
-  --data name=web-service \
-  --data paths=/
+2. Add an `http` route:
+  ```sh
+  curl -X POST localhost:8001/services/grpc/routes \
+    --data protocols=http \
+    --data name=web-service \
+    --data paths[]=/
+  ```
 
-$ # add the plugin to the route
-$ curl -X POST localhost:8001/routes/web-service/plugins \
-  --data name=grpc-web
-```
+3. Add the plugin to the route:
+  ```sh
+  curl -X POST localhost:8001/routes/web-service/plugins \
+    --data name=grpc-web
+  ```
 
 In these examples, we don't set any plugin configurations.
 This minimal setup works for the default varieties of the [gRPC-Web protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2),
@@ -158,8 +162,7 @@ services:
 or via the Admin API:
 
 ```bash
-$ # add the plugin to the route
-$ curl -X POST localhost:8001/routes/web-service/plugins \
+curl -X POST localhost:8001/routes/web-service/plugins \
   --data name=grpc-web \
   --data proto=path/to/hello.proto
 ```

--- a/app/_hub/kong-inc/hmac-auth/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/_index.md
@@ -123,9 +123,9 @@ You can provision new username/password credentials by making the following
 HTTP request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/hmac-auth \
-    --data "username=bob" \
-    --data "secret=secret456"
+curl -X POST http://kong:8001/consumers/{consumer}/hmac-auth \
+  --data "username=bob" \
+  --data "secret=secret456"
 ```
 {% endnavtab %}
 
@@ -351,8 +351,8 @@ The HMAC plugin can be enabled on a service or a route. This example uses a serv
     a service or a route.
 
     ```bash
-    $ curl -i -X PATCH http://localhost:8001/plugins/{plugin-id} \
-        -d "config.validate_request_body=true"
+    curl -i -X PATCH http://localhost:8001/plugins/{plugin-id} \
+      -d "config.validate_request_body=true"
     ```
     Response:
     ```

--- a/app/_hub/kong-inc/ip-restriction/_index.md
+++ b/app/_hub/kong-inc/ip-restriction/_index.md
@@ -111,10 +111,10 @@ An `allow` list provides a positive security model, in which the configured CIDR
 You can configure the plugin with both `allow` and `deny` configurations. An interesting use case of this flexibility is to allow a CIDR range, but deny an IP address on that CIDR range:
 
 ```bash
-$ curl -X POST http://kong:8001/services/{service}/plugins \
-    --data "name=ip-restriction" \
-    --data "config.allow=127.0.0.0/24" \
-    --data "config.deny=127.0.0.1"
+curl -X POST http://kong:8001/services/{service}/plugins \
+  --data "name=ip-restriction" \
+  --data "config.allow=127.0.0.0/24" \
+  --data "config.deny=127.0.0.1"
 ```
 {% endif_plugin_version %}
 

--- a/app/_hub/kong-inc/jwt-signer/_index.md
+++ b/app/_hub/kong-inc/jwt-signer/_index.md
@@ -798,7 +798,7 @@ GET kong:8001/jwt-signer/jwks
 Example:
 
 ```bash
-$ curl -X GET http://<kong>:8001/jwt-signer/jwks
+curl -X GET http://<kong>:8001/jwt-signer/jwks
 ```
 ```json
 {
@@ -877,7 +877,7 @@ GET kong:8001/jwt-signer/jwks/<name-or-id>
 Example:
 
 ```bash
-$ curl -X GET http://<kong>:8001/jwt-signer/jwks/kong
+curl -X GET http://<kong>:8001/jwt-signer/jwks/kong
 ```
 ```json
 {
@@ -921,7 +921,7 @@ DELETE kong:8001/jwt-signer/jwks/<name-or-id>
 Example:
 
 ```bash
-$ curl -X DELETE http://<kong>:8001/jwt-signer/jwks/kong
+curl -X DELETE http://<kong>:8001/jwt-signer/jwks/kong
 ```
 
 The plugin automatically reloads or regenerates missing JWKS if it cannot
@@ -950,7 +950,7 @@ POST kong:8001/jwt-signer/jwks/<name-or-id>/rotate
 Example:
 
 ```bash
-$ curl -X POST http://<kong>:8001/jwt-signer/jwks/kong/rotate
+curl -X POST http://<kong>:8001/jwt-signer/jwks/kong/rotate
 ```
 Response:
 

--- a/app/_hub/kong-inc/jwt/_index.md
+++ b/app/_hub/kong-inc/jwt/_index.md
@@ -142,7 +142,11 @@ parameter                       | description
 You can provision a new HS256 JWT credential by issuing the following HTTP request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/jwt -H "Content-Type: application/x-www-form-urlencoded"
+curl -X POST http://kong:8001/consumers/{consumer}/jwt -H "Content-Type: application/x-www-form-urlencoded"
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 
 {
@@ -194,7 +198,11 @@ You can remove a Consumer's JWT credential by issuing the following HTTP
 request:
 
 ```bash
-$ curl -X DELETE http://kong:8001/consumers/{consumer}/jwt/{id}
+curl -X DELETE http://kong:8001/consumers/{consumer}/jwt/{id}
+```
+
+Response:
+```
 HTTP/1.1 204 No Content
 ```
 
@@ -207,7 +215,11 @@ You can list a Consumer's JWT credentials by issuing the following HTTP
 request:
 
 ```bash
-$ curl -X GET http://kong:8001/consumers/{consumer}/jwt
+curl -X GET http://kong:8001/consumers/{consumer}/jwt
+```
+
+Response:
+```
 HTTP/1.1 200 OK
 ```
 
@@ -268,14 +280,14 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMzZjMzA0OWIzNjI0OWEzYzlmODg5MWN
 The JWT can now be included in a request to Kong by adding it as a header, if configured in `config.header_names` (which contains `Authorization` by default):
 
 ```bash
-$ curl http://kong:8000/{route path} \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMzZjMzA0OWIzNjI0OWEzYzlmODg5MWNiMTI3MjQzYyIsImV4cCI6MTQ0MjQzMDA1NCwibmJmIjoxNDQyNDI2NDU0LCJpYXQiOjE0NDI0MjY0NTR9.AhumfY35GFLuEEjrOXiaADo7Ae6gt_8VLwX7qffhQN4'
+curl http://kong:8000/{route path} \
+  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMzZjMzA0OWIzNjI0OWEzYzlmODg5MWNiMTI3MjQzYyIsImV4cCI6MTQ0MjQzMDA1NCwibmJmIjoxNDQyNDI2NDU0LCJpYXQiOjE0NDI0MjY0NTR9.AhumfY35GFLuEEjrOXiaADo7Ae6gt_8VLwX7qffhQN4'
 ```
 
 as a querystring parameter, if configured in `config.uri_param_names` (which contains `jwt` by default):
 
 ```bash
-$ curl http://kong:8000/{route path}?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMzZjMzA0OWIzNjI0OWEzYzlmODg5MWNiMTI3MjQzYyIsImV4cCI6MTQ0MjQzMDA1NCwibmJmIjoxNDQyNDI2NDU0LCJpYXQiOjE0NDI0MjY0NTR9.AhumfY35GFLuEEjrOXiaADo7Ae6gt_8VLwX7qffhQN4
+curl http://kong:8000/{route path}?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMzZjMzA0OWIzNjI0OWEzYzlmODg5MWNiMTI3MjQzYyIsImV4cCI6MTQ0MjQzMDA1NCwibmJmIjoxNDQyNDI2NDU0LCJpYXQiOjE0NDI0MjY0NTR9.AhumfY35GFLuEEjrOXiaADo7Ae6gt_8VLwX7qffhQN4
 ```
 
 or as cookie, if the name is configured in `config.cookie_names` (which is not enabled by default):
@@ -312,8 +324,8 @@ You can patch an existing JWT plugin:
 
 ```bash
 # This adds verification for both nbf and exp claims:
-$ curl -X PATCH http://kong:8001/plugins/{jwt plugin id} \
-    --data "config.claims_to_verify=exp,nbf"
+curl -X PATCH http://kong:8001/plugins/{jwt plugin id} \
+  --data "config.claims_to_verify=exp,nbf"
 ```
 
 Supported claims:
@@ -331,15 +343,15 @@ Enable this option in the plugin's configuration.
 You can patch an existing Route:
 
 ```bash
-$ curl -X PATCH http://kong:8001/routes/{route id}/plugins/{jwt plugin id} \
-    --data "config.secret_is_base64=true"
+curl -X PATCH http://kong:8001/routes/{route id}/plugins/{jwt plugin id} \
+  --data "config.secret_is_base64=true"
 ```
 
 Then, base64 encode your Consumers' secrets:
 
 ```bash
 # secret is: "blob data"
-$ curl -X POST http://kong:8001/consumers/{consumer}/jwt \
+curl -X POST http://kong:8001/consumers/{consumer}/jwt \
   --data "secret=YmxvYiBkYXRh"
 ```
 
@@ -352,8 +364,12 @@ select `RS256` or `ES256` as the `algorithm`, and explicitly upload the public k
 in the `rsa_public_key` field (including for ES256 signed tokens). For example:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/jwt \
-      -F "rsa_public_key=@/path/to/public_key.pem" \
+curl -X POST http://kong:8001/consumers/{consumer}/jwt \
+  -F "rsa_public_key=@/path/to/public_key.pem" \
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 
 {
@@ -391,8 +407,8 @@ Then, create the signature using your private keys. Using the JWT debugger at
 associated public key. Then, append the resulting value in the `Authorization` header, for example:
 
 ```bash
-$ curl http://kong:8000/{route path} \
-    -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxM2Q1ODE0NTcyZTc0YTIyYjFhOWEwMDJmMmQxN2MzNyJ9.uNPTnDZXVShFYUSiii78Q-IAfhnc2ExjarZr_WVhGrHHBLweOBJxGJlAKZQEKE4rVd7D6hCtWSkvAAOu7BU34OnlxtQqB8ArGX58xhpIqHtFUkj882JQ9QD6_v2S2Ad-EmEx5402ge71VWEJ0-jyH2WvfxZ_pD90n5AG5rAbYNAIlm2Ew78q4w4GVSivpletUhcv31-U3GROsa7dl8rYMqx6gyo9oIIDcGoMh3bu8su5kQc5SQBFp1CcA5H8sHGfYs-Et5rCU2A6yKbyXtpHrd1Y9oMrZpEfQdgpLae0AfWRf6JutA9SPhst9-5rn4o3cdUmto_TBGqHsFmVyob8VQ'
+curl http://kong:8000/{route path} \
+  -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxM2Q1ODE0NTcyZTc0YTIyYjFhOWEwMDJmMmQxN2MzNyJ9.uNPTnDZXVShFYUSiii78Q-IAfhnc2ExjarZr_WVhGrHHBLweOBJxGJlAKZQEKE4rVd7D6hCtWSkvAAOu7BU34OnlxtQqB8ArGX58xhpIqHtFUkj882JQ9QD6_v2S2Ad-EmEx5402ge71VWEJ0-jyH2WvfxZ_pD90n5AG5rAbYNAIlm2Ew78q4w4GVSivpletUhcv31-U3GROsa7dl8rYMqx6gyo9oIIDcGoMh3bu8su5kQc5SQBFp1CcA5H8sHGfYs-Et5rCU2A6yKbyXtpHrd1Y9oMrZpEfQdgpLae0AfWRf6JutA9SPhst9-5rn4o3cdUmto_TBGqHsFmVyob8VQ'
 ```
 
 ### Generate public/private keys
@@ -400,13 +416,13 @@ $ curl http://kong:8000/{route path} \
 To create a brand new pair of public/private keys, run the following command:
 
 ```bash
-$ openssl genrsa -out private.pem 2048
+openssl genrsa -out private.pem 2048
 ```
 
 This private key must be kept secret. To generate a public key corresponding to the private key, execute:
 
 ```bash
-$ openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+openssl rsa -in private.pem -outform PEM -pubout -out public.pem
 ```
 
 If you run the commands above, the public key is written to `public.pem`, whereas the
@@ -426,17 +442,17 @@ _Note: Auth0 does not use base64-encoded secrets._
 Create a Service:
 
 ```bash
-$ curl -i -f -X POST http://localhost:8001/services \
-    --data "name=example-service" \
-    --data "url=http://httpbin.org"
+curl -i -f -X POST http://localhost:8001/services \
+  --data "name=example-service" \
+  --data "url=http://httpbin.org"
 ```
 
 Then create a Route:
 
 ```bash
-$ curl -i -f -X POST http://localhost:8001/routes \
-    --data "service.id={example-service's id}" \
-    --data "paths[]=/example_path"
+curl -i -f -X POST http://localhost:8001/routes \
+  --data "service.id={example-service's id}" \
+  --data "paths[]=/example_path"
 ```
 
 #### Add the JWT Plugin
@@ -444,33 +460,33 @@ $ curl -i -f -X POST http://localhost:8001/routes \
 Add the plugin to your Route:
 
 ```bash
-$ curl -X POST http://localhost:8001/route/{route id}/plugins \
-    --data "name=jwt"
+curl -X POST http://localhost:8001/route/{route id}/plugins \
+  --data "name=jwt"
 ```
 
 Download your Auth0 account's X509 Certificate:
 
 ```bash
-$ curl -o {COMPANYNAME}.pem https://{COMPANYNAME}.{REGION-ID}.auth0.com/pem
+curl -o {COMPANYNAME}.pem https://{COMPANYNAME}.{REGION-ID}.auth0.com/pem
 ```
 
 Extract the public key from the X509 Certificate:
 
 ```bash
-$ openssl x509 -pubkey -noout -in {COMPANYNAME}.pem > pubkey.pem
+openssl x509 -pubkey -noout -in {COMPANYNAME}.pem > pubkey.pem
 ```
 
 Create a Consumer with the Auth0 public key:
 
 ```bash
-$ curl -i -X POST http://kong:8001/consumers \
-    --data "username=<USERNAME>" \
-    --data "custom_id=<CUSTOM_ID>"
+curl -i -X POST http://kong:8001/consumers \
+  --data "username=<USERNAME>" \
+  --data "custom_id=<CUSTOM_ID>"
 
-$ curl -i -X POST http://localhost:8001/consumers/{consumer}/jwt \
-    -F "algorithm=RS256" \
-    -F "rsa_public_key=@./pubkey.pem" \
-    -F "key=https://{COMPANYNAME}.auth0.com/" # the `iss` field
+curl -i -X POST http://localhost:8001/consumers/{consumer}/jwt \
+  -F "algorithm=RS256" \
+  -F "rsa_public_key=@./pubkey.pem" \
+  -F "key=https://{COMPANYNAME}.auth0.com/" # the `iss` field
 ```
 
 The JWT plugin by default validates the `key_claim_name` against the `iss`
@@ -482,9 +498,9 @@ Consumer.
 Send requests through. Only tokens signed by Auth0 will work:
 
 ```bash
-$ curl -i http://localhost:8000 \
-    -H "Host:example.com" \
-    -H "Authorization:Bearer <TOKEN>"
+curl -i http://localhost:8000 \
+  -H "Host:example.com" \
+  -H "Authorization:Bearer <TOKEN>"
 ```
 
 ### Upstream Headers
@@ -513,8 +529,11 @@ You can paginate through the JWTs for all Consumers using the following
 request:
 
 ```bash
-$ curl -X GET http://kong:8001/jwts
+curl -X GET http://kong:8001/jwts
+```
 
+Response:
+```json
 {
     "total": 3,
     "data": [
@@ -549,8 +568,11 @@ $ curl -X GET http://kong:8001/jwts
 You can filter the list by consumer by using this other path:
 
 ```bash
-$ curl -X GET http://kong:8001/consumers/{username or id}/jwt
+curl -X GET http://kong:8001/consumers/{username or id}/jwt
+```
 
+Response:
+```json
 {
     "total": 1,
     "data": [
@@ -581,7 +603,10 @@ using the following request:
 
 ```bash
 curl -X GET http://kong:8001/jwts/{key or id}/consumer
+```
 
+Response:
+```json
 {
    "created_at":1507936639000,
    "username":"foo",

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -160,7 +160,7 @@ service, you must add the new Consumer to the allowed group. See
 Provision new credentials by making the following HTTP request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer}/key-auth-enc -d ""
+curl -X POST http://kong:8001/consumers/{consumer}/key-auth-enc -d ""
 ```
 
 Response:
@@ -200,7 +200,7 @@ field/parameter     | description
 Make a request with the key as a query string parameter:
 
 ```bash
-$ curl http://kong:8000/{proxy path}?apikey=<some_key>
+curl http://kong:8000/{proxy path}?apikey=<some_key>
 ```
 
 **Note:** The `key_in_query` parameter must be set to `true` (default).
@@ -208,8 +208,8 @@ $ curl http://kong:8000/{proxy path}?apikey=<some_key>
 Make a request with the key in the body:
 
 ```bash
-$ curl http://kong:8000/{proxy path} \
-    --data 'apikey: <some_key>'
+curl http://kong:8000/{proxy path} \
+  --data 'apikey: <some_key>'
 ```
 
 **Note:** The `key_in_body` parameter must be set to `true` (default is `false`).
@@ -217,8 +217,8 @@ $ curl http://kong:8000/{proxy path} \
 Make a request with the key in a header:
 
 ```bash
-$ curl http://kong:8000/{proxy path} \
-    -H 'apikey: <some_key>'
+curl http://kong:8000/{proxy path} \
+  -H 'apikey: <some_key>'
 ```
 
 **Note:** The `key_in_header` parameter must be set to `true` (default).
@@ -226,7 +226,7 @@ $ curl http://kong:8000/{proxy path} \
 gRPC clients are supported too:
 
 ```bash
-$ grpcurl -H 'apikey: <some_key>' ...
+grpcurl -H 'apikey: <some_key>' ...
 ```
 ### About API Key Locations in a Request
 
@@ -248,7 +248,7 @@ curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
 Delete an API Key by making the following request:
 
 ```bash
-$ curl -X DELETE http://kong:8001/consumers/{consumer}/key-auth-enc/{id}
+curl -X DELETE http://kong:8001/consumers/{consumer}/key-auth-enc/{id}
 ```
 
 Response:
@@ -270,7 +270,7 @@ Paginate through the API keys for all Consumers using the following
 request:
 
 ```bash
-$ curl -X GET http://kong:8001/key-auths-enc
+curl -X GET http://kong:8001/key-auths-enc
 ```
 
 Response:
@@ -305,7 +305,7 @@ Response:
 Filter the list by Consumer by using a different endpoint:
 
 ```bash
-$ curl -X GET http://kong:8001/consumers/{username or id}/key-auth-enc
+curl -X GET http://kong:8001/consumers/{username or id}/key-auth-enc
 ```
 
 `username or id`: The username or id of the Consumer whose credentials need to be listed.

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -260,8 +260,11 @@ search uses `scope="sub"`, `filter="<config.attribute>=<username>"`, and
 using the `ldapsearch` command line utility:
 
 ```bash
-$ ldapsearch -x -h "<config.ldap_host>" -D "<config.bind_dn>" -b
-"<config.attribute>=<username><config.base_dn>" -w "<config.ldap_password>"
+ldapsearch -x \
+  -h "<config.ldap_host>" \
+  -D "<config.bind_dn>" \
+  -b "<config.attribute>=<username><config.base_dn>" \
+  -w "<config.ldap_password>"
 ```
 
 [api-object]: /gateway/latest/admin-api/#api-object

--- a/app/_hub/kong-inc/mocking/_index.md
+++ b/app/_hub/kong-inc/mocking/_index.md
@@ -122,7 +122,7 @@ The `<service>` is the id or name of the service that this plugin configuration 
 Configure this plugin on a [route](/gateway/latest/admin-api/#route-object):
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
+curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
    --data "name=mocking" \
    --data "config.api_specification_filename=multipleexamples.json" \
    --data "config.random_delay=true" \
@@ -138,11 +138,11 @@ Configure this plugin on a [consumer](/gateway/latest/admin-api/#consumer-object
 
 ```bash
 curl -X POST http://<admin-hostname>:8001/consumers/<consumer>/plugins \
-    --data "name=mocking"  \
-    --data "config.api_specification_filename=multipleexamples.json" \
-    --data "config.random_delay=true" \
-    --data "config.max_delay_time=1" \
-    --data "config.min_delay_time=0.001"
+  --data "name=mocking"  \
+  --data "config.api_specification_filename=multipleexamples.json" \
+  --data "config.random_delay=true" \
+  --data "config.max_delay_time=1" \
+  --data "config.min_delay_time=0.001"
 ```
 
 The `<consumer>` is the id or username of the consumer that this plugin configuration will target.

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -469,57 +469,57 @@ plugin with WebSocket services, an additional non-WebSocket route must be used
 to issue tokens.
 
 1. Create a WebSocket service:
-  ```bash
-  curl -X POST http://localhost:8001/services/ \
-    --data "name=my-websocket-service" \
-    --data "url=ws://my-websocket-backend:8080/"
-  ```
+    ```bash
+    curl -X POST http://localhost:8001/services/ \
+      --data "name=my-websocket-service" \
+      --data "url=ws://my-websocket-backend:8080/"
+    ```
 
 2. Attach a route to the service:
-  ```sh
-  curl -X POST http://localhost:8001/services/my-websocket-service/routes \
-    --data "name=my-websocket-route" \
-    --data "protocols=wss" \
-    --data "hosts=my-websocket-hostname.com" \
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/services/my-websocket-service/routes \
+      --data "name=my-websocket-route" \
+      --data "protocols=wss" \
+      --data "hosts=my-websocket-hostname.com" \
+    ```
 
 3. Attach an OAuth2 plugin instance to the service:
 
-  {:.note}
-  > **Note**: Setting `global_credentials=true` is necessary to allow tokens
-  created by other plugin instances.
+    {:.note}
+    > **Note**: Setting `global_credentials=true` is necessary to allow tokens
+    created by other plugin instances.
 
-  ```sh
-  curl -x POST http://localhost:8001/services/my-websocket-service/plugins \
-    --data "name=oauth2" \
-    --data "config.scopes=email" \
-    --data "config.scopes=profile" \
-    --data "config.global_credentials=true"
-  ```
+    ```sh
+    curl -x POST http://localhost:8001/services/my-websocket-service/plugins \
+      --data "name=oauth2" \
+      --data "config.scopes=email" \
+      --data "config.scopes=profile" \
+      --data "config.global_credentials=true"
+    ```
 
 
 4. Create another route to handle token creation:
-  {:.note}
-  > **Note**: Adding a POST method matcher ensures that regular WebSocket
-  handshake requests will not match this route.
+    {:.note}
+    > **Note**: Adding a POST method matcher ensures that regular WebSocket
+    handshake requests will not match this route.
 
-  ```sh
-  curl -X POST http://localhost:8001/routes \
-    --data "name=my-websocket-token-helper" \
-    --data "protocols=https" \
-    --data "hosts=my-websocket-hostname.com" \
-    --data "methods=POST"
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/routes \
+      --data "name=my-websocket-token-helper" \
+      --data "protocols=https" \
+      --data "hosts=my-websocket-hostname.com" \
+      --data "methods=POST"
+    ```
 
 5. Finally, add the additional OAuth2 plugin instance, using the route:
 
-  ```sh
-  curl -x POST http://localhost:8001/routes/my-websocket-token-helper/plugins \
-    --data "name=oauth2" \
-    --data "config.scopes=email" \
-    --data "config.scopes=profile" \
-    --data "config.global_credentials=true"
-  ```
+    ```sh
+    curl -x POST http://localhost:8001/routes/my-websocket-token-helper/plugins \
+      --data "name=oauth2" \
+      --data "config.scopes=email" \
+      --data "config.scopes=profile" \
+      --data "config.global_credentials=true"
+    ```
 
 Client token requests (for example: `POST https://my-websocket-hostname.com/oauth2/authorize`)
 will be handled by the `oauth2` plugin instance attached to the `my-websocket-token-helper`

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -195,9 +195,9 @@ The clients trying to authorize and request access tokens must use these endpoin
 You need to associate a credential to an existing [Consumer][consumer-object] object. To create a Consumer, you can execute the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/ \
-    --data "username=user123" \
-    --data "custom_id=SOME_CUSTOM_ID"
+curl -X POST http://kong:8001/consumers/ \
+  --data "username=user123" \
+  --data "custom_id=SOME_CUSTOM_ID"
 ```
 
 parameter                       | default | description
@@ -212,12 +212,12 @@ A [Consumer][consumer-object] can have many credentials.
 Then you can finally provision new OAuth 2.0 credentials (also called "OAuth applications") by making the following HTTP request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/{consumer_id}/oauth2 \
-    --data "name=Test%20Application" \
-    --data "client_id=SOME-CLIENT-ID" \
-    --data "client_secret=SOME-CLIENT-SECRET" \
-    --data "redirect_uris=http://some-domain/endpoint/" \
-    --data "hash_secret=true"
+curl -X POST http://kong:8001/consumers/{consumer_id}/oauth2 \
+  --data "name=Test%20Application" \
+  --data "client_id=SOME-CLIENT-ID" \
+  --data "client_secret=SOME-CLIENT-SECRET" \
+  --data "redirect_uris=http://some-domain/endpoint/" \
+  --data "hash_secret=true"
 ```
 
 `consumer_id`: The [Consumer][consumer-object] entity to associate the credentials to
@@ -238,12 +238,12 @@ If you are migrating your existing OAuth 2.0 applications and access tokens over
 * Migrate access tokens using the `/oauth2_tokens` endpoints in the Kong's Admin API. For example:
 
 ```bash
-$ curl -X POST http://kong:8001/oauth2_tokens \
-    --data 'credential.id=KONG-APPLICATION-ID' \
-    --data "token_type=bearer" \
-    --data "access_token=SOME-TOKEN" \
-    --data "refresh_token=SOME-TOKEN" \
-    --data "expires_in=3600"
+curl -X POST http://kong:8001/oauth2_tokens \
+  --data 'credential.id=KONG-APPLICATION-ID' \
+  --data "token_type=bearer" \
+  --data "access_token=SOME-TOKEN" \
+  --data "refresh_token=SOME-TOKEN" \
+  --data "expires_in=3600"
 ```
 
 form parameter                        | default | description
@@ -261,7 +261,11 @@ form parameter                        | default | description
 Active tokens can be listed and modified using the Admin API. A GET on the `/oauth2_tokens` endpoint returns the following:
 
 ```bash
-$ curl -sX GET http://kong:8001/oauth2_tokens/
+curl -sX GET http://kong:8001/oauth2_tokens/
+```
+
+Response:
+```json
 {
   "total": 2,
   "data": [
@@ -339,9 +343,7 @@ The authorization page is made of two parts:
 
 A diagram representing this flow:
 
-<div class="alert alert-info">
-  <a title="OAuth 2.0 Flow" href="/assets/images/docs/oauth2/oauth2-flow.png" target="_blank"><img src="/assets/images/docs/oauth2/oauth2-flow.png"/></a>
-</div>
+![OAuth2 flow](/assets/images/docs/oauth2/oauth2-flow.png)
 
 1. The client application will redirect the end user to the authorization page on your web application, passing `client_id`, `response_type` and `scope` (if required) as query string parameters. This is a sample authorization page:
     <div class="alert alert-info">
@@ -353,7 +355,7 @@ A diagram representing this flow:
 3. The client application will send the `client_id` in the query string, from which the web application can retrieve both the OAuth 2.0 application name, and developer name, by making the following request to Kong:
 
     ```bash
-    $ curl kong:8001/oauth2?client_id=XXX
+    curl kong:8001/oauth2?client_id=XXX
     ```
 
 4. If the end user authorized the application, the form will submit the data to your backend with a `POST` request, sending the `client_id`, `response_type` and `scope` parameters that were placed in `<input type="hidden" .. />` fields.
@@ -361,13 +363,13 @@ A diagram representing this flow:
 5. The backend must add the `provision_key` and `authenticated_userid` parameters to the `client_id`, `response_type` and `scope` parameters and it will make a `POST` request to Kong at your Service address, on the `/oauth2/authorize` endpoint. If an `Authorization` header has been sent by the client, that must be added too. The equivalent of:
 
     ```bash
-    $ curl https://your.service.com/oauth2/authorize \
-        --header "Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW" \
-        --data "client_id=XXX" \
-        --data "response_type=XXX" \
-        --data "scope=XXX" \
-        --data "provision_key=XXX" \
-        --data "authenticated_userid=XXX"
+    curl https://your.service.com/oauth2/authorize \
+      --header "Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW" \
+      --data "client_id=XXX" \
+      --data "response_type=XXX" \
+      --data "scope=XXX" \
+      --data "provision_key=XXX" \
+      --data "authenticated_userid=XXX"
     ```
 
     The `provision_key` is the key the plugin has generated when it has been added to the Service while `authenticated_userid` is the ID of the logged-in end user who has granted the permission.
@@ -407,16 +409,16 @@ The [Resource Owner Password Credentials Grant](https://tools.ietf.org/html/rfc6
 2. The backend of your web-application will authenticate the `username` and `password` sent by the client, and if successful will add the `provision_key`, `authenticated_userid` and `grant_type` parameters to the parameters originally sent by the client, and it will make a `POST` request to Kong at, on the `/oauth2/token` endpoint of the configured plugin. If an `Authorization` header has been sent by the client, that must be added too. The equivalent of:
 
     ```bash
-    $ curl https://your.service.com/oauth2/token \
-        --header "Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW" \
-        --data "client_id=XXX" \
-        --data "client_secret=XXX" \
-        --data "grant_type=password" \
-        --data "scope=XXX" \
-        --data "provision_key=XXX" \
-        --data "authenticated_userid=XXX" \
-        --data "username=XXX" \
-        --data "password=XXX"
+    curl https://your.service.com/oauth2/token \
+      --header "Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW" \
+      --data "client_id=XXX" \
+      --data "client_secret=XXX" \
+      --data "grant_type=password" \
+      --data "scope=XXX" \
+      --data "provision_key=XXX" \
+      --data "authenticated_userid=XXX" \
+      --data "username=XXX" \
+      --data "password=XXX"
     ```
 
     The `provision_key` is the key the plugin has generated when it has been added to the Service, while `authenticated_userid` is the ID of the end user whose `username` and `password` belong to.
@@ -436,11 +438,11 @@ In this flow, the steps that you need to implement are:
 When your access token expires, you can generate a new access token using the refresh token you received in conjunction to your expired access token.
 
 ```bash
-$ curl -X POST https://your.service.com/oauth2/token \
-    --data "grant_type=refresh_token" \
-    --data "client_id=XXX" \
-    --data "client_secret=XXX" \
-    --data "refresh_token=XXX"
+curl -X POST https://your.service.com/oauth2/token \
+  --data "grant_type=refresh_token" \
+  --data "client_id=XXX" \
+  --data "client_secret=XXX" \
+  --data "refresh_token=XXX"
 ```
 
 ----
@@ -450,7 +452,7 @@ $ curl -X POST https://your.service.com/oauth2/token \
 The same access tokens can be used by gRPC applications:
 
 ```bash
-$ grpcurl -H 'authorization: bearer XXX' ...
+grpcurl -H 'authorization: bearer XXX' ...
 ```
 
 Note that the rest of the credentials flow uses HTTPS and not gRPC protocol.  Depending on your application, you might have to configure the `oauth2` plugin on two separate routes: one under `protocols: ["https"]` and another under `protocols: ["grpcs"]`.
@@ -466,45 +468,58 @@ will be rejected as an invalid WebSocket handshake. Therefore, to use this
 plugin with WebSocket services, an additional non-WebSocket route must be used
 to issue tokens.
 
-```bash
-# create a WebSocket service
-$ curl -X POST http://localhost:8001/services/ \
-  --data "name=my-websocket-service" \
-  --data "url=ws://my-websocket-backend:8080/"
+1. Create a WebSocket service:
+  ```bash
+  curl -X POST http://localhost:8001/services/ \
+    --data "name=my-websocket-service" \
+    --data "url=ws://my-websocket-backend:8080/"
+  ```
 
-# attach a route to the service
-$ curl -X POST http://localhost:8001/services/my-websocket-service/routes \
-  --data "name=my-websocket-route" \
-  --data "protocols=wss" \
-  --data "hosts=my-websocket-hostname.com" \
+2. Attach a route to the service:
+  ```sh
+  curl -X POST http://localhost:8001/services/my-websocket-service/routes \
+    --data "name=my-websocket-route" \
+    --data "protocols=wss" \
+    --data "hosts=my-websocket-hostname.com" \
+  ```
 
-# attach an oauth2 plugin instance to the service
-#
-# NOTE: setting `global_credentials=true` is necessary to allow tokens
-# created by other plugin instances
-$ curl -x POST http://localhost:8001/services/my-websocket-service/plugins \
-  --data "name=oauth2" \
-  --data "config.scopes=email" \
-  --data "config.scopes=profile" \
-  --data "config.global_credentials=true"
+3. Attach an OAuth2 plugin instance to the service:
 
-# create another route to handle token creation
-#
-# NOTE: adding a POST method matcher ensures that regular WebSocket handshake
-# requests will not match this route
-$ curl -X POST http://localhost:8001/routes \
-  --data "name=my-websocket-token-helper" \
-  --data "protocols=https" \
-  --data "hosts=my-websocket-hostname.com" \
-  --data "methods=POST"
+  {:.note}
+  > **Note**: Setting `global_credentials=true` is necessary to allow tokens
+  created by other plugin instances.
 
-# finally, add the additional oauth2 plugin instance, using the same
-$ curl -x POST http://localhost:8001/routes/my-websocket-token-helper/plugins \
-  --data "name=oauth2" \
-  --data "config.scopes=email" \
-  --data "config.scopes=profile" \
-  --data "config.global_credentials=true"
-```
+  ```sh
+  curl -x POST http://localhost:8001/services/my-websocket-service/plugins \
+    --data "name=oauth2" \
+    --data "config.scopes=email" \
+    --data "config.scopes=profile" \
+    --data "config.global_credentials=true"
+  ```
+
+
+4. Create another route to handle token creation:
+  {:.note}
+  > **Note**: Adding a POST method matcher ensures that regular WebSocket
+  handshake requests will not match this route.
+
+  ```sh
+  curl -X POST http://localhost:8001/routes \
+    --data "name=my-websocket-token-helper" \
+    --data "protocols=https" \
+    --data "hosts=my-websocket-hostname.com" \
+    --data "methods=POST"
+  ```
+
+5. Finally, add the additional OAuth2 plugin instance, using the route:
+
+  ```sh
+  curl -x POST http://localhost:8001/routes/my-websocket-token-helper/plugins \
+    --data "name=oauth2" \
+    --data "config.scopes=email" \
+    --data "config.scopes=profile" \
+    --data "config.global_credentials=true"
+  ```
 
 Client token requests (for example: `POST https://my-websocket-hostname.com/oauth2/authorize`)
 will be handled by the `oauth2` plugin instance attached to the `my-websocket-token-helper`

--- a/app/_hub/kong-inc/opentelemetry/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/_index.md
@@ -253,9 +253,9 @@ The following is an example for adding a custom span using {{site.base_gateway}}
 2. Apply the Lua code using the `post-function` plugin using a cURL file upload:
 
     ```bash
-    $ curl -i -X POST http://<admin-hostname>:8001/plugins \
-        -F "name=post-function" \
-        -F "config.access[1]=@custom-span.lua"
+    curl -i -X POST http://<admin-hostname>:8001/plugins \
+      -F "name=post-function" \
+      -F "config.access[1]=@custom-span.lua"
 
     HTTP/1.1 201 Created
     ...

--- a/app/_hub/kong-inc/openwhisk/_index.md
+++ b/app/_hub/kong-inc/openwhisk/_index.md
@@ -21,7 +21,7 @@ installation: |
   You can either use the LuaRocks package manager to install the plugin
 
   ```bash
-  $ luarocks install kong-plugin-openwhisk
+  luarocks install kong-plugin-openwhisk
   ```
 
   or install it from [source](https://github.com/Kong/kong-plugin-openwhisk).
@@ -121,7 +121,7 @@ function main(params) {
 ```
 
 ```bash
-$ wsk action create hello hello.js
+wsk action create hello hello.js
 ```
 
 ```
@@ -136,7 +136,7 @@ ok: created action hello
 Create a service:
 
 ```bash
-$ curl -i -X  POST http://localhost:8001/services/ \
+curl -i -X  POST http://localhost:8001/services/ \
   --data "name=openwhisk-test" \
   --data "url=http://example.com"
 ```
@@ -150,7 +150,7 @@ HTTP/1.1 201 Created
 Create a route that uses the service:
 
 ```bash
-$ curl -i -f -X  POST http://localhost:8001/services/openwhisk-test/routes/ \
+curl -i -f -X  POST http://localhost:8001/services/openwhisk-test/routes/ \
   --data "paths[]=/"
 ```
 
@@ -186,12 +186,12 @@ routes:
 Plugins can be enabled on a service or a route (or globally). This example uses a service.
 
 ```bash
-$ curl -i -X POST http://localhost:8001/services/openwhisk-test/plugins \
-    --data "name=openwhisk" \
-    --data "config.host=192.168.33.13" \
-    --data "config.service_token=username:key" \
-    --data "config.action=hello" \
-    --data "config.path=/api/v1/namespaces/guest"
+curl -i -X POST http://localhost:8001/services/openwhisk-test/plugins \
+  --data "name=openwhisk" \
+  --data "config.host=192.168.33.13" \
+  --data "config.service_token=username:key" \
+  --data "config.action=hello" \
+  --data "config.path=/api/v1/namespaces/guest"
 ```
 
 Response:
@@ -225,7 +225,7 @@ plugins:
 **Without parameters:**
 
   ```bash
-  $ curl -i -X POST http://localhost:8000/ -H "Host:example.com"
+  curl -i -X POST http://localhost:8000/ -H "Host:example.com"
   ```
 
   Response:
@@ -242,7 +242,7 @@ plugins:
 **Parameters as form-urlencoded:**
 
   ```bash
-  $ curl -i -X POST http://localhost:8000/ -H "Host:example.com" --data "name=bar"
+  curl -i -X POST http://localhost:8000/ -H "Host:example.com" --data "name=bar"
   ```
   Response:
   ```
@@ -257,7 +257,7 @@ plugins:
 **Parameters as JSON body:**
 
   ```bash
-  $ curl -i -X POST http://localhost:8000/ -H "Host:example.com" \
+  curl -i -X POST http://localhost:8000/ -H "Host:example.com" \
     -H "Content-Type:application/json" --data '{"name":"bar"}'
   ```
   Response:
@@ -273,7 +273,7 @@ plugins:
 **Parameters as multipart form:**
 
   ```bash
-  $ curl -i -X POST http://localhost:8000/ -H "Host:example.com"  -F name=bar
+  curl -i -X POST http://localhost:8000/ -H "Host:example.com"  -F name=bar
   ```
   Response:
   ```
@@ -290,9 +290,9 @@ plugins:
 **Parameters as querystring:**
 
   ```bash
-  $ curl -i -X POST http://localhost:8000/?name=foo -H "Host:example.com"
+  curl -i -X POST http://localhost:8000/?name=foo -H "Host:example.com"
   ```
-Response:
+  Response:
   ```
   HTTP/1.1 200 OK
   ...
@@ -308,9 +308,9 @@ Response:
   returned in the response.
 
   ```bash
-  $ curl -i -X POST http://localhost:8000/?name=foo -H "Host:example.com"
+  curl -i -X POST http://localhost:8000/?name=foo -H "Host:example.com"
   ```
-Response:
+  Response:
   ```
   HTTP/1.1 200 OK
   ...

--- a/app/_hub/kong-inc/prometheus/_index.md
+++ b/app/_hub/kong-inc/prometheus/_index.md
@@ -131,7 +131,11 @@ When `upstream_health_metrics` is set to true:
 Here is an example of output you could expect from the `/metrics` endpoint:
 
 ```bash
-$ curl -i http://localhost:8001/metrics
+curl -i http://localhost:8001/metrics
+```
+
+Response:
+```sh
 HTTP/1.1 200 OK
 Server: openresty/1.15.8.3
 Date: Tue, 7 Jun 2020 16:35:40 GMT

--- a/app/_hub/kong-inc/response-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/_index.md
@@ -196,7 +196,7 @@ similarly for Services.
 - Add multiple headers by passing each `header:value` pair separately:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
   --data "config.add.headers[2]=h2:v1"
@@ -218,7 +218,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Add multiple headers by passing comma-separated `header:value` pair:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
 ```
@@ -240,7 +240,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Add multiple headers passing config as a JSON body:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "response-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
 ```
@@ -261,7 +261,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Add a body property and a header:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.add.json=p1:v1,p2=v2" \
   --data "config.add.headers=h1:v1"
@@ -295,7 +295,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Append multiple headers and remove a body property:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "response-transformer-advanced", "config": {"append": {"headers": ["h1:v2", "h2:v1"]}, "remove": {"json": ["p1"]}}}'
 ```
@@ -321,7 +321,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Replace entire response body if response code is 500:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.replace.body='{\"error\": \"internal server error\"}'" \
   --data "config.replace.if_status=500"
@@ -369,7 +369,7 @@ end
 ```
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   -F "name=response-transformer-advanced" \
   -F "config.transform.functions=@transform.lua" \
   -F "config.transform.if_status=200"
@@ -378,7 +378,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Remove the entire header field with a given header name:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.remove.headers=h1,h2"
 ```
@@ -391,7 +391,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Remove a specific header value of a given header field:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.remove.headers=h1:v1,h1:v2"
 ```
@@ -403,7 +403,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Remove a specific header value from a comma-separated list of header values:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.remove.headers=h1:v1,h1:v2"
 ```
@@ -418,7 +418,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Remove a specific header value defined by a regular expression
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.remove.headers=h1:/JSESSIONID=.*/, h2://status/$/"
 ```
@@ -437,7 +437,7 @@ $ curl -X POST http://localhost:8001/routes/{route id}/plugins \
 - Explicitly set the type of the added JSON value `-1` to be a `number` (instead of the implicitly inferred type `string`) if the response code is 500:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route id}/plugins \
+curl -X POST http://localhost:8001/routes/{route id}/plugins \
   --data "name=response-transformer-advanced" \
   --data "config.add.json=p1:-1" \
   --data "config.add.json_types=number" \

--- a/app/_hub/kong-inc/response-transformer/_index.md
+++ b/app/_hub/kong-inc/response-transformer/_index.md
@@ -147,7 +147,7 @@ similar for Services.
 {% navtab With a database %}
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route}/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
   --data "name=response-transformer" \
   --data "config.add.headers[1]=h1:v1" \
   --data "config.add.headers[2]=h2:v1"
@@ -186,7 +186,7 @@ plugins:
 - Add multiple headers by passing comma separated header:value pair (only possible with a database):
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route}/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
   --data "name=response-transformer" \
   --data "config.add.headers=h1:v1,h2:v2"
 ```
@@ -207,7 +207,7 @@ $ curl -X POST http://localhost:8001/routes/{route}/plugins \
 - Add multiple headers passing config as JSON body (only possible with a database):
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route}/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "response-transformer", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
 ```
@@ -231,7 +231,7 @@ $ curl -X POST http://localhost:8001/routes/{route}/plugins \
 {% navtab With a database %}
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route}/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
   --data "name=response-transformer" \
   --data "config.add.json=p1:v1,p2=v2" \
   --data "config.add.headers=h1:v1"
@@ -281,7 +281,7 @@ plugins:
 {% navtab With a database %}
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/{route}/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "response-transformer", "config": {"append": {"headers": ["h1:v2", "h2:v1"]}, "remove": {"json": ["p1"]}}}'
 ```
@@ -324,7 +324,7 @@ plugins:
 - Explicitly set the type of the added JSON value `-1` to be a `number` (instead of the implicitly inferred type `string`) if the response code is 500:
 
 ```
-$ curl -X POST http://localhost:8001/routes/{route}/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
   --data "name=response-transformer" \
   --data "config.add.json=p1:-1" \
   --data "config.add.json_types=number"

--- a/app/_hub/kong-inc/route-by-header/_index.md
+++ b/app/_hub/kong-inc/route-by-header/_index.md
@@ -56,14 +56,22 @@ a Kong service `serviceA`, which routes all the requests to upstream `default.do
 Add an upstream object and a target:
 
 ```bash
-$ curl -i -X POST http://kong:8001/upstreams -d name=default.domain.com
+curl -i -X POST http://kong:8001/upstreams -d name=default.domain.com
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {created_at":1534537731231, .. "slots":10000}
 ```
 
 ```bash
-$ curl -i -X POST http://kong:8001/upstreams/default.domain.com/targets --data target="default.host.com:9000"
+curl -i -X POST http://kong:8001/upstreams/default.domain.com/targets --data target="default.host.com:9000"
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534538010468, .. ,"id":"ffd8815b-fd6c-4e0e-aa67-06e9cda39c3b"}
@@ -72,14 +80,22 @@ HTTP/1.1 201 Created
 Now we will add a `service` and a `route` object, using the upstream `default.domain.com` we just created:
 
 ```bash
-$ curl -i -X POST http://kong:8001/services --data protocol=http --data host=default.domain.com --data name=serviceA
+curl -i -X POST http://kong:8001/services --data protocol=http --data host=default.domain.com --data name=serviceA
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"host":"default.domain.com", .. ,"write_timeout":60000}
 ```
 
 ```bash
-$ curl -i -X POST http://kong:8001/routes  --data "paths[]=/" --data service.id=6e7f5274-62da-469e-bdd5-03c4a212c15b
+curl -i -X POST http://kong:8001/routes  --data "paths[]=/" --data service.id=6e7f5274-62da-469e-bdd5-03c4a212c15b
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534538701, .. ,"id":"12ceb66b-51ed-488a-9de0-112270e6f370"}
@@ -96,28 +112,44 @@ set to `us-west` to upstream `west.domain.com`.
 Add the two upstreams and corresponding targets:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/upstreams -d name=east.domain.com
+curl -i -X POST http://localhost:8001/upstreams -d name=east.domain.com
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534541064946, .. ,"slots":10000}
 ```
 
 ```bash
-$ curl -i -X POST http://kong:8001/upstreams/east.domain.com/targets --data target="east.host.com:9001"
+curl -i -X POST http://kong:8001/upstreams/east.domain.com/targets --data target="east.host.com:9001"
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534541248416, .. ,"id":"3164a588-09d7-4a72-895f-fa19535e3682"}
 ```
 
 ```bash
-$ curl -i -X POST http://localhost:8001/upstreams -d name=west.domain.com
+curl -i -X POST http://localhost:8001/upstreams -d name=west.domain.com
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534541385227, .. ,"slots":10000}
 ```
 
 ```bash
-$ curl -i -X POST http://kong:8001/upstreams/west.domain.com/targets --data target="west.host.com:9002"
+curl -i -X POST http://kong:8001/upstreams/west.domain.com/targets --data target="west.host.com:9002"
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534541405038, .. ,"id":"96cb469f-280f-4b0a-bd3d-1a0599b82585"}
@@ -126,7 +158,13 @@ HTTP/1.1 201 Created
 Enable plugin on service `serviceA`:
 
 ```bash
-$ curl -i -X POST http://kong:8001/services/serviceA/plugins -H 'Content-Type: application/json' --data '{"name": "route-by-header", "config": {"rules":[{"condition": {"location":"us-east"}, "upstream_name": "east.doamin.com"}, {"condition": {"location":"us-west"}, "upstream_name": "west.doamin.com"}]}}'
+curl -i -X POST http://kong:8001/services/serviceA/plugins \
+  -H 'Content-Type: application/json' \
+  --data '{"name": "route-by-header", "config": {"rules":[{"condition": {"location":"us-east"}, "upstream_name": "east.doamin.com"}, {"condition": {"location":"us-west"}, "upstream_name": "west.doamin.com"}]}}'
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 {"created_at":1534540916000,"config":{"rules":{"":"{\"condition\": {\"location\":\"us-east\"}, \"upstream_name\": \"east.doamin.com\"}, {\"condition\": {\"location\":\"us-west\"}, \"upstream_name\": \"west.doamin.com\"}"}},"id":"0df16085-76b2-4a50-ac30-c8a1eade389a","enabled":true,"service_id":"6e7f5274-62da-469e-bdd5-03c4a212c15b","name":"route-by-header"}
@@ -143,7 +181,13 @@ on the provided headers in the `condition` field of each rule.
 Let's patch above plugin to add one more rule with multiple headers:
 
 ```bash
-$ curl -i -X PATCH http://kong:8001/plugins/0df16085-76b2-4a50-ac30-c8a1eade389a -H 'Content-Type: application/json' --data '{"name": "route-by-header", "config": {"rules":[{"condition": {"location":"us-east"}, "upstream_name": "east.doamin.com"}, {"condition": {"location":"us-west"}, "upstream_name": "west.doamin.com"},  {"condition": {"location":"us-south", "region": "US"}, "upstream_name": "south.doamin.com"}]}}'
+curl -i -X PATCH http://kong:8001/plugins/0df16085-76b2-4a50-ac30-c8a1eade389a \
+  -H 'Content-Type: application/json' \
+  --data '{"name": "route-by-header", "config": {"rules":[{"condition": {"location":"us-east"}, "upstream_name": "east.doamin.com"}, {"condition": {"location":"us-west"}, "upstream_name": "west.doamin.com"},  {"condition": {"location":"us-south", "region": "US"}, "upstream_name": "south.doamin.com"}]}}'
+```
+
+Response:
+```
 HTTP/1.1 200 OK
 ...
 {"created_at":1534540916000,"config":{"rules":{"":"{\"condition\": {\"location\":\"us-east\"}, \"upstream_name\": \"east.doamin.com\"}, {\"condition\": {\"location\":\"us-west\"}, \"upstream_name\": \"west.doamin.com\"}, {\"condition\": {\"location\":\"us-south\", \"region\": \"us\"}, \"upstream_name\": \"south.doamin.com\"}"}},"id":"0df16085-76b2-4a50-ac30-c8a1eade389a","enabled":true,"service_id":"6e7f5274-62da-469e-bdd5-03c4a212c15b","name":"route-by-header"}

--- a/app/_hub/kong-inc/serverless-functions/_index.md
+++ b/app/_hub/kong-inc/serverless-functions/_index.md
@@ -96,22 +96,16 @@ params:
 1. Create a service on Kong:
 
     ```bash
-    $ curl -i -X  POST http://localhost:8001/services/ \
+    curl -i -X  POST http://localhost:8001/services/ \
       --data "name=plugin-testing" \
       --data "url=http://httpbin.org/headers"
-
-    HTTP/1.1 201 Created
-    ...
     ```
 
 2. Add a route to the service:
 
     ```bash
-    $ curl -i -X  POST http://localhost:8001/services/plugin-testing/routes \
+    curl -i -X  POST http://localhost:8001/services/plugin-testing/routes \
       --data "paths[]=/test"
-
-    HTTP/1.1 201 Created
-    ...
     ```
 
 1. Create a file named `custom-auth.lua` with the following content:
@@ -133,20 +127,23 @@ params:
 4. Ensure the file contents:
 
     ```bash
-    $ cat custom-auth.lua
+    cat custom-auth.lua
     ```
 
 5. Apply our Lua code using the `pre-function` plugin using cURL file upload:
 
     ```bash
-    $ curl -i -X POST http://localhost:8001/services/plugin-testing/plugins \
+    curl -i -X POST http://localhost:8001/services/plugin-testing/plugins \
         -F "name=pre-function" \
         -F "config.access[1]=@custom-auth.lua" \
         -F "config.access[2]=kong.log.err('Hi there Access!')" \
         -F "config.header_filter[1]=kong.log.err('Hi there Header_Filter!')" \
         -F "config.body_filter[1]=kong.log.err('Hi there Body_Filter!')" \
         -F "config.log[1]=kong.log.err('Hi there Log!')"
+    ```
 
+    Response:
+    ```
     HTTP/1.1 201 Created
     ...
     ```

--- a/app/_hub/kong-inc/session/_index.md
+++ b/app/_hub/kong-inc/session/_index.md
@@ -14,7 +14,6 @@ description: |
 type: plugin
 categories:
   - authentication
-source_url: 'https://github.com/Kong/kong-plugin-session'
 kong_version_compatibility:
   community_edition:
     compatible: true

--- a/app/_hub/kong-inc/session/_index.md
+++ b/app/_hub/kong-inc/session/_index.md
@@ -162,7 +162,7 @@ For usage with [Key Auth] plugin
    mockbin.org, which echoes the request:
 
    ```bash
-   $ curl -i -X POST \
+   curl -i -X POST \
      --url http://localhost:8001/services/ \
      --data 'name=example-service' \
      --data 'url=http://mockbin.org/request'
@@ -171,7 +171,7 @@ For usage with [Key Auth] plugin
    Add a route to the Service:
 
    ```bash
-   $ curl -i -X POST \
+   curl -i -X POST \
      --url http://localhost:8001/services/example-service/routes \
      --data 'paths[]=/sessions-test'
    ```
@@ -184,7 +184,7 @@ For usage with [Key Auth] plugin
    Issue the following cURL request to add the key-auth plugin to the Service:
 
    ```bash
-   $ curl -i -X POST \
+   curl -i -X POST \
      --url http://localhost:8001/services/example-service/plugins/ \
      --data 'name=key-auth'
    ```
@@ -197,7 +197,7 @@ For usage with [Key Auth] plugin
    plugin is properly configured on the Service:
 
    ```bash
-   $ curl -i -X GET \
+   curl -i -X GET \
      --url http://localhost:8000/sessions-test
    ```
 
@@ -211,7 +211,7 @@ For usage with [Key Auth] plugin
    the following request:
 
    ```bash
-   $ curl -i -X POST \
+   curl -i -X POST \
      --url http://localhost:8001/consumers/ \
      --data "username=anonymous_users"
    ```
@@ -221,7 +221,7 @@ For usage with [Key Auth] plugin
    Now create a consumer that authenticates via sessions:
 
    ```bash
-   $ curl -i -X POST \
+   curl -i -X POST \
      --url http://localhost:8001/consumers/ \
      --data "username=fiona"
    ```
@@ -229,7 +229,7 @@ For usage with [Key Auth] plugin
 1. Provision `key-auth` credentials for your Consumer
 
    ```bash
-   $ curl -i -X POST \
+   curl -i -X POST \
      --url http://localhost:8001/consumers/fiona/key-auth/ \
      --data 'key=open_sesame'
    ```
@@ -241,7 +241,7 @@ For usage with [Key Auth] plugin
    from previous steps**):
 
    ```bash
-   $ curl -i -X PATCH \
+   curl -i -X PATCH \
      --url http://localhost:8001/plugins/<your-key-auth-plugin-id> \
      --data "config.anonymous=<anonymous_consumer_id>"
    ```
@@ -249,10 +249,10 @@ For usage with [Key Auth] plugin
 1. Add the Kong Session plugin to the service
 
    ```bash
-   $ curl -X POST http://localhost:8001/services/example-service/plugins \
-       --data "name=session"  \
-       --data "config.storage=kong" \
-       --data "config.cookie_secure=false"
+   curl -X POST http://localhost:8001/services/example-service/plugins \
+     --data "name=session"  \
+     --data "config.storage=kong" \
+     --data "config.cookie_secure=false"
    ```
 
    > Note: cookie_secure is true by default, and should always be true, but is set to
@@ -264,11 +264,11 @@ For usage with [Key Auth] plugin
    authentication credentials, enable the Request Termination plugin.
 
    ```bash
-   $ curl -X POST http://localhost:8001/services/example-service/plugins \
-       --data "name=request-termination"  \
-       --data "config.status_code=403" \
-       --data "config.message=So long and thanks for all the fish!" \
-       --data "consumer.id=<anonymous_consumer_id>"
+   curl -X POST http://localhost:8001/services/example-service/plugins \
+     --data "name=request-termination"  \
+     --data "config.status_code=403" \
+     --data "config.message=So long and thanks for all the fish!" \
+     --data "consumer.id=<anonymous_consumer_id>"
    ```
 
 ### Set up Without a Database
@@ -320,8 +320,8 @@ plugins:
 1. Check that Anonymous requests are disabled:
 
    ```bash
-     $ curl -i -X GET \
-       --url http://localhost:8000/sessions-test
+   curl -i -X GET \
+     --url http://localhost:8000/sessions-test
    ```
 
    Should return `403`.
@@ -329,7 +329,7 @@ plugins:
 2. Verify that a user can authenticate via sessions
 
    ```bash
-   $ curl -i -X GET \
+   curl -i -X GET \
      --url http://localhost:8000/sessions-test?apikey=open_sesame
    ```
 
@@ -345,9 +345,9 @@ plugins:
    Use it like this:
 
    ```bash
-     $ curl -i -X GET \
-       --url http://localhost:8000/sessions-test \
-       -H "cookie:session=emjbJ3MdyDsoDUkqmemFqw..|1544654411|4QMKAE3I-jFSgmvjWApDRmZHMB8."
+   curl -i -X GET \
+     --url http://localhost:8000/sessions-test \
+     -H "cookie:session=emjbJ3MdyDsoDUkqmemFqw..|1544654411|4QMKAE3I-jFSgmvjWApDRmZHMB8."
    ```
 
    This request should succeed and the `Set-Cookie` response header does not appear

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -79,9 +79,13 @@ In order to use the plugin, you first need to create a Consumer to associate one
 You need to associate a credential to an existing [Consumer][consumer-object] object. To create a Consumer, you can execute the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/ \
-    --data "username=<USERNAME>" \
-    --data "custom_id=<CUSTOM_ID>"
+curl -X POST http://kong:8001/consumers/ \
+  --data "username=<USERNAME>" \
+  --data "custom_id=<CUSTOM_ID>"
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 
 {
@@ -117,7 +121,7 @@ in a vault. References must follow a [specific format](/gateway/latest/plan-and-
 Vault objects can be created via the following HTTP request:
 
 ```bash
-$ curl -X POST http://localhost:8001/vault-auth \
+curl -X POST http://localhost:8001/vault-auth \
   --header 'Content-Type: multipart/form-data' \
   --form name=kong-auth \
   --form mount=kong-auth \
@@ -127,7 +131,7 @@ $ curl -X POST http://localhost:8001/vault-auth \
   --form vault_token=<token>
 ```
 
-```bash
+```json
 HTTP/1.1 201 Created
 
 {
@@ -152,7 +156,11 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 Token pairs can be managed either via the Kong Admin API, or independently via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/vault-auth/{vault}/credentials/{consumer}
+curl -X POST http://kong:8001/vault-auth/{vault}/credentials/{consumer}
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 
 {
@@ -175,9 +183,13 @@ When the `access_token` or `secret_token` values are not provided, token values 
 Vault objects are treated as foreign references in plugin configs, creating a seamless lifecycle relationship between Vault instances and plugins with which they're associated. `vault-auth` plugins require an association with a Vault object, which can be defined with the following HTTP request during plugin creation:
 
 ```bash
-$ curl -X POST http://kong:8001/plugins \
+curl -X POST http://kong:8001/plugins \
   --data name=vault-auth \
   --data config.vault.id=<uuid>
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 
 {
@@ -211,15 +223,15 @@ Where `<uuid>` is the `id` of an existing Vault object.
 Simply make a request with the `access_token` and `secret_token` as querystring parameters:
 
 ```bash
-$ curl http://kong:8000/{proxy path}?access_token=<access token>&secret_token=<secret token>
+curl http://kong:8000/{proxy path}?access_token=<access token>&secret_token=<secret token>
 ```
 
 Or in a header:
 
 ```bash
-$ curl http://kong:8000/{proxy path} \
-    -H 'access_token: <access_token>' \
-    -H 'secret_token: <secret_token>'
+curl http://kong:8000/{proxy path} \
+  -H 'access_token: <access_token>' \
+  -H 'secret_token: <secret_token>'
 ```
 
 ### Deleting an Access/Secret Token Pair
@@ -227,8 +239,11 @@ $ curl http://kong:8000/{proxy path} \
 Existing Vault credentials can be removed from the Vault server via the following API:
 
 ```bash
-$ curl -X DELETE http://kong:8001/vault-auth/{vault}/credentials/token/{access token}
+curl -X DELETE http://kong:8001/vault-auth/{vault}/credentials/token/{access token}
+```
 
+Response:
+```
 HTTP/1.1 204 No Content
 ```
 
@@ -258,7 +273,7 @@ Additional fields within the secret are ignored. The key must be the `access_tok
 `vault-auth` token pairs can be created with the Vault HTTP API or the `vault write` command:
 
 ```bash
-$ vault write kong-auth/foo - <<EOF
+vault write kong-auth/foo - <<EOF
 {
   "access_token": "foo",
   "secret_token": "supersecretvalue",
@@ -270,6 +285,7 @@ $ vault write kong-auth/foo - <<EOF
 EOF
 ```
 
+---
 
 ## Changelog
 

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -254,8 +254,8 @@ the <code>{{include.params.name}}</code> plugin on a
 Make the following request:
 
 ```bash
-$ curl -X POST http://localhost:8001/routes/ROUTE_NAME|ROUTE_ID/plugins \
-    --data "name={{include.params.name}}" {{ config_required_fields }}
+curl -X POST http://localhost:8001/routes/ROUTE_NAME|ROUTE_ID/plugins \
+  --data "name={{include.params.name}}" {{ config_required_fields }}
 ```
 
 Replace `ROUTE_NAME|ROUTE_ID` with the `id` or `name` of the route that this plugin configuration will target.
@@ -391,8 +391,8 @@ the <code>{{include.params.name}}</code> plugin on a
 Make the following request:
 
 ```bash
-$ curl -X POST http://localhost:8001/consumers/CONSUMER_NAME|CONSUMER_ID/plugins \
-    --data "name={{include.params.name}}" {{ config_required_fields }}
+curl -X POST http://localhost:8001/consumers/CONSUMER_NAME|CONSUMER_ID/plugins \
+  --data "name={{include.params.name}}" {{ config_required_fields }}
 ```
 
 Replace `CONSUMER_NAME|CONSUMER_ID` with the `id` or `name` of the consumer that this plugin configuration will target.
@@ -510,8 +510,8 @@ the <code>{{include.params.name}}</code> plugin globally.
 Make the following request:
 
 ```bash
-$ curl -X POST http://localhost:8001/plugins/ \
-    --data "name={{include.params.name}}" {{ config_required_fields }}
+curl -X POST http://localhost:8001/plugins/ \
+  --data "name={{include.params.name}}" {{ config_required_fields }}
 ```
 
 {% endnavtab %}

--- a/src/gateway/get-started/proxy-caching.md
+++ b/src/gateway/get-started/proxy-caching.md
@@ -5,27 +5,27 @@ book: get-started
 chapter: 4
 ---
 
-One of the ways Kong delivers performance is through caching. 
+One of the ways Kong delivers performance is through caching.
 The [Proxy Cache plugin](/hub/kong-inc/proxy-cache/) accelerates performance by caching
 responses based on configurable response codes, content types, and request methods.
-When caching is enabled, upstream services are not bogged down with repetitive requests, 
-because {{site.base_gateway}} responds on their behalf with cached results. Caching can be 
+When caching is enabled, upstream services are not bogged down with repetitive requests,
+because {{site.base_gateway}} responds on their behalf with cached results. Caching can be
 enabled on specific {{site.base_gateway}} objects or for all requests globally.
 
 ### Cache Time To Live (TTL)
 
-TTL governs the refresh rate of cached content, which is critical for ensuring 
-that clients aren't served outdated content. A TTL of 30 seconds means content older than 
-30 seconds is deemed expired and will be refreshed on subsequent requests. 
-TTL configurations should be set differently based on the type of the content the upstream 
-service is serving. 
+TTL governs the refresh rate of cached content, which is critical for ensuring
+that clients aren't served outdated content. A TTL of 30 seconds means content older than
+30 seconds is deemed expired and will be refreshed on subsequent requests.
+TTL configurations should be set differently based on the type of the content the upstream
+service is serving.
 
 * Static data that is rarely updated can have longer TTL
 
 * Dynamic data should use shorter TTL to avoid serving outdated data  
 
 {{site.base_gateway}} follows [RFC-7234 section 5.2](https://tools.ietf.org/html/rfc7234)
-for cached controlled operations. See the specification and the Proxy Cache 
+for cached controlled operations. See the specification and the Proxy Cache
 plugin [parameter reference](/hub/kong-inc/proxy-cache/#parameters) for more details on TTL configurations.
 
 ## Enable caching
@@ -35,13 +35,13 @@ The following tutorial walks through managing proxy caching across various aspec
 ### Prerequisites
 
 This chapter is part of the *Get Started with Kong* series. For the best experience, it is recommended that you follow the
-series from the beginning. 
+series from the beginning.
 
 Start with the introduction [Get Kong](/gateway/latest/get-started/), which includes
 a list of prerequisites and instructions for running a local {{site.base_gateway}}.
 
 Step two of the guide, [Services and Routes](/gateway/latest/get-started/services-and-routes),
-includes instructions for installing a mock service used throughout this series. 
+includes instructions for installing a mock service used throughout this series.
 
 If you haven't completed these steps already, complete them before proceeding.
 
@@ -52,9 +52,9 @@ will potentially be cached.
 
 1. **Enable proxy caching**
 
-   The Proxy Cache plugin is installed by default on {{site.base_gateway}}, and can be enabled by 
+   The Proxy Cache plugin is installed by default on {{site.base_gateway}}, and can be enabled by
    sending a `POST` request to the plugins object on the Admin API:
-   
+
    ```sh
    curl -i -X POST http://localhost:8001/plugins \
      --data "name=proxy-cache" \
@@ -64,15 +64,15 @@ will potentially be cached.
      --data "config.cache_ttl=30" \
      --data "config.strategy=memory"
    ```
-   
-   If configuration was successful, you will receive a `201` response code. 
-  
+
+   If configuration was successful, you will receive a `201` response code.
+
    This Admin API request configured a Proxy Cache plugin for all `GET` requests that resulted
    in response codes of `200` and *response* `Content-Type` headers that *equal*
    `application/json; charset=utf-8`. `cache_ttl` instructed the plugin to flush values after 30 seconds.
-   
+
    The final option `config.strategy=memory` specifies the backing data store for cached responses. More
-   information on `strategy` can be found in the [parameter reference](/hub/kong-inc/proxy-cache/) 
+   information on `strategy` can be found in the [parameter reference](/hub/kong-inc/proxy-cache/)
    for the Proxy Cache plugin.
 
 1. **Validate**
@@ -81,20 +81,20 @@ will potentially be cached.
    the returned headers. In step two of this guide, [services and routes](/gateway/latest/get-started/services-and-routes),
    you setup a `/mock` route and service that can help you see proxy caching in action.
 
-   First, make an initial request to the `/mock` route. The Proxy Cache plugin returns status 
+   First, make an initial request to the `/mock` route. The Proxy Cache plugin returns status
    information headers prefixed with `X-Cache`, so use `grep` to filter for that information:
 
    ```
    curl -i -s -XGET http://localhost:8000/mock/requests | grep X-Cache
    ```
-  
+
    On the initial request, there should be no cached responses, and the headers will indicate this with
    `X-Cache-Status: Miss`.
 
    ```
    X-Cache-Key: c9e1d4c8e5fd8209a5969eb3b0e85bc6
    X-Cache-Status: Miss
-   ``` 
+   ```
 
    Within 30 seconds of the initial request, repeat the command to send an identical request and the
    headers will indicate a cache `Hit`:
@@ -105,7 +105,7 @@ will potentially be cached.
    ```
 
    The `X-Cache-Status` headers can return the following cache results:
-   
+
    |State| Description|
    |---|---|
    |Miss| The request could be satisfied in cache, but an entry for the resource was not found in cache, and the request was proxied upstream.|
@@ -132,7 +132,7 @@ curl -X POST http://localhost:8001/services/example_service/plugins \
 The Proxy Caching plugin can be enabled for specific routes. The request is the same as above, but the request is sent to the route URL:
 
 ```sh
-$ curl -X POST http://localhost:8001/routes/example_route/plugins \
+curl -X POST http://localhost:8001/routes/example_route/plugins \
    --data "name=proxy-cache" \
    --data "config.request_method=GET" \
    --data "config.response_code=200" \
@@ -143,10 +143,10 @@ $ curl -X POST http://localhost:8001/routes/example_route/plugins \
 
 ### Consumer level proxy caching
 
-In {{site.base_gateway}}, [consumers](/gateway/latest/admin-api/#consumer-object) are an abstraction that defines a user of a service. 
+In {{site.base_gateway}}, [consumers](/gateway/latest/admin-api/#consumer-object) are an abstraction that defines a user of a service.
 Consumer-level proxy caching can be used to cache responses per consumer.
 
-1. **Create a consumer** 
+1. **Create a consumer**
 
 Consumers are created using the consumer object in the Admin API.
 
@@ -173,10 +173,10 @@ The Proxy Cache plugin supports administrative endpoints to manage cached entiti
 view and delete cached entities, or purge the entire cache by sending requests to the Admin API.
 
 To retrieve the cached entity, submit a request to the Admin API `/proxy-cache` endpoint with the
-`X-Cache-Key` value of a known cached value. This request must be submitted prior to the TTL expiration, 
-otherwise the cached entity has been purged. 
+`X-Cache-Key` value of a known cached value. This request must be submitted prior to the TTL expiration,
+otherwise the cached entity has been purged.
 
-For example, using the response headers above, pass the `X-Cache-Key` value of 
+For example, using the response headers above, pass the `X-Cache-Key` value of
 `c9e1d4c8e5fd8209a5969eb3b0e85bc6` to the Admin API:
 
 ```sh
@@ -187,4 +187,3 @@ A response with `200 OK` will contain full details of the cached entity.
 
 See the [Proxy Cache plugin documentation](/hub/kong-inc/proxy-cache/#admin-api) for the full list of the
 Proxy Cache specific Admin API endpoints.
-

--- a/src/gateway/get-started/quickstart/enabling-plugins.md
+++ b/src/gateway/get-started/quickstart/enabling-plugins.md
@@ -25,7 +25,7 @@ To configure the key-auth plugin for the Service you <a href="/gateway/{{page.ko
 issue the following cURL request:
 
 ```bash
-$ curl -i -X POST \
+curl -i -X POST \
   --url http://localhost:8001/services/example-service/plugins/ \
   --data 'name=key-auth'
 ```

--- a/src/gateway/get-started/ratelimiting.md
+++ b/src/gateway/get-started/ratelimiting.md
@@ -6,12 +6,12 @@ content-type: tutorial
 
 ## What is rate limiting?
 
-Rate limiting is used to control the rate of requests sent to an upstream service. It can be used to prevent DoS attacks, limit web scraping, and other forms of overuse. Without rate limiting, a user may make requests as often as they like, this leads to traffic spikes and it can impact other users of your upstream services. In {{site.base_gateway}} rate limiting allows you to set parameters that limit requests to your upstream service. 
+Rate limiting is used to control the rate of requests sent to an upstream service. It can be used to prevent DoS attacks, limit web scraping, and other forms of overuse. Without rate limiting, a user may make requests as often as they like, this leads to traffic spikes and it can impact other users of your upstream services. In {{site.base_gateway}} rate limiting allows you to set parameters that limit requests to your upstream service.
 
 
 ## The rate limiting plugin
 
-{{site.base_gateway}} manages rate limiting through the use of Kong's [Rate Limiting plugin](/hub/kong-inc/rate-limiting). The rate limiting plugin has an open source and an enterprise version, with the enterprise version giving you access to features like [sliding window algorithm support](https://en.wikipedia.org/wiki/Sliding_window_protocol), and Redis support. 
+{{site.base_gateway}} manages rate limiting through the use of Kong's [Rate Limiting plugin](/hub/kong-inc/rate-limiting). The rate limiting plugin has an open source and an enterprise version, with the enterprise version giving you access to features like [sliding window algorithm support](https://en.wikipedia.org/wiki/Sliding_window_protocol), and Redis support.
 
 
 The rate limiting plug-ins limit how often each user can call the API. This protects them from inadvertent or malicious overuse. Without rate limiting, each user may request as often as they like, which can lead to “spikes” of requests that starve other consumers. After rate limiting is enabled, they are limited to a fixed number of requests per second. Kong offers an open source and an Enterprise version of the rate limiting plug-in, with the Enterprise version providing support for the sliding window algorithm to prevent the API from being overloaded near window boundaries, and adds Redis support for greater performance. For this guide we will use the Enterprise version of plug-in.  More details on the advanced rate limiting plug-in can be found here.
@@ -27,7 +27,7 @@ Kong's [Rate Limiting plugin](/hub/kong-inc/rate-limiting) lets you restrict how
 ## Configure the Rate Limiting plugin
 
 
-To activate a plugin send a `POST` request to the [plugins](/gateway/latest/admin-api/#add-plugin) object of the Admin API: 
+To activate a plugin send a `POST` request to the [plugins](/gateway/latest/admin-api/#add-plugin) object of the Admin API:
 
 ```sh
 curl -i -X POST http://localhost:8001/plugins \
@@ -40,9 +40,9 @@ This request configures the rate limiting plugin to enforce rate limiting on req
 
 ### validate rate limiting
 
-After configuring rate limiting, you can verify that it was configured correctly and is working, by creating 6 requests within a 5 minute period. 
-To validate rate limiting, send a request to the API six (6) times from the CLI to confirm the requests are rate limited. 
-If you configured {{site.base_gateway}} with the [configure services and routes](/gateway/latest/get-started/configure-services-and-routes) guide use the example below, otherwise substitute the existing values for your own: 
+After configuring rate limiting, you can verify that it was configured correctly and is working, by creating 6 requests within a 5 minute period.
+To validate rate limiting, send a request to the API six (6) times from the CLI to confirm the requests are rate limited.
+If you configured {{site.base_gateway}} with the [configure services and routes](/gateway/latest/get-started/configure-services-and-routes) guide use the example below, otherwise substitute the existing values for your own:
 
 {% navtabs %}
 {% navtab Admin API %}
@@ -71,9 +71,9 @@ After the 6th request, you should receive a 429 "API rate limit exceeded" error:
 }
 ```
 
-Every request triggers a counter that checks against the policy that was configured in the `POST` request. 
+Every request triggers a counter that checks against the policy that was configured in the `POST` request.
 The value `config.policy = local` instructs {{site.base_gateway}} to store the policies and counters locally in memory.
-The available options for `config.policy` are: 
+The available options for `config.policy` are:
 
 * `local` - Counters are stored locally in-memory on the node.
 * `cluster` - Counters are stored in the Kong data store and shared across the nodes.
@@ -83,13 +83,13 @@ The available options for `config.policy` are:
 ### Rate limiting by domain
 
 
-The Rate Limiting plugin can be enabled and associated to three different scopes: 
+The Rate Limiting plugin can be enabled and associated to three different scopes:
 
 * Service — restricts every consumer making requests to the service.
 
 * Route — restricts every consumer making requests to the specific route of the service.
 
-* Consumer — restricts only that specified consumer making requests to any routes of the service, using a `consumer_id`. 
+* Consumer — restricts only that specified consumer making requests to any routes of the service, using a `consumer_id`.
 
 
 ### Service-level rate limiting
@@ -108,7 +108,7 @@ curl -X POST http://localhost:8001/services/example_service/plugins \
 
 ### Route-level rate limiting
 
-You can limit traffic to a specific route: 
+You can limit traffic to a specific route:
 
 ```sh
 
@@ -119,7 +119,7 @@ curl -X POST http://localhost:8001/routes/mock/plugins \
 
 ```
 
-If you did not follow the [configure services and routes](/gateway/latest/get-started/configure-services-and-routes) guide, replace the `mock` value with a `route_id`. 
+If you did not follow the [configure services and routes](/gateway/latest/get-started/configure-services-and-routes) guide, replace the `mock` value with a `route_id`.
 
 
 ### Consumer-level rate limiting
@@ -134,10 +134,10 @@ curl -X POST http://localhost:8001/consumers/ \
 
 ```
 
-And with the `example_consumer` variable, create another request to the `plugins` object, and pass `example_consumer` to the `consumer.id` parameter. 
+And with the `example_consumer` variable, create another request to the `plugins` object, and pass `example_consumer` to the `consumer.id` parameter.
 ```sh
 
-$ curl -X POST http://localhost:8001/plugins \
+curl -X POST http://localhost:8001/plugins \
 --data "name=rate-limiting" \
 --data "consumer.id=example_consumer" \
 --data "config.second=5" \
@@ -157,7 +157,7 @@ Rate Limiting Advanced provides:
 
 ### Additional configuration
 
-The configuration process for the Rate Limiting Advanced plugin is similar to configuring the Rate Limiting plugin. To configure the Rate Limiting Advanced plugin create a `POST` request like this: 
+The configuration process for the Rate Limiting Advanced plugin is similar to configuring the Rate Limiting plugin. To configure the Rate Limiting Advanced plugin create a `POST` request like this:
 
 ```sh
 
@@ -172,15 +172,13 @@ This request utilizes the `config.limit` and `config.window_size` form parameter
 
 
 * config.limit: Number of requests allows per window.
-* config.window_size: Window size to track request for in seconds. 
-* config.sync_rate: how often to sync counter data to the central data store. 	`-1` ignores sync behavior entirely and only stores counters in node memory, `>0 ` sync the counters in that many number of seconds. 
+* config.window_size: Window size to track request for in seconds.
+* config.sync_rate: how often to sync counter data to the central data store. 	`-1` ignores sync behavior entirely and only stores counters in node memory, `>0 ` sync the counters in that many number of seconds.
 
 
 The word "window" here refers to a window of time, and the requests that can be made within that time frame. In the request you created, 5 requests can be made within a 30 second window of time. On the 6th request, the server will return a `429` response code. You can add multiple `window_size` and `config.limit` parameters to this request to specify, with granularity, the rate limiting rules.  
 
 
-### Next steps 
+### Next steps
 
 The next tutorial in this series walks you through how and why to [configure proxy caching](/gateway/latest/get-started/configure-ratelimiting/).
-
-

--- a/src/gateway/how-kong-works/health-checks.md
+++ b/src/gateway/how-kong-works/health-checks.md
@@ -195,7 +195,11 @@ health checker that the target should be enabled again, via an
 Admin API endpoint:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
+curl -i -X POST http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
+```
+
+Response:
+```
 HTTP/1.1 204 No Content
 ```
 

--- a/src/gateway/how-kong-works/routing-traffic.md
+++ b/src/gateway/how-kong-works/routing-traffic.md
@@ -95,9 +95,13 @@ how Kong is configured via the [Admin API][API].
 Adding a service to {{site.base_gateway}} is done by sending an HTTP request to the Admin API:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/services/ \
-    -d 'name=foo-service' \
-    -d 'url=http://foo-service.com'
+curl -i -X POST http://localhost:8001/services/ \
+  -d 'name=foo-service' \
+  -d 'url=http://foo-service.com'
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 ...
 
@@ -127,10 +131,14 @@ Now, in order to send traffic to this service through {{site.base_gateway}}, we 
 a route, which acts as an entry point to {{site.base_gateway}}:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/routes/ \
-    -d 'hosts[]=example.com' \
-    -d 'paths[]=/foo' \
-    -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+curl -i -X POST http://localhost:8001/routes/ \
+  -d 'hosts[]=example.com' \
+  -d 'paths[]=/foo' \
+  -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+```
+
+Response:
+```json
 HTTP/1.1 201 Created
 ...
 
@@ -256,9 +264,13 @@ entity.
 them via the Admin API, and is represented in a JSON payload:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/routes/ \
-    -H 'Content-Type: application/json' \
-    -d '{"hosts":["example.com", "foo-service.com"]}'
+curl -i -X POST http://localhost:8001/routes/ \
+  -H 'Content-Type: application/json' \
+  -d '{"hosts":["example.com", "foo-service.com"]}'
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 ```
@@ -267,9 +279,13 @@ But since the Admin API also supports form-urlencoded content types, you
 can specify an array via the `[]` notation:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/routes/ \
-    -d 'hosts[]=example.com' \
-    -d 'hosts[]=foo-service.com'
+curl -i -X POST http://localhost:8001/routes/ \
+  -d 'hosts[]=example.com' \
+  -d 'hosts[]=foo-service.com'
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 ```
@@ -289,9 +305,13 @@ Host: foo-service.com
 
 Similarly, any other header can be used for routing:
 
+```sh
+curl -i -X POST http://localhost:8001/routes/ \
+  -d 'headers.region=north'
 ```
-$ curl -i -X POST http://localhost:8001/routes/ \
-    -d 'headers.region=north'
+
+Response:
+```
 HTTP/1.1 201 Created
 ```
 
@@ -616,8 +636,12 @@ Admin API, be sure to URL encode your payload if necessary**. For example,
 with `curl` and using an `application/x-www-form-urlencoded` MIME type:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/routes \
-    --data-urlencode 'uris[]=/status/\d+'
+curl -i -X POST http://localhost:8001/routes \
+  --data-urlencode 'uris[]=/status/\d+'
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 ```
@@ -1074,10 +1098,14 @@ Here is how to configure a TLS certificate on a given route: first, upload
 your TLS certificate and key via the Admin API:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/certificates \
-    -F "cert=@/path/to/cert.pem" \
-    -F "key=@/path/to/cert.key" \
-    -F "snis=*.tls-example.com,other-tls-example.com"
+curl -i -X POST http://localhost:8001/certificates \
+  -F "cert=@/path/to/cert.pem" \
+  -F "key=@/path/to/cert.key" \
+  -F "snis=*.tls-example.com,other-tls-example.com"
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 ```
@@ -1100,10 +1128,14 @@ A default certificate can be added using the following parameters in {{site.base
 Or, by dynamically configuring the default certificate with an SNI of `*`:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/certificates \
-    -F "cert=@/path/to/default-cert.pem" \
-    -F "key=@/path/to/default-cert.key" \
-    -F "snis=*"
+curl -i -X POST http://localhost:8001/certificates \
+  -F "cert=@/path/to/default-cert.pem" \
+  -F "key=@/path/to/default-cert.key" \
+  -F "snis=*"
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 ```
@@ -1120,9 +1152,13 @@ You must now register the following route within {{site.base_gateway}}. We match
 to this route using only the Host header for convenience:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/routes \
-    -d 'hosts=prefix.tls-example.com,other-tls-example.com' \
-    -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+curl -i -X POST http://localhost:8001/routes \
+  -d 'hosts=prefix.tls-example.com,other-tls-example.com' \
+  -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+```
+
+Response:
+```
 HTTP/1.1 201 Created
 ...
 ```
@@ -1130,8 +1166,12 @@ HTTP/1.1 201 Created
 You can now expect the route to be served over HTTPS by {{site.base_gateway}}:
 
 ```bash
-$ curl -i https://localhost:8443/ \
+curl -i https://localhost:8443/ \
   -H "Host: prefix.tls-example.com"
+```
+
+Response:
+```
 HTTP/1.1 200 OK
 ...
 ```

--- a/src/gateway/install/kubernetes/helm.md
+++ b/src/gateway/install/kubernetes/helm.md
@@ -79,20 +79,20 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
 1.  Create a session config file for Kong Manager:
 
     ```bash
-    $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
+    echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
     ```
 
 1.  Create a session config file for Kong Dev Portal:
 
     ```bash
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
     Or, if you have different subdomains for the `portal_api_url` and `portal_gui_host`, set the `cookie_domain`
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/src/gateway/install/kubernetes/openshift.md
+++ b/src/gateway/install/kubernetes/openshift.md
@@ -72,20 +72,20 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
 1.  Create a session config file for Kong Manager:
 
     ```bash
-    $ echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
+    echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
     ```
 
 1.  Create a session config file for Kong Dev Portal:
 
     ```bash
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
     Or, if you have different subdomains for the `portal_api_url` and `portal_gui_host`, set the `cookie_domain`
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/src/gateway/kong-enterprise/analytics/index.md
+++ b/src/gateway/kong-enterprise/analytics/index.md
@@ -73,8 +73,8 @@ The Status Codes view displays visualizations of cluster-wide status code classe
 1. Edit the configuration file to enable or disable Vitals:    
     ```bash
     # via your Kong configuration file; e.g., kong.conf
-    $ vitals = on  # vitals is enabled
-    $ vitals = off # vitals is disabled
+    vitals = on  # vitals is enabled
+    vitals = off # vitals is disabled
     ```
 2. Restart Kong.
 
@@ -84,8 +84,8 @@ The Status Codes view displays visualizations of cluster-wide status code classe
 1. Use environment variables to enable or disable Vitals:
     ```bash
     # or via environment variables
-    $ export KONG_VITALS=on
-    $ export KONG_VITALS=off
+    export KONG_VITALS=on
+    export KONG_VITALS=off
     ```
 
 2. Restart Kong.

--- a/src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -124,7 +124,7 @@ effort, but for proof-of-concept testing, running a local InfluxDB instance
 is possible with Docker:
 
 ```bash
-$ docker run -p 8086:8086 \
+docker run -p 8086:8086 \
   --network=<YOUR_NETWORK_NAME> \
   --name influxdb \
   -e INFLUXDB_DB=kong \
@@ -149,13 +149,13 @@ In addition to enabling Kong Vitals, {{site.base_gateway}} must be configured to
 backing strategy for Vitals. The InfluxDB host and port must also be defined:
 
 ```bash
-$ echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kong reload exit" \
+echo "KONG_VITALS_STRATEGY=influxdb KONG_VITALS_TSDB_ADDRESS=influxdb:8086 kong reload exit" \
 | docker exec -i kong-ee /bin/sh
 ```
 
 {:.note}
-> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy) 
-and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address) 
+> **Note**: In Hybrid Mode, configure [`vitals_strategy`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_strategy)
+and [`vitals_tsdb_address`](/gateway/{{page.kong_version}}/reference/configuration/#vitals_tsdb_address)
 on both the control plane and all data planes.
 
 ## Understanding Vitals data using InfluxDB measurements
@@ -174,13 +174,13 @@ in Docker:
 1. Open command line in your InfluxDB Docker container.
 
     ```sh
-    $ docker exec -it influxdb /bin/sh
+    docker exec -it influxdb /bin/sh
     ```
 
 2. Log in to the InfluxDB CLI.
 
     ```sh
-    $ influx -precision rfc3339
+    influx -precision rfc3339
     ```
 
 3. Enter the InfluxQL query for returning a list of tag keys associated

--- a/src/gateway/kong-enterprise/dev-portal/authentication/azure-oidc-config.md
+++ b/src/gateway/kong-enterprise/dev-portal/authentication/azure-oidc-config.md
@@ -211,7 +211,7 @@ flows with your Azure AD implementation.
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
+curl -X POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
 --data scope="<your_client_id>/.default" \
 --data grant_type="client_credentials" \
 --data client_id="<your_client_id>" \
@@ -222,7 +222,7 @@ $ curl -X POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/t
 {% navtab Using HTTPie %}
 
 ```bash
-$ https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
+https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
   scope=<your_client_id>/.default \
   grant_type=client_credentials \
   -a <your_client_id>:<your_client_secret> \

--- a/src/gateway/kong-enterprise/dev-portal/authentication/basic-auth.md
+++ b/src/gateway/kong-enterprise/dev-portal/authentication/basic-auth.md
@@ -66,7 +66,7 @@ portal_session_conf={ "cookie_name":"portal_session","secret":"<CHANGE_THIS>","s
 To patch a Dev Portal's authentication property directly, run:
 
 ```bash
-$ curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE_NAME> \
+curl -X PATCH http://localhost:8001/workspaces/<WORKSPACE_NAME> \
   --data "config.portal_auth=basic-auth"
 ```
 

--- a/src/gateway/kong-enterprise/secrets-management/advanced-usage.md
+++ b/src/gateway/kong-enterprise/secrets-management/advanced-usage.md
@@ -78,10 +78,10 @@ Create a Vault entity:
 {% navtab cURL %}
 
 ```bash
-$ curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault-1  \
-        --data name=env \
-        --data description='ENV vault for secrets' \
-        --data config.prefix=SECRET_
+curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault-1  \
+  --data name=env \
+  --data description='ENV vault for secrets' \
+  --data config.prefix=SECRET_
 ```
 
 {% endnavtab %}

--- a/src/gateway/kong-plugins/authentication/oidc/azure-ad.md
+++ b/src/gateway/kong-plugins/authentication/oidc/azure-ad.md
@@ -40,7 +40,7 @@ include a `YOUR_CLIENT_ID/.default` scope in your plugin configuration as shown 
 Add a plugin with the configuration below to your Route using an HTTP client or [Kong Manager][enable-plugin].
 
 ```bash
-$ curl -i -X POST https://admin.kong.example/routes/ROUTE_ID/plugins --data name="openid-connect" \
+curl -i -X POST https://admin.kong.example/routes/ROUTE_ID/plugins --data name="openid-connect" \
   --data config.issuer="https://login.microsoftonline.com/YOUR_DIRECTORY_ID/v2.0/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID" \
   --data config.client_secret="YOUR_CLIENT_SECRET" \
@@ -92,11 +92,13 @@ For this example, the user's Azure AD account GUID is mapped to a Consumer by se
 it as the `custom_id` on their Consumer:
 
 ```bash
-$ curl -i -X POST http://admin.kong.example/consumers/ \
+curl -i -X POST http://admin.kong.example/consumers/ \
   --data username="Yoda" \
   --data custom_id="e5634b31-d67f-4661-a6fb-b6cb77849bcf"
+```
 
-$ curl -i -X PATCH http://admin.kong.example/plugins/OIDC_PLUGIN_ID \
+```bash
+curl -i -X PATCH http://admin.kong.example/plugins/OIDC_PLUGIN_ID \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="oid"
 ```

--- a/src/gateway/kong-plugins/authentication/oidc/okta.md
+++ b/src/gateway/kong-plugins/authentication/oidc/okta.md
@@ -175,7 +175,7 @@ For a list of all available configuration parameters and what they do, see the
 Configure the OpenID Connect plugin using the following sample values:
 
 ```bash
-$ curl -i -X POST https://KONG_ADMIN_URL/routes/ROUTE_ID/plugins
+curl -i -X POST https://KONG_ADMIN_URL/routes/ROUTE_ID/plugins \
   --data name="openid-connect"                                                                             \
   --data config.issuer="https://YOUR_OKTA_DOMAIN/oauth2/YOUR_AUTH_SERVER/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID"                                                                 \
@@ -226,11 +226,13 @@ For this example, the user's Okta's AD account GUID is mapped to a Consumer by s
 as the `custom_id` on their consumer:
 
 ```bash
-$ curl -i -X POST http://admin.kong.example/consumers/ \
+curl -i -X POST http://admin.kong.example/consumers/ \
   --data username="Yoda" \
   --data custom_id="e5634b31-d67f-4661-a6fb-b6cb77849bcf"
+```
 
-$ curl -i -X PATCH http://admin.kong.example/plugins/OIDC_PLUGIN_ID \
+```bash
+curl -i -X PATCH http://admin.kong.example/plugins/OIDC_PLUGIN_ID \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="sub"
 ```

--- a/src/gateway/kong-plugins/authentication/reference.md
+++ b/src/gateway/kong-plugins/authentication/reference.md
@@ -51,7 +51,7 @@ the corresponding Route:
     the request:
 
     ```bash
-    $ curl -i -X POST \
+    curl -i -X POST \
       --url http://localhost:8001/services/ \
       --data 'name=example-service' \
       --data 'url=http://mockbin.org/request'
@@ -60,7 +60,7 @@ the corresponding Route:
     Add a Route to the Service:
 
     ```bash
-    $ curl -i -X POST \
+    curl -i -X POST \
       --url http://localhost:8001/services/example-service/routes \
       --data 'paths[]=/auth-sample'
     ```
@@ -72,7 +72,7 @@ the corresponding Route:
     Issue the following cURL request to add a plugin to a Service:
 
     ```bash
-    $ curl -i -X POST \
+    curl -i -X POST \
       --url http://localhost:8001/services/example-service/plugins/ \
       --data 'name=key-auth'
     ```
@@ -85,7 +85,7 @@ the corresponding Route:
     plugin was properly configured on the Service:
 
     ```bash
-    $ curl -i -X GET \
+    curl -i -X GET \
       --url http://localhost:8000/auth-sample
     ```
 
@@ -108,7 +108,7 @@ the corresponding Route:
     following request:
 
     ```bash
-    $ curl -i -X POST \
+    curl -i -X POST \
       --url http://localhost:8001/consumers/ \
       --data "username=anonymous_users"
     ```
@@ -135,7 +135,7 @@ the corresponding Route:
     request (**replace the sample uuids below by the `id` values from step 2 and 4**):
 
     ```bash
-    $ curl -i -X PATCH \
+    curl -i -X PATCH \
       --url http://localhost:8001/plugins/<your-plugin-id> \
       --data "config.anonymous=<your-consumer-id>"
     ```
@@ -151,7 +151,7 @@ the corresponding Route:
     Confirm that your Service now permits anonymous access by issuing the following request:
 
     ```bash
-    $ curl -i -X GET \
+    curl -i -X GET \
       --url http://localhost:8000/auth-sample
     ```
 

--- a/src/gateway/kong-plugins/graphql.md
+++ b/src/gateway/kong-plugins/graphql.md
@@ -20,12 +20,15 @@ Use {{site.base_gateway}} to protect and manage an existing GraphQL endpoint. Th
 After installing and starting {{site.base_gateway}}, use the Admin API on port 8001 to add a new Service and Route. In this example, {{site.base_gateway}} will reverse proxy every incoming request with the specified incoming host to the associated upstream URL. You can implement very complex routing mechanisms beyond simple host matching.
 
 
-```
-$ curl -i -X POST \
+```sh
+curl -i -X POST \
   --url http://localhost:8001/services/ \
   --data 'name=graphql-service' \
   --data 'url=http://example.com'
-$ curl -i -X POST \
+```
+
+```sh
+curl -i -X POST \
   --url http://localhost:8001/services/example-service/routes \
   --data 'hosts[]=example.com' \
 ```  
@@ -34,8 +37,8 @@ $ curl -i -X POST \
 
 Proxy caching for GraphQL provides advanced caching over queries.
 
-```
-$ curl -i -X POST \
+```sh
+curl -i -X POST \
   --url http://localhost:8001/services/example-service/plugins/ \
   --data 'name=graphql-proxy-cache-advanced' \
   --data 'config.strategy=memory'
@@ -43,8 +46,8 @@ $ curl -i -X POST \
 
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
-```
-$ curl -i -X POST http://kong:8001/services/example-service/plugins \
+```sh
+curl -i -X POST http://kong:8001/services/example-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/src/gateway/plugin-development/configuration.md
+++ b/src/gateway/plugin-development/configuration.md
@@ -22,9 +22,9 @@ Service, Route, or Consumer.
 For example, a user performs the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
-    -d "name=my-custom-plugin" \
-    -d "config.foo=bar"
+curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+  -d "name=my-custom-plugin" \
+  -d "config.foo=bar"
 ```
 
 If all properties of the `config` object are valid according to your schema,
@@ -343,10 +343,10 @@ Such a configuration will allow a user to post the configuration to your plugin
 as follows:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
-    -d "name=my-custom-plugin" \
-    -d "config.environment=development" \
-    -d "config.server.host=http://localhost"
+curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+  -d "name=my-custom-plugin" \
+  -d "config.environment=development" \
+  -d "config.server.host=http://localhost"
 ```
 
 And the following will be available in

--- a/src/gateway/plugin-development/distribution.md
+++ b/src/gateway/plugin-development/distribution.md
@@ -26,21 +26,21 @@ template][plugin-template]. For more info about the format, see the LuaRocks
 Pack your rock using the following command (from the plugin repo):
 
 1. Install it locally (based on the `.rockspec` in the current directory):
-  ```sh
-  luarocks make
-  ```
+    ```sh
+    luarocks make
+    ```
 
 2. Pack the installed rock:
-  ```sh
-  luarocks pack <plugin-name> <version>
-  ```
+    ```sh
+    luarocks pack <plugin-name> <version>
+    ```
 
-  Assuming your plugin rockspec is called
-  `kong-plugin-my-plugin-0.1.0-1.rockspec`, the above would become;
+    Assuming your plugin rockspec is called
+    `kong-plugin-my-plugin-0.1.0-1.rockspec`, the above would become;
 
-  ```sh
-  luarocks pack kong-plugin-my-plugin 0.1.0-1
-  ```
+    ```sh
+    luarocks pack kong-plugin-my-plugin 0.1.0-1
+    ```
 
 The LuaRocks `pack` command has now created a `.rock` file (this is simply a
 zip file containing everything needed to install the rock).
@@ -178,40 +178,42 @@ equivalent: `KONG_LUA_PACKAGE_PATH`.
 1. Add the custom plugin's name to the `plugins` list in your
 Kong configuration (on each Kong node):
 
-  ```
-  plugins = bundled,<plugin-name>
-  ```
+    ```
+    plugins = bundled,<plugin-name>
+    ```
 
-  Or, if you don't want to include the bundled plugins:
+    Or, if you don't want to include the bundled plugins:
 
-  ```
-  plugins = <plugin-name>
-  ```
+    ```
+    plugins = <plugin-name>
+    ```
 
-  If you are using two or more custom plugins, insert commas in between, like so:
+    If you are using two or more custom plugins, insert commas in between, like so:
 
-  ```
-  plugins = bundled,plugin1,plugin2
-  ```
-  Or:
-  ```
-  plugins = plugin1,plugin2
-  ```
+    ```
+    plugins = bundled,plugin1,plugin2
+    ```
+    Or:
+    ```
+    plugins = plugin1,plugin2
+    ```
 
-  You can also set this property via its environment variable equivalent:
-  `KONG_PLUGINS`.
+    You can also set this property via its environment variable equivalent:
+    `KONG_PLUGINS`.
 
 1. Update the `plugins` directive for each node in your Kong cluster.
 
 1. Restart Kong to apply the plugin:
 
-        kong restart
-
+    ```
+    kong restart
+    ```
     Or, if you want to apply a plugin without stopping Kong, you can use this:
 
-        kong prepare
-        kong reload
-
+    ```
+    kong prepare
+    kong reload
+    ```
 
 ## Verify loading the plugin
 
@@ -301,8 +303,6 @@ directive is properly set to load this plugin's Lua sources.
 unable to load the `schema.lua` source file from the file system. To resolve,
 make sure tha the `schema.lua` file is present alongside the plugin's
 `handler.lua` file.
-
----
 
 [rockspec]: https://github.com/keplerproject/luarocks/wiki/Creating-a-rock
 [plugin-template]: https://github.com/Kong/kong-plugin

--- a/src/gateway/plugin-development/distribution.md
+++ b/src/gateway/plugin-development/distribution.md
@@ -25,16 +25,22 @@ template][plugin-template]. For more info about the format, see the LuaRocks
 
 Pack your rock using the following command (from the plugin repo):
 
-    # install it locally (based on the `.rockspec` in the current directory)
-    $ luarocks make
+1. Install it locally (based on the `.rockspec` in the current directory):
+  ```sh
+  luarocks make
+  ```
 
-    # pack the installed rock
-    $ luarocks pack <plugin-name> <version>
+2. Pack the installed rock:
+  ```sh
+  luarocks pack <plugin-name> <version>
+  ```
 
-Assuming your plugin rockspec is called
-`kong-plugin-my-plugin-0.1.0-1.rockspec`, the above would become;
+  Assuming your plugin rockspec is called
+  `kong-plugin-my-plugin-0.1.0-1.rockspec`, the above would become;
 
-    $ luarocks pack kong-plugin-my-plugin 0.1.0-1
+  ```sh
+  luarocks pack kong-plugin-my-plugin 0.1.0-1
+  ```
 
 The LuaRocks `pack` command has now created a `.rock` file (this is simply a
 zip file containing everything needed to install the rock).
@@ -46,17 +52,18 @@ systems.
 
 The contents of this archive should be close to the following:
 
-    $ tree <plugin-name>
-    <plugin-name>
-    ├── INSTALL.txt
-    ├── README.md
-    ├── kong
-    │   └── plugins
-    │       └── <plugin-name>
-    │           ├── handler.lua
-    │           └── schema.lua
-    └── <plugin-name>-<version>.rockspec
-
+```
+tree <plugin-name>
+<plugin-name>
+├── INSTALL.txt
+├── README.md
+├── kong
+│   └── plugins
+│       └── <plugin-name>
+│           ├── handler.lua
+│           └── schema.lua
+└── <plugin-name>-<version>.rockspec
+```
 
 ## Install the plugin
 
@@ -78,8 +85,9 @@ install the 'rock' in your LuaRocks tree (a directory in which LuaRocks
 installs Lua modules).
 
 It can be installed by doing:
-
-    $ luarocks install <rock-filename>
+```sh
+luarocks install <rock-filename>
+```
 
 The filename can be a local name, or any of the supported methods, eg.
 `http://myrepository.lan/rocks/my-plugin-0.1.0-1.all.rock`
@@ -94,11 +102,15 @@ LuaRocks installs Lua modules).
 You can do so by changing the current directory to the extracted archive,
 where the rockspec file is:
 
-    $ cd <plugin-name>
+```sh
+cd <plugin-name>
+```
 
 And then run the following:
 
-    $ luarocks make
+```sh
+luarocks make
+```
 
 This will install the Lua sources in `kong/plugins/<plugin-name>` in your
 system's LuaRocks tree, where all the Kong sources are already present.
@@ -117,7 +129,9 @@ Those properties contain a semicolon-separated list of directories in
 which to search for Lua sources. It should be set like so in your Kong
 configuration file:
 
-    lua_package_path = /<path-to-plugin-location>/?.lua;;
+```
+lua_package_path = /<path-to-plugin-location>/?.lua;;
+```
 
 Where:
 
@@ -132,19 +146,25 @@ Where:
 For example, if the plugin `something` is located on the file system and the
 handler file is in the following directory:
 
-    /usr/local/custom/kong/plugins/<something>/handler.lua
+```
+/usr/local/custom/kong/plugins/<something>/handler.lua
+```
 
 The location of the `kong` directory is `/usr/local/custom`, so the
 proper path setup would be:
 
-    lua_package_path = /usr/local/custom/?.lua;;
+```
+lua_package_path = /usr/local/custom/?.lua;;
+```
 
 #### Multiple plugins
 
 If you want to install two or more custom plugins this way, you can set
 the variable to something like:
 
-    lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
+```
+lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
+```
 
 * `;` is the separator between directories.
 * `;;` still means "the default Lua path".
@@ -158,23 +178,28 @@ equivalent: `KONG_LUA_PACKAGE_PATH`.
 1. Add the custom plugin's name to the `plugins` list in your
 Kong configuration (on each Kong node):
 
-        plugins = bundled,<plugin-name>
+  ```
+  plugins = bundled,<plugin-name>
+  ```
 
-    Or, if you don't want to include the bundled plugins:
+  Or, if you don't want to include the bundled plugins:
 
-        plugins = <plugin-name>
+  ```
+  plugins = <plugin-name>
+  ```
 
+  If you are using two or more custom plugins, insert commas in between, like so:
 
-    If you are using two or more custom plugins, insert commas in between, like so:
+  ```
+  plugins = bundled,plugin1,plugin2
+  ```
+  Or:
+  ```
+  plugins = plugin1,plugin2
+  ```
 
-        plugins = bundled,plugin1,plugin2
-
-    Or
-
-        plugins = plugin1,plugin2
-
-    You can also set this property via its environment variable equivalent:
-    `KONG_PLUGINS`.
+  You can also set this property via its environment variable equivalent:
+  `KONG_PLUGINS`.
 
 1. Update the `plugins` directive for each node in your Kong cluster.
 
@@ -197,16 +222,18 @@ on a Service, Route, or Consumer entity.
 1. To make sure your plugin is being loaded by Kong, you can start Kong with a
 `debug` log level:
 
-        log_level = debug
-
+    ```
+    log_level = debug
+    ```
     or:
-
-        KONG_LOG_LEVEL=debug
-
+    ```
+    KONG_LOG_LEVEL=debug
+    ```
 2. Then, you should see the following log for each plugin being loaded:
 
-        [debug] Loading plugin <plugin-name>
-
+    ```
+    [debug] Loading plugin <plugin-name>
+    ```
 
 ## Remove a plugin
 

--- a/src/gateway/plugin-development/pluginserver/external-plugins.md
+++ b/src/gateway/plugin-development/pluginserver/external-plugins.md
@@ -189,9 +189,12 @@ no plugin loading, and no compiler, library, or environment compatibility issues
 The resulting executable can be placed somewhere in your path (for example,
 `/usr/local/bin`). The common `-h` flag shows a usage help message:
 
+```sh
+my-plugin -h
 ```
-$ my-plugin -h
 
+Output:
+```
 Usage of my-plugin:
   -dump
         Dump info about plugins

--- a/src/gateway/plugin-development/pluginserver/go.md
+++ b/src/gateway/plugin-development/pluginserver/go.md
@@ -19,12 +19,12 @@ To write a {{site.base_gateway}} plugin in Go, you need to:
 6. Compile as an executable with `go build`.
 
 {:.note}
-> **Note**: [The Kong Go plugins repository](https://github.com/Kong/go-plugins) contains example Go plugins. 
+> **Note**: [The Kong Go plugins repository](https://github.com/Kong/go-plugins) contains example Go plugins.
 
 ## Configuration
 
 ### `Struct`
-The plugin you write needs a way to handle incoming configuration data from the data store or the Admin API. 
+The plugin you write needs a way to handle incoming configuration data from the data store or the Admin API.
 You can use a `struct` to create a schema of the incoming data.
 
 ```go
@@ -69,9 +69,12 @@ func main () {
 Executables can be placed somewhere in your path (for example,
 `/usr/local/bin`). The common `-h` flag shows a usage help message:
 
+```sh
+my-plugin -h
 ```
-$ my-plugin -h
 
+Output:
+```
 Usage of my-plugin:
   -dump
         Dump info about plugins
@@ -82,7 +85,7 @@ Usage of my-plugin:
 ```
 
 When you run the plugin without arguments, it creates a socket file within the
-`kong-prefix` and the executable name, appending `.socket`. 
+`kong-prefix` and the executable name, appending `.socket`.
 For example, if the executable is `my-plugin`, the socket file would be
 `/usr/local/kong/my-plugin.socket`.
 

--- a/src/gateway/production/access-control/start-securely.md
+++ b/src/gateway/production/access-control/start-securely.md
@@ -56,7 +56,7 @@ be present in the environment where database migrations will run.
 > **Important**: Setting your Kong password (`KONG_PASSWORD`) using a value containing four ticks (for example, `KONG_PASSWORD="a''a'a'a'a"`) causes a PostgreSQL syntax error on bootstrap. To work around this issue, do not use special characters in your password.
 
 ```
-$ export KONG_PASSWORD=<password-only-you-know>
+export KONG_PASSWORD=<password-only-you-know>
 ```
 
 This automatically creates a user, `kong_admin`, and a password that
@@ -76,7 +76,7 @@ To add additional Super Admins it is necessary to
 Issue the following command to prepare your data store by running the Kong migrations:
 
 ```
-$ kong migrations bootstrap [-c /path/to/kong.conf]
+kong migrations bootstrap [-c /path/to/kong.conf]
 ```
 
 ## Step 3
@@ -84,7 +84,7 @@ $ kong migrations bootstrap [-c /path/to/kong.conf]
 Start Kong:
 
 ```
-$ kong start [-c /path/to/kong.conf]
+kong start [-c /path/to/kong.conf]
 ```
 
 **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)

--- a/src/gateway/production/blue-green.md
+++ b/src/gateway/production/blue-green.md
@@ -10,33 +10,33 @@ service to change its `host` value.
 Set up the "blue" environment, running version one of the address service:
 
 1. Create an upstream:
-  ```bash
-  curl -X POST http://localhost:8001/upstreams \
-      --data "name=address.v1.service"
-  ```
+    ```bash
+    curl -X POST http://localhost:8001/upstreams \
+        --data "name=address.v1.service"
+    ```
 
 2. Add two targets to the upstream:
-  ```sh
-  curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
-      --data "target=192.168.34.15:80"
-      --data "weight=100"
-  curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
-      --data "target=192.168.34.16:80"
-      --data "weight=50"
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
+        --data "target=192.168.34.15:80"
+        --data "weight=100"
+    curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
+        --data "target=192.168.34.16:80"
+        --data "weight=50"
+    ```
 3. Create a service targeting the Blue upstream:
-  ```sh
-  curl -X POST http://localhost:8001/services/ \
-      --data "name=address-service" \
-      --data "host=address.v1.service" \
-      --data "path=/address"
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/services/ \
+        --data "name=address-service" \
+        --data "host=address.v1.service" \
+        --data "path=/address"
+    ```
 
 4. Finally, add a route as an entry-point into the service:
-  ```sh
-  curl -X POST http://localhost:8001/services/address-service/routes/ \
-      --data "hosts[]=address.mydomain.com"
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/services/address-service/routes/ \
+        --data "hosts[]=address.mydomain.com"
+    ```
 
 Requests with host header set to `address.mydomain.com` will now be proxied
 by {{site.base_gateway}} to the two defined targets. Two-thirds of the requests will go to
@@ -47,28 +47,28 @@ Before deploying version two of the address service, set up the "Green"
 environment:
 
 1. Create a new Green upstream for address service v2:
-  ```sh
-  curl -X POST http://localhost:8001/upstreams \
-      --data "name=address.v2.service"
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/upstreams \
+        --data "name=address.v2.service"
+    ```
 
 2. Add targets to the upstream:
-  ```sh
-  curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
-      --data "target=192.168.34.17:80"
-      --data "weight=100"
-  curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
-      --data "target=192.168.34.18:80"
-      --data "weight=100"
-  ```
+    ```sh
+    curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+        --data "target=192.168.34.17:80"
+        --data "weight=100"
+    curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+        --data "target=192.168.34.18:80"
+        --data "weight=100"
+    ```
 
 3. To activate the blue/green switch, we now only need to update the service.
 Switch the Service from Blue to Green upstream, v1 -> v2:
 
-  ```bash
-  curl -X PATCH http://localhost:8001/services/address-service \
-    --data "host=address.v2.service"
-  ```
+    ```bash
+    curl -X PATCH http://localhost:8001/services/address-service \
+      --data "host=address.v2.service"
+    ```
 
 Incoming requests with host header set to `address.mydomain.com` are now
 proxied by Kong to the new targets. Half of the requests will go to

--- a/src/gateway/production/blue-green.md
+++ b/src/gateway/production/blue-green.md
@@ -9,29 +9,34 @@ service to change its `host` value.
 
 Set up the "blue" environment, running version one of the address service:
 
-```bash
-# create an upstream
-$ curl -X POST http://localhost:8001/upstreams \
-    --data "name=address.v1.service"
+1. Create an upstream:
+  ```bash
+  curl -X POST http://localhost:8001/upstreams \
+      --data "name=address.v1.service"
+  ```
 
-# add two targets to the upstream
-$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
-    --data "target=192.168.34.15:80"
-    --data "weight=100"
-$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
-    --data "target=192.168.34.16:80"
-    --data "weight=50"
+2. Add two targets to the upstream:
+  ```sh
+  curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
+      --data "target=192.168.34.15:80"
+      --data "weight=100"
+  curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
+      --data "target=192.168.34.16:80"
+      --data "weight=50"
+  ```
+3. Create a service targeting the Blue upstream:
+  ```sh
+  curl -X POST http://localhost:8001/services/ \
+      --data "name=address-service" \
+      --data "host=address.v1.service" \
+      --data "path=/address"
+  ```
 
-# create a service targeting the Blue upstream
-$ curl -X POST http://localhost:8001/services/ \
-    --data "name=address-service" \
-    --data "host=address.v1.service" \
-    --data "path=/address"
-
-# finally, add a route as an entry-point into the service
-$ curl -X POST http://localhost:8001/services/address-service/routes/ \
-    --data "hosts[]=address.mydomain.com"
-```
+4. Finally, add a route as an entry-point into the service:
+  ```sh
+  curl -X POST http://localhost:8001/services/address-service/routes/ \
+      --data "hosts[]=address.mydomain.com"
+  ```
 
 Requests with host header set to `address.mydomain.com` will now be proxied
 by {{site.base_gateway}} to the two defined targets. Two-thirds of the requests will go to
@@ -41,27 +46,29 @@ by {{site.base_gateway}} to the two defined targets. Two-thirds of the requests 
 Before deploying version two of the address service, set up the "Green"
 environment:
 
-```bash
-# create a new Green upstream for address service v2
-$ curl -X POST http://localhost:8001/upstreams \
-    --data "name=address.v2.service"
+1. Create a new Green upstream for address service v2:
+  ```sh
+  curl -X POST http://localhost:8001/upstreams \
+      --data "name=address.v2.service"
+  ```
 
-# add targets to the upstream
-$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
-    --data "target=192.168.34.17:80"
-    --data "weight=100"
-$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
-    --data "target=192.168.34.18:80"
-    --data "weight=100"
-```
+2. Add targets to the upstream:
+  ```sh
+  curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+      --data "target=192.168.34.17:80"
+      --data "weight=100"
+  curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+      --data "target=192.168.34.18:80"
+      --data "weight=100"
+  ```
 
-To activate the blue/green switch, we now only need to update the service:
+3. To activate the blue/green switch, we now only need to update the service.
+Switch the Service from Blue to Green upstream, v1 -> v2:
 
-```bash
-# Switch the Service from Blue to Green upstream, v1 -> v2
-$ curl -X PATCH http://localhost:8001/services/address-service \
+  ```bash
+  curl -X PATCH http://localhost:8001/services/address-service \
     --data "host=address.v2.service"
-```
+  ```
 
 Incoming requests with host header set to `address.mydomain.com` are now
 proxied by Kong to the new targets. Half of the requests will go to

--- a/src/gateway/production/canary.md
+++ b/src/gateway/production/canary.md
@@ -10,12 +10,14 @@ Using a very simple two target example:
 
 ```bash
 # first target at 1000
-$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=1000"
+```
 
+```sh
 # second target at 0
-$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=0"
 ```
@@ -25,12 +27,14 @@ slowly be routed towards the other target. For example, set it at 10%:
 
 ```bash
 # first target at 900
-$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=900"
+```
 
+```sh
 # second target at 100
-$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
+curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```

--- a/src/gateway/production/clustering.md
+++ b/src/gateway/production/clustering.md
@@ -40,14 +40,14 @@ will instantly take effect. Example:
 Consider a single Kong node `A`. If we delete a previously registered Service:
 
 ```bash
-$ curl -X DELETE http://127.0.0.1:8001/services/test-service
+curl -X DELETE http://127.0.0.1:8001/services/test-service
 ```
 
 Then any subsequent request to `A` would instantly return `404 Not Found`, as
 the node purged it from its local cache:
 
 ```bash
-$ curl -i http://127.0.0.1:8000/test-service
+curl -i http://127.0.0.1:8000/test-service
 ```
 
 ## Multiple nodes Kong clusters
@@ -99,12 +99,12 @@ On node `A`, we add a Service and a Route:
 
 ```bash
 # node A
-$ curl -X POST http://127.0.0.1:8001/services \
-    --data "name=example-service" \
-    --data "url=http://example.com"
+curl -X POST http://127.0.0.1:8001/services \
+  --data "name=example-service" \
+  --data "url=http://example.com"
 
-$ curl -X POST http://127.0.0.1:8001/services/example-service/routes \
-    --data "paths[]=/example"
+curl -X POST http://127.0.0.1:8001/services/example-service/routes \
+  --data "paths[]=/example"
 ```
 
 (Note that we used `/services/example-service/routes` as a shortcut: we
@@ -116,14 +116,22 @@ the fact that no plugin is configured on it:
 
 ```bash
 # node A
-$ curl http://127.0.0.1:8000/example
+curl http://127.0.0.1:8000/example
+```
+
+Response:
+```
 HTTP 200 OK
 ...
 ```
 
 ```bash
 # node B
-$ curl http://127.0.0.2:8000/example
+curl http://127.0.0.2:8000/example
+```
+
+Response:
+```
 HTTP 200 OK
 ...
 ```
@@ -132,8 +140,8 @@ Now, say we add a plugin to this Service via node `A`'s Admin API:
 
 ```bash
 # node A
-$ curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
-    --data "name=example-plugin"
+curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
+  --data "name=example-plugin"
 ```
 
 Because this request was issued via node `A`'s Admin API, node `A` will locally

--- a/src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -206,8 +206,11 @@ Once you are done editing the file, it is possible to check the syntax
 for any errors before attempting to load it into Kong:
 
 ```
-$ kong config -c kong.conf parse kong.yml
+kong config -c kong.conf parse kong.yml
+```
 
+Response:
+```
 parse successful
 ```
 

--- a/src/gateway/production/deployment-topologies/traditional/index.md
+++ b/src/gateway/production/deployment-topologies/traditional/index.md
@@ -40,14 +40,14 @@ will instantly take effect. Example:
 Consider a single Kong node `A`. If we delete a previously registered Service:
 
 ```bash
-$ curl -X DELETE http://127.0.0.1:8001/services/test-service
+curl -X DELETE http://127.0.0.1:8001/services/test-service
 ```
 
 Then any subsequent request to `A` would instantly return `404 Not Found`, as
 the node purged it from its local cache:
 
 ```bash
-$ curl -i http://127.0.0.1:8000/test-service
+curl -i http://127.0.0.1:8000/test-service
 ```
 
 ## Multiple nodes Kong clusters
@@ -99,12 +99,12 @@ On node `A`, we add a Service and a Route:
 
 ```bash
 # node A
-$ curl -X POST http://127.0.0.1:8001/services \
-    --data "name=example-service" \
-    --data "url=http://example.com"
+curl -X POST http://127.0.0.1:8001/services \
+  --data "name=example-service" \
+  --data "url=http://example.com"
 
-$ curl -X POST http://127.0.0.1:8001/services/example-service/routes \
-    --data "paths[]=/example"
+curl -X POST http://127.0.0.1:8001/services/example-service/routes \
+  --data "paths[]=/example"
 ```
 
 (Note that we used `/services/example-service/routes` as a shortcut: we
@@ -116,14 +116,22 @@ the fact that no plugin is configured on it:
 
 ```bash
 # node A
-$ curl http://127.0.0.1:8000/example
+curl http://127.0.0.1:8000/example
+```
+
+Response:
+```
 HTTP 200 OK
 ...
 ```
 
 ```bash
 # node B
-$ curl http://127.0.0.2:8000/example
+curl http://127.0.0.2:8000/example
+```
+
+Response:
+```
 HTTP 200 OK
 ...
 ```
@@ -132,8 +140,8 @@ Now, say we add a plugin to this Service via node `A`'s Admin API:
 
 ```bash
 # node A
-$ curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
-    --data "name=example-plugin"
+curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
+  --data "name=example-plugin"
 ```
 
 Because this request was issued via node `A`'s Admin API, node `A` will locally

--- a/src/gateway/production/running-kong/kong-user.md
+++ b/src/gateway/production/running-kong/kong-user.md
@@ -34,7 +34,7 @@ When {{site.base_gateway}} is installed with a package management system such as
 1. Switch to the built-in `kong` user:
 
     ```sh
-    $ su kong
+    su kong
     ```
 2. Start Kong:
 


### PR DESCRIPTION
### Summary
Taking advantage of clean src branch and single-sourced plugins to get rid of `$` command prompt markers. This PR covers everything under `src/gateway` and all `_index.md` files in `app/_hub/kong-inc`.

Also some minor formatting and breaking apart codeblocks - if I was already removing the `$` marker and the codeblock needed to be split or cleaned up, I did that too.

### Reason
https://konghq.atlassian.net/browse/DOCU-2369

### Testing
Netlify