### PR TITLE
update gatewayAPI to v1beta1 in KIC >= 2.6.x

### DIFF
--- a/src/kubernetes-ingress-controller/references/gateway-api-support.md
+++ b/src/kubernetes-ingress-controller/references/gateway-api-support.md
@@ -1,7 +1,6 @@
 ---
 title: Gateway API Support
 content_type: reference
-content_type: reference
 ---
 
 The {{site.kic_product_name}} supports the following resources and features in the
@@ -15,8 +14,12 @@ The {{site.kic_product_name}} supports the following resources and features in t
 ## Gateways and GatewayClasses
 
 ### Supported Versions
+{% if_version gte: 2.6.x %}
 - `v1beta1`
+{% endif_version %}
+{% if_version lte: 2.5.x %}
 - `v1alpha2`
+{% endif_version %}
 
 ## HTTPRoutes
 
@@ -27,8 +30,13 @@ to allow you to fine-tune the load-balancing between those backend
 services.
 
 ### Supported Versions
+
+{% if_version gte: 2.6.x %}
 - `v1beta1`
+{% endif_version %}
+{% if_version lte: 2.5.x %}
 - `v1alpha2`
+{% endif_version %}
 
 ### Supported Extended Features
 - Supports `method` in route matches.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

update gateway apiVersion to `v1beta1` for resource `Gateway`, `GatewayClass`, `HTTPRoute`.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Gateway API has removed `v1alpha2` resources  `Gateway`, `GatewayClass`, `HTTPRoute`, and we decided to remove support for the resources above in `v1alpha2` version: https://github.com/Kong/kubernetes-ingress-controller/issues/2887. We need to update the docs for KIC 2.6 to update the references of these resources. 

Would fix #4407.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
