### PR TITLE
Fix KIC's kustomize manifests path

### DIFF
--- a/src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
+++ b/src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
@@ -94,7 +94,7 @@ IP address to the `kong-proxy` Service.
 Use Kustomize to install Kong for Kubernetes Enterprise:
 
 ```
-kustomize build github.com/kong/kubernetes-ingress-controller/deploy/manifests/enterprise-k8s
+kustomize build github.com/kong/kubernetes-ingress-controller/config/variants/enterprise
 ```
 
 You can use the above URL as a base kustomization and build on top of it

--- a/src/kubernetes-ingress-controller/deployment/k4k8s.md
+++ b/src/kubernetes-ingress-controller/deployment/k4k8s.md
@@ -38,7 +38,7 @@ Please pick one of the following guides depending on your platform:
 Use Kustomize to install Kong for Kubernetes:
 
 ```
-kustomize build github.com/kong/kubernetes-ingress-controller/deploy/manifests/base
+kustomize build github.com/kong/kubernetes-ingress-controller/config/base
 ```
 
 You can use the above URL as a base kustomization and build on top of it


### PR DESCRIPTION
### Summary
Kustomize manifests have been moved from `deploy/manifests/base` to `config/base` in KIC repository and the kustomize command was no longer valid. 

Proof for the changed manifests location: https://github.com/Kong/kubernetes-ingress-controller/tree/main/config/base

### Reason
I have discovered the issue while trying to deploy KIC using the documentation. 

### Testing
I have verified that the updated command works. 
