### PR TITLE
Add OpenTracing item to Known Limitations

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -364,7 +364,7 @@ Debian 8 [reached end-of-life in June 30, 2020](https://www.debian.org/News/2020
 * Tags may now contain space characters.
   [#9143](https://github.com/Kong/kong/pull/9143)
 * Support for the `nginx-opentracing` module is deprecated as of `3.0` and will
-  be removed from Kong in `4.0` (see the `Known Limitations` section for additional
+  be removed from Kong in `4.0` (see the [Known Limitations](#known-limitations) section for additional
   information).
 
 #### Admin API
@@ -766,7 +766,7 @@ openid-connect
     * Upgrades from versions before 2.1.0.0 are not supported with 3.0.0.0.
 
 * OpenTracing: There is an issue with `nginx-opentracing` in this release, so it is not
-  recommended to upgrade quite yet if you are an OpenTracing user. This will be
+  recommended to upgrade yet if you are an OpenTracing user. This will be
   rectified in an upcoming patch/minor release.
 
 ### Dependencies

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -762,6 +762,10 @@ openid-connect
     * Upgrades from 2.8.x.x to 3.0.0.0 are currently not supported, as there is a known issue planned to be fixed in the next 2.8.x.x release.
     * Upgrades from versions before 2.1.0.0 are not supported with 3.0.0.0.
 
+* OpenTracing: There is an issue with `nginx-opentracing` in this release, so it is not
+  recommended to upgrade quite yet if you are an OpenTracing user. This will be
+  rectified in an upcoming patch/minor release.
+
 ### Dependencies
 
 * Bumped `openresty` from 1.19.9.1 to 1.21.4.1

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -363,6 +363,9 @@ Debian 8 [reached end-of-life in June 30, 2020](https://www.debian.org/News/2020
   [#9078](https://github.com/Kong/kong/pull/9078)
 * Tags may now contain space characters.
   [#9143](https://github.com/Kong/kong/pull/9143)
+* Support for the `nginx-opentracing` module is deprecated as of `3.0` and will
+  be removed from Kong in `4.0` (see the `Known Limitations` section for additional
+  information).
 
 #### Admin API
 


### PR DESCRIPTION
### Summary

This adds a line item to the Known Limitations section about `nginx-opentracing` as well as a deprecation notice.

### Reason
https://konghq.atlassian.net/browse/FT-3356

---

Ready for review, but please do not merge without a final :+1: from @tyler-ball or a core gateway manager.