### PR TITLE
[DOCU-2478] Konnect 3.0 support

### DIFF
--- a/app/_data/tables/version_errors_konnect.yml
+++ b/app/_data/tables/version_errors_konnect.yml
@@ -1,0 +1,501 @@
+---
+messages:
+- ID: D100
+  Severity: error
+  Description: Plugin `jq` is not available in Kong Gateway versions < 2.6.0.0.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [jq plugin](/hub/kong-inc/jq/)
+- ID: D101
+  Severity: error
+  Description: |
+    For the `canary` plugin, one or more of the following `config`
+    fields are set: `hash_header` but Kong Gateway versions < 2.6.0.0 do not support
+    these fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [Canary plugin](/hub/kong-inc/canary/)
+- ID: D102
+  Severity: error
+  Description: |
+    For the `canary` plugin, `config.hash` field has been set to `header`.
+    This is not supported in Kong Gateway versions < 2.6.0.0. The plugin configuration
+    has been changed to `config.hash=consumer` in the data-plane.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [Canary plugin](/hub/kong-inc/canary/)
+- ID: D103
+  Severity: error
+  Description: |
+    For the `kafka-log` plugin, one or more of the following `config`
+    fields are set: `authentication`, `keepalive_enabled`, `security` but Kong
+    Gateway versions < 2.6.0.0 do not support these fields. Plugin features that rely
+    on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [Kafka Log plugin](/hub/kong-inc/kafka-log/)
+- ID: D104
+  Severity: error
+  Description: |
+    For the `kafka-upstream` plugin, one or more of the following `config`
+    fields are set: `authentication`, `keepalive_enabled`, `security` but Kong
+    Gateway versions < 2.6.0.0 do not support these fields. Plugin features that rely
+    on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [Kafka Upstream plugin](/hub/kong-inc/kafka-upstream/)
+- ID: D105
+  Severity: error
+  Description: |
+    For the `rate-limiting-advanced` plugin, either `config.strategy`
+    is set to `local` or `config.identifier` is set to `path` or both. These
+    settings are not supported in Kong Gateway versions < 2.6.0.0. In the data-plane,
+    the plugin configuration has one or more of the following changes: (a) `config.strategy`
+    has been updated to `redis`, (b) `config.sync_rate` has been updated to `1`,
+    (c) `config.identifier has been updated to `path`.`
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/)
+- ID: D106
+  Severity: error
+  Description: |
+    For the `openid-connect` plugin, one or more of the following unsupported
+    `config` fields or values for a `config` field are in use: `by_username_ignore_case`,
+    `disable_session`, `downstream_introspection_jwt_header`, `downstream_user_info_jwt_header`,
+    `introspection_accept`, `introspection_check_active`, `upstream_introspection_jwt_header`,
+    `upstream_user_info_jwt_header`, `userinfo_accept`, `userinfo_headers_client`,
+    `userinfo_headers_names`, `userinfo_headers_values`, `userinfo_query_args_client`,
+    `userinfo_query_args_names`, `userinfo_query_args_values`, `auth_methods`
+    array field with value `userinfo`, `ignore_signature` array field with value
+    `introspection`, `ignore_signature` array field with value `userinfo`, `login_methods`
+    array field with value `userinfo`, `token_headers_grants` array field with
+    value `refresh_token`.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [OpenID Connect plugin](/hub/kong-inc/openid-connect/)
+- ID: D107
+  Severity: error
+  Description: |
+    For the `rate-limiting-advanced` plugin, one or more of the following
+    `config` fields are set: `path` but Kong Gateway versions < 2.6.0.0 do not
+    support these fields. Plugin features that rely on these fields are not working
+    as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6.0.0` or above.
+  DocumentationURL: |
+    [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/)
+- ID: D108
+  Severity: error
+  Description: |
+    For the `forward-proxy` plugin, one or more of the following `config`
+    fields are set: `auth_username`, `auth_password` but Kong Gateway versions
+    < 2.7.0.0 do not support these fields. Plugin features that rely on these fields
+    are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7.0.0` or above.
+  DocumentationURL: |
+    [Forward Proxy plugin](/hub/kong-inc/forward-proxy/)
+- ID: D109
+  Severity: error
+  Description: |
+    For the `mocking` plugin, one or more of the following `config`
+    fields are set: `random_examples` but Kong Gateway versions < 2.7.0.0 do not
+    support these fields. Plugin features that rely on these fields are not working
+    as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7.0.0` or above.
+  DocumentationURL: |
+    [Mocking plugin](/hub/kong-inc/mocking/)
+- ID: D110
+  Severity: error
+  Description: |
+    For the `rate-limiting-advanced` plugin, one or more of the following
+    `config` fields are set: `enforce_consumer_groups`, `consumer_groups`
+    but Kong Gateway versions < 2.7.0.0 do not support these fields. Plugin features
+    that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7.0.0` or above.
+  DocumentationURL: |
+    [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/)
+- ID: D111
+  Severity: error
+  Description: |
+    For the `rate-limiting-advanced` plugin, one or more of the following
+    `config` fields are set: `redis.username`, `redis.sentinel_username` but
+    Kong Gateway versions < 2.8.0.0 do not support these fields. Plugin features that
+    rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/)
+- ID: D112
+  Severity: error
+  Description: |
+    For the `proxy-cache-advanced` plugin, one or more of the following
+    `config` fields are set: `redis.username`, `redis.sentinel_username` but
+    Kong Gateway versions < 2.8.0.0 do not support these fields. Plugin features that
+    rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [Proxy Cache Advanced plugin](/hub/kong-inc/proxy-cache-advanced/)
+- ID: D113
+  Severity: error
+  Description: |
+    For the `canary` plugin, one or more of the following `config`
+    fields are set: `canary_by_header_name` but Kong Gateway versions < 2.8.0.0
+    do not support these fields. Plugin features that rely on these fields are not
+    working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [Canary plugin](/hub/kong-inc/canary/)
+- ID: D114
+  Severity: error
+  Description: |
+    For the `forward-proxy` plugin, one or more of the following `config`
+    fields are set: `https_proxy_host`, `https_proxy_port` but Kong Gateway versions
+    < 2.8.0.0 do not support these fields. Plugin features that rely on these fields
+    are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [Forward Proxy plugin](/hub/kong-inc/forward-proxy/)
+- ID: D115
+  Severity: warning
+  Description: N/A
+  Resolution: N/A
+  DocumentationURL:
+- ID: D116
+  Severity: error
+  Description: |
+    For the `openid-connect` plugin, one or more of the following `config`
+    fields are set: `session_redis_username`, `resolve_distributed_claims` but
+    Kong Gateway versions < 2.8.0.0 do not support these fields. Plugin features that
+    rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [OpenID Connect plugin](/hub/kong-inc/openid-connect/)
+- ID: D118
+  Severity: error
+  Description: |
+    For the `kafka-log` plugin, one or more of the following `config`
+    fields are set: `cluster_name` but Kong Gateway versions < 2.8.0.0 do not support
+    these fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [Kafka Log plugin](/hub/kong-inc/kafka-log/)
+- ID: D119
+  Severity: error
+  Description: |
+    For the `kafka-upstream` plugin, one or more of the following `config`
+    fields are set: `cluster_name` but Kong Gateway versions < 2.8.0.0 do not support
+    these fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.0.0` or above.
+  DocumentationURL: |
+    [Kafka Upstream plugin](/hub/kong-inc/kafka-upstream/)
+- ID: D120
+  Severity: error
+  Description: |
+    For the `kafka-log` plugin `config.authentication.mechanism` is set
+    to `SCRAM-SHA-512`. This is not supported in Kong Gateway versions < 2.8.1.1.
+    The value for the field has been changed to `SCRAM-SHA-256` in the data-plane.
+  Resolution: Please upgrade Kong Gateway to version `2.8.1.1` or above.
+  DocumentationURL: |
+    [Kafka Log plugin](/hub/kong-inc/kafka-log/)
+- ID: D121
+  Severity: error
+  Description: |
+    For the `kafka-upstream` plugin `config.authentication.mechanism` is
+    set to `SCRAM-SHA-512`. This is not supported in Kong Gateway versions < 2.8.1.1.
+    The value for the field has been changed to `SCRAM-SHA-256` in the data-plane.
+  Resolution: Please upgrade Kong Gateway to version `2.8.1.1` or above.
+  DocumentationURL: |
+    [Kafka Upstream plugin](/hub/kong-inc/kafka-upstream/)
+- ID: D122
+  Severity: error
+  Description: |
+    For the `mtls-auth` plugin, one or more of the following `config`
+    fields are set: `http_proxy_host`, `http_proxy_port`, `https_proxy_host`,
+    `https_proxy_port` but Kong Gateway versions < 2.8.1.1 do not support these
+    fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8.1.1` or above.
+  DocumentationURL: |
+    [mTLS Authentication plugin](/hub/kong-inc/mtls-auth/)
+- ID: D123
+  Severity: error
+  Description: |
+    It seems you are using Konnect Developer Portal with Kong Gateway.
+    For the Developer Portal's application registration feature to work correctly,
+    `konnect-application-auth` plugin is required but this plugin is not available
+    on Kong Gateway versions < 3.0. The feature is not working as intended and can
+    cause severe security issues including authentication and authorization not being
+    enforced in the Gateway.
+  Resolution: Please upgrade Kong Gateway to version `3.0.0.0` or above.
+  DocumentationURL: Not applicable
+- ID: D124
+  Severity: error
+  Description: |
+    For the `ldap-auth-advanced` plugin, one or more of the following
+    `config` fields are set: `group_required` but Kong Gateway versions < 3.0.0.0
+    do not support these fields. Plugin features that rely on these fields are not
+    working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0.0.0` or above.
+  DocumentationURL: |
+    [LDAP Authentication Advanced plugin](/hub/kong-inc/ldap-auth-advanced/)
+- ID: D125
+  Severity: error
+  Description: |
+    For the `opa` plugin, one or more of the following `config`
+    fields are set: `include_body_in_opa_input`, `include_parsed_json_body_in_opa_input`,
+    `ssl_verify` but Kong Gateway versions < 3.0.0.0 do not support these fields.
+    Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0.0.0` or above.
+  DocumentationURL: |
+    [OPA plugin](/hub/kong-inc/opa/)
+- ID: D126
+  Severity: error
+  Description: |
+    For the `statsd-advanced` plugin, one or more of the following `config`
+    fields are set: `consumer_identifier_default`, `service_identifier_default`,
+    `workspace_identifier_default` but Kong Gateway versions < 3.0.0.0 do not support
+    these fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0.0.0` or above.
+  DocumentationURL: |
+    [StatsD Advanced plugin](/hub/kong-inc/statsd-advanced/)
+- ID: P101
+  Severity: error
+  Description: |
+    For the `acme` plugin, one or more of the following `config` fields
+    are set: `preferred_chain`, `storage_config.vault.auth_method`, `storage_config.vault.auth_path`,
+    `storage_config.vault.auth_role`, `storage_config.vault.jwt_path` but Kong
+    Gateway versions < 2.6 do not support these fields. Plugin features that rely
+    on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6` or above.
+  DocumentationURL: |
+    [ACME plugin](/hub/kong-inc/acme/)
+- ID: P102
+  Severity: error
+  Description: |
+    For the `aws-lambda` plugin, one or more of the following `config`
+    fields are set: `base64_encode_body` but Kong Gateway versions < 2.6 do not
+    support these fields. Plugin features that rely on these fields are not working
+    as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6` or above.
+  DocumentationURL: |
+    [AWS Lambda plugin](/hub/kong-inc/aws-lambda/)
+- ID: P103
+  Severity: error
+  Description: |
+    For the `grpc-web` plugin, one or more of the following `config`
+    fields are set: `allow_origin_header` but Kong Gateway versions < 2.6 do not
+    support these fields. Plugin features that rely on these fields are not working
+    as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6` or above.
+  DocumentationURL: |
+    [gRPC Web plugin](/hub/kong-inc/grpc-web/)
+- ID: P104
+  Severity: error
+  Description: |
+    For the `request-termination` plugin, one or more of the following
+    `config` fields are set: `echo`, `trigger` but Kong Gateway versions < 2.6
+    do not support these fields. Plugin features that rely on these fields are not
+    working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.6` or above.
+  DocumentationURL: |
+    [Request Termination plugin](/hub/kong-inc/request-termination/)
+- ID: P105
+  Severity: error
+  Description: |
+    For the `datadog` plugin, one or more of the following `config`
+    fields are set: `service_name_tag`, `status_tag`, `consumer_tag` but Kong
+    Gateway versions < 2.7 do not support these fields. Plugin features that rely
+    on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [Datadog plugin](/hub/kong-inc/datadog/)
+- ID: P106
+  Severity: error
+  Description: |
+    For the `datadog` plugin, distribution metric type is not support in
+    Kong gateway versions < 2.7. Distribution metrics will not be emitted by the gateway.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [Datadog plugin](/hub/kong-inc/datadog/)
+- ID: P107
+  Severity: error
+  Description: |
+    For the `ip-restriction` plugin, one or more of the following `config`
+    fields are set: `status`, `message` but Kong Gateway versions < 2.7 do not
+    support these fields. Plugin features that rely on these fields are not working
+    as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [IP Restriction plugin](/hub/kong-inc/ip-restriction/)
+- ID: P108
+  Severity: error
+  Description: |
+    For the `rate-limiting` plugin, one or more of the following `config`
+    fields are set: `redis_ssl`, `redis_ssl_verify`, `redis_server_name` but
+    Kong Gateway versions < 2.7 do not support these fields. Plugin features that
+    rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [Rate Limiting plugin](/hub/kong-inc/rate-limiting/)
+- ID: P109
+  Severity: error
+  Description: |
+    For the `zipkin` plugin, `config.header_type` field has been set to
+    `ignore`. This is not supported in Kong Gateway versions < 2.7. The plugin configuration
+    has been changed to `config.header_type=preserve` in the data-plane.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [Zipkin plugin](/hub/kong-inc/zipkin/)
+- ID: P110
+  Severity: error
+  Description: |
+    For the `zipkin` plugin, one or more of the following `config`
+    fields are set: `local_service_name` but Kong Gateway versions < 2.7 do not
+    support these fields. Plugin features that rely on these fields are not working
+    as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [Zipkin plugin](/hub/kong-inc/zipkin/)
+- ID: P111
+  Severity: error
+  Description: |
+    For the `acme` plugin, one or more of the following `config` fields
+    are set: `rsa_key_size` but Kong Gateway versions < 2.8 do not support these
+    fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8` or above.
+  DocumentationURL: |
+    [ACME plugin](/hub/kong-inc/acme/)
+- ID: P112
+  Severity: error
+  Description: |
+    For the `rate-limiting` plugin, one or more of the following `config`
+    fields are set: `redis_username` but Kong Gateway versions < 2.8 do not support
+    these fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8` or above.
+  DocumentationURL: |
+    [Rate Limiting plugin](/hub/kong-inc/rate-limiting/)
+- ID: P113
+  Severity: error
+  Description: |
+    For the `response-ratelimiting` plugin, one or more of the following
+    `config` fields are set: `redis_username` but Kong Gateway versions < 2.8
+    do not support these fields. Plugin features that rely on these fields are not
+    working as intended.
+  Resolution: Please upgrade Kong Gateway to version `2.8` or above.
+  DocumentationURL: |
+    [Response Rate Limiting plugin](/hub/kong-inc/response-ratelimiting/)
+- ID: P114
+  Severity: error
+  Description: |
+    For the `response-ratelimiting` plugin, one or more of the following
+    `config` fields are set: `redis_username` but Kong Gateway versions < 2.8
+    do not support these fields. Plugin features that rely on these fields are not
+    working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0` or above.
+  DocumentationURL: |
+    [Response Rate Limiting plugin](/hub/kong-inc/response-ratelimiting/)
+- ID: P115
+  Severity: error
+  Description: |
+    Plugin `opentelemetry` is not available in Kong gateway versions <
+    3.0.
+  Resolution: Please upgrade Kong Gateway to version `3.0` or above.
+  DocumentationURL: |
+    [OpenTelemetry plugin](/hub/kong-inc/opentelemetry/)
+- ID: P116
+  Severity: error
+  Description: |
+    For the `zipkin` plugin, one or more of the following `config`
+    fields are set: `http_span_name`, `connect_timeout`, `send_timeout`, `read_timeout`
+    but Kong Gateway versions < 3.0 do not support these fields. Plugin features that
+    rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0` or above.
+  DocumentationURL: |
+    [Zipkin plugin](/hub/kong-inc/zipkin/)
+- ID: P117
+  Severity: error
+  Description: |
+    For the `prometheus` plugin, one or more of the following `config`
+    fields are set: `status_code_metrics`, `latency_metrics`, `bandwidth_metrics`,
+    `upstream_health_metrics` but Kong Gateway versions < 3.0 do not support these
+    fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0` or above.
+  DocumentationURL: |
+    [Prometheus plugin](/hub/kong-inc/prometheus/)
+- ID: P118
+  Severity: error
+  Description: |
+    For the `acme` plugin, one or more of the following `config` fields
+    are set: `allow_any_domain` but Kong Gateway versions < 3.0 do not support these
+    fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please upgrade Kong Gateway to version `3.0` or above.
+  DocumentationURL: |
+    [ACME plugin](/hub/kong-inc/acme/)
+- ID: P119
+  Severity: error
+  Description: |
+    For the `Service` entity, `enabled` field has been set to `true` but
+    Kong Gateway versions < 2.7 do not support this feature. The Service has been
+    left enabled in the Kong Gateway, and the traffic for the Service is being routed
+    by Kong Gateway. This is a critical error and may result in unwanted traffic being
+    routed to the upstream Services via Kong Gateway.
+  Resolution: Please upgrade Kong Gateway to version `2.7` or above.
+  DocumentationURL: |
+    [Service entity](/gateway/latest/admin-api/#service-object/)
+- ID: P120
+  Severity: error
+  Description: |
+    For the `aws-lambda` plugin, one or more of the following `config`
+    fields are set: `proxy_scheme` but Kong Gateway versions >= 3.0 do not support
+    these fields. Plugin features that rely on these fields are not working as intended.
+  Resolution: Please use `config.proxy_url` instead of `config.proxy_scheme` field.
+  DocumentationURL: |
+    [AWS Lambda plugin](/hub/kong-inc/aws-lambda/)
+- ID: P121
+  Severity: error
+  Description: |
+    For the `aws-lambda` plugin, `config.aws_region` and `config.host`
+    fields are set. These fields were mutually exclusive for Kong gateway versions
+    < 3.0. The plugin configuration has been changed to remove the `config.host` field.
+  Resolution: Please upgrade Kong Gateway to version `3.0` or above.
+  DocumentationURL: |
+    [AWS Lambda plugin](/hub/kong-inc/aws-lambda/)
+- ID: P122
+  Severity: error
+  Description: |
+    For the `pre-function` plugin, `config.functions` field has been used.
+    This is not supported in Kong Gateway versions >= 3.0. The plugin configuration
+    has been updated to rename `config.functions` to `config.access` in the data-plane.
+  Resolution: |
+    Please update the configuration to use `config.access` field instead
+    of `config.functions`.
+  DocumentationURL: |
+    [Serverless Functions plugin](/hub/kong-inc/serverless-functions/)
+- ID: P123
+  Severity: error
+  Description: |
+    For the `post-function` plugin, `config.functions` field has been used.
+    This is not supported in Kong Gateway versions >= 3.0. The plugin configuration
+    has been updated to rename `config.functions` to `config.access` in the data-plane.
+  Resolution: |
+    Please update the configuration to use `config.access` field instead
+    of `config.functions`.
+  DocumentationURL: |
+    [Serverless Functions plugin](/hub/kong-inc/serverless-functions/)
+- ID: P124
+  Severity: warning
+  Description: |
+    For the `pre-function` plugin, `config.functions` field has been used.
+    This field is deprecated and it is no longer supported in Kong Gateway versions >= 3.0.
+  Resolution: |
+    Please update the plugin configuration to use `config.access` field
+    in place of `config.functions` field
+  DocumentationURL: |
+    [Serverless Functions plugin](/hub/kong-inc/serverless-functions/)
+- ID: P125
+  Severity: warning
+  Description: |
+    For the `post-function` plugin, `config.functions` field has been used.
+    This field is deprecated and it is no longer supported in Kong Gateway versions >= 3.0.
+  Resolution: |
+    Please update the plugin configuration to use `config.access` field
+    in place of `config.functions` field
+  DocumentationURL: |
+    [Serverless Functions plugin](/hub/kong-inc/serverless-functions/)

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -122,5 +122,5 @@ see [{{site.ee_product_name}} for Kubernetes Deployment Options](/gateway/latest
 
 ### Deployment
 
-[Deployment plugins](/hub) are not bundled with any version of Konnect, and are
-simply tools to help you deploy Kong Gateway in various environments.
+[Deployment plugins](/hub/) are not bundled with any version of {{site.konnect_short_name}}, and are
+simply tools to help you deploy {{site.base_gateway}} in various environments.

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -9,7 +9,7 @@ no_version: true
 |----------------------------------|:--:|:----:|:-------:|:------:|:------:|
 | {{site.konnect_saas}} |  <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |  <i class="fa fa-check"></i> |  <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
-## Runtime compatibility
+## Runtime version compatibility
 
 {:.note}
 > **Note:** Currently, the only supported runtime type in
@@ -18,6 +18,7 @@ data plane.
 
 |                                | {{site.konnect_saas}} | First supported patch version
 |--------------------------------|:---------------------:|-----------------------------
+| {{site.ee_product_name}} 3.0.x | <i class="fa fa-check"></i>    | 3.0.0.0
 | {{site.ee_product_name}} 2.8.x | <i class="fa fa-check"></i>    | 2.8.0.0
 | {{site.ee_product_name}} 2.7.x | <i class="fa fa-check"></i>    | 2.7.0.0
 | {{site.ee_product_name}} 2.6.x | <i class="fa fa-check"></i>    | 2.6.0.0

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -26,7 +26,7 @@ no_version: true
 
   <a href="/deck/guides/konnect/" class="docs-grid-install-block no-description">
     <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/icn-references-color.svg" alt="">
-    <div class="install-text">Manage Konnect with decK</div>
+    <div class="install-text">Manage {{site.konnect_short_name}} with decK</div>
   </a>
 
   <a href="/hub/" class="docs-grid-install-block no-description">

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -4,18 +4,51 @@ subtitle: The SaaS API Platform
 no_version: true
 ---
 
-{{site.konnect_short_name}} is an API lifecycle 
-management platform designed from the ground up for the cloud native era 
-and delivered as a service. This platform lets you build modern applications 
-better, faster, and more securely. The management plane is hosted 
-in the cloud by Kong, while the runtime engine, {{site.base_gateway}} — Kong's 
-lightweight, fast, and flexible API gateway  — is managed by you within your 
-preferred network environment. 
+## Quick Links
+
+<div class="docs-grid-install">
+
+  <!-- TO DO: ADD KONNECT FEATURES TABLE
+   <a href="#features" class="docs-grid-install-block no-description">
+    <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/icn-flag.svg" alt="">
+    <div class="install-text">Features</div>
+  </a> -->
+
+  <a href="/konnect/getting-started/" class="docs-grid-install-block no-description">
+    <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/icn-learning.svg" alt="">
+    <div class="install-text">Get Started</div>
+  </a>
+
+  <a href="/konnect/runtime-manager/runtime-groups" class="docs-grid-install-block no-description">
+    <img class="install-icon no-image-expand" src="/assets/images/icons/konnect/icn-runtimes-nav.svg" alt="">
+    <div class="install-text">Runtime Groups</div>
+  </a>
+
+  <a href="/deck/guides/konnect/" class="docs-grid-install-block no-description">
+    <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/icn-references-color.svg" alt="">
+    <div class="install-text">Manage Konnect with decK</div>
+  </a>
+
+  <a href="/hub/" class="docs-grid-install-block no-description">
+    <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/icn-api-plugins-color.svg" alt="">
+    <div class="install-text">Plugins</div>
+  </a>
+</div>
+
+## Introducing {{site.konnect_short_name}}
+
+{{site.konnect_short_name}} is an API lifecycle
+management platform designed from the ground up for the cloud native era
+and delivered as a service. This platform lets you build modern applications
+better, faster, and more securely. The management plane is hosted
+in the cloud by Kong, while the runtime engine, {{site.base_gateway}} — Kong's
+lightweight, fast, and flexible API gateway  — is managed by you within your
+preferred network environment.
 
 {{site.konnect_short_name}} helps simplify multi-cloud API management by:
 
-* Offering a single management plane to deploy and manage your APIs and microservices in any environment: cloud, on-premises, Kubernetes, and virtual machines. 
- 
+* Offering a single management plane to deploy and manage your APIs and microservices in any environment: cloud, on-premises, Kubernetes, and virtual machines.
+
 * Instantly applying authentication, API security, and traffic control policies consistently across all your services using powerful enterprise and community plugins.
 
 * Providing a real-time, centralized view of all your services. Monitor golden signals such as error rate and latency for each service and route to gain deep insights into your API products.
@@ -31,12 +64,12 @@ preferred network environment.
 
 ### Service Hub
 
-[Service Hub](/konnect/servicehub) makes internal APIs discoverable, 
+[Service Hub](/konnect/servicehub) makes internal APIs discoverable,
 consumable, and reusable for internal development teams. Catalog
-all your services through the Service Hub to create a single source of 
-truth for your organization’s service inventory. By leveraging Service Hub, 
-your application developers 
-can search, discover, and consume existing services to accelerate their 
+all your services through the Service Hub to create a single source of
+truth for your organization’s service inventory. By leveraging Service Hub,
+your application developers
+can search, discover, and consume existing services to accelerate their
 time-to-market, while enabling a more consistent end-user experience
 across the organization’s applications.
 
@@ -45,7 +78,7 @@ across the organization’s applications.
 ### Runtime Manager
 
 [Runtime Manager](/konnect/runtime-manager) empowers your teams to securely
-collaborate and manage their own set of runtimes and services without 
+collaborate and manage their own set of runtimes and services without
 the risk of impacting other teams and projects. Runtime Manager instantly
 provisions hosted {{site.base_gateway}} control planes and supports securely
 attaching {{site.base_gateway}} data planes from your cloud or hybrid environments.

--- a/app/konnect/runtime-manager/gateway-config.md
+++ b/app/konnect/runtime-manager/gateway-config.md
@@ -45,6 +45,11 @@ routes in the runtime group from here.
 See the [route object API reference](/gateway/latest/admin-api/#route-object)
 for all configuration options.
 
+{:.important}
+> **Important**: Starting with {{site.base_gateway}} 3.0.0.0, the router supports logical expressions.
+Regex routes must begin with a `~` character. For example: `~/foo/bar/(?baz\w+)`.
+Learn more in the [route configuration guide](/gateway/latest/key-concepts/routes/expressions/).
+
 ### Consumers
 
 The **Consumers** configuration page lists all consumers in the runtime group.

--- a/app/konnect/runtime-manager/index.md
+++ b/app/konnect/runtime-manager/index.md
@@ -46,6 +46,9 @@ serving traffic for the proxy. Data plane nodes are not directly connected
 to a database. Instead, they receive configuration from their runtime group,
 which stores and manages the configuration in {{site.konnect_saas}}.
 
+We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane. Mixing versions may cause [compatibility issues](/konnect/runtime-manager/troubleshoot/#version-compatibility).
+
+### Set up a runtime instance
 
 Choose an installation type below:
 

--- a/app/konnect/runtime-manager/runtime-instances/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/runtime-instances/gateway-runtime-docker.md
@@ -84,7 +84,7 @@ $ docker run -d --name kong-dp \
   -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system" \
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly \
   -p 8000:8000 \
-  kong/kong-gateway:2.8.0.0-alpine
+  kong/kong-gateway:3.0.0.0-alpine
 ```
 {% endnavtab %}
 {% navtab Windows PowerShell %}
@@ -102,7 +102,7 @@ docker run -d --name kong-dp `
   -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system" `
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly `
   -p 8000:8000 `
-  kong/kong-gateway:2.8.0.0-alpine
+  kong/kong-gateway:3.0.0.0-alpine
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/konnect/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
@@ -81,7 +81,7 @@ like this:
     ```yaml
     image:
       repository: kong/kong-gateway
-      tag: "2.8.0.0-alpine"
+      tag: "3.0.0.0-alpine"
 
     secretVolumes:
     - kong-cluster-cert

--- a/app/konnect/runtime-manager/runtime-instances/upgrade.md
+++ b/app/konnect/runtime-manager/runtime-instances/upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade a Runtime to a New Version
+title: Upgrade a Runtime Instance to a New Version
 no_version: true
 content-type: how-to
 ---
@@ -8,9 +8,17 @@ You can upgrade runtimes to a new {{site.base_gateway}} version by bringing
 up new runtime instances, and then shutting down the old ones. This is the best
 method for high availability, as the new node starts processing data before the
 old node is removed. It is the cleanest and safest way to upgrade with no
-proxy downtime. 
+proxy downtime.
 
-To upgrade a runtime to a new version follow these steps: 
+We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane. Mixing versions may cause [compatibility issues](/konnect/runtime-manager/troubleshoot/#version-compatibility).
+
+## Prerequisites
+
+Read through the [{{site.base_gateway}} upgrade considerations](/gateway/latest/upgrade) for the version that you're upgrading to.
+
+## Upgrade a runtime instance
+
+To upgrade a runtime instance to a new version, follow these steps:
 
 1. Provision a new runtime instance through the Runtime Manager:
   * [Docker](/konnect/runtime-manager/runtime-instances/gateway-runtime-docker)
@@ -18,7 +26,7 @@ To upgrade a runtime to a new version follow these steps:
   * [Kubernetes (Helm)](/konnect/runtime-manager/runtime-instances/gateway-runtime-kubernetes)
 
 2. Open {% konnect_icon runtimes %} **Runtime Manager**, then choose a runtime group.
-    
+
     Make sure that your new runtime instance appears in the list of runtime
     instances, displays a _Connected_ status, and that it was last seen _Just Now_.
 

--- a/app/konnect/runtime-manager/troubleshoot.md
+++ b/app/konnect/runtime-manager/troubleshoot.md
@@ -63,9 +63,9 @@ If your version is up to date but the feature still isn't working, contact
 We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane.
 
 If you mix major runtime instance versions, the control plane will support the least common subset of configurations across all the versions connected to the {{site.konnect_short_name}} control plane.
-For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configurations that can be used by the 2.8.1.3 runtime instance.
+For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configuration that can be used by the 2.8.1.3 runtime instance.
 
-If you experience compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
+If you are running into compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
 
 Possible compatibility errors:
 
@@ -77,7 +77,7 @@ Possible compatibility errors:
       <th>Severity</th>
       <th>Description</th>
       <th>Resolution</th>
-      <th class="width=20%">References</th>
+      <th class="width=25%">References</th>
   </thead>
 <tbody>
   {% for message in errors.messages %}

--- a/app/konnect/runtime-manager/troubleshoot.md
+++ b/app/konnect/runtime-manager/troubleshoot.md
@@ -46,7 +46,7 @@ Verify that your instance versions are up to date:
 1. Open {% konnect_icon runtimes %} **Runtime Manager**, then open your runtime group.
 
 1. Click **+ Add runtime instance** and check the {{site.base_gateway}} version
-in the code block. This is the version that the {{site.konnect_short_name}} 
+in the code block. This is the version that the {{site.konnect_short_name}}
 control plane is running.
 
 1. Return to the runtime instances page.
@@ -57,3 +57,47 @@ instance may need [upgrading](/konnect/runtime-manager/runtime-instances/upgrade
 
 If your version is up to date but the feature still isn't working, contact
 [Kong Support](https://support.konghq.com/).
+
+## Version compatibility
+
+We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane.
+
+If you mix major runtime instance versions, the control plane will support the least common subset of configurations across all the versions connected to the {{site.konnect_short_name}} control plane.
+For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configuration that can be used by the 2.8.1.3 runtime instance.
+
+If you are running into compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
+
+Possible compatibility errors:
+
+{% assign errors = site.data.tables.version_errors_konnect %}
+
+<table>
+  <thead>
+      <th>Error code</th>
+      <th>Severity</th>
+      <th>Description</th>
+      <th>Resolution</th>
+      <th class="width=20%">References</th>
+  </thead>
+<tbody>
+  {% for message in errors.messages %}
+      <tr>
+        <td>
+          {{ message.ID | markdownify }}
+        </td>
+        <td>
+          {{ message.Severity | markdownify }}
+        </td>
+        <td>
+          {{ message.Description | markdownify }}
+        </td>
+        <td>
+          {{ message.Resolution | markdownify }}
+        </td>
+        <td>
+          {{ message.DocumentationURL | markdownify }}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/app/konnect/runtime-manager/troubleshoot.md
+++ b/app/konnect/runtime-manager/troubleshoot.md
@@ -63,9 +63,9 @@ If your version is up to date but the feature still isn't working, contact
 We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane.
 
 If you mix major runtime instance versions, the control plane will support the least common subset of configurations across all the versions connected to the {{site.konnect_short_name}} control plane.
-For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configuration that can be used by the 2.8.1.3 runtime instance.
+For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configurations that can be used by the 2.8.1.3 runtime instance.
 
-If you are running into compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
+If you experience compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
 
 Possible compatibility errors:
 

--- a/app/konnect/servicehub/index.md
+++ b/app/konnect/servicehub/index.md
@@ -54,6 +54,11 @@ need to specify a route. Routes determine how successful requests are sent to
 their services after they reach the API gateway. A single service version
 can have only one implementation, but potentially many routes.
 
+{:.important}
+> **Important**: Starting with {{site.base_gateway}} 3.0.0.0, the router supports logical expressions.
+Regex routes must begin with a `~` character. For example: `~/foo/bar/(?baz\w+)`.
+Learn more in the [route configuration guide](/gateway/latest/key-concepts/routes/expressions/).
+
 After configuring the service, version, implementation, and at least one route,
 you’ll be able to start making requests through {{site.konnect_saas}}.
 

--- a/app/konnect/servicehub/service-implementations.md
+++ b/app/konnect/servicehub/service-implementations.md
@@ -80,6 +80,11 @@ first one.
 
 All routes are created in the same runtime group as their parent service version.
 
+{:.important}
+> **Important**: Starting with {{site.base_gateway}} 3.0.0.0, the router supports logical expressions.
+Regex routes must begin with a `~` character. For example: `~/foo/bar/(?baz\w+)`.
+Learn more in the [route configuration guide](/gateway/latest/key-concepts/routes/expressions/).
+
 From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service version.
 Add a route from this page:
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -32,8 +32,7 @@ and much more.
 : To use any new features in the release,
 [start up a new 3.0.0.0 runtime](/konnect/runtime-manager/runtime-instances/upgrade/).
 
-: {:.important}
-> **Limitation**: [Secrets management](/gateway/latest/kong-enterprise/secrets-management) is not yet supported in {{site.konnect_saas}}.
+: **Limitation**: [Secrets management](/gateway/latest/kong-enterprise/secrets-management) is not yet supported in {{site.konnect_saas}}.
 
 
 ## August 2022

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -10,7 +10,33 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services.
 
-## August  2022
+## September 2022
+
+### 2022.09.09
+
+**{{site.base_gateway}} 3.0.0.0 support**
+: {{site.konnect_saas}} now supports {{site.base_gateway}} 3.0.0.0 runtimes.
+You can keep using existing 2.8.x runtimes, or you can upgrade to
+3.0.0.0 to take advantage of any new features, updates, and bug fixes.
+
+: With this major release, {{site.base_gateway}} introduces many new features, including:
+* Five new plugins, including WebSocket validation support, TLS connection customization, and OpenTelemetry
+* A new expression-based router
+* Dynamic plugin ordering through declarative configuration
+* Slim and UBI Docker images
+and much more.
+
+: For all the changes and new features in {{site.base_gateway}} 3.0.0.0, see the
+[changelog](/gateway/changelog/#3000).
+
+: To use any new features in the release,
+[start up a new 3.0.0.0 runtime](/konnect/runtime-manager/runtime-instances/upgrade/).
+
+: {:.important}
+> **Limitation**: [Secrets management](/gateway/latest/kong-enterprise/secrets-management) is not yet supported in {{site.konnect_saas}}.
+
+
+## August 2022
 
 ### 2022.08.31
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -26,14 +26,18 @@ You can keep using existing 2.8.x runtimes, or you can upgrade to
 * Slim and UBI Docker images
 and much more.
 
+: **3.0.0.0 is a major release**. This means that it contains breaking changes and incompatibilities with 2.x versions.
+Review the list of [breaking changes](/gateway/changelog/#breaking-changes-and-deprecations) before upgrading to 3.0.
+: In particular, note the following:
+* **Changes to regex route path format**: 3.0 has a new router. To make sure your existing routes work in 3.0, add a `~` to any regex routes. Learn more in the [route configuration guide](/gateway/latest/key-concepts/routes/expressions/).
+* **Limitations** ({{site.konnect_short_name}} only): [Secrets management](/gateway/latest/kong-enterprise/secrets-management/) and [consumer groups](/gateway/latest/kong-enterprise/consumer-groups/) are not yet supported in {{site.konnect_saas}}.
+
+
 : For all the changes and new features in {{site.base_gateway}} 3.0.0.0, see the
 [changelog](/gateway/changelog/#3000).
 
 : To use any new features in the release,
 [start up a new 3.0.0.0 runtime](/konnect/runtime-manager/runtime-instances/upgrade/).
-
-: **Limitation**: [Secrets management](/gateway/latest/kong-enterprise/secrets-management) is not yet supported in {{site.konnect_saas}}.
-
 
 ## August 2022
 


### PR DESCRIPTION
### Summary
Update the Konnect docs with Gateway 3.0 info and support.

* Bump version for docker images to 3.0.0.0
  * Still using `alpine` since that's what the UI uses; PM made this decision because these sample scripts are meant to target the net new user, ie the tester.
* Table for error messages based on eng-provided content. Turned the provided data into yaml and added links to relevant plugin docs.
* Mentions of the version compatibility issues in various places
* release note
* adding a quick links section to match Gateway 3.0

I couldn't find anything that made sense to add to the decK docs; those docs are already up to date for all the things decK supports (plugin ordering, PATs, etc).

### Reason
https://konghq.atlassian.net/browse/DOCU-2478

### Testing
Broken links are to be expected right now. This depends on some changes coming in Gateway 3.0, and should only be merged AFTER the Gateway 3.0 docs.

Netlify links 
https://deploy-preview-4417--kongdocs.netlify.app/konnect/
https://deploy-preview-4417--kongdocs.netlify.app/konnect/runtime-manager/troubleshoot/#version-compatibility
https://deploy-preview-4417--kongdocs.netlify.app/konnect/runtime-manager/runtime-instances/upgrade/
https://deploy-preview-4417--kongdocs.netlify.app/konnect/runtime-manager/#runtime-instances
