### PR TITLE
Removing reference to Verbose in the CLI

### DIFF
--- a/app/gateway/2.8.x/developer-portal/helpers/cli.md
+++ b/app/gateway/2.8.x/developer-portal/helpers/cli.md
@@ -28,7 +28,7 @@ Make sure Kong is running and portal is on.
 
 Now, from the root folder of the templates repo, you can run:
 
-```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
+```portal [-h,--help] [--config PATH] <command> <workspace>```
 
 Where `<command>` is one of:
 


### PR DESCRIPTION
### Summary
In testing, there does not appear to be a verbose option, and in the Portal CLI GitHub there is no reference to verbose either.
Reference: https://github.com/Kong/kong-portal-cli

### Reason
Because the docs included mention of verbose mode which doesn't seem to exist in Portal CLI.