### PR TITLE
Clean up k8s install (Gateway)

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -83,12 +83,12 @@ items:
             url: /install/
           - text: Kubernetes
             items:
-              - text: kubectl apply
-                url: /install/kubernetes/kubectl
               - text: Helm
                 url: /install/kubernetes/helm-quickstart
               - text: OpenShift with Helm
                 url: /install/kubernetes/openshift
+              - text: kubectl apply
+                url: /install/kubernetes/kubectl
               - text: Kubernetes Deployment Options
                 url: /install/kubernetes/deployment-options
           - text: Docker

--- a/src/gateway/install/kubernetes/kubectl.md
+++ b/src/gateway/install/kubernetes/kubectl.md
@@ -23,15 +23,18 @@ The {{site.base_gateway}} software is governed by the
 
 Create the namespace for {{site.base_gateway}} with {{site.kic_product_name}}. For example:
 
+{% navtabs codeblock %}
+{% navtab Kubernetes %}
 ```sh
-## on Kubernetes native
 kubectl create namespace kong
 ```
-
+{% endnavtab %}
+{% navtab OpenShift %}
 ```sh
-## on OpenShift
 oc new-project kong
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Create license secret
 {:.badge .enterprise}
@@ -40,48 +43,66 @@ oc new-project kong
 
 1.  Run:
 
-    ```sh
-    ## on Kubernetes native
-    kubectl create secret generic kong-enterprise-license --from-file=<absolute-path-to>/license -n kong
-    ```
-
-    ```sh
-    ## on OpenShift
-    oc create secret generic kong-enterprise-license --from-file=./license -n kong
-    ```
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Kubernetes %}
+```sh
+kubectl create secret generic kong-enterprise-license --from-file=<absolute-path-to>/license -n kong
+```
+{% endnavtab %}
+{% navtab OpenShift %}
+```sh
+oc create secret generic kong-enterprise-license --from-file=./license -n kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
 
 ## Deploy
 
 1.  Run one of the following:
 
-    ```sh
-    ## Kong Gateway on Kubernetes native
-    kubectl apply -f https://bit.ly/k4k8s-enterprise-install
-    ```
-
-    ```sh
-    ## Kong Gateway on OpenShift
-    oc create -f https://bit.ly/k4k8s-enterprise-install
-    ```
-
-    ```sh
-    ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://bit.ly/kong-ingress-dbless
-    ```
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Kubernetes %}
+```sh
+kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+```
+{% endnavtab %}
+{% navtab Kubernetes (OSS) %}
+```sh
+kubectl apply -f https://bit.ly/kong-ingress-dbless
+```
+{% endnavtab %}
+{% navtab OpenShift %}
+```sh
+oc create -f https://bit.ly/k4k8s-enterprise-install
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
 
     This might take a few minutes.
 
 1.  Check the install status:
 
-    ```sh
-    kubectl get pods -n kong
-    ```
-
-    or:
-
-    ```sh
-    oc get pods -n kong
-    ```
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Kubernetes %}
+```sh
+kubectl get pods -n kong
+```
+{% endnavtab %}
+{% navtab OpenShift %}
+```sh
+oc get pods -n kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
 
 1.  To make HTTP requests, you need the IP address of the load balancer. Get the `loadBalancer` address and store it in a local `PROXY_IP` environment variable:
 
@@ -92,6 +113,18 @@ oc new-project kong
     export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
     ```
 
+    If you're testing locally and have not deployed a loadbalancer, you can port forward the `kong-proxy` service to test:
+
+    ```sh
+    kubectl port-forward -n kong svc/kong-proxy 8000:80
+    ```
+
+    Then in a different terminal window:
+
+    ```sh
+    export PROXY_IP=localhost:8000
+    ```
+
 1.  Verify that the value of `$PROXY_IP` matches the value of the external host:
 
     ```sh
@@ -100,15 +133,21 @@ oc new-project kong
 
     This should match the `EXTERNAL_IP` value of the `kong-proxy` service returned by the Kubernetes API:
 
-    ```sh
-    kubectl get service kong-proxy -n kong
-    ```
-
-    or:
-
-    ```sh
-    oc get service kong-proxy -n kong
-    ```
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Kubernetes %}
+```sh
+kubectl get service kong-proxy -n kong
+```
+{% endnavtab %}
+{% navtab OpenShift %}
+```sh
+oc get service kong-proxy -n kong
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
 
 1. Invoke a test request:
     ```sh


### PR DESCRIPTION
### Summary
Add `navtabs` to the k8s manifest install

### Reason
The page felt messy whilst I was working through the manifest instructions to ensure that they work with 3.0

### Testing
/install/kubernetes/kubectl