### PR TITLE
Add review label to workflow

### DIFF
--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "review:tech, review:copyedit, review:general, review:autodoc"
+          labels: "review:tech, review:copyedit, review:general, review:autodoc, review:sme"


### PR DESCRIPTION
### Summary
Adding the new `review:sme` label to label-checking workflow.

### Reason
Added a new label to split the job of `review:tech` into two. `review:tech` now means internal docs platform changes, whereas `review:sme` is asking for external review (engineering, PM).

### Testing
Putting the label on this PR to test. If it passes, then it worked.
Edit: yep, it worked.