### PR TITLE
Add missing knative guide to nav

### DIFF
--- a/app/_data/docs_nav_kic_2.5.x.yml
+++ b/app/_data/docs_nav_kic_2.5.x.yml
@@ -123,6 +123,8 @@ items:
         url: /guides/preserve-client-ip
       - text: Using Gateway API
         url: /guides/using-gateway-api
+      - text: Using Kong with Knative
+        url: /guides/using-kong-with-knative
   - title: References
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     items:


### PR DESCRIPTION
### Summary
Guide is missing from 2.5.x nav in KIC docs. Seems like the previous fix to add it to the nav wasn't picked up by 2.5.x as it had already branched from `main` and wasn't rebased.

### Reason
Broken link + missing guide. Reported here: https://github.com/Kong/docs.konghq.com/issues/2939#issuecomment-1216912331

### Testing
Netlify.