### PR TITLE
doc: add KIC 2.6 and Kong 3.x controller guide

### DIFF
--- a/app/_data/docs_nav_kic_2.6.x.yml
+++ b/app/_data/docs_nav_kic_2.6.x.yml
@@ -125,6 +125,8 @@ items:
         url: /guides/preserve-client-ip
       - text: Using Gateway API
         url: /guides/using-gateway-api
+      - text: Using Kong with Knative
+        url: /guides/using-kong-with-knative
   - title: References
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     items:

--- a/app/_data/docs_nav_kic_2.6.x.yml
+++ b/app/_data/docs_nav_kic_2.6.x.yml
@@ -1,0 +1,148 @@
+product: kubernetes-ingress-controller
+release: 2.6.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /kubernetes-ingress-controller/
+    absolute_url: true
+    items:
+      - text: FAQ
+        url: /faq
+      - text: Version Support Policy
+        url: /support-policy
+      - text: Stages of Software Availability
+        url: /availability-stages
+      - text: Changelog
+        url: https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md
+        absolute_url: true
+        target_blank: true
+
+  - title: Concepts
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: Architecture
+        url: /concepts/design
+      - text: Custom Resources
+        url: /concepts/custom-resources
+      - text: Deployment Methods
+        url: /concepts/deployment
+      - text: Kong for Kubernetes with Kong Enterprise
+        url: /concepts/k4k8s-with-kong-enterprise
+      - text: High-Availability and Scaling
+        url: /concepts/ha-and-scaling
+      - text: Resource Classes
+        url: /concepts/ingress-classes
+      - text: Security
+        url: /concepts/security
+      - text: Ingress Resource API Versions
+        url: /concepts/ingress-versions
+      - text: Gateway API
+        url: /concepts/gateway-api
+  - title: Deployment
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /deployment/overview
+    items:
+      - text: Kong Ingress on Minikube
+        url: /deployment/minikube
+      - text: Kong for Kubernetes
+        url: /deployment/k4k8s
+      - text: Kong for Kubernetes Enterprise
+        url: /deployment/k4k8s-enterprise
+      - text: Kong for Kubernetes with Kong Enterprise
+        url: /deployment/kong-enterprise
+      - text: Kong Ingress on AKS
+        url: /deployment/aks
+      - text: Kong Ingress on EKS
+        url: /deployment/eks
+      - text: Kong Ingress on GKE
+        url: /deployment/gke
+      - text: Admission Controller
+        url: /deployment/admission-webhook
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /guides/overview
+    items:
+      - text: Getting Started with KIC
+        url: /guides/getting-started
+      - text: Upgrading from previous versions
+        url: /guides/upgrade
+      - text: Upgrading to Kong 3.x
+        url: /guides/upgrade-kong-3x
+      - text: Getting Started using Istio
+        url: /guides/getting-started-istio
+      - text: Using Custom Resources
+        items:
+          - text: Using the KongPlugin Resource
+            url: /guides/using-kongplugin-resource
+          - text: Using the KongIngress Resource
+            url: /guides/using-kongingress-resource
+          - text: Using KongConsumer and KongCredential Resources
+            url: /guides/using-consumer-credential-resource
+          - text: Using the KongClusterPlugin Resource
+            url: /guides/using-kongclusterplugin-resource
+          - text: Using the TCPIngress Resource
+            url: /guides/using-tcpingress
+          - text: Using the UDPIngress Resource
+            url: /guides/using-udpingress
+      - text: Using the ACL and JWT Plugins
+        url: /guides/configure-acl-plugin
+      - text: Using cert-manager with Kong
+        url: /guides/cert-manager
+      - text: Configuring a Fallback Service
+        url: /guides/configuring-fallback-service
+      - text: Using an External Service
+        url: /guides/using-external-service
+      - text: Configuring HTTPS Redirects for Services
+        url: /guides/configuring-https-redirect
+      - text: Using Redis for Rate Limiting
+        url: /guides/redis-rate-limiting
+      - text: Integrate KIC with Prometheus/Grafana
+        url: /guides/prometheus-grafana
+      - text: Configuring Circuit-Breaker and Health-Checking
+        url: /guides/configuring-health-checks
+      - text: Setting up a Custom Plugin
+        url: /guides/setting-up-custom-plugins
+      - text: Using Ingress with gRPC
+        url: /guides/using-ingress-with-grpc
+      - text: Setting up Upstream mTLS
+        url: /guides/upstream-mtls
+      - text: Exposing a TCP-based Service
+        url: /guides/using-tcpingress
+        generate: false # Generated in the CustomResources section above
+      - text: Exposing a UDP-based Service
+        url: /guides/using-udpingress
+        generate: false # Generated in the CustomResources section above
+      - text: Using the mTLS Auth Plugin
+        url: /guides/using-mtls-auth-plugin
+      - text: Configuring Custom Entities
+        url: /guides/configuring-custom-entities
+      - text: Using the OpenID Connect Plugin
+        url: /guides/using-oidc-plugin
+      - text: Rewriting Hosts and Paths
+        url: /guides/using-rewrites
+      - text: Preserving Client IP Address
+        url: /guides/preserve-client-ip
+      - text: Using Gateway API
+        url: /guides/using-gateway-api
+  - title: References
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: KIC Annotations
+        url: /references/annotations
+      - text: CLI Arguments
+        url: /references/cli-arguments
+      - text: Custom Resource Definitions
+        url: /references/custom-resources
+      - text: Plugin Compatibility
+        url: /references/plugin-compatibility
+      - text: Version Compatibility
+        url: /references/version-compatibility
+      - text: Troubleshooting
+        url: /troubleshooting
+      - text: Prometheus Metrics
+        url: /references/prometheus
+      - text: Feature Gates
+        url: /references/feature-gates
+      - text: Gateway API Support
+        url: /references/gateway-api-support

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -350,3 +350,7 @@
   release: "2.5.x"
   version: "2.5.0"
   edition: "kubernetes-ingress-controller"
+-
+  release: "2.6.x"
+  version: "2.6.0"
+  edition: "kubernetes-ingress-controller"

--- a/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
+++ b/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
@@ -82,10 +82,6 @@ non-regular expression paths. If you have existing Ingresses with regular
 expression paths, those paths will no longer be routed correctly if you upgrade
 to 3.x without updating configuration.
 
-The preferred option for configuring regular expression Ingress rules for Kong
-3.x is to add the `~` prefix to Ingress rules directly. However, this is not
-compatible with Kong 2.x, and therefore cannot be easily done prior to the 3.x
-upgrade.
 
 To smooth the migration process and allow users to update rules gradually, KIC
 2.6 includes an option to continue applying the 2.x regular expression

--- a/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
+++ b/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
@@ -15,6 +15,7 @@ controller-managed Kong instance from 2.x to 3.x.
 * [Helm v3][helm] is installed
 * You are familiar with Helm `install` and `upgrade` operations. See the [documentation for Helm v3][helm-docs].
 
+{:.note}
 > **Note:** Deploying and upgrading via the [Helm chart][chart] is the
 supported mechanism for production deployments of KIC. If you're deploying KIC
 using Kustomize or some other mechanism, you need to develop and test your own
@@ -27,15 +28,15 @@ upgrade strategy based on the following examples.
 
 ### Update CRDs
 
-Helm does not update CRDs automatically, and 2.6 includes Kong 3.x
-compatibility changes to the controller CRDs. You must apply them manually
+KIC 2.6 includes {{site.base_gateway}} 3.x
+compatibility changes to the controller CRDs. Helm does not update CRDs automatically. You must apply them manually
 before upgrading KIC:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/crds/custom-resource-definitions.yaml
 ```
 
-## Upgrading your KIC version
+## Upgrade your KIC version
 
 KIC 2.6 is the first version that supports Kong 3.x. You must upgrade to KIC
 2.6 before upgrading to Kong 3.x. See the [KIC Changelog][changelog] for all
@@ -65,12 +66,12 @@ if available.
 gate, but is otherwise not expected to require changes to existing
 configuration.
 
-## Updating Ingress regular expression paths for Kong 3.x compatibility
+## Update Ingress regular expression paths for Kong 3.x compatibility
 
-Kong 3.x includes a number of its own [breaking changes](https://docs.konghq.com/gateway/changelog/#breaking-changes-and-deprecations),
+Kong 3.x includes a number of its own [breaking changes](/gateway/changelog/#breaking-changes-and-deprecations),
 but most do not affect its interactions with KIC, or are handled automatically
 by 2.6 changes. You should still review these changes for changes that do not
-interact with KIC, such as changes to kong.conf/environment variable settings
+interact with KIC, such as changes to `kong.conf` or environment variable settings
 and changes to the PDK that affect custom plugins.
 
 Kong 3.x's changes to regular expression path handling _do_ require manual
@@ -91,10 +92,10 @@ The preferred option for configuring regular expression Ingress rules for Kong
 compatible with Kong 2.x, and therefore cannot be easily done prior to the 3.x
 upgrade.
 
-To smooth the migration process and allow users to update rules gradually. KIC
+To smooth the migration process and allow users to update rules gradually, KIC
 2.6 includes an option to continue applying the 2.x regular expression
-heuristic on KIC's end: if the option is enabled, the Kong version is 3.0 or
-higher,  and a path matches the 2.x heuristic, KIC will insert the `~` prefix
+heuristic on KIC's end. If the option is enabled, the Kong version is 3.0 or
+higher, and a path matches the 2.x heuristic, KIC will insert the `~` prefix
 for you unless the path already begins with `~`. This allows for a mixture of
 paths that have and have not been migrated to 3.x-style configuration.
 
@@ -128,19 +129,19 @@ kubectl patch ingressclass kong --patch '
 }'
 ```
 
-If you use a non-standard namespace and/or ingress class, you will need to
-replace the `kong` ingress class name and `kong` namespace with values
+If you use a non-standard namespace or Ingress class, you will need to
+replace the `kong` Ingress class name and `kong` namespace with values
 appropriate to your environment.
 
-After you have upgraded to Kong 3.x, you should work to update all of your
-regular expression paths to include the `~` prefix in the Ingress itself at
-your earliest convenience. The heuristic is available for upgrade convenience
-and thus behaves exactly like the version included in Kong 2.8.x, bugs
+After you have upgraded to Kong 3.x, update all of your regular expression paths 
+to include the `~` prefix in the Ingress itself at your earliest convenience. 
+The heuristic is only intended for decreasing downtime during upgrades, so 
+it behaves exactly like the version included in Kong 2.8.x, bugs
 included. Once you added the prefix to all regular expression paths, you can
 disable `enableLegacyRegexDetection`.
 
-Lastly, Gateway API HTTPRoute resources are not affected by this problem: they
-do have a dedicated regular expression path type, and KIC does insert the `~`
+Gateway API HTTPRoute resources are not affected by this problem. They
+do have a dedicated regular expression path type, and KIC inserts the `~`
 prefix automatically for these.
 
 ## Testing environment
@@ -177,10 +178,12 @@ your production environment, deploy a copy to your test cluster
 with the `--version` flag:
 
 ```shell
-$ helm install kong-upgrade-testing kong/kong \
+helm install kong-upgrade-testing kong/kong \
   --version ${YOUR_VERSION} \
   -f ${PATH_TO_YOUR_VALUES_FILE}
 ```
+
+{:.note}
 > **Note:** You may need to adjust your chart further to work in a development or
 staging environment. See the [Helm chart documentation][chart-docs].
 Use this testing environment to walk through the following
@@ -221,7 +224,7 @@ kong    https://charts.konghq.com
 If the repository is not present, add it:
 
 ```shell
-$ helm repo add kong https://charts.konghq.com
+helm repo add kong https://charts.konghq.com
 ```
 
 Update the repository to pull the latest repository updates:
@@ -251,22 +254,22 @@ Run the following command, specifying the old release name, the namespace where
 you've configured {{site.base_gateway}}, and the existing `values.yaml` configuration file:
 
 ```shell
-$ helm upgrade ${YOUR_RELEASE_NAME} kong/kong \
+helm upgrade ${YOUR_RELEASE_NAME} kong/kong \
   --namespace ${YOUR_NAMESPACE} \
   -f ${PATH_TO_YOUR_VALUES_FILE} \
   --set image.tag="3.0"
 ```
 
-After the upgrade completes there is a brief period of time before the new
+After the upgrade completes, there is a brief period of time before the new
 resources are online. You can wait for the relevant Pod resources to complete
 by watching them in your release namespace:
 
 ```shell
-$ kubectl -n ${YOUR_RELEASE_NAMESPACE} get pods -w
+kubectl -n ${YOUR_RELEASE_NAMESPACE} get pods -w
 ```
 
 Once the new pods are in a `Ready` state, the upgrade is complete. Update your
-values.yaml file to use the new Kong and ingress controller image versions to
+`values.yaml` file to use the new Kong and ingress controller image versions to
 continue using these through future upgrades.
 
 ### Rollback
@@ -275,14 +278,14 @@ If you run into problems during or after the upgrade, Helm provides a
 rollback mechanism to revert to a previous revision of the release:
 
 ```shell
-$ helm rollback --namespace ${YOUR_RELEASE_NAMESPACE} ${YOUR_RELEASE_NAME}
+helm rollback --namespace ${YOUR_RELEASE_NAMESPACE} ${YOUR_RELEASE_NAME}
 ```
 
 You can wait for the rollback to complete by watching the relevant Pod
 resources:
 
 ```shell
-$ kubectl -n ${YOUR_RELEASE_NAMESPACE} get pods -w
+kubectl -n ${YOUR_RELEASE_NAMESPACE} get pods -w
 ```
 
 After a rollback, if you ran into issues in production,

--- a/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
+++ b/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
@@ -148,7 +148,7 @@ Using Helm, check the deployed chart version:
 {% navtab Command %}
 
 ```shell
-$ helm list -A
+helm list -A
 ```
 
 {% endnavtab %}

--- a/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
+++ b/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
@@ -2,11 +2,6 @@
 title: Upgrading to Kong 3.x
 ---
 
-This guide walks through the steps needed to upgrade to 2.1.x and later
-versions from earlier versions, and covers changes from older versions to help
-operators evaluate whether they need to make changes to their configuration. It
-also covers creation of a testing environment to test the upgrade.
-
 This guide covers the changes required when upgrading an ingress
 controller-managed Kong instance from 2.x to 3.x.
 

--- a/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
+++ b/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
@@ -39,6 +39,10 @@ changes in this release.
 
 [changelog]:https://github.com/kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#260
 
+2.6 does include a minor breaking change affecting the `CombinedRoutes` feature
+gate, but is otherwise not expected to require changes to existing
+configuration.
+
 As KIC 2.6 is compatible with all 2.x Kong releases, you should upgrade it and
 the chart first:
 
@@ -56,10 +60,6 @@ helm upgrade ${YOUR_RELEASE_NAME} kong/kong \
 
 2.13 is the first chart version that supports 2.6. You can use later versions
 if available.
-
-2.6 does include a minor breaking change affecting the `CombinedRoutes` feature
-gate, but is otherwise not expected to require changes to existing
-configuration.
 
 ## Update Ingress regular expression paths for Kong 3.x compatibility
 

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -41,7 +41,7 @@ other enterprise functionality, built on top of the Open-Source {{site.base_gate
 | Kong Enterprise 2.6.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kong Enterprise 2.7.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kong Enterprise 2.8.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.8.x     | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 3.0.x     | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
 
 ## Kubernetes
 

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -11,49 +11,52 @@ those versions' documentation.
 
 By Kong, we are here referring to the official distribution of the Open-Source {{site.base_gateway}}.
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
-| Kong 1.5.x                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kong 2.0.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.1.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.2.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.3.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.4.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.5.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.6.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.7.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong 2.8.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Kong 1.5.x                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kong 2.0.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.1.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.2.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.3.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.4.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.5.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.6.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.7.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 2.8.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong 3.0.x                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
 
 ## Kong Enterprise
 
 Kong Enterprise is the official enterprise distribution, which includes all
 other enterprise functionality, built on top of the Open-Source {{site.base_gateway}}.
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
-| Kong Enterprise 1.5.x     | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kong Enterprise 2.1.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.2.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.3.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.4.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.5.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.6.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.7.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kong Enterprise 2.8.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Kong Enterprise 1.5.x     | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kong Enterprise 2.1.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.2.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.3.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.4.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.5.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.6.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.7.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.8.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kong Enterprise 2.8.x     | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
 
 ## Kubernetes
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
-| Kubernetes 1.16           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.17           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.22           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Kubernetes 1.16           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.17           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.22           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 ## Istio
 
@@ -61,15 +64,16 @@ The {{site.kic_product_name}} can be integrated with an [Istio Service Mesh][ist
 
 For each {{site.kic_product_name}} release, tests are run to verify this documentation with upcoming versions of KIC and Istio. The following table lists the tested combinations:
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
-| Istio 1.8                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Istio 1.9                 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Istio 1.10                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Istio 1.11                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Istio 1.12                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Istio 1.13                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Istio 1.14                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Istio 1.8                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Istio 1.9                 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Istio 1.10                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Istio 1.11                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Istio 1.12                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Istio 1.13                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Istio 1.14                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Istio 1.15                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 [istio]:https://istio.io
 [istio-guide]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/getting-started-istio/


### PR DESCRIPTION
### Summary
Adds documentation for KIC 2.6. consisting of metadata updates, compat table updates, and a new article for Kong 3.x upgrades.

### Reason
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/2880

Normally I would submit docs after the KIC release is actually out, but in this case I'd like to link to the doc from the KIC changelog. I think we probably just allow the changelog link to be a dead link temporarily and merge this once the release is available, but wasn't sure we wanted to order it that way.

### Testing
Awaiting preview.

Partial runthrough of the new guide commands. I tested the commands to create the IngressClassParameters resource and patch the IngressClass. The rest are copied from https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/upgrade/ with minor adjustments (updating versions and adding a few `--set` parameters for the KIC/Kong versions and I did  not test them separately. Chart 2.13 isn't actually out yet; the controller needs to be released before that will happen.
