### PR TITLE
File log plugin: missing `params` key

### DIFF
--- a/app/_hub/kong-inc/file-log/_index.md
+++ b/app/_hub/kong-inc/file-log/_index.md
@@ -17,6 +17,7 @@ kong_version_compatibility:
     compatible: true
   enterprise_edition:
     compatible: true
+params:
   name: file-log
   service_id: true
   route_id: true


### PR DESCRIPTION
### Summary
Add missing key to File Log plugin doc. 

### Reason
Without the key, plugin doc generates without a configuration section.

### Testing
Netlify
Check that the plugin has a configuration reference section