### PR TITLE
Fix for get-started rate limiting test command

### DIFF
--- a/src/gateway/get-started/rate-limiting.md
+++ b/src/gateway/get-started/rate-limiting.md
@@ -85,7 +85,7 @@ will be subject to rate limit enforcement.
 Run the following command to quickly send 6 mock requests:
 
 ```sh
-for _ in {1..6}; do {curl -s -i localhost:8000/mock/request; echo; sleep 1; } done
+for _ in {1..6}; do curl -s -i localhost:8000/mock/request; echo; sleep 1; done
 ```
 
 {% endnavtab %}


### PR DESCRIPTION
### Summary
Fixes a command in the getting started guide that doesn't work on bash (worked on zsh).

### Reason
bash compatibility is important for the guide

### Testing
Tested the command in bash as well as zsh
