### PR TITLE
Make 'referenceable' a parameter attribute in plugins

### DIFF
--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -33,12 +33,9 @@ params:
       value_in_examples: example@example.com
       encrypted: true
       datatype: string
+      referenceable: true
       description: |
         The account identifier. Can be reused in a different plugin instance.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: api_uri
       required: false
       default: '` https://acme-v02.api.letsencrypt.org/directory`'
@@ -110,23 +107,17 @@ params:
       required: false
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         External account binding (EAB) key id. You usually don't need to set this unless it is explicitly required by the CA.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: eab_hmac_key
       minimum_version: "2.4.x"
       required: false
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         External account binding (EAB) base64-encoded URL string of the HMAC key. You usually don't need to set this unless it is explicitly required by the CA.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: rsa_key_size
       minimum_version: "2.8.x"
       required: false

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -31,16 +31,13 @@ params:
       default: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         The AWS key credential to be used when invoking the function. The `aws_key` value is required
         if `aws_secret` is defined. If `aws_key` and `aws_secret` are not set, the plugin uses an
         IAM role inherited from the instance running Kong to authenticate. Can be symmetrically encrypted
         if using Kong Gateway and [data encryption](/gateway/latest/kong-production/db-encryption/)
         is configured.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: aws_secret
       required: semi
       value_in_examples: <AWS_SECRET>
@@ -48,16 +45,13 @@ params:
       default: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         The AWS secret credential to be used when invoking the function. The `aws_secret` value is required
         if `aws_key` is defined. If `aws_key` and `aws_secret` are not set, the plugin uses an
         IAM role inherited from the instance running Kong to authenticate. Can be symmetrically encrypted
         if using Kong Gateway and [data encryption](/gateway/latest/kong-production/db-encryption/)
         is configured.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: aws_region  # old version, do not update
       maximum_version: "2.5.x"
       required: true
@@ -123,13 +117,10 @@ params:
       default: null
       value_in_examples: <AWS_ASSUME_ROLE_ARN>
       datatype: string
+      referenceable: true
       description: |
         The target AWS IAM role ARN used to invoke the Lambda function. Typically this is
         used for a cross-account Lambda function invocation.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: aws_role_session_name
       minimum_version: "2.8.x"
       required: false

--- a/app/_hub/kong-inc/azure-functions/_index.md
+++ b/app/_hub/kong-inc/azure-functions/_index.md
@@ -55,24 +55,18 @@ params:
       value_in_examples: <AZURE_APIKEY>
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         The apikey to access the Azure resources. If provided, it is injected as the `x-functions-key` header.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: clientid
       required: false
       default: null
       value_in_examples: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         The `clientid` to access the Azure resources. If provided, it is injected as the `x-functions-clientid` header.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: https_verify
       required: false
       default: false

--- a/app/_hub/kong-inc/forward-proxy/_index.md
+++ b/app/_hub/kong-inc/forward-proxy/_index.md
@@ -127,25 +127,19 @@ params:
       default: null
       value_in_examples: example_user
       datatype: string
+      referenceable: true
       description: |
         The username to authenticate with, if the forward proxy is protected
         by basic authentication.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: auth_password
       required: false
       default: null
       value_in_examples: example_pass
       datatype: string
+      referenceable: true
       description: |
         The password to authenticate with, if the forward proxy is protected
         by basic authentication.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: https_verify
       required: true
       default: false

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -174,26 +174,20 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Username to use for Redis connection when the `redis` strategy is defined and ACL authentication is desired.
         If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
       minimum_version: "2.8.x"
     - name: redis.password
       required: semi
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Password to use for Redis connection when the `redis` strategy is defined.
         If undefined, no AUTH commands are sent to Redis.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.database
       required: semi
       default: 0
@@ -213,26 +207,20 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Sentinel username to authenticate with a Redis Sentinel instance.
         If undefined, ACL authentication will not be performed. This requires Redis v6.2.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
       minimum_version: "2.8.x"
     - name: redis.sentinel_password
       required: semi
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Sentinel password to authenticate with a Redis Sentinel instance.
         If undefined, no AUTH commands are sent to Redis Sentinels.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.sentinel_role
       required: semi
       default: null

--- a/app/_hub/kong-inc/kafka-log/_index.md
+++ b/app/_hub/kong-inc/kafka-log/_index.md
@@ -66,12 +66,9 @@ params:
       default: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         Username for SASL authentication.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: authentication.password
       required: false
       value_in_examples: admin-secret
@@ -79,12 +76,9 @@ params:
       default: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         Password for SASL authentication.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: authentication.tokenauth
       required: false
       value_in_examples: false

--- a/app/_hub/kong-inc/kafka-upstream/_index.md
+++ b/app/_hub/kong-inc/kafka-upstream/_index.md
@@ -68,12 +68,9 @@ params:
       default: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         Username for SASL authentication.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: authentication.password
       required: false
       value_in_examples: admin-secret
@@ -81,12 +78,9 @@ params:
       default: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         Password for SASL authentication.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: authentication.tokenauth
       required: false
       value_in_examples: false

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -57,12 +57,9 @@ params:
       value_in_examples: null
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         The password to the LDAP server.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/secrets-management/reference-format).
     - name: start_tls
       required: true
       default: '`false`'
@@ -173,13 +170,10 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         The DN to bind to. Used to perform LDAP search of user. This `bind_dn`
         should have permissions to search for the user being authenticated.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/secrets-management/reference-format).
     - name: group_base_dn
       required: null
       default: matches `conf.base_dn`

--- a/app/_hub/kong-inc/loggly/_index.md
+++ b/app/_hub/kong-inc/loggly/_index.md
@@ -44,12 +44,9 @@ params:
       value_in_examples: YOUR_LOGGLY_SERVICE_TOKEN
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         Loggly [customer token](https://www.loggly.com/docs/customer-token-authentication-token/).
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: tags
       required: false
       default: '`kong`'

--- a/app/_hub/kong-inc/openid-connect/_2.2.x.md
+++ b/app/_hub/kong-inc/openid-connect/_2.2.x.md
@@ -245,6 +245,7 @@ params:
       default: null
       datatype: array of string elements (the plugin supports multiple clients)
       encrypted: true
+      referenceable: true
       description: |
         The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.
         Other settings that are associated with the client are:
@@ -260,10 +261,6 @@ params:
         - `config.unexpected_redirect_uri`
 
         Use the same array index when configuring related settings for the client.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
     - name: client_arg
       required: false
       default: null
@@ -297,14 +294,11 @@ params:
       default: null
       datatype: array of string elements (one for each client)
       encrypted: true
+      referenceable: true
       description: |
         The client secret.
         > Specify one if using `client_secret_*` authentication with the client on
         > the identity provider endpoints.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
     - name: client_jwk
       required: false
       default: (plugin managed)
@@ -995,12 +989,9 @@ params:
       datatype: string
       encrypted: true
       value_in_examples: <session-secret>
+      referenceable: true
       description: |
         The session secret.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
     - name: disable_session
       required: false
       default: null
@@ -1092,25 +1083,19 @@ params:
       required: false
       default: null
       datatype: string
+      referenceable: true
       description: |
         Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired.
         If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
     - name: session_redis_password
       required: false
       default: (from kong)
       encrypted: true
       datatype: string
+      referenceable: true
       description: |
         Password to use for Redis connection when the `redis` session storage is defined.
         If undefined, no AUTH commands are sent to Redis.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
     - name: session_redis_auth
       required: false
       default: (from kong)

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -245,6 +245,7 @@ params:
       default: null
       datatype: array of string elements (the plugin supports multiple clients)
       encrypted: true
+      referenceable: true
       description: |
         The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.
         Other settings that are associated with the client are:
@@ -260,10 +261,6 @@ params:
         - `config.unexpected_redirect_uri`
 
         Use the same array index when configuring related settings for the client.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: client_arg
       required: false
       default: null
@@ -297,14 +294,11 @@ params:
       default: null
       datatype: array of string elements (one for each client)
       encrypted: true
+      referenceable: true
       description: |
         The client secret.
         > Specify one if using `client_secret_*` authentication with the client on
         > the identity provider endpoints.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: client_jwk
       required: false
       default: (plugin managed)
@@ -995,12 +989,9 @@ params:
       datatype: string
       encrypted: true
       value_in_examples: <session-secret>
+      referenceable: true
       description: |
         The session secret.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: disable_session
       required: false
       default: null
@@ -1092,25 +1083,19 @@ params:
       required: false
       default: null
       datatype: string
+      referenceable: true
       description: |
         Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired.
         If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: session_redis_password
       required: false
       default: (from kong)
       encrypted: true
       datatype: string
+      referenceable: true
       description: |
         Password to use for Redis connection when the `redis` session storage is defined.
         If undefined, no AUTH commands are sent to Redis.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: session_redis_auth
       required: false
       default: (from kong)

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -168,13 +168,10 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Password to use for Redis connection when the `redis` strategy is defined.
         If undefined, no AUTH commands are sent to Redis.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.database
       required: semi
       default: 0
@@ -195,26 +192,20 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Sentinel username to authenticate with a Redis Sentinel instance.
         If undefined, ACL authentication will not be performed. This requires Redis v6.2.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.sentinel_password
       minimum_version: "2.8.x"
       required: semi
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Sentinel password to authenticate with a Redis Sentinel instance.
         If undefined, no AUTH commands are sent to Redis Sentinels.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.sentinel_role
       required: semi
       default: null

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -248,25 +248,19 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Username to use for Redis connection when the `redis` strategy is defined and ACL authentication is desired.
         If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.password
       required: semi
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Password to use for Redis connection when the `redis` strategy is defined.
         If undefined, no AUTH commands are sent to Redis.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.database
       required: semi
       default: 0
@@ -288,25 +282,19 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Sentinel username to authenticate with a Redis Sentinel instance.
         If undefined, ACL authentication will not be performed. This requires Redis v6.2.0+.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.sentinel_password
       required: semi
       default: null
       value_in_examples: null
       datatype: string
+      referenceable: true
       description: |
         Sentinel password to authenticate with a Redis Sentinel instance.
         If undefined, no AUTH commands are sent to Redis Sentinels.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis.sentinel_role
       required: semi
       default: null

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -126,22 +126,16 @@ params:
       minimum_version: "2.8.x"
       required: false
       datatype: string
+      referenceable: true
       description: |
         When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis_password
       minimum_version: "2.7.x"
       required: false
       datatype: string
+      referenceable: true
       description: |
         When using the `redis` policy, this property specifies the password to connect to the Redis server.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis_ssl
       minimum_version: "2.7.x"
       required: true

--- a/app/_hub/kong-inc/request-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/_index.md
@@ -65,25 +65,19 @@ params:
       default: null
       value_in_examples: null
       datatype: array of string elements
+      referenceable: true
       description: |
         List of headername:value pairs. If and only if the header is already set,
         replace its old value with the new one. Ignored if the header is not already set.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: replace.querystring
       required: false
       default: null
       value_in_examples: null
       datatype: array of string elements
+      referenceable: true
       description: |
         List of queryname:value pairs. If and only if the querystring name is already set,
         replace its old value with the new one. Ignored if the header is not already set.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: replace.uri
       required: false
       default: null
@@ -99,14 +93,11 @@ params:
         - 'body-param1:new-value-1'
         - 'body-param2:new-value-2'
       datatype: array of string elements
+      referenceable: true
       description: |
         List of paramname:value pairs. If and only if content-type is one the
         following: [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`];
         and the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: rename.headers
       required: false
       default: null
@@ -114,13 +105,10 @@ params:
         - 'header-old-name:header-new-name'
         - 'another-old-name:another-new-name'
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `headername:value` pairs. If and only if the header is already set,
         rename the header. The value is unchanged. Ignored if the header is not already set.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: rename.querystring
       required: false
       default: null
@@ -128,13 +116,10 @@ params:
         - 'qs-old-name:qs-new-name'
         - 'qs2-old-name:qs2-new-name'
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `queryname:value` pairs. If and only if the field name is already set,
         rename the field name. The value is unchanged. Ignored if the field name is not already set.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: rename.body
       required: false
       default: null
@@ -142,13 +127,10 @@ params:
         - 'param-old:param-new'
         - 'param2-old:param2-new'
       datatype: array of string elements
+      referenceable: true
       description: |
         List of parameter `name:value` pairs. Rename the parameter name if and only if content-type is
         one of the following: [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`]; and parameter is present.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: add.headers
       required: false
       default: null
@@ -156,13 +138,10 @@ params:
         - 'x-new-header:value'
         - 'x-another-header:something'
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `headername:value` pairs. If and only if the header is not already set,
         set a new header with the given value. Ignored if the header is already set.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: add.querystring
       required: false
       default: null
@@ -170,61 +149,46 @@ params:
         - 'new-param:some_value'
         - 'another-param:some_value'
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `queryname:value` pairs. If and only if the querystring name is not already set,
         set a new querystring with the given value. Ignored if the querystring name is already set.
-      
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: add.body
       required: false
       default: null
       value_in_examples: null
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `paramname:value` pairs. If and only if content-type is one the following: [`application/json, multipart/form-data`, `application/x-www-form-urlencoded`]; and the parameter is not present, add a new parameter with the given value to form-encoded body.
         Ignored if the parameter is already present.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: append.headers
       required: false
       default: null
       value_in_examples: null
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `headername:value` pairs. If the header is not set, set it with the given value.
         If it is already set, a new header with the same name and the new value will be set.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: append.querystring
       required: false
       default: null
       value_in_examples: null
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `queryname:value` pairs. If the querystring is not set, set it with the given value.
         If it is already set, a new querystring with the same name and the new value will be set.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: append.body
       required: false
       default: null
       value_in_examples: null
       datatype: array of string elements
+      referenceable: true
       description: |
         List of `paramname:value` pairs. If the content-type is one the following: [`application/json`, `application/x-www-form-urlencoded`]; add a new parameter with the given value if the parameter is not present. Otherwise, if it is already present,
         the two values (old and new) will be aggregated in an array.
-        
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: allow.body
       required: false
       default: null

--- a/app/_hub/kong-inc/response-ratelimiting/_index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/_index.md
@@ -153,21 +153,15 @@ params:
       minimum_version: "2.8.x"
       required: false
       datatype: string
+      referenceable: true
       description: |
         When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis_password
       required: false
       datatype: string
+      referenceable: true
       description: |
         When using the `redis` policy, this property specifies the password to connect to the Redis server.
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: redis_timeout
       required: false
       default: '`2000`'

--- a/app/_hub/kong-inc/session/_index.md
+++ b/app/_hub/kong-inc/session/_index.md
@@ -36,12 +36,9 @@ params:
       value_in_examples: opensesame
       datatype: string
       encrypted: true
+      referenceable: true
       description: |
         The secret that is used in keyed HMAC generation.​
-
-        This field is _referenceable_, which means it can be securely stored as a
-        [secret](/gateway/latest/kong-enterprise/security/secrets-management/getting-started)
-        in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format).
     - name: cookie_name
       required: false
       default: '`session`'

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -92,7 +92,14 @@ breadcrumbs:
         </td>
         <td>
           <br>{{ field.description | markdownify }}
-          <p>{% if field.encrypted == true %}If <a href="/gateway/latest/plan-and-deploy/security/db-encryption">keyring database encryption</a> is enabled, this value will be encrypted.{% endif %}</p>
+          {% if field.encrypted == true %}<p>If <a href="/gateway/latest/plan-and-deploy/security/db-encryption">keyring database encryption</a> is enabled, this value will be encrypted.</p>{% endif %}
+          {% if field.referenceable == true %}
+          <p>
+            This field is <em>referenceable</em>, which means it can be securely stored as a
+            <a href="/gateway/latest/kong-enterprise/secrets-management/">secret</a>
+            in a vault. References must follow a <a href="/gateway/latest/kong-enterprise/secrets-management/reference-format/">specific format</a>.
+          </p>
+          {% endif %}
         </td>
       </tr>
       {% endif %}


### PR DESCRIPTION
### Summary
Add a `referenceable` attribute to plugin parameters that will render the `referenceable` help text rather than manually adding it to the description

### Reason
Fixes a broken link, and helps with maintenance

### Testing
Check any referenceable fields in plugins