### PR TITLE
Add missing port to get-started/proxy-caching code snippet

### DIFF
--- a/src/gateway/get-started/proxy-caching.md
+++ b/src/gateway/get-started/proxy-caching.md
@@ -180,7 +180,7 @@ For example, using the response headers above, pass the `X-Cache-Key` value of
 `c9e1d4c8e5fd8209a5969eb3b0e85bc6` to the Admin API:
 
 ```sh
-curl -i http://localhost/proxy-cache/c9e1d4c8e5fd8209a5969eb3b0e85bc6
+curl -i http://localhost:8001/proxy-cache/c9e1d4c8e5fd8209a5969eb3b0e85bc6
 ```
 
 A response with `200 OK` will contain full details of the cached entity.


### PR DESCRIPTION
### Summary
Add missing `port number` to a code snippet in `/gateway/get-started/proxy-caching.md`

### Reason
The current snippet was broken.

### Testing
Go to [Manage cached entities](https://deploy-preview-4455--kongdocs.netlify.app/gateway/3.0.x/get-started/proxy-caching/#manage-cached-entities) and run the last code snippet.

