### PR TITLE
Fix curl for consumer rate limiting plugin

### DIFF
--- a/src/gateway/get-started/rate-limiting.md
+++ b/src/gateway/get-started/rate-limiting.md
@@ -152,8 +152,8 @@ that defines a user of a service. Consumer-level rate limiting can be used to li
    ```sh
    curl -X POST http://localhost:8001/plugins \
       --data "name=rate-limiting" \
-      --data "consumer.id=jsmith" \
-      --data "config.second=5" \
+      --data "consumer.username=jsmith" \
+      --data "config.second=5"
    ```
 
 ## Advanced rate limiting


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Step 1:
```
curl -X POST http://localhost:8001/consumers/ \
  --data username=jsmith
```
Step 2:
```
curl -X POST http://localhost:8001/plugins \
   --data "name=rate-limiting" \
   --data "consumer.id=jsmith" \
   --data "config.second=5" \
```

If you run the above, the 2nd curl returns
```"message":"schema violation (consumer.id: expected a valid UUID)"```

Should plugin be created with `--data "consumer.username=jsmith` instead.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Command does not work.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

Follow the quick start guide and create a consumer and create the rate limiting plugin.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
