### PR TITLE
Fix Secrets Management link in 3.0 release notes

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -43,7 +43,7 @@ This lets you run plugins such as `rate-limiting` before authentication plugins.
   * Added license level to phone home metrics.
   * Added more tooltips.
 
-* [Secrets management](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/) is now generally available.
+* [Secrets management](/gateway/3.0.x/kong-enterprise/secrets-management/) is now generally available.
   * Added GCP integration support for the secrets manager. GCP is now available as a vault backend.
   * The `/vaults-beta` entity has been deprecated and replaced with the `/vaults` entity.
   [#8871](https://github.com/Kong/kong/pull/8871)


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Fixed the link to secrets management in the release notes.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Link was a 404.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
/gateway/changelog/
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
