### PR TITLE
Adding FIPS 3.0.0.0 release documentation

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -326,6 +326,8 @@ items:
         url: /kong-enterprise/consumer-groups
       - text: Event Hooks
         url: /kong-enterprise/event-hooks
+      - text: FIPS 140-2
+        url: /kong-enterprise/fips-support
   - title: Kong Manager
     icon: /assets/images/icons/documentation/icn-manager-color.svg
     items:

--- a/app/_data/tables/features/gateway.yml
+++ b/app/_data/tables/features/gateway.yml
@@ -89,6 +89,10 @@ features:
         tooltip: Encrypt sensitive keys, certificates, and passwords
         oss: false
         enterprise: true
+      - name: FIPS 140-2 Compliance
+        tooltip: Generally available (GA) version coming soon. Kong Gateway in a FIPS 140-2 compliant mode.
+        oss: false
+        enterprise: true
   - name: Observability
     items:
       - name: Simple logging

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -19,6 +19,11 @@ Review the [breaking changes and deprecations](#breaking-changes-and-deprecation
 You can change a plugin's static priority by specifing the order in which plugins run.
 This lets you run plugins such as `rate-limiting` before authentication plugins.
 
+* Kong Gateway now offers a FIPS package. The package replaces the primary library, OpenSSL, with [BoringSSL](https://boringssl.googlesource.com/boringssl/), which at its core uses the FIPS 140-2 compliant BoringCrypto for cryptographic operations.
+
+  To enable FIPS mode, set [`fips`](/gateway/3.0.x/reference/configuration/#fips) to `on`.
+  FIPS mode is only supported in Ubuntu 20.04.
+
 * Kong Gateway now includes WebSocket validation functionality. Websockets are a type of persistent connection that works on top of HTTP.
 
   Previously, Kong Gateway 2.x supported limited WebSocket connections, where plugins only ran during the initial connection phase instead of for each frame.

--- a/src/gateway/kong-enterprise/fips-support.md
+++ b/src/gateway/kong-enterprise/fips-support.md
@@ -1,0 +1,42 @@
+---
+title: FIPS 140-2
+badge: enterprise
+content_type: reference
+---
+
+{{site.base_gateway}} provides support for the Federal Information Processing Standard (FIPS 140-2). Compliance with this standard is typically required for working with U.S. federal government agencies and their contractors.
+
+{{site.base_gateway}} offers a FIPS package. The package replaces the primary library in {{site.base_gateway}}, OpenSSL, with the [BoringSSL](https://boringssl.googlesource.com/boringssl/), which at its core uses the FIPS 140-2 compliant BoringCrypto for cryptographic operations.
+
+{{site.base_gateway}} uses BoringSSL algorithms in all core components when configured.
+
+{:.note .no-icon}
+> {{site.base_gateway}} and the {{site.base_gateway}} FIPS package are not FIPS-validated or certified.
+
+## Install the {{site.base_gateway}} FIPS package
+
+The only supported {{site.base_gateway}} distribution is based on Ubuntu 20.04 and can be installed with the package distinctively named `kong-enterprise-edition-fips`.
+
+To install the {{site.base_gateway}} FIPS package use:
+
+    apt install kong-enterprise-edition-fips`.
+
+{:.note .no-icon}
+> FIPS mode is only supported in Ubuntu 20.04
+
+### Configure FIPS
+
+To start in FIPS mode, set the following variable to `on` in the `kong.conf` configuration file before starting {{site.base_gateway}}. 
+
+```
+fips = on # fips mode is enabled, causing incompatible ciphers to be disabled
+```
+
+You can also use an environment variable:
+
+```bash
+export KONG_FIPS=on
+```
+
+{:.important .no-icon}
+> Migrating from non-FIPS to FIPS mode and backwards is not supported.

--- a/src/gateway/kong-enterprise/fips-support.md
+++ b/src/gateway/kong-enterprise/fips-support.md
@@ -19,7 +19,7 @@ The only supported {{site.base_gateway}} distribution is based on Ubuntu 20.04 a
 
 To install the {{site.base_gateway}} FIPS package use:
 
-    apt install kong-enterprise-edition-fips`.
+    apt install kong-enterprise-edition-fips
 
 {:.note .no-icon}
 > FIPS mode is only supported in Ubuntu 20.04

--- a/src/gateway/kong-enterprise/index.md
+++ b/src/gateway/kong-enterprise/index.md
@@ -99,6 +99,12 @@ You can configure event hooks through the Admin API.
 
 [Learn more about event hooks &rarr;](/gateway/{{page.kong_version}}/admin-api/event-hooks/reference/)
 
+## FIPS support
+
+With version 3.0.0.0, {{site.base_gateway}} provides built-in support for the Federal Information Processing Standard (FIPS 140-2). Compliance with this standard is typically required for working with U.S. federal government agencies and their contractors.
+
+[Learn more about FIPS support &rarr;](/gateway/{{page.kong_version}}/kong-enterprise/fips-support/)
+
 ## More information
 
 See [Plugin Compatibility](/hub/plugins/compatibility/) for more information about Enterprise-only plugins.

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -789,10 +789,11 @@ total memory Kong uses to cache entities might be double this value.
 
 Defines the TLS ciphers served by Nginx.
 
-Accepted values are `modern`, `intermediate`, `old`, or `custom`.
+Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`.
 
 See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions
-of each cipher suite.
+of each cipher suite. `fips` cipher suites are as decribed in
+https://wiki.openssl.org/index.php/FIPS_mode_and_TLS.
 
 **Default:** `intermediate`
 
@@ -1855,6 +1856,14 @@ that are triggered send associated data.
 See: https://docs.konghq.com/gateway/latest/admin-api/event-hooks/reference/
 
 **Default:** `on`
+
+
+
+### fips
+
+Turn on FIPS mode; this mode is only available on a FIPS build.
+
+**Default:** `off`
 
 
 ---

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -789,7 +789,7 @@ total memory Kong uses to cache entities might be double this value.
 
 Defines the TLS ciphers served by Nginx.
 
-Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`.
+Accepted values are `modern`, `intermediate`, `old`, `fips`, or `custom`.
 
 See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions
 of each cipher suite. `fips` cipher suites are as decribed in


### PR DESCRIPTION
### Summary

We had an issue with the FIPS packages so held off on releasing that with the rest of the 3.0.0.0 packages. We fixed the issue and preparing to release only the 3.0.0.0 FIPS packagges.

Reverts https://github.com/Kong/docs.konghq.com/pull/4416

### Testing

Netlify