### PR TITLE
docs(gateway) add note on pg_sql and fips

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -24,6 +24,10 @@ This lets you run plugins such as `rate-limiting` before authentication plugins.
   To enable FIPS mode, set [`fips`](/gateway/3.0.x/reference/configuration/#fips) to `on`.
   FIPS mode is only supported in Ubuntu 20.04.
 
+  {:.note}
+  > **Note**: The Kong Gateway FIPS package is not compatible at this point with SSL 
+  > connections to PostgreSQL.
+
 * Kong Gateway now includes WebSocket validation functionality. Websockets are a type of persistent connection that works on top of HTTP.
 
   Previously, Kong Gateway 2.x supported limited WebSocket connections, where plugins only ran during the initial connection phase instead of for each frame.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -333,6 +333,8 @@ Kong Gateway version.
 * OpenTracing: There is an issue with `nginx-opentracing` in this release, so it is not
   recommended to upgrade yet if you are an OpenTracing user. This will be
   rectified in an upcoming patch/minor release.
+
+* The Kong Gateway FIPS package is not currently compatible with SSL connections to PostgreSQL.
   
 * TLS connections are not supported when using the prebuilt Alpine Docker image.
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -25,7 +25,7 @@ This lets you run plugins such as `rate-limiting` before authentication plugins.
   FIPS mode is only supported in Ubuntu 20.04.
 
   {:.note}
-  > **Note**: The Kong Gateway FIPS package is not compatible at this point with SSL 
+  > **Note**: The Kong Gateway FIPS package is not currently compatible with SSL 
   > connections to PostgreSQL.
 
 * Kong Gateway now includes WebSocket validation functionality. Websockets are a type of persistent connection that works on top of HTTP.


### PR DESCRIPTION
### Summary

Add a note clarifying that `pg_ssl` in FIPS mode isn't supported in 3.0.