### PR TITLE
No more limitation for TLS connections in Alpine builds

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -329,9 +329,7 @@ Kong Gateway version.
 * OpenTracing: There is an issue with `nginx-opentracing` in this release, so it is not
   recommended to upgrade yet if you are an OpenTracing user. This will be
   rectified in an upcoming patch/minor release.
-  
-* TLS connections are not supported when using the prebuilt Alpine Docker image.
-
+ 
 ### Breaking changes and deprecations
 
 #### Deployment


### PR DESCRIPTION
### Summary
Removing limitation. 

### Reason
See slack convo: https://kongstrong.slack.com/archives/CDSTDSG9J/p1663272232698729

### Testing
Netlify