### PR TITLE
Release: Gateway 2.8.2.0

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -166,7 +166,7 @@
   lua_doc: true
 -
   release: "2.8.x"
-  ee-version: "2.8.1.4"
+  ee-version: "2.8.2.0"
   ce-version: "2.8.1"
   edition: "gateway"
   luarocks_version: "2.5.1-0"

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -25,7 +25,7 @@ This lets you run plugins such as `rate-limiting` before authentication plugins.
   FIPS mode is only supported in Ubuntu 20.04.
 
   {:.note}
-  > **Note**: The Kong Gateway FIPS package is not currently compatible with SSL 
+  > **Note**: The Kong Gateway FIPS package is not currently compatible with SSL
   > connections to PostgreSQL.
 
 * Kong Gateway now includes WebSocket validation functionality. Websockets are a type of persistent connection that works on top of HTTP.
@@ -335,7 +335,7 @@ Kong Gateway version.
   rectified in an upcoming patch/minor release.
 
 * The Kong Gateway FIPS package is not currently compatible with SSL connections to PostgreSQL.
-  
+
 ### Breaking changes and deprecations
 
 #### Deployment
@@ -830,8 +830,67 @@ openid-connect
 * Bumped `lodash` for Dev Portal from 4.17.11 to 4.17.21
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 
+## 2.8.2.0
+**Release Date** 2022/09/21
+
+### Features
+
+#### Plugins
+
+* [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/) (`request-transformer-advanced`)
+  * Values stored in `key:value` pairs in this plugin's configuration are now referenceable, which means they can be stored as [secrets](/gateway/latest/kong-enterprise/secrets-management/) in a vault.
+
+### Fixes
+
+#### Enterprise
+
+* **Kong Manager**:
+  * Fixed an issue where workspaces with zero roles were not correctly sorted by the number of roles.
+  * Fixed the Cross Site Scripting (XSS) security vulnerability in the Kong Manager UI.
+  * Fixed an issue where registering an admin without `admin_gui_auth` set resulted in a `500` error.
+  * Fixed an issue that allowed unauthorized IDP users to log in to Kong Manager.
+  These users had no access to any resources in Kong Manager, but were able to go beyond the login screen.
+
+* Fixed OpenSSL vulnerabilities [CVE-2022-2097](https://nvd.nist.gov/vuln/detail/CVE-2022-2097) and [CVE-2022-2068](https://nvd.nist.gov/vuln/detail/CVE-2022-2068).
+* Hybrid mode: Fixed an issue with consumer groups, where the control plane wasn't sending the correct number of consumer entries to data planes.
+* Targets with a weight of `0` are no longer included in health checks, and checking their status via the `upstreams/<upstream>/health` endpoint results in the status `HEALTHCHECK_OFF`.
+Previously, the `upstreams/<upstream>/health` endpoint was incorrectly reporting targets with `weight=0` as `HEALTHY`, and the health check was reporting the same targets as `UNDEFINED`.
+
+#### Plugins
+
+* [Azure Functions](/hub/kong-inc/azure-functions/) (`azure-functions`)
+  * Fixed an issue where calls made by this plugin would fail in the following situations:
+    * The plugin was associated with a route that had no service.
+    * The route's associated service had a `path` value.
+
+* [Route Transformer Advanced](/hub/kong-inc/route-transformer-advanced/) (`route-transformer-advanced`)
+  * Fixed an issue where URIs that included `%20` or a whitespace would return a `400 Bad Request`.
+
+* [GraphQL Rate Limiting Advanced](/hub/kong-inc/graphql-rate-limiting-advanced/) (`graphql-rate-limiting-advanced`)
+  * The plugin now returns a `500` error when using the `cluster` strategy in hybrid or DB-less modes instead of crashing.
+
+* [Request Transformer](/hub/kong-inc/request-transformer/) (`request-transformer`) and [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/) (`request-transformer-advanced`)
+  * Fixed an issue where empty arrays were being converted to empty objects.
+  Empty arrays are now preserved.
+
+* [HTTP Log](/hub/kong-inc/http-log/) (`http-log`)
+  * Fixed the `could not update kong admin` internal error caused by empty headers.
+  This error occurred when using this plugin with the Kubernetes Ingress Controller.
+
+* [GraphQL Proxy Cache Advanced](/hub/kong-inc/graphql-proxy-cache-advanced/) (`graphql-proxy-cache-advanced`) and [Proxy Cache Advanced](/hub/kong-inc/proxy-cache-advanced/) (`proxy-cache-advanced`)
+  * Fixed the error `function cannot be called in access phase (only in: log)`, which was preventing the plugin from working consistently.
+
+* [Forward Proxy](/hub/kong-inc/forward-proxy/) (`forward-proxy`)
+  * If the `https_proxy` configuration parameter is not set, it now defaults to `http_proxy` to avoid DNS errors.
+
+* [OpenID Connect](/hub/kong-inc/openid-connect/) (`openid-connect`)
+  * Fixed issues with OIDC role mapping where admins couldn't be added to more than one workspace, and permissions were not being updated.
+
+* [LDAP Authentication Advanced](/hub/kong-inc/ldap-auth-advanced/)
+  * The characters `.` and `:` are now allowed in group attributes.
+
 ## 2.8.1.4
-**Release Date**  2022/08/23
+**Release Date** 2022/08/23
 
 * Fixed vulnerabilities [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434) and [CVE-2022-24975](https://nvd.nist.gov/vuln/detail/CVE-2022-24975).
 


### PR DESCRIPTION
### Summary
Changelog for Gateway 2.8.2.0 patch.

### Reason
Upcoming patch release.
Compiled from https://konghq.atlassian.net/wiki/spaces/FTT/pages/2884239361/Kong+Enterprise+2.8.2.0 and linked tickets.

https://konghq.atlassian.net/browse/DOCU-2498

### Testing
Netlify