### PR TITLE
Rework KongIngress documentation.

### DIFF
--- a/.github/styles/kong/auto-ignore.txt
+++ b/.github/styles/kong/auto-ignore.txt
@@ -41,3 +41,17 @@ start_cmd
 stream_listen
 stringified
 trusted_ips
+Gateway
+GatewayClass
+HTTPRoute
+TCPRoute
+TLSRoute
+UDPRoute
+GRPCRoute
+ReferenceGrant
+KongIngress
+TCPIngress
+UDPIngress
+KongPlugin
+KongClusterPlugin
+KongConsumer

--- a/src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -24,33 +24,42 @@ The following CRDs allow users to declaratively configure all aspects of Kong:
 
 ## KongIngress
 
-The Ingress resource in Kubernetes is a fairly narrow and ambiguous API, and
-doesn't offer resources to describe the specifics of proxying.
-To overcome this limitation, `KongIngress` Custom Resource is used as an
-"extension" to the existing Ingress API to provide fine-grained control
-over proxy behavior.
-In other words, `KongIngress` works in conjunction with
-the existing Ingress resource and extends it.
-It is not meant as a replacement for the `Ingress` resource in Kubernetes.
-Using `KongIngress`, all properties of [Upstream][kong-upstream],
-[Service][kong-service] and [Route][kong-route]
-entities in Kong related to an Ingress resource can be modified.
+{:.note}
+> **Note:** Many fields available on KongIngress are also available as
+> [annotations](/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations).
+> You can add these annotations directly to Service and Ingress resources
+> without creating a separate KongIngress resource. When an annotation is
+> available, it is the preferred means of configuring that setting, and the
+> annotation value will take precedence over a KongIngress value if both set
+> the same setting.
 
-Once a `KongIngress` resource is created, you can use the `configuration.konghq.com`
-annotation to associate the `KongIngress` resource with an `Ingress` or a `Service`
+The standard Ingress and Service Kubernetes resources cannot express the full
+range of Kong's routing capabilities. KongIngress is a custom resource that
+attaches to Ingresses and Services to extend their capabilities and allow them
+to control all settings on the Kong [routes][kong-route],
+[services][kong-service], and [upstreams][kong-upstream] generated for them.
+KongIngress is not an alternative to Ingress: it cannot be used independently
+and only functions when attached to another resource.
+
+Once a KongIngress resource is created, you can use the `konghq.com/override`
+annotation to associate the KongIngress resource with an Ingress or a Service
 resource:
 
-- When the annotation is added to the `Ingress` resource, the routing
+- When the annotation is added to the Ingress resource, the routing
   configurations are updated, meaning all routes associated with the annotated
-  `Ingress` are updated to use the values defined in the `KongIngress`'s route
+  Ingress are updated to use the values defined in the KongIngress's `route`
   section.
-- When the annotation is added to a `Service` resource in Kubernetes,
-  the corresponding `Service` and `Upstream` in Kong are updated to use the
-  `proxy` and `upstream` blocks as defined in the associated
-  `KongIngress` resource.
+- When the annotation is added to a Service resource in Kubernetes, the
+  corresponding service and upstream in Kong are updated to use the `proxy` and
+  `upstream` blocks as defined in the associated KongIngress resource.
 
-The below diagram shows how the resources are linked
-with one another:
+While you can attach a KongIngress that sets values in the `proxy` and
+`upstream` sections to an Ingress, this will not have any effect: these
+sections are only honored when a KongIngress is attached to a Service.
+Similarly, the `route` section has no effect when attached to a Service, only
+when attached to an Ingress.
+
+The below diagram shows how the resources are linked with one another:
 
 ![Associating Kong Ingress](/assets/images/docs/kubernetes-ingress-controller/kong-ingress-association.png "Associating Kong Ingress")
 
@@ -63,11 +72,11 @@ These plugins can be used to modify the request/response or impose restrictions
 on the traffic.
 
 Once this resource is created, the resource needs to be associated with an
-`Ingress`, `Service`, or `KongConsumer` resource in Kubernetes.
-For more details, please read the reference documentation on `KongPlugin`.
+Ingress, Service, or KongConsumer resource in Kubernetes.
+For more details, please read the reference documentation on KongPlugin.
 
-The below diagram shows how you can link `KongPlugin` resource to an
-`Ingress`, `Service`, or `KongConsumer`:
+The below diagram shows how you can link KongPlugin resource to an
+Ingress, Service, or KongConsumer:
 
 |  |  |
 :-:|:-:
@@ -83,7 +92,7 @@ This can help when the configuration of the plugin needs to be centralized
 and the permissions to add/update plugin configuration rests with a different
 persona than application owners.
 
-This resource can be associated with `Ingress`, `Service` or `KongConsumer`
+This resource can be associated with Ingress, Service or KongConsumer
 and can be used in the exact same way as KongPlugin.
 
 A namespaced KongPlugin resource takes priority over a
@@ -95,8 +104,8 @@ _This resource requires the `kubernetes.io/ingress.class` annotation. Its value
 must match the value of the controller's `--ingress-class` argument, which is
 `kong` by default._
 
-This custom resource configures `Consumers` in Kong.
-Every `KongConsumer` resource in Kubernetes directly translates to a
+This custom resource configures consumers in Kong.
+Every KongConsumer resource in Kubernetes directly translates to a
 [Consumer][kong-consumer] object in Kong.
 
 ## TCPIngress

--- a/src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -55,6 +55,11 @@ resource:
   corresponding service and upstream in Kong are updated to use the `proxy` and
   `upstream` blocks as defined in the associated KongIngress resource.
 
+- **Annotated Ingress resource:** All routes associated with the annotated
+  Ingress are updated to use the values defined in the KongIngress's route section.
+- **Annotated Service resource:** The
+  corresponding service and upstream in Kong are updated to use the proxy and upstream blocks as defined in the associated KongIngress resource.
+
 Don't attach a KongIngress that sets values in the `proxy` and
 `upstream` sections to an Ingress, as it won't have any effect. These
 sections are only honored when a KongIngress is attached to a Service.

--- a/src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -33,9 +33,11 @@ The following CRDs allow users to declaratively configure all aspects of Kong:
 > annotation value will take precedence over a KongIngress value if both set
 > the same setting.
 
-The standard Ingress and Service Kubernetes resources cannot express the full
-range of Kong's routing capabilities. KongIngress is a custom resource that
-attaches to Ingresses and Services to extend their capabilities and allow them
+The standard Ingress and Service Kubernetes resources can't express the full
+range of Kong's routing capabilities. You can use KongIngress to extend these resources. 
+
+KongIngress is a custom resource that
+attaches to Ingresses and Services and allows them
 to control all settings on the Kong [routes][kong-route],
 [services][kong-service], and [upstreams][kong-upstream] generated for them.
 KongIngress is not an alternative to Ingress. It can't be used independently

--- a/src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -38,7 +38,7 @@ range of Kong's routing capabilities. KongIngress is a custom resource that
 attaches to Ingresses and Services to extend their capabilities and allow them
 to control all settings on the Kong [routes][kong-route],
 [services][kong-service], and [upstreams][kong-upstream] generated for them.
-KongIngress is not an alternative to Ingress: it cannot be used independently
+KongIngress is not an alternative to Ingress. It can't be used independently
 and only functions when attached to another resource.
 
 Once a KongIngress resource is created, you can use the `konghq.com/override`
@@ -53,13 +53,13 @@ resource:
   corresponding service and upstream in Kong are updated to use the `proxy` and
   `upstream` blocks as defined in the associated KongIngress resource.
 
-While you can attach a KongIngress that sets values in the `proxy` and
-`upstream` sections to an Ingress, this will not have any effect: these
+Don't attach a KongIngress that sets values in the `proxy` and
+`upstream` sections to an Ingress, as it won't have any effect. These
 sections are only honored when a KongIngress is attached to a Service.
 Similarly, the `route` section has no effect when attached to a Service, only
 when attached to an Ingress.
 
-The below diagram shows how the resources are linked with one another:
+The following diagram shows how the resources are linked with one another:
 
 ![Associating Kong Ingress](/assets/images/docs/kubernetes-ingress-controller/kong-ingress-association.png "Associating Kong Ingress")
 
@@ -73,9 +73,9 @@ on the traffic.
 
 Once this resource is created, the resource needs to be associated with an
 Ingress, Service, or KongConsumer resource in Kubernetes.
-For more details, please read the reference documentation on KongPlugin.
+For more details, read the reference documentation on [KongPlugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kongplugin-resource/).
 
-The below diagram shows how you can link KongPlugin resource to an
+The following diagram shows how you can link a KongPlugin resource to an
 Ingress, Service, or KongConsumer:
 
 |  |  |
@@ -92,7 +92,7 @@ This can help when the configuration of the plugin needs to be centralized
 and the permissions to add/update plugin configuration rests with a different
 persona than application owners.
 
-This resource can be associated with Ingress, Service or KongConsumer
+This resource can be associated with an Ingress, Service, or KongConsumer, 
 and can be used in the exact same way as KongPlugin.
 
 A namespaced KongPlugin resource takes priority over a

--- a/src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -47,18 +47,11 @@ Once a KongIngress resource is created, you can use the `konghq.com/override`
 annotation to associate the KongIngress resource with an Ingress or a Service
 resource:
 
-- When the annotation is added to the Ingress resource, the routing
-  configurations are updated, meaning all routes associated with the annotated
-  Ingress are updated to use the values defined in the KongIngress's `route`
-  section.
-- When the annotation is added to a Service resource in Kubernetes, the
-  corresponding service and upstream in Kong are updated to use the `proxy` and
-  `upstream` blocks as defined in the associated KongIngress resource.
-
 - **Annotated Ingress resource:** All routes associated with the annotated
-  Ingress are updated to use the values defined in the KongIngress's route section.
+  Ingress are updated to use the values defined in the KongIngress's `route` section.
 - **Annotated Service resource:** The
-  corresponding service and upstream in Kong are updated to use the proxy and upstream blocks as defined in the associated KongIngress resource.
+  corresponding service and upstream in Kong are updated to use the `proxy` and `upstream`
+  blocks as defined in the associated KongIngress resource.
 
 Don't attach a KongIngress that sets values in the `proxy` and
 `upstream` sections to an Ingress, as it won't have any effect. These

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -5,6 +5,16 @@ title: Using KongIngress resource
 In this guide, we will learn how to use KongIngress resource to control
 proxy behavior.
 
+{:.note}
+> **Note:** Many fields available on KongIngress are also available as
+> [annotations](/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations).
+> You can add these annotations directly to Service and Ingress resources
+> without creating a separate KongIngress resource. When an annotation is
+> available, it is the preferred means of configuring that setting, and the
+> annotation value will take precedence over a KongIngress value if both set
+> the same setting. This guide focuses on settings that can only be set using
+> KongIngress.
+
 ## Installation
 
 Please follow the [deployment](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview) documentation to install
@@ -35,12 +45,17 @@ This is expected as Kong does not yet know how to proxy the request.
 
 ## Install a dummy service
 
-We will start by installing the echo service.
+We will start by installing the echo service and increasing its replica count:
 
 ```bash
 $ kubectl apply -f https://bit.ly/echo-service
 service/echo created
 deployment.apps/echo created
+```
+
+```bash
+$ kubectl patch deploy echo --patch '{"spec": {"replicas": 2}}'
+deployment.apps/echo patched
 ```
 
 ## Setup Ingress
@@ -104,13 +119,17 @@ Request Information:
   request_uri=http://35.233.170.67:8080/foo
 ```
 
-## Use KongIngress with Ingress resource
+## Use KongIngress with a Service resource
 
-By default, Kong will proxy the entire path to the service.
-This can be seen in the real path value in the above response.
+By default, Kong will round-robin requests between upstream replicas. If you
+run `curl -s $PROXY_IP/foo | grep "pod name:"` repeatedly, you should see the
+reported Pod name alternate between two values.
 
-We can configure Kong to strip out the part of the path defined in the
-Ingress rule and to only respond to GET requests for this particular rule.
+We can configure the Kong upstream associated with the Service to use a
+different [load balancing strategy](/gateway/latest/how-kong-works/load-balancing/#balancing-algorithms),
+such as consistently sending requests to the same upstream based on a header
+value. This and other fields available on the Kong upstream resource cannot be
+configured using annotations, only using KongIngress.
 
 To modify these behaviours, let's first create a KongIngress resource
 defining the new behaviour:
@@ -120,132 +139,210 @@ $ echo "apiVersion: configuration.konghq.com/v1
 kind: KongIngress
 metadata:
   name: sample-customization
-route:
-  methods:
-  - GET
-  strip_path: true" | kubectl apply -f -
+upstream:
+  hash_on: header
+  hash_on_header: x-lb
+  hash_fallback: ip
+  algorithm: consistent-hashing" | kubectl apply -f -
 kongingress.configuration.konghq.com/test created
 ```
 
-Now, let's associate this KongIngress resource with our Ingress resource
+Now, let's associate this KongIngress resource with our Service resource
 using the `konghq.com/override` annotation.
 
 ```bash
-$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/override":"sample-customization"}}}'
-ingress.extensions/demo patched
-```
-
-Now, Kong will proxy only GET requests on `/foo` path and
-strip away `/foo`:
-
-```bash
-$ curl -s $PROXY_IP/foo -X POST
-{"message":"no Route matched with those values"}
-
-
-$ curl -s $PROXY_IP/foo/baz
-
-
-Hostname: echo-d778ffcd8-vrrtw
-
-Pod Information:
-  node name:	gke-harry-k8s-dev-default-pool-bb23a167-8pgh
-  pod name:	echo-d778ffcd8-vrrtw
-  pod namespace:	default
-  pod IP:	10.60.0.9
-
-Server values:
-  server_version=nginx: 1.12.2 - lua: 10010
-
-Request Information:
-  client_address=10.60.1.10
-  method=GET
-  real path=/baz
-  query=
-  request_version=1.1
-  request_scheme=http
-  request_uri=http://35.233.170.67:8080/baz
-```
-
-As you can see, the real path value is `/baz`.
-
-## Use KongIngress with Service resource
-
-KongIngress can be used to change load-balancing, health-checking and other
-proxy behaviours in Kong.
-
-Next, we are going to tweak two settings:
-
-- Configure Kong to hash the requests based on IP address of the client.
-- Configure Kong to proxy all the request on `/foo` to `/bar`.
-
-Let's create a KongIngress resource with these settings:
-
-```bash
-$ echo 'apiVersion: configuration.konghq.com/v1
-kind: KongIngress
-metadata:
-  name: demo-customization
-upstream:
-  hash_on: ip
-proxy:
-  path: /bar/' | kubectl apply -f -
-kongingress.configuration.konghq.com/demo-customization created
-```
-
-Now, let's associate this KongIngress resource to the echo service.
-
-```bash
-$ kubectl patch service echo -p '{"metadata":{"annotations":{"konghq.com/override":"demo-customization"}}}'
+$ kubectl patch service echo -p '{"metadata":{"annotations":{"konghq.com/override":"sample-customization"}}}'
 service/echo patched
 ```
 
-Let's test this now:
+Sending repeated requests now without any `x-lb` header will send them to the
+same Pod, since we're using consistent hashing and fall back to the client IP
+if no header is present:
 
 ```bash
-$ curl $PROXY_IP/foo/baz
-Hostname: echo-d778ffcd8-vrrtw
-
-Pod Information:
-  node name:	gke-harry-k8s-dev-default-pool-bb23a167-8pgh
-  pod name:	echo-d778ffcd8-vrrtw
-  pod namespace:	default
-  pod IP:	10.60.0.9
-
-Server values:
-  server_version=nginx: 1.12.2 - lua: 10010
-
-Request Information:
-  client_address=10.60.1.10
-  method=GET
-  real path=/bar/baz
-  query=
-  request_version=1.1
-  request_scheme=http
-  request_uri=http://35.233.170.67:8080/bar/baz
-
-<-- clipped -->
+$ for n in {1..5}; do curl -s $PROXY_IP/foo | grep "pod name:"; done
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-6jrmn
 ```
 
-Real path received by the upstream service (echo) is now changed to `/bar/baz`.
-
-Also, now all the requests will be sent to the same upstream pod:
+If we then add the header, Kong will hash its value and distribute it to the
+same replica when we use the same value:
 
 ```bash
-$ curl -s $PROXY_IP/foo | grep "pod IP"
-  pod IP:	10.60.0.9
-$ curl -s $PROXY_IP/foo | grep "pod IP"
-  pod IP:	10.60.0.9
-$ curl -s $PROXY_IP/foo | grep "pod IP"
-  pod IP:	10.60.0.9
-$ curl -s $PROXY_IP/foo | grep "pod IP"
-  pod IP:	10.60.0.9
-$ curl -s $PROXY_IP/foo | grep "pod IP"
-  pod IP:	10.60.0.9
-$ curl -s $PROXY_IP/foo | grep "pod IP"
-  pod IP:	10.60.0.9
+$ for n in {1..3}; do
+  curl -s $PROXY_IP/foo -H "x-lb: foo" | grep "pod name:";
+  curl -s $PROXY_IP/foo -H "x-lb: bar" | grep "pod name:";
+  curl -s $PROXY_IP/foo -H "x-lb: baz" | grep "pod name:";
+done
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-6jrmn
 ```
 
+Increasing the replicas will redistribute some subsequent requests onto the new
+replica:
 
-You can experiment with various load balancing and health-checking settings
-that KongIngress resource exposes to suit your specific use case.
+```bash
+$ kubectl patch deploy echo --patch '{"spec": {"replicas": 3}}'
+deployment.apps/echo patched
+```
+
+```bash
+$ for n in {1..3}; do
+  curl -s $PROXY_IP/foo -H "x-lb: foo" | grep "pod name:";
+  curl -s $PROXY_IP/foo -H "x-lb: bar" | grep "pod name:";
+  curl -s $PROXY_IP/foo -H "x-lb: baz" | grep "pod name:";
+done
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-d477r
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-d477r
+	pod name:	echo-588c888c78-6jrmn
+	pod name:	echo-588c888c78-nk4jc
+	pod name:	echo-588c888c78-d477r
+	pod name:	echo-588c888c78-6jrmn
+```
+
+Kong's load balancer does not directly distribute requests to each of the
+Service's Endpoints. It first distributes them evenly across a number of
+equal-size buckets. These buckets are then distributed across the available
+Endpoints according to their weight. For Ingresses, however, there is a single
+Service, and the controller assigns each Endpoint (represented by a Kong
+upstream target) equal weight, and requests are indeed evenly hashed across all
+Endpoints.
+
+Gateway API HTTPRoutes support multiple backend Services with associated
+weights per Service. The controller still assigns each Endpoint for a given
+Service the same weight, but assigns them proportionally across the
+multi-Service backend: the Endpoints of a Service will have a Kong target
+weight such they collectively receive a percentage of requests equal to their
+Service's weight in the HTTPRoute. For example, if you have two Services, one
+with 4 Endpoints and one with 2, and each Service has weight 50 in the
+HTTPRoute, the targets created for the 2-Endpoint Service have double the
+weight of the targets created for the 4-Endpoint Service.
+
+KongIngress can also configure upstream [health checking behavior as
+well](/gateway/latest/reference/health-checks-circuit-breakers/). See [the
+KongIngress reference](/kubernetes-ingress-controller/{{page.kong_version}}/references/custom-resources/#kongingress)
+for the health check fields.
+
+## Use KongIngress with Ingress resource
+
+Kong can match routes based on request headers. For example, you can have two
+separate foutes for `/foo`, one which matches requests that include an
+`x-split: alpha` and another that matches requests with `x-split: bravo` or
+`x-legacy: charlie`. Configuring this using the ingress controller requires
+attaching a KongIngress to an Ingress resource. It is not available via an
+Ingress annotation.
+
+To start, create a copy of the Ingress we created earlier with a different
+name:
+
+
+```bash
+$ echo "
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: demo-copy
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: echo
+            port:
+              number: 80
+" | kubectl apply -f -
+ingress.extensions/demo-copy created
+```
+
+The controller will create this route, but it will not be accessible: all
+requests for `/foo` will match the original `demo` route. When two routes have
+identical matching criteria, Kong uses their creation time as a tiebreaker (you
+may, however, see the matched route flipped if you restart the container when
+using DB-less mode, as both routes will then be re-added at the same time). To
+fix this, we'll create KongIngresses that differentiate the routes via headers:
+
+```bash
+$ echo "
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongIngress
+metadata:
+  name: header-alpha
+route:
+  headers:
+    x-split:
+	- alpha
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongIngress
+metadata:
+  name: header-bravo
+route:
+  headers:
+    x-split:
+	- bravo
+	- charlie
+    x-legacy:
+	- enabled
+  " | kubectl apply -f -
+kongingress.configuration.konghq.com/header-alpha created
+kongingress.configuration.konghq.com/header-bravo created
+```
+
+Now, let's associate these KongIngress resources with our Ingress resources
+using the `konghq.com/override` annotation.
+
+```bash
+$ kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/override":"header-alpha"}}}'
+ingress.extensions/demo patched
+```
+
+```bash
+$ kubectl patch ingress demo-copy -p '{"metadata":{"annotations":{"konghq.com/override":"header-bravo"}}}'
+ingress.extensions/demo-copy patched
+```
+
+Now, neither of the routes will match:
+
+```bash
+$ curl -s $PROXY_IP/foo
+{"message":"no Route matched with those values"}
+```
+
+Adding headers to your requests will make your requests match routes again, and
+you'll be able to access both routes depending on which header you use:
+
+```bash
+$ curl -sv $PROXY_IP/foo -H "kong-debug: 1" -H "x-split: alpha" 2>&1 | grep -i kong-route-name
+< Kong-Route-Name: default.demo.00
+```
+
+```bash
+$ curl -sv $PROXY_IP/foo -H "kong-debug: 1" -H "x-split: bravo" -H "x-legacy: enabled"  2>&1 | grep -i kong-route-name
+< Kong-Route-Name: default.demo-copy.00
+```
+
+```bash
+$ curl -sv $PROXY_IP/foo -H "kong-debug: 1" -H "x-split: charlie" -H "x-legacy: enabled"  2>&1 | grep -i kong-route-name
+< Kong-Route-Name: default.demo-copy.00
+```
+
+Note that demo-copy requires _both_ headers, but will match any of the
+individual values configured for a given header.

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -321,23 +321,22 @@ Endpoints.
 Gateway API HTTPRoute rules support distributing traffic across multiple
 Services. The rule can assign weights to the Services to change the proportion
 of requests an individual Service receives. In Kong's implementation, all
-Endpoint of a Service have the same weight. Kong calculates a per-Endpoint
+Endpoints of a Service have the same weight. Kong calculates a per-Endpoint
 upstream target weight such that the aggregate target weight of the Endpoints
 is equal to the proportion indicated by the HTTPRoute weight.
 
 For example, say you have two Services with the following configuration:
  * One Service has four Endpoints
  * The other Service has two Endpoints
- * Each Service has weight 50 in the HTTPRoute
+ * Each Service has weight `50` in the HTTPRoute
 
 The targets created for the two-Endpoint Service have double the
-weight of the targets created for the four-Endpoint Service (two weight 16
-targets and four weight 8 targets) . Scaling the
+weight of the targets created for the four-Endpoint Service (two weight `16`
+targets and four weight `8` targets). Scaling the
 four-Endpoint Service to eight would halve the weight of its targets (two
-weight 16 targets and eight weight 4 targets).
+weight `16` targets and eight weight `4` targets).
 
-KongIngress can also configure upstream [health checking behavior as
-well](/gateway/latest/reference/health-checks-circuit-breakers/). See [the
+KongIngress can also configure upstream [health checking behavior](/gateway/latest/reference/health-checks-circuit-breakers/) as well. See [the
 KongIngress reference](/kubernetes-ingress-controller/{{page.kong_version}}/references/custom-resources/#kongingress)
 for the health check fields.
 

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -54,7 +54,7 @@ deployment.apps/echo created
 ```
 
 ```bash
-$ kubectl patch deploy echo --patch '{"spec": {"replicas": 2}}'
+kubectl patch deploy echo --patch '{"spec": {"replicas": 2}}'
 deployment.apps/echo patched
 ```
 

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -344,7 +344,7 @@ for the health check fields.
 ## Use KongIngress with Ingress resource
 
 Kong can match routes based on request headers. For example, you can have two
-separate foutes for `/foo`, one that matches requests which include an
+separate routes for `/foo`, one that matches requests which include an
 `x-split: alpha`, and another that matches requests with `x-split: bravo` or
 `x-legacy: charlie`. Configuring this using the ingress controller requires
 attaching a KongIngress to an Ingress resource. It is not available via an

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -220,18 +220,23 @@ Service, and the controller assigns each Endpoint (represented by a Kong
 upstream target) equal weight. In this case, requests are evenly hashed across all
 Endpoints.
 
-Gateway API HTTPRoutes support multiple backend Services with associated
-weights per Service. For each Service, the controller still assigns the same weight per Endpoint, but it assigns them proportionally across the
-multi-Service backend: the Endpoints of a Service will have a Kong target
-weight such they collectively receive a percentage of requests equal to their
-Service's weight in the HTTPRoute. 
+Gateway API HTTPRoute rules support distributing traffic across multiple
+Services. The rule can assign weights to the Services to change the proportion
+of requests an individual Service receives. In Kong's implementation, all
+Endpoint of a Service have the same weight. Kong calculates a per-Endpoint
+upstream target weight such that the aggregate target weight of the Endpoints
+is equal to the proportion indicated by the HTTPRoute weight.
 
 For example, say you have two Services with the following configuration:
  * One Service has four Endpoints
  * The other Service has two Endpoints
  * Each Service has weight 50 in the HTTPRoute
+
 The targets created for the two-Endpoint Service have double the
-weight of the targets created for the four-Endpoint Service.
+weight of the targets created for the four-Endpoint Service (two weight 16
+targets and four weight 8 targets) . Scaling the
+four-Endpoint Service to eight would halve the weight of its targets (two
+weight 16 targets and eight weight 4 targets).
 
 KongIngress can also configure upstream [health checking behavior as
 well](/gateway/latest/reference/health-checks-circuit-breakers/). See [the

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -33,17 +33,17 @@ HTTP 404 Not Found.
 {% navtabs codeblock %}
 {% navtab Command %}
 ```bash
-$ curl -i $PROXY_IP
+curl -i $PROXY_IP
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
 HTTP/1.1 404 Not Found
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
 Server: kong/1.2.1
-```
-{% endnavtab %}
 
-{% navtab Response %}
-```json
 {"message":"no Route matched with those values"}
 ```
 {% endnavtab %}
@@ -58,7 +58,7 @@ We will start by installing the echo service and increasing its replica count:
 {% navtabs codeblock %}
 {% navtab Command %}
 ```bash
-$ kubectl apply -f https://bit.ly/echo-service
+kubectl apply -f https://bit.ly/echo-service
 ```
 {% endnavtab %}
 
@@ -74,7 +74,6 @@ deployment.apps/echo created
 {% navtab Command %}
 ```bash
 kubectl patch deploy echo --patch '{"spec": {"replicas": 2}}'
-$ kubectl patch deploy echo --patch '{"spec": {"replicas": 2}}'
 ```
 {% endnavtab %}
 
@@ -93,7 +92,7 @@ by defining an Ingress.
 {% navtabs codeblock %}
 {% navtab Command %}
 ```bash
-$ echo "
+echo "
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -126,7 +125,7 @@ Let's test:
 {% navtabs codeblock %}
 {% navtab Command %}
 ```bash
-$ curl -i $PROXY_IP/foo
+curl -i $PROXY_IP/foo
 ```
 {% endnavtab %}
 
@@ -182,7 +181,7 @@ defining the new behaviour:
 {% navtabs codeblock %}
 {% navtab Command %}
 ```bash
-$ echo "apiVersion: configuration.konghq.com/v1
+echo "apiVersion: configuration.konghq.com/v1
 kind: KongIngress
 metadata:
   name: sample-customization
@@ -207,7 +206,7 @@ using the `konghq.com/override` annotation.
 {% navtabs codeblock %}
 {% navtab Command %}
 ```bash
-$ kubectl patch service echo -p '{"metadata":{"annotations":{"konghq.com/override":"sample-customization"}}}'
+kubectl patch service echo -p '{"metadata":{"annotations":{"konghq.com/override":"sample-customization"}}}'
 ```
 {% endnavtab %}
 

--- a/src/kubernetes-ingress-controller/references/custom-resources.md
+++ b/src/kubernetes-ingress-controller/references/custom-resources.md
@@ -213,6 +213,15 @@ meaning it will be executed for every request that is proxied via Kong.
 
 ## KongIngress
 
+{:.note}
+> **Note:** Many fields available on KongIngress are also available as
+> [annotations](/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations).
+> You can add these annotations directly to Service and Ingress resources
+> without creating a separate KongIngress resource. When an annotation is
+> available, it is the preferred means of configuring that setting, and the
+> annotation value will take precedence over a KongIngress value if both set
+> the same setting.
+
 Ingress resource spec in Kubernetes can define routing policies
 based on HTTP Host header and paths.
 While this is sufficient in most cases,
@@ -257,7 +266,7 @@ kind: KongIngress
 metadata:
   name: configuration-demo
 upstream:
-  slots: 10
+  slots: 10000
   hash_on: none
   hash_fallback: none
   healthchecks:


### PR DESCRIPTION
### Summary
Fix #4474

This makes several changes to KongIngress documentation:
- All KongIngress docs now recommend the use of annotations where possible and explain the precedence order when both are present. This has been our recommendation for some time but was never properly documented.
- The KongIngress guide has been largely rewritten to expand the existing load balancer configuration documentation for Services and cover header routing for Ingress (it's the only KongIngress-exclusive Ingress configuration).
- The KongIngress section of the custom resources concepts documentation has been updated to remove some outdated information, simplify language, and remove inline code formatting for resource names (for everything, not just KongIngress). The formatting change is based on the convention used in Kubernetes documentation (e.g. https://kubernetes.io/docs/concepts/services-networking/ingress/#default-backend) where resource names are in plaintext, and only field names and values are inline code.

~The guide has two outstanding TODOs. I'm waiting on feedback from the gateway team about how exactly the minimum slots value is determined and need to verify some of the math inside the controller. Those need to be filled in but are not expected to change the rest of the document. This is a draft pending those but outside those paragraphs it's ready for review.~

### Reason
This resource has been a long-standing source of confusion, and will probably continue to be one until we (hopefully) remove it entirely and replace it with some combination of annotations and resources that aren't a catch-all for any Kong configuration that didn't fit into the stock resources. Questions about it came up today and I needed to write some some docs anyway, so I'm finally giving it a long-needed update.

### Testing
Example commands and output in the guide were copied from my test environment, where I confirmed the configuration was deployed and working as expected.

Awaiting preview to confirm formatting and such.