### PR TITLE
[TDX-2195] Dev portal app reg with multi-runtime group support

### DIFF
--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -22,7 +22,7 @@ We are rolling out full support in any non-`default` runtime group, using the `k
 - A service that is versioned and published to the
   {{site.konnect_short_name}} Dev Portal so that it appears in the catalog.
 
-- The service version can be in any runtime group.
+- The service version can be in any runtime group, as long as the following conditions are met:
 
   - Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -15,7 +15,7 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 
 - The service version can be in any runtime group.
 
-  - {:.badge .alpha} Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
+  - Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
 
   - Service versions in the `default` runtime group can be proxied with any version of {{site.base_gateway}}
 
@@ -122,8 +122,8 @@ at any time.
 
 ### Differences between runtime groups
 
-If you need to use a version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher, and support is currently in {:.badge .alpha}.
+If you need to use a version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher.
 
 In the `default` runtime group, applications are still linked to {{site.base_gateway}} `consumers` and use the `acl` plugin to control access between an application's `consumer` and a service version. This configuration is deprecated. It is recommended to upgrade your data planes to {{site.base_gateway}} version 3.0+ to ensure future compatibility with the `konnect-application-auth` plugin, which has a built-in replacement for the `acl` plugin and doesn't rely on `consumers`.
 
-The `konnect-application-auth` plugin {:.badge .alpha} is used to manage access control and API key authentication for app registration and replaces the need for the `acl` and `key-auth` plugins. It is only supported in {{site.base_gateway}} 3.0+ and is used for app registration in every non-`default` runtime group.
+The `konnect-application-auth` plugin is used to manage access control and API key authentication for app registration and replaces the need for the `acl` and `key-auth` plugins. It is only supported in {{site.base_gateway}} 3.0+ and is used for app registration in every non-`default` runtime group.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -33,6 +33,13 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 > **Note:** For instructions on configuring {{site.konnect_short_name}} declaratively, read our [declarative guide](/konnect/runtime-manager/runtime-groups/declarative-config).
 
 
+### Support for Kong Gateways less than version 3.0
+
+Enabling application registration requires the service version to be proxied with a version of Kong Gateway that is greater than or equal to version 3.0.
+
+If you need to use version of Kong Gateway less than 3.0, then you can opt-in for support by using the `default` runtime group. Non-default runtime groups
+are only compatible with Kong Gateway 3.0 and higher.
+
 ## Enable app registration with key authentication {#key-auth-flow}
 
 To enable app registration with key authentication, from the {{site.konnect_short_name}} menu, click {% konnect_icon servicehub %} **Service Hub**, select a
@@ -48,8 +55,13 @@ service, and follow these steps:
 
 5. Click **Enable**.
 
-    All versions of this service now include
-    read-only entries for the `acl` and `key-auth` plugins.
+    This version of the service package now includes a
+    read-only entry for the `konnect-application-auth` plugin.
+
+{:.note}
+> **Note:** If the service version is in the `default` runtime group, it will
+instead receive read-only entries for the `acl` and `key-auth` plugins to provide
+support for Kong Gateway versions less than 3.0.
 
 ## Enable app registration with OpenID Connect {#oidc-flow}
 
@@ -68,8 +80,13 @@ service, and follow these steps:
 
 4. Click **Enable**.
 
-    All versions of this service now include
-    read-only entries for the  `acl` and `oidc` plugins.
+    This versions of this service packages now includes
+    read-only entries for the  `konnect-application-auth` and `openid-connect` plugins.
+
+{:.note}
+> **Note:** If the service version is in the `default` runtime group, it will
+instead receive read-only entries for the `acl` and `openid-connect` plugins to provide
+support for Kong Gateway versions less than 3.0.
 
 ###  OpenID Connect configuration parameters {#openid-config-parameters}
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -13,7 +13,8 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 - A service that is versioned and published to the
   {{site.konnect_short_name}} Dev Portal so that it appears in the catalog.
 
-- The service version must be in the `default` runtime group.
+- The service version can be in any runtime group.
+
 - The service version must have an [implementation](/konnect/servicehub/service-implementations).
 
 - If you are using [OpenID Connect](#oidc-flow) for your authorization:

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -15,6 +15,10 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 
 - The service version can be in any runtime group.
 
+  - Service versions **not** in the `default` runtime group must be proxied with a version of Kong Gateway >= 3.0
+
+  - Service versions in the `default` runtime group can be proxied with any version of Kong Gateway
+
 - The service version must have an [implementation](/konnect/servicehub/service-implementations).
 
 - If you are using [OpenID Connect](#oidc-flow) for your authorization:

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -19,6 +19,9 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 
   - Service versions in the `default` runtime group can be proxied with any version of {{site.base_gateway}}
 
+{:.note}
+> **Note:** The `default` runtime group is the one that is first created in each region when you create an organization. Although it can be renamed, it will always be the oldest runtime group in the region.
+
 - The service version must have an [implementation](/konnect/servicehub/service-implementations).
 
 - If you are using [OpenID Connect](#oidc-flow) for your authorization:

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -4,7 +4,7 @@ content_type: how-to
 ---
 
 To grant developers access to [register an application](/konnect/dev-portal/applications/dev-reg-app-service), you must enable application registration for a service version.
-When you enable application registration, {{site.konnect_saas}} enables plugins automatically to support the desired mode, either Key Auth or OIDC.
+When you enable application registration, {{site.konnect_saas}} enables plugins automatically to support the desired mode, either key authentication or OpenID Connect.
 These plugins run inside the {{site.base_gateway}} runtime instances to support application registration for the service and are managed by
 {{site.konnect_saas}}.
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -4,8 +4,8 @@ content_type: how-to
 ---
 
 To grant developers access to [register an application](/konnect/dev-portal/applications/dev-reg-app-service), you must enable application registration for a service version.
-When you enable application registration, {{site.konnect_saas}} enables two plugins automatically: [ACL](/hub/kong-inc/acl), and your choice of [Key Authentication](/hub/kong-inc/key-auth)
-or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to support application registration for the service and are managed by
+When you enable application registration, {{site.konnect_saas}} enables plugins automatically to support the desired mode, either Key Auth or OIDC (using the [`openid-connect` plugin](/hub/kong-inc/key-auth)).
+These plugins run inside the {{site.base_gateway}} runtime instances to support application registration for the service and are managed automatically by
 {{site.konnect_saas}}.
 
 ## Support for any runtime group
@@ -129,6 +129,6 @@ at any time.
 
 If you need to use a version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher.
 
-In the `default` runtime group, applications are still linked to {{site.base_gateway}} `consumers` and use the `acl` plugin to control access between an application's `consumer` and a service version. This configuration is deprecated. It is recommended to upgrade your data planes to {{site.base_gateway}} version 3.0+ to ensure future compatibility with the `konnect-application-auth` plugin, which has a built-in replacement for the `acl` plugin and doesn't rely on `consumers`.
+In the `default` runtime group, applications are still linked to {{site.base_gateway}} `consumers` and use the `acl` plugin to control access between an application's `consumer` and a service version. This configuration is deprecated. It is recommended to upgrade your runtime instances to {{site.base_gateway}} version 3.0+ to ensure future compatibility with the `konnect-application-auth` plugin, which has a built-in replacement for the `acl` plugin and doesn't rely on `consumers`.
 
 The `konnect-application-auth` plugin is used to manage access control and API key authentication for app registration and replaces the need for the `acl` and `key-auth` plugins. It is only supported in {{site.base_gateway}} 3.0+ and is used for app registration in every non-`default` runtime group.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -20,7 +20,7 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
   - Service versions in the `default` runtime group can be proxied with any version of {{site.base_gateway}}
 
 {:.note}
-> **Note:** The `default` runtime group is the one that is first created in each region when you create an organization. Although it can be renamed, it will always be the oldest runtime group in the region.
+> **Note:** The `default` runtime group is the one that is first created in each region when you create an organization. Although it can be renamed, it will always be the oldest runtime group in the region. See [default runtime group](/konnect/runtime-manager/runtime-groups/#default-runtime-group) for additional context.
 
 - The service version must have an [implementation](/konnect/servicehub/service-implementations).
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -94,8 +94,8 @@ support for {{site.base_gateway}} versions less than 3.0.
    | `Hide Credentials` |**Default: disabled**<br>  Hide the credential from the upstream service. If enabled, the plugin strips the credential from the request header, query string, or request body, before proxying it. | **False** |
    | `Auto Approve`| **Default: disabled** <br>Automatically approve developer application requests for an application.| **False**
 
-   {:.note}
-   > **Note:** In the `default` runtime group, **Credential claim** is used as a **Consumer claim** which identifies a consumer. In non-`default` runtime groups, the **Credential claim** should be mapped to a claim that contains the unique `clientId` or `applicationId` in the identity provider.
+{:.note}
+> **Note:** In the `default` runtime group, **Credential claim** is used as a **Consumer claim** which identifies a consumer. In non-`default` runtime groups, the **Credential claim** should be mapped to a claim that contains the unique `clientId` or `applicationId` in the identity provider.
 
    For more background information about OpenID Connect plugin parameters, see
    [Important Configuration Parameters](/hub/kong-inc/openid-connect/#important-configuration-parameters).

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -15,9 +15,9 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 
 - The service version can be in any runtime group.
 
-  - Service versions **not** in the `default` runtime group must be proxied with a version of Kong Gateway >= 3.0
+  - Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
 
-  - Service versions in the `default` runtime group can be proxied with any version of Kong Gateway
+  - Service versions in the `default` runtime group can be proxied with any version of {{site.base_gateway}}
 
 - The service version must have an [implementation](/konnect/servicehub/service-implementations).
 
@@ -53,7 +53,7 @@ service, and follow these steps:
 {:.note}
 > **Note:** If the service version is in the `default` runtime group, it will
 instead receive read-only entries for the `acl` and `key-auth` plugins to provide
-support for Kong Gateway versions less than 3.0.
+support for {{site.base_gateway}} versions less than 3.0.
 
 ## Enable app registration with OpenID Connect {#oidc-flow}
 
@@ -78,7 +78,7 @@ service, and follow these steps:
 {:.note}
 > **Note:** If the service version is in the `default` runtime group, it will
 instead receive read-only entries for the `acl` and `openid-connect` plugins to provide
-support for Kong Gateway versions less than 3.0.
+support for {{site.base_gateway}} versions less than 3.0.
 
 ###  OpenID Connect configuration parameters {#openid-config-parameters}
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -76,7 +76,7 @@ service, and follow these steps:
 4. Click **Enable**.
 
     This versions of this service packages now includes
-    read-only entries for the  `konnect-application-auth` and `openid-connect` plugins.
+    read-only entries for the `konnect-application-auth` and `openid-connect` plugins.
 
 {:.note}
 > **Note:** If the service version is in the `default` runtime group, it will
@@ -122,7 +122,7 @@ at any time.
 
 ### Differences between runtime groups
 
-If you need to use version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher.
+If you need to use a version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher.
 
 In the `default` runtime group, applications are still linked to {{site.base_gateway}} `consumers` and use the `acl` plugin to control access between an application's `consumer` and a service version. This configuration is deprecated. It is recommended to upgrade your data planes to {{site.base_gateway}} version 3.0+ to ensure future compatibility with the `konnect-application-auth` plugin, which has a built-in replacement for the `acl` plugin and doesn't rely on `consumers`.
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -8,9 +8,9 @@ When you enable application registration, {{site.konnect_saas}} enables two plug
 or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to support application registration for the service and are managed by
 {{site.konnect_saas}}.
 
-## {:.badge .alpha} Support for any runtime group
+## Support for any runtime group
 
-App registration is fully supported in the `default` runtime group, using application `consumers` and the `acl` plugin.
+{:.badge .alpha} App registration is fully supported in the `default` runtime group, using application `consumers` and the `acl` plugin.
 We are rolling out full support in any non-`default` runtime group, using the `konnect-application-auth` plugin that was created for {{site.base_gateway}} 3.0.
 
 {:.note}

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -4,8 +4,8 @@ content_type: how-to
 ---
 
 To grant developers access to [register an application](/konnect/dev-portal/applications/dev-reg-app-service), you must enable application registration for a service version.
-When you enable application registration, {{site.konnect_saas}} enables plugins automatically to support the desired mode, either Key Auth or OIDC (using the [`openid-connect` plugin](/hub/kong-inc/key-auth)).
-These plugins run inside the {{site.base_gateway}} runtime instances to support application registration for the service and are managed automatically by
+When you enable application registration, {{site.konnect_saas}} enables plugins automatically to support the desired mode, either Key Auth or OIDC.
+These plugins run inside the {{site.base_gateway}} runtime instances to support application registration for the service and are managed by
 {{site.konnect_saas}}.
 
 ## Support for any runtime group

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -15,7 +15,7 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 
 - The service version can be in any runtime group.
 
-  - Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
+  - {:.badge .alpha} Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
 
   - Service versions in the `default` runtime group can be proxied with any version of {{site.base_gateway}}
 
@@ -122,8 +122,8 @@ at any time.
 
 ### Differences between runtime groups
 
-If you need to use a version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher.
+If you need to use a version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher, and support is currently in {:.badge .alpha}.
 
 In the `default` runtime group, applications are still linked to {{site.base_gateway}} `consumers` and use the `acl` plugin to control access between an application's `consumer` and a service version. This configuration is deprecated. It is recommended to upgrade your data planes to {{site.base_gateway}} version 3.0+ to ensure future compatibility with the `konnect-application-auth` plugin, which has a built-in replacement for the `acl` plugin and doesn't rely on `consumers`.
 
-The `konnect-application-auth` plugin is used to manage access control and API key authentication for app registration and replaces the need for the `acl` and `key-auth` plugins. It is only supported in {{site.base_gateway}} 3.0+ and is used for app registration in every non-`default` runtime group.
+The `konnect-application-auth` plugin {:.badge .alpha} is used to manage access control and API key authentication for app registration and replaces the need for the `acl` and `key-auth` plugins. It is only supported in {{site.base_gateway}} 3.0+ and is used for app registration in every non-`default` runtime group.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -32,14 +32,6 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
 {:.note}
 > **Note:** For instructions on configuring {{site.konnect_short_name}} declaratively, read our [declarative guide](/konnect/runtime-manager/runtime-groups/declarative-config).
 
-
-### Support for Kong Gateways less than version 3.0
-
-Enabling application registration requires the service version to be proxied with a version of Kong Gateway that is greater than or equal to version 3.0.
-
-If you need to use version of Kong Gateway less than 3.0, then you can opt-in for support by using the `default` runtime group. Non-default runtime groups
-are only compatible with Kong Gateway 3.0 and higher.
-
 ## Enable app registration with key authentication {#key-auth-flow}
 
 To enable app registration with key authentication, from the {{site.konnect_short_name}} menu, click {% konnect_icon servicehub %} **Service Hub**, select a

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -9,8 +9,9 @@ These plugins run inside the {{site.base_gateway}} runtime instances to support 
 {{site.konnect_saas}}.
 
 ## Support for any runtime group
+{:.badge .alpha}
 
-{:.badge .alpha} App registration is fully supported in the `default` runtime group, using application `consumers` and the `acl` plugin.
+App registration is fully supported in the `default` runtime group, using application `consumers` and the `acl` plugin.
 We are rolling out full support in any non-`default` runtime group, using the `konnect-application-auth` plugin that was created for {{site.base_gateway}} 3.0.
 
 {:.note}

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -8,6 +8,14 @@ When you enable application registration, {{site.konnect_saas}} enables two plug
 or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to support application registration for the service and are managed by
 {{site.konnect_saas}}.
 
+## {:.badge .alpha} Support for any runtime group
+
+App registration is fully supported in the `default` runtime group, using application `consumers` and the `acl` plugin.
+We are rolling out full support in any non-`default` runtime group, using the `konnect-application-auth` plugin that was created for {{site.base_gateway}} 3.0.
+
+{:.note}
+> **Note:** The `default` runtime group is the one that is first created in each region when you create an organization. Although it can be renamed, it will always be the oldest runtime group in the region. See [default runtime group](/konnect/runtime-manager/runtime-groups/#default-runtime-group) for additional context.
+
 ## Prerequisites
 
 - A service that is versioned and published to the
@@ -18,9 +26,6 @@ or [OIDC](/hub/kong-inc/openid-connect). These plugins run in the background to 
   - Service versions **not** in the `default` runtime group must be proxied with a version of {{site.base_gateway}} >= 3.0
 
   - Service versions in the `default` runtime group can be proxied with any version of {{site.base_gateway}}
-
-{:.note}
-> **Note:** The `default` runtime group is the one that is first created in each region when you create an organization. Although it can be renamed, it will always be the oldest runtime group in the region. See [default runtime group](/konnect/runtime-manager/runtime-groups/#default-runtime-group) for additional context.
 
 - The service version must have an [implementation](/konnect/servicehub/service-implementations).
 

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -116,3 +116,11 @@ To remove a plugin by disabling application registration, follow these steps:
 You can
 [re-enable application registration](/konnect/dev-portal/applications/enable-app-reg)
 at any time.
+
+### Differences between runtime groups
+
+If you need to use version of {{site.base_gateway}} less than 3.0, you must create your service version in the `default` runtime group. Non-default runtime groups are only compatible with {{site.base_gateway}} 3.0 and higher.
+
+In the `default` runtime group, applications are still linked to {{site.base_gateway}} `consumers` and use the `acl` plugin to control access between an application's `consumer` and a service version. This configuration is deprecated. It is recommended to upgrade your data planes to {{site.base_gateway}} version 3.0+ to ensure future compatibility with the `konnect-application-auth` plugin, which has a built-in replacement for the `acl` plugin and doesn't rely on `consumers`.
+
+The `konnect-application-auth` plugin is used to manage access control and API key authentication for app registration and replaces the need for the `acl` and `key-auth` plugins. It is only supported in {{site.base_gateway}} 3.0+ and is used for app registration in every non-`default` runtime group.

--- a/app/konnect/dev-portal/applications/enable-app-reg.md
+++ b/app/konnect/dev-portal/applications/enable-app-reg.md
@@ -89,10 +89,13 @@ support for {{site.base_gateway}} versions less than 3.0.
    |:---------------|:----------------------------------------------------------------------------------|--|
    | `Issuer` | The issuer URL from which the OpenID Connect configuration can be discovered. For example: `https://dev-1234567.okta.com/oauth2/default`.  |**True** |
    | `Scopes` | The scopes to be requested from the OpenID Provider. Enter one or more scopes separated by spaces, for example: `open_id` `myscope1`.  | **False**
-   | `Consumer claims` |  Name of the claim that is used to find a consumer. | **True**
+   | `Credential claims` |  Name of the claim that maps to the unique client id in the identity provider. | **True**
    | `Auth method` | The supported authentication method(s) you want to enable. This field should contain only the authentication methods that you need to use. Individual entries must be separated by commas. Available options: `password`, `client_credentials`, `authorization_code`, `bearer`, `introspection`, `kong_oauth2`, `refresh_token`, `session`. | **True**
    | `Hide Credentials` |**Default: disabled**<br>  Hide the credential from the upstream service. If enabled, the plugin strips the credential from the request header, query string, or request body, before proxying it. | **False** |
    | `Auto Approve`| **Default: disabled** <br>Automatically approve developer application requests for an application.| **False**
+
+   {:.note}
+   > **Note:** In the `default` runtime group, **Credential claim** is used as a **Consumer claim** which identifies a consumer. In non-`default` runtime groups, the **Credential claim** should be mapped to a claim that contains the unique `clientId` or `applicationId` in the identity provider.
 
    For more background information about OpenID Connect plugin parameters, see
    [Important Configuration Parameters](/hub/kong-inc/openid-connect/#important-configuration-parameters).

--- a/app/konnect/runtime-manager/runtime-groups/index.md
+++ b/app/konnect/runtime-manager/runtime-groups/index.md
@@ -32,35 +32,6 @@ organization starts with one default group.
 This group can't be renamed or deleted, and its status as the default
 group can't be changed.
 
-### Application registration in the Dev Portal
-
-When publishing documentation from the Service Hub to the Dev Portal, you can
-publish API specs from any version -- no matter which runtime group the version
-is in. However, application registration is only supported for service versions
-running in the default runtime group.
-
-So, if you want a service version to be available for application registration,
-create the version in the *default* runtime group. This means that you can have a
-mix of service versions running in different groups for different purposes.
-
-For example, you might have:
-
-* The latest version of a service published to the Dev Portal with the latest
-spec, running in the *default* group with application registration enabled.
-
-* A previous version of the service published to the Dev Portal,
-running in the *default* group, but with application registration disabled.
-Any app with existing credentials can continue using them, but the version is
-not available for new registrations.
-
-* Another previous version of the service, published to the Dev Portal, and
-running in a *custom* runtime group. This version would only have the documentation
-available, and developers would not have access to application registration for
-this version.
-
-Out of these three scenarios, only the service version in the first scenario
-would be available for application registration.
-
 ## Multiple runtime groups
 {:.badge .enterprise}
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

This describes an update to dev portal's app registration. It was previously available only in the `default` runtime group. App registration is now available as a `Tech Preview` in all runtime groups. However, for compatibility with Kong Gateway's < 3.0, there are some differences with how it is applied, depending on the runtime group.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
https://konghq.atlassian.net/browse/TDX-2195
Application registration is opening support for any runtime group. Only compatible with Kong Gateway versions >= 3.0

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
