### PR TITLE
update gateway api related docs for KIC 2.6

### DIFF
--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -193,23 +193,22 @@ Change `example-cert-secret` to the name of your Secret.
 Because KIC and Kong instances are installed independent of their Gateway
 resource, we set the `konghq.com/gateway-unmanaged` annotation to the
 `<namespace>/<name>` of the Kong proxy Service. This instructs KIC to populate
-that Gateway resource with listener and status information. 
+that {{site.base_gateway}} resource with listener and status information. 
 {% endif_version %}
 
 {% if_version gte: 2.6.x %}
-To configure KIC to reconcile `Gateway` resource, you need to set the 
-`konghq.com/gateway-unmanaged` annotation in `GatewayClass` resource used in 
-`spec.gatewayClassName` in `Gateway` resource, as the example. Also, the 
+To configure KIC to reconcile the `Gateway` resource, you must set the 
+`konghq.com/gateway-unmanaged` annotation as the example in `GatewayClass` resource used in 
+`spec.gatewayClassName` in `Gateway` resource. Also, the 
 `spec.controllerName` of `GatewayClass` needs to be same as the value of the
-`--gateway-api-controller-name` flag configured in KIC:
-[kic-flags](kubernetes-ingress-controller/{{page.kong_version}}/references/cli-arguments/#flags)
+`--gateway-api-controller-name` flag configured in KIC. For more information, see [kic-flags](kubernetes-ingress-controller/{{page.kong_version}}/references/cli-arguments/#flags).
 {% endif_version %}
 
-You can check to confirm if KIC has updated the bound Gateway by 
+You can check to confirm if KIC has updated the bound {{site.base_gateway}} by 
 inspecting the list of associated addresses:
 
 ```bash
-$ kubectl get gateway kong -o=jsonpath='{.status.addresses}' | jq
+kubectl get gateway kong -o=jsonpath='{.status.addresses}' | jq
 ```
 
 ```

--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -204,7 +204,7 @@ To configure KIC to reconcile the `Gateway` resource, you must set the
 `--gateway-api-controller-name` flag configured in KIC. For more information, see [kic-flags](kubernetes-ingress-controller/{{page.kong_version}}/references/cli-arguments/#flags).
 {% endif_version %}
 
-You can check to confirm if KIC has updated the bound {{site.base_gateway}} by 
+You can check to confirm if KIC has updated the bound `Gateway` by 
 inspecting the list of associated addresses:
 
 ```bash

--- a/src/kubernetes-ingress-controller/references/cli-arguments.md
+++ b/src/kubernetes-ingress-controller/references/cli-arguments.md
@@ -52,7 +52,10 @@ Following table describes all the flags that are available:
 | `--enable-controller-tcpingress`                | `boolean` | Enable the TCPIngress controller.                                                                     | `true`                         |
 | `--enable-controller-udpingress`                | `boolean` | Enable the UDPIngress controller.                                                                     | `true`                         |
 | `--enable-reverse-sync`                  | `boolean`          | Send configuration to Kong even if the configuration checksum has not changed since previous update.                                                | `false`                           |
-| `--health-probe-bind-address`            | `string`           | The address the probe endpoint binds. to.                                                                                                            | `":10254"`                        |
+{% if_version gte 2.6.x %}
+| `--gateway-api-controller-name`          | `string`           | Controller name of gateway API. `Gateway` resources are reconciled only when their `GatewayClass` has same value in `spec.controllerName`.           | `konghq.com/kic-gateway-controller` |
+{% endif_version %}
+| `--health-probe-bind-address`            | `string`           | The address the probe endpoint binds to.                                                                                                            | `":10254"`                        |
 | `--help`                                 | `boolean`          | Help for this command.                                                                                                                               | `false`                           |
 | `--ingress-class`                        | `string`           | Name of the ingress class to route through this controller.                                                                                         | `"kong"`                          |
 | `--kong-admin-ca-cert`                   | `string`           | PEM-encoded CA certificate to verify Kong's Admin SSL certificate.                                                                                  |                                   |

--- a/src/kubernetes-ingress-controller/references/cli-arguments.md
+++ b/src/kubernetes-ingress-controller/references/cli-arguments.md
@@ -54,7 +54,7 @@ Following table describes all the flags that are available:
 | `--enable-reverse-sync`                  | `boolean`          | Send configuration to Kong even if the configuration checksum has not changed since previous update.                                                | `false`                           |
 
 {% if_version gte: 2.6.x %}
-| `--gateway-api-controller-name`          | `string`           | Controller name of the Kong Gateway API. `Gateway` resources are reconciled only when their `GatewayClass` has the same value in `spec.controllerName`.           | `konghq.com/kic-gateway-controller` |
+| `--gateway-api-controller-name`          | `string`           | Controller name of the Kubernetes Gateway API. `Gateway` resources are reconciled only when their `GatewayClass` has the same value in `spec.controllerName`.           | `konghq.com/kic-gateway-controller` |
 {% endif_version %}
 
 | `--health-probe-bind-address`            | `string`           | The address the probe endpoint binds to.                                                                                                            | `":10254"`                        |

--- a/src/kubernetes-ingress-controller/references/cli-arguments.md
+++ b/src/kubernetes-ingress-controller/references/cli-arguments.md
@@ -52,9 +52,11 @@ Following table describes all the flags that are available:
 | `--enable-controller-tcpingress`                | `boolean` | Enable the TCPIngress controller.                                                                     | `true`                         |
 | `--enable-controller-udpingress`                | `boolean` | Enable the UDPIngress controller.                                                                     | `true`                         |
 | `--enable-reverse-sync`                  | `boolean`          | Send configuration to Kong even if the configuration checksum has not changed since previous update.                                                | `false`                           |
-{% if_version gte 2.6.x %}
-| `--gateway-api-controller-name`          | `string`           | Controller name of gateway API. `Gateway` resources are reconciled only when their `GatewayClass` has same value in `spec.controllerName`.           | `konghq.com/kic-gateway-controller` |
+
+{% if_version gte: 2.6.x %}
+| `--gateway-api-controller-name`          | `string`           | Controller name of the Kong Gateway API. `Gateway` resources are reconciled only when their `GatewayClass` has the same value in `spec.controllerName`.           | `konghq.com/kic-gateway-controller` |
 {% endif_version %}
+
 | `--health-probe-bind-address`            | `string`           | The address the probe endpoint binds to.                                                                                                            | `":10254"`                        |
 | `--help`                                 | `boolean`          | Help for this command.                                                                                                                               | `false`                           |
 | `--ingress-class`                        | `string`           | Name of the ingress class to route through this controller.                                                                                         | `"kong"`                          |

--- a/src/kubernetes-ingress-controller/references/feature-gates.md
+++ b/src/kubernetes-ingress-controller/references/feature-gates.md
@@ -21,7 +21,13 @@ Features that reach GA and become stable are removed from this table, but they c
 | Feature                | Default | Stage | Since | Until |
 |------------------------|---------|-------|-------|-------|
 | Knative                | `true`  | Alpha | 0.8.0 | TBD   |
-| Gateway                | `false` | Alpha | 2.2.0 | TBD   |
+{% if_version lte 2.5.x %}
+| Gateway                | `false` | Alpha | 2.2.0 | 2.5.0 |
+{% endif_version %}
+{% if_version gte 2.6.x %}
+| Gateway                | `true`  | Beta  | 2.6.0 | TBD   |
+| GatewayAlpha           | `false` | Alpha | 2.6.0 | TBD   |
+{% endif_version %}
 | CombinedRoutes         | `false` | Alpha | 2.4.0 | TBD   |
 | IngressClassParameters | `false` | Alpha | 2.6.0 | TBD   |
 

--- a/src/kubernetes-ingress-controller/references/feature-gates.md
+++ b/src/kubernetes-ingress-controller/references/feature-gates.md
@@ -21,13 +21,16 @@ Features that reach GA and become stable are removed from this table, but they c
 | Feature                | Default | Stage | Since | Until |
 |------------------------|---------|-------|-------|-------|
 | Knative                | `true`  | Alpha | 0.8.0 | TBD   |
-{% if_version lte 2.5.x %}
+
+{% if_version lte: 2.5.x %}
 | Gateway                | `false` | Alpha | 2.2.0 | 2.5.0 |
 {% endif_version %}
-{% if_version gte 2.6.x %}
+
+{% if_version gte: 2.6.x %}
 | Gateway                | `true`  | Beta  | 2.6.0 | TBD   |
 | GatewayAlpha           | `false` | Alpha | 2.6.0 | TBD   |
 {% endif_version %}
+
 | CombinedRoutes         | `false` | Alpha | 2.4.0 | TBD   |
 | IngressClassParameters | `false` | Alpha | 2.6.0 | TBD   |
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
update KIC docs about gateway APIs for KIC 2.6 release. Includes:
- feature gate `Gateway` turned on by default, and added `GatewayAlpha`  feature gate.
- added `--gateway-api-controller-name` flag.
- conditions of reconciling `Gateway` changed. 

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

KIC 2.6 released and docs are added, but the docs about gateway APIs are not updated. fixes: #4480, also fixes #4479.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
https://deploy-preview-4481--kongdocs.netlify.app/