### PR TITLE
[DOCU-2499] decK: 3.0 migration guide

### DIFF
--- a/app/_data/docs_nav_deck_1.15.x.yml
+++ b/app/_data/docs_nav_deck_1.15.x.yml
@@ -30,6 +30,8 @@ items:
         url: /guides/getting-started
       - text: Backup and Restore
         url: /guides/backup-restore
+      - text: Upgrade to Kong Gateway 3.x
+        url: /guides/3.0-upgrade
       - text: Configuration as Code and GitOps
         url: /guides/ci-driven-configuration
       - text: Distributed Configuration

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -18,7 +18,7 @@ Would need to be rewritten in the new 3.0 format:
 ~/status/\d+
 ```
 
-If you [migrated your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the route paths in the database will have had the `~` prefix added automatically.
+If you [migrated your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the `~` prefix is automatically added to the route paths in the database.
 This causes configuration drift between the formats of the routes that exist in the database and the routes in your configuration file.
 
 Before using your state files to update the database, convert them into the 3.0 format using `deck convert`.

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -3,7 +3,7 @@ title: Upgrade to Kong Gateway 3.x
 content_type: reference
 ---
 
-With the [release of {{site.base_gateway}} 3.0](/gateway/changelog/), paths that use regular expressions are no longer automatically detected.
+With the [release of {{site.base_gateway}} 3.0](/gateway/changelog/), route paths that use regular expressions are no longer automatically detected.
 For {{site.base_gateway}} to parse a path that contains a regular expression, the path must be prefixed with a **`~`**.
 
 For example, in 2.x, a route path that was expressed like this:

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -8,15 +8,15 @@ The decK format version must be `3.0` to work with the new paths.
 If you [migrate your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the paths in the database will have the `~` prefix added.
 This can cause configuration drift between state files and the database.
 
-Before using your state files to update the database, convert them into 3.0 format using `deck convert`.
+Before using your state files to update the database, convert them into the 3.0 format using `deck convert`.
 
 {:.important}
-> **Important**: Do not use `deck sync` with {{site.base_gateway}} 3.x before converting paths into 3.0 format.
+> **Important**: Don't use `deck sync` with {{site.base_gateway}} 3.x before converting paths into the 3.0 format.
 This will break all regex routing in 3.x.
 
 ## decK command behavior with 3.x
 
-When running decK commands against {{site.base_gateway}} 3.x, take note of the following behavior:
+When running decK commands against {{site.base_gateway}} 3.x, keep the following behavior in mind:
 
 `deck dump`
 : Explicitly sets the format version to 3.0.
@@ -72,7 +72,7 @@ For all `diff`, `sync`, or `validate` (with `--online` flag) operations against 
 
 **What happens if I set the format version to 3.0 but don't update regex paths?**
 
-The state file will be broken. Avoid setting the format version manually.
+The state file will break. Avoid setting the format version manually.
 
 **Can I still apply configuration if there are warnings?**
 

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -57,7 +57,10 @@ This will break all regex routing in 3.x.
 
 **What happens if I set the format version to 3.0 but don't update regex paths?**
 
-The state file will break. Avoid setting the format version manually.
+You should avoid setting the format version manually.
+When you sync the file without updating regex paths, the incorrect values will be pushed to the database and your routes will break. 
+
+decK will issue a warning stating that an invalid regex pattern was detected and that it must be updated with a `~` to distinguish it from a standard prefix match.
 
 **I ran decK convert but there are still errors or warnings, what do I do?**
 

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -51,14 +51,14 @@ This will break all regex routing in 3.x.
 
     {:.important}
     > **Important**: Manual validation is strongly recommended.
-    Incorrect changes will result in unintended traffic routing by Kong Gateway.
+    Incorrect changes will result in unintended traffic routing by {{site.base_gateway}}.
 
 ## FAQ
 
 **What happens if I set the format version to 3.0 but don't update regex paths?**
 
 You should avoid setting the format version manually.
-When you sync the file without updating regex paths, the incorrect values will be pushed to the database and your routes will break. 
+When you sync the file without updating regex paths, the incorrect values will be pushed to the database and your routes will break.
 
 decK will issue a warning stating that an invalid regex pattern was detected and that it must be updated with a `~` to distinguish it from a standard prefix match.
 

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -46,11 +46,9 @@ This will break all regex routing in 3.x.
 
 2. Validate the converted files in a test environment.
 
-    These changes may not be fully correct or exhaustive, so perform manual audits of the generated file before applying
-    the configuration in production.
+    Perform manual audits of the generated file before applying the configuration in production.
+    These changes may not be fully correct or exhaustive, so manual validation is **strongly recommended**.
 
-    {:.important}
-    > **Important**: Manual validation is strongly recommended.
     Incorrect changes will result in unintended traffic routing by {{site.base_gateway}}.
 
 ## FAQ
@@ -58,7 +56,7 @@ This will break all regex routing in 3.x.
 **What happens if I set the format version to 3.0 but don't update regex paths?**
 
 You should avoid setting the format version manually.
-When you sync the file without updating regex paths, the incorrect values will be pushed to the database and your routes will break.
+When you sync the file without updating regex paths, the incorrect values will be pushed to the database and {{site.base_gateway}} will route traffic incorrectly.
 
 decK will issue a warning stating that an invalid regex pattern was detected and that it must be updated with a `~` to distinguish it from a standard prefix match.
 
@@ -72,6 +70,7 @@ If you have validated the configuration and found no issues but are still gettin
 the warning may be a false positive.
 You can still apply the configuration, but do so at your own risk.
 
+If you run into false positives, [file an issue](https://github.com/Kong/deck/issues) to let us know.
 
 ### Changes to decK commands in 3.x
 

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -1,0 +1,85 @@
+---
+title: Upgrade to Kong Gateway 3.x
+---
+
+Starting with {{site.base_gateway}} 3.0, paths using regular expressions must have a `~` prefix.
+The decK format version must be `3.0` to work with the new paths.
+
+If you [migrate your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the paths in the database will have the `~` prefix added.
+This can cause configuration drift between state files and the database.
+
+Before using your state files to update the database, convert them into 3.0 format using `deck convert`.
+
+{:.important}
+> **Important**: Do not use `deck sync` with {{site.base_gateway}} 3.x before converting paths into 3.0 format.
+This will break all regex routing in 3.x.
+
+## decK command behavior with 3.x
+
+When running decK commands against {{site.base_gateway}} 3.x, take note of the following behavior:
+
+`deck dump`
+: Explicitly sets the format version to 3.0.
+It assumes that the paths have been correctly transformed, either via Kong migrations, manually, or through a `deck convert`.
+
+`deck diff`, `deck validate`, or `deck sync`
+: decK performs a check to ensure all regex routes are correctly prefixed.
+If not, the behavior depends on the control plane type:
+* Self-hosted {{site.base_gateway}} 2.x (format version 1.1 or earlier): Prints an error and stops the operation.
+* Self-hosted {{site.base_gateway}} 3.x (format version 3.0): Prints a warning and goes ahead with the diff, sync, or validate operation as usual.
+* {{site.konnect_short_name}}: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
+
+`deck convert`
+: Includes `--from` and `--to` flags for converting state files between major versions.
+Converts all relevant files in the present working directory:
+  * Upgrades the `_format_version` setting to `3.0`
+  * Adds the `~` prefix to all route paths containing a regex pattern
+
+: You can optionally provide `--input-file` and `--output-file` flags to limit conversion to
+a subset of files.
+
+### Using decK with {{site.konnect_short_name}} data planes
+
+{{site.konnect_short_name}} supports 3.x and 2.x data planes, but the {{site.konnect_short_name}} control plane version is 3.x.
+Since decK can't tell if a runtime group is intended for 2.x or 3.x data planes, it will always dump configuration with `_format_version: 3.0`.
+
+To avoid compatibility errors, make sure that all data planes in a single runtime group are of the same major version (all 2.x or all 3.x).
+
+For all `validate`, `diff`, or `sync` operations against {{site.konnect_short_name}}, decK issues warnings when it detects incorrect regex path configurations.
+
+## Convert 2.x state file to 3.x
+
+1. Run `deck-convert` against your 2.x state file to turn it into a 3.x file:
+
+    ```sh
+    deck convert \
+    --from kong-gateway-2.x \
+    --to kong-gateway-3.x \
+    --input-file kong.yaml \
+    --output-file new-kong.yaml
+    ```
+
+    You can leave `input-file` out to convert all declarative configuration files in your working directory.
+    We recommend specifying both input and output files.
+
+
+2. Validate the converted files in a test environment.
+
+    These changes may not be fully correct or exhaustive, so perform manual audits of the generated file before applying
+    the configuration in production.
+
+## FAQ
+
+**What happens if I set the format version to 3.0 but don't update regex paths?**
+
+The state file will be broken. Avoid setting the format version manually.
+
+**Can I still apply configuration if there are warnings?**
+
+If you have validated the configuration and found no issues but are still getting a warning,
+the warning may be a false positive.
+You can still apply the configuration, but do so at your own risk.
+
+**I ran decK convert but there are still errors or warnings, what do I do?**
+
+Manually validate the file, then make any necessary updates to your state file.

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -25,8 +25,8 @@ It assumes that the paths have been correctly transformed, either via Kong migra
 `deck diff`, `deck validate`, or `deck sync`
 : decK performs a check to ensure all regex routes are correctly prefixed.
 If not, the behavior depends on the control plane type:
-* Self-hosted {{site.base_gateway}} 2.x (format version 1.1 or earlier): Prints an error and stops the operation.
-* Self-hosted {{site.base_gateway}} 3.x (format version 3.0): Prints a warning and goes ahead with the diff, sync, or validate operation as usual.
+* Self-managed {{site.base_gateway}} 2.x (format version 1.1 or earlier): Prints an error and stops the operation.
+* Self-managed {{site.base_gateway}} 3.x (format version 3.0): Prints a warning and goes ahead with the diff, sync, or validate operation as usual.
 * {{site.konnect_short_name}}: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 
 `deck convert`

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -25,8 +25,8 @@ It assumes that the paths have been correctly transformed, either via Kong migra
 `deck diff`, `deck validate`, or `deck sync`
 : decK performs a check to ensure all regex routes are correctly prefixed.
 If not, the behavior depends on the control plane type:
-* Self-managed {{site.base_gateway}} 2.x (format version 1.1 or earlier): Prints an error and stops the operation.
-* Self-managed {{site.base_gateway}} 3.x (format version 3.0): Prints a warning and goes ahead with the diff, sync, or validate operation as usual.
+* Self-managed {{site.base_gateway}} 2.x (`_format_version: 1.1` or earlier): Prints an error and stops the operation.
+* Self-managed {{site.base_gateway}} 3.x (`_format_version: 3.0`): Prints a warning and goes ahead with the diff, sync, or validate operation as usual.
 * {{site.konnect_short_name}}: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 
 `deck convert`

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -49,6 +49,10 @@ This will break all regex routing in 3.x.
     These changes may not be fully correct or exhaustive, so perform manual audits of the generated file before applying
     the configuration in production.
 
+    {:.important}
+    > **Important**: Manual validation is strongly recommended.
+    Incorrect changes will result in unintended traffic routing by Kong Gateway.
+
 ## FAQ
 
 **What happens if I set the format version to 3.0 but don't update regex paths?**

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -1,12 +1,20 @@
 ---
 title: Upgrade to Kong Gateway 3.x
+content-type: reference
 ---
 
-Starting with {{site.base_gateway}} 3.0, paths using regular expressions must have a `~` prefix.
-The decK format version must be `3.0` to work with the new paths.
+With the [release of {{site.base_gateway}} 3.0](/gateway/changelog/), paths that use regular expressions are no longer automatically detected.
+For {{site.base_gateway}} to parse a path that contains a regular expression, the path must be prefixed with a **`~`**. 
+For example: 
 
-If you [migrate your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the paths in the database will have the `~` prefix added.
-This can cause configuration drift between state files and the database.
+In 2.8, a route that was expressed like this:
+
+`/status/\d+` 
+
+would need to be rewritten in the new 3.0 format: 
+`~/status/\d+` 
+If you [migrated your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the route paths in the database will have had the `~` prefix added automatically.
+This causes configuration drift between the formats of the routes that exist in the database and the routes in your configuration file.
 
 Before using your state files to update the database, convert them into the 3.0 format using `deck convert`.
 
@@ -14,7 +22,7 @@ Before using your state files to update the database, convert them into the 3.0 
 > **Important**: Don't use `deck sync` with {{site.base_gateway}} 3.x before converting paths into the 3.0 format.
 This will break all regex routing in 3.x.
 
-## decK command behavior with 3.x
+## Changes to decK commands in 3.x
 
 When running decK commands against {{site.base_gateway}} 3.x, keep the following behavior in mind:
 
@@ -38,7 +46,7 @@ Converts all relevant files in the present working directory:
 : You can optionally provide `--input-file` and `--output-file` flags to limit conversion to
 a subset of files.
 
-### Using decK with {{site.konnect_short_name}} data planes
+### Using decK with {{site.konnect_short_name}} runtime instances
 
 {{site.konnect_short_name}} supports 3.x and 2.x data planes, but the {{site.konnect_short_name}} control plane version is 3.x.
 Since decK can't tell if a runtime group is intended for 2.x or 3.x data planes, it will always dump configuration with `_format_version: 3.0`.

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -6,7 +6,7 @@ content-type: reference
 With the [release of {{site.base_gateway}} 3.0](/gateway/changelog/), paths that use regular expressions are no longer automatically detected.
 For {{site.base_gateway}} to parse a path that contains a regular expression, the path must be prefixed with a **`~`**.
 
-For example, in 2.x, a route that was expressed like this:
+For example, in 2.x, a route path that was expressed like this:
 
 ```
 /status/\d+
@@ -46,7 +46,7 @@ This will break all regex routing in 3.x.
 
 2. Validate the converted files in a test environment.
 
-    Perform manual audits of the generated file before applying the configuration in production.
+    Perform a manual audit of the generated file before applying the configuration in production.
     These changes may not be fully correct or exhaustive, so manual validation is **strongly recommended**.
 
     Incorrect changes will result in unintended traffic routing by {{site.base_gateway}}.

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -22,11 +22,11 @@ When running decK commands against {{site.base_gateway}} 3.x, take note of the f
 : Explicitly sets the format version to 3.0.
 It assumes that the paths have been correctly transformed, either via Kong migrations, manually, or through a `deck convert`.
 
-`deck diff`, `deck validate`, or `deck sync`
+`deck diff`, `deck validate` (with `--online` flag only), or `deck sync`
 : decK performs a check to ensure all regex routes are correctly prefixed.
 If not, the behavior depends on the control plane type:
 * Self-managed {{site.base_gateway}} 2.x (`_format_version: 1.1` or earlier): Prints an error and stops the operation.
-* Self-managed {{site.base_gateway}} 3.x (`_format_version: 3.0`): Prints a warning and goes ahead with the diff, sync, or validate operation as usual.
+* Self-managed {{site.base_gateway}} 3.x (`_format_version: 3.0`): Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 * {{site.konnect_short_name}}: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 
 `deck convert`
@@ -45,7 +45,7 @@ Since decK can't tell if a runtime group is intended for 2.x or 3.x data planes,
 
 To avoid compatibility errors, make sure that all data planes in a single runtime group are of the same major version (all 2.x or all 3.x).
 
-For all `validate`, `diff`, or `sync` operations against {{site.konnect_short_name}}, decK issues warnings when it detects incorrect regex path configurations.
+For all `diff`, `sync`, or `validate` (with `--online` flag) operations against {{site.konnect_short_name}}, decK issues warnings when it detects incorrect regex path configurations.
 
 ## Convert 2.x state file to 3.x
 

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade to Kong Gateway 3.x
-content-type: reference
+content_type: reference
 ---
 
 With the [release of {{site.base_gateway}} 3.0](/gateway/changelog/), paths that use regular expressions are no longer automatically detected.
@@ -44,9 +44,9 @@ This will break all regex routing in 3.x.
     You can leave `input-file` out to convert all declarative configuration files in your working directory.
     We recommend specifying both input and output files.
 
-2. Validate the converted files in a test environment.
+2. Look over all the changes carefully and validate the converted file in a test environment.
 
-    Perform a manual audit of the generated file before applying the configuration in production.
+    Make sure to manually audit the generated file before applying the configuration in production.
     These changes may not be fully correct or exhaustive, so manual validation is **strongly recommended**.
 
     Incorrect changes will result in unintended traffic routing by {{site.base_gateway}}.

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -27,7 +27,7 @@ Before using your state files to update the database, convert them into the 3.0 
 > **Important**: Don't use `deck sync` with {{site.base_gateway}} 3.x before converting paths into the 3.0 format.
 This will break all regex routing in 3.x.
 
-## Convert 2.x state file to 3.x
+## Convert declarative configuration files
 
 1. Run `deck-convert` against your 2.x state file to turn it into a 3.x file:
 

--- a/src/deck/guides/3.0-upgrade.md
+++ b/src/deck/guides/3.0-upgrade.md
@@ -4,15 +4,20 @@ content-type: reference
 ---
 
 With the [release of {{site.base_gateway}} 3.0](/gateway/changelog/), paths that use regular expressions are no longer automatically detected.
-For {{site.base_gateway}} to parse a path that contains a regular expression, the path must be prefixed with a **`~`**. 
-For example: 
+For {{site.base_gateway}} to parse a path that contains a regular expression, the path must be prefixed with a **`~`**.
 
-In 2.8, a route that was expressed like this:
+For example, in 2.x, a route that was expressed like this:
 
-`/status/\d+` 
+```
+/status/\d+
+```
 
-would need to be rewritten in the new 3.0 format: 
-`~/status/\d+` 
+Would need to be rewritten in the new 3.0 format:
+
+```
+~/status/\d+
+```
+
 If you [migrated your {{site.base_gateway}} database](/gateway/latest/upgrade/) from 2.8.x to 3.0, the route paths in the database will have had the `~` prefix added automatically.
 This causes configuration drift between the formats of the routes that exist in the database and the routes in your configuration file.
 
@@ -22,7 +27,46 @@ Before using your state files to update the database, convert them into the 3.0 
 > **Important**: Don't use `deck sync` with {{site.base_gateway}} 3.x before converting paths into the 3.0 format.
 This will break all regex routing in 3.x.
 
-## Changes to decK commands in 3.x
+## Convert 2.x state file to 3.x
+
+1. Run `deck-convert` against your 2.x state file to turn it into a 3.x file:
+
+    ```sh
+    deck convert \
+    --from kong-gateway-2.x \
+    --to kong-gateway-3.x \
+    --input-file kong.yaml \
+    --output-file new-kong.yaml
+    ```
+
+    This command upgrades the `_format_version` setting to `3.0` and adds the `~` prefix to all route paths containing a regex pattern.
+
+    You can leave `input-file` out to convert all declarative configuration files in your working directory.
+    We recommend specifying both input and output files.
+
+2. Validate the converted files in a test environment.
+
+    These changes may not be fully correct or exhaustive, so perform manual audits of the generated file before applying
+    the configuration in production.
+
+## FAQ
+
+**What happens if I set the format version to 3.0 but don't update regex paths?**
+
+The state file will break. Avoid setting the format version manually.
+
+**I ran decK convert but there are still errors or warnings, what do I do?**
+
+Manually validate the file, then make any necessary updates to your state file.
+
+**Can I still apply configuration if there are warnings?**
+
+If you have validated the configuration and found no issues but are still getting a warning,
+the warning may be a false positive.
+You can still apply the configuration, but do so at your own risk.
+
+
+### Changes to decK commands in 3.x
 
 When running decK commands against {{site.base_gateway}} 3.x, keep the following behavior in mind:
 
@@ -48,46 +92,9 @@ a subset of files.
 
 ### Using decK with {{site.konnect_short_name}} runtime instances
 
-{{site.konnect_short_name}} supports 3.x and 2.x data planes, but the {{site.konnect_short_name}} control plane version is 3.x.
-Since decK can't tell if a runtime group is intended for 2.x or 3.x data planes, it will always dump configuration with `_format_version: 3.0`.
+{{site.konnect_short_name}} supports 3.x and 2.x runtime instances, but the {{site.konnect_short_name}} control plane version is 3.x.
+Since decK can't tell if a runtime group is intended for 2.x or 3.x runtime instances, it will always dump configuration with `_format_version: 3.0`.
 
-To avoid compatibility errors, make sure that all data planes in a single runtime group are of the same major version (all 2.x or all 3.x).
+To avoid compatibility errors, make sure that all runtime instances in a single runtime group are of the same major version (all 2.x or all 3.x).
 
 For all `diff`, `sync`, or `validate` (with `--online` flag) operations against {{site.konnect_short_name}}, decK issues warnings when it detects incorrect regex path configurations.
-
-## Convert 2.x state file to 3.x
-
-1. Run `deck-convert` against your 2.x state file to turn it into a 3.x file:
-
-    ```sh
-    deck convert \
-    --from kong-gateway-2.x \
-    --to kong-gateway-3.x \
-    --input-file kong.yaml \
-    --output-file new-kong.yaml
-    ```
-
-    You can leave `input-file` out to convert all declarative configuration files in your working directory.
-    We recommend specifying both input and output files.
-
-
-2. Validate the converted files in a test environment.
-
-    These changes may not be fully correct or exhaustive, so perform manual audits of the generated file before applying
-    the configuration in production.
-
-## FAQ
-
-**What happens if I set the format version to 3.0 but don't update regex paths?**
-
-The state file will break. Avoid setting the format version manually.
-
-**Can I still apply configuration if there are warnings?**
-
-If you have validated the configuration and found no issues but are still getting a warning,
-the warning may be a false positive.
-You can still apply the configuration, but do so at your own risk.
-
-**I ran decK convert but there are still errors or warnings, what do I do?**
-
-Manually validate the file, then make any necessary updates to your state file.

--- a/src/deck/reference/deck_convert.md
+++ b/src/deck/reference/deck_convert.md
@@ -17,7 +17,9 @@ deck convert [command-specific flags] [global flags]
 ## Flags
 
 `--from`
-:  format of the source file, allowed formats: `kong-gateway`
+:  format of the source file, allowed formats:
+{% if_version gte:1.15.x %}[`kong-gateway` `kong-gateway-2.x`]{% endif_version %}{%
+   if_version gte:1.7.x lte:1.14.x %}`kong-gateway`{% endif_version %}
 
 `-h`, `--help`
 :  help for convert (Default: `false`)
@@ -29,7 +31,9 @@ deck convert [command-specific flags] [global flags]
 :  file to write configuration to after conversion. Use `-` to write to stdout.
 
 `--to`
-:  desired format of the output, allowed formats: `konnect`
+:  desired format of the output, allowed formats:
+{% if_version gte:1.15.x %}[`konnect` `kong-gateway-3.x`]{% endif_version %}{%
+   if_version gte:1.7.x lte:1.14.x %}`konnect`{% endif_version %}
 
 
 {% if_version gte:1.7.x %}


### PR DESCRIPTION
### Summary
Upgrade/convert guide for declarative config in Gateway 3.0. 

### Reason
Although db migrations cover config data already in the database, state files are not updated with migrations. These have to be converted in 3.0 format separately.

https://konghq.atlassian.net/browse/DOCU-2499

### Testing
See netlify.
