### PR TITLE
Add support for frontmatter overrides

### DIFF
--- a/app/_plugins/generators/single_source_generator.rb
+++ b/app/_plugins/generators/single_source_generator.rb
@@ -124,6 +124,30 @@ module SingleSource
 
       # Set the layout if it's not already provided
       @data['layout'] = 'docs-v2' unless data['layout']
+
+      # Apply any overrides
+      current = to_version(@data['release'])
+      @data['overrides']&.each do |key, entries|
+        entries.each do |value, conditions|
+          gte = conditions['gte'] ? to_version(conditions['gte']) : nil
+          lte = conditions['lte'] ? to_version(conditions['lte']) : nil
+          eq = conditions['eq'] ? to_version(conditions['eq']) : nil
+
+          if gte && lte
+            @data[key] = value if current >= gte && current <= lte
+          elsif gte
+            @data[key] = value if current >= gte
+          elsif lte
+            @data[key] = value if current <= lte
+          elsif eq
+            @data[key] = value if current == eq
+          end
+        end
+      end
+    end
+
+    def to_version(input)
+      Gem::Version.new(input.gsub(/\.x$/, '.0'))
     end
   end
 end

--- a/docs/single-sourced-versions.md
+++ b/docs/single-sourced-versions.md
@@ -187,9 +187,9 @@ If using `if_version` in a sentence, specify `inline:true` like so:
 Hello {% if_version eq:1.0.0 inline:true %}everyone in the {% endif_version %} world
 ```
 
-### Frontmatter
+### Front matter
 
-You may want to set values in the frontmatter conditionally. You can do this using `overrides`:
+You may want to set values in the front matter conditionally. You can do this using `overrides`:
 
 ```yaml
 ---

--- a/docs/single-sourced-versions.md
+++ b/docs/single-sourced-versions.md
@@ -139,6 +139,8 @@ unlisted:
 
 ## Conditional Rendering
 
+### Content
+
 As we add new functionality, we'll want content to be displayed for specific releases of a product. We can use the `if_version` block for this:
 
 ```
@@ -183,4 +185,37 @@ If using `if_version` in a sentence, specify `inline:true` like so:
 
 ```
 Hello {% if_version eq:1.0.0 inline:true %}everyone in the {% endif_version %} world
+```
+
+### Frontmatter
+
+You may want to set values in the frontmatter conditionally. You can do this using `overrides`:
+
+```yaml
+---
+title: Page Here
+alpha: false # This is the default, but is here for completeness
+
+overrides:
+  alpha:
+    true:
+      gte: 2.3.x
+      lte: 2.5.x
+---
+```
+
+In the above example, versions `2.3.x`, `2.4.x` and `2.5.x` will have `alpha: true`, and all other versions will have `alpha: false`.
+
+You can set the key to any scalar value. Here's an example using strings to switch something from "Private Beta" (2.8.x and before) to GA (anything later than this).
+
+```yaml
+---
+title: Another Page
+availability: GA
+
+overrides:
+  availability:
+    Private Beta:
+      lte: 2.8.x
+---
 ```

--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -1,11 +1,6 @@
 ---
 title: Using Gateway API
-
-overrides:
-  alpha:
-    true:
-      gte: 2.3.x
-      lte: 2.5.x
+alpha: true
 ---
 
 [Gateway API](https://gateway-api.sigs.k8s.io/) is a set of resources for

--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -1,6 +1,11 @@
 ---
 title: Using Gateway API
-alpha: true
+
+overrides:
+  alpha:
+    true:
+      gte: 2.3.x
+      lte: 2.5.x
 ---
 
 [Gateway API](https://gateway-api.sigs.k8s.io/) is a set of resources for


### PR DESCRIPTION
### Summary
Allow setting frontmatter values for specific versions

### Reason
Needed to mark some versions as `alpha` and later versions as non-alpha.

### Testing
/kubernetes-ingress-controller/2.5.x/guides/using-gateway-api/
/kubernetes-ingress-controller/2.6.x/guides/using-gateway-api/