### PR TITLE
Fix vale ignore rules

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -13,8 +13,6 @@ WordTemplate = \s(?:%s)\s
 [*.md]
 BasedOnStyles = kong
 
-[ignores]
-
 BlockIgnores = (\((http.*://|\.\/|\/).*?\)), \
 {\:.*?}
 TokenIgnores = {%.*?%}, \


### PR DESCRIPTION
### Summary
Vale is currently ignoring the ignore rules.

### Reason
The `[ignores]` tag was added in https://github.com/Kong/docs.konghq.com/pull/4448, from what I can tell, accidentally. There were some changes tested out for ignoring blocks of text that were reverted, but this change stuck around.

Currently, it's breaking the check, as [Vale flags everything](https://github.com/Kong/docs.konghq.com/runs/8459427205) that we originally had an ignore rule for (eg navtabs or lte/gte tags). 

### Testing
Run `vale` locally on this branch on some topic with navtabs or version labels, eg 
```
vale src/kubernetes-ingress-controller/guides/using-gateway-api.md
```