### PR TITLE
Change "control plane" to "data planes"

### DIFF
--- a/app/konnect/network-resiliency.md
+++ b/app/konnect/network-resiliency.md
@@ -18,8 +18,10 @@ the config as `config.json.gz` into `/usr/local/kong` by default.
 
 ### How do the control plane and data planes communicate?
 
-Data travelling between control planes and data planes is secured through a
-mutual TLS handshake.
+Data traveling between control planes and data planes is secured through a
+mutual TLS handshake. 
+Data planes initiate the connection to the {{site.konnect_short_name}} control plane.
+Once the connection is established, the control plane can send configuration data to the connected data planes.
 
 Normally, the data plane maintains a persistent connection with the control
 plane. The data plane sends a heartbeat to the control plane every 30 seconds to

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -35,13 +35,17 @@ want to use port `3001` for the proxy, map `3001:8000`.
 
 ## Hostnames
 
-Add the following hostnames to the allowlist to give data planes access through the firewall:
+Data planes initiate the connection to the {{site.konnect_short_name}} control plane.
+They require access through firewalls to communicate with the control plane.
+
+To let data planes request and receive configuration, and send telemetry data,
+add the following hostnames to the firewall allowlist:
 
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
 * `us.api.konghq.com`: The {{site.konnect_short_name}} API.
     Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
 * `RUNTIME_GROUP_ID.us.cp0.konghq.com`: Handles configuration for a runtime group.
-    Runtime instances connect to this host to receive configuration updates. 
+    Runtime instances connect to this host to receive configuration updates.
     This hostname is unique to each organization and runtime group.
 * `RUNTIME_GROUP_ID.us.tp0.konghq.com`: Gathers telemetry data for a runtime group.
     This hostname is unique to each organization and runtime group.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -35,10 +35,10 @@ want to use port `3001` for the proxy, map `3001:8000`.
 
 ## Hostnames
 
-Data planes initiate the connection to the {{site.konnect_short_name}} control plane.
+Runtime instances initiate the connection to the {{site.konnect_short_name}} control plane. 
 They require access through firewalls to communicate with the control plane.
 
-To let data planes request and receive configuration, and send telemetry data,
+To let a runtime instances request and receive configuration, and send telemetry data, 
 add the following hostnames to the firewall allowlist:
 
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -35,8 +35,7 @@ want to use port `3001` for the proxy, map `3001:8000`.
 
 ## Hostnames
 
-Add the following hostnames to the allowlist to give the
-{{site.konnect_short_name}} control plane access through the firewall:
+Add the following hostnames to the allowlist to give data planes access through the firewall:
 
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
 * `us.api.konghq.com`: The {{site.konnect_short_name}} API.


### PR DESCRIPTION
### Summary
Clarifying info about DP access through firewalls. Previously, the doc was saying that the CP needs access, which is incorrect.

### Reason
See https://kongstrong.slack.com/archives/CQK8J4VN3/p1663685608861879?thread_ts=1663682193.400399&cid=CQK8J4VN3.

### Testing
Netlify.