### PR TITLE
Kong Quickstart: Pipes quickstart to script to bash instead of sh

### DIFF
--- a/src/gateway/get-started/index.md
+++ b/src/gateway/get-started/index.md
@@ -39,7 +39,7 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
 1. Run {{site.base_gateway}} with the `quickstart` script:
 
    ```sh
-   curl -Ls get.konghq.com/quickstart | sh -s
+   curl -Ls get.konghq.com/quickstart | bash -s
    ```
 
    This script runs Docker containers for {{site.base_gateway}} and the supporting PostgreSQL database.

--- a/src/gateway/production/monitoring/prometheus.md
+++ b/src/gateway/production/monitoring/prometheus.md
@@ -30,7 +30,7 @@ and Prometheus locally.
         connectivity and installed {{site.base_gateway}} services and routes.
 
    ```sh
-   curl -Ls get.konghq.com/quickstart | sh -s -- -m
+   curl -Ls get.konghq.com/quickstart | bash -s -- -m
    ```
    The `-m` flag instructs the script to install a mock service that is used in this guide to generate sample metrics.
 
@@ -137,7 +137,7 @@ commands to stop and remove the services created in this guide:
 
 ```sh
 docker stop kong-quickstart-prometheus
-curl -Ls get.konghq.com/quickstart | sh -s -- -d
+curl -Ls get.konghq.com/quickstart | bash -s -- -d
 ```
 
 ### More information

--- a/src/gateway/production/monitoring/statsd.md
+++ b/src/gateway/production/monitoring/statsd.md
@@ -27,7 +27,7 @@ observe the collected monitoring data.
         connectivity and installed {{site.base_gateway}} services and routes.
 
    ```sh
-   curl -Ls get.konghq.com/quickstart | sh -s -- -m
+   curl -Ls get.konghq.com/quickstart | bash -s -- -m
    ```
    The `-m` flag instructs the script to install a mock service that is used in this guide to generate sample metrics.
 
@@ -95,7 +95,7 @@ commands to stop and remove the software ran in this guide:
 
 ```sh
 docker stop kong-quickstart-statsd
-curl -Ls get.konghq.com/quickstart | sh -s -- -d
+curl -Ls get.konghq.com/quickstart | bash -s -- -d
 ```
 
 ### More information


### PR DESCRIPTION
### Summary

Kat Morgan and I discovered on Ubuntu that when piping the script to sh (which is dash on ubuntu) the shell does not respect the bash shebang and the script syntax is invalid. Modifying the instructions to pass the script to bash works on Ubuntu and MacOS.


### Reason
The instructions do not work on Ubuntu

### Testing
Tested code locally on Ubuntu and MacOS.  Did not test the docs build itself as the change is trivial