### PR TITLE
Add ability to provide k8s-specific examples

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/_index.md
@@ -30,6 +30,28 @@ params:
       required: true
       value_in_examples:
         - '@example/my_function.lua'
+      value_in_examples_serialized:
+        - |
+          |
+            local responses = {
+              ["Invalid authentication credentials"] = {
+                message = "Invalid API key",
+              },
+            }
+
+            return function(status, body, headers)
+              if not body or not body.message then
+                return status, body, headers
+              end
+
+              local response = responses[body.message]
+
+              body.message = response.message or body.message
+              status = response.status or status
+              headers = response.headers or headers
+
+              return status, body, headers
+            end
       datatype: array of string elements
       description: Array of functions used to transform any Kong proxy exit response.
     - name: handle_unknown

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -75,27 +75,32 @@ endcapture %}
 {% capture config_required_fields_k8s
 %}config: {%
 for field in include.params.config %}{% if_plugin_version gte:field.minimum_version lte:field.maximum_version %}{%
-if field.value_in_examples != nil %}{%
-  if field.value_in_examples.first %}{%
+assign example = field.value_in_examples
+%}{%
+if field.value_in_examples_serialized%}{%
+assign example = field.value_in_examples_serialized
+%}{% endif %}{%
+if example != nil %}{%
+  if example.first %}{%
       if field.name contains "." %}{%
         assign names = field.name | split: "." %}
   {{ names[0] }}:{%
     for name in names offset:1 %}
     {{ name }}:{% endfor %}{%
-    for value in field.value_in_examples %}
+    for value in example %}
     - {{ value }}{%
     endfor %}{% else %}
   {{ field.name }}:{%
-  for value in field.value_in_examples %}
+  for value in example %}
   - {{ value }}{%
   endfor %}{% endif %}{%
   elsif field.name contains "." %}{%
         assign names = field.name | split: "." %}
   {{ names[0] }}:{%
     for name in names offset:1 %}
-    {{ name }}:{% endfor %} {{ field.value_in_examples }}{%
+    {{ name }}:{% endfor %} {{ example }}{%
   else %}
-  {{ field.name }}: {{ field.value_in_examples }}{%
+  {{ field.name }}: {{ example }}{%
   endif %}{%
 endif %}{% endif_plugin_version %}{% endfor
 %}{% endcapture %}


### PR DESCRIPTION
### Summary
Add the ability to add k8s-specific examples in the plugin hub

### Reason
Some values need specifying inline in the YAML. The existing examples assumed that `curl` was being used

### Testing
See the Kubernetes tab in /hub/kong-inc/exit-transformer/#example-config