### PR TITLE
Router docs improvement

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -581,7 +581,7 @@ items:
         url: /reference/cli
       - text: Performance Testing Framework
         url: /reference/performance-testing-framework
-      - text: Router Operators
-        url: /reference/router-operators
+      - text: Router Expressions Language
+        url: /reference/router-expressions-language
       - text: FAQ
         url: /reference/faq

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -87,7 +87,7 @@ The new router can be used in traditional-compatible mode, or use the new expres
 
   Learn more about the router:
   * [Configure routes using expressions](/gateway/3.0.x/key-concepts/routes/expressions)
-  * [Router operator reference](/gateway/3.0.x/reference/router-operators)
+  * [Router Expressions Language reference](/reference/router-expressions-language)
 
   [#8938](https://github.com/Kong/kong/pull/8938)
 * Implemented delayed response in stream mode.

--- a/src/gateway/key-concepts/routes/expressions.md
+++ b/src/gateway/key-concepts/routes/expressions.md
@@ -6,7 +6,7 @@ content-type: how-to
 
 Expressions can describe routes or paths as patterns using logical expressions.
 This how-to guide will walk through switching to the new router, and configuring routes with the new expressive domain specific language.
-For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-operators).
+For a list of all available operators and configurable fields please review the [reference documentation](/gateway/latest/reference/router-expressions-language).
 
 ## Prerequisite
 
@@ -16,7 +16,7 @@ be configurable and you must specify Expressions in the `expression` field.
 
 ## Create routes with Expressions
 
-To create a new router object using expressions, send a `POST` request to the [services endpoint](/gateway/latest/admin-api/#update-route) like this: 
+To create a new router object using expressions, send a `POST` request to the [services endpoint](/gateway/latest/admin-api/#update-route) like this:
 ```sh
 curl --request POST \
   --url http://localhost:8001/services/example-service/routes \
@@ -58,7 +58,7 @@ curl --request POST \
 ```
 
 
-For a list of all available operators, see the [reference documentation](/gateway/latest/reference/router-operators/).
+For a list of all available operators, see the [reference documentation](/gateway/latest/reference/router-expressions-language).
 
 ### Matching priority
 
@@ -160,4 +160,4 @@ This reduces the number of routes the Expressions engine has to consider, which 
 ## More information
 
 * [Expressions repository](https://github.com/Kong/atc-router#table-of-contents)
-* [Expressions Reference](/gateway/latest/reference/router-operators)
+* [Expressions Language Reference](/gateway/latest/reference/router-expressions-language)

--- a/src/gateway/key-concepts/routes/expressions.md
+++ b/src/gateway/key-concepts/routes/expressions.md
@@ -62,11 +62,11 @@ For a list of all available operators, see the [reference documentation](/gatewa
 
 ### Matching priority
 
-When Expressions router is used, available expressions are evaluated by the `priority` field of the corresponding `Route` object
-where the expression is configured, from routes with highest priority number to the lowest. If two routes has the same priority, then
+When the Expressions router is used, available expressions are evaluated using the `priority` field of the corresponding `Route` object
+where the expression is configured. Routes are evaluated in order of priority. If two routes have the same priority, then
 the newest route (that is, routes with the highest `created_at` will be evaluated first).
 
-Expressions router stops evaluating the remaining rules as soon as the first match is found.
+The Expressions router stops evaluating the remaining rules as soon as the first match is found.
 
 For example, given the following config:
 

--- a/src/gateway/key-concepts/routes/expressions.md
+++ b/src/gateway/key-concepts/routes/expressions.md
@@ -31,7 +31,7 @@ curl --request POST \
   --header 'Content-Type: multipart/form-data' \
   --form 'expression=(http.path == "/mock" || net.protocol == "https")'
 ```
-In this example the || operator created an expression that set variables for the following fields: 
+In this example the || operator created an expression that set variables for the following fields:
 
 ```
 curl --request POST \
@@ -59,6 +59,35 @@ curl --request POST \
 
 
 For a list of all available operators, see the [reference documentation](/gateway/latest/reference/router-operators/).
+
+### Matching priority
+
+When Expressions router is used, available expressions are evaluated by the `priority` field of the corresponding `Route` object
+where the expression is configured, from routes with highest priority number to the lowest. If two routes has the same priority, then
+the newest route (that is, routes with the highest `created_at` will be evaluated first).
+
+Expressions router stops evaluating the remaining rules as soon as the first match is found.
+
+For example, given the following config:
+
+```
+Route 1 =>
+created_at: 100000001
+priority: 100,
+expression: ...
+
+Route 2 =>
+created_at: 100000000
+priority: 100,
+expression: ...
+
+Route 3 =>
+created_at: 100000002
+priority: 99,
+expression: ...
+```
+
+The evaluation order will be: Route 1 then Route 2 and finally Route 3.
 
 ## Performance considerations when using Expressions
 

--- a/src/gateway/reference/router-expressions-language.md
+++ b/src/gateway/reference/router-expressions-language.md
@@ -1,5 +1,5 @@
 ---
-title: Router Operator Reference for Kong Gateway
+title: Router Expressions Language Reference for Kong Gateway
 content-type: reference
 ---
 

--- a/src/gateway/reference/router-expressions-language.md
+++ b/src/gateway/reference/router-expressions-language.md
@@ -41,7 +41,7 @@ Example:
 ## Types
 
 Router expressions are strongly typed. The operators available to each field depends on the type of that field.
-For example, you can not perform String comparisons on a Integer type field.
+For example, you can not perform string comparisons on a integer type field.
 
 ## Available fields
 

--- a/src/gateway/reference/router-operators.md
+++ b/src/gateway/reference/router-operators.md
@@ -38,6 +38,11 @@ Example:
 (http.path ^= "/prefix/" && net.port == 80) || http.method == "POST"
 ```
 
+## Types
+
+Router expressions are strongly typed. The operators available to each field depends on the type of that field.
+For example, you can not perform String comparisons on a Integer type field.
+
 ## Available fields
 
 | Field | Description | Type |


### PR DESCRIPTION
This PR adds more description of expressions matching priority. It also renames the "Router operators" reference page to a more meaningful name, that page is already much more than just about operators.