### PR TITLE
[DOCU-2522] decK: order of precedence for Gateway vs Konnect modes

### DIFF
--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -241,7 +241,7 @@ If the {{site.konnect_short_name}} service doesn't exist, this configuration sni
 ### Authentication with a {{site.konnect_short_name}} password or token file is not working
 
 If you have verified that your password or token is correct but decK can't connect to your account, check for conflicts with the decK config file (`$HOME/.deck.yaml`) and the {{site.konnect_short_name}} password or token file.
-There is likely a decK config file conflicting with the password or token file and passing another set of credentials.
+A decK config file is likely conflicting with the password or token file and passing another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.
 
@@ -303,13 +303,13 @@ They are managed entirely by {{site.konnect_short_name}}, so you can't manage th
 
 {% if_version gte:1.15 %}
 
-### decK keeps targeting {{site.base_gateway}} instead of {{site.konnect_short_name}}
+### decK targets {{site.base_gateway}} instead of {{site.konnect_short_name}}
 
 decK can run against {{site.base_gateway}} or {{site.konnect_short_name}}.
 By default, it targets {{site.base_gateway}}, unless a setting tells decK to point to {{site.konnect_short_name}} instead.
 Make sure that one of the {{site.konnect_short_name}} options is present.
 
-decK determines which environment to run against in the following order of precedence:
+decK determines the environment using the following order of precedence:
 
 1. If the declarative configuration file contains the `_konnect` entry, decK runs
 against {{site.konnect_short_name}}.

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -251,7 +251,7 @@ To resolve, remove one of the duplicate sets of credentials.
 ### Authentication with a {{site.konnect_short_name}} password file is not working
 
 If you have verified that your password is correct but decK can't connect to your account, check for conflicts with the decK config file (`$HOME/.deck.yaml`) and the {{site.konnect_short_name}} password file.
-There is likely a decK config file conflicting with the password file and passing another set of credentials.
+A decK config file is likely conflicting with the password or token file and passing another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.
 
@@ -307,7 +307,6 @@ They are managed entirely by {{site.konnect_short_name}}, so you can't manage th
 
 decK can run against {{site.base_gateway}} or {{site.konnect_short_name}}.
 By default, it targets {{site.base_gateway}}, unless a setting tells decK to point to {{site.konnect_short_name}} instead.
-Make sure that one of the {{site.konnect_short_name}} options is present.
 
 decK determines the environment using the following order of precedence:
 

--- a/src/deck/guides/konnect.md
+++ b/src/deck/guides/konnect.md
@@ -49,9 +49,21 @@ Those commands are deprecated and have been replaced with the flags in this guid
 
 decK looks for {{site.konnect_short_name}} credentials in the following order of precedence:
 
-1. Password set with the `--konnect-password` flag
+{% if_version gte:1.14.x %}
+
+1. Credentials set with a flag, either `--konnect-password` or `--konnect-token`
+2. decK configuration file, if one exists (default lookup path: `$HOME/.deck.yaml`)
+3. Credential file passed with a flag, either `--konnect-password-file` or `--konnect-token-file`
+
+{% endif_version %}
+
+{% if_version lte:1.13.x %}
+
+1.  Password set with the `--konnect-password` flag
 2. decK configuration file, if one exists (default lookup path: `$HOME/.deck.yaml`)
 3. File passed with the `--konnect-password-file` flag
+
+{% endif_version %}
 
 For example, if you have both a decK config file and a {{site.konnect_short_name}} password file, decK uses the password in the config file.
 
@@ -110,7 +122,7 @@ Successfully Konnected as MyName (Konnect Org)!
 {% if_version gte:1.14.x %}
 ### Authenticate using a personal access token
 
-You can generate a personal access token (PAT) in {{site.konnect_short_name}} for authentication with decK commands. This is more secure than basic authentication, and can be useful for organizations with CI pipelines that can't use the standard username and password authentication. 
+You can generate a personal access token (PAT) in {{site.konnect_short_name}} for authentication with decK commands. This is more secure than basic authentication, and can be useful for organizations with CI pipelines that can't use the standard username and password authentication.
 
 Before you generate a PAT, keep the following in mind:
 
@@ -119,8 +131,8 @@ Before you generate a PAT, keep the following in mind:
 * There is a limit of 10 personal access tokens per user.
 * Unused tokens are deleted and revoked after 12 months of inactivity.
 
-To generate a PAT in {{site.konnect_short_name}}, select your name to open the context menu 
- and click **Personal access tokens**, then click **Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location. 
+To generate a PAT in {{site.konnect_short_name}}, select your name to open the context menu
+ and click **Personal access tokens**, then click **Generate token**. After configuring the name and expiration date, make sure you copy the token to a secure location.
 
 You can use the `--konnect-token` flag to pass the PAT directly in the command:
 
@@ -225,12 +237,25 @@ If the {{site.konnect_short_name}} service doesn't exist, this configuration sni
 
 ## Troubleshoot
 
+{% if_version gte:1.14.x %}
+### Authentication with a {{site.konnect_short_name}} password or token file is not working
+
+If you have verified that your password or token is correct but decK can't connect to your account, check for conflicts with the decK config file (`$HOME/.deck.yaml`) and the {{site.konnect_short_name}} password or token file.
+There is likely a decK config file conflicting with the password or token file and passing another set of credentials.
+
+To resolve, remove one of the duplicate sets of credentials.
+
+{% endif_version %}
+
+{% if_version lte:1.13.x %}
 ### Authentication with a {{site.konnect_short_name}} password file is not working
 
 If you have verified that your password is correct but decK can't connect to your account, check for conflicts with the decK config file (`$HOME/.deck.yaml`) and the {{site.konnect_short_name}} password file.
 There is likely a decK config file conflicting with the password file and passing another set of credentials.
 
 To resolve, remove one of the duplicate sets of credentials.
+
+{% endif_version %}
 
 ### Workspace connection refused
 
@@ -276,7 +301,28 @@ They are managed entirely by {{site.konnect_short_name}}, so you can't manage th
 
 [Manage application registration](/konnect/dev-portal/applications/enable-app-reg) through the Service Hub to avoid any issues.
 
+{% if_version gte:1.15 %}
+
+### decK keeps targeting {{site.base_gateway}} instead of {{site.konnect_short_name}}
+
+decK can run against {{site.base_gateway}} or {{site.konnect_short_name}}.
+By default, it targets {{site.base_gateway}}, unless a setting tells decK to point to {{site.konnect_short_name}} instead.
+Make sure that one of the {{site.konnect_short_name}} options is present.
+
+decK determines which environment to run against in the following order of precedence:
+
+1. If the declarative configuration file contains the `_konnect` entry, decK runs
+against {{site.konnect_short_name}}.
+
+2. If the `--kong-addr` flag is set to a non-default value, decK runs against {{site.base_gateway}}.
+
+3. If {{site.konnect_short_name}} credentials are set in any way (flag, file, or decK config), decK runs against {{site.konnect_short_name}}.
+
+4. If none of the above are present, decK runs against {{site.base_gateway}}.
+
+{% endif_version %}
+
 ## See also
 
-* [Import {{site.base_gateway}} entities into {{site.konnect_saas}}](/konnect/getting-started/import)
+* [Import {{site.base_gateway}} entities into {{site.konnect_short_name}}](/konnect/getting-started/import)
 * [Manage runtime groups with decK](/konnect/runtime-manager/runtime-groups/declarative-config)


### PR DESCRIPTION
### Summary
Add an environment precedence section to the decK Konnect reference. 
Also updating any place in the guide where it should mention PATs but only mentions passwords.

### Reason

Precedence fix coming in decK 1.15. 

https://konghq.atlassian.net/browse/DOCU-2522

### Testing
https://deploy-preview-4498--kongdocs.netlify.app/deck/latest/guides/konnect/