### PR TITLE
doc(kic) add 2.7 docs

### DIFF
--- a/app/_data/docs_nav_kic_2.7.x.yml
+++ b/app/_data/docs_nav_kic_2.7.x.yml
@@ -1,0 +1,150 @@
+product: kubernetes-ingress-controller
+release: 2.7.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /kubernetes-ingress-controller/
+    absolute_url: true
+    items:
+      - text: FAQ
+        url: /faq
+      - text: Version Support Policy
+        url: /support-policy
+      - text: Stages of Software Availability
+        url: /availability-stages
+      - text: Changelog
+        url: https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md
+        absolute_url: true
+        target_blank: true
+
+  - title: Concepts
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: Architecture
+        url: /concepts/design
+      - text: Custom Resources
+        url: /concepts/custom-resources
+      - text: Deployment Methods
+        url: /concepts/deployment
+      - text: Kong for Kubernetes with Kong Enterprise
+        url: /concepts/k4k8s-with-kong-enterprise
+      - text: High-Availability and Scaling
+        url: /concepts/ha-and-scaling
+      - text: Resource Classes
+        url: /concepts/ingress-classes
+      - text: Security
+        url: /concepts/security
+      - text: Ingress Resource API Versions
+        url: /concepts/ingress-versions
+      - text: Gateway API
+        url: /concepts/gateway-api
+  - title: Deployment
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /deployment/overview
+    items:
+      - text: Kong Ingress on Minikube
+        url: /deployment/minikube
+      - text: Kong for Kubernetes
+        url: /deployment/k4k8s
+      - text: Kong for Kubernetes Enterprise
+        url: /deployment/k4k8s-enterprise
+      - text: Kong for Kubernetes with Kong Enterprise
+        url: /deployment/kong-enterprise
+      - text: Kong Ingress on AKS
+        url: /deployment/aks
+      - text: Kong Ingress on EKS
+        url: /deployment/eks
+      - text: Kong Ingress on GKE
+        url: /deployment/gke
+      - text: Admission Controller
+        url: /deployment/admission-webhook
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /guides/overview
+    items:
+      - text: Getting Started with KIC
+        url: /guides/getting-started
+      - text: Upgrading from previous versions
+        url: /guides/upgrade
+      - text: Upgrading to Kong 3.x
+        url: /guides/upgrade-kong-3x
+      - text: Getting Started using Istio
+        url: /guides/getting-started-istio
+      - text: Using Custom Resources
+        items:
+          - text: Using the KongPlugin Resource
+            url: /guides/using-kongplugin-resource
+          - text: Using the KongIngress Resource
+            url: /guides/using-kongingress-resource
+          - text: Using KongConsumer and KongCredential Resources
+            url: /guides/using-consumer-credential-resource
+          - text: Using the KongClusterPlugin Resource
+            url: /guides/using-kongclusterplugin-resource
+          - text: Using the TCPIngress Resource
+            url: /guides/using-tcpingress
+          - text: Using the UDPIngress Resource
+            url: /guides/using-udpingress
+      - text: Using the ACL and JWT Plugins
+        url: /guides/configure-acl-plugin
+      - text: Using cert-manager with Kong
+        url: /guides/cert-manager
+      - text: Configuring a Fallback Service
+        url: /guides/configuring-fallback-service
+      - text: Using an External Service
+        url: /guides/using-external-service
+      - text: Configuring HTTPS Redirects for Services
+        url: /guides/configuring-https-redirect
+      - text: Using Redis for Rate Limiting
+        url: /guides/redis-rate-limiting
+      - text: Integrate KIC with Prometheus/Grafana
+        url: /guides/prometheus-grafana
+      - text: Configuring Circuit-Breaker and Health-Checking
+        url: /guides/configuring-health-checks
+      - text: Setting up a Custom Plugin
+        url: /guides/setting-up-custom-plugins
+      - text: Using Ingress with gRPC
+        url: /guides/using-ingress-with-grpc
+      - text: Setting up Upstream mTLS
+        url: /guides/upstream-mtls
+      - text: Exposing a TCP-based Service
+        url: /guides/using-tcpingress
+        generate: false # Generated in the CustomResources section above
+      - text: Exposing a UDP-based Service
+        url: /guides/using-udpingress
+        generate: false # Generated in the CustomResources section above
+      - text: Using the mTLS Auth Plugin
+        url: /guides/using-mtls-auth-plugin
+      - text: Configuring Custom Entities
+        url: /guides/configuring-custom-entities
+      - text: Using the OpenID Connect Plugin
+        url: /guides/using-oidc-plugin
+      - text: Rewriting Hosts and Paths
+        url: /guides/using-rewrites
+      - text: Preserving Client IP Address
+        url: /guides/preserve-client-ip
+      - text: Using Gateway API
+        url: /guides/using-gateway-api
+      - text: Using Kong with Knative
+        url: /guides/using-kong-with-knative
+  - title: References
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: KIC Annotations
+        url: /references/annotations
+      - text: CLI Arguments
+        url: /references/cli-arguments
+      - text: Custom Resource Definitions
+        url: /references/custom-resources
+      - text: Plugin Compatibility
+        url: /references/plugin-compatibility
+      - text: Version Compatibility
+        url: /references/version-compatibility
+      - text: Troubleshooting
+        url: /troubleshooting
+      - text: Prometheus Metrics
+        url: /references/prometheus
+      - text: Feature Gates
+        url: /references/feature-gates
+      - text: Gateway API Support
+        url: /references/gateway-api-support

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -339,3 +339,7 @@
   release: "2.6.x"
   version: "2.6.0"
   edition: "kubernetes-ingress-controller"
+-
+  release: "2.7.x"
+  version: "2.7.0"
+  edition: "kubernetes-ingress-controller"

--- a/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
+++ b/src/kubernetes-ingress-controller/guides/upgrade-kong-3x.md
@@ -39,11 +39,11 @@ changes in this release.
 
 [changelog]:https://github.com/kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#260
 
-2.7 does include a minor breaking change affecting the `CombinedRoutes` feature
-gate, but is otherwise not expected to require changes to existing
+2.7 includes a minor breaking change that affects the `CombinedRoutes` feature
+gate, but is otherwise not expected to require changes to the existing
 configuration.
 
-As KIC 2.7 is compatible with all 2.x Kong releases, you should upgrade it and
+Because KIC 2.7 is compatible with all 2.x {{site.base_gateway}} releases, you should upgrade it and
 the chart first:
 
 ```shell
@@ -72,10 +72,9 @@ and changes to the PDK that affect custom plugins.
 Kong 3.x includes changes to regular expression path handling, which _do_ require
 manual updates to Ingress configuration. In Kong 2.x, Kong applied a heuristic based
 on the presence of special characters in a route path to determine if a path
-was a regular expression. This heuristic was imperfect and Kong 3.x has removed
-it, instead requiring that any regular expression begin with a `~` prefix.
-Ingress does not allow paths that begin with any character other than `/`,
-however, so Ingress rules with a regular expression path must begin with `/~`
+was a regular expression. This heuristic was imperfect and {{site.base_gateway}} 3.x removed
+it, and instead requires that any regular expression begins with a `~` prefix.
+Ingress does not allow paths that begin with any character other than `/`,  so Ingress rules with a regular expression path must begin with `/~`
 instead.
 
 Ingress rule paths have no way to indicate that a path is a regular expression.
@@ -94,7 +93,7 @@ process and allow users to update rules gradually, KIC 2.7 includes the
 `enableLegacyRegexDetection` option to continue applying the 2.x regular
 expression heuristic on KIC's end.
 
-If the following sets of rules are met, KIC will create a Kong route path with
+If the following sets of rules are met, KIC creates a Kong route path with
 the `~` prefix:
 
 * The `enableLegacyRegexDetection` option is enabled

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -11,7 +11,7 @@ those versions' documentation.
 
 By Kong, we are here referring to the official distribution of the Open-Source {{site.base_gateway}}.
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+| {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
 | Kong 1.5.x                | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
 | Kong 2.0.x                | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
@@ -30,7 +30,7 @@ By Kong, we are here referring to the official distribution of the Open-Source {
 Kong Enterprise is the official enterprise distribution, which includes all
 other enterprise functionality, built on top of the Open-Source {{site.base_gateway}}.
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+| {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
 | Kong Enterprise 1.5.x     | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
 | Kong Enterprise 2.1.x     | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
@@ -45,14 +45,14 @@ other enterprise functionality, built on top of the Open-Source {{site.base_gate
 
 ## Kubernetes
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+| {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
 | Kubernetes 1.16           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.17           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.17           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
 | Kubernetes 1.22           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
@@ -64,7 +64,7 @@ The {{site.kic_product_name}} can be integrated with an [Istio Service Mesh][ist
 
 For each {{site.kic_product_name}} release, tests are run to verify this documentation with upcoming versions of KIC and Istio. The following table lists the tested combinations:
 
-| {{site.kic_product_name}} |            2.0.x            |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |
+| {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
 | Istio 1.8                 | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
 | Istio 1.9                 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |


### PR DESCRIPTION
### Summary
Adds KIC 2.7 with a revised Kong 3.x upgrade guide.

Updates the 2.6 compatibility information based on what we've learned about older EOL Kubernetes versions.

This should not be merged automatically. We will merge it once the release is actually out.

### Reason
2.7 is effectively 2.6.1, but our fix required a breaking change, so it's getting a minor version bump instead of a patch release. The upgrade guide refers to 2.7 as the first version that supports Kong 3.x now, which isn't technically true, but is close enough to true because of 2.6's incomplete support. We don't want to maintain separate versions of the guide for 2.6 and 2.7 because the recommended configuration for 2.6 isn't actually possible.

### Testing
https://deploy-preview-4503--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/upgrade-kong-3x/
https://deploy-preview-4503--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/version-compatibility/
