### PR TITLE
fix(admin-api): fix wrong api path

### DIFF
--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -4083,7 +4083,7 @@ target](#delete-target) instead.
 
 Note: This API is not available when Kong is running in hybrid mode.
 
-<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/{address}/unhealthy</div>
 
 {:.indent}
 Attributes | Description


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Fix the wrong API path of "Set Target Address As Unhealthy"

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

The correct API path of "Set Target Address As Unhealthy" is `/upstreams/{upstream name or id}/targets/{target or id}/{address}/unhealthy`

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
