### PR TITLE
chore: add kic to dictionary.txt

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -94,6 +94,7 @@ Keycloak
 keyspace
 kiali
 kibibytes
+kic
 Knative
 kong
 Kong/kong


### PR DESCRIPTION
### Summary

Add `kic` to `dictionary.txt` to prevent CI failures like this:

https://github.com/Kong/docs.konghq.com/pull/4471/files#annotation_4669837944
