### PR TITLE
Added an example for global plugin using KongClusterPlugin

### DIFF
--- a/src/kubernetes-ingress-controller/guides/using-kongclusterplugin-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongclusterplugin-resource.md
@@ -331,3 +331,37 @@ services running in different namespaces.
 This can prove to be useful if the persona controlling the plugin
 configuration is different from service owners that are responsible for the
 Service and Ingress resources in Kubernetes.
+
+## Configure a global plugin
+
+Now, we will protect our Kubernetes cluster.
+For this, we will be configuring a rate-limiting plugin, which
+will throttle requests coming from the same client.
+
+This must be a cluster-level `KongClusterPlugin` resource, as `KongPlugin`
+resources cannot be applied globally, to preserve Kubernetes RBAC guarantees
+for cross-namespace isolation.
+
+Let's create the `KongClusterPlugin` resource:
+
+```bash
+$ echo "
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+metadata:
+  name: global-rate-limit
+  annotations:
+    kubernetes.io/ingress.class: kong
+  labels:
+    global: \"true\"
+config:
+  minute: 5
+  limit_by: consumer
+  policy: local
+plugin: rate-limiting
+" | kubectl apply -f -
+kongclusterplugin.configuration.konghq.com/global-rate-limit created
+```
+
+With this plugin (please note the `global` label), every request through
+the {{site.kic_product_name}} will be rate-limited:


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Issue Reference - #2748

There are examples present for creating KongClusterPlugin resource but there are no examples for creating global plugin using KongClusterPlugin resource which will run on each request.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

There are examples present for creating KongClusterPlugin resource but there are no examples for creating global plugin using KongClusterPlugin resource which will run on each request.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
