### PR TITLE
Pin KIC install versions

### DIFF
--- a/src/kubernetes-ingress-controller/deployment/admission-webhook.md
+++ b/src/kubernetes-ingress-controller/deployment/admission-webhook.md
@@ -20,7 +20,7 @@ If you are using the stock YAML manifests to install and setup Kong for
 Kubernetes, then you can set up the admission webhook using a single command:
 
 ```bash
-curl -sL https://bit.ly/install-kong-admission-webhook | bash
+curl -sL https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/main/hack/deploy-admission-controller.sh | bash
 ```
 The output is similar to the following:
 ```

--- a/src/kubernetes-ingress-controller/deployment/aks.md
+++ b/src/kubernetes-ingress-controller/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/aks.md
+++ b/src/kubernetes-ingress-controller/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/eks.md
+++ b/src/kubernetes-ingress-controller/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/eks.md
+++ b/src/kubernetes-ingress-controller/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/gke.md
+++ b/src/kubernetes-ingress-controller/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/gke.md
+++ b/src/kubernetes-ingress-controller/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
+++ b/src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
+++ b/src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/src/kubernetes-ingress-controller/deployment/kong-enterprise.md
+++ b/src/kubernetes-ingress-controller/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/src/kubernetes-ingress-controller/deployment/kong-enterprise.md
+++ b/src/kubernetes-ingress-controller/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/src/kubernetes-ingress-controller/deployment/minikube.md
+++ b/src/kubernetes-ingress-controller/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/src/kubernetes-ingress-controller/deployment/minikube.md
+++ b/src/kubernetes-ingress-controller/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
During releases, we publish KIC manifests with the updated version before that image becomes available. In the event that something goes wrong during the release, there may be an extended period where the manifests at the tip of master or main do not work.

To avoid documentation pointing to broken manifests, this change replaces short URLs with their full versions, and uses templates to inject the doc page's version into the URL. There may be a better way to get this version, but replacing bits of the `kong_version` value at least achieves the right end result. I furthermore want to avoid the bitly URLs in particular because we don't have a paid account and can't modify them. Until such time as we do, I don't want to use them.

This does have a side effect of always using the first release of a given minor release, we don't usually have branches that point to the latest patch. IMO this is acceptable since the manifests pinned versions already, so you'd only get the latest version at install, not any subsequent updates. We'd need to update the KIC repo automation to make latest patch URLs viable.

### Testing
Spot check of template in https://deploy-preview-4519--kongdocs.netlify.app/kubernetes-ingress-controller/latest/deployment/eks/ before changing the rest to use the same pattern.

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
