### PR TITLE
[fix] Add links to router docs in router object api documentation

### DIFF
--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -1799,14 +1799,14 @@ A route can't have both `tls` and `tls_passthrough` protocols at same time.
 The 3.0.x release introduces a new router implementation: `atc-router`.
 The router adds:
 
-* Reduced router rebuild time when changing Kong’s configuration
+* Reduced router rebuild time when changing {{site.base_gateway}}’s configuration
 * Increased runtime performance when routing requests
 * Reduced P99 latency from 1.5s to 0.1s with 10,000 routes
 
 Learn more about the router: 
 
-[Configure routes using expressions](/gateway/3.0.x/key-concepts/routes/expressions)
-[Router Expressions language reference](/gateway/3.0.x/reference/router-expressions-language/)
+* [Configure routes using expressions](/gateway/3.0.x/key-concepts/routes/expressions)
+* [Router Expressions language reference](/gateway/3.0.x/reference/router-expressions-language/)
 
 #### Path handling algorithms
 

--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -1796,6 +1796,18 @@ following attributes must be set:
 
 A route can't have both `tls` and `tls_passthrough` protocols at same time.
 
+The 3.0.x release introduces a new router implementation: `atc-router`.
+The router adds:
+
+* Reduced router rebuild time when changing Kong’s configuration
+* Increased runtime performance when routing requests
+* Reduced P99 latency from 1.5s to 0.1s with 10,000 routes
+
+Learn more about the router: 
+
+[Configure routes using expressions](/gateway/3.0.x/key-concepts/routes/expressions)
+[Router Expressions language reference](/gateway/3.0.x/reference/router-expressions-language/)
+
 #### Path handling algorithms
 
 {:.note}


### PR DESCRIPTION
Adds links. 

[corresponding PR](https://github.com/Kong/kong-ee/pull/3829) 