### PR TITLE
Updated index.md for OAuth2 Authentication

### DIFF
--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -320,6 +320,27 @@ You can use this information on your side to implement additional logic. You can
 ### Client Credentials
 
 The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow will work out of the box, without building any authorization page. The clients will need to use the `/oauth2/token` endpoint to request an access token.
+  
+Below are the various ways we can consume "/oauth2/token" endpoint to retrieve the access_token.
+
+_Content-Type set to application/x-www-form-urlencoded and sending the credentials as a form data in a POST call._
+```bash  
+curl --location --request POST 'https://your.service.com/oauth2/token' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'client_id=XXXX' \
+  --data-urlencode 'client_secret=XXXX' \
+  --data-urlencode 'grant_type=client_credentials'
+```
+_Content-Type set to application/json and sending the credentials as a JSON body in a POST call._
+```bash 
+curl --location --request POST 'https://your.service.com/oauth2/token' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{ "client_id": "XXXXX", "client_secret": "XXXX", "grant_type": "client_credentials" }'
+```
+_Sending the credentials in URL as query parameters in a POST call._
+```bash 
+curl --location --request POST 'https://your.service.com/oauth2/token?client_id=XXXX&client_secret=XXXX&grant_type=client_credentials'
+```
 
 ### Authorization Code
 


### PR DESCRIPTION
Change is to mention various ways of how we can call OAuth2/token endpoint to retrieve access_token for client_credentials grant_type.

Where is the problem?
https://docs.konghq.com/hub/kong-inc/oauth2/

What happened?
I dont see documentation of various ways of calling "/oauth2/token" call for client_credentials flow.

What did you expect to happen?
In Client credentials flow, there is a provision to make "oauth2/token" call by passing the client ID, client secret and grant_type as query param or a JSON body or in a url-encoded form data.

I would like to see if this approved, can be submitted for Kong Hackathon 2022 under documentation category.

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
