### PR TITLE
[DOCU-2585] Update runtime terminology

### DIFF
--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -11,10 +11,10 @@ New to {{site.konnect_saas}}? Get started with the basics through the web app:
 
     [Create an account &gt;](/konnect/getting-started/access-account)
 
-1.  **Set up a runtime connection**:
+1.  **Set up a runtime instance**:
 
-    Set up a runtime and connect it to your account. Your first runtime
-    connection gives you a data plane for proxying traffic.
+    Set up a runtime instance and connect it to your account. Your first runtime
+    instance gives you a data plane for proxying traffic.
 
     Start with a data plane proxy so that when your service configuration is
     ready, your services are immediately connected, configured,

--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -13,14 +13,13 @@ New to {{site.konnect_saas}}? Get started with the basics through the web app:
 
 1.  **Set up a runtime instance**:
 
-    Set up a runtime instance and connect it to your account. Your first runtime
-    instance gives you a data plane for proxying traffic.
+    Set up your first runtime instance, which gives you a data plane for proxying traffic.
 
     Start with a data plane proxy so that when your service configuration is
     ready, your services are immediately connected, configured,
     and available for testing.
 
-    [Set up a runtime connection &gt;](/konnect/getting-started/configure-runtime)
+    [Set up a runtime instance &gt;](/konnect/getting-started/configure-runtime)
 
 
 2.  **Create a service**:


### PR DESCRIPTION
### Summary
Updating "runtime connection" to "runtime instance".

### Reason
"runtime connection" is old terminology left over from pre-Helium. It's not present anywhere else in the docs, UI, or any of our communications.

https://konghq.atlassian.net/browse/DOCU-2585

### Testing
Netlify