### PR TITLE
Add KIC Gateway API and Kubernetes support table

### DIFF
--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -45,6 +45,12 @@ other enterprise functionality, built on top of the Open-Source {{site.base_gate
 
 ## Kubernetes
 
+### General
+
+The following table presents the general compatibility of {{site.kic_product_name}} with specific Kubernetes versions.
+Users should expect all the combinations marked with <i class="fa fa-check"></i> to work, and to be supported
+in case of potential bugs.
+
 | {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
 | Kubernetes 1.16           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
@@ -57,6 +63,31 @@ other enterprise functionality, built on top of the Open-Source {{site.base_gate
 | Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+
+### Gateway API
+
+The following table presents the git compatibility of {{site.kic_product_name}}'s [Gateway API][gateway-api]
+features with specific Kubernetes minor versions. As {{site.kic_product_name}} implements these features on top of the upstream
+project which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
+of Gateway API features might be limited to those.
+
+| {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Kubernetes 1.17           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.22           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+
+For specific Gateway API resources support, please refer to our [Gateway API Support][gateway-api-support] page.
+
+[gateway-api]:https://github.com/kubernetes-sigs/gateway-api
+[gateway-api-support]:/kubernetes-ingress-controller/{{page.kong_version}}/references/gateway-api-support/
+[gateway-api-supported-versions]:https://gateway-api.sigs.k8s.io/concepts/versioning/#supported-versions
 
 ## Istio
 

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -49,7 +49,7 @@ other enterprise functionality, built on top of the Open-Source {{site.base_gate
 
 The following table presents the general compatibility of {{site.kic_product_name}} with specific Kubernetes versions.
 Users should expect all the combinations marked with <i class="fa fa-check"></i> to work and to be supported
-in case of potential bugs.
+if there are bugs.
 
 | {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
 |:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
@@ -67,8 +67,8 @@ in case of potential bugs.
 ### Gateway API
 
 The following table presents the compatibility of {{site.kic_product_name}}'s [Gateway API][gateway-api]
-features with specific Kubernetes minor versions. As {{site.kic_product_name}} implements these features on top of the upstream
-project which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
+with specific Kubernetes minor versions. As {{site.kic_product_name}} implements Gateway API features in addition to the upstream
+project, which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
 of Gateway API features might be limited to those.
 
 | {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
@@ -83,7 +83,7 @@ of Gateway API features might be limited to those.
 | Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
-For specific Gateway API resources support, please refer to our [Gateway API Support][gateway-api-support] page.
+For specific Gateway API resources support, please refer to the [Gateway API Support][gateway-api-support] page.
 
 [gateway-api]:https://github.com/kubernetes-sigs/gateway-api
 [gateway-api-support]:/kubernetes-ingress-controller/{{page.kong_version}}/references/gateway-api-support/

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -64,6 +64,8 @@ if there are bugs.
 | Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
+
+{% if_version gte:2.4.0 %}
 ### Gateway API
 
 The following table presents the compatibility of {{site.kic_product_name}}'s [Gateway API][gateway-api]
@@ -71,23 +73,25 @@ with specific Kubernetes minor versions. As {{site.kic_product_name}} implements
 project, which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
 of Gateway API features might be limited to those.
 
-| {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
-| Kubernetes 1.17           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
-| Kubernetes 1.22           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kic_product_name}} |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|:---------------------------:|
+| Kubernetes 1.17           | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.18           | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.19           | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.20           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.21           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> | <i class="fa fa-times"></i> |
+| Kubernetes 1.22           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.23           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.24           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 For specific Gateway API resources support, please refer to the [Gateway API Support][gateway-api-support] page.
 
 [gateway-api]:https://github.com/kubernetes-sigs/gateway-api
-[gateway-api-support]:/kubernetes-ingress-controller/{{page.kong_version}}/references/gateway-api-support/
 [gateway-api-supported-versions]:https://gateway-api.sigs.k8s.io/concepts/versioning/#supported-versions
+[gateway-api-support]:/kubernetes-ingress-controller/{{page.kong_version}}/references/gateway-api-support/
+
+{% endif_version %}
 
 ## Istio
 

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -48,7 +48,7 @@ other enterprise functionality, built on top of the Open-Source {{site.base_gate
 ### General
 
 The following table presents the general compatibility of {{site.kic_product_name}} with specific Kubernetes versions.
-Users should expect all the combinations marked with <i class="fa fa-check"></i> to work, and to be supported
+Users should expect all the combinations marked with <i class="fa fa-check"></i> to work and to be supported
 in case of potential bugs.
 
 | {{site.kic_product_name}} |            2.1.x            |            2.2.x            |            2.3.x            |            2.4.x            |            2.5.x            |            2.6.x            |            2.7.x            |

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -67,7 +67,7 @@ if there are bugs.
 ### Gateway API
 
 The following table presents the compatibility of {{site.kic_product_name}}'s [Gateway API][gateway-api]
-with specific Kubernetes minor versions. As {{site.kic_product_name}} implements Gateway API features in addition to the upstream
+with specific Kubernetes minor versions. As {{site.kic_product_name}} implements Gateway API features using the upstream
 project, which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
 of Gateway API features might be limited to those.
 

--- a/src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -66,7 +66,7 @@ in case of potential bugs.
 
 ### Gateway API
 
-The following table presents the git compatibility of {{site.kic_product_name}}'s [Gateway API][gateway-api]
+The following table presents the compatibility of {{site.kic_product_name}}'s [Gateway API][gateway-api]
 features with specific Kubernetes minor versions. As {{site.kic_product_name}} implements these features on top of the upstream
 project which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
 of Gateway API features might be limited to those.


### PR DESCRIPTION
### Summary
Adds a compatibility matrix of supported KIC Gateway API features vs Kubernetes minor versions. 

My reasoning behind the support and why it's limited to fewer versions than what we've got for the general Kubernetes support: 

* [Gateway API declares to support the 5 recent versions of Kubernetes](https://gateway-api.sigs.k8s.io/concepts/versioning/#supported-versions),
* I inspected all KIC releases' go.mods to verify which Gateway API bundle versions were used for each of them.
* Based on the release dates, I verified which Kubernetes version was the latest at the time of the Gateway API bundle release for every KIC version.
* The supported Kubernetes versions are the 5 recent ones at the time of the bundle release + newer ones. 

### Reason
Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/2848

### Testing
https://deploy-preview-4531--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/version-compatibility/
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
