### PR TITLE
add filter mode to vale

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,6 +39,6 @@ jobs:
       - uses: errata-ai/vale-action@v2
         with:
           # path where vale checks checking only modified files.
-          files: __onlyModified
+          filter_mode: added
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This adds `filter_mode: added` instead of using `__onlymodified`. 


testing:
This is now:
![Screen Shot 2022-09-30 at 11 59 38 AM](https://user-images.githubusercontent.com/23319190/193310433-70b7f193-fe81-46f6-8510-dceb5cb43ee5.png)
It creates an output of:


![Screen Shot 2022-09-30 at 12 00 48 PM](https://user-images.githubusercontent.com/23319190/193310628-597c6ced-7a84-4106-b51c-600ffd1ff252.png)

While only expressing the errors in the changed files:
![image](https://user-images.githubusercontent.com/23319190/193310699-4d815f8e-0a98-4ce6-8b09-f694e7c0b65c.png)



