### PR TITLE
[fix] Vale on modified files

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,6 +39,6 @@ jobs:
       - uses: errata-ai/vale-action@v2
         with:
           # path where vale checks checking only modified files.
-          filter_mode: added
+          filter_mode: file
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Summary
Previously I enabled this on annotated lines. It should be on modified files. 


## Testing

I'll make two more commits to this PR to test if the second commit flags the spelling mistake in the first commit. [2785e6f](https://github.com/Kong/docs.konghq.com/pull/4552/commits/2785e6f6dcb8fd251b98dd55fe08595163c84bcf) contains 4 mistakes, [36c0ef6](https://github.com/Kong/docs.konghq.com/pull/4552/commits/36c0ef600ec1feead545c0c2102769559014d43c) brings the total to 7. 



Here are the results:
![image](https://user-images.githubusercontent.com/23319190/193669094-ac453cd4-3442-434f-b8ca-334fe33e996c.png)

![image](https://user-images.githubusercontent.com/23319190/193669181-fd43bf86-6934-4b05-b1ba-8bb7eefe6889.png)


forced push over those commits so this can be merged. 
