### PR TITLE
Swap comma for semicolon in Zipkin plugin docs

### DIFF
--- a/app/_hub/kong-inc/zipkin/_index.md
+++ b/app/_hub/kong-inc/zipkin/_index.md
@@ -164,7 +164,7 @@ params:
         format is `name_of_tag=value_of_tag`, separated by commas.
 
         For example: with the default value, a request with the header
-        `Zipkin-Tags: fg=blue, bg=red` will generate a trace with the tag `fg` with
+        `Zipkin-Tags: fg=blue; bg=red` will generate a trace with the tag `fg` with
         value `blue`, and another tag called `bg` with value `red`.
     - name: static_tags
       minimum_version: "2.3.x"

--- a/app/_hub/kong-inc/zipkin/_index.md
+++ b/app/_hub/kong-inc/zipkin/_index.md
@@ -161,7 +161,7 @@ params:
       description: |
         The Zipkin plugin will add extra headers to the tags associated with any HTTP
         requests that come with a header named as configured by this property. The
-        format is `name_of_tag=value_of_tag`, separated by commas.
+        format is `name_of_tag=value_of_tag`, separated by semicolons (`;`).
 
         For example: with the default value, a request with the header
         `Zipkin-Tags: fg=blue; bg=red` will generate a trace with the tag `fg` with


### PR DESCRIPTION
# What

The documentation for the Zipkin plugin say to use commas to separate values passed in to the "Zipkin-Tags" header. The code says semicolons.

# Reference

https://github.com/Kong/kong/blob/fab7b28cc1dddd1e2bd3ac28bf93316322186e48/kong/plugins/zipkin/request_tags.lua#L21

# Testing

I haven't tested this yet. I just noticed while writing a test around a pre-function that leverages this functionality.