### PR TITLE
Removing OS part of image tag names

### DIFF
--- a/src/gateway/install/docker/index.md
+++ b/src/gateway/install/docker/index.md
@@ -85,7 +85,7 @@ docker run --rm --network=kong-net \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PASSWORD=test" \
-kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine kong migrations bootstrap
+kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}} kong migrations bootstrap
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -94,7 +94,7 @@ docker run --rm --network=kong-net \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
-kong:{{page.kong_versions[page.version-index].ce-version}}-alpine kong migrations bootstrap
+kong:{{page.kong_versions[page.version-index].ce-version}} kong migrations bootstrap
 ```
 <!-- vale off -->
 {% endnavtab %}
@@ -163,7 +163,7 @@ docker run -d --name kong-gateway \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+ kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -183,7 +183,7 @@ docker run -d --name kong-gateway \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+ kong:{{page.kong_versions[page.version-index].ce-version}}
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -351,7 +351,7 @@ docker run -d --name kong-dbless \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+ kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -370,7 +370,7 @@ docker run -d --name kong-dbless \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+ kong:{{page.kong_versions[page.version-index].ce-version}}
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}


### PR DESCRIPTION
### Summary
Removed operating system portion of the image tags used in the documentation for install commands. 

### Reason
It seems we are moving away from Alpine image recommendations (for prod systems) in 3.0 to Debian or RHEL based images instead. As a result of that change in 3.0, our docs should reflect that better in the commands we provide for installing an instance of Kong in Docker, since we already called it out as not production-worthy in the main Install Kong page. 

Since this doc is generated based on the selected version of Kong, I felt it was perhaps best to remove all references to alpine in the tags and stick to just the version itself. Reason behind that was that Alpine is the default image in 2.x when using just the version tag, and Debian is the default image for 3.x when using just the version tag, achieving the appropriate image type already by using just the version tag alone.
