### PR TITLE
Remove konnect UI examples from route by header plugin

### DIFF
--- a/app/_hub/kong-inc/route-by-header/_index.md
+++ b/app/_hub/kong-inc/route-by-header/_index.md
@@ -21,6 +21,7 @@ params:
   consumer_id: true
   dbless_compatible: 'yes'
   konnect_examples: false
+  manager_examples: false
   config:
     - name: rules
       required: false

--- a/app/_hub/kong-inc/route-by-header/_index.md
+++ b/app/_hub/kong-inc/route-by-header/_index.md
@@ -20,6 +20,7 @@ params:
   route_id: true
   consumer_id: true
   dbless_compatible: 'yes'
+  konnect_examples: false
   config:
     - name: rules
       required: false


### PR DESCRIPTION
### Summary
Remove UI examples for `route-by-header`

### Reason
The route-by-header plugin can't be configured using the UI

Also resolves DOCU-2592


### Testing
TBC