### PR TITLE
[DOCU-2259] Key auth encrypted plugin example fix

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -10,7 +10,7 @@ description: |
   exception that API keys are stored in an encrypted format within the API gateway datastore.
 
   {:.note}
-  > **Note**: Before configuring this plugin, Kong's encryption keyring must be enabled. See the
+  > **Note**: Before configuring this plugin, you must enable Kong Gateway's encryption keyring. See the
   [keyring getting started guide](/gateway/latest/kong-enterprise/db-encryption#getting-started) for more details.
 
 enterprise: true
@@ -154,9 +154,9 @@ service, you must add the new consumer to the allowed group. See
 ### Create a key
 
 {:.note}
-> **Note:** We recommend letting Kong auto-generate the key.
-Only specify it yourself if you are migrating an existing system to Kong.
-You must re-use your keys to make the migration to Kong transparent to your consumers.
+> **Note:** We recommend that {{site.base_gateway}} auto generates the key.
+Only specify it yourself if you are migrating an existing system to {{site.base_gateway}}.
+You must reuse your keys to make the migration to {{site.base_gateway}} transparent to your consumers.
 
 {% navtabs %}
 {% navtab With a database %}
@@ -173,7 +173,10 @@ Response:
 HTTP/1.1 201 Created
 
 {
-    "consumer": { "id": "876bf719-8f18-4ce5-cc9f-5b5af6c36007" },
+    "consumer": 
+       { 
+           "id": "876bf719-8f18-4ce5-cc9f-5b5af6c36007" 
+           },
     "created_at": 1443371053000,
     "id": "62a7d3b7-b995-49f9-c9c8-bac4d781fb59",
     "key": "62eb165c070a41d5c1b58d9d3d725ca1",
@@ -262,7 +265,7 @@ You can also use this option with a gRPC client:
 grpcurl -H 'apikey: <some_key>' ...
 ```
 
-### API key locations in a eequest
+### API key locations in a request
 
 {% include /md/plugins-hub/api-key-locations.md %}
 

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -1,13 +1,18 @@
 ---
 name: Key Authentication - Encrypted
 publisher: Kong Inc.
-desc: Add key authentication to your Services
+desc: Add key authentication to your services
 description: |
-  Add key authentication (also sometimes referred to as an _API key_) to a Service
-  or a Route. Consumers then add their key either in a query string parameter or a
+  Add key authentication (also sometimes referred to as an _API key_) to a service
+  or a route. Consumers then add their key either in a query string parameter or a
   header to authenticate their requests. This plugin is functionally identical to the
   open source [Key Authentication](/hub/kong-inc/key-auth/) plugin, with the
   exception that API keys are stored in an encrypted format within the API gateway datastore.
+
+  {:.note}
+  > **Note**: Before configuring this plugin, Kong's encryption keyring must be enabled. See the
+  [keyring getting started guide](/gateway/latest/kong-enterprise/db-encryption#getting-started) for more details.
+
 enterprise: true
 cloud: false
 type: plugin
@@ -29,9 +34,9 @@ params:
     - grpcs
   dbless_compatible: partially
   dbless_explanation: |
-    Consumers and Credentials can be created with declarative configuration.
+    Consumers and credentials can be created with declarative configuration.
 
-    Admin API endpoints that do POST, PUT, PATCH, or DELETE on Credentials are not available on DB-less mode.
+    Admin API endpoints that do POST, PUT, PATCH, or DELETE on credentials are not available on DB-less mode.
   config:
     - name: key_names
       required: true
@@ -43,7 +48,9 @@ params:
         Describes an array of parameter names where the plugin will look for a key. The client must send the
         authentication key in one of those key names, and the plugin will try to read the credential from a
         header, request body, or query string parameter with the same name.
-        <br>**Note**: The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.
+
+        Key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.
+
     - name: key_in_body
       required: false
       default: '`false`'
@@ -74,9 +81,9 @@ params:
       default: null
       datatype: string
       description: |
-        An optional string (Consumer UUID) value to use as an anonymous Consumer if authentication fails. If empty (default),
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails. If empty (default),
         the request will fail with an authentication failure `4xx`. Note that this value
-        must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+        must refer to the consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
     - name: run_on_preflight
       required: false
       default: '`true`'
@@ -84,53 +91,49 @@ params:
       description: |
         A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests.
         If set to `false`, then `OPTIONS` requests are always allowed.
-  extra: |
-
-    ## Case sensitivity
-
-     Note that, according to their respective specifications, HTTP header names are treated as
-     case _insensitive_, while HTTP query string parameter names are treated as case _sensitive_.
-     Kong follows these specifications as designed, meaning that the `key_names`
-     configuration values are treated differently when searching the request header fields versus
-     searching the query string. As a best practice, administrators are advised against defining
-     case-sensitive `key_names` values when expecting the authorization keys to be sent in the request headers.
-
-     Once applied, any user with a valid credential can access the Service.
-     To restrict usage to certain authenticated users, also add the
-     [ACL](/plugins/acl/) plugin (not covered here) and create allowed or
-     denied groups of users.
 ---
 
-## Prerequisite
+## Case sensitivity
 
-Prior to configuring this plugin, Kong's encryption keyring must be enabled. See the
-[keyring Getting Started guide](/gateway/latest/plan-and-deploy/security/db-encryption#getting-started) for more details.
+Note that, according to their respective specifications, HTTP header names are treated as
+case _insensitive_, while HTTP query string parameter names are treated as case _sensitive_.
+Kong follows these specifications as designed, meaning that the `key_names`
+configuration values are treated differently when searching the request header fields versus
+searching the query string. As a best practice, administrators are advised against defining
+case-sensitive `key_names` values when expecting the authorization keys to be sent in the request headers.
+
+Once applied, any user with a valid credential can access the service.
+To restrict usage to certain authenticated users, also add the
+[ACL](/hub/kong-inc/acl/) plugin (not covered here) and create allowed or
+denied groups of users.
 
 ## Usage
 
-### Create a Consumer
+### Create a consumer
 
-You need to associate a credential to an existing [Consumer][consumer-object] object.
-A Consumer can have many credentials.
+You need to associate a credential to an existing [consumer][consumer-object] object.
+A consumer can have many credentials.
 
 {% navtabs %}
 {% navtab With a database %}
 
-To create a Consumer, make the following request:
+To create a consumer, make the following request:
 
 ```bash
-curl -d "username=user123&custom_id=SOME_CUSTOM_ID" http://kong:8001/consumers/
+curl -i -X POST http://localhost:8001/consumers/ \
+  --data "username=example_user" \
+  --data "custom_id=SOME_CUSTOM_ID"
 ```
 {% endnavtab %}
 
 {% navtab Without a database %}
 
-Your declarative configuration file will need to have one or more Consumers. You can create them
+Your declarative configuration file will need to have one or more consumers. You can create them
 on the `consumers:` yaml section:
 
 ``` yaml
 consumers:
-- username: user123
+- username: example_user
   custom_id: SOME_CUSTOM_ID
 ```
 
@@ -141,18 +144,19 @@ In both cases, the parameters are as described below:
 
 parameter                       | description
 ---                             | ---
-`username`<br>*semi-optional*   | The username of the Consumer. Either this field or `custom_id` must be specified.
-`custom_id`<br>*semi-optional*  | A custom identifier used to map the Consumer to another database. Either this field or `username` must be specified.
+`username`<br>*semi-optional*   | The username of the consumer. Either this field or `custom_id` must be specified.
+`custom_id`<br>*semi-optional*  | A custom identifier used to map the consumer to another database. Either this field or `username` must be specified.
 
-If you are also using the [ACL](/plugins/acl/) plugin and allow lists with this
-service, you must add the new Consumer to the allowed group. See
+If you are also using the [ACL](/hub/kong-inc/acl/) plugin and allow lists with this
+service, you must add the new consumer to the allowed group. See
 [ACL: Associating Consumers][acl-associating] for details.
 
-### Create a Key
+### Create a key
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> It is recommended to let Kong auto-generate the key. Only specify it yourself if you are migrating an existing system to Kong. You must re-use your keys to make the migration to Kong transparent to your Consumers.
-</div>
+{:.note}
+> **Note:** We recommend letting Kong auto-generate the key.
+Only specify it yourself if you are migrating an existing system to Kong.
+You must re-use your keys to make the migration to Kong transparent to your consumers.
 
 {% navtabs %}
 {% navtab With a database %}
@@ -160,7 +164,7 @@ service, you must add the new Consumer to the allowed group. See
 Provision new credentials by making the following HTTP request:
 
 ```bash
-curl -X POST http://kong:8001/consumers/{consumer}/key-auth-enc -d ""
+curl -X POST http://localhost:8001/consumers/{consumer}/key-auth-enc
 ```
 
 Response:
@@ -172,9 +176,30 @@ HTTP/1.1 201 Created
     "consumer": { "id": "876bf719-8f18-4ce5-cc9f-5b5af6c36007" },
     "created_at": 1443371053000,
     "id": "62a7d3b7-b995-49f9-c9c8-bac4d781fb59",
-    "key": "62eb165c070a41d5c1b58d9d3d725ca1"
+    "key": "62eb165c070a41d5c1b58d9d3d725ca1",
 }
 ```
+
+If you prefer to specify a key, set the `key` in the request body:
+
+```bash
+curl -X POST http://localhost:8001/consumers/{consumer}/key-auth-enc
+  --data "key=myapikey"
+```
+
+Response:
+
+```json
+HTTP/1.1 201 Created
+
+{
+    "consumer": { "id": "876bf719-8f18-4ce5-cc9f-5b5af6c36007" },
+    "created_at": 1443371053000,
+    "id": "62a7d3b7-b995-49f9-c9c8-bac4d781fb59",
+    "key": "myapikey",
+}
+```
+
 {% endnavtab %}
 {% navtab Without a database %}
 
@@ -188,22 +213,29 @@ keyauth_credentials:
 {% endnavtab %}
 {% endnavtabs %}
 
-In both cases, the fields/parameters work as follows:
+The fields/parameters work as follows:
 
-field/parameter     | description
+Field/parameter     | Description
 ---                 | ---
-`{consumer}`        | The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
+`{consumer}`        | The `id` or `username` property of the [consumer][consumer-object] entity to associate the credentials to.
 `key`<br>*optional* | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
 
-### Make a Request with the Key
+### Make a request with the key
+
+#### Key in query
+
+To use the key in URL queries, set the configuration parameter `key_in_query` to `true` (default option).
 
 Make a request with the key as a query string parameter:
 
 ```bash
-curl http://kong:8000/{proxy path}?apikey=<some_key>
+curl http://localhost:8000/{proxy path}?apikey=<some_key>
 ```
 
-**Note:** The `key_in_query` parameter must be set to `true` (default).
+#### Key in body
+
+To use the key in a request body, set the configuration parameter `key_in_body` to `true`.
+The default value is `false`.
 
 Make a request with the key in the body:
 
@@ -212,7 +244,9 @@ curl http://kong:8000/{proxy path} \
   --data 'apikey: <some_key>'
 ```
 
-**Note:** The `key_in_body` parameter must be set to `true` (default is `false`).
+#### Key in header
+
+To use the key in a request body, set the configuration parameter `key_in_header` to `true` (default option).
 
 Make a request with the key in a header:
 
@@ -221,34 +255,34 @@ curl http://kong:8000/{proxy path} \
   -H 'apikey: <some_key>'
 ```
 
-**Note:** The `key_in_header` parameter must be set to `true` (default).
 
-gRPC clients are supported too:
+You can also use this option with a gRPC client:
 
 ```bash
 grpcurl -H 'apikey: <some_key>' ...
 ```
-### About API Key Locations in a Request
+
+### API key locations in a eequest
 
 {% include /md/plugins-hub/api-key-locations.md %}
 
-### Disable a Key Location
+### Disable a key location
 
 This example disables using a key in a query parameter:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
+curl -X POST http://localhost:8001/routes/{route}/plugins \
     --data "name=key-auth-enc"  \
     --data "config.key_names=apikey" \
     --data "config.key_in_query=false"
 ```
 
-### Delete a Key
+### Delete a key
 
-Delete an API Key by making the following request:
+Delete an API key by making the following request:
 
 ```bash
-curl -X DELETE http://kong:8001/consumers/{consumer}/key-auth-enc/{id}
+curl -X DELETE http://localhost:8001/consumers/{consumer}/key-auth-enc/{id}
 ```
 
 Response:
@@ -257,7 +291,7 @@ Response:
 HTTP/1.1 204 No Content
 ```
 
-* `consumer`: The `id` or `username` property of the [Consumer][consumer-object] entity to associate the credentials to.
+* `consumer`: The `id` or `username` property of the [consumer][consumer-object] entity to associate the credentials to.
 * `id`: The `id` attribute of the key credential object.
 
 ### Upstream Headers
@@ -266,11 +300,11 @@ HTTP/1.1 204 No Content
 
 ### Paginate through keys
 
-Paginate through the API keys for all Consumers using the following
+Paginate through the API keys for all consumers using the following
 request:
 
 ```bash
-curl -X GET http://kong:8001/key-auths-enc
+curl -X GET http://localhost:8001/key-auths-enc
 ```
 
 Response:
@@ -302,13 +336,13 @@ Response:
 }
 ```
 
-Filter the list by Consumer by using a different endpoint:
+Filter the list by consumer by using a different endpoint:
 
 ```bash
 curl -X GET http://kong:8001/consumers/{username or id}/key-auth-enc
 ```
 
-`username or id`: The username or id of the Consumer whose credentials need to be listed.
+`username or id`: The username or ID of the consumer whose credentials need to be listed.
 
 Response:
 
@@ -327,11 +361,11 @@ Response:
 }
 ```
 
-`username or id`: The username or id of the consumer whose credentials need to be listed
+`username or id`: The username or ID of the consumer whose credentials need to be listed.
 
-### Retrieve the Consumer associated with a key
+### Retrieve the consumer associated with a key
 
-Retrieve a [Consumer][consumer-object] associated with an API
+Retrieve a [consumer][consumer-object] associated with an API
 key by making the following request:
 
 ```bash
@@ -339,7 +373,7 @@ curl -X GET http://kong:8001/key-auths-enc/{key or id}/consumer
 ```
 
 `key or id`: The `id` or `key` property of the API key for which to get the
-associated Consumer.
+associated consumer.
 
 ```json
 {

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -196,7 +196,9 @@ Response:
 HTTP/1.1 201 Created
 
 {
-    "consumer": { "id": "876bf719-8f18-4ce5-cc9f-5b5af6c36007" },
+    "consumer": {
+      "id": "876bf719-8f18-4ce5-cc9f-5b5af6c36007" 
+    },
     "created_at": 1443371053000,
     "id": "62a7d3b7-b995-49f9-c9c8-bac4d781fb59",
     "key": "myapikey",
@@ -320,19 +322,25 @@ Response:
          "id":"17ab4e95-9598-424f-a99a-ffa9f413a821",
          "created_at":1507941267000,
          "key":"Qslaip2ruiwcusuSUdhXPv4SORZrfj4L",
-         "consumer": { "id": "c0d92ba9-8306-482a-b60d-0cfdd2f0e880" }
+         "consumer": { 
+              "id": "c0d92ba9-8306-482a-b60d-0cfdd2f0e880" 
+         }
       },
       {
          "id":"6cb76501-c970-4e12-97c6-3afbbba3b454",
          "created_at":1507936652000,
          "key":"nCztu5Jrz18YAWmkwOGJkQe9T8lB99l4",
-         "consumer": { "id": "c0d92ba9-8306-482a-b60d-0cfdd2f0e880" }
+         "consumer": { 
+              "id": "c0d92ba9-8306-482a-b60d-0cfdd2f0e880" 
+         }
       },
       {
          "id":"b1d87b08-7eb6-4320-8069-efd85a4a8d89",
          "created_at":1507941307000,
          "key":"26WUW1VEsmwT1ORBFsJmLHZLDNAxh09l",
-         "consumer": { "id": "3c2c8fc1-7245-4fbb-b48b-e5947e1ce941" }
+         "consumer": { 
+              "id": "3c2c8fc1-7245-4fbb-b48b-e5947e1ce941" 
+         }
       }
    ]
    "next":null,
@@ -357,7 +365,9 @@ Response:
          "id":"6cb76501-c970-4e12-97c6-3afbbba3b454",
          "created_at":1507936652000,
          "key":"nCztu5Jrz18YAWmkwOGJkQe9T8lB99l4",
-         "consumer": { "id": "c0d92ba9-8306-482a-b60d-0cfdd2f0e880" }
+         "consumer": { 
+              "id": "c0d92ba9-8306-482a-b60d-0cfdd2f0e880" 
+         }
        }
     ]
     "next":null,


### PR DESCRIPTION
### Summary
Make some examples for the Key Auth Advanced plugin clearer, clean up a bunch of formatting, and use formatting consistent with style guide.

### Reason
https://konghq.atlassian.net/browse/DOCU-2259

Technically, the example did work as documented before, but it wasn't very clear, and the request format looked like an error. Provided two options - with key and and without - to make it more obvious that not providing a key in the request is intentional.

### Testing
Netlify