### PR TITLE
fix: diverse typos in mesh getting started docs

### DIFF
--- a/src/mesh/installation/amazonlinux.md
+++ b/src/mesh/installation/amazonlinux.md
@@ -11,8 +11,8 @@ instead.
 To install and run {{site.mesh_product_name}} on Amazon Linux (**x86_64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
 

--- a/src/mesh/installation/centos.md
+++ b/src/mesh/installation/centos.md
@@ -5,8 +5,8 @@ title: Kong Mesh with CentOS
 To install and run {{site.mesh_product_name}} on CentOS (**x86_64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/src/mesh/installation/debian.md
+++ b/src/mesh/installation/debian.md
@@ -5,8 +5,8 @@ title: Kong Mesh with Debian
 To install and run {{site.mesh_product_name}} on Debian (**amd64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/src/mesh/installation/docker.md
+++ b/src/mesh/installation/docker.md
@@ -103,13 +103,12 @@ Or, you can enable mTLS on the `default` Mesh with:
 
 ```sh
 $ echo "type: Mesh
-  name: default
-  mtls:
-    enabledBackend: ca-1
-    backends:
-    - name: ca-1
-      type: builtin" | docker run -i --net="host" \
-    kong/kumactl:{{page.kong_latest.version}} kumactl apply -f -
+name: default
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin" | docker run -i --net="host" kong/kumactl:{{page.kong_latest.version}} kumactl apply -f -
 ```
 
 This runs `kumactl` from the Docker

--- a/src/mesh/installation/ecs.md
+++ b/src/mesh/installation/ecs.md
@@ -35,7 +35,7 @@ join the cluster, the controller requests a new data plane token scoped to that 
 
 With Kong Mesh on ECS, each service enumerates
 other services it contacts in the mesh and
-[exposes them in `Dataplane` specification](https://kuma.io/docs/1.8.x/generated/resources/proxy_dataplane/).
+[exposes them in `Dataplane` specification](https://kuma.io/docs/latest/generated/resources/proxy_dataplane/).
 
 ## Deployment
 

--- a/src/mesh/installation/ecs.md
+++ b/src/mesh/installation/ecs.md
@@ -137,10 +137,10 @@ definition](https://github.com/Kong/kong-mesh-ecs/blob/main/deploy/counter-demo/
 When a task starts, the following happens:
 
 1. The task requests the `token` JSON key from an existing AWS secret.
-1. Initially, the secret does not contain this key and ECS continues
+2. Initially, the secret does not contain this key and ECS continues
    trying to create the task.
-1. Shortly after the task is created, while it's in the retry loop, the ECS
+3. Shortly after the task is created, while it's in the retry loop, the ECS
    controller sees the task and checks whether `token` exists in the corresponding secret.
-1. The controller sees an empty secret and generates a new data plane token via the
+4. The controller sees an empty secret and generates a new data plane token via the
    mesh API, saving the result as `token` in the secret.
-1. Finally, ECS is able to fetch the `token` value and starts the task successfully.
+5. Finally, ECS is able to fetch the `token` value and starts the task successfully.

--- a/src/mesh/installation/ecs.md
+++ b/src/mesh/installation/ecs.md
@@ -35,7 +35,7 @@ join the cluster, the controller requests a new data plane token scoped to that 
 
 With Kong Mesh on ECS, each service enumerates
 other services it contacts in the mesh and
-[exposes them in `Dataplane` specification](https://kuma.io/docs/latest/reference/dpp-specification).
+[exposes them in `Dataplane` specification](https://kuma.io/docs/1.8.x/generated/resources/proxy_dataplane/).
 
 ## Deployment
 

--- a/src/mesh/installation/helm.md
+++ b/src/mesh/installation/helm.md
@@ -5,8 +5,8 @@ title: Kong Mesh with Helm
 To install and run {{site.mesh_product_name}} on Kubernetes using Helm:
 
 1. [Add the {{site.mesh_product_name}} Helm Repository](#1-add-the-kong-mesh-helm-repository)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
 
@@ -60,9 +60,9 @@ suggest `kong-mesh-system`.
     ```sh
     $ helm repo update
     $ helm upgrade -i -n kong-mesh-system kong-mesh kong-mesh/kong-mesh \
-      --set kuma.controlPlane.secrets[0].Env="KMESH_LICENSE_INLINE" \
-      --set kuma.controlPlane.secrets[0].Secret="kong-mesh-license" \
-      --set kuma.controlPlane.secrets[0].Key="license.json"
+      --set 'kuma.controlPlane.secrets[0].Env="KMESH_LICENSE_INLINE"' \
+      --set 'kuma.controlPlane.secrets[0].Secret="kong-mesh-license"' \
+      --set 'kuma.controlPlane.secrets[0].Key="license.json"'
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
@@ -118,15 +118,15 @@ Or, you can enable mTLS on the `default` Mesh with:
 
 ```sh
 $ echo "apiVersion: kuma.io/v1alpha1
-  kind: Mesh
-  metadata:
-    name: default
-  spec:
-    mtls:
-      enabledBackend: ca-1
-      backends:
-      - name: ca-1
-        type: builtin" | kubectl apply -f -
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kubectl apply -f -
 ```
 
 {% endnavtab %}

--- a/src/mesh/installation/kubernetes.md
+++ b/src/mesh/installation/kubernetes.md
@@ -52,16 +52,10 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 
 ## 2. Run {{site.mesh_product_name}}
 
-Navigate to the `bin` folder:
-
-```sh
-$ cd kong-mesh-{{page.kong_latest.version}}/bin
-```
-
 Then, run the control plane with:
 
 ```sh
-$ kumactl install control-plane --license-path=/path/to/license.json | kubectl apply -f -
+$ kong-mesh-{{page.kong_latest.version}}/bin/kumactl install control-plane --license-path=/path/to/license.json | kubectl apply -f -
 ```
 
 {:.note}
@@ -79,7 +73,7 @@ available in every working directory. Alternatively, you can create a link
 in `/usr/local/bin/` by running:
 
 ```sh
-$ ln -s ./kumactl /usr/local/bin/kumactl
+$ ln -s kong-mesh-{{page.kong_latest.version}}/bin/kumactl /usr/local/bin/kumactl
 ```
 
 It may take a while for Kubernetes to start the
@@ -125,15 +119,15 @@ Or, you can enable mTLS on the `default` Mesh with:
 
 ```sh
 $ echo "apiVersion: kuma.io/v1alpha1
-  kind: Mesh
-  metadata:
-    name: default
-  spec:
-    mtls:
-      enabledBackend: ca-1
-      backends:
-      - name: ca-1
-        type: builtin" | kubectl apply -f -
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kubectl apply -f -
 ```
 
 {% endnavtab %}

--- a/src/mesh/installation/macos.md
+++ b/src/mesh/installation/macos.md
@@ -5,8 +5,8 @@ title: Kong Mesh with macOS
 To install and run {{site.mesh_product_name}} on macOS:
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.

--- a/src/mesh/installation/openshift.md
+++ b/src/mesh/installation/openshift.md
@@ -5,8 +5,8 @@ title: Kong Mesh with OpenShift
 To install and run {{site.mesh_product_name}} on OpenShift:
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
@@ -58,16 +58,12 @@ $ tar xvzf kong-mesh-{{page.kong_latest.version}}*.tar.gz
 
 Navigate to the `bin` folder:
 
-```sh
-$ cd kong-mesh-{{page.kong_latest.version}}/bin
-```
-
 We suggest adding the `kumactl` executable to your `PATH` so that it's always
 available in every working directory. Alternatively, you can also create a link
 in `/usr/local/bin/` by executing:
 
 ```sh
-$ ln -s ./kumactl /usr/local/bin/kumactl
+$ ln -s kong-mesh-{{page.kong_latest.version}}/bin/kumactl /usr/local/bin/kumactl
 ```
 
 Then, run the control plane on OpenShift with:
@@ -166,15 +162,15 @@ Or, you can enable mTLS on the `default` Mesh with:
 
 ```sh
 $ echo "apiVersion: kuma.io/v1alpha1
-  kind: Mesh
-  metadata:
-    name: default
-  spec:
-    mtls:
-      enabledBackend: ca-1
-      backends:
-      - name: ca-1
-        type: builtin" | oc apply -f -
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | oc apply -f -
 ```
 
 {% endnavtab %}

--- a/src/mesh/installation/redhat.md
+++ b/src/mesh/installation/redhat.md
@@ -5,8 +5,8 @@ title: Kong Mesh with Red Hat
 To install and run {{site.mesh_product_name}} on Red Hat (**x86_64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
 

--- a/src/mesh/installation/ubuntu.md
+++ b/src/mesh/installation/ubuntu.md
@@ -5,8 +5,8 @@ title: Kong Mesh with Ubuntu
 To install and run {{site.mesh_product_name}} on Ubuntu (**amd64**):
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here and continue your {{site.mesh_product_name}} journey.
 

--- a/src/mesh/installation/windows.md
+++ b/src/mesh/installation/windows.md
@@ -5,8 +5,8 @@ title: Kong Mesh with Windows
 To install and run {{site.mesh_product_name}} on Windows:
 
 1. [Download {{site.mesh_product_name}}](#1-download-kong-mesh)
-1. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
-1. [Verify the Installation](#3-verify-the-installation)
+2. [Run {{site.mesh_product_name}}](#2-run-kong-mesh)
+3. [Verify the Installation](#3-verify-the-installation)
 
 Finally, you can follow the [Quickstart](#4-quickstart) to take it from here
 and continue your {{site.mesh_product_name}} journey.
@@ -75,4 +75,3 @@ but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-
 {% include /md/mesh/install-universal-verify.md %}
 
 {% include /md/mesh/install-universal-quickstart.md %}
-


### PR DESCRIPTION
Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Summary
There were a few issues in the getting started docs that were mostly typos.
