### PR TITLE
Updated cli.md to show workspace tag

### DIFF
--- a/src/gateway/kong-enterprise/dev-portal/cli.md
+++ b/src/gateway/kong-enterprise/dev-portal/cli.md
@@ -40,7 +40,7 @@ Where `<command>` is one of:
 * `fetch`    Fetches content and themes from the given workspace.
 * `wipe`     Deletes all content and themes from upstream workspace
 
-Where <workspace> indicates the directory/workspace pairing you would like to operate on.
+Where `<workspace>` indicates the directory/workspace pairing you would like to operate on.
 
 #### For `deploy`
 - Add `-W` or `--watch` to make changes reactive.


### PR DESCRIPTION
### Summary
Tiny update to correctly display the <workspace> code tag

### Reason
Came across the page & noticed the tag is invisible, making the sentence awkward to read.

### Testing
N/A

review:general

