### PR TITLE
Use correct gatewayClass annotation in the guide

### DIFF
--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -109,12 +109,11 @@ spec:
 {% if_version gte: 2.6.x %}
 ```bash
 $ echo "apiVersion: gateway.networking.k8s.io/v1beta1
-apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   name: kong
   annotations:
-    konghq.com/gateway-unmanaged: true
+    konghq.com/gatewayclass-unmanaged: 'true'
 spec:
   controllerName: konghq.com/kic-gateway-controller
 " | kubectl apply -f -
@@ -198,7 +197,7 @@ that {{site.base_gateway}} resource with listener and status information.
 
 {% if_version gte: 2.6.x %}
 To configure KIC to reconcile the `Gateway` resource, you must set the 
-`konghq.com/gateway-unmanaged` annotation as the example in `GatewayClass` resource used in 
+`konghq.com/gatewayclass-unmanaged` annotation as the example in `GatewayClass` resource used in 
 `spec.gatewayClassName` in `Gateway` resource. Also, the 
 `spec.controllerName` of `GatewayClass` needs to be same as the value of the
 `--gateway-api-controller-name` flag configured in KIC. For more information, see [kic-flags](/kubernetes-ingress-controller/{{page.kong_version}}/references/cli-arguments/#flags).


### PR DESCRIPTION
### Summary
Update using-gateway-api.md to use correct gatewayClass annotation. The 2.6x KIC [release](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#260) mentions that the gatewayClass requires the annotation `konghq.com/gatewayclass-unmanaged`. This PR tries to correct the annotation used in the guide.

### Reason
Just to make sure that those who are following the guide will use the correct gatewayClass annotation.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
