### PR TITLE
Request to modify the OIDC plug in documentation

### DIFF
--- a/src/gateway/kong-plugins/authentication/oidc/okta.md
+++ b/src/gateway/kong-plugins/authentication/oidc/okta.md
@@ -105,13 +105,22 @@ guide, assume the route is in the default workspace.
 
 Configure the following parameters:
 
+__In the common tab__
+
 * **`issuer`**: The issuer `url` from which OpenID Connect configuration can be discovered. Using Okta, specify the domain and server in the path:
     * `https://YOUR_OKTA_DOMAIN/oauth2/YOUR_AUTH_SERVER/.well-known/openid-configuration`
 * **`auth_method`**: A list of authentication methods to use with the plugin, such as passwords, introspection tokens, etc. The majority of cases use `authorization_code`, and {{site.base_gateway}} will accept all methods if no methods are specified.
 * **`client_id`**: The `client_id` of the OpenID Connect client registered in OpenID Connect Provider. Okta provides one to identify itself.  
 * **`client_secret`**: The `client_secret` of the OpenID Connect client registered in OpenID Connect Provider. These credentials should never be publicly exposed.
-* **`redirect_uri`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
-* **`scopes`**:  The scope of what OpenID Connect checks. `openid` by default; set to `email` and `profile` for this example.
+
+__In the authorization tab__
+
+* **`Config.Scopes Required`**:  The scope of what OpenID Connect checks. `openid` by default; set to `email` and `profile` for this example. 
+* **`Config.Scopes Claim`**: This should be set to `scp`.
+
+__In the advanced tab__
+
+* **`Config.Redirect Uri`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
 
 {% navtabs %}
 {% navtab Configure plugin with Kong Manager %}


### PR DESCRIPTION
Okta configuration by default send `openid` scope under the claim label `scp`. By default in the plug the label is set to 'scope' and therefore developers have to spend time trying to figure out why the default scopes are not being passed. This documentation correct aims to reduce the friction for developers.

### Summary
I followed the documentation but I was still facing a problem with required scopes not being passed.

### Reason
As a developer I had to struggle a bit to understand where the problem was and why I was getting scope errors despite following the documentation

### Testing
Re-did the steps of setting up a Okta developer account from scratch and tested the plugin with the correct labels for claim.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
review:copyedit: Request for writer review.
review:tech: Request for technical review from an SME.
