### PR TITLE
Add Segment tracking

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -29,6 +29,16 @@
 
     {% include_cached footer.html %} {% include_cached anchor_links.html %}
 
+    {% if jekyll.environment == "production" %}
+      <script>
+        // Segment
+        window.analytics = window.analytics || {};
+        window.analytics._writeKey = "X7EZTdbdUKQ8M6x42SHHPWiEhjsfs1EQ";
+        setTimeout(function(){
+          analytics.page();
+        }, 500);
+      </script>
+    {% endif %}
     <script src="/assets/app.js?v={{ site.time | date: '%s' }}"></script>
 
     <div id="fb-root"></div>
@@ -138,65 +148,6 @@
         };
       })();
       _vwo_settings_timer = _vwo_code.init();
-    </script>
-
-    <script type="text/javascript">
-      !(function() {
-        var analytics = (window.analytics = window.analytics || []);
-        if (!analytics.initialize)
-          if (analytics.invoked)
-            window.console &&
-              console.error &&
-              console.error('Segment snippet included twice.');
-          else {
-            analytics.invoked = !0;
-            analytics.methods = [
-              'trackSubmit',
-              'trackClick',
-              'trackLink',
-              'trackForm',
-              'pageview',
-              'identify',
-              'group',
-              'track',
-              'ready',
-              'alias',
-              'page',
-              'once',
-              'off',
-              'on'
-            ];
-            analytics.factory = function(t) {
-              return function() {
-                var e = Array.prototype.slice.call(arguments);
-                e.unshift(t);
-                analytics.push(e);
-                return analytics;
-              };
-            };
-            for (var t = 0; t < analytics.methods.length; t++) {
-              var e = analytics.methods[t];
-              analytics[e] = analytics.factory(e);
-            }
-            analytics.load = function(t) {
-              var e = document.createElement('script');
-              e.type = 'text/javascript';
-              e.async = !0;
-              e.src =
-                ('https:' === document.location.protocol
-                  ? 'https://'
-                  : 'http://') +
-                'cdn.segment.com/analytics.js/v1/' +
-                t +
-                '/analytics.min.js';
-              var n = document.getElementsByTagName('script')[0];
-              n.parentNode.insertBefore(e, n);
-            };
-            analytics.SNIPPET_VERSION = '3.0.1';
-            analytics.load('WDj0nSS7hpyxwL3evgbOzK755s0NUye6');
-            analytics.page();
-          }
-      })();
     </script>
 
     <script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,7 @@ var sources = {
   styles: paths.assets + "stylesheets/**/*",
   js: [
     paths.assets + "javascripts/jquery-3.6.0.min.js",
+    "node_modules/@segment/analytics-next/dist/umd/standalone.js",
     paths.assets + "javascripts/app.js",
     paths.assets + "javascripts/compat-dropdown.js",
     paths.assets + "javascripts/subscribe.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "docs.konghq.com",
       "version": "1.0.0",
       "license": "proprietary",
+      "dependencies": {
+        "@segment/analytics-next": "^1.43.0"
+      },
       "devDependencies": {
         "broken-link-checker": "0.7.8",
         "browser-sync": "2.27.10",
@@ -1683,6 +1686,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
+      "integrity": "sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.0.tgz",
+      "integrity": "sha512-dUz8OmYvlY5A9wXaroHIMSPASpSYRLCqbPvxGSyHguhtTQIy24lC+EGxQlwv71AhRCO55WOtgwhzQLpw27JaJQ==",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
@@ -1716,6 +1738,98 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.0.1.tgz",
+      "integrity": "sha512-aty64DNqhigwnKYWR5YFYV5t61x8KfVKM5w9M25Cpxoy8UPz5pnCNl7+leGHJlnIUO5ULQ2PH7Db+LF10apuYA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@segment/analytics-core/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@segment/analytics-next": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.43.0.tgz",
+      "integrity": "sha512-jGj+9Iv3rKYmXqCkF0bPnXIOS1QasCvPOjSkjUkU6o4JlAtDQ0DuuKej5N3NOATD3F3ckeL4cwMcuSh+s+MD3A==",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.0.1",
+        "@segment/analytics.js-video-plugins": "^0.2.1",
+        "@segment/facade": "^3.4.9",
+        "@segment/tsub": "^0.1.12",
+        "dset": "^3.1.2",
+        "js-cookie": "3.0.1",
+        "node-fetch": "^2.6.7",
+        "spark-md5": "^3.0.1",
+        "tslib": "^2.4.0",
+        "unfetch": "^4.1.0"
+      }
+    },
+    "node_modules/@segment/analytics-next/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@segment/analytics.js-video-plugins": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
+      "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
+      "dependencies": {
+        "unfetch": "^3.1.1"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins/node_modules/unfetch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
+      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw=="
+    },
+    "node_modules/@segment/facade": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.9.tgz",
+      "integrity": "sha512-0RTLB0g4HiJASc6pTD2/Tru+Qz+VPGL1W+/EvkBGhY6WYk00cZhTjLsMJ8X5BO6iPqLb3vsxtfjVM/RREG5oQQ==",
+      "dependencies": {
+        "@segment/isodate-traverse": "^1.1.1",
+        "inherits": "^2.0.4",
+        "new-date": "^1.0.3",
+        "obj-case": "0.2.1"
+      }
+    },
+    "node_modules/@segment/facade/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/@segment/isodate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A=="
+    },
+    "node_modules/@segment/isodate-traverse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
+      "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
+      "dependencies": {
+        "@segment/isodate": "^1.0.3"
+      }
+    },
+    "node_modules/@segment/tsub": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@segment/tsub/-/tsub-0.1.12.tgz",
+      "integrity": "sha512-35JB0+HuMZrn7mus/s4yOHAcuid+MzaOYxV8YAogTR4Z7AsHwn/Zn/y9XdoHp2kKdn54s6jO4IaO826v0j7qmw==",
+      "dependencies": {
+        "@stdlib/math-base-special-ldexp": "^0.0.5",
+        "dlv": "^1.1.3",
+        "dset": "^3.1.1",
+        "tiny-hashes": "^1.0.1"
+      },
+      "bin": {
+        "tsub": "dist/index.js"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1765,6 +1879,2785 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
       "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
       "dev": true
+    },
+    "node_modules/@stdlib/array-float32": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-float32/-/array-float32-0.0.6.tgz",
+      "integrity": "sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-float32array-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/array-float64": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-float64/-/array-float64-0.0.6.tgz",
+      "integrity": "sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-float64array-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/array-uint16": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-uint16/-/array-uint16-0.0.6.tgz",
+      "integrity": "sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-uint16array-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/array-uint32": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-uint32/-/array-uint32-0.0.6.tgz",
+      "integrity": "sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-uint32array-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/array-uint8": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-uint8/-/array-uint8-0.0.7.tgz",
+      "integrity": "sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-uint8array-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-float32array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-float32array-support/-/assert-has-float32array-support-0.0.8.tgz",
+      "integrity": "sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-float32array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-float64-pinf": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-float32array-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-float64array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-float64array-support/-/assert-has-float64array-support-0.0.8.tgz",
+      "integrity": "sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-float64array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-float64array-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-node-buffer-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-node-buffer-support/-/assert-has-node-buffer-support-0.0.8.tgz",
+      "integrity": "sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-buffer": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-node-buffer-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-own-property": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-own-property/-/assert-has-own-property-0.0.7.tgz",
+      "integrity": "sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-symbol-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-symbol-support/-/assert-has-symbol-support-0.0.8.tgz",
+      "integrity": "sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-symbol-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-tostringtag-support": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-tostringtag-support/-/assert-has-tostringtag-support-0.0.9.tgz",
+      "integrity": "sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-symbol-support": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-tostringtag-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-uint16array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint16array-support/-/assert-has-uint16array-support-0.0.8.tgz",
+      "integrity": "sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-uint16array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-uint16-max": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-uint16array-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-uint32array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint32array-support/-/assert-has-uint32array-support-0.0.8.tgz",
+      "integrity": "sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-uint32array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-uint32-max": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-uint32array-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-has-uint8array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint8array-support/-/assert-has-uint8array-support-0.0.8.tgz",
+      "integrity": "sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-uint8array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-uint8-max": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "has-uint8array-support": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-array": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-array/-/assert-is-array-0.0.7.tgz",
+      "integrity": "sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-big-endian": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-big-endian/-/assert-is-big-endian-0.0.7.tgz",
+      "integrity": "sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-uint16": "^0.0.x",
+        "@stdlib/array-uint8": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "is-big-endian": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-boolean": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-boolean/-/assert-is-boolean-0.0.8.tgz",
+      "integrity": "sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-buffer": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-buffer/-/assert-is-buffer-0.0.8.tgz",
+      "integrity": "sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-object-like": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-float32array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-float32array/-/assert-is-float32array-0.0.8.tgz",
+      "integrity": "sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-float64array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-float64array/-/assert-is-float64array-0.0.8.tgz",
+      "integrity": "sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-function": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-function/-/assert-is-function-0.0.8.tgz",
+      "integrity": "sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-type-of": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-little-endian": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-little-endian/-/assert-is-little-endian-0.0.7.tgz",
+      "integrity": "sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-uint16": "^0.0.x",
+        "@stdlib/array-uint8": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "is-little-endian": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-number": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-number/-/assert-is-number-0.0.7.tgz",
+      "integrity": "sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/number-ctor": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-object": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-object/-/assert-is-object-0.0.8.tgz",
+      "integrity": "sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-array": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-object-like": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-object-like/-/assert-is-object-like-0.0.8.tgz",
+      "integrity": "sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-tools-array-function": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-plain-object": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-plain-object/-/assert-is-plain-object-0.0.7.tgz",
+      "integrity": "sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-object": "^0.0.x",
+        "@stdlib/utils-get-prototype-of": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-regexp": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-regexp/-/assert-is-regexp-0.0.7.tgz",
+      "integrity": "sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-regexp-string": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-regexp-string/-/assert-is-regexp-string-0.0.9.tgz",
+      "integrity": "sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/regexp-eol": "^0.0.x",
+        "@stdlib/regexp-regexp": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x"
+      },
+      "bin": {
+        "is-regexp-string": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-string": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-string/-/assert-is-string-0.0.8.tgz",
+      "integrity": "sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-uint16array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint16array/-/assert-is-uint16array-0.0.8.tgz",
+      "integrity": "sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-uint32array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint32array/-/assert-is-uint32array-0.0.8.tgz",
+      "integrity": "sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-is-uint8array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint8array/-/assert-is-uint8array-0.0.8.tgz",
+      "integrity": "sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/assert-tools-array-function": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-tools-array-function/-/assert-tools-array-function-0.0.7.tgz",
+      "integrity": "sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-array": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/buffer-ctor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/buffer-ctor/-/buffer-ctor-0.0.7.tgz",
+      "integrity": "sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-node-buffer-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/buffer-from-string": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/buffer-from-string/-/buffer-from-string-0.0.8.tgz",
+      "integrity": "sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/buffer-ctor": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/cli-ctor": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@stdlib/cli-ctor/-/cli-ctor-0.0.3.tgz",
+      "integrity": "sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-noop": "^0.0.x",
+        "minimist": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/complex-float32": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-float32/-/complex-float32-0.0.7.tgz",
+      "integrity": "sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-number": "^0.0.x",
+        "@stdlib/number-float64-base-to-float32": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-define-property": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/complex-float64": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-float64/-/complex-float64-0.0.8.tgz",
+      "integrity": "sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-number": "^0.0.x",
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-define-property": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/complex-reim": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-reim/-/complex-reim-0.0.6.tgz",
+      "integrity": "sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/complex-float64": "^0.0.x",
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/complex-reimf": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-reimf/-/complex-reimf-0.0.1.tgz",
+      "integrity": "sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-float32": "^0.0.x",
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-exponent-bias": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-exponent-bias/-/constants-float64-exponent-bias-0.0.7.tgz",
+      "integrity": "sha512-F0f95YUVGijNzBEgOzvQXwZC41SQyefB0sYntfVMi071I5Luv1HlYc+H80Ree/Wfn3gFNACe7JdfFIMpeJgTNg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-high-word-exponent-mask": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-high-word-exponent-mask/-/constants-float64-high-word-exponent-mask-0.0.7.tgz",
+      "integrity": "sha512-7/GL1DW/BeWLvTcfbuWUyKJkcIN9fM6m8xPEGfq6vAvv+dRIAlwKsVZVTBIAD1FcoXLKV/GDptOPTQRAPoxGqA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-max-base2-exponent": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-max-base2-exponent/-/constants-float64-max-base2-exponent-0.0.7.tgz",
+      "integrity": "sha512-9vOMjILdOE7f3glCWuvQtfmiipE/WsImmAbG3u5KAeLluJhosNRhnfGbfRGydJiyDDYcs3W3l1ViXhLnRLuJZA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-max-base2-exponent-subnormal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-max-base2-exponent-subnormal/-/constants-float64-max-base2-exponent-subnormal-0.0.7.tgz",
+      "integrity": "sha512-2SKF0w6XZe1O6S3TAPHjS8pUXujSCeiCzuskQyBBw1ZbbsU0Y6Qh4f99rk1L7f/C9Kp2h8GUh4KV25bdIO8jiQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-min-base2-exponent-subnormal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-min-base2-exponent-subnormal/-/constants-float64-min-base2-exponent-subnormal-0.0.7.tgz",
+      "integrity": "sha512-SFw/ZA2BP0pyLkKkbWdGGMJ9zqqHZs3NyXvGjuEAVgmCFwdH+xTyvcOo/dC543WUoPKTkLsZ4D8h4TBUksfw8A==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-ninf": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-ninf/-/constants-float64-ninf-0.0.7.tgz",
+      "integrity": "sha512-piVlJxJDTd5v2ZTYNyXVV2qzc5kNibhpgK+H+ykaO80FNQvqt8bIP3TTca98q+u/8tmJi15qLLRBapiT+cczjA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/number-ctor": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-pinf": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-pinf/-/constants-float64-pinf-0.0.7.tgz",
+      "integrity": "sha512-kITkBiwGkrbjDOPG9TqwW9ryTpGKs5Evlf5CJjz59kvnXtVq2FDXpJ2oePPlyWa6cc1fyGkeLwBZMCWsRgs1rQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-float64-smallest-normal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-smallest-normal/-/constants-float64-smallest-normal-0.0.7.tgz",
+      "integrity": "sha512-3v0kxGdIj9bW4s/jy/g1A3mmAlWP9sEEJwUMTW5QKjlw5vpYJj7QvDb8Ofvc2/hk5DgzIMNefkZMOUs3ancXfA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-uint16-max": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-uint16-max/-/constants-uint16-max-0.0.7.tgz",
+      "integrity": "sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-uint32-max": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-uint32-max/-/constants-uint32-max-0.0.7.tgz",
+      "integrity": "sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/constants-uint8-max": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-uint8-max/-/constants-uint8-max-0.0.7.tgz",
+      "integrity": "sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/fs-exists": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/fs-exists/-/fs-exists-0.0.8.tgz",
+      "integrity": "sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-cwd": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "bin": {
+        "exists": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/fs-read-file": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/fs-read-file/-/fs-read-file-0.0.8.tgz",
+      "integrity": "sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "bin": {
+        "read-file": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/fs-resolve-parent-path": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/fs-resolve-parent-path/-/fs-resolve-parent-path-0.0.8.tgz",
+      "integrity": "sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-plain-object": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-exists": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-cwd": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "bin": {
+        "resolve-parent-path": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-assert-is-infinite": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-assert-is-infinite/-/math-base-assert-is-infinite-0.0.9.tgz",
+      "integrity": "sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/constants-float64-ninf": "^0.0.x",
+        "@stdlib/constants-float64-pinf": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-assert-is-nan": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-assert-is-nan/-/math-base-assert-is-nan-0.0.8.tgz",
+      "integrity": "sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-napi-binary": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-napi-binary/-/math-base-napi-binary-0.0.8.tgz",
+      "integrity": "sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/complex-float64": "^0.0.x",
+        "@stdlib/complex-reim": "^0.0.x",
+        "@stdlib/complex-reimf": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-napi-unary": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-napi-unary/-/math-base-napi-unary-0.0.8.tgz",
+      "integrity": "sha512-xKbGBxbgrEe7dxCDXJrooXPhXSDUl/QPqsN74Qa0+8Svsc4sbYVdU3yHSN5vDgrcWt3ZkH51j0vCSBIjvLL15g==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/complex-float64": "^0.0.x",
+        "@stdlib/complex-reim": "^0.0.x",
+        "@stdlib/complex-reimf": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-special-abs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-abs/-/math-base-special-abs-0.0.6.tgz",
+      "integrity": "sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/math-base-napi-unary": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-special-copysign": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-copysign/-/math-base-special-copysign-0.0.6.tgz",
+      "integrity": "sha512-2u2ariXtGK0c+Z8y0QHUrdP2aEvkKSZZ4GRNehVYMZT1cwDnZZOZRdTNKFquDldJ/C407upOvLpkzIeS9WmkUQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/math-base-napi-binary": "^0.0.x",
+        "@stdlib/number-float64-base-from-words": "^0.0.x",
+        "@stdlib/number-float64-base-get-high-word": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/math-base-special-ldexp": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-ldexp/-/math-base-special-ldexp-0.0.5.tgz",
+      "integrity": "sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/constants-float64-exponent-bias": "^0.0.x",
+        "@stdlib/constants-float64-max-base2-exponent": "^0.0.x",
+        "@stdlib/constants-float64-max-base2-exponent-subnormal": "^0.0.x",
+        "@stdlib/constants-float64-min-base2-exponent-subnormal": "^0.0.x",
+        "@stdlib/constants-float64-ninf": "^0.0.x",
+        "@stdlib/constants-float64-pinf": "^0.0.x",
+        "@stdlib/math-base-assert-is-infinite": "^0.0.x",
+        "@stdlib/math-base-assert-is-nan": "^0.0.x",
+        "@stdlib/math-base-special-copysign": "^0.0.x",
+        "@stdlib/number-float64-base-exponent": "^0.0.x",
+        "@stdlib/number-float64-base-from-words": "^0.0.x",
+        "@stdlib/number-float64-base-normalize": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-ctor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-ctor/-/number-ctor-0.0.7.tgz",
+      "integrity": "sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-float64-base-exponent": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-exponent/-/number-float64-base-exponent-0.0.6.tgz",
+      "integrity": "sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/constants-float64-exponent-bias": "^0.0.x",
+        "@stdlib/constants-float64-high-word-exponent-mask": "^0.0.x",
+        "@stdlib/number-float64-base-get-high-word": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-float64-base-from-words": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-from-words/-/number-float64-base-from-words-0.0.6.tgz",
+      "integrity": "sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/array-uint32": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-float64-base-get-high-word": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-get-high-word/-/number-float64-base-get-high-word-0.0.6.tgz",
+      "integrity": "sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/array-uint32": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-float64-base-normalize": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-normalize/-/number-float64-base-normalize-0.0.6.tgz",
+      "integrity": "sha512-+RvDf+vQdtGOg7lwz2vGFYL2hA0FyfAJyWVjBkesfHyyKL8nQclA83NJp6bjh+pVkOW3obBDX9zi8Gir4ORm1g==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/constants-float64-smallest-normal": "^0.0.x",
+        "@stdlib/math-base-assert-is-infinite": "^0.0.x",
+        "@stdlib/math-base-assert-is-nan": "^0.0.x",
+        "@stdlib/math-base-special-abs": "^0.0.x",
+        "@stdlib/types": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-float64-base-to-float32": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-to-float32/-/number-float64-base-to-float32-0.0.7.tgz",
+      "integrity": "sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-float32": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/number-float64-base-to-words": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-to-words/-/number-float64-base-to-words-0.0.6.tgz",
+      "integrity": "sha512-J7S0+yOBcrU9/gMTLE3oQUrtGvDj6uSxC8swOnXCLrCm0l3WItYlBl4PHPxJ+cgRiduHd1ol+ud7ctFI5/66sw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/array-uint32": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/os-byte-order": "^0.0.x",
+        "@stdlib/os-float-word-order": "^0.0.x",
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/os-byte-order": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/os-byte-order/-/os-byte-order-0.0.7.tgz",
+      "integrity": "sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-big-endian": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "bin": {
+        "byte-order": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/os-float-word-order": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/os-float-word-order/-/os-float-word-order-0.0.7.tgz",
+      "integrity": "sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/os-byte-order": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      },
+      "bin": {
+        "float-word-order": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/process-cwd": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/process-cwd/-/process-cwd-0.0.8.tgz",
+      "integrity": "sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      },
+      "bin": {
+        "cwd": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/process-read-stdin": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/process-read-stdin/-/process-read-stdin-0.0.7.tgz",
+      "integrity": "sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/buffer-ctor": "^0.0.x",
+        "@stdlib/buffer-from-string": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/utils-next-tick": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/regexp-eol": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-eol/-/regexp-eol-0.0.7.tgz",
+      "integrity": "sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-is-boolean": "^0.0.x",
+        "@stdlib/assert-is-plain-object": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/regexp-extended-length-path": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-extended-length-path/-/regexp-extended-length-path-0.0.7.tgz",
+      "integrity": "sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/regexp-function-name": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-function-name/-/regexp-function-name-0.0.7.tgz",
+      "integrity": "sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/regexp-regexp": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-regexp/-/regexp-regexp-0.0.8.tgz",
+      "integrity": "sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/streams-node-stdin": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/streams-node-stdin/-/streams-node-stdin-0.0.7.tgz",
+      "integrity": "sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/string-base-format-interpolate": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-base-format-interpolate/-/string-base-format-interpolate-0.0.4.tgz",
+      "integrity": "sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/string-base-format-tokenize": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-base-format-tokenize/-/string-base-format-tokenize-0.0.4.tgz",
+      "integrity": "sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/string-format": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-format/-/string-format-0.0.3.tgz",
+      "integrity": "sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/string-base-format-interpolate": "^0.0.x",
+        "@stdlib/string-base-format-tokenize": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/string-lowercase": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-lowercase/-/string-lowercase-0.0.9.tgz",
+      "integrity": "sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      },
+      "bin": {
+        "lowercase": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/string-replace": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-replace/-/string-replace-0.0.11.tgz",
+      "integrity": "sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-regexp": "^0.0.x",
+        "@stdlib/assert-is-regexp-string": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/regexp-eol": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x",
+        "@stdlib/utils-escape-regexp-string": "^0.0.x",
+        "@stdlib/utils-regexp-from-string": "^0.0.x"
+      },
+      "bin": {
+        "replace": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/types": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@stdlib/types/-/types-0.0.14.tgz",
+      "integrity": "sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-constructor-name": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-constructor-name/-/utils-constructor-name-0.0.8.tgz",
+      "integrity": "sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-buffer": "^0.0.x",
+        "@stdlib/regexp-function-name": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-convert-path": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-convert-path/-/utils-convert-path-0.0.8.tgz",
+      "integrity": "sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/regexp-eol": "^0.0.x",
+        "@stdlib/regexp-extended-length-path": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/string-lowercase": "^0.0.x",
+        "@stdlib/string-replace": "^0.0.x"
+      },
+      "bin": {
+        "convert-path": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-define-nonenumerable-read-only-property": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-define-nonenumerable-read-only-property/-/utils-define-nonenumerable-read-only-property-0.0.7.tgz",
+      "integrity": "sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-define-property": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-define-property": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-define-property/-/utils-define-property-0.0.9.tgz",
+      "integrity": "sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/types": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-escape-regexp-string": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-escape-regexp-string/-/utils-escape-regexp-string-0.0.9.tgz",
+      "integrity": "sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-get-prototype-of": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-get-prototype-of/-/utils-get-prototype-of-0.0.7.tgz",
+      "integrity": "sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-global": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-global/-/utils-global-0.0.7.tgz",
+      "integrity": "sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-boolean": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-library-manifest": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-library-manifest/-/utils-library-manifest-0.0.8.tgz",
+      "integrity": "sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-resolve-parent-path": "^0.0.x",
+        "@stdlib/utils-convert-path": "^0.0.x",
+        "debug": "^2.6.9",
+        "resolve": "^1.1.7"
+      },
+      "bin": {
+        "library-manifest": "bin/cli"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-native-class": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-native-class/-/utils-native-class-0.0.8.tgz",
+      "integrity": "sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-next-tick": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-next-tick/-/utils-next-tick-0.0.8.tgz",
+      "integrity": "sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-noop": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-noop/-/utils-noop-0.0.13.tgz",
+      "integrity": "sha512-JRWHGWYWP5QK7SQ2cOYiL8NETw8P33LriZh1p9S2xC4e0rBoaY849h1A2IL2y1+x3s29KNjSaBWMrMUIV5HCSw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-regexp-from-string": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-regexp-from-string/-/utils-regexp-from-string-0.0.9.tgz",
+      "integrity": "sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/regexp-regexp": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
+    },
+    "node_modules/@stdlib/utils-type-of": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-type-of/-/utils-type-of-0.0.8.tgz",
+      "integrity": "sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==",
+      "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+      ],
+      "dependencies": {
+        "@stdlib/utils-constructor-name": "^0.0.x",
+        "@stdlib/utils-global": "^0.0.x"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/athan"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -4560,7 +7453,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -4990,8 +7882,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -5154,6 +8045,14 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
       "engines": {
         "node": ">=4"
       }
@@ -7864,8 +10763,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -8968,7 +11866,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -9687,7 +12584,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -12097,6 +14993,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13069,8 +15973,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mitt": {
       "version": "1.2.0",
@@ -13106,8 +16009,7 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/mute-stdout": {
       "version": "1.0.1",
@@ -13191,6 +16093,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/new-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
+      "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
+      "dependencies": {
+        "@segment/isodate": "1.0.3"
+      }
+    },
     "node_modules/next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -13207,7 +16117,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13495,6 +16404,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -14170,8 +17084,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-root": {
       "version": "0.1.1",
@@ -15004,7 +17917,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -16129,6 +19041,11 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
+    },
     "node_modules/sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
@@ -16665,7 +19582,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -17055,6 +19971,11 @@
         "next-tick": "1"
       }
     },
+    "node_modules/tiny-hashes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-hashes/-/tiny-hashes-1.0.1.tgz",
+      "integrity": "sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g=="
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -17178,8 +20099,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trim-newlines": {
       "version": "1.0.0",
@@ -17371,6 +20291,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -17802,14 +20727,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -19369,6 +22292,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@lukeed/csprng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
+      "integrity": "sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g=="
+    },
+    "@lukeed/uuid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.0.tgz",
+      "integrity": "sha512-dUz8OmYvlY5A9wXaroHIMSPASpSYRLCqbPvxGSyHguhtTQIy24lC+EGxQlwv71AhRCO55WOtgwhzQLpw27JaJQ==",
+      "requires": {
+        "@lukeed/csprng": "^1.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
@@ -19393,6 +22329,103 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.2",
         "fastq": "^1.6.0"
+      }
+    },
+    "@segment/analytics-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.0.1.tgz",
+      "integrity": "sha512-aty64DNqhigwnKYWR5YFYV5t61x8KfVKM5w9M25Cpxoy8UPz5pnCNl7+leGHJlnIUO5ULQ2PH7Db+LF10apuYA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@segment/analytics-next": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.43.0.tgz",
+      "integrity": "sha512-jGj+9Iv3rKYmXqCkF0bPnXIOS1QasCvPOjSkjUkU6o4JlAtDQ0DuuKej5N3NOATD3F3ckeL4cwMcuSh+s+MD3A==",
+      "requires": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.0.1",
+        "@segment/analytics.js-video-plugins": "^0.2.1",
+        "@segment/facade": "^3.4.9",
+        "@segment/tsub": "^0.1.12",
+        "dset": "^3.1.2",
+        "js-cookie": "3.0.1",
+        "node-fetch": "^2.6.7",
+        "spark-md5": "^3.0.1",
+        "tslib": "^2.4.0",
+        "unfetch": "^4.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@segment/analytics.js-video-plugins": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
+      "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
+      "requires": {
+        "unfetch": "^3.1.1"
+      },
+      "dependencies": {
+        "unfetch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
+          "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw=="
+        }
+      }
+    },
+    "@segment/facade": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.9.tgz",
+      "integrity": "sha512-0RTLB0g4HiJASc6pTD2/Tru+Qz+VPGL1W+/EvkBGhY6WYk00cZhTjLsMJ8X5BO6iPqLb3vsxtfjVM/RREG5oQQ==",
+      "requires": {
+        "@segment/isodate-traverse": "^1.1.1",
+        "inherits": "^2.0.4",
+        "new-date": "^1.0.3",
+        "obj-case": "0.2.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
+    "@segment/isodate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A=="
+    },
+    "@segment/isodate-traverse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
+      "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
+      "requires": {
+        "@segment/isodate": "^1.0.3"
+      }
+    },
+    "@segment/tsub": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@segment/tsub/-/tsub-0.1.12.tgz",
+      "integrity": "sha512-35JB0+HuMZrn7mus/s4yOHAcuid+MzaOYxV8YAogTR4Z7AsHwn/Zn/y9XdoHp2kKdn54s6jO4IaO826v0j7qmw==",
+      "requires": {
+        "@stdlib/math-base-special-ldexp": "^0.0.5",
+        "dlv": "^1.1.3",
+        "dset": "^3.1.1",
+        "tiny-hashes": "^1.0.1"
       }
     },
     "@sinclair/typebox": {
@@ -19436,6 +22469,898 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
       "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
       "dev": true
+    },
+    "@stdlib/array-float32": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-float32/-/array-float32-0.0.6.tgz",
+      "integrity": "sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==",
+      "requires": {
+        "@stdlib/assert-has-float32array-support": "^0.0.x"
+      }
+    },
+    "@stdlib/array-float64": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-float64/-/array-float64-0.0.6.tgz",
+      "integrity": "sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==",
+      "requires": {
+        "@stdlib/assert-has-float64array-support": "^0.0.x"
+      }
+    },
+    "@stdlib/array-uint16": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-uint16/-/array-uint16-0.0.6.tgz",
+      "integrity": "sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==",
+      "requires": {
+        "@stdlib/assert-has-uint16array-support": "^0.0.x"
+      }
+    },
+    "@stdlib/array-uint32": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-uint32/-/array-uint32-0.0.6.tgz",
+      "integrity": "sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==",
+      "requires": {
+        "@stdlib/assert-has-uint32array-support": "^0.0.x"
+      }
+    },
+    "@stdlib/array-uint8": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/array-uint8/-/array-uint8-0.0.7.tgz",
+      "integrity": "sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==",
+      "requires": {
+        "@stdlib/assert-has-uint8array-support": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-float32array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-float32array-support/-/assert-has-float32array-support-0.0.8.tgz",
+      "integrity": "sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==",
+      "requires": {
+        "@stdlib/assert-is-float32array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-float64-pinf": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-float64array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-float64array-support/-/assert-has-float64array-support-0.0.8.tgz",
+      "integrity": "sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==",
+      "requires": {
+        "@stdlib/assert-is-float64array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-node-buffer-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-node-buffer-support/-/assert-has-node-buffer-support-0.0.8.tgz",
+      "integrity": "sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==",
+      "requires": {
+        "@stdlib/assert-is-buffer": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-own-property": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-own-property/-/assert-has-own-property-0.0.7.tgz",
+      "integrity": "sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ=="
+    },
+    "@stdlib/assert-has-symbol-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-symbol-support/-/assert-has-symbol-support-0.0.8.tgz",
+      "integrity": "sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==",
+      "requires": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-tostringtag-support": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-tostringtag-support/-/assert-has-tostringtag-support-0.0.9.tgz",
+      "integrity": "sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==",
+      "requires": {
+        "@stdlib/assert-has-symbol-support": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-uint16array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint16array-support/-/assert-has-uint16array-support-0.0.8.tgz",
+      "integrity": "sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==",
+      "requires": {
+        "@stdlib/assert-is-uint16array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-uint16-max": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-uint32array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint32array-support/-/assert-has-uint32array-support-0.0.8.tgz",
+      "integrity": "sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==",
+      "requires": {
+        "@stdlib/assert-is-uint32array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-uint32-max": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-has-uint8array-support": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint8array-support/-/assert-has-uint8array-support-0.0.8.tgz",
+      "integrity": "sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==",
+      "requires": {
+        "@stdlib/assert-is-uint8array": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/constants-uint8-max": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-array": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-array/-/assert-is-array-0.0.7.tgz",
+      "integrity": "sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==",
+      "requires": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-big-endian": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-big-endian/-/assert-is-big-endian-0.0.7.tgz",
+      "integrity": "sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==",
+      "requires": {
+        "@stdlib/array-uint16": "^0.0.x",
+        "@stdlib/array-uint8": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-boolean": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-boolean/-/assert-is-boolean-0.0.8.tgz",
+      "integrity": "sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==",
+      "requires": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-buffer": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-buffer/-/assert-is-buffer-0.0.8.tgz",
+      "integrity": "sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==",
+      "requires": {
+        "@stdlib/assert-is-object-like": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-float32array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-float32array/-/assert-is-float32array-0.0.8.tgz",
+      "integrity": "sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==",
+      "requires": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-float64array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-float64array/-/assert-is-float64array-0.0.8.tgz",
+      "integrity": "sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==",
+      "requires": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-function": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-function/-/assert-is-function-0.0.8.tgz",
+      "integrity": "sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==",
+      "requires": {
+        "@stdlib/utils-type-of": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-little-endian": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-little-endian/-/assert-is-little-endian-0.0.7.tgz",
+      "integrity": "sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==",
+      "requires": {
+        "@stdlib/array-uint16": "^0.0.x",
+        "@stdlib/array-uint8": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-number": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-number/-/assert-is-number-0.0.7.tgz",
+      "integrity": "sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==",
+      "requires": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/number-ctor": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-object": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-object/-/assert-is-object-0.0.8.tgz",
+      "integrity": "sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==",
+      "requires": {
+        "@stdlib/assert-is-array": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-object-like": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-object-like/-/assert-is-object-like-0.0.8.tgz",
+      "integrity": "sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==",
+      "requires": {
+        "@stdlib/assert-tools-array-function": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-plain-object": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-plain-object/-/assert-is-plain-object-0.0.7.tgz",
+      "integrity": "sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==",
+      "requires": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-object": "^0.0.x",
+        "@stdlib/utils-get-prototype-of": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-regexp": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-regexp/-/assert-is-regexp-0.0.7.tgz",
+      "integrity": "sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==",
+      "requires": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-regexp-string": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-regexp-string/-/assert-is-regexp-string-0.0.9.tgz",
+      "integrity": "sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==",
+      "requires": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/regexp-eol": "^0.0.x",
+        "@stdlib/regexp-regexp": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-string": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-string/-/assert-is-string-0.0.8.tgz",
+      "integrity": "sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==",
+      "requires": {
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-uint16array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint16array/-/assert-is-uint16array-0.0.8.tgz",
+      "integrity": "sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==",
+      "requires": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-uint32array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint32array/-/assert-is-uint32array-0.0.8.tgz",
+      "integrity": "sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==",
+      "requires": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-is-uint8array": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint8array/-/assert-is-uint8array-0.0.8.tgz",
+      "integrity": "sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==",
+      "requires": {
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/assert-tools-array-function": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/assert-tools-array-function/-/assert-tools-array-function-0.0.7.tgz",
+      "integrity": "sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==",
+      "requires": {
+        "@stdlib/assert-is-array": "^0.0.x"
+      }
+    },
+    "@stdlib/buffer-ctor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/buffer-ctor/-/buffer-ctor-0.0.7.tgz",
+      "integrity": "sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==",
+      "requires": {
+        "@stdlib/assert-has-node-buffer-support": "^0.0.x"
+      }
+    },
+    "@stdlib/buffer-from-string": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/buffer-from-string/-/buffer-from-string-0.0.8.tgz",
+      "integrity": "sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==",
+      "requires": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/buffer-ctor": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      }
+    },
+    "@stdlib/cli-ctor": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@stdlib/cli-ctor/-/cli-ctor-0.0.3.tgz",
+      "integrity": "sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==",
+      "requires": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-noop": "^0.0.x",
+        "minimist": "^1.2.0"
+      }
+    },
+    "@stdlib/complex-float32": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-float32/-/complex-float32-0.0.7.tgz",
+      "integrity": "sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==",
+      "requires": {
+        "@stdlib/assert-is-number": "^0.0.x",
+        "@stdlib/number-float64-base-to-float32": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-define-property": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/complex-float64": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-float64/-/complex-float64-0.0.8.tgz",
+      "integrity": "sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==",
+      "requires": {
+        "@stdlib/assert-is-number": "^0.0.x",
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+        "@stdlib/utils-define-property": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/complex-reim": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-reim/-/complex-reim-0.0.6.tgz",
+      "integrity": "sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==",
+      "requires": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/complex-float64": "^0.0.x",
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/complex-reimf": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@stdlib/complex-reimf/-/complex-reimf-0.0.1.tgz",
+      "integrity": "sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==",
+      "requires": {
+        "@stdlib/array-float32": "^0.0.x",
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/constants-float64-exponent-bias": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-exponent-bias/-/constants-float64-exponent-bias-0.0.7.tgz",
+      "integrity": "sha512-F0f95YUVGijNzBEgOzvQXwZC41SQyefB0sYntfVMi071I5Luv1HlYc+H80Ree/Wfn3gFNACe7JdfFIMpeJgTNg=="
+    },
+    "@stdlib/constants-float64-high-word-exponent-mask": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-high-word-exponent-mask/-/constants-float64-high-word-exponent-mask-0.0.7.tgz",
+      "integrity": "sha512-7/GL1DW/BeWLvTcfbuWUyKJkcIN9fM6m8xPEGfq6vAvv+dRIAlwKsVZVTBIAD1FcoXLKV/GDptOPTQRAPoxGqA=="
+    },
+    "@stdlib/constants-float64-max-base2-exponent": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-max-base2-exponent/-/constants-float64-max-base2-exponent-0.0.7.tgz",
+      "integrity": "sha512-9vOMjILdOE7f3glCWuvQtfmiipE/WsImmAbG3u5KAeLluJhosNRhnfGbfRGydJiyDDYcs3W3l1ViXhLnRLuJZA=="
+    },
+    "@stdlib/constants-float64-max-base2-exponent-subnormal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-max-base2-exponent-subnormal/-/constants-float64-max-base2-exponent-subnormal-0.0.7.tgz",
+      "integrity": "sha512-2SKF0w6XZe1O6S3TAPHjS8pUXujSCeiCzuskQyBBw1ZbbsU0Y6Qh4f99rk1L7f/C9Kp2h8GUh4KV25bdIO8jiQ=="
+    },
+    "@stdlib/constants-float64-min-base2-exponent-subnormal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-min-base2-exponent-subnormal/-/constants-float64-min-base2-exponent-subnormal-0.0.7.tgz",
+      "integrity": "sha512-SFw/ZA2BP0pyLkKkbWdGGMJ9zqqHZs3NyXvGjuEAVgmCFwdH+xTyvcOo/dC543WUoPKTkLsZ4D8h4TBUksfw8A=="
+    },
+    "@stdlib/constants-float64-ninf": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-ninf/-/constants-float64-ninf-0.0.7.tgz",
+      "integrity": "sha512-piVlJxJDTd5v2ZTYNyXVV2qzc5kNibhpgK+H+ykaO80FNQvqt8bIP3TTca98q+u/8tmJi15qLLRBapiT+cczjA==",
+      "requires": {
+        "@stdlib/number-ctor": "^0.0.x"
+      }
+    },
+    "@stdlib/constants-float64-pinf": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-pinf/-/constants-float64-pinf-0.0.7.tgz",
+      "integrity": "sha512-kITkBiwGkrbjDOPG9TqwW9ryTpGKs5Evlf5CJjz59kvnXtVq2FDXpJ2oePPlyWa6cc1fyGkeLwBZMCWsRgs1rQ=="
+    },
+    "@stdlib/constants-float64-smallest-normal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-smallest-normal/-/constants-float64-smallest-normal-0.0.7.tgz",
+      "integrity": "sha512-3v0kxGdIj9bW4s/jy/g1A3mmAlWP9sEEJwUMTW5QKjlw5vpYJj7QvDb8Ofvc2/hk5DgzIMNefkZMOUs3ancXfA=="
+    },
+    "@stdlib/constants-uint16-max": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-uint16-max/-/constants-uint16-max-0.0.7.tgz",
+      "integrity": "sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw=="
+    },
+    "@stdlib/constants-uint32-max": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-uint32-max/-/constants-uint32-max-0.0.7.tgz",
+      "integrity": "sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw=="
+    },
+    "@stdlib/constants-uint8-max": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/constants-uint8-max/-/constants-uint8-max-0.0.7.tgz",
+      "integrity": "sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw=="
+    },
+    "@stdlib/fs-exists": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/fs-exists/-/fs-exists-0.0.8.tgz",
+      "integrity": "sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==",
+      "requires": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-cwd": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/fs-read-file": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/fs-read-file/-/fs-read-file-0.0.8.tgz",
+      "integrity": "sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==",
+      "requires": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/fs-resolve-parent-path": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/fs-resolve-parent-path/-/fs-resolve-parent-path-0.0.8.tgz",
+      "integrity": "sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==",
+      "requires": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-plain-object": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-exists": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-cwd": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-assert-is-infinite": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-assert-is-infinite/-/math-base-assert-is-infinite-0.0.9.tgz",
+      "integrity": "sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==",
+      "requires": {
+        "@stdlib/constants-float64-ninf": "^0.0.x",
+        "@stdlib/constants-float64-pinf": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-assert-is-nan": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-assert-is-nan/-/math-base-assert-is-nan-0.0.8.tgz",
+      "integrity": "sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==",
+      "requires": {
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-napi-binary": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-napi-binary/-/math-base-napi-binary-0.0.8.tgz",
+      "integrity": "sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==",
+      "requires": {
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/complex-float64": "^0.0.x",
+        "@stdlib/complex-reim": "^0.0.x",
+        "@stdlib/complex-reimf": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-napi-unary": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-napi-unary/-/math-base-napi-unary-0.0.8.tgz",
+      "integrity": "sha512-xKbGBxbgrEe7dxCDXJrooXPhXSDUl/QPqsN74Qa0+8Svsc4sbYVdU3yHSN5vDgrcWt3ZkH51j0vCSBIjvLL15g==",
+      "requires": {
+        "@stdlib/complex-float32": "^0.0.x",
+        "@stdlib/complex-float64": "^0.0.x",
+        "@stdlib/complex-reim": "^0.0.x",
+        "@stdlib/complex-reimf": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-special-abs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-abs/-/math-base-special-abs-0.0.6.tgz",
+      "integrity": "sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==",
+      "requires": {
+        "@stdlib/math-base-napi-unary": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-special-copysign": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-copysign/-/math-base-special-copysign-0.0.6.tgz",
+      "integrity": "sha512-2u2ariXtGK0c+Z8y0QHUrdP2aEvkKSZZ4GRNehVYMZT1cwDnZZOZRdTNKFquDldJ/C407upOvLpkzIeS9WmkUQ==",
+      "requires": {
+        "@stdlib/math-base-napi-binary": "^0.0.x",
+        "@stdlib/number-float64-base-from-words": "^0.0.x",
+        "@stdlib/number-float64-base-get-high-word": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/math-base-special-ldexp": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-ldexp/-/math-base-special-ldexp-0.0.5.tgz",
+      "integrity": "sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==",
+      "requires": {
+        "@stdlib/constants-float64-exponent-bias": "^0.0.x",
+        "@stdlib/constants-float64-max-base2-exponent": "^0.0.x",
+        "@stdlib/constants-float64-max-base2-exponent-subnormal": "^0.0.x",
+        "@stdlib/constants-float64-min-base2-exponent-subnormal": "^0.0.x",
+        "@stdlib/constants-float64-ninf": "^0.0.x",
+        "@stdlib/constants-float64-pinf": "^0.0.x",
+        "@stdlib/math-base-assert-is-infinite": "^0.0.x",
+        "@stdlib/math-base-assert-is-nan": "^0.0.x",
+        "@stdlib/math-base-special-copysign": "^0.0.x",
+        "@stdlib/number-float64-base-exponent": "^0.0.x",
+        "@stdlib/number-float64-base-from-words": "^0.0.x",
+        "@stdlib/number-float64-base-normalize": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x"
+      }
+    },
+    "@stdlib/number-ctor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-ctor/-/number-ctor-0.0.7.tgz",
+      "integrity": "sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow=="
+    },
+    "@stdlib/number-float64-base-exponent": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-exponent/-/number-float64-base-exponent-0.0.6.tgz",
+      "integrity": "sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==",
+      "requires": {
+        "@stdlib/constants-float64-exponent-bias": "^0.0.x",
+        "@stdlib/constants-float64-high-word-exponent-mask": "^0.0.x",
+        "@stdlib/number-float64-base-get-high-word": "^0.0.x"
+      }
+    },
+    "@stdlib/number-float64-base-from-words": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-from-words/-/number-float64-base-from-words-0.0.6.tgz",
+      "integrity": "sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==",
+      "requires": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/array-uint32": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/number-float64-base-get-high-word": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-get-high-word/-/number-float64-base-get-high-word-0.0.6.tgz",
+      "integrity": "sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==",
+      "requires": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/array-uint32": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/number-float64-base-to-words": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/number-float64-base-normalize": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-normalize/-/number-float64-base-normalize-0.0.6.tgz",
+      "integrity": "sha512-+RvDf+vQdtGOg7lwz2vGFYL2hA0FyfAJyWVjBkesfHyyKL8nQclA83NJp6bjh+pVkOW3obBDX9zi8Gir4ORm1g==",
+      "requires": {
+        "@stdlib/constants-float64-smallest-normal": "^0.0.x",
+        "@stdlib/math-base-assert-is-infinite": "^0.0.x",
+        "@stdlib/math-base-assert-is-nan": "^0.0.x",
+        "@stdlib/math-base-special-abs": "^0.0.x",
+        "@stdlib/types": "^0.0.x"
+      }
+    },
+    "@stdlib/number-float64-base-to-float32": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-to-float32/-/number-float64-base-to-float32-0.0.7.tgz",
+      "integrity": "sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==",
+      "requires": {
+        "@stdlib/array-float32": "^0.0.x"
+      }
+    },
+    "@stdlib/number-float64-base-to-words": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-to-words/-/number-float64-base-to-words-0.0.6.tgz",
+      "integrity": "sha512-J7S0+yOBcrU9/gMTLE3oQUrtGvDj6uSxC8swOnXCLrCm0l3WItYlBl4PHPxJ+cgRiduHd1ol+ud7ctFI5/66sw==",
+      "requires": {
+        "@stdlib/array-float64": "^0.0.x",
+        "@stdlib/array-uint32": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/os-byte-order": "^0.0.x",
+        "@stdlib/os-float-word-order": "^0.0.x",
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/os-byte-order": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/os-byte-order/-/os-byte-order-0.0.7.tgz",
+      "integrity": "sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==",
+      "requires": {
+        "@stdlib/assert-is-big-endian": "^0.0.x",
+        "@stdlib/assert-is-little-endian": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/os-float-word-order": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/os-float-word-order/-/os-float-word-order-0.0.7.tgz",
+      "integrity": "sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==",
+      "requires": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/os-byte-order": "^0.0.x",
+        "@stdlib/utils-library-manifest": "^0.0.x"
+      }
+    },
+    "@stdlib/process-cwd": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/process-cwd/-/process-cwd-0.0.8.tgz",
+      "integrity": "sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==",
+      "requires": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x"
+      }
+    },
+    "@stdlib/process-read-stdin": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/process-read-stdin/-/process-read-stdin-0.0.7.tgz",
+      "integrity": "sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==",
+      "requires": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/buffer-ctor": "^0.0.x",
+        "@stdlib/buffer-from-string": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/utils-next-tick": "^0.0.x"
+      }
+    },
+    "@stdlib/regexp-eol": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-eol/-/regexp-eol-0.0.7.tgz",
+      "integrity": "sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==",
+      "requires": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-is-boolean": "^0.0.x",
+        "@stdlib/assert-is-plain-object": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/regexp-extended-length-path": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-extended-length-path/-/regexp-extended-length-path-0.0.7.tgz",
+      "integrity": "sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==",
+      "requires": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/regexp-function-name": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-function-name/-/regexp-function-name-0.0.7.tgz",
+      "integrity": "sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==",
+      "requires": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/regexp-regexp": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/regexp-regexp/-/regexp-regexp-0.0.8.tgz",
+      "integrity": "sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==",
+      "requires": {
+        "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x"
+      }
+    },
+    "@stdlib/streams-node-stdin": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/streams-node-stdin/-/streams-node-stdin-0.0.7.tgz",
+      "integrity": "sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg=="
+    },
+    "@stdlib/string-base-format-interpolate": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-base-format-interpolate/-/string-base-format-interpolate-0.0.4.tgz",
+      "integrity": "sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg=="
+    },
+    "@stdlib/string-base-format-tokenize": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-base-format-tokenize/-/string-base-format-tokenize-0.0.4.tgz",
+      "integrity": "sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow=="
+    },
+    "@stdlib/string-format": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-format/-/string-format-0.0.3.tgz",
+      "integrity": "sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==",
+      "requires": {
+        "@stdlib/string-base-format-interpolate": "^0.0.x",
+        "@stdlib/string-base-format-tokenize": "^0.0.x"
+      }
+    },
+    "@stdlib/string-lowercase": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-lowercase/-/string-lowercase-0.0.9.tgz",
+      "integrity": "sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==",
+      "requires": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      }
+    },
+    "@stdlib/string-replace": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@stdlib/string-replace/-/string-replace-0.0.11.tgz",
+      "integrity": "sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==",
+      "requires": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/assert-is-regexp": "^0.0.x",
+        "@stdlib/assert-is-regexp-string": "^0.0.x",
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/regexp-eol": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x",
+        "@stdlib/utils-escape-regexp-string": "^0.0.x",
+        "@stdlib/utils-regexp-from-string": "^0.0.x"
+      }
+    },
+    "@stdlib/types": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@stdlib/types/-/types-0.0.14.tgz",
+      "integrity": "sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw=="
+    },
+    "@stdlib/utils-constructor-name": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-constructor-name/-/utils-constructor-name-0.0.8.tgz",
+      "integrity": "sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==",
+      "requires": {
+        "@stdlib/assert-is-buffer": "^0.0.x",
+        "@stdlib/regexp-function-name": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-convert-path": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-convert-path/-/utils-convert-path-0.0.8.tgz",
+      "integrity": "sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==",
+      "requires": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-read-file": "^0.0.x",
+        "@stdlib/process-read-stdin": "^0.0.x",
+        "@stdlib/regexp-eol": "^0.0.x",
+        "@stdlib/regexp-extended-length-path": "^0.0.x",
+        "@stdlib/streams-node-stdin": "^0.0.x",
+        "@stdlib/string-lowercase": "^0.0.x",
+        "@stdlib/string-replace": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-define-nonenumerable-read-only-property": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-define-nonenumerable-read-only-property/-/utils-define-nonenumerable-read-only-property-0.0.7.tgz",
+      "integrity": "sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==",
+      "requires": {
+        "@stdlib/types": "^0.0.x",
+        "@stdlib/utils-define-property": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-define-property": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-define-property/-/utils-define-property-0.0.9.tgz",
+      "integrity": "sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==",
+      "requires": {
+        "@stdlib/types": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-escape-regexp-string": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-escape-regexp-string/-/utils-escape-regexp-string-0.0.9.tgz",
+      "integrity": "sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==",
+      "requires": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-get-prototype-of": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-get-prototype-of/-/utils-get-prototype-of-0.0.7.tgz",
+      "integrity": "sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==",
+      "requires": {
+        "@stdlib/assert-is-function": "^0.0.x",
+        "@stdlib/utils-native-class": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-global": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-global/-/utils-global-0.0.7.tgz",
+      "integrity": "sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==",
+      "requires": {
+        "@stdlib/assert-is-boolean": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-library-manifest": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-library-manifest/-/utils-library-manifest-0.0.8.tgz",
+      "integrity": "sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==",
+      "requires": {
+        "@stdlib/cli-ctor": "^0.0.x",
+        "@stdlib/fs-resolve-parent-path": "^0.0.x",
+        "@stdlib/utils-convert-path": "^0.0.x",
+        "debug": "^2.6.9",
+        "resolve": "^1.1.7"
+      }
+    },
+    "@stdlib/utils-native-class": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-native-class/-/utils-native-class-0.0.8.tgz",
+      "integrity": "sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==",
+      "requires": {
+        "@stdlib/assert-has-own-property": "^0.0.x",
+        "@stdlib/assert-has-tostringtag-support": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-next-tick": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-next-tick/-/utils-next-tick-0.0.8.tgz",
+      "integrity": "sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg=="
+    },
+    "@stdlib/utils-noop": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-noop/-/utils-noop-0.0.13.tgz",
+      "integrity": "sha512-JRWHGWYWP5QK7SQ2cOYiL8NETw8P33LriZh1p9S2xC4e0rBoaY849h1A2IL2y1+x3s29KNjSaBWMrMUIV5HCSw=="
+    },
+    "@stdlib/utils-regexp-from-string": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-regexp-from-string/-/utils-regexp-from-string-0.0.9.tgz",
+      "integrity": "sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==",
+      "requires": {
+        "@stdlib/assert-is-string": "^0.0.x",
+        "@stdlib/regexp-regexp": "^0.0.x",
+        "@stdlib/string-format": "^0.0.x"
+      }
+    },
+    "@stdlib/utils-type-of": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@stdlib/utils-type-of/-/utils-type-of-0.0.8.tgz",
+      "integrity": "sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==",
+      "requires": {
+        "@stdlib/utils-constructor-name": "^0.0.x",
+        "@stdlib/utils-global": "^0.0.x"
+      }
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -21673,7 +25598,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -22016,8 +25940,7 @@
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -22149,6 +26072,11 @@
           "dev": true
         }
       }
+    },
+    "dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q=="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -24211,8 +28139,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -25097,7 +29024,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -25627,7 +29553,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -27384,6 +31309,11 @@
         "logalot": "^2.0.0"
       }
     },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -28163,8 +32093,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mitt": {
       "version": "1.2.0",
@@ -28196,8 +32125,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stdout": {
       "version": "1.0.1",
@@ -28265,6 +32193,14 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
+    "new-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
+      "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
+      "requires": {
+        "@segment/isodate": "1.0.3"
+      }
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -28281,7 +32217,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -28491,6 +32426,11 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -28987,8 +32927,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-root": {
       "version": "0.1.1",
@@ -29639,7 +33578,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -30560,6 +34498,11 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
+    },
     "sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
@@ -30960,8 +34903,7 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "sver-compat": {
       "version": "1.5.0",
@@ -31294,6 +35236,11 @@
         "next-tick": "1"
       }
     },
+    "tiny-hashes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-hashes/-/tiny-hashes-1.0.1.tgz",
+      "integrity": "sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -31390,8 +35337,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -31532,6 +35478,11 @@
       "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
       "dev": true
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -31875,14 +35826,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "testPathIgnorePatterns": [
       "/__utils__/"
     ]
+  },
+  "dependencies": {
+    "@segment/analytics-next": "^1.43.0"
   }
 }


### PR DESCRIPTION
### Summary
Add segment.io tracking to docs

### Reason
Help understand cross-site journeys

### Testing
The CORS headers are set up to allow `*.konghq.com` only. I tested by copying a blocked request from the network panel as `curl` and executing it in a terminal. The event showed up in Segment as intended.

Based on this, I believe that this will work once deployed to production
