### PR TITLE
kic: add alpha banner for Gateway API support in KIC in v2.4 and v2.5

### DIFF
--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -1,5 +1,12 @@
 ---
 title: Using Gateway API
+alpha: false # This is the default, but is here for completeness
+
+overrides:
+  alpha:
+    true:
+      gte: 2.4.x
+      lte: 2.5.x
 ---
 
 [Gateway API](https://gateway-api.sigs.k8s.io/) is a set of resources for

--- a/src/kubernetes-ingress-controller/references/gateway-api-support.md
+++ b/src/kubernetes-ingress-controller/references/gateway-api-support.md
@@ -1,6 +1,14 @@
 ---
 title: Gateway API Support
 content_type: reference
+alpha: false # This is the default, but is here for completeness
+
+overrides:
+  alpha:
+    true:
+      gte: 2.4.x
+      lte: 2.5.x
+
 ---
 
 The {{site.kic_product_name}} supports the following resources and features in the


### PR DESCRIPTION
### Summary

This PR addresses a missing alpha banner for older KIC version (between 2.4 and 2.5 inclusive) that is missing after my last PR #4588