### PR TITLE
pr/okta-oidc-doc-changes

### DIFF
--- a/src/gateway/kong-plugins/authentication/oidc/okta.md
+++ b/src/gateway/kong-plugins/authentication/oidc/okta.md
@@ -190,9 +190,11 @@ curl -i -X POST https://KONG_ADMIN_URL/routes/ROUTE_ID/plugins \
   --data config.client_id="YOUR_CLIENT_ID"                                                                 \
   --data config.client_secret="YOUR_CLIENT_SECRET"                                                         \
   --data config.redirect_uri="https://kong.com/api"                                                        \
+  --data config.scopes_claim="scp"                                                                         \
   --data config.scopes="openid"                                                                            \
   --data config.scopes="email"                                                                             \
-  --data config.scopes="profile"
+  --data config.scopes="profile"                                                                           \
+  --data config.auth_methods=authorization_code
 ```
 
 For a list of all available configuration parameters and what they do, see the

--- a/src/gateway/kong-plugins/authentication/oidc/okta.md
+++ b/src/gateway/kong-plugins/authentication/oidc/okta.md
@@ -105,13 +105,22 @@ guide, assume the route is in the default workspace.
 
 Configure the following parameters:
 
+__In the common tab__
+
 * **`issuer`**: The issuer `url` from which OpenID Connect configuration can be discovered. Using Okta, specify the domain and server in the path:
     * `https://YOUR_OKTA_DOMAIN/oauth2/YOUR_AUTH_SERVER/.well-known/openid-configuration`
 * **`auth_method`**: A list of authentication methods to use with the plugin, such as passwords, introspection tokens, etc. The majority of cases use `authorization_code`, and {{site.base_gateway}} will accept all methods if no methods are specified.
 * **`client_id`**: The `client_id` of the OpenID Connect client registered in OpenID Connect Provider. Okta provides one to identify itself.  
 * **`client_secret`**: The `client_secret` of the OpenID Connect client registered in OpenID Connect Provider. These credentials should never be publicly exposed.
-* **`redirect_uri`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
-* **`scopes`**:  The scope of what OpenID Connect checks. `openid` by default; set to `email` and `profile` for this example.
+
+__In the authorization tab__
+
+* **`Config.Scopes Required`**:  The scope of what OpenID Connect checks. `openid` by default; set to `email` and `profile` for this example. 
+* **`Config.Scopes Claim`**: This should be set to `scp`.
+
+__In the advanced tab__
+
+* **`Config.Redirect Uri`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
 
 {% navtabs %}
 {% navtab Configure plugin with Kong Manager %}

--- a/src/gateway/kong-plugins/authentication/oidc/okta.md
+++ b/src/gateway/kong-plugins/authentication/oidc/okta.md
@@ -105,7 +105,7 @@ guide, assume the route is in the default workspace.
 
 Configure the following parameters:
 
-__In the common tab__
+From the **Common Tab**:
 
 * **`issuer`**: The issuer `url` from which OpenID Connect configuration can be discovered. Using Okta, specify the domain and server in the path:
     * `https://YOUR_OKTA_DOMAIN/oauth2/YOUR_AUTH_SERVER/.well-known/openid-configuration`
@@ -113,14 +113,14 @@ __In the common tab__
 * **`client_id`**: The `client_id` of the OpenID Connect client registered in OpenID Connect Provider. Okta provides one to identify itself.  
 * **`client_secret`**: The `client_secret` of the OpenID Connect client registered in OpenID Connect Provider. These credentials should never be publicly exposed.
 
-__In the authorization tab__
+From the **Authorization Tab**
 
-* **`Config.Scopes Required`**:  The scope of what OpenID Connect checks. `openid` by default; set to `email` and `profile` for this example. 
+* **`Config.Scopes Required`**:  The scope of what OpenID Connect checks, this value is set to `openid` by default. The example is set to `email` and `profile`.
 * **`Config.Scopes Claim`**: This should be set to `scp`.
 
-__In the advanced tab__
+From the **Advanced Tab**
 
-* **`Config.Redirect Uri`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
+* **`Config.Redirect URI`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
 
 {% navtabs %}
 {% navtab Configure plugin with Kong Manager %}


### PR DESCRIPTION
### Summary
changes include
Original doc changes to for config.scope - claim  should be set to `scp`
New change modification to admin API call to create plugin so it includes the `config.scopes_claim` with the value `scp`

### Reason
Correct the documentation so that both the UI set up and the API set up work for Okta.

### Testing
Follow the steps in the documentation

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
