### PR TITLE
fix(admin-api): remove consumers type field from examples

### DIFF
--- a/src/gateway/admin-api/index.md
+++ b/src/gateway/admin-api/index.md
@@ -189,7 +189,6 @@ consumer_json: |
         "created_at": 1422386534,
         "username": "my-username",
         "custom_id": "my-custom-id",
-        "type": 0,
         "tags": ["user-level", "low-priority"]
     }
 
@@ -199,14 +198,12 @@ consumer_data: |
         "created_at": 1422386534,
         "username": "my-username",
         "custom_id": "my-custom-id",
-        "type": 0,
         "tags": ["user-level", "low-priority"]
     }, {
         "id": "01c23299-839c-49a5-a6d5-8864c09184af",
         "created_at": 1422386534,
         "username": "my-username",
         "custom_id": "my-custom-id",
-        "type": 0,
         "tags": ["admin", "high-priority", "critical"]
     }],
 


### PR DESCRIPTION
### Summary

After https://github.com/Kong/docs.konghq.com/pull/4573 , the invalid field `type` is still present in the code examples. This MR fixes this.

Related https://github.com/Kong/kong/issues/9501

:hammer_and_wrench: with :heart: by [Siemens](https://opensource.siemens.com/)
