### PR TITLE
Change Fail to Ignore on failurePolicy for Admission Controller

### DIFF
--- a/src/kubernetes-ingress-controller/deployment/admission-webhook.md
+++ b/src/kubernetes-ingress-controller/deployment/admission-webhook.md
@@ -119,6 +119,11 @@ to supply a CA certificate (in the `caBunde` parameter)
 as part of the Validation Webhook configuration
 as the API-server already trusts the internal CA.
 
+{% capture failure_policy %}
+{% if_version gte:2.5.x %}Ignore{% endif_version %}
+{% if_version lte:2.4.x %}Fail{% endif_version %}
+{% endcapture %}
+
 ```bash
 echo "apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -132,7 +137,7 @@ webhooks:
       operator: NotIn
       values:
       - helm
-  failurePolicy: Ignore
+  failurePolicy: {{ failure_policy | strip }}
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:

--- a/src/kubernetes-ingress-controller/deployment/admission-webhook.md
+++ b/src/kubernetes-ingress-controller/deployment/admission-webhook.md
@@ -132,7 +132,7 @@ webhooks:
       operator: NotIn
       values:
       - helm
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:


### PR DESCRIPTION
### Summary
Changing failurePolicy from Fail to Ignore to match 2.5.0 and newer KIC version defaults.

### Reason
In KIC 2.5.0 and higher, we changed the Admission Controller to use a new default of Ignore instead of Fail, so just bringing the docs into alignment too. Ref: https://github.com/Kong/kubernetes-ingress-controller/issues/2501
