### PR TITLE
feat(request-validator): support config.allowed_content_types to be configured with parameter

### DIFF
--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -35,8 +35,10 @@ params:
       value_in_examples: null
       datatype: Set of string elements
       description: |
-        List of allowed content types. <br>**Note:** Body validation is only
-        done for `application/json` and skipped for any other allowed content types.
+        List of allowed content types. The value can be configured with the `charset` parameter(e.g. `application/json; charset=UTF-8`).
+        Note that if no charset parameter is provided, all charsets will be allowed.
+        <br>**Note:** Body validation is only done for `application/json` and skipped for any other allowed content types.
+        
     - name: version
       required: true
       default: kong

--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -36,7 +36,6 @@ params:
       datatype: Set of string elements
       description: |
         List of allowed content types. The value can be configured with the `charset` parameter(e.g. `application/json; charset=UTF-8`).
-        Note that if no charset parameter is provided, all charsets will be allowed.
         <br>**Note:** Body validation is only done for `application/json` and skipped for any other allowed content types.
         
     - name: version


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Support `config.allowed_content_types` to be configured with parameter

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Currently, the config.allowed_content_types doesn't support being configured with a parameter(especially `charset`). 

Request with header "Content-type: application/json, charset=UTF-8" will always get 400 {"message":"request param doesn't conform to schema"}


### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->

Would like to release this to 3.1 and the next **feature** release of 2.8.x.x(after 2.8.2.0)

[FTI-2650]

[FTI-2650]: https://konghq.atlassian.net/browse/FTI-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ