### PR TITLE
[DOCU-275] Validate and improve the Dev Portal enablement doc

### DIFF
--- a/src/gateway/kong-enterprise/dev-portal/enable.md
+++ b/src/gateway/kong-enterprise/dev-portal/enable.md
@@ -6,6 +6,8 @@ badge: enterprise
 If you're running {{site.base_gateway}} with a database (either in traditional
 or hybrid mode), you can use the Dev Portal.
 
+Dev Portals are tied to workspaces. Each workspace has a separate Dev Portal instance.
+
 To enable the Dev Portal, you must first [deploy a license](/gateway/{{page.kong_version}}/licenses/deploy).
 
 {% navtabs %}
@@ -23,14 +25,14 @@ To enable the Dev Portal, you must first [deploy a license](/gateway/{{page.kong
     {:.note}
     > The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should not be preceded by a protocol, for example, `http://`.
 
-1. Execute the following command:
+1. Enable the Dev Portal for a workspace:
 
     ```sh
     curl -i -X PATCH http://localhost:8001/workspaces/default \
       --data "config.portal=true"
     ```
 
-1. Access the Dev Portal for the default workspace using the URL specified
+1. Access the Dev Portal for the workspace using the URL specified
 in the `KONG_PORTAL_GUI_HOST` variable:
 
     ```sh
@@ -53,25 +55,24 @@ configuration file ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong
    kong reload
    ```
 
-1. Enable Dev Portal for the `default` workspace using one of the following methods:
+1. Enable Dev Portal for a workspace using one of the following methods:
 
 {% capture enable-portal %}
 {% navtabs %}
 {% navtab Kong Manager %}
 
-1. Navigate to the default workspace in Kong Manager.
+1. Navigate to a workspace in Kong Manager.
 2. In the **Dev Portal** menu section, click **Overview**.
 3. Click the button to **Enable Developer Portal**.
 
 {% endnavtab %}
 {% navtab Admin API %}
 
-Enable the `default` workspace's Dev Portal via the command line using the following command:
-
 ```bash
 curl -i -X PATCH http://localhost:8001/workspaces/default \
   --data "config.portal=true"
 ```
+
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}
@@ -82,6 +83,7 @@ curl -i -X PATCH http://localhost:8001/workspaces/default \
 {% endnavtabs %}
 
 Enabling the Dev Portal exposes the following URLs:
-* `default` workspace's Dev Portal: `http://localhost:8003/default`.
+* The workspace's Dev Portal URL.
+For example, for the `default` workspace, the URL is: `http://localhost:8003/default`.
 * Dev Portal files endpoint: `http://localhost:8001/files`
 * Public Dev Portal files API: `http://localhost:8004/files`

--- a/src/gateway/kong-enterprise/dev-portal/enable.md
+++ b/src/gateway/kong-enterprise/dev-portal/enable.md
@@ -23,7 +23,7 @@ To enable the Dev Portal, you must first [deploy a license](/gateway/{{page.kong
     Replace `kong-container-name` with your {{site.base_gateway}} container.
 
     {:.note}
-    > The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should not be preceded by a protocol, for example, `http://`.
+    > The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should not be preceded by a protocol. For example, `http://`.
 
 1. Enable the Dev Portal for a workspace:
 
@@ -49,7 +49,7 @@ configuration file ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong
    portal = on
    ```
 
-   {{site.base_gateway}} must be **restarted** for this value to take effect.
+   Restart {{site.base_gateway}} for this value to take effect:
 
    ```
    kong reload

--- a/src/gateway/kong-enterprise/dev-portal/enable.md
+++ b/src/gateway/kong-enterprise/dev-portal/enable.md
@@ -8,6 +8,12 @@ or hybrid mode), you can use the Dev Portal.
 
 Dev Portals are tied to workspaces. Each workspace has a separate Dev Portal instance.
 
+Enabling the Dev Portal exposes the following URLs:
+* The workspace's Dev Portal URL.
+For example, for the `default` workspace, the URL is: `http://localhost:8003/default`.
+* Dev Portal files endpoint: `http://localhost:8001/files`
+* Public Dev Portal files API: `http://localhost:8004/files`
+
 To enable the Dev Portal, you must first [deploy a license](/gateway/{{page.kong_version}}/licenses/deploy).
 
 {% navtabs %}
@@ -84,8 +90,3 @@ curl -i -X PATCH http://localhost:8001/workspaces/default \
 {% endnavtab %}
 {% endnavtabs %}
 
-Enabling the Dev Portal exposes the following URLs:
-* The workspace's Dev Portal URL.
-For example, for the `default` workspace, the URL is: `http://localhost:8003/default`.
-* Dev Portal files endpoint: `http://localhost:8001/files`
-* Public Dev Portal files API: `http://localhost:8004/files`

--- a/src/gateway/kong-enterprise/dev-portal/enable.md
+++ b/src/gateway/kong-enterprise/dev-portal/enable.md
@@ -61,9 +61,11 @@ configuration file ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong
 {% navtabs %}
 {% navtab Kong Manager %}
 
+<!-- vale off -->
 1. Navigate to a workspace in Kong Manager.
 2. In the **Dev Portal** menu section, click **Overview**.
 3. Click the button to **Enable Developer Portal**.
+<!-- vale on -->
 
 {% endnavtab %}
 {% navtab Admin API %}

--- a/src/gateway/kong-enterprise/dev-portal/enable.md
+++ b/src/gateway/kong-enterprise/dev-portal/enable.md
@@ -1,62 +1,87 @@
 ---
-title: How To Enable the Dev Portal
+title: Enable the Dev Portal
 badge: enterprise
 ---
 
-Enable Dev Portal in the Kong Configuration or within a Docker container for Docker installations.
+If you're running {{site.base_gateway}} with a database (either in traditional
+or hybrid mode), you can use the Dev Portal.
 
-## Enable Dev Portal in the Kong Configuration
+To enable the Dev Portal, you must first [deploy a license](/gateway/{{page.kong_version}}/licenses/deploy).
 
-1. To enable the Dev Portal, the following properties must be set in the Kong
-configuration file (`kong.conf`):
+{% navtabs %}
+{% navtab Docker %}
 
-   ```bash
+1. In your Docker container, set the Portal URL and set `KONG_PORTAL` to `on`:
+
+    ```sh
+    echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=on kong reload exit" \
+      | docker exec -i kong-container-name /bin/sh
+    ```
+
+    Replace `kong-container-name` with your {{site.base_gateway}} container.
+
+    {:.note}
+    > The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should not be preceded by a protocol, for example, `http://`.
+
+1. Execute the following command:
+
+    ```sh
+    curl -i -X PATCH http://localhost:8001/workspaces/default \
+      --data "config.portal=true"
+    ```
+
+1. Access the Dev Portal for the default workspace using the URL specified
+in the `KONG_PORTAL_GUI_HOST` variable:
+
+    ```sh
+    http://localhost:8003/default
+    ```
+
+{% endnavtab %}
+{% navtab Linux (kong.conf) %}
+
+1. To enable the Dev Portal, the following property must be set in the Kong
+configuration file ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)):
+
+   ```
    portal = on
    ```
 
    {{site.base_gateway}} must be **restarted** for this value to take effect.
 
-2. Enable the default Workspace Dev Portal via Kong Manager:
-
-   1. Navigate to the default Workspace in Kong Manager
-   2. Click the **Settings** link under **Dev Portal**
-   3. Toggle the **Dev Portal Switch**
-
-   It may take a few seconds for the Settings page to populate.
-
-   To enable the default Workspace's Dev portal via the command line:
-
-   ```bash
-   curl -X PATCH http://localhost:8001/workspaces/default   --data "config.portal=true"
+   ```
+   kong reload
    ```
 
-   - This will expose the **default Dev Portal** at [http://localhost:8003/default](http://localhost:8003/default)
-   - The **Dev Portal Files endpoint** can be accessed at `:8001/files`
-   - The **Public Dev Portal Files API** can be accessed at `:8004/files`
+1. Enable Dev Portal for the `default` workspace using one of the following methods:
 
-## Enable Dev Portal with Docker installation
+{% capture enable-portal %}
+{% navtabs %}
+{% navtab Kong Manager %}
 
-{:.note}
-> This feature is only available with a [{{site.konnect_product_name}} Enterprise](/gateway/{{page.kong_version}}/licenses) subscription.
+1. Navigate to the default workspace in Kong Manager.
+2. In the **Dev Portal** menu section, click **Overview**.
+3. Click the button to **Enable Developer Portal**.
 
-1. [Deploy a license](/gateway/{{page.kong_version}}/licenses/deploy).
+{% endnavtab %}
+{% navtab Admin API %}
 
-2. In your Docker container, set the Portal URL and set `KONG_PORTAL` to `on`:
+Enable the `default` workspace's Dev Portal via the command line using the following command:
 
-    ```plaintext
-    echo "KONG_PORTAL_GUI_HOST=localhost:8003 KONG_PORTAL=on kong reload exit" \
-      | docker exec -i kong /bin/sh
-    ```
+```bash
+curl -i -X PATCH http://localhost:8001/workspaces/default \
+  --data "config.portal=true"
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
 
-    {:.note}
-    > The `HOSTNAME` for `KONG_PORTAL_GUI_HOST` should not be preceded by a protocol, for example, `http://`.
+{{ enable-portal | indent | replace: " </code>", "</code>"}}
 
-3. Execute the following command:
+{% endnavtab %}
+{% endnavtabs %}
 
-    <pre><code>curl -X PATCH --url http://<div contenteditable="true">{HOSTNAME}</div>:8001/workspaces/default \
-        --data "config.portal=true"</code></pre>
-
-4. Access the Dev Portal for the default workspace using the URL specified
-in the `KONG_PORTAL_GUI_HOST` variable:
-
-    <pre><code>http://<div contenteditable="true">{HOSTNAME}</div>:8003/default</code></pre>
+Enabling the Dev Portal exposes the following URLs:
+* `default` workspace's Dev Portal: `http://localhost:8003/default`.
+* Dev Portal files endpoint: `http://localhost:8001/files`
+* Public Dev Portal files API: `http://localhost:8004/files`

--- a/src/gateway/kong-manager/enable.md
+++ b/src/gateway/kong-manager/enable.md
@@ -10,7 +10,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
 {% navtabs %}
 {% navtab Docker %}
 
-1. Set the [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) property in the `kong.conf` configuration file to the DNS, or IP address, of your system, then restart Kong for the setting to take effect. For example:
+1. Set the [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) property in the ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)) configuration file to the DNS, or IP address, of your system, then restart Kong for the setting to take effect. For example:
 
     ```bash
     echo "-e 'KONG_ADMIN_GUI_URL=http://localhost:8002' \

--- a/src/gateway/kong-manager/enable.md
+++ b/src/gateway/kong-manager/enable.md
@@ -10,7 +10,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
 {% navtabs %}
 {% navtab Docker %}
 
-1. Set the [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) property in the ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)) configuration file to the DNS, or IP address, of your system, then restart Kong for the setting to take effect. For example:
+1. Set the [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) property in the ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)) configuration file to the DNS or IP address of your system, then restart {{site.base_gateway}} for the setting to take effect. For example:
 
     ```bash
     echo "-e 'KONG_ADMIN_GUI_URL=http://localhost:8002' \


### PR DESCRIPTION
### Summary
Add links to kong.conf and clean up + validate Dev Portal set up instructions.

### Reason
Dev Portal on-prem setup instructions were very outdated; this has been on my to-do list for a bit.

https://konghq.atlassian.net/browse/DOCU-275 (papercut ticket, needed something to do while waiting at airport)

### Testing
Netlify