### PR TITLE
Remove version-index from pages in `src`

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -152,10 +152,10 @@ defaults:
       version-index: 2
 
   - scope:
-      path: "gateway/3.0.x/"
+      path: "gateway/2.8.x/"
     values:
       layout: "docs-v2"
-      version-index: 3
+      version-index: 2
 
   - scope:
       path: "about"

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -153,12 +153,6 @@ defaults:
       version-index: 2
 
   - scope:
-      path: "gateway/3.0.x/"
-    values:
-      layout: "docs-v2"
-      version-index: 3
-
-  - scope:
       path: "about"
     values:
       layout: "about"

--- a/src/gateway/install/docker/build-custom-images.md
+++ b/src/gateway/install/docker/build-custom-images.md
@@ -12,7 +12,7 @@ If you would like to build your own images to further customise the base image a
 
 1. Download the [docker-entrypoint.sh](https://raw.githubusercontent.com/Kong/docker-kong/master/docker-entrypoint.sh) script from `docker-kong` and make it executable with `chmod +x docker-entrypoint.sh`
 
-1. Download the [.deb]({{ site.links.download }}/gateway-3.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{ page.kong_versions[page.version-index].ee-version }}_amd64.deb), [.rpm]({{ site.links.download }}/gateway-3.x-rhel-8/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel8.amd64.rpm) or .apk ([amd64]({{ site.links.download }}/gateway-3.x-alpine/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.amd64.apk.tar.gz), [arm64]({{ site.links.download }}/gateway-3.x-alpine/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.arm64.apk.tar.gz)) as required
+1. Download the [.deb]({{ site.links.download }}/gateway-3.x-ubuntu-focal/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb), [.rpm]({{ site.links.download }}/gateway-3.x-rhel-8/Packages/k/kong-enterprise-edition-{{page.versions.ee}}.rhel8.amd64.rpm) or .apk ([amd64]({{ site.links.download }}/gateway-3.x-alpine/kong-enterprise-edition-{{page.versions.ee}}.amd64.apk.tar.gz), [arm64]({{ site.links.download }}/gateway-3.x-alpine/kong-enterprise-edition-{{page.versions.ee}}.arm64.apk.tar.gz)) as required
 
 1. Create a `Dockerfile` with the following contents:
 

--- a/src/gateway/install/docker/index.md
+++ b/src/gateway/install/docker/index.md
@@ -85,7 +85,7 @@ docker run --rm --network=kong-net \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
  -e "KONG_PASSWORD=test" \
-kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}} kong migrations bootstrap
+kong/kong-gateway:{{page.versions.ee}} kong migrations bootstrap
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -94,7 +94,7 @@ docker run --rm --network=kong-net \
  -e "KONG_DATABASE=postgres" \
  -e "KONG_PG_HOST=kong-database" \
  -e "KONG_PG_PASSWORD=kongpass" \
-kong:{{page.kong_versions[page.version-index].ce-version}} kong migrations bootstrap
+kong:{{page.versions.ce}} kong migrations bootstrap
 ```
 <!-- vale off -->
 {% endnavtab %}
@@ -163,7 +163,7 @@ docker run -d --name kong-gateway \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}
+ kong/kong-gateway:{{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -183,7 +183,7 @@ docker run -d --name kong-gateway \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:{{page.kong_versions[page.version-index].ce-version}}
+ kong:{{page.versions.ce}}
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -351,7 +351,7 @@ docker run -d --name kong-dbless \
  -p 8445:8445 \
  -p 8003:8003 \
  -p 8004:8004 \
- kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}
+ kong/kong-gateway:{{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -370,7 +370,7 @@ docker run -d --name kong-dbless \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
  -p 127.0.0.1:8444:8444 \
- kong:{{page.kong_versions[page.version-index].ce-version}}
+ kong:{{page.versions.ce}}
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/src/gateway/install/linux/amazon-linux.md
+++ b/src/gateway/install/linux/amazon-linux.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on Amazon Linux from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.aws.amd64.rpm "{{ site.links.download }}/gateway-3.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.aws.amd64.rpm"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.aws.amd64.rpm "{{ site.links.download }}/gateway-3.x-amazonlinux-2/Packages/k/kong-enterprise-edition-{{page.versions.ee}}.aws.amd64.rpm"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm "{{ site.links.download }}/gateway-3.x-amazonlinux-2/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm"
+curl -Lo kong-{{page.versions.ce}}.aws.amd64.rpm "{{ site.links.download }}/gateway-3.x-amazonlinux-2/Packages/k/kong-{{page.versions.ce}}.aws.amd64.rpm"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -46,12 +46,12 @@ curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rp
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.aws.amd64.rpm
+sudo yum install kong-enterprise-edition-{{page.versions.ee}}.aws.amd64.rpm
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.aws.amd64.rpm
+sudo yum install kong-{{page.versions.ce}}.aws.amd64.rpm
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -75,12 +75,12 @@ Install the YUM repository from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
+sudo yum install kong-enterprise-edition-{{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}
+sudo yum install kong-{{page.versions.ce}}
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/src/gateway/install/linux/centos.md
+++ b/src/gateway/install/linux/centos.md
@@ -36,13 +36,13 @@ Install {{site.base_gateway}} on CentOS from the command line.
 1. Download the Kong package:
 
     ```bash
-    curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-3.x-centos-%{centos_ver}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.el%{centos_ver}.amd64.rpm")
+    curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-3.x-centos-%{centos_ver}/Packages/k/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.amd64.rpm")
     ```
 
 2. Install the package:
 
     ```bash
-    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+    sudo yum install kong-enterprise-edition-{{page.versions.ee}}.rpm
     ```
 
 {% endnavtab %}
@@ -58,7 +58,7 @@ Install the YUM repository from the command line.
 2. Install Kong:
 
     ```bash
-    sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
+    sudo yum install kong-enterprise-edition-{{page.versions.ee}}
     ```
 
 {% endnavtab %}

--- a/src/gateway/install/linux/debian.md
+++ b/src/gateway/install/linux/debian.md
@@ -31,12 +31,12 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-3.x-debian-$(lsb_release -cs)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.download }}/gateway-3.x-debian-$(lsb_release -cs)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-3.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.download }}/gateway-3.x-debian-$(lsb_release -cs)/pool/all/k/kong/kong_{{page.versions.ce}}_amd64.deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -50,12 +50,12 @@ curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
+sudo dpkg -i kong-enterprise-edition-{{page.versions.ee}}.all.deb
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
+sudo dpkg -i kong-{{page.versions.ce}}.amd64.deb
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -94,12 +94,12 @@ Install the APT repository from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-apt install -y kong-enterprise-edition={{page.kong_versions[page.version-index].ee-version}}
+apt install -y kong-enterprise-edition={{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
+apt install -y kong={{page.versions.ce}}
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/src/gateway/install/linux/rhel.md
+++ b/src/gateway/install/linux/rhel.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on RHEL from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-3.x-rhel-%{rhel}/Packages/k/kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rhel%{rhel}.amd64.rpm")
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-3.x-rhel-%{rhel}/Packages/k/kong-enterprise-edition-{{page.versions.ee}}.rhel%{rhel}.amd64.rpm")
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-3.x-rhel-%{rhel}/Packages/k/kong-{{page.kong_versions[page.version-index].ce-version}}.rhel%{rhel}.amd64.rpm")
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval "{{ site.links.download }}/gateway-3.x-rhel-%{rhel}/Packages/k/kong-{{page.versions.ce}}.rhel%{rhel}.amd64.rpm")
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -50,12 +50,12 @@ curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.rpm $(rpm --
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.rpm
+sudo yum install kong-enterprise-edition-{{page.versions.ee}}.rpm
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
+sudo yum install kong-{{page.versions.ce}}.rpm
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -66,7 +66,7 @@ sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
 > The `rpm` method is only available for open-source packages. For the `kong-enterprise-edition` package, use `yum`.
 
 ```bash
-rpm -iv kong-{{page.kong_versions[page.version-index].ce-version}}.rpm
+rpm -iv kong-{{page.versions.ce}}.rpm
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -91,12 +91,12 @@ Install the YUM repository from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo yum install kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}
+sudo yum install kong-enterprise-edition-{{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo yum install kong-{{page.kong_versions[page.version-index].ce-version}}
+sudo yum install kong-{{page.versions.ce}}
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/src/gateway/install/linux/ubuntu.md
+++ b/src/gateway/install/linux/ubuntu.md
@@ -34,12 +34,12 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.kong_versions[page.version-index].ee-version}}_amd64.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong/kong_{{page.kong_versions[page.version-index].ce-version}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong/kong_{{page.versions.ce}}_amd64.deb"
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -53,12 +53,12 @@ curl -Lo kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb "{
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo dpkg -i kong-enterprise-edition-{{page.kong_versions[page.version-index].ee-version}}.all.deb
+sudo dpkg -i kong-enterprise-edition-{{page.versions.ee}}.all.deb
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo dpkg -i kong-{{page.kong_versions[page.version-index].ce-version}}.amd64.deb
+sudo dpkg -i kong-{{page.versions.ce}}.amd64.deb
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -99,12 +99,12 @@ Install the APT repository from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo apt install -y kong-enterprise-edition={{page.kong_versions[page.version-index].ee-version}}
+sudo apt install -y kong-enterprise-edition={{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-apt install -y kong={{page.kong_versions[page.version-index].ce-version}}
+apt install -y kong={{page.versions.ce}}
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -27,7 +27,7 @@ will work for the purposes of this guide.
 1. Pull the following Docker image.
 
     ```bash
-    docker pull kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+    docker pull kong/kong-gateway:{{page.versions.ee}}-alpine
     ```
 
     {:.important}
@@ -41,7 +41,7 @@ will work for the purposes of this guide.
 1. Tag the image.
 
     ```bash
-    docker tag kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine kong-ee
+    docker tag kong/kong-gateway:{{page.versions.ee}}-alpine kong-ee
     ```
 
 

--- a/src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -405,7 +405,7 @@ docker run -d --name kong-dp --network=kong-net \
 -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
 --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
 -p 8000:8000 \
-kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+kong/kong-gateway:{{page.versions.ee}}-alpine
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -420,7 +420,7 @@ docker run -d --name kong-dp --network=kong-net \
 -e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/cluster.key" \
 --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
 -p 8000:8000 \
-kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+kong:{{page.versions.ce}}-alpine
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -446,7 +446,7 @@ docker run -d --name kong-dp --network=kong-net \
 -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
 --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
 -p 8000:8000 \
-kong/kong-gateway:{{page.kong_versions[page.version-index].ee-version}}-alpine
+kong/kong-gateway:{{page.versions.ee}}-alpine
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -464,7 +464,7 @@ docker run -d --name kong-dp --network=kong-net \
 -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
 --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
 -p 8000:8000 \
-kong:{{page.kong_versions[page.version-index].ce-version}}-alpine
+kong:{{page.versions.ce}}-alpine
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Summary
Remove `version-index` from single sourced content and replace it with `page.versions.ce` and `page.versions.ee`

### Reason
We don't need it any more. It was error-prone and we forget to update it

### Testing
Spot check changed pages

I grepped for any usage and they've all been removed:

```
$ fgrep -r "version-index" src
```