### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ Trello card, etc. -->
 
 <!--
 
+!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!
+
 When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:
 
     review:copyedit: Request for writer review.


### PR DESCRIPTION
### Summary
Add a note that only Kong employees can add labels

### Reason
OSS contributors are getting confused that they can't add labels

### Testing
