### PR TITLE
Make root-user-note.md shown in important section

### DIFF
--- a/app/_includes/md/gateway/root-user-note.md
+++ b/app/_includes/md/gateway/root-user-note.md
@@ -6,8 +6,8 @@ and Seed Super Admin.
 -->
 
 {% if_version lte:2.8.x %}
-{:.note}
-> **Note:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
+{:.important}
+> **Important:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see
@@ -15,7 +15,7 @@ For more information, see
 
 {% endif_version %}
 {% if_version gte:3.0.x %}
-> **Note:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
+> **Important:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see


### PR DESCRIPTION
### Summary
Highlight the root-user-note section in "important"

### Reason
https://konghq.atlassian.net/browse/FTI-4351
We have discovered potential users skip/ignore the section 
Highlighting this section might help with this issue

### Testing
review the section and verify it's shown in "Important" instead of "Note"

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
