### PR TITLE
Add missing .important class in non-root user content

### DIFF
--- a/app/_includes/md/gateway/root-user-note.md
+++ b/app/_includes/md/gateway/root-user-note.md
@@ -5,20 +5,17 @@ Included in the setup.md include located in this folder - in two sections - Usin
 and Seed Super Admin.
 -->
 
-{% if_version lte:2.8.x %}
 {:.important}
 > **Important:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
+
+{% if_version lte:2.8.x %}
 For more information, see
 [Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/plan-and-deploy/kong-user).
 
 {% endif_version %}
 {% if_version gte:3.0.x %}
-{:.important}
-> **Important:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
-run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
-to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.
 For more information, see
 [Running Kong as a Non-Root User](/gateway/{{include.kong_version}}/production/running-kong/kong-user).
 {% endif_version %}

--- a/app/_includes/md/gateway/root-user-note.md
+++ b/app/_includes/md/gateway/root-user-note.md
@@ -15,6 +15,7 @@ For more information, see
 
 {% endif_version %}
 {% if_version gte:3.0.x %}
+{:.important}
 > **Important:** When you start {{site.base_gateway}}, the NGINX master process runs as `root`, and the worker processes
 run as `kong` by default. If this is not the desired behavior, you can switch the NGINX master process
 to run on the built-in `kong` user or to a custom non-root user before starting {{site.base_gateway}}.


### PR DESCRIPTION
### Summary
Followup to #4618 

cc @Guaris 

### Reason
There was a missing class, which meant that the blockquote is not being styled correctly
