### PR TITLE
Correct limit_by service for rate-limiting plugin

### DIFF
--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -65,14 +65,14 @@ params:
       default: '`consumer`'
       datatype: string
       description: |
-        The entity that is used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, and `path`.
+        The entity that is used when aggregating the limits. Available values are:
+        - `consumer`
+        - `credential`
+        - `ip`
+        - `service` (The `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.)
+        - `header` (The `header_name` configuration must be provided.)
+        - `path` (The `path` configuration must be provided.)
         If the entity value for aggregating the limits cannot be determined, the system falls back to `ip`.
-        
-        If the `service` value is chosen, the `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.
-        
-        If the `header` value is chosen, the `header_name` configuration must be provided.
-        
-        If the `path` value is chosen, the `path` configuration must be provided.
     - name: header_name
       required: semi
       datatype: string

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -65,11 +65,7 @@ params:
       default: '`consumer`'
       datatype: string
       description: |
-        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`. If the value for the entity chosen to aggregate the limit cannot be determined, the system will always fallback to `ip`. If value `service` is chosen, the `service_id` configuration must be provided. If value `header` is chosen, the `header_name` configuration must be provided. If value `path` is chosen, the `path` configuration must be provided.
-    - name: service_id
-      required: semi
-      datatype: string
-      description: The service id to be used if `limit_by` is set to `service`.
+        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`. If the value for the entity chosen to aggregate the limit cannot be determined, the system will always fallback to `ip`. If value `service` is chosen, the `service.id` or `service.name` configuration must be provided if adding the plugin to a service through the top-level `/plugins` endpoint. If value `header` is chosen, the `header_name` configuration must be provided. If value `path` is chosen, the `path` configuration must be provided.
     - name: header_name
       required: semi
       datatype: string

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -65,7 +65,14 @@ params:
       default: '`consumer`'
       datatype: string
       description: |
-        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`. If the value for the entity chosen to aggregate the limit cannot be determined, the system will always fallback to `ip`. If value `service` is chosen, the `service.id` or `service.name` configuration must be provided if adding the plugin to a service through the top-level `/plugins` endpoint. If value `header` is chosen, the `header_name` configuration must be provided. If value `path` is chosen, the `path` configuration must be provided.
+        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`.
+        If the value for the entity chosen to aggregate the limit cannot be determined, the system will always fallback to `ip`.
+        
+        If value `service` is chosen, the `service.id` or `service.name` configuration must be provided if adding the plugin to a service through the top-level `/plugins` endpoint.
+        
+        If value `header` is chosen, the `header_name` configuration must be provided.
+        
+        If value `path` is chosen, the `path` configuration must be provided.
     - name: header_name
       required: semi
       datatype: string

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -72,6 +72,7 @@ params:
         - `service` (The `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.)
         - `header` (The `header_name` configuration must be provided.)
         - `path` (The `path` configuration must be provided.)
+        
         If the entity value for aggregating the limits cannot be determined, the system falls back to `ip`.
     - name: header_name
       required: semi

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -65,14 +65,14 @@ params:
       default: '`consumer`'
       datatype: string
       description: |
-        The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, `path`.
-        If the value for the entity chosen to aggregate the limit cannot be determined, the system will always fallback to `ip`.
+        The entity that is used when aggregating the limits: `consumer`, `credential`, `ip`, `service`, `header`, and `path`.
+        If the entity value for aggregating the limits cannot be determined, the system falls back to `ip`.
         
-        If value `service` is chosen, the `service.id` or `service.name` configuration must be provided if adding the plugin to a service through the top-level `/plugins` endpoint.
+        If the `service` value is chosen, the `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.
         
-        If value `header` is chosen, the `header_name` configuration must be provided.
+        If the `header` value is chosen, the `header_name` configuration must be provided.
         
-        If value `path` is chosen, the `path` configuration must be provided.
+        If the `path` value is chosen, the `path` configuration must be provided.
     - name: header_name
       required: semi
       datatype: string


### PR DESCRIPTION
### Summary
The description for the rate-limiting plugin's `limit_by` parameter was incorrect.
Limiting by service does not use a (non-existent) config.service_id parameter, but instead uses the service.id the plugin is configured against.

### Reason
https://github.com/Kong/docs.konghq.com/issues/4580

### Testing
Tested behavior on local Kong 3.0 instance. The config.service_id parameter is invalid, and results in an error:
```json
{
    "fields": {
        "config": {
            "service_id": "unknown field"
        }
    },
    "name": "schema violation",
    "code": 2,
    "message": "schema violation (config.service_id: unknown field)"
}
```

Benjamin Bertow <benjamin.bertow@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
