### PR TITLE
kic: add Gateway API mention in KIC's architecture design overview

### DIFF
--- a/src/kubernetes-ingress-controller/concepts/design.md
+++ b/src/kubernetes-ingress-controller/concepts/design.md
@@ -4,8 +4,8 @@ title: Kubernetes Ingress Controller Design
 
 ## Overview
 
-The {{site.kic_product_name}} configures Kong
-using Ingress resources created inside a Kubernetes cluster.
+The {{site.kic_product_name}} configures Kong using Ingress
+or [Gateway API][gateway-api] resources created inside a Kubernetes cluster.
 
 The {{site.kic_product_name}} is made up of two high level components:
 
@@ -29,25 +29,29 @@ Kong is updated dynamically to respond to changes around scaling,
 configuration changes, failures that are happening inside a Kubernetes
 cluster.
 
+---
+
+For more information on how Kong works with Routes, Services, and Upstreams,
+please see the [Proxy](/gateway/latest/reference/proxy/)
+and [Load balancing](/gateway/latest/how-kong-works/load-balancing/) references.
+
 ## Translation
 
-Kubernetes resources are mapped to Kong resources to correctly
-proxy all the traffic.
+Kubernetes resources are mapped to Kong resources to correctly proxy all the traffic.
 
-The following figure describes the mapping between Kubernetes concepts
-to Kong's configuration:
+There exist 2 flavors of objects in Kubernetes that can be used with
+{{site.kic_product_name}} in order to procure a working {{site.base_gateway}}.
 
-![translating Kubernetes to Kong](/assets/images/docs/kubernetes-ingress-controller/k8s-to-kong.png "Translating k8s resources to Kong")
+- an [Ingress][ingress]
+- [Gateway API objects][gateway-api]
 
-Let's go through how Kubernetes resources are being mapped to Kong's
-configuration:
+### Generic Kubernetes resources
 
-- An [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-  resource in Kubernetes defines a set of rules for proxying
-  traffic. These rules corresponds to the concept of Route in Kong.
-- A [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
-  inside Kubernetes is a way to abstract an application that is
-  running on a set of pods.
+In Kubernetes there are several main concepts which we use to logically identify
+workloads and route traffic between/to them. Some of them are:
+
+- A [Service][k8s-service] inside Kubernetes is a way to abstract an application
+  that is running on a set of pods.
   This maps to two objects in Kong: Service and Upstream.
   The service object in Kong holds the information on the protocol
   to use to talk to the upstream service and various other protocol
@@ -59,6 +63,39 @@ configuration:
   This means that all requests flowing through Kong are not directed via
   kube-proxy but directly to the pod.
 
-For more information on how Kong works with Routes, Services, and Upstreams,
-please see the [Proxy](/gateway/latest/reference/proxy/)
-and [Load balancing](/gateway/latest/how-kong-works/load-balancing/) references.
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service/
+
+### Ingress
+
+An [Ingress][ingress] resource in Kubernetes defines a set of rules for proxying
+traffic. These rules corresponds to the concept of Route in Kong.
+
+The following figure describes the mapping between Kubernetes concepts and Kong's
+configuration, while using `Ingress`:
+
+![translating Kubernetes to Kong](/assets/images/docs/kubernetes-ingress-controller/k8s-to-kong.png "Translating k8s resources to Kong")
+
+### Gateway API
+
+Gateway API resources can also be used to produce running instances
+and configurations for {{site.base_gateway}}.
+
+The main concepts here are:
+
+- A [`Gateway`][gateway-api-gateway] resource in Kubernetes describes how traffic
+  can be translated to Services within the cluster.
+- A [`GatewayClass`][gateway-api-gatewayclass] defines a set of Gateways that share
+  a common configuration and behaviour.
+  Each `GatewayClass` will be handled by a single controller, although controllers
+  may handle more than one `GatewayClass`.
+- [`HTTPRoute`][gateway-api-httproute] can be attached to a Gateway which will
+  configure the HTTP routing behavior.
+  
+You can find more details about Gateway API concepts supported by {{site.kic_product_name}}
+in [here](/kubernetes-ingress-controller/latest/references/gateway-api-support).
+
+[gateway-api]: https://gateway-api.sigs.k8s.io/
+[gateway-api-gateway]: https://gateway-api.sigs.k8s.io/concepts/api-overview/#gateway
+[gateway-api-gatewayclass]: https://gateway-api.sigs.k8s.io/concepts/api-overview/#gatewayclass
+[gateway-api-httproute]: https://gateway-api.sigs.k8s.io/concepts/api-overview/#httproute
+[ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/src/kubernetes-ingress-controller/concepts/design.md
+++ b/src/kubernetes-ingress-controller/concepts/design.md
@@ -4,7 +4,7 @@ title: Kubernetes Ingress Controller Design
 
 ## Overview
 
-The {{site.kic_product_name}} configures Kong using Ingress
+The {{site.kic_product_name}} configures {{site.base_gateway}} using Ingress
 or [Gateway API][gateway-api] resources created inside a Kubernetes cluster.
 
 The {{site.kic_product_name}} is made up of two high level components:
@@ -31,13 +31,13 @@ cluster.
 
 ---
 
-For more information on how Kong works with Routes, Services, and Upstreams,
-please see the [Proxy](/gateway/latest/reference/proxy/)
-and [Load balancing](/gateway/latest/how-kong-works/load-balancing/) references.
+For more information on how Kong works with routes, services, and upstreams,
+please see the [proxy](/gateway/latest/reference/proxy/)
+and [load balancing](/gateway/latest/how-kong-works/load-balancing/) references.
 
 ## Translation
 
-Kubernetes resources are mapped to Kong resources to correctly proxy all the traffic.
+Kubernetes resources are mapped to Kong resources to proxy traffic.
 
 There exist 2 flavors of objects in Kubernetes that can be used with
 {{site.kic_product_name}} in order to procure a working {{site.base_gateway}}.
@@ -47,11 +47,10 @@ There exist 2 flavors of objects in Kubernetes that can be used with
 
 ### Generic Kubernetes resources
 
-In Kubernetes there are several main concepts which we use to logically identify
-workloads and route traffic between/to them. Some of them are:
+In Kubernetes, there are several main concepts that are use to logically identify
+workloads and route traffic between them. Some of them are:
 
-- A [Service][k8s-service] inside Kubernetes is a way to abstract an application
-  that is running on a set of pods.
+- A [Service][k8s-service] inside Kubernetes is a way to abstract an application that is running on a set of pods.
   This maps to two objects in Kong: Service and Upstream.
   The service object in Kong holds the information on the protocol
   to use to talk to the upstream service and various other protocol
@@ -67,11 +66,11 @@ workloads and route traffic between/to them. Some of them are:
 
 ### Ingress
 
-An [Ingress][ingress] resource in Kubernetes defines a set of rules for proxying
-traffic. These rules corresponds to the concept of Route in Kong.
+An [Ingress][ingress] resource in Kubernetes defines a set of rules for proxying traffic.
+These rules correspond to the concept of a route in Kong.
 
-The following figure describes the mapping between Kubernetes concepts and Kong's
-configuration, while using `Ingress`:
+The following image describes the relationship between Kubernetes concepts and Kong's
+`Ingress` configuration.
 
 ![translating Kubernetes to Kong](/assets/images/docs/kubernetes-ingress-controller/k8s-to-kong.png "Translating k8s resources to Kong")
 
@@ -83,7 +82,7 @@ and configurations for {{site.base_gateway}}.
 The main concepts here are:
 
 - A [`Gateway`][gateway-api-gateway] resource in Kubernetes describes how traffic
-  can be translated to Services within the cluster.
+  can be translated to services within the cluster.
 - A [`GatewayClass`][gateway-api-gatewayclass] defines a set of Gateways that share
   a common configuration and behaviour.
   Each `GatewayClass` will be handled by a single controller, although controllers
@@ -92,7 +91,7 @@ The main concepts here are:
   configure the HTTP routing behavior.
   
 You can find more details about Gateway API concepts supported by {{site.kic_product_name}}
-in [here](/kubernetes-ingress-controller/latest/references/gateway-api-support).
+[here](/kubernetes-ingress-controller/latest/references/gateway-api-support).
 
 [gateway-api]: https://gateway-api.sigs.k8s.io/
 [gateway-api-gateway]: https://gateway-api.sigs.k8s.io/concepts/api-overview/#gateway

--- a/src/kubernetes-ingress-controller/concepts/gateway-api.md
+++ b/src/kubernetes-ingress-controller/concepts/gateway-api.md
@@ -87,8 +87,9 @@ and matching Kong `proxy_listen` configuration in the container environment:
 KONG_PROXY_LISTEN="0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384 http2"
 KONG_STREAM_LISTEN="0.0.0.0:9901 reuseport backlog=16384, 0.0.0.0:9902 reuseport backlog=16384 udp", 0.0.0.0:9903 reuseport backlog=16384 ssl"
 ```
-The Helm chart manages both of these for you from the `proxy` configuration
-block:
+
+[The Helm chart](https://github.com/Kong/charts/tree/main/charts/kong) manages
+both of these for you from the `proxy` configuration block:
 
 ```
 proxy:
@@ -115,6 +116,7 @@ proxy:
       parameters:
         - "ssl"
 ```
+
 Ports missing appropriate Kong-side configuration will result in an error
 condition in the Gateway's status:
 

--- a/src/kubernetes-ingress-controller/concepts/gateway-api.md
+++ b/src/kubernetes-ingress-controller/concepts/gateway-api.md
@@ -89,7 +89,7 @@ KONG_STREAM_LISTEN="0.0.0.0:9901 reuseport backlog=16384, 0.0.0.0:9902 reuseport
 ```
 
 [The Helm chart](https://github.com/Kong/charts/tree/main/charts/kong) manages
-both of these for you from the `proxy` configuration block:
+both of these from the `proxy` configuration block:
 
 ```
 proxy:

--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -37,7 +37,6 @@ Currently, the {{site.kic_product_name}}'s implementation of the Gateway API sup
 - [`ReferenceGrant`](/kubernetes-ingress-controller/{{page.kong_version}}/references/gateway-api-support/#referencegrants)
 {% endif_version %}
 
-
 ## Enable the feature
 
 The Gateway API CRDs are not yet available by default in Kubernetes. You must
@@ -327,9 +326,14 @@ Hostname: echo-758859bbfb-cnfmx
 ...
 ```
 
+{% if_version lte: 2.5.x %}
 ## Alpha limitations
+{% endif_version %}
+{% if_version gte: 2.6.x %}
+## Beta limitations
+{% endif_version %}
 
-The KIC Gateway API alpha is a work in progress, and not all features of
+{{site.kic_product_name}} Gateway API support is a work in progress, and not all features of
 Gateway APIs are supported. In particular:
 
 {% if_version lte: 2.3.x %}

--- a/src/kubernetes-ingress-controller/references/gateway-api-support.md
+++ b/src/kubernetes-ingress-controller/references/gateway-api-support.md
@@ -22,6 +22,7 @@ The {{site.kic_product_name}} supports the following resources and features in t
 ## Gateways and GatewayClasses
 
 ### Supported Versions
+
 {% if_version gte: 2.6.x %}
 - `v1beta1`
 {% endif_version %}
@@ -31,11 +32,10 @@ The {{site.kic_product_name}} supports the following resources and features in t
 
 ## HTTP Routes
 
-{{site.kic_product_name}}'s implementation of `HTTPRoute` supports multiple `BackendRefs` with a 
-round-robin load-balancing strategy applied by default across the 
-`Endpoints` or the `Services`. `BackendRefs` weights are now supported 
-to allow you to fine-tune the load-balancing between those backend 
-services.
+{{site.kic_product_name}}'s implementation of `HTTPRoute` supports multiple `BackendRefs` with a
+round-robin load-balancing strategy applied by default across the
+`Endpoints` or the `Services`. `BackendRefs` weights are now supported
+to allow you to fine-tune the load-balancing between those backend services.
 
 ### Supported Versions
 
@@ -55,7 +55,7 @@ services.
 
 ## TCP Routes
 
-The {{site.kic_product_name}}'s implementation of `TCPRoute` supports multiple `BackendRefs` in 
+The {{site.kic_product_name}}'s implementation of `TCPRoute` supports multiple `BackendRefs` in
 `TCPRoute` resources for load balancing.
 
 ### Supported Versions
@@ -77,7 +77,7 @@ The {{site.kic_product_name}}'s implementation of `UDPRoute` supports multiple `
 {% if_version gte:2.6.x %}
 ## Reference Grants
 
-Kong implementation supports `ReferenceGrant` to allow routes to 
+Kong implementation supports `ReferenceGrant` to allow routes to
 reference backends in other namespaces in `BackendRefs`.
 
 ### Supported Versions
@@ -85,9 +85,9 @@ reference backends in other namespaces in `BackendRefs`.
 {% endif_version %}
 
 {% if_version gte:2.4.x lte:2.5.x %}
-## Reference Policies 
+## Reference Policies
 
-The {{site.kic_product_name}}'s implementation supports using `ReferencePolicy` to allow routes to 
+The {{site.kic_product_name}}'s implementation supports using `ReferencePolicy` to allow routes to
 reference backends in other namespaces in `BackendRefs`.
 
 ### Supported Versions


### PR DESCRIPTION
### Summary

This PR adds Gateway API concepts to KIC's design/architecture overview.

It also does some minor tweaks to the docs, as well as changing the section title in "Using Gateway API" from `Alpha` to `Beta` for KIC versions 2.6 and above.

### Reason

https://github.com/Kong/kubernetes-ingress-controller/issues/2968


