### PR TITLE
[FTI-4272] add escape_path to route-transformer-adv plugin

### DIFF
--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -16,6 +16,7 @@ daos
 datastore
 datastores
 endpoint_key
+escape_path
 foogineer
 if_version
 included_status_codes

--- a/app/_hub/kong-inc/route-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/_index.md
@@ -38,6 +38,12 @@ params:
       datatype: string
       description: |
         Updates the upstream request Port with given value/template. Note that the port as set may be overridden again by DNS resolution (in case of SRV records,or an Upstream) One of `config.path` or `config.host` or `config.port` must be specified.
+    - name: escape_path
+      required: false
+      datatype: boolean
+      dafault: false
+      description: |
+        If set to true, the path after being transformed will be escaped.
 ---
 
 _NOTE_: The advanced label is only attached because this is an Enterprise-only

--- a/app/_hub/kong-inc/route-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/_index.md
@@ -41,9 +41,10 @@ params:
     - name: escape_path
       required: false
       datatype: boolean
-      dafault: false
+      default: false
       description: |
-        If set to true, the path after being transformed will be escaped.
+        If set to true, the path is escaped after being transformed.
+      minimum_version: "3.1.0"
 ---
 
 _NOTE_: The advanced label is only attached because this is an Enterprise-only


### PR DESCRIPTION
### Summary
Add a new option escape_path to the route-transformer-adv plugin.
The new option will enable the ability to escape the path transformed.

Realted PR: https://github.com/Kong/kong-ee/pull/3760

### Reason
https://konghq.atlassian.net/browse/FTI-4272

### Testing


