### PR TITLE
fix(kong-manager): add how RBAC rules work in Kong section

### DIFF
--- a/app/gateway/2.6.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/index.md
@@ -33,11 +33,11 @@ the Admin assigned to the Role will not be able to see the related navigation li
 > Important: Although a default Admin has full permissions with every
 endpoint in Kong, only a Super Admin has the ability to assign and modify RBAC Permissions. An Admin is not able to modify their own Permissions or delimit a Super Admin's Permissions.
 
-### How RBAC rules work in Kong
+### How RBAC rules work in {{site.base_gateway}}
 
-Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for {{site.base_gateway}} to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
-Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+{{site.base_gateway}} uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request {{site.base_gateway}} checks for an RBAC rule assigned to the requesting user in the following order:
 
 * An allow or deny rule against the current endpoint in the current workspace
 
@@ -51,10 +51,10 @@ If {{site.base_gateway}} finds a matching rule for the current user, endpoint, a
 that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
 The default admin roles define permissions for any workspace is (`*`).
-Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+{{site.base_gateway}} stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
 other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
 as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
-Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+{{site.base_gateway}} allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.6.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/index.md
@@ -54,3 +54,30 @@ These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
 > assigned, roles in workspaces other than `default` take precedent. For example, a super admin assigned to the
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
+
+### How RBAC rules work in Kong
+
+Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+
+Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+
+* An allow or deny rule against the current endpoint in the current workspace
+
+* An allow or deny rule against the current endpoint in any workspace (`*`)
+
+* An allow or deny rule against any endpoint (`*`) in the current workspace
+
+* An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
+
+If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
+is found the request is denied.
+
+The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
+which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
+other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
+as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+
+Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.6.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/index.md
@@ -33,31 +33,9 @@ the Admin assigned to the Role will not be able to see the related navigation li
 > Important: Although a default Admin has full permissions with every
 endpoint in Kong, only a Super Admin has the ability to assign and modify RBAC Permissions. An Admin is not able to modify their own Permissions or delimit a Super Admin's Permissions.
 
-### RBAC in Workspaces
-
-RBAC Roles and Permissions will be specific to a Workspace if they are assigned
-from within one. For example, if there are two Workspaces, Payments and
-Deliveries, an Admin created in Payments will not have access to any
-endpoints in Deliveries.
-
-When a Super Admin creates a new Workspace, there are three default Roles that
-mirror the cluster-level Roles, and a fourth unique to each Workspace:
-`workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
-`workspace-portal-admin`.
-
-These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
-
-
-{:.important}
-> **Important:** Any role assigned in the `default` workspace has permissions to all subsequently created
-> workspaces unless roles in specific workspaces are explicitly assigned. When roles across multiple workspaces are
-> assigned, roles in workspaces other than `default` take precedent. For example, a super admin assigned to the
-> `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
-> and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
-
 ### How RBAC rules work in Kong
 
-Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
 Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
 
@@ -69,15 +47,14 @@ Kong uses a precedence model, from most specificity to least specificity, to det
 
 * An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
 
-If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
-the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
-is found the request is denied.
+If {{site.base_gateway}} finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
-The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
-which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+The default admin roles define permissions for any workspace is (`*`).
+Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
-other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
-as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
+as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
 Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.7.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.7.x/configure/auth/rbac/index.md
@@ -57,7 +57,7 @@ These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
 
 ### How RBAC rules work in Kong
 
-Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
 Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
 
@@ -69,15 +69,14 @@ Kong uses a precedence model, from most specificity to least specificity, to det
 
 * An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
 
-If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
-the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
-is found the request is denied.
+If {{site.base_gateway}} finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
-The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
-which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+The default admin roles define permissions for any workspace is (`*`).
+Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
-other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
-as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
+as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
 Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.7.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.7.x/configure/auth/rbac/index.md
@@ -54,3 +54,30 @@ These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
 > assigned, roles in workspaces other than `default` take precedent. For example, a super admin assigned to the
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
+
+### How RBAC rules work in Kong
+
+Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+
+Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+
+* An allow or deny rule against the current endpoint in the current workspace
+
+* An allow or deny rule against the current endpoint in any workspace (`*`)
+
+* An allow or deny rule against any endpoint (`*`) in the current workspace
+
+* An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
+
+If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
+is found the request is denied.
+
+The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
+which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
+other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
+as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+
+Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.7.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.7.x/configure/auth/rbac/index.md
@@ -55,11 +55,11 @@ These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
 
-### How RBAC rules work in Kong
+### How RBAC rules work in {{site.base_gateway}}
 
-Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for {{site.base_gateway}} to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
-Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+{{site.base_gateway}} uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request {{site.base_gateway}} checks for an RBAC rule assigned to the requesting user in the following order:
 
 * An allow or deny rule against the current endpoint in the current workspace
 
@@ -73,10 +73,10 @@ If {{site.base_gateway}} finds a matching rule for the current user, endpoint, a
 that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
 The default admin roles define permissions for any workspace is (`*`).
-Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+{{site.base_gateway}} stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
 other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
 as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
-Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+{{site.base_gateway}} allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.8.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.8.x/configure/auth/rbac/index.md
@@ -33,11 +33,11 @@ the Admin assigned to the Role will not be able to see the related navigation li
 > Important: Although a default Admin has full permissions with every
 endpoint in Kong, only a Super Admin has the ability to assign and modify RBAC Permissions. An Admin is not able to modify their own Permissions or delimit a Super Admin's Permissions.
 
-### How RBAC rules work in Kong
+### How RBAC rules work in {{site.base_gateway}}
 
-Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for {{site.base_gateway}} to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
-Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+{{site.base_gateway}} uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request {{site.base_gateway}} checks for an RBAC rule assigned to the requesting user in the following order:
 
 * An allow or deny rule against the current endpoint in the current workspace
 
@@ -51,10 +51,10 @@ If {{site.base_gateway}} finds a matching rule for the current user, endpoint, a
 that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
 The default admin roles define permissions for any workspace is (`*`).
-Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+{{site.base_gateway}} stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
 other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
 as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
-Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+{{site.base_gateway}} allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.8.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.8.x/configure/auth/rbac/index.md
@@ -54,3 +54,30 @@ These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
 > assigned, roles in workspaces other than `default` take precedent. For example, a super admin assigned to the
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
+
+### How RBAC rules work in Kong
+
+Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+
+Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+
+* An allow or deny rule against the current endpoint in the current workspace
+
+* An allow or deny rule against the current endpoint in any workspace (`*`)
+
+* An allow or deny rule against any endpoint (`*`) in the current workspace
+
+* An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
+
+If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
+is found the request is denied.
+
+The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
+which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
+other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
+as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+
+Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/app/gateway/2.8.x/configure/auth/rbac/index.md
+++ b/app/gateway/2.8.x/configure/auth/rbac/index.md
@@ -33,31 +33,9 @@ the Admin assigned to the Role will not be able to see the related navigation li
 > Important: Although a default Admin has full permissions with every
 endpoint in Kong, only a Super Admin has the ability to assign and modify RBAC Permissions. An Admin is not able to modify their own Permissions or delimit a Super Admin's Permissions.
 
-### RBAC in Workspaces
-
-RBAC Roles and Permissions will be specific to a Workspace if they are assigned
-from within one. For example, if there are two Workspaces, Payments and
-Deliveries, an Admin created in Payments will not have access to any
-endpoints in Deliveries.
-
-When a Super Admin creates a new Workspace, there are three default Roles that
-mirror the cluster-level Roles, and a fourth unique to each Workspace:
-`workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
-`workspace-portal-admin`.
-
-These roles can be viewed in the **Teams > Roles** tab in Kong Manager.
-
-
-{:.important}
-> **Important:** Any role assigned in the `default` workspace has permissions to all subsequently created
-> workspaces unless roles in specific workspaces are explicitly assigned. When roles across multiple workspaces are
-> assigned, roles in workspaces other than `default` take precedent. For example, a super admin assigned to the
-> `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
-> and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
-
 ### How RBAC rules work in Kong
 
-Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
 Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
 
@@ -69,15 +47,14 @@ Kong uses a precedence model, from most specificity to least specificity, to det
 
 * An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
 
-If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
-the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
-is found the request is denied.
+If {{site.base_gateway}} finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
-The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
-which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+The default admin roles define permissions for any workspace is (`*`).
+Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
-other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
-as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
+as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
 Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/src/gateway/kong-manager/auth/rbac/index.md
+++ b/src/gateway/kong-manager/auth/rbac/index.md
@@ -56,11 +56,11 @@ These roles can be viewed in the **Teams** > **Roles** tab in Kong Manager.
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
 
-### How RBAC rules work in Kong 2
+### How RBAC rules work in {{site.base_gateway}}
 
-Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for {{site.base_gateway}} to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
-Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+{{site.base_gateway}} uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request {{site.base_gateway}} checks for an RBAC rule assigned to the requesting user in the following order:
 
 * An allow or deny rule against the current endpoint in the current workspace
 
@@ -74,10 +74,10 @@ If {{site.base_gateway}} finds a matching rule for the current user, endpoint, a
 that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
 The default admin roles define permissions for any workspace is (`*`).
-Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+{{site.base_gateway}} stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
 other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
 as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
-Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+{{site.base_gateway}} allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/src/gateway/kong-manager/auth/rbac/index.md
+++ b/src/gateway/kong-manager/auth/rbac/index.md
@@ -54,3 +54,30 @@ These roles can be viewed in the **Teams** > **Roles** tab in Kong Manager.
 > assigned, roles in workspaces other than `default` take precedent. For example, a super admin assigned to the
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
+
+### How RBAC rules work in Kong
+
+Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+
+Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
+
+* An allow or deny rule against the current endpoint in the current workspace
+
+* An allow or deny rule against the current endpoint in any workspace (`*`)
+
+* An allow or deny rule against any endpoint (`*`) in the current workspace
+
+* An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
+
+If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
+is found the request is denied.
+
+The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
+which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
+other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
+as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+
+Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
+Meanwhile, a negative rule precedes other non-negative rules while following the above rules.

--- a/src/gateway/kong-manager/auth/rbac/index.md
+++ b/src/gateway/kong-manager/auth/rbac/index.md
@@ -1,6 +1,7 @@
 ---
 title: RBAC in Kong Manager
 badge: enterprise
+content_type: explanation
 ---
 
 In addition to authenticating admins and segmenting workspaces,
@@ -55,9 +56,9 @@ These roles can be viewed in the **Teams** > **Roles** tab in Kong Manager.
 > `super-admin` role in the `default` workspace as well as the `workspace-read-only` role in the `ws` workspace has RBAC permissions across all workspaces
 > and full permissions to endpoints in workspaces except the `ws` workspace. The admin only has read-only permissions to endpoints in the `ws` workspace.
 
-### How RBAC rules work in Kong
+### How RBAC rules work in Kong 2
 
-Although there are concepts like groups and roles in Kong, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
+Although there are concepts like groups and roles in {{site.base_gateway}}, when determining if a user has sufficient permissions to access the endpoint, combinations of workspace and endpoint are collected from roles and groups assigned to a user, being the minimal unit for Kong to check for permissions. These combinations will be referred to as “rules” in the following paragraphs.
 
 Kong uses a precedence model, from most specificity to least specificity, to determine if a user has access to an endpoint. For each request Kong checks for an RBAC rule assigned to the requesting user in the following order:
 
@@ -69,15 +70,14 @@ Kong uses a precedence model, from most specificity to least specificity, to det
 
 * An allow or deny rule against any endpoint (`*`) in any workspace (`*`)
 
-If Kong finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
-the rule. Kong does not continue checking for less specific rules, it stops on the first rule found. If no matching rule
-is found the request is denied.
+If {{site.base_gateway}} finds a matching rule for the current user, endpoint, and workspace it allows or denies the request according to
+that rule. Once {{site.base_gateway}} finds an applicable rule, it stops, and does not continue checking for less specific rules. If no rules are found, the request is denied. 
 
-The default admin roles define permissions to any workspace (`*`). Kong stops at the first role found in the list above,
-which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
+The default admin roles define permissions for any workspace is (`*`).
+Kong stops at the first role, which means any role assigned in the default workspace has permissions to all subsequently created workspaces unless roles
 in specific workspaces are explicitly assigned. When roles across multiple workspaces are assigned, roles in workspaces
-other than default take precedent. For example, a user assigned to the super-admin role in the default workspace as well
-as the workspace-read-only role in the ws workspace has full permissions to endpoints in workspaces except the ws workspace. However, the user only has read-only permissions to endpoints in the ws workspace.
+other than default take precedent. For example, a user assigned to the `super-admin` role in the default workspace as well
+as the `workspace-read-only` role in the `ws` workspace has full permissions to endpoints in all workspaces except the `ws` workspace. The user only has read-only permissions to endpoints in the `ws` workspace.
 
 Kong allows you to add negative rules to a role. A negative rule denies actions associated with the endpoint.
 Meanwhile, a negative rule precedes other non-negative rules while following the above rules.


### PR DESCRIPTION
### Summary

This pull request adds a _How RBAC rules work in Kong_ section for `2.6.x`, `2.7.x`, `2.8.x`, and `3.0.x`.

This clarifies how RBAC rules work in Kong and provides references for previously implicit concepts within the role-based access control.

[FTI-4295](https://konghq.atlassian.net/browse/FTI-4295) [FTI-2581](https://konghq.atlassian.net/browse/FTI-2581)
