### PR TITLE
add link to guides for using gateway api in gettingstarted page

### DIFF
--- a/src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/src/kubernetes-ingress-controller/guides/getting-started.md
@@ -314,4 +314,7 @@ HTTP requests with /bar -> Kong enforces rate-limit +   -> echo-server
 
 * To learn how to secure proxied routes, see the [ACL and JWT Plugins Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configure-acl-plugin/).
 * The [External Services Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-external-service/) explains how to proxy services outside of your Kubernetes cluster.
-
+{% if_version gte:2.6.x %}
+* [Gateway API](https://gateway-api.sigs.k8s.io/) is a set of resources for
+configuring networking in Kubernetes. Now the kubernetes ingress controller supports Gateway API by default. To learn how to use Gateway API supported by the kubernetes ingress controller, please refer to [this guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-gateway-api).
+{% endif_version %}

--- a/src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/src/kubernetes-ingress-controller/guides/getting-started.md
@@ -316,5 +316,5 @@ HTTP requests with /bar -> Kong enforces rate-limit +   -> echo-server
 * The [External Services Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-external-service/) explains how to proxy services outside of your Kubernetes cluster.
 {% if_version gte:2.6.x %}
 * [Gateway API](https://gateway-api.sigs.k8s.io/) is a set of resources for
-configuring networking in Kubernetes. Now the kubernetes ingress controller supports Gateway API by default. To learn how to use Gateway API supported by the kubernetes ingress controller, please refer to [this guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-gateway-api).
+configuring networking in Kubernetes. The Kubernetes Ingress Controller supports Gateway API by default. To learn how to use Gateway API supported by the Kubernetes Ingress Controller, see [Using Gateway API](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-gateway-api).
 {% endif_version %}


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Add a link to guide of using gateway API in getting started page of KIC. To make the docs of gateway API more visible.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

KIC has supported gateway API by default from 2.6.0. But we do not have a place on getting started page to guide users of KIC to use gateway API. So I added a link to the guide of gateway API at the bottom. fixes #4638.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

https://deploy-preview-4639--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/getting-started/

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
