### PR TITLE
[DOCU-2620] Deck Updates 

### DIFF
--- a/app/_data/docs_nav_deck_1.16.x.yml
+++ b/app/_data/docs_nav_deck_1.16.x.yml
@@ -1,0 +1,79 @@
+product: deck
+release: 1.16.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    url: /deck/1.16.x/
+    absolute_url: true
+    items:
+      - text: Terminology
+        url: /terminology
+      - text: Architecture
+        url: /design-architecture
+      - text: Compatibility Promise
+        url: /compatibility-promise
+
+  - title: Changelog
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: https://github.com/kong/deck/blob/main/CHANGELOG.md
+    absolute_url: true
+
+  - title: Installation
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    url: /installation
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Getting Started with decK
+        url: /guides/getting-started
+      - text: Backup and Restore
+        url: /guides/backup-restore
+      - text: Upgrade to Kong Gateway 3.x
+        url: /3.0-upgrade
+      - text: Configuration as Code and GitOps
+        url: /guides/ci-driven-configuration
+      - text: Distributed Configuration
+        url: /guides/distributed-configuration
+      - text: Best Practices
+        url: /guides/best-practices
+      - text: Using decK with Kong Gateway (Enterprise)
+        url: /guides/kong-enterprise
+      - text: Using decK with Konnect
+        url: /guides/konnect
+      - text: Using Multiple Files to Store Configuration
+        url: /guides/multi-file-state
+      - text: De-duplicate Plugin Configuration
+        url: /guides/deduplicate-plugin-configuration
+      - text: Set Up Object Defaults
+        url: /guides/defaults
+      - text: Using environment variables with decK
+        url: /guides/environment-variables
+
+  - title: decK CLI Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: /reference/deck
+    items:
+      - text: deck completion
+        url: /reference/deck_completion
+      - text: deck convert
+        url: /reference/deck_convert
+      - text: deck diff
+        url: /reference/deck_diff
+      - text: deck dump
+        url: /reference/deck_dump
+      - text: deck ping
+        url: /reference/deck_ping
+      - text: deck reset
+        url: /reference/deck_reset
+      - text: deck sync
+        url: /reference/deck_sync
+      - text: deck validate
+        url: /reference/deck_validate
+      - text: deck version
+        url: /reference/deck_version
+
+  - title: FAQ
+    icon: /assets/images/icons/documentation/icn-faq-color.svg
+    url: /faqs

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -256,6 +256,10 @@
   version: "1.15.0"
   edition: "deck"
 -
+  release: "1.16.x"
+  version: "1.16.0"
+  edition: "deck"
+-
   release: "1.0.x"
   version: "1.0.4"
   edition: "mesh"

--- a/src/deck/guides/distributed-configuration.md
+++ b/src/deck/guides/distributed-configuration.md
@@ -74,7 +74,7 @@ configuration of other teams. You no longer need to maintain Kong's
 configuration in a single repository, where multiple teams need to
 co-ordinate.
 
-> The `--select-tag` flag is present on those two commands for use cases where
+The `--select-tag` flag is present on those two commands for use cases where
 the file cannot have `select_tags` defined inside it. It is strongly advised
 that you do not supply select-tags to sync and diff commands via flags.
 This is because the tag information should be part of the declarative

--- a/src/deck/reference/deck_convert.md
+++ b/src/deck/reference/deck_convert.md
@@ -29,12 +29,17 @@ deck convert [command-specific flags] [global flags]
 
 `--output-file`
 :  file to write configuration to after conversion. Use `-` to write to stdout.
+   {% if_version gte:1.16.x %} (Default: `"kong.yaml"`){% endif_version %}
 
 `--to`
 :  desired format of the output, allowed formats:
 {% if_version gte:1.15.x %}[`konnect` `kong-gateway-3.x`]{% endif_version %}{%
    if_version gte:1.7.x lte:1.14.x %}`konnect`{% endif_version %}
 
+{% if_version gte: 1.16.x %}
+`--yes`
+:  assume `yes` to prompts and run non-interactively. (Default: `false`)
+{% endif_version %}
 
 {% if_version gte:1.7.x %}
 

--- a/src/deck/reference/deck_sync.md
+++ b/src/deck/reference/deck_sync.md
@@ -55,7 +55,7 @@ When this setting has multiple tag values, entities must match every tag.
 This flag can be specified multiple times for multiple files.
 Use `-` to read from stdin. (Default: `[kong.yaml]`)
 
-`--workspace`
+`-w`, `--workspace`
 :  Sync configuration to a specific workspace (Kong Enterprise only).
 This takes precedence over `_workspace` fields in state files.
 

--- a/src/deck/reference/deck_sync.md
+++ b/src/deck/reference/deck_sync.md
@@ -55,7 +55,8 @@ When this setting has multiple tag values, entities must match every tag.
 This flag can be specified multiple times for multiple files.
 Use `-` to read from stdin. (Default: `[kong.yaml]`)
 
-`-w`, `--workspace`
+
+{% if_version gte:1.16.x %} `-w`,{% endif_version %} `--workspace`
 :  Sync configuration to a specific workspace (Kong Enterprise only).
 This takes precedence over `_workspace` fields in state files.
 


### PR DESCRIPTION
* Creates a version 1.16 nav bar. 
* Adds the `-w` flag to `deck sync` reference. 
* Fixes a formatting issue in https://docs.konghq.com/deck/latest/guides/distributed-configuration/#sync
* Adds default file to `deck convert`, 

### Reason
[DOCU-2620](https://konghq.atlassian.net/browse/DOCU-2620)
https://github.com/Kong/deck/pull/765
https://github.com/Kong/deck/pull/775
https://github.com/Kong/deck/pull/775



