### PR TITLE
Release: Changelog for Gateway 3.0.1.0

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -167,9 +167,10 @@
     libyaml: "0.2.5"
     pcre: "8.45"
   lua_doc: true
-- release: "3.0.x"
-  ee-version: "3.0.0.0"
-  ce-version: "3.0.0"
+-
+  release: "3.0.x"
+  ee-version: "3.0.1.0"
+  ce-version: "3.0.1"
   edition: "gateway"
   luarocks_version: "3.0.0-0"
   dependencies:

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -4,6 +4,72 @@ no_version: true
 ---
 <!-- vale off -->
 
+## 3.0.1.0
+**Release Date** 2022/10/27
+
+### Features
+
+#### Plugins
+
+* [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/) (`request-transformer-advanced`)
+  * Values stored in `key:value` pairs in this plugin's configuration are now referenceable, which means they can be stored as [secrets](/gateway/latest/kong-enterprise/secrets-management/) in a vault.
+
+### Fixes
+
+#### Enterprise
+
+* Removed the endpoint `all_routes` from configurable RBAC endpoint permissions.
+This endpoint was erroneously appearing in the endpoints list, and didn't configure anything.
+
+* **Kong Manager**:
+  * Fixed an issue that allowed unauthorized IDP users to log in to Kong Manager.
+  These users had no access to any resources in Kong Manager, but were able to go beyond the login screen.
+  * Fixed an issue where, in an environment with a valid Enterprise license, admins with no access to the `default` workspace would see a message prompting them to upgrade to Kong Enterprise.
+  * Fixed pagination issues with Kong Manager tables.
+  * Fixed broken `Learn more` links.
+  * Fixed an issue with group to role mapping, where it didn't support group names with spaces.
+  * Fixed the Cross Site Scripting (XSS) security vulnerability in the Kong Manager UI.
+  * Fixed an RBAC issue where permissions applied to specific endpoints (for example, an individual service or route) were not reflected in the Kong Manager UI.
+  * Removed New Relic from Kong Manager. Previously, `VUE_APP_NEW_RELIC_LICENSE_KEY` and
+  `VUE_APP_SEGMENT_WRITE_KEY` were being exposed in Kong Manager with invalid values.
+  * Removed the action dropdown menu on service and route pages for read-only users.
+  * Fixed the **Edit Configuration** button for Dev Portal applications.
+  * Fixed an RBAC issue where the roles page listed deleted roles.
+  * Fixed an issue where the orphaned roles would remain after deleting a workspace and cause the **Teams** > **Admins** page to break.
+  * Added the missing **Copy JSON** button for plugin configuration.
+  * Fixed an issue where the **New Workspace** button on the globl workspace dashboard wasn't clickable on the first page load.
+  * Removed the ability to add multiple documents per service from the UI.
+  Each service only supports one document, so the UI now reflects that.
+  * The Upstream Timeout plugin now has an icon and is part of the Traffic Control category.
+  * Fixed an error that would occur when attempting to delete ACL credentials
+  from the consumer credentials list.
+  This happened because the the name of the plugin, `acl`, and its endpoint, `/acls`, don't match.
+  * Fixed a caching issue with Dev Portal, where enabling or disabling the Dev Portal for a workspace wouldn't change the Kong Manager menu.
+
+* Unpinned the version of `alpine` used in the `kong/kong-gateway` Docker image.
+Previously, the version was pinned to 3.10, which was creating outdated `alpine` builds.
+
+#### Core
+
+* Fixed an issue with how Kong initializes `resty.events`. The code was
+previously using `ngx.config.prefix()` to determine the listening socket
+path to provide to the resty.events module. This caused breakage when
+Nginx was started with a relative path prefix.
+
+    Instead of using `ngx.config.prefix()`, Kong will now prefer the
+    `kong.configuration.prefix` when available, as it is already normalized
+    to an absolute path. If `kong.configuration.prefix` is not defined, the
+    result of `ngx.config.prefix()` will be used after resolving it to an
+    absolute path. [#9337](https://github.com/Kong/kong/pull/9337)
+
+* Fixed an issue with secret management references. By default, Kong passes secrets to Nginx using environment variables when using `kong start`. Nginx was being started directly without calling `kong start`, so the secrets were not available at initialization. [#9478](https://github.com/Kong/kong/pull/9478)
+
+### Deprecations and removals
+
+* The deprecated `/oas-config` endpoint and the `openapi2kong` cli tool have been removed from Kong Gateway.
+Use [Insomnia's declarative configuration generator](https://docs.insomnia.rest/inso-cli/cli-command-reference/inso-generate-config) instead.
+
+
 ## 3.0.0.0
 **Release Date** 2022/09/09
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -2,6 +2,7 @@
 title: Kong Gateway Changelog
 no_version: true
 ---
+
 <!-- vale off -->
 
 ## 3.0.1.0
@@ -37,13 +38,13 @@ This endpoint was erroneously appearing in the endpoints list, and didn't config
   * Fixed an RBAC issue where the roles page listed deleted roles.
   * Fixed an issue where the orphaned roles would remain after deleting a workspace and cause the **Teams** > **Admins** page to break.
   * Added the missing **Copy JSON** button for plugin configuration.
-  * Fixed an issue where the **New Workspace** button on the globl workspace dashboard wasn't clickable on the first page load.
+  * Fixed an issue where the **New Workspace** button on the global workspace dashboard wasn't clickable on the first page load.
   * Removed the ability to add multiple documents per service from the UI.
   Each service only supports one document, so the UI now reflects that.
   * The Upstream Timeout plugin now has an icon and is part of the Traffic Control category.
   * Fixed an error that would occur when attempting to delete ACL credentials
   from the consumer credentials list.
-  This happened because the the name of the plugin, `acl`, and its endpoint, `/acls`, don't match.
+  This happened because the name of the plugin, `acl`, and its endpoint, `/acls`, don't match.
   * Fixed a caching issue with Dev Portal, where enabling or disabling the Dev Portal for a workspace wouldn't change the Kong Manager menu.
 
 * Unpinned the version of `alpine` used in the `kong/kong-gateway` Docker image.
@@ -66,9 +67,8 @@ Nginx was started with a relative path prefix.
 
 ### Deprecations and removals
 
-* The deprecated `/oas-config` endpoint and the `openapi2kong` cli tool have been removed from Kong Gateway.
+* The deprecated `/oas-config` endpoint and the `openapi2kong` CLI tool have been removed from Kong Gateway.
 Use [Insomnia's declarative configuration generator](https://docs.insomnia.rest/inso-cli/cli-command-reference/inso-generate-config) instead.
-
 
 ## 3.0.0.0
 **Release Date** 2022/09/09

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -19,10 +19,9 @@ no_version: true
 
 #### Enterprise
 
-* Removed the endpoint `all_routes` from configurable RBAC endpoint permissions.
-This endpoint was erroneously appearing in the endpoints list, and didn't configure anything.
-
 * **Kong Manager**:
+  * Removed the endpoint `all_routes` from configurable RBAC endpoint permissions.
+  This endpoint was erroneously appearing in the endpoints list, and didn't configure anything.
   * Fixed an issue that allowed unauthorized IDP users to log in to Kong Manager.
   These users had no access to any resources in Kong Manager, but were able to go beyond the login screen.
   * Fixed an issue where, in an environment with a valid Enterprise license, admins with no access to the `default` workspace would see a message prompting them to upgrade to Kong Enterprise.
@@ -56,6 +55,8 @@ Previously, the version was pinned to 3.10, which was creating outdated `alpine`
 previously using `ngx.config.prefix()` to determine the listening socket
 path to provide to the resty.events module. This caused breakage when
 Nginx was started with a relative path prefix.
+This meant that you couldn't start 3.0.x with the same default configuration as
+2.8.x.
 
     Instead of using `ngx.config.prefix()`, Kong will now prefer the
     `kong.configuration.prefix` when available, as it is already normalized
@@ -63,12 +64,9 @@ Nginx was started with a relative path prefix.
     result of `ngx.config.prefix()` will be used after resolving it to an
     absolute path. [#9337](https://github.com/Kong/kong/pull/9337)
 
-* Fixed an issue with secret management references. By default, Kong passes secrets to Nginx using environment variables when using `kong start`. Nginx was being started directly without calling `kong start`, so the secrets were not available at initialization. [#9478](https://github.com/Kong/kong/pull/9478)
+* Fixed an issue with secret management references for HashiCorp Vault. By default, Kong passes secrets to the Nginx using environment variables when using `kong start`. Nginx was being started directly without calling `kong start`, so the secrets were not available at initialization. [#9478](https://github.com/Kong/kong/pull/9478)
 
-### Deprecations and removals
-
-* The deprecated `/oas-config` endpoint and the `openapi2kong` CLI tool have been removed from Kong Gateway.
-Use [Insomnia's declarative configuration generator](https://docs.insomnia.rest/inso-cli/cli-command-reference/inso-generate-config) instead.
+* Fixed the Amazon Linux RPM installation instructions.
 
 ## 3.0.0.0
 **Release Date** 2022/09/09

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -6,7 +6,7 @@ no_version: true
 <!-- vale off -->
 
 ## 3.0.1.0
-**Release Date** 2022/10/27
+**Release Date** 2022/11/02
 
 ### Features
 


### PR DESCRIPTION
### Summary
Changelog for 3.0.1.0 and 3.0.1 based on committed eng ticket list.

### Reason
Planned 3.0.1.0 patch release.

https://konghq.atlassian.net/browse/DOCU-2619

### Testing
https://deploy-preview-4643--kongdocs.netlify.app/gateway/changelog/