### PR TITLE
moved statsd plugins into the analytics and monitoring category

### DIFF
--- a/app/_hub/kong-inc/statsd-advanced/_1.3-x.md
+++ b/app/_hub/kong-inc/statsd-advanced/_1.3-x.md
@@ -15,7 +15,7 @@ description: |
 enterprise: true
 type: plugin
 categories:
-  - logging
+  - analytics-monitoring
 
 kong_version_compatibility:
     community_edition:

--- a/app/_hub/kong-inc/statsd-advanced/_2.2.x.md
+++ b/app/_hub/kong-inc/statsd-advanced/_2.2.x.md
@@ -18,7 +18,7 @@ description: |
 enterprise: true
 type: plugin
 categories:
-  - logging
+  - analytics-monitoring
 kong_version_compatibility:
   community_edition:
     compatible: null

--- a/app/_hub/kong-inc/statsd-advanced/_index.md
+++ b/app/_hub/kong-inc/statsd-advanced/_index.md
@@ -21,7 +21,7 @@ description: |
 enterprise: true
 type: plugin
 categories:
-  - logging
+  - analytics-monitoring
 kong_version_compatibility:
   community_edition:
     compatible: null

--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -9,7 +9,7 @@ description: |
   [StatsD plugin](https://collectd.org/wiki/index.php/Plugin:StatsD).
 type: plugin
 categories:
-  - logging
+  - analytics-monitoring
 kong_version_compatibility:
   community_edition:
     compatible: true


### PR DESCRIPTION
### Summary
Moved statsd plugins into the analytics and monitoring category 

### Reason
Both statsd plugins are about metrics and monitoring and shouldn't belong to the logging category.
