### PR TITLE
doc(compat) add back RHEL 7.9

### DIFF
--- a/app/_data/tables/compat.json
+++ b/app/_data/tables/compat.json
@@ -2,8 +2,8 @@
   "2.8.x": {
     "os": {
       "amazon-linux": "1, 2",
-      "centos": "8",
-      "rhel": "8",
+      "centos": "7-2009, 8",
+      "rhel": "7.9, 8",
       "ubuntu": "16.04 Xenial, 18.04 Bionic, 20.04 Focal",
       "debian": "9 Stretch, 10 Buster, 11 Bullseye"
     },
@@ -22,8 +22,8 @@
   "2.7.x": {
     "os": {
       "amazon-linux": "1, 2",
-      "centos": "8",
-      "rhel": "8",
+      "centos": "7-2009, 8",
+      "rhel": "7.9, 8",
       "ubuntu": "16.04 Xenial, 18.04 Bionic, 20.04 Focal",
       "debian": "9 Stretch, 10 Buster, 11 Bullseye"
     },
@@ -42,8 +42,8 @@
   "2.6.x": {
     "os": {
       "amazon-linux": "1, 2",
-      "centos": "8",
-      "rhel": "8",
+      "centos": "7-2009, 8",
+      "rhel": "7.9, 8",
       "ubuntu": "16.04 Xenial, 18.04 Bionic, 20.04 Focal",
       "debian": "9 Stretch"
     },


### PR DESCRIPTION


### Summary
- Adding back RHEL 7.9 support that was incorrectly dropped in https://github.com/Kong/docs.konghq.com/pull/4594

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
