### PR TITLE
fix priority order

### DIFF
--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -452,8 +452,8 @@ session                     | 1900
 oauth2-introspection        | 1700
 acme                        | 1705
 mtls-auth                   | 1600
-jwt                         | 1450
 degraphql                   | 1500
+jwt                         | 1450
 oauth2                      | 1400
 vault-auth                  | 1350
 key-auth                    | 1250


### PR DESCRIPTION
### Summary
Fixing an ordering bug in the plugin table

### Reason
the ordering is not correct for the graphql plugin 
<img width="433" alt="Screen Shot 2022-10-26 at 9 32 02 PM" src="https://user-images.githubusercontent.com/984353/198192012-eec7daf7-d9d4-48f3-8b56-45f330345204.png">

### Testing
verify that the plugin are ordered correctly

