### PR TITLE
Add automatic submodule update workflow

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -1,0 +1,17 @@
+name: Submodule Sync
+on:
+  workflow_dispatch:
+
+jobs:
+  submodule-sync:
+    name: Submodule Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submodule Sync
+        uses: mheap/submodule-sync-action@v1
+        with:
+          path: src/.repos/kuma
+          ref: release/kuma-2.0
+          pr_branch: automated-kuma-update
+          base_branch: release/mesh-2.0
+          target_branch: release/mesh-2.0


### PR DESCRIPTION
### Summary
Adds a GitHub Action to update the Kuma submodule automatically

### Reason
Makes updating the submodule as easy as clicking a button!

### Testing
This needs to be on `main` to test. I've tested the action locally using these parameters and it worked as expected