### PR TITLE
Replace Kuma with Kong Mesh in titles

### DIFF
--- a/app/_plugins/generators/kuma_to_kong_mesh.rb
+++ b/app/_plugins/generators/kuma_to_kong_mesh.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module KumaToKongMesh
+  class Generator < Jekyll::Generator
+    priority :lowest
+    def generate(site)
+      site.pages.each do |page|
+        next unless page.data['title']
+
+        page.data['title'] = page.data['title'].gsub('Kuma', 'Kong Mesh')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary
Replace Kuma with Kong Mesh in titles

### Reason
When using single sourced content, we can't use `{{ site.mesh_product_name }}` in titles. This blanket replaces Kuma with Kong Mesh in titles

### Testing
/mesh/latest/features/policy-enforcement/choosing-policies/ in the review app