### PR TITLE
kic: add Gateway API HTTPRoute traffic splitting

### DIFF
--- a/app/_assets/kubernetes-ingress-controller/examples/echo-service.yaml
+++ b/app/_assets/kubernetes-ingress-controller/examples/echo-service.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  ports:
+  - protocol: TCP
+    name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        command:
+        - /agnhost
+        - netexec
+        - --http-port=8080
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 10m

--- a/app/_assets/kubernetes-ingress-controller/examples/echo-services.yaml
+++ b/app/_assets/kubernetes-ingress-controller/examples/echo-services.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  ports:
+  - protocol: TCP
+    name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        command:
+        - /agnhost
+        - netexec
+        - --http-port=8080
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo2
+spec:
+  ports:
+  - protocol: TCP
+    name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: echo2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo2
+  name: echo2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo2
+  template:
+    metadata:
+      labels:
+        app: echo2
+    spec:
+      containers:
+      - name: echo
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        command:
+        - /agnhost
+        - netexec
+        - --http-port=8080
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 10m

--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -1,11 +1,12 @@
 ---
 title: Using Gateway API
 alpha: false # This is the default, but is here for completeness
+content_type: tutorial
 
 overrides:
   alpha:
     true:
-      gte: 2.4.x
+      gte: 2.2.x
       lte: 2.5.x
 ---
 
@@ -89,22 +90,21 @@ Server: kong/1.2.1
 
 This is expected, as Kong does not yet know how to proxy the request.
 
-## Set up an echo-server
+## Set up an echo service
 
-Set up an echo-server application to demonstrate how
-to use the {{site.kic_product_name}}:
+Set up an echo service to demonstrate how to use the {{site.kic_product_name}}:
 
 ```bash
-$ kubectl apply -f https://bit.ly/echo-service
+$ kubectl apply -f {{site.links.web}}/kubernetes-ingress-controller/{{page.kong_version}}/examples/echo-service.yaml
 ```
 
-## Add a Gateway class and gateway
+## Add a `GatewayClass` and `Gateway`
 
-The Gateway resource represents the proxy instance that handles traffic for a
-set of Gateway API routes, and a GatewayClass describes characteristics shared
-by all Gateways of a given type.
+The `Gateway` resource represents the proxy instance that handles traffic for a
+set of Gateway API routes, and a `GatewayClass` describes characteristics shared
+by all `Gateway`s of a given type.
 
-Add a GatewayClass:
+Add a `GatewayClass`:
 
 {% if_version lte: 2.5.x %}
 ```bash
@@ -133,12 +133,11 @@ spec:
 ```
 {% endif_version %}
 
-
 ```
 gatewayclass.gateway.networking.k8s.io/kong created
 ```
 
-Add a Gateway: 
+Add a `Gateway`:
 
 {% if_version lte: 2.5.x %}
 ```bash
@@ -231,16 +230,12 @@ kubectl get gateway kong -o=jsonpath='{.status.addresses}' | jq
   },
   {
     "type": "IPAddress",
-    "value": "10.96.179.122"
-  },
-  {
-    "type": "IPAddress",
     "value": "172.18.0.240"
   }
 ]
 ```
 
-## Add an HTTP Route
+## Add an `HTTPRoute`
 
 `HTTPRoute` resources are similar to Ingress resources: they contain a set of
 matching criteria for HTTP requests and upstream Services to route those
@@ -252,6 +247,8 @@ $ echo "apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
   name: echo
+  annotations:
+    konghq.com/strip-path: "true"
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -280,6 +277,8 @@ $ echo "apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: echo
+  annotations:
+    konghq.com/strip-path: 'true'
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -302,29 +301,90 @@ spec:
 ```
 {% endif_version %}
 
-After creating an HTTP Route, accessing `/echo` forwards a request to the
-echo service:
+After creating an `HTTPRoute`, accessing `/echo/hostname` forwards a request to the
+echo service's `/hostname` path, which yields the name of the pod that served the request:
 
 ```bash
-$ curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+$ curl -i http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
 ```
 
 ```
 HTTP/1.1 200 OK
-Content-Type: text/plain; charset=UTF-8
-Transfer-Encoding: chunked
+Content-Type: text/plain; charset=utf-8
+Content-Length: 21
 Connection: keep-alive
-Date: Fri, 21 Jun 2019 18:09:02 GMT
-Server: echoserver
+Date: Fri, 28 Oct 2022 08:18:18 GMT
 X-Kong-Upstream-Latency: 1
-X-Kong-Proxy-Latency: 1
-Via: kong/1.1.2
+X-Kong-Proxy-Latency: 0
+Via: kong/3.0.0
 
-
-
-Hostname: echo-758859bbfb-cnfmx
-...
+echo-658c5ff5ff-8cvgj%
 ```
+
+{% if_version gte: 2.6.x %}
+## Traffic splitting with `HTTPRoute`
+
+`HTTPRoute` contains a [`BackendRefs`][gateway-api-backendref] field, which allows
+users to specify `weight` parameters for echo `BackendRef`.
+This can be used to perform traffic splitting.
+
+In order to do so let's deploy a second echo `Service` so that we have
+an second `BackendRef` to use for traffic splitting.
+
+```bach
+$ kubectl apply -f {{site.links.web}}/kubernetes-ingress-controller/{{page.kong_version}}/examples/echo-services.yaml
+```
+
+> NOTE: This example contains the previous echo `Service` so you may deploy
+> it without deploying the previous example from
+> [Set up an echo service](#set-up-an-echo-service) section.
+
+Having those 2 `Services` deployed we can now deploy our `HTTPRoute` which will
+perform the traffic splitting between them using the weight parameters:
+
+```bash
+$ echo 'apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: echo
+  annotations:
+    konghq.com/strip-path: "true"
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /echo
+    backendRefs:
+    - name: echo
+      kind: Service
+      port: 80
+      weight: 75
+    - name: echo2
+      kind: Service
+      port: 80
+      weight: 25
+' | kubectl apply -f -
+```
+
+Now, accessing `/echo/hostname` should distribute around 75% of requests to `Service`
+echo and around 25% of requests to `Service` echo2.
+
+```bash
+$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+echo2-7cb798f47-gh4xg%
+$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+echo-658c5ff5ff-8cvgj%
+$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+echo-658c5ff5ff-8cvgj%
+$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+echo-658c5ff5ff-8cvgj%
+```
+
+[gateway-api-backendref]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.BackendRef
+{% endif_version %}
 
 {% if_version lte: 2.5.x %}
 ## Alpha limitations

--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -95,10 +95,10 @@ This is expected, as Kong does not yet know how to proxy the request.
 Set up an echo service to demonstrate how to use the {{site.kic_product_name}}:
 
 ```bash
-$ kubectl apply -f {{site.links.web}}/kubernetes-ingress-controller/{{page.kong_version}}/examples/echo-service.yaml
+kubectl apply -f {{site.links.web}}/kubernetes-ingress-controller/{{page.kong_version}}/examples/echo-service.yaml
 ```
 
-## Add a `GatewayClass` and `Gateway`
+## Add a GatewayClass and Gateway
 
 The `Gateway` resource represents the proxy instance that handles traffic for a
 set of Gateway API routes, and a `GatewayClass` describes characteristics shared
@@ -235,7 +235,7 @@ kubectl get gateway kong -o=jsonpath='{.status.addresses}' | jq
 ]
 ```
 
-## Add an `HTTPRoute`
+## Add an HTTPRoute
 
 `HTTPRoute` resources are similar to Ingress resources: they contain a set of
 matching criteria for HTTP requests and upstream Services to route those
@@ -305,7 +305,7 @@ After creating an `HTTPRoute`, accessing `/echo/hostname` forwards a request to 
 echo service's `/hostname` path, which yields the name of the pod that served the request:
 
 ```bash
-$ curl -i http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl -i http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
 ```
 
 ```
@@ -322,28 +322,28 @@ echo-658c5ff5ff-8cvgj%
 ```
 
 {% if_version gte: 2.6.x %}
-## Traffic splitting with `HTTPRoute`
+## Traffic splitting with HTTPRoute
 
 `HTTPRoute` contains a [`BackendRefs`][gateway-api-backendref] field, which allows
 users to specify `weight` parameters for echo `BackendRef`.
 This can be used to perform traffic splitting.
 
-In order to do so let's deploy a second echo `Service` so that we have
-an second `BackendRef` to use for traffic splitting.
+To do so, you can deploy a second echo `Service` so that you have
+a second `BackendRef` to use for traffic splitting.
 
 ```bach
-$ kubectl apply -f {{site.links.web}}/kubernetes-ingress-controller/{{page.kong_version}}/examples/echo-services.yaml
+kubectl apply -f {{site.links.web}}/kubernetes-ingress-controller/{{page.kong_version}}/examples/echo-services.yaml
 ```
-
-> NOTE: This example contains the previous echo `Service` so you may deploy
-> it without deploying the previous example from
+{:.note}
+> **Note**: This example contains the previous echo `Service` so you may deploy
+> it without deploying the previous example from the
 > [Set up an echo service](#set-up-an-echo-service) section.
 
-Having those 2 `Services` deployed we can now deploy our `HTTPRoute` which will
+Now that those two `Services` are deployed, you can now deploy your `HTTPRoute`. This will
 perform the traffic splitting between them using the weight parameters:
 
 ```bash
-$ echo 'apiVersion: gateway.networking.k8s.io/v1beta1
+echo 'apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: echo
@@ -373,13 +373,13 @@ Now, accessing `/echo/hostname` should distribute around 75% of requests to `Ser
 echo and around 25% of requests to `Service` echo2.
 
 ```bash
-$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
 echo2-7cb798f47-gh4xg%
-$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
 echo-658c5ff5ff-8cvgj%
-$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
 echo-658c5ff5ff-8cvgj%
-$ curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
 echo-658c5ff5ff-8cvgj%
 ```
 


### PR DESCRIPTION
### Summary

This adds info about traffic splitting using Gateway API HTTPRoute.

This PR also makes the "Using Gateway API" page only visible in KIC versions >= 2.2.x since that's the version that initial implementation was released in: https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#220

### Reason

#4157 

