### PR TITLE
[DOCU-2595] decK upgrade guide: correct descriptions for sync, diff, validate

### DIFF
--- a/src/deck/3.0-upgrade.md
+++ b/src/deck/3.0-upgrade.md
@@ -82,10 +82,10 @@ It assumes that the paths have been correctly transformed, either via Kong migra
 
 `deck diff`, `deck validate` (with `--online` flag only), or `deck sync`
 : decK performs a check to ensure all regex routes are correctly prefixed.
-If not, the behavior depends on the control plane type:
-* Self-managed {{site.base_gateway}} 2.x (`_format_version: 1.1` or earlier): Prints an error and stops the operation.
-* Self-managed {{site.base_gateway}} 3.x (`_format_version: 3.0`): Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
-* {{site.konnect_short_name}}: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
+The behavior of the command depends on the format version in the declarative configuration file:
+* `_format_version: 1.1` or earlier: Prints an error and stops the operation.
+* `_format_version: 3.0` with _incorrectly_ prefixed routes: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
+* `_format_version: 3.0` with _correctly_ prefixed routes: Goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 
 `deck convert`
 : Includes `--from` and `--to` flags for converting state files between major versions.


### PR DESCRIPTION
### Summary
Adjusting description for decK diff, sync, and validate command behavior in 3.0.
### Reason

DOCU-2595

Previously the doc had two different descriptions for self-managed vs Konnect control planes for the sync, diff, and validate commands. The Konnect description was incomplete + misleading, so I fixed that, then tested all of the documented scenarios on Konnect and on a self-managed gateway instance and came to the conclusion that the control plane type (konnect vs self-managed) doesn't actually matter here. What makes the difference is the format version in the config file and the validity of the routes.

### Testing

Netlify
