### PR TITLE
doc(kic) add plugin ordering config

### DIFF
--- a/src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -48,6 +48,27 @@ http -f post :8001/plugins \
 <!-- end codeblock tabs -->
 
 {% endnavtab %}
+{% navtab  Kubernetes %}
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+metadata:
+  name: limit-before-key-auth
+  labels:
+    global: "true"
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+config:
+  minute: 5
+  policy: local
+  limit_by: ip
+plugin: rate-limiting
+ordering:
+  before:
+    access:
+    - key-auth
+```
+{% endnavtab %}
 {% navtab decK (YAML) %}
 
 1. Add a new `plugins` section to the bottom of your `kong.yaml` file. Enable
@@ -148,6 +169,23 @@ http -f post :8001/plugins \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
+{% endnavtab %}
+{% navtab  Kubernetes %}
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+metadata:
+  name: auth-after-transform
+  labels:
+    global: "true"
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+plugin: basic-auth
+ordering:
+  after:
+    access:
+    - request-transformer
+```
 {% endnavtab %}
 {% navtab decK (YAML) %}
 

--- a/src/kubernetes-ingress-controller/references/custom-resources.md
+++ b/src/kubernetes-ingress-controller/references/custom-resources.md
@@ -43,12 +43,23 @@ metadata:
   namespace: <object namespace>
 disabled: <boolean>  # optionally disable the plugin in Kong
 config:              # configuration for the plugin
-    key: value
+  key: value
 configFrom:
-    secretKeyRef:
-       name: <Secret name>
-       key: <Secret key>
+  secretKeyRef:
+     name: <Secret name>
+     key: <Secret key>
 plugin: <name-of-plugin> # like key-auth, rate-limiting etc
+{% if_version gte:2.6.x %}
+ordering:
+  before:
+    <phase>:
+    - <plugin>
+    - <plugin>
+  after:
+    <phase>:
+    - <plugin>
+    - <plugin>
+{% endif_version %}
 ```
 
 - `config` contains a list of `key` and `value`
@@ -66,6 +77,14 @@ plugin: <name-of-plugin> # like key-auth, rate-limiting etc
   or `configFrom` may be used in a KongPlugin, not both at once.
 - `plugin` field determines the name of the plugin in Kong.
   This field was introduced in {{site.kic_product_name}} 0.2.0.
+{% if_version gte:2.6.x %}
+- `ordering` is only available on {{site.ee_product_name}}. `<phase>` is a
+  request processing phase (for example, `access` or `body_filter`) and
+  `<plugin>` is the name of the plugin that will run before or after the
+  KongPlugin. For example, a KongPlugin with `plugin: rate-limiting` and
+  `before.access: ["key-auth"]` will create a rate limiting plugin that limits
+  requests _before_ they are authenticated.
+{% endif_version %}
 
 **Please note:** validation of the configuration fields is left to the user
 by default. It is advised to setup and use the admission validating controller
@@ -204,6 +223,17 @@ configFrom:
        key: <Secret key>
        namespace: <Secret namespace>
 plugin: correlation-id
+{% if_version gte:2.6.x %}
+ordering:
+  before:
+    <phase>:
+    - <plugin>
+    - <plugin>
+  after:
+    <phase>:
+    - <plugin>
+    - <plugin>
+{% endif_version %}
 ```
 
 As with KongPlugin, only one of `config` or `configFrom` can be used.


### PR DESCRIPTION
### Summary
Adds a reference and example for configuring plugin ordering using KIC.

### Reason
#4654 

### Testing
Waiting for Netlify to confirm formatting.

[test.txt](https://github.com/Kong/docs.konghq.com/files/9891024/test.txt) is a basic test to confirm that the example is accepted and results in a plugin with ordering configuration.