### PR TITLE
Add KIC HTTPRoute port limitation

### DIFF
--- a/src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -415,3 +415,5 @@ Gateway APIs are supported. In particular:
 - Gateways [are not provisioned automatically](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/gateway-api#gateway-management).
 - Kong [only supports a single Gateway per GatewayClass](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/gateway-api#listener-compatibility-and-handling-multiple-gateways).
 {% endif_version %}
+- HTTPRoutes cannot be bound to a specific port using a [ParentReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.ParentReference).
+  Kong serves all HTTP routes on all HTTP listens.


### PR DESCRIPTION
### Summary
Adds a limitation to KIC's Gateway API guide.

### Reason
https://github.com/Kong/kubernetes-ingress-controller/issues/3016#issuecomment-1267266712

### Testing
None. Simple change, not expected to need any testing.