### PR TITLE
docs(compat) specify the minor version of RHEL 7

### DIFF
--- a/app/_data/tables/os_support.yml
+++ b/app/_data/tables/os_support.yml
@@ -119,7 +119,7 @@
   status: deprecated
   deprecation_date: November 30, 2020
   eol_link: https://access.redhat.com/support/policy/updates/errata
-- name: RHEL 7
+- name: RHEL 7.9
   enterprise: true
   enterprise_versions:
     first_version: 1.5.x


### PR DESCRIPTION
### Summary

Specify the minor version of RHEL 7 we supporting. Associated PR [#4594](https://github.com/Kong/docs.konghq.com/pull/4594) and [#4649](https://github.com/Kong/docs.konghq.com/pull/4649)

### Reason

[FTI-4457](https://konghq.atlassian.net/browse/FTI-4457) [DOCU-2489](https://konghq.atlassian.net/browse/DOCU-2489)
