### PR TITLE
fix: add table headers in String Transformations section

### DIFF
--- a/src/gateway/reference/router-expressions-language.md
+++ b/src/gateway/reference/router-expressions-language.md
@@ -69,7 +69,9 @@ For example, you can not perform string comparisons on a integer type field.
 
 ## String transformations
 
-| lower() | Lowercase |
+| Transformation | Meaning |
+| -------------- | ------- |
+| lower()        | turn the uppercase letters into lowercase |
 
 ## Integer
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Add table headers in String Transformations section of router expression reference page

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

fixes #4695.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

https://deploy-preview-4696--kongdocs.netlify.app/gateway/latest/reference/router-expressions-language/

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->

