### PR TITLE
docs(mesh) Add docs for mesh RBAC for new policies

### DIFF
--- a/src/mesh/features/rbac.md
+++ b/src/mesh/features/rbac.md
@@ -17,6 +17,8 @@ Role-Based Access Control (RBAC) lets you restrict access to resources and actio
 It is global-scoped, which means it is not bound to a mesh.
 
 {% navtabs %}
+{% navtab Source and Destination selectors %}
+{% navtabs %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -69,6 +71,57 @@ rules:
       - name: kuma.io/service
         value: web
 ```
+{% endnavtab %}
+{% endnavtabs %}
+{% endnavtab %}
+{% navtab `targetRef` selectors %}
+For policies using `targetRef` selector. You can specify which `targetRef` kinds users should have access to.
+
+{% navtabs %}
+{% navtab Kubernetes %}
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: AccessRole
+metadata:
+  name: role-1
+spec:
+  rules:
+  - types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If empty, then access is granted to all types.
+    names: ["res-1"] # List of allowed type names that are granted access. If empty, then access is granted to resources regardless of the name.
+    mesh: default # Grants access to the resources in the named mesh. It can only be used with the mesh-scoped resources.
+    access: ["CREATE", "UPDATE", "DELETE"] # The action bound to a type.
+    when: # A set of qualifiers to receive access. Only one of them needs to be fulfilled to receive access.
+    - tagetRef: # A condition on the targetRef section in policies 2.0 (like MeshAccessLog or MeshTrace).
+        kind: MeshService
+        name: backend
+    - targetRef:
+        kind: MeshSubset
+        tags: 
+        - name: k8s.kuma.io/namespace
+          value: kuma-demo
+```
+{% endnavtab %}
+{% navtab Universal %}
+```yaml
+type: AccessRole
+name: role-1
+rules:
+- types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If empty, then access is granted to all types.
+  names: ["res-1"] # List of allowed type names that are granted access. If empty, then access is granted to resources regardless of the name.
+  mesh: default # Grants access to the resources in the named mesh. It can only be used with the mesh-scoped resources.
+  access: ["CREATE", "UPDATE", "DELETE"] # The action bound to a type.
+  when: # A set of qualifiers to receive access. Only one of them needs to be fulfilled to receive access.
+  - tagetRef: # A condition on the targetRef section in policies 2.0 (like MeshAccessLog or MeshTrace).
+        kind: MeshService
+        name: backend
+  - targetRef:
+      kind: MeshSubset
+      tags: 
+      - name: k8s.kuma.io/namespace
+        value: kuma-demo
+```
+{% endnavtab %}
+{% endnavtabs %}
 {% endnavtab %}
 {% endnavtabs %}
 
@@ -225,6 +278,9 @@ This way a service owners can:
   This changes the configuration of data plane proxies that are connecting to backend, but the configuration only affects connections to backend service.
   It's useful because the service owner of backend has the best knowledge what (`Timeout`, `HealthCheck`) should be applied when communicating with their service.
 * Modify `TrafficTrace` or `ProxyTemplate` that matches backend service. This changes the configuration of data plane proxy that implements `backend` service.
+
+{:.note}
+> **Note**: When giving users `UPDATE` permission, remember to add `UPDATE` permission to all selectors they can switch between. For example, if a user only has access to `sources` selector, they won't be able to update policy with `destinations` selector or new `targetRef` selectors. Likewise, when a user only has access to `targetRef` kind `MeshService`, they won't be able to update the policy to use a different `targetRef` kind.
 
 ### Observability operator
 
@@ -416,16 +472,18 @@ roles:
 Here are the steps to create a new user and restrict the access only to `TrafficPermission` for backend service.
 
 {% navtabs %}
+{% navtab Source and Destination selectors %}
+{% navtabs %}
 {% navtab Kubernetes %}
 
 1.  Create a backend-owner Kubernetes user and configure kubectl:
 
     ```sh
-    $ mkdir -p /tmp/k8s-certs
-    $ cd /tmp/k8s-certs
-    $ openssl genrsa -out backend-owner.key 2048 # generate client key
-    $ openssl req -new -key backend-owner.key -subj "/CN=backend-owner" -out backend-owner.csr # generate client certificate request
-    $ CSR=$(cat backend-owner.csr | base64 | tr -d "\n") && echo "apiVersion: certificates.k8s.io/v1
+    mkdir -p /tmp/k8s-certs
+    cd /tmp/k8s-certs
+    openssl genrsa -out backend-owner.key 2048 # generate client key
+    openssl req -new -key backend-owner.key -subj "/CN=backend-owner" -out backend-owner.csr # generate client certificate request
+    CSR=$(cat backend-owner.csr | base64 | tr -d "\n") && echo "apiVersion: certificates.k8s.io/v1
     kind: CertificateSigningRequest
     metadata:
       name: backend-owner
@@ -434,19 +492,19 @@ Here are the steps to create a new user and restrict the access only to `Traffic
       signerName: kubernetes.io/kube-apiserver-client
       usages:
       - client auth" | kubectl apply -f -
-    $ kubectl certificate approve backend-owner
-    $ kubectl get csr backend-owner -o jsonpath='{.status.certificate}'| base64 -d > backend-owner.crt
-    $ kubectl config set-credentials backend-owner \
+    kubectl certificate approve backend-owner
+    kubectl get csr backend-owner -o jsonpath='{.status.certificate}'| base64 -d > backend-owner.crt
+    kubectl config set-credentials backend-owner \
     --client-key=/tmp/k8s-certs/backend-owner.key \
     --client-certificate=/tmp/k8s-certs/backend-owner.crt \
     --embed-certs=true
-    $ kubectl config set-context backend-owner --cluster=YOUR_CLUSTER_NAME --user=backend-owner
+    kubectl config set-context backend-owner --cluster=YOUR_CLUSTER_NAME --user=backend-owner
     ```
 
 1.  Create Kubernetes RBAC to allow backend-owner to manage all `TrafficPermission`:
 
     ```sh
-    $ echo "
+    echo "
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -484,7 +542,7 @@ Here are the steps to create a new user and restrict the access only to `Traffic
 1.  Change default {{site.mesh_product_name}} RBAC to restrict access to resources by default:
 
     ```sh
-    $ echo "
+    echo "
     apiVersion: kuma.io/v1alpha1
     kind: AccessRoleBinding
     metadata:
@@ -505,7 +563,7 @@ Here are the steps to create a new user and restrict the access only to `Traffic
 1.  Create an AccessRole to grant permissions to user `backend-owner` to modify `TrafficPermission` only for the backend service:
 
     ```sh
-    $ echo "
+    echo '
     ---
     apiVersion: kuma.io/v1alpha1
     kind: AccessRole
@@ -531,14 +589,14 @@ Here are the steps to create a new user and restrict the access only to `Traffic
         name: backend-owner
       roles:
       - backend-owner
-    " | kubectl apply -f -
+    ' | kubectl apply -f -
     ```
 
 1.  Change the service to test user access:
 
     ```sh
-    $ kubectl config use-context backend-owner
-    $ echo "
+    kubectl config use-context backend-owner
+    echo "
     apiVersion: kuma.io/v1alpha1
     kind: TrafficPermission
     mesh: default
@@ -554,7 +612,7 @@ Here are the steps to create a new user and restrict the access only to `Traffic
     " | kubectl apply -f -
     # operation should succeed, access to backend service access is granted
 
-    $ echo "
+    echo "
     apiVersion: kuma.io/v1alpha1
     kind: TrafficPermission
     mesh: default
@@ -580,8 +638,8 @@ In order for this example to work you must either run the control plane with `KU
 1.  Extract admin token and configure kumactl with admin:
 
     ```sh
-    $ export ADMIN_TOKEN=$(curl http://localhost:5681/global-secrets/admin-user-token | jq -r .data | base64 -d)
-    $ kumactl config control-planes add \
+    export ADMIN_TOKEN=$(curl http://localhost:5681/global-secrets/admin-user-token | jq -r .data | base64 -d)
+    kumactl config control-planes add \
     --name=cp-admin \
     --address=https://localhost:5682 \
     --skip-verify=true \
@@ -592,20 +650,20 @@ In order for this example to work you must either run the control plane with `KU
 1.  Configure backend-owner:
 
     ```sh
-    $ export BACKEND_OWNER_TOKEN=$(kumactl generate user-token --valid-for=24h --name backend-owner)
-    $ kumactl config control-planes add \
+    export BACKEND_OWNER_TOKEN=$(kumactl generate user-token --valid-for=24h --name backend-owner)
+    kumactl config control-planes add \
     --name=cp-backend-owner \
     --address=https://localhost:5682 \
     --skip-verify=true \
     --auth-type=tokens \
     --auth-conf token=$BACKEND_OWNER_TOKEN
-    $ kumactl config control-planes switch --name cp-admin # switch back to admin
+    kumactl config control-planes switch --name cp-admin # switch back to admin
     ```
 
 1.  Change default {{site.mesh_product_name}} RBAC to restrict access to resources by default:
 
     ```sh
-    $ echo "type: AccessRoleBinding
+    echo "type: AccessRoleBinding
     name: default
     subjects:
     - type: Group
@@ -617,7 +675,7 @@ In order for this example to work you must either run the control plane with `KU
 1.  Create {{site.mesh_product_name}} RBAC to restrict backend-owner to only modify `TrafficPermission` for backend:
 
     ```sh
-    $ echo '
+    echo '
     type: AccessRole
     name: backend-owner
     rules:
@@ -629,7 +687,7 @@ In order for this example to work you must either run the control plane with `KU
           match:
             kuma.io/service: backend
     ' | kumactl apply -f -
-    $ echo '
+    echo '
     type: AccessRoleBinding
     name: backend-owners
     subjects:
@@ -642,8 +700,8 @@ In order for this example to work you must either run the control plane with `KU
 1.  Change the user and test RBAC:
 
     ```sh
-    $ kumactl config control-planes switch --name cp-backend-owner
-    $ echo "
+    kumactl config control-planes switch --name cp-backend-owner
+    echo "
     type: TrafficPermission
     mesh: default
     name: web-to-backend
@@ -656,7 +714,7 @@ In order for this example to work you must either run the control plane with `KU
     " | kumactl apply -f -
     # this operation should succeed
 
-    $ echo "
+    echo "
     type: TrafficPermission
     mesh: default
     name: web-to-backend
@@ -672,6 +730,285 @@ In order for this example to work you must either run the control plane with `KU
 
 {% endnavtab %}
 {% endnavtabs %}
+{% endnavtab %}
+{% navtab `targetRef` selectors %}
+{% navtabs %}
+{% navtab Kubernetes %}
+
+1.  Create a backend-owner Kubernetes user and configure kubectl:
+
+    ```sh
+    mkdir -p /tmp/k8s-certs
+    cd /tmp/k8s-certs
+    openssl genrsa -out backend-owner.key 2048 # generate client key
+    openssl req -new -key backend-owner.key -subj "/CN=backend-owner" -out backend-owner.csr # generate client certificate request
+    CSR=$(cat backend-owner.csr | base64 | tr -d "\n") && echo "apiVersion: certificates.k8s.io/v1
+    kind: CertificateSigningRequest
+    metadata:
+      name: backend-owner
+    spec:
+      request: $CSR
+      signerName: kubernetes.io/kube-apiserver-client
+      usages:
+      - client auth" | kubectl apply -f -
+    kubectl certificate approve backend-owner
+    kubectl get csr backend-owner -o jsonpath='{.status.certificate}'| base64 -d > backend-owner.crt
+    kubectl config set-credentials backend-owner \
+    --client-key=/tmp/k8s-certs/backend-owner.key \
+    --client-certificate=/tmp/k8s-certs/backend-owner.crt \
+    --embed-certs=true
+    kubectl config set-context backend-owner --cluster=YOUR_CLUSTER_NAME --user=backend-owner
+    ```
+
+1.  Create Kubernetes RBAC to allow backend-owner to manage all `TrafficPermission`:
+
+    ```sh
+    echo "
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kuma-policy-management
+    rules:
+    - apiGroups:
+      - kuma.io
+      resources:
+      - meshtrafficpermissions
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kuma-policy-management-backend-owner
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kuma-policy-management
+    subjects:
+    - kind: User
+      name: backend-owner
+      apiGroup: rbac.authorization.k8s.io
+    " | kubectl apply -f -
+    ```
+
+1.  Change default {{site.mesh_product_name}} RBAC to restrict access to resources by default:
+
+    ```sh
+    echo "
+    apiVersion: kuma.io/v1alpha1
+    kind: AccessRoleBinding
+    metadata:
+      name: default
+    spec:
+      subjects:
+      - type: Group
+        name: mesh-system:admin
+      - type: Group
+        name: system:masters
+      - type: Group
+        name: system:serviceaccounts:kube-system
+      roles:
+      - admin
+    " | kubectl apply -f -
+    ```
+
+1.  Create an AccessRole to grant permissions to user `backend-owner` to modify `TrafficPermission` only for the backend service:
+
+    ```sh
+    echo '
+    ---
+    apiVersion: kuma.io/v1alpha1
+    kind: AccessRole
+    metadata:
+      name: backend-owner
+    spec:
+      rules:
+      - types: ["MeshTrafficPermission"]
+        mesh: default
+        access: ["CREATE", "UPDATE", "DELETE"]
+        when:
+        - targetRef:
+            kind: MeshService
+            name: backend
+    ---
+    apiVersion: kuma.io/v1alpha1
+    kind: AccessRoleBinding
+    metadata:
+      name: backend-owners
+    spec:
+      subjects:
+      - type: User
+        name: backend-owner
+      roles:
+      - backend-owner
+    ' | kubectl apply -f -
+    ```
+
+1.  Change the service to test user access:
+
+    ```sh
+    kubectl config use-context backend-owner
+    echo "
+    apiVersion: kuma.io/v1alpha1
+    kind: MeshTrafficPermission
+    metadata:
+      name: web-to-backend
+      namespace: kong-mesh-system
+      labels:
+        kuma.io/mesh: default
+    spec:
+      targetRef:
+        kind: MeshService
+        name: backend
+      from:
+        - targetRef:
+            kind: MeshService
+            name: web
+          default:
+            action: ALLOW
+    " | kubectl apply -f -
+    # operation should succeed, access to backend service access is granted
+
+    echo "
+    apiVersion: kuma.io/v1alpha1
+    kind: MeshTrafficPermission
+    metadata:
+      name: web-to-backend
+      namespace: kong-mesh-system
+      labels:
+        kuma.io/mesh: default
+    spec:
+      targetRef:
+        kind: MeshService
+        name: not-backend # access to this service is not granted
+      from:
+        - targetRef:
+            kind: MeshService
+            name: web
+          default:
+            action: ALLOW
+    " | kubectl apply -f -
+    # operation should not succeed
+    ```
+{% endnavtab %}
+{% navtab Universal %}
+
+{:.note}
+> **Note**: By default, all requests that originate from localhost are authenticated as the `admin` user in the `mesh-system:admin` group.
+For this example to work, you must either run the control plane with `KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN` set to `false` or access the control plane using a method other than localhost.
+
+1.  Extract admin token and configure kumactl with admin:
+
+    ```sh
+    export ADMIN_TOKEN=$(curl http://localhost:5681/global-secrets/admin-user-token | jq -r .data | base64 -d)
+    kumactl config control-planes add \
+    --name=cp-admin \
+    --address=https://localhost:5682 \
+    --skip-verify=true \
+    --auth-type=tokens \
+    --auth-conf token=$ADMIN_TOKEN
+    ```
+
+1.  Configure backend-owner:
+
+    ```sh
+    export BACKEND_OWNER_TOKEN=$(kumactl generate user-token --valid-for=24h --name backend-owner)
+    kumactl config control-planes add \
+    --name=cp-backend-owner \
+    --address=https://localhost:5682 \
+    --skip-verify=true \
+    --auth-type=tokens \
+    --auth-conf token=$BACKEND_OWNER_TOKEN
+    kumactl config control-planes switch --name cp-admin # switch back to admin
+    ```
+
+1.  Change default {{site.mesh_product_name}} RBAC to restrict access to resources by default:
+
+    ```sh
+    echo "type: AccessRoleBinding
+    name: default
+    subjects:
+    - type: Group
+      name: mesh-system:admin
+    roles:
+    - admin" | kumactl apply -f -
+    ```
+
+1.  Create {{site.mesh_product_name}} RBAC to only allow the backend-owner to modify `TrafficPermission` for backend:
+
+    ```sh
+    echo '
+    type: AccessRole
+    name: backend-owner
+    rules:
+    - types: ["MeshTrafficPermission"]
+      mesh: default
+      access: ["CREATE", "UPDATE", "DELETE"]
+      when:
+      - targetRef:
+          kind: MeshService
+          name: backend
+    ' | kumactl apply -f -
+    echo '
+    type: AccessRoleBinding
+    name: backend-owners
+    subjects:
+    - type: User
+      name: backend-owner
+    roles:
+    - backend-owner' | kumactl apply -f -
+    ```
+
+1.  Change the user and test RBAC:
+
+    ```sh
+    kumactl config control-planes switch --name cp-backend-owner
+    echo "
+    type: MeshTrafficPermission
+    mesh: default
+    name: web-to-backend
+    spec:
+      targetRef:
+        kind: MeshService
+        name: backend
+      from:
+        - targetRef:
+            kind: MeshService
+            name: web
+          default:
+            action: ALLOW
+    " | kumactl apply -f -
+    # this operation should succeed
+
+    echo "
+    type: MeshTrafficPermission
+    mesh: default
+    name: web-to-backend
+    spec:
+      targetRef:
+        kind: MeshService
+        name: not-backend
+      from:
+        - targetRef:
+            kind: MeshService
+            name: web
+          default:
+            action: ALLOW
+    " | kumactl apply -f -
+    Error: Access Denied (user "backend-owner/mesh-system:authenticated" cannot access the resource)
+    ```
+
+{% endnavtab %}
+{% endnavtabs %}
+{% endnavtab %}
+{% endnavtabs %}óļ
 
 ## Multi-zone
 

--- a/src/mesh/features/rbac.md
+++ b/src/mesh/features/rbac.md
@@ -75,7 +75,7 @@ rules:
 {% endnavtabs %}
 {% endnavtab %}
 {% navtab `targetRef` selectors %}
-For policies using `targetRef` selector. You can specify which `targetRef` kinds users should have access to.
+For policies using the `targetRef` selector. You can specify which `targetRef` kinds users should have access to.
 
 {% navtabs %}
 {% navtab Kubernetes %}
@@ -86,8 +86,8 @@ metadata:
   name: role-1
 spec:
   rules:
-  - types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If empty, then access is granted to all types.
-    names: ["res-1"] # List of allowed type names that are granted access. If empty, then access is granted to resources regardless of the name.
+  - types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If it's empty, access is granted to all types.
+    names: ["res-1"] # List of allowed type names that are granted access. If it's empty, access is granted to resources regardless of the name.
     mesh: default # Grants access to the resources in the named mesh. It can only be used with the mesh-scoped resources.
     access: ["CREATE", "UPDATE", "DELETE"] # The action bound to a type.
     when: # A set of qualifiers to receive access. Only one of them needs to be fulfilled to receive access.
@@ -106,8 +106,8 @@ spec:
 type: AccessRole
 name: role-1
 rules:
-- types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If empty, then access is granted to all types.
-  names: ["res-1"] # List of allowed type names that are granted access. If empty, then access is granted to resources regardless of the name.
+- types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If it's empty, access is granted to all types.
+  names: ["res-1"] # List of allowed type names that are granted access. If it's empty, access is granted to resources regardless of the name.
   mesh: default # Grants access to the resources in the named mesh. It can only be used with the mesh-scoped resources.
   access: ["CREATE", "UPDATE", "DELETE"] # The action bound to a type.
   when: # A set of qualifiers to receive access. Only one of them needs to be fulfilled to receive access.
@@ -280,7 +280,7 @@ This way a service owners can:
 * Modify `TrafficTrace` or `ProxyTemplate` that matches backend service. This changes the configuration of data plane proxy that implements `backend` service.
 
 {:.note}
-> **Note**: When giving users `UPDATE` permission, remember to add `UPDATE` permission to all selectors they can switch between. For example, if a user only has access to `sources` selector, they won't be able to update policy with `destinations` selector or new `targetRef` selectors. Likewise, when a user only has access to `targetRef` kind `MeshService`, they won't be able to update the policy to use a different `targetRef` kind.
+> **Note**: When giving users `UPDATE` permission, remember to add `UPDATE` permission to all selectors they can switch between. For example, if a user only has access to `sources` selector, they won't be able to update policy with `destinations` selector or new `targetRef` selectors. Likewise, when a user only has access to the `targetRef` kind `MeshService`, they won't be able to update the policy to use a different `targetRef` kind.
 
 ### Observability operator
 


### PR DESCRIPTION
Signed-off-by: Marcin Skalski [marcin.skalski@konghq.com](mailto:marcin.skalski@konghq.com)

Summary
Extend Kong Mesh docs with RBAC to include usage of new policies introduces in 2.0 version

Reason
https://github.com/Kong/kong-mesh/issues/1874