### PR TITLE
Set links web url accordingly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -425,6 +425,14 @@ function build_site(steps, append) {
   steps = steps || [];
   append = append || [];
 
+  if (process.env.JEKYLL_ENV == "preview") {
+    var linksWebOverride = `
+links:
+  web: ${process.env.DEPLOY_PRIME_URL}
+`;
+    fs.appendFileSync("./jekyll.yml", linksWebOverride);
+  }
+
   // These are the steps that always run for every build
   // If set_dev is called, some of these methods behave differently
   steps = steps.concat([

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -21,7 +21,7 @@ name: Kong Docs
 title: Kong Docs
 description: "Documentation for Kong, the Cloud Connectivity Company for APIs and Microservices."
 links:
-  web: https://docs.konghq.com
+  web: http://localhost:3000
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters
   download: https://download.konghq.com
   instaclustr: "https://www.instaclustr.com/products/kong/?utm_source=partnership&utm_medium=link&utm_campaign=mashape"


### PR DESCRIPTION
### Summary
Set the `site.links.web` to the corresponding url when running it locally and in preview apps, i.e.:
* `http://localhost:3000` for localhost
* `process.env.DEPLOY_PRIME_URL` for preview apps 

### Reason
Some [links](https://github.com/Kong/docs.konghq.com/search?q=site.links.web) use the `site.links.web` config, which was hardcoded to production's url making it impossible to test changes before releasing them.

Make contributors' life easier by allowing them to test changes locally and in review apps by setting the right url based on the `environment`. 

### Testing
Visit https://deploy-preview-4701--kongdocs.netlify.app//kubernetes-ingress-controller/latest/guides/using-gateway-api/#traffic-splitting-with-httproute and verify that file in the code snippet can be downloaded.
