### PR TITLE
Version links to Kuma

### DIFF
--- a/app/_includes/md/mesh/install-universal-quickstart.md
+++ b/app/_includes/md/mesh/install-universal-quickstart.md
@@ -1,5 +1,16 @@
 <!-- Shared between Mesh installation topics: Ubuntu, Amazon Linux, RedHat, Debian, MacOS, CentOS -->
 ## 4. Quickstart
 
+{% if_version gte:2.0.x %}
 To start using {{site.mesh_product_name}}, see the
 [quickstart guide for Universal deployments](/mesh/{{page.kong_version}}/quickstart/universal/).
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+The Kuma quickstart documentation is fully compatible with
+{{site.mesh_product_name}}, except that you are running {{site.mesh_product_name}}
+binaries instead of the Kuma binaries.
+
+To start using {{site.mesh_product_name}}, see the
+[quickstart guide for Universal deployments](https://kuma.io/docs/latest/quickstart/universal/).
+{% endif_version %}

--- a/app/_includes/md/mesh/install-universal-run.md
+++ b/app/_includes/md/mesh/install-universal-run.md
@@ -19,7 +19,7 @@ Where `/path/to/file/license.json` is the path to a valid
 {{site.mesh_product_name}} license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/)
+deployment, but there are more advanced [deployment modes][deployments]
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always
@@ -30,5 +30,16 @@ in `/usr/local/bin/` by executing:
 $ ln -s ./kumactl /usr/local/bin/kumactl
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](/mesh/{{page.kong_version}}/explore/backends/), 
+This runs {{site.mesh_product_name}} with a [memory backend][backends],
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+[backends]: /mesh/{{page.kong_version}}/explore/backends/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+[backends]: https://kuma.io/docs/latest/explore/backends/
+{% endif_version %}

--- a/src/mesh/features/acmpca.md
+++ b/src/mesh/features/acmpca.md
@@ -20,9 +20,10 @@ server.
 
 * `acmpca`: {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
-
+{% if_version gte:1.8.x %}
 * [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates data plane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
+{% endif_version %}
 
 ## ACM Private CA mode
 

--- a/src/mesh/features/acmpca.md
+++ b/src/mesh/features/acmpca.md
@@ -4,7 +4,7 @@ title: ACM Private CA Policy
 
 ## Amazon Certificate Manager Private CA Backend
 
-The default [mTLS policy in {{site.mesh_product_name}}](/mesh/{{page.kong_version}}/policies/mutual-tls/)
+The default [mTLS policy in {{site.mesh_product_name}}][mtls-policy]
 supports the following backends:
 
 * `builtin`: {{site.mesh_product_name}} automatically generates the Certificate
@@ -68,7 +68,7 @@ AWS credentials and CA Certificate may be supplied inline, as a path to a file o
 same host as `kuma-cp`, or contained in a `secret`. Inline specification of credentials should
 be used for testing purposes only.
 When using a `secret`, it should be a mesh-scoped
-secret (see [the {{site.mesh_product_name}} Secrets documentation](/mesh/{{page.kong_version}}/security/secrets/) for details
+secret (see [the {{site.mesh_product_name}} Secrets documentation][secrets] for details
 on mesh-scoped secrets versus global secrets). On Kubernetes, this mesh-scoped secret should be stored
 in the system namespace (`kong-mesh-system` by default) and should be configured as `type: system.kuma.io/secret`.
 
@@ -133,7 +133,7 @@ mtls:
             file: /tmp/accesss_key.txt # one of file, secret or inline.
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](/mesh/{{page.kong_version}}/reference/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API][http-api].
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -143,3 +143,16 @@ Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](/me
 In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with ACM Private CA. This is because certificates for data plane proxies are requested from ACM Private CA by the zone control plane, not the global control plane.
 
 You must also make sure the global control plane can communicate with ACM Private CA. When a new `acmpca` backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multi-zone environment, validation is performed on the global control plane.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[mtls-policy]: /mesh/{{page.kong_version}}/policies/mutual-tls/
+[secrets]: /mesh/{{page.kong_version}}/security/secrets/
+[http-api]: /mesh/{{page.kong_version}}/reference/http-api/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[mtls-policy]: https://kuma.io/docs/latest/policies/mutual-tls/
+[secrets]: https://kuma.io/docs/latest/security/secrets/
+[http-api]: https://kuma.io/docs/latest/reference/http-api
+{% endif_version %}

--- a/src/mesh/features/cert-manager.md
+++ b/src/mesh/features/cert-manager.md
@@ -4,7 +4,7 @@ title: Kong Mesh - Kubernetes cert-manager CA Policy
 
 ## cert-manager CA Backend
 
-The default [mTLS policy in {{site.mesh_product_name}}](/mesh/{{page.kong_version}}/policies/mutual-tls/)
+The default [mTLS policy in {{site.mesh_product_name}}][mtls-policy]
 supports the following backends:
 
 * `builtin`: {{site.mesh_product_name}} automatically generates the Certificate
@@ -110,3 +110,12 @@ Universal and Kubernetes cannot be used together in a multi-zone environment whi
 You must also ensure the global control plan can access cert-manager.
 When a new `certmanager`backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate.
 In a multi-zone environment, validation is performed on the global control plane.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[mtls-policy]: /mesh/{{page.kong_version}}/policies/mutual-tls/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[mtls-policy]: https://kuma.io/docs/latest/policies/mutual-tls/
+{% endif_version %}

--- a/src/mesh/features/kds-auth.md
+++ b/src/mesh/features/kds-auth.md
@@ -4,7 +4,7 @@ title: Multi-zone authentication
 
 To add to the security of your deployments, Kong Mesh provides authentication of zone control planes to the global control plane.
 Authentication is based on the Zone Token which is also used to authenticate the zone proxy.
-See [zone proxy authentication](/mesh/{{page.kong_version}}/security/zoneproxy-auth/) to learn about token characteristics, revocation, rotation, and more.
+See [zone proxy authentication][zoneproxy] to learn about token characteristics, revocation, rotation, and more.
 {{site.mesh_product_name}} introduces additional `cp` scope. Only tokens with `cp` scope can be used to authenticate with the zone control plane.
 
 ## Set up tokens
@@ -17,7 +17,7 @@ To generate the tokens you need and configure your clusters:
 
 ### Generate token for each zone
 
-On the global control plane, [authenticate](/mesh/{{page.kong_version}}/security/certificates/#user-to-control-plane-communication) and run the following command:
+On the global control plane, [authenticate][auth] and run the following command:
 
 ```
 kumactl generate zone-token --zone=west --scope=cp --valid-for=720h > /tmp/token
@@ -146,8 +146,21 @@ Verify the zone control plane is connected with authentication by looking at the
 
 ## Additional security
 
-By default, a connection from the zone control plane to the global control plane is secured with TLS. You should also configure the zone control plane to [verify the certificate authority (CA) of the global control plane](/mesh/{{page.kong_version}}/security/certificates/#control-plane-to-control-plane-multizone){:target="_blank"}.
+By default, a connection from the zone control plane to the global control plane is secured with TLS. You should also configure the zone control plane to [verify the certificate authority (CA) of the global control plane][certs].
 
 ## Legacy Control Plane Token
 
-You can still authenticate a control plane using the separate [Control Plane Token](/mesh/1.9.x/features/kds-auth), but it is deprecated and will be removed in the future.
+You can still authenticate a control plane using the separate [Control Plane Token](/mesh/{{page.kong_version}}/features/kds-auth), but it is deprecated and will be removed in the future.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[zoneproxy]: /mesh/{{page.kong_version}}/security/zoneproxy-auth/
+[auth]: /mesh/{{page.kong_version}}/security/certificates/#user-to-control-plane-communication
+[certs]: /mesh/{{page.kong_version}}/security/certificates/#control-plane-to-control-plane-multizone
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[zoneproxy]: https://kuma.io/docs/dev/security/zoneproxy-auth/
+[auth]: https://kuma.io/docs/latest/security/certificates/#user-to-control-plane-communication
+[certs]: https://kuma.io/docs/latest/security/certificates/#control-plane-to-control-plane-multizone
+{% endif_version %}

--- a/src/mesh/features/kds-auth.md
+++ b/src/mesh/features/kds-auth.md
@@ -152,15 +152,18 @@ By default, a connection from the zone control plane to the global control plane
 
 You can still authenticate a control plane using the separate [Control Plane Token](/mesh/{{page.kong_version}}/features/kds-auth), but it is deprecated and will be removed in the future.
 
+<!-- vale off -->
 <!-- links -->
 {% if_version gte:2.0.x %}
-[zoneproxy]: /mesh/{{page.kong_version}}/security/zoneproxy-auth/
+[zone-proxy]: /mesh/{{page.kong_version}}/security/zoneproxy-auth/
 [auth]: /mesh/{{page.kong_version}}/security/certificates/#user-to-control-plane-communication
 [certs]: /mesh/{{page.kong_version}}/security/certificates/#control-plane-to-control-plane-multizone
 {% endif_version %}
 
 {% if_version lte:1.9.x %}
-[zoneproxy]: https://kuma.io/docs/dev/security/zoneproxy-auth/
+[zone-proxy]: https://kuma.io/docs/dev/security/zoneproxy-auth/
 [auth]: https://kuma.io/docs/latest/security/certificates/#user-to-control-plane-communication
 [certs]: https://kuma.io/docs/latest/security/certificates/#control-plane-to-control-plane-multizone
 {% endif_version %}
+
+<!-- vale on -->

--- a/src/mesh/features/opa.md
+++ b/src/mesh/features/opa.md
@@ -11,7 +11,7 @@ The agent is included in the data plane proxy sidecar, instead of the more commo
 When `OPAPolicy` is applied, the control plane configures:
 
 - the embedded policy agent, with the specified policy
-- Envoy, to use [External Authorization](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/http/ext_authz/v2/ext_authz.proto) that points to the embedded policy agent
+- Envoy, to use [External Authorization](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto) that points to the embedded policy agent
 
 ## Usage
 
@@ -636,7 +636,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 
 <!-- links -->
 {% if_version gte:2.0.x %}
-[protocols]: /mesh/{{page.kong_version}}/policies/protocol-support-in-kuma/
+[protocols]: /mesh/{{page.kong_version}}/policies/protocol-support-in-kong-mesh/
 [secrets]: /mesh/{{page.kong_version}}/security/secrets/
 {% endif_version %}
 

--- a/src/mesh/features/opa.md
+++ b/src/mesh/features/opa.md
@@ -15,7 +15,7 @@ When `OPAPolicy` is applied, the control plane configures:
 
 ## Usage
 
-To apply a policy with OPA: 
+To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
@@ -57,7 +57,7 @@ type: Dataplane
 mesh: default
 name: web
 networking:
-  address: 192.168.0.1 
+  address: 192.168.0.1
   inbound:
   - port: 80
     servicePort: 8080
@@ -69,7 +69,7 @@ networking:
 {% endnavtab %}
 {% endnavtabs %}
 
-For more information, see [the {{site.mesh_product_name}} documentation about protocol support](/mesh/{{page.kong_version}}/policies/protocol-support-in-kuma/).
+For more information, see [the {{site.mesh_product_name}} documentation about protocol support][protocols].
 
 ### Inline
 
@@ -140,28 +140,28 @@ conf:
   policies: # optional
     - inlineString: | # one of: inlineString, secret
         package envoy.authz
-  
+
         import input.attributes.request.http as http_request
-  
+
         default allow = false
-  
+
         token = {"valid": valid, "payload": payload} {
             [_, encoded] := split(http_request.headers.authorization, " ")
             [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
         }
-  
+
         allow {
             is_token_valid
             action_allowed
         }
-  
+
         is_token_valid {
           token.valid
           now := time.now_ns() / 1000000000
           token.payload.nbf <= now
           now < token.payload.exp
         }
-  
+
         action_allowed {
           http_request.method == "GET"
           token.payload.role == "admin"
@@ -173,7 +173,7 @@ conf:
 
 ### With Secrets
 
-Encoding the policy in a [Secret](/mesh/{{page.kong_version}}/security/secrets/) provides some security for policies that contain sensitive data.
+Encoding the policy in a [Secret][secrets] provides some security for policies that contain sensitive data.
 
 {% navtabs %}
 {% navtab Kubernetes %}
@@ -259,7 +259,7 @@ The following environment variables are available:
 
 You can customize the agent in either of the following ways:
 
-- Override variables in the data plane proxy config: 
+- Override variables in the data plane proxy config:
 {% navtabs %}
 {% navtab kumactl %}
 
@@ -311,12 +311,12 @@ The `run` command on the data plane proxy accepts the following equivalent param
 
 
 ```
---opa-addr 
---opa-config-path 
---opa-diagnostic-addr 
+--opa-addr
+--opa-config-path
+--opa-diagnostic-addr
 --opa-enabled                    
---opa-ext-authz-addr 
---opa-set strings 
+--opa-ext-authz-addr
+--opa-set strings
 ```
 
 {% endnavtab %}
@@ -428,7 +428,7 @@ spec:
             credentials:
               bearer:
                 token: "bGFza2RqZmxha3NkamZsa2Fqc2Rsa2ZqYWtsc2RqZmtramRmYWxkc2tm"
-        
+
         discovery:
           name: example
           resource: /configuration/example/discovery
@@ -489,7 +489,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     > Host: backend:3001
     > User-Agent: curl/7.67.0
     > Accept: */*
-    > 
+    >
     * Mark bundle as not supporting multiuse
     < HTTP/1.1 200 OK
     < x-powered-by: Express
@@ -507,7 +507,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     < date: Tue, 16 Mar 2021 15:33:18 GMT
     < x-envoy-upstream-service-time: 1521
     < server: envoy
-    < 
+    <
     * Connection #0 to host backend left intact
     Hello World! Marketplace with sales and reviews made with <3 by the OCTO team at Kong Inc.
     ```
@@ -515,7 +515,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 1.  Apply an OPA Policy that requires a valid JWT token:
 
     ```
-    echo " 
+    echo "
     apiVersion: kuma.io/v1alpha1
     kind: OPAPolicy
     mesh: default
@@ -609,7 +609,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     > Host: backend:3001
     > User-Agent: curl/7.67.0
     > Accept: */*
-    > 
+    >
     * Mark bundle as not supporting multiuse
     < HTTP/1.1 200 OK
     < x-powered-by: Express
@@ -627,9 +627,20 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
     < date: Tue, 16 Mar 2021 17:26:00 GMT
     < x-envoy-upstream-service-time: 261
     < server: envoy
-    < 
+    <
     * Connection #0 to host backend left intact
     Hello World! Marketplace with sales and reviews made with <3 by the OCTO team at Kong Inc.
     ```
 
     The request is valid again because the token is signed with the `secret` private key, its payload includes the admin role, and it is not expired.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[protocols]: /mesh/{{page.kong_version}}/policies/protocol-support-in-kuma/
+[secrets]: /mesh/{{page.kong_version}}/security/secrets/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[protocols]: https://kuma.io/docs/latest/policies/protocol-support-in-kuma/
+[secrets]: https://kuma.io/docs/latest/security/secrets/
+{% endif_version %}

--- a/src/mesh/features/vault.md
+++ b/src/mesh/features/vault.md
@@ -20,9 +20,10 @@ server.
 
 * [`acmpca`](/mesh/{{page.kong_version}}/features/acmpca) {{site.mesh_product_name}} generates data plane certificates
 using Amazon Certificate Manager Private CA.
-
+{% if_version gte:1.8.x %}
 * [`certmanager`](/mesh/{{page.kong_version}}/features/cert-manager): {{site.mesh_product_name}} generates data plane certificates
 using Kubernetes [cert-manager](https://cert-manager.io) certificate controller.
+{% endif_version %}
 
 ## Vault mode
 

--- a/src/mesh/features/vault.md
+++ b/src/mesh/features/vault.md
@@ -4,7 +4,7 @@ title: Kong Mesh - Vault Policy
 
 ## Vault CA Backend
 
-The default [mTLS policy in {{site.mesh_product_name}}](/mesh/{{page.kong_version}}/policies/mutual-tls/)
+The default [mTLS policy in {{site.mesh_product_name}}][mtls-policy]
 supports the following backends:
 
 * `builtin`: {{site.mesh_product_name}} automatically generates the Certificate
@@ -178,12 +178,12 @@ vault token create -format=json -policy="kmesh-default-dataplane-proxies" | jq -
 The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 
 {:.note}
-> **Note:** There are some failure modes where the `vault` CLI still returns a token 
-even though an error was encountered and the token is invalid. For example, if the 
-policy creation fails in the previous step, then the `vault token create` command 
-both returns a token and exposes an error. In such situations, using `jq` to parse 
-the output hides the error message provided in the `vault` CLI output. Manually 
-parse the output instead of using `jq` so that the full output of the `vault` CLI 
+> **Note:** There are some failure modes where the `vault` CLI still returns a token
+even though an error was encountered and the token is invalid. For example, if the
+policy creation fails in the previous step, then the `vault token create` command
+both returns a token and exposes an error. In such situations, using `jq` to parse
+the output hides the error message provided in the `vault` CLI output. Manually
+parse the output instead of using `jq` so that the full output of the `vault` CLI
 command is available.
 
 {{site.mesh_product_name}} also supports AWS Instance Role authentication to Vault. Vault must be configured to accept EC2 or IAM role authentication. See [Vault documentation](https://www.vaultproject.io/docs/auth/aws) for details.  With Vault configured, select AWS authentication in the `Mesh` object by setting `conf.fromCp.auth.aws`. {{site.mesh_product_name}} will authenticate using the instance or IRSA role available within the environment.
@@ -196,9 +196,9 @@ Vault, you must provide credentials in the configuration of the `mesh` object of
 You can authenticate with the `token`, with client certificates by providing `clientKey` and `clientCert`, or by AWS role-based authentication.
 
 You can provide these values inline for testing purposes only, as a path to a file on the
-same host as `kuma-cp`, or contained in a `secret`. When using a `secret`, it should be a mesh-scoped 
-secret (see [the {{site.mesh_product_name}} Secrets documentation](/mesh/{{page.kong_version}}/security/secrets/) for details 
-on mesh-scoped secrets versus global secrets). On Kubernetes, this mesh-scoped secret should be stored 
+same host as `kuma-cp`, or contained in a `secret`. When using a `secret`, it should be a mesh-scoped
+secret (see [the {{site.mesh_product_name}} Secrets documentation][secrets] for details
+on mesh-scoped secrets versus global secrets). On Kubernetes, this mesh-scoped secret should be stored
 in the system namespace (`kong-mesh-system` by default) and should be configured as `type: system.kuma.io/secret`.
 
 Here's an example of a configuration with a `vault`-backed CA:
@@ -292,7 +292,7 @@ mtls:
               iamServerIdHeader: example.com # Optional server ID header value
 ```
 
-Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](/mesh/{{page.kong_version}}/reference/http-api).
+Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API][http-api].
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -301,10 +301,23 @@ Apply the configuration with `kumactl apply -f [..]`, or with the [HTTP API](/me
 
 Kong Mesh uses Service Alternative Name with `spiffe://` format to verify secure connection between services. In this case, the common name in the certificate is not used.
 You may need to set a common name in the certificate, for compliance reasons. To do this, set the `commonName` field in the Vault mTLS backend configuration.
-The value contains the template that will be used to generate the name. For example, assuming that the template is {% raw %}'{{ tag "kuma.io/service" }}.mesh'{% endraw %}, a data plane proxy with `kuma.io/service: backend` tag will receive a certificate with the `backend.mesh` common name. You can also use the `replace` function to replace `_` with `-`, for example {% raw %}'{{ tag "kuma.io/service" | replace "_" "-" }}.mesh'{% endraw %} will change the common name of `kuma.io/service: my_backend` from `my_backend.mesh` to `my-backend.mesh`.
+The value contains the template that will be used to generate the name. For example, assuming that the template is `{% raw %}'{{ tag "kuma.io/service" }}.mesh'{% endraw %}`, a data plane proxy with `kuma.io/service: backend` tag will receive a certificate with the `backend.mesh` common name. You can also use the `replace` function to replace `_` with `-`, for example `{% raw %}'{{ tag "kuma.io/service" | replace "_" "-" }}.mesh'{% endraw %}` changes the common name of `kuma.io/service: my_backend` from `my_backend.mesh` to `my-backend.mesh`.
 
 ## Multi-zone and Vault
 
 In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane communicates with Vault over the same address. This is because certificates for data plane proxies are issued from the zone control plane, not from the global control plane.
 
 You must also make sure the global control plane communicates with Vault. When a new Vault backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multi-zone environment, validation is performed on the global control plane.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[mtls-policy]: /mesh/{{page.kong_version}}/policies/mutual-tls/
+[secrets]: /mesh/{{page.kong_version}}/security/secrets/
+[http-api]: /mesh/{{page.kong_version}}/reference/http-api/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[mtls-policy]: https://kuma.io/docs/latest/policies/mutual-tls/
+[secrets]: https://kuma.io/docs/latest/security/secrets/
+[http-api]: https://kuma.io/docs/latest/reference/http-api
+{% endif_version %}

--- a/src/mesh/gettingstarted.md
+++ b/src/mesh/gettingstarted.md
@@ -2,30 +2,41 @@
 title: Getting Started with Kong Mesh
 ---
 
-## Getting Started
-
 {{site.mesh_product_name}} &mdash; built on top of CNCF's [Kuma](https://kuma.io) and Envoy &mdash;
  tries to be as close as possible to the usage of Kuma itself, while providing
  drop-in binary replacements for both the control plane and data plane
  executables.
 
+{% if_version gte:2.0.x %}
 You can download the {{site.mesh_product_name}} binaries from the
 [official installation page](/mesh/{{page.kong_version}}/install).
+{% endif_version %}
 
-<div class="alert alert-ee blue">
-   Kuma, a donated CNCF project, was originally created by Kong, which is
-   currently maintaining both the project and the documentation.
-</div>
+{% if_version lte:1.9.x %}
+You can download the {{site.mesh_product_name}} binaries from the
+[official installation page](/mesh/{{page.kong_version}}/install), then follow
+[Kuma's official documentation](https://kuma.io/docs) to start using the product.
+{% endif_version %}
+
+{:.note}
+> Kuma, a donated CNCF project, was originally created by Kong, which is
+currently maintaining both the project and the documentation.
 
 ## 1. Installing {{site.mesh_product_name}}
 
 Download and install {{site.mesh_product_name}} from the
 [official installation page](/mesh/{{page.kong_version}}/install).
 
-## 2. Getting Started
+## 2. Getting started
 
 After you install, follow the getting started guides to get
-{{site.mesh_product_name}} up and running:
+{{site.mesh_product_name}} up and running.
+
+{% if_version lte:1.9.x %}
+The Kuma quickstart documentation
+is fully compatible with {{site.mesh_product_name}}, except that you are
+running {{site.mesh_product_name}} containers instead of Kuma containers:
+{% endif_version %}
 
 * [Getting started with Kubernetes][get-started-k8s]
 * [Getting started with Universal][get-started-universal]

--- a/src/mesh/index.md
+++ b/src/mesh/index.md
@@ -136,7 +136,7 @@ hybrid Kubernetes/VMs:
      organization.</i>
 </center>
 <br>
-Learn more about the [standalone and multi-zone deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/).
+Learn more about the [standalone and multi-zone deployment modes][deployments].
 
 ## Support policy
 Kong primarily follows a [semantic versioning](https://semver.org/) (SemVer)
@@ -144,3 +144,12 @@ model for its products.
 
 For the latest version support information for
 {{site.mesh_product_name}}, see our [version support policy](/mesh/latest/support-policy).
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+{% endif_version %}

--- a/src/mesh/installation/docker.md
+++ b/src/mesh/installation/docker.md
@@ -54,10 +54,10 @@ license file on the host that will be mounted as `/license.json` into the
 container.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/)
+deployment, but there are more advanced [deployment modes][deployments]
 like _multi-zone_.
 
-This runs {{site.mesh_product_name}} with a [memory backend](/mesh/{{page.kong_version}}/explore/backends/),
+This runs {{site.mesh_product_name}} with a [memory backend][backends],
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 ## 3. Verify the Installation
@@ -134,6 +134,21 @@ entity with the name `default`.
 ## 4. Quickstart
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Universal deployments](/mesh/{{page.kong_version}}/quickstart/universal/).
+[quickstart guide for Universal deployments][get-started-universal].
 If you are entirely using Docker, you may also be interested in checking out the
-[Kubernetes quickstart](/mesh/{{page.kong_version}}/quickstart/kubernetes/) as well.
+[Kubernetes quickstart][get-started-k8s] as well.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+[backends]: /mesh/{{page.kong_version}}/explore/backends/
+[get-started-k8s]: /mesh/{{page.kong_version}}/quickstart/kubernetes/
+[get-started-universal]: /mesh/{{page.kong_version}}/quickstart/universal/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+[backends]: https://kuma.io/docs/latest/explore/backends/
+[get-started-k8s]: https://kuma.io/docs/latest/quickstart/kubernetes/
+[get-started-universal]: https://kuma.io/docs/latest/quickstart/universal/
+{% endif_version %}

--- a/src/mesh/installation/docker.md
+++ b/src/mesh/installation/docker.md
@@ -141,14 +141,14 @@ If you are entirely using Docker, you may also be interested in checking out the
 <!-- links -->
 {% if_version gte:2.0.x %}
 [deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
-[backends]: /mesh/{{page.kong_version}}/explore/backends/
+[backends]: /mesh/{{page.kong_version}}/documentation/configuration/
 [get-started-k8s]: /mesh/{{page.kong_version}}/quickstart/kubernetes/
 [get-started-universal]: /mesh/{{page.kong_version}}/quickstart/universal/
 {% endif_version %}
 
 {% if_version lte:1.9.x %}
 [deployments]: https://kuma.io/docs/latest/introduction/deployments/
-[backends]: https://kuma.io/docs/latest/explore/backends/
+[backends]: https://kuma.io/docs/latest/documentation/configuration/
 [get-started-k8s]: https://kuma.io/docs/latest/quickstart/kubernetes/
 [get-started-universal]: https://kuma.io/docs/latest/quickstart/universal/
 {% endif_version %}

--- a/src/mesh/installation/ecs.md
+++ b/src/mesh/installation/ecs.md
@@ -147,9 +147,9 @@ When a task starts, the following happens:
 
 <!-- links -->
 {% if_version gte:2.0.x %}
-[dpp-spec]: /mesh/{{page.kong_version}}/reference/dpp-specification
+[dpp-spec]: /mesh/{{page.kong_version}}/generated/resources/proxy_dataplane/
 {% endif_version %}
 
 {% if_version lte:1.9.x %}
-[dpp-spec]: https://kuma.io/docs/latest/reference/dpp-specification
+[dpp-spec]: https://kuma.io/docs/latest/generated/resources/proxy_dataplane/
 {% endif_version %}

--- a/src/mesh/installation/ecs.md
+++ b/src/mesh/installation/ecs.md
@@ -35,7 +35,7 @@ join the cluster, the controller requests a new data plane token scoped to that 
 
 With Kong Mesh on ECS, each service enumerates
 other services it contacts in the mesh and
-[exposes them in `Dataplane` specification](/mesh/{{page.kong_version}}/reference/dpp-specification).
+[exposes them in `Dataplane` specification][dpp-spec].
 
 ## Deployment
 
@@ -108,7 +108,7 @@ Services are bootstrapped with a `Dataplane` specification.
 
 Transparent proxy is not supported on ECS, so the `Dataplane` resource for a
 service must enumerate all other mesh services this service contacts and include them
-[in the `Dataplane` specification as `outbounds`](/mesh/{{page.kong_version}}/reference/dpp-specification).
+[in the `Dataplane` specification as `outbounds`][dpp-spec].
 
 See the example repository to learn
 [how to handle the `Dataplane` template with Cloudformation](https://github.com/Kong/kong-mesh-ecs/blob/main/deploy/counter-demo/demo-app.yaml#L30-L46).
@@ -144,3 +144,12 @@ When a task starts, the following happens:
 1. The controller sees an empty secret and generates a new data plane token via the
    mesh API, saving the result as `token` in the secret.
 1. Finally, ECS is able to fetch the `token` value and starts the task successfully.
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[dpp-spec]: /mesh/{{page.kong_version}}/reference/dpp-specification
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[dpp-spec]: https://kuma.io/docs/latest/reference/dpp-specification
+{% endif_version %}

--- a/src/mesh/installation/helm.md
+++ b/src/mesh/installation/helm.md
@@ -66,7 +66,7 @@ suggest `kong-mesh-system`.
     ```
 
     This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-    deployment, but there are more advanced [deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/)
+    deployment, but there are more advanced [deployment modes][deployments]
     like _multi-zone_.
 
     You can see all possible parameters of the charts by running `helm show values kong-mesh/kong-mesh`.
@@ -180,4 +180,15 @@ entity with the name `default`.
 ## 4. Quickstart
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](/mesh/{{page.kong_version}}/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments][get-started-k8s].
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+[get-started-k8s]: /mesh/{{page.kong_version}}/quickstart/kubernetes/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+[get-started-k8s]: https://kuma.io/docs/latest/quickstart/kubernetes/
+{% endif_version %}

--- a/src/mesh/installation/kubernetes.md
+++ b/src/mesh/installation/kubernetes.md
@@ -71,7 +71,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/)
+deployment, but there are more advanced [deployment modes][deployments]
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always
@@ -187,4 +187,15 @@ entity with the name `default`.
 ## 4. Quickstart
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](/mesh/{{page.kong_version}}/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments][get-started-k8s].
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+[get-started-k8s]: /mesh/{{page.kong_version}}/quickstart/kubernetes/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+[get-started-k8s]: https://kuma.io/docs/latest/quickstart/kubernetes/
+{% endif_version %}

--- a/src/mesh/installation/openshift.md
+++ b/src/mesh/installation/openshift.md
@@ -121,7 +121,7 @@ Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/)
+deployment, but there are more advanced [deployment modes][deployments]
 like _multi-zone_.
 
 It may take a while for OpenShift to start the
@@ -258,4 +258,15 @@ One of the components in the demo requires root access, therefore it uses the
 `anyuid` instead of the `nonroot` permission.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](/mesh/{{page.kong_version}}/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments][get-started-k8s].
+
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+[get-started-k8s]: /mesh/{{page.kong_version}}/quickstart/kubernetes/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+[get-started-k8s]: https://kuma.io/docs/latest/quickstart/kubernetes/
+{% endif_version %}

--- a/src/mesh/installation/windows.md
+++ b/src/mesh/installation/windows.md
@@ -79,10 +79,10 @@ but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-
 <!-- links -->
 {% if_version gte:2.0.x %}
 [deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
-[backends]: /mesh/{{page.kong_version}}/explore/backends/
+[backends]: /mesh/{{page.kong_version}}/documentation/configuration/
 {% endif_version %}
 
 {% if_version lte:1.9.x %}
 [deployments]: https://kuma.io/docs/latest/introduction/deployments/
-[backends]: https://kuma.io/docs/latest/explore/backends/
+[backends]: https://kuma.io/docs/latest/documentation/configuration/
 {% endif_version %}

--- a/src/mesh/installation/windows.md
+++ b/src/mesh/installation/windows.md
@@ -60,7 +60,7 @@ $ KMESH_LICENSE_PATH=/path/to/file/license.json kuma-cp run
 ```
 
 This example will run {{site.mesh_product_name}} in standalone mode for a _flat_
-deployment, but there are more advanced [deployment modes](/mesh/{{page.kong_version}}/introduction/deployments/)
+deployment, but there are more advanced [deployment modes][deployments]
 like _multi-zone_.
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory (PowerShell as Administrator):
@@ -69,10 +69,20 @@ We suggest adding the `kumactl` executable to your `PATH` so that it's always av
 New-Item -ItemType SymbolicLink -Path C:\Windows\kumactl.exe -Target .\kumactl.exe
 ```
 
-This runs {{site.mesh_product_name}} with a [memory backend](/mesh/{{page.kong_version}}/explore/backends/),
+This runs {{site.mesh_product_name}} with a [memory backend][backends],
 but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 
 {% include /md/mesh/install-universal-verify.md %}
 
 {% include /md/mesh/install-universal-quickstart.md %}
 
+<!-- links -->
+{% if_version gte:2.0.x %}
+[deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
+[backends]: /mesh/{{page.kong_version}}/explore/backends/
+{% endif_version %}
+
+{% if_version lte:1.9.x %}
+[deployments]: https://kuma.io/docs/latest/introduction/deployments/
+[backends]: https://kuma.io/docs/latest/explore/backends/
+{% endif_version %}


### PR DESCRIPTION
### Summary
Versioning links for single-sourced content.

### Reason
We're getting broken links on versions pre-2.0.

### Testing
Netlify - check the links on 2.0.x and an earlier version. 2.0.x should go to the page on docs.konghq.com, while 1.9.x and earlier will go to the Kuma site.