### PR TITLE
Add default namespace variable

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -180,6 +180,7 @@ ee_product_name: Kong Enterprise
 ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
 mesh_product_name: Kong Mesh
+default_namespace: kong-mesh-system
 kic_product_name: Kubernetes Ingress Controller
 konnect_product_name: Kong Konnect
 konnect_short_name: Konnect

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -181,6 +181,7 @@ ee_product_name: Kong Enterprise
 ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
 mesh_product_name: Kong Mesh
+default_namespace: kong-mesh-system
 kic_product_name: Kubernetes Ingress Controller
 konnect_product_name: Kong Konnect
 konnect_short_name: Konnect


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Made a variable for the the default namespace so that "kuma-system" is replaced with "kong-mesh-system".
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
https://github.com/kumahq/kuma-website/pull/1122
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Locally, "kuma-system" wasn't being replaced with "kong-mesh-system". I'm hoping it displays correctly in the Netlify preview. Or it might be a submodule issue?

To test, look at /mesh/latest/deployments/multi-zone/ to see if "kuma-system" was replaced with "kong-mesh-system". 
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
