### PR TITLE
Update 2.0 Mesh nav to point to the correct folder

### DIFF
--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -80,7 +80,6 @@ items:
       - text: Overview
         url: /explore/overview/
         src: /.repos/kuma/app/docs/2.0.x/explore/overview/
-        items:
       - text: Data plane proxy
         url: /explore/dpp/
         src: /.repos/kuma/app/docs/2.0.x/explore/dpp/

--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -10,13 +10,13 @@ items:
         absolute_url: true
       - text: What is Service Mesh?
         url: /introduction/what-is-a-service-mesh/
-        src: /.repos/kuma/app/docs/dev/introduction/what-is-a-service-mesh/
+        src: /.repos/kuma/app/docs/2.0.x/introduction/what-is-a-service-mesh/
       - text: How Kong Mesh works
         url: /introduction/how-kong-mesh-works/
-        src: /.repos/kuma/app/docs/dev/introduction/how-kuma-works/
+        src: /.repos/kuma/app/docs/2.0.x/introduction/how-kuma-works/
       - text: Deployments
         url: /introduction/deployments/
-        src: /.repos/kuma/app/docs/dev/introduction/deployments/
+        src: /.repos/kuma/app/docs/2.0.x/introduction/deployments/
       - text: Version support policy
         url: /support-policy/
       - text: Stability
@@ -62,16 +62,16 @@ items:
     items:
       - text: Explore Kong Mesh with the Kubernetes demo app
         url: /quickstart/kubernetes/
-        src: /.repos/kuma/app/docs/dev/quickstart/kubernetes/
+        src: /.repos/kuma/app/docs/2.0.x/quickstart/kubernetes/
       - text: Explore Kong Mesh with the Universal demo app
         url: /quickstart/universal/
-        src: /.repos/kuma/app/docs/dev/quickstart/universal/
+        src: /.repos/kuma/app/docs/2.0.x/quickstart/universal/
       - text: Standalone deployment
         url: /deployments/stand-alone/
-        src: /.repos/kuma/app/docs/dev/deployments/stand-alone/
+        src: /.repos/kuma/app/docs/2.0.x/deployments/stand-alone/
       - text: Multi-zone deployment
         url: /deployments/multi-zone/
-        src: /.repos/kuma/app/docs/dev/deployments/multi-zone/
+        src: /.repos/kuma/app/docs/2.0.x/deployments/multi-zone/
       - text: License
         url: /plan-and-deploy/license
   - title: Explore
@@ -79,104 +79,104 @@ items:
     items:
       - text: Overview
         url: /explore/overview/
-        src: /.repos/kuma/app/docs/dev/explore/overview/
+        src: /.repos/kuma/app/docs/2.0.x/explore/overview/
         items:
-          - text: Data plane proxy
-            url: /explore/dpp/
-            src: /.repos/kuma/app/docs/dev/explore/dpp/
-          - text: Data plane on Kubernetes
-            url: /explore/dpp-on-kubernetes/
-            src: /.repos/kuma/app/docs/dev/explore/dpp-on-kubernetes/
-          - text: Data plane on Universal
-            url: /explore/dpp-on-universal/
-            src: /.repos/kuma/app/docs/dev/explore/dpp-on-universal/
-          - text: Gateway
-            url: /explore/gateway/
-            src: /.repos/kuma/app/docs/dev/explore/gateway/
-          - text: Zone Ingress
-            url: /explore/zone-ingress/
-            src: /.repos/kuma/app/docs/dev/explore/zone-ingress/
-          - text: Zone Egress
-            url: /explore/zoneegress/
-            src: /.repos/kuma/app/docs/dev/explore/zoneegress/
-          - text: CLI
-            url: /explore/cli/
-            src: /.repos/kuma/app/docs/dev/explore/cli/
-          - text: GUI
-            url: /explore/gui/
-            src: /.repos/kuma/app/docs/dev/explore/gui/
-          - text: Observability
-            url: /explore/observability/
-            src: /.repos/kuma/app/docs/dev/explore/observability/
-          - text: Inspect API
-            url: /explore/inspect-api/
-            src: /.repos/kuma/app/docs/dev/explore/inspect-api/
-          - text: Kubernetes Gateway API
-            url: /explore/gateway-api/
-            src: /.repos/kuma/app/docs/dev/explore/gateway-api/
+      - text: Data plane proxy
+        url: /explore/dpp/
+        src: /.repos/kuma/app/docs/2.0.x/explore/dpp/
+      - text: Data plane on Kubernetes
+        url: /explore/dpp-on-kubernetes/
+        src: /.repos/kuma/app/docs/2.0.x/explore/dpp-on-kubernetes/
+      - text: Data plane on Universal
+        url: /explore/dpp-on-universal/
+        src: /.repos/kuma/app/docs/2.0.x/explore/dpp-on-universal/
+      - text: Gateway
+        url: /explore/gateway/
+        src: /.repos/kuma/app/docs/2.0.x/explore/gateway/
+      - text: Zone Ingress
+        url: /explore/zone-ingress/
+        src: /.repos/kuma/app/docs/2.0.x/explore/zone-ingress/
+      - text: Zone Egress
+        url: /explore/zoneegress/
+        src: /.repos/kuma/app/docs/2.0.x/explore/zoneegress/
+      - text: CLI
+        url: /explore/cli/
+        src: /.repos/kuma/app/docs/2.0.x/explore/cli/
+      - text: GUI
+        url: /explore/gui/
+        src: /.repos/kuma/app/docs/2.0.x/explore/gui/
+      - text: Observability
+        url: /explore/observability/
+        src: /.repos/kuma/app/docs/2.0.x/explore/observability/
+      - text: Inspect API
+        url: /explore/inspect-api/
+        src: /.repos/kuma/app/docs/2.0.x/explore/inspect-api/
+      - text: Kubernetes Gateway API
+        url: /explore/gateway-api/
+        src: /.repos/kuma/app/docs/2.0.x/explore/gateway-api/
   - title: Networking
     icon: /assets/images/icons/documentation/icn-brain-color.svg
     items:
       - text: Networking
         url: /networking/networking/
-        src: /.repos/kuma/app/docs/dev/networking/networking/
+        src: /.repos/kuma/app/docs/2.0.x/networking/networking/
       - text: Service Discovery
         url: /networking/service-discovery/
-        src: /.repos/kuma/app/docs/dev/networking/service-discovery/
+        src: /.repos/kuma/app/docs/2.0.x/networking/service-discovery/
       - text: DNS
         url: /networking/dns/
-        src: /.repos/kuma/app/docs/dev/networking/dns/
+        src: /.repos/kuma/app/docs/2.0.x/networking/dns/
       - text: Kong Mesh CNI
         url: /networking/cni/
-        src: /.repos/kuma/app/docs/dev/networking/cni/
+        src: /.repos/kuma/app/docs/2.0.x/networking/cni/
       - text: Transparent Proxying
         url: /networking/transparent-proxying/
-        src: /.repos/kuma/app/docs/dev/networking/transparent-proxying/
+        src: /.repos/kuma/app/docs/2.0.x/networking/transparent-proxying/
       - text: IPv6 support
         url: /networking/ipv6/
-        src: /.repos/kuma/app/docs/dev/networking/ipv6/
+        src: /.repos/kuma/app/docs/2.0.x/networking/ipv6/
   - title: Security
     icon: /assets/images/icons/konnect/icn-organizations-nav.svg
     items:
       - text: Secure access across Kong Mesh components
         url: /security/certificates/
-        src: /.repos/kuma/app/docs/dev/security/certificates/
+        src: /.repos/kuma/app/docs/2.0.x/security/certificates/
       - text: Secrets
         url: /security/secrets/
-        src: /.repos/kuma/app/docs/dev/security/secrets/
+        src: /.repos/kuma/app/docs/2.0.x/security/secrets/
       - text: Kong Mesh API Access Control
         url: /security/api-access-control/
-        src: /.repos/kuma/app/docs/dev/security/api-access-control/
+        src: /.repos/kuma/app/docs/2.0.x/security/api-access-control/
       - text: API server authentication
         url: /security/api-server-auth/
-        src: /.repos/kuma/app/docs/dev/security/api-server-auth/
+        src: /.repos/kuma/app/docs/2.0.x/security/api-server-auth/
       - text: Data plane proxy authentication
         url: /security/dp-auth/
-        src: /.repos/kuma/app/docs/dev/security/dp-auth/
+        src: /.repos/kuma/app/docs/2.0.x/security/dp-auth/
       - text: Zone proxy authentication
         url: /security/zoneproxy-auth/
-        src: /.repos/kuma/app/docs/dev/security/zoneproxy-auth/
+        src: /.repos/kuma/app/docs/2.0.x/security/zoneproxy-auth/
       - text: Data plane proxy membership
         url: /security/dp-membership/
-        src: /.repos/kuma/app/docs/dev/security/dp-membership/
+        src: /.repos/kuma/app/docs/2.0.x/security/dp-membership/
   - title: Monitor and Manage
     icon: /assets/images/icons/konnect/icn-analytics-nav.svg
     items:
       - text: Dataplane Health
         url: /documentation/health/
-        src: /.repos/kuma/app/docs/dev/documentation/health/
+        src: /.repos/kuma/app/docs/2.0.x/documentation/health/
       - text: Fine-tuning
         url: /documentation/fine-tuning/
-        src: /.repos/kuma/app/docs/dev/documentation/fine-tuning/
+        src: /.repos/kuma/app/docs/2.0.x/documentation/fine-tuning/
       - text: Control Plane Configuration
         url: /documentation/configuration/
-        src: /.repos/kuma/app/docs/dev/documentation/configuration/
+        src: /.repos/kuma/app/docs/2.0.x/documentation/configuration/
       - text: Upgrades
         url: /documentation/upgrades/
-        src: /.repos/kuma/app/docs/dev/documentation/upgrades/
+        src: /.repos/kuma/app/docs/2.0.x/documentation/upgrades/
       - text: Requirements
         url: /documentation/requirements/
-        src: /.repos/kuma/app/docs/dev/documentation/requirements/
+        src: /.repos/kuma/app/docs/2.0.x/documentation/requirements/
   - title: Policies
     icon: /assets/images/icons/documentation/icn-documentation-small.svg
     items:
@@ -184,10 +184,10 @@ items:
         url: /policies/
       - text: General notes about Kong Mesh policies
         url: /policies/general-notes-about-kong-mesh-policies/
-        src: /.repos/kuma/app/docs/dev/policies/general-notes-about-kuma-policies/
+        src: /.repos/kuma/app/docs/2.0.x/policies/general-notes-about-kuma-policies/
       - text: Applying Policies
         url: /policies/applying-policies/
-        src: /.repos/kuma/app/docs/dev/policies/applying-policies/
+        src: /.repos/kuma/app/docs/2.0.x/policies/applying-policies/
       - text: How Kong Mesh chooses the right policy to apply
         url: /policies/how-kong-mesh-chooses-the-right-policy-to-apply/
         src: /.repos/kuma/app/docs/dev/policies/how-kuma-chooses-the-right-policy-to-apply/
@@ -196,70 +196,70 @@ items:
         src: /.repos/kuma/app/docs/dev/policies/matching/
       - text: Protocol support in Kong Mesh
         url: /policies/protocol-support-in-kong-mesh/
-        src: /.repos/kuma/app/docs/dev/policies/protocol-support-in-kuma/
+        src: /.repos/kuma/app/docs/2.0.x/policies/protocol-support-in-kuma/
       - text: Mesh
         url: /policies/mesh/
-        src: /.repos/kuma/app/docs/dev/policies/mesh/
+        src: /.repos/kuma/app/docs/2.0.x/policies/mesh/
       - text: Mutual TLS
         url: /policies/mutual-tls/
-        src: /.repos/kuma/app/docs/dev/policies/mutual-tls/
+        src: /.repos/kuma/app/docs/2.0.x/policies/mutual-tls/
       - text: Traffic Permissions
         url: /policies/traffic-permissions/
-        src: /.repos/kuma/app/docs/dev/policies/traffic-permissions/
+        src: /.repos/kuma/app/docs/2.0.x/policies/traffic-permissions/
       - text: Traffic Route
         url: /policies/traffic-route/
-        src: /.repos/kuma/app/docs/dev/policies/traffic-route/
+        src: /.repos/kuma/app/docs/2.0.x/policies/traffic-route/
       - text: Traffic Metrics
         url: /policies/traffic-metrics/
-        src: /.repos/kuma/app/docs/dev/policies/traffic-metrics/
+        src: /.repos/kuma/app/docs/2.0.x/policies/traffic-metrics/
       - text: Traffic Trace
         url: /policies/traffic-trace/
-        src: /.repos/kuma/app/docs/dev/policies/traffic-trace/
+        src: /.repos/kuma/app/docs/2.0.x/policies/traffic-trace/
       - text: Traffic Log
         url: /policies/traffic-log/
-        src: /.repos/kuma/app/docs/dev/policies/traffic-log/
+        src: /.repos/kuma/app/docs/2.0.x/policies/traffic-log/
       - text: Locality-aware Load Balancing
         url: /policies/locality-aware/
-        src: /.repos/kuma/app/docs/dev/policies/locality-aware/
+        src: /.repos/kuma/app/docs/2.0.x/policies/locality-aware/
       - text: Fault Injection
         url: /policies/fault-injection/
-        src: /.repos/kuma/app/docs/dev/policies/fault-injection/
+        src: /.repos/kuma/app/docs/2.0.x/policies/fault-injection/
       - text: Health Check
         url: /policies/health-check/
-        src: /.repos/kuma/app/docs/dev/policies/health-check/
+        src: /.repos/kuma/app/docs/2.0.x/policies/health-check/
       - text: Circuit Breaker
         url: /policies/circuit-breaker/
-        src: /.repos/kuma/app/docs/dev/policies/circuit-breaker/
+        src: /.repos/kuma/app/docs/2.0.x/policies/circuit-breaker/
       - text: Proxy Template
         url: /policies/proxy-template/
-        src: /.repos/kuma/app/docs/dev/policies/proxy-template/
+        src: /.repos/kuma/app/docs/2.0.x/policies/proxy-template/
       - text: External Service
         url: /policies/external-services/
-        src: /.repos/kuma/app/docs/dev/policies/external-services/
+        src: /.repos/kuma/app/docs/2.0.x/policies/external-services/
       - text: Retry
         url: /policies/retry/
-        src: /.repos/kuma/app/docs/dev/policies/retry/
+        src: /.repos/kuma/app/docs/2.0.x/policies/retry/
       - text: Timeout
         url: /policies/timeout/
-        src: /.repos/kuma/app/docs/dev/policies/timeout/
+        src: /.repos/kuma/app/docs/2.0.x/policies/timeout/
       - text: Rate Limit
         url: /policies/rate-limit/
-        src: /.repos/kuma/app/docs/dev/policies/rate-limit/
+        src: /.repos/kuma/app/docs/2.0.x/policies/rate-limit/
       - text: Virtual Outbound
         url: /policies/virtual-outbound/
-        src: /.repos/kuma/app/docs/dev/policies/virtual-outbound/
+        src: /.repos/kuma/app/docs/2.0.x/policies/virtual-outbound/
       - text: MeshGateway
         url: /policies/mesh-gateway/
-        src: /.repos/kuma/app/docs/dev/policies/mesh-gateway/
+        src: /.repos/kuma/app/docs/2.0.x/policies/mesh-gateway/
       - text: MeshGatewayRoute
         url: /policies/mesh-gateway-route/
-        src: /.repos/kuma/app/docs/dev/policies/mesh-gateway-route/
+        src: /.repos/kuma/app/docs/2.0.x/policies/mesh-gateway-route/
       - text: Service Health Probes
         url: /policies/service-health-probes/
-        src: /.repos/kuma/app/docs/dev/policies/service-health-probes/
+        src: /.repos/kuma/app/docs/2.0.x/policies/service-health-probes/
       - text: MeshTrace (Beta)
         url: /policies/meshtrace/
-        src: /.repos/kuma/app/docs/dev/policies/meshtrace/
+        src: /.repos/kuma/app/docs/2.0.x/policies/meshtrace/
   - title: Enterprise Features
     icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
     items:
@@ -293,323 +293,323 @@ items:
     items:
       - text: HTTP API
         url: /reference/http-api/
-        src: /.repos/kuma/app/docs/dev/reference/http-api/
+        src: /.repos/kuma/app/docs/2.0.x/reference/http-api/
       - text: Annotations and labels in Kubernetes mode
         url: /reference/kubernetes-annotations/
-        src: /.repos/kuma/app/docs/dev/reference/kubernetes-annotations/
+        src: /.repos/kuma/app/docs/2.0.x/reference/kubernetes-annotations/
       - text: Kong Mesh data collection
         url: /reference/data-collection/
-        src: /.repos/kuma/app/docs/dev/reference/data-collection/
+        src: /.repos/kuma/app/docs/2.0.x/reference/data-collection/
       - text: Resources
         items:
           - text: Mesh
             url: /generated/resources/other_mesh/
-            src: /.repos/kuma/app/docs/dev/generated/resources/other_mesh/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/other_mesh/
           - text: CircuitBreaker
             url: /generated/resources/policy_circuit-breaker/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_circuit-breaker/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_circuit-breaker/
           - text: ExternalService
             url: /generated/resources/policy_external-service/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_external-service/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_external-service/
           - text: FaultInjection
             url: /generated/resources/policy_fault-injection/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_fault-injection/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_fault-injection/
           - text: HealthCheck
             url: /generated/resources/policy_health-check/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_health-check/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_health-check/
           - text: MeshGateway
             url: /generated/resources/policy_meshgateway/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_meshgateway/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_meshgateway/
           - text: MeshGatewayRoute
             url: /generated/resources/policy_meshgatewayroute/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_meshgatewayroute/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_meshgatewayroute/
           - text: ProxyTemplate
             url: /generated/resources/policy_proxy-template/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_proxy-template/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_proxy-template/
           - text: RateLimit
             url: /generated/resources/policy_rate-limit/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_rate-limit/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_rate-limit/
           - text: Retry
             url: /generated/resources/policy_retry/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_retry/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_retry/
           - text: Timeout
             url: /generated/resources/policy_timeout/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_timeout/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_timeout/
           - text: TrafficLog
             url: /generated/resources/policy_traffic-log/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_traffic-log/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_traffic-log/
           - text: TrafficPermission
             url: /generated/resources/policy_traffic-permissions/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_traffic-permissions/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_traffic-permissions/
           - text: TrafficRoute
             url: /generated/resources/policy_traffic-route/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_traffic-route/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_traffic-route/
           - text: TrafficTrace
             url: /generated/resources/policy_traffic-trace/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_traffic-trace/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_traffic-trace/
           - text: VirtualOutbound
             url: /generated/resources/policy_virtual-outbound/
-            src: /.repos/kuma/app/docs/dev/generated/resources/policy_virtual-outbound/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/policy_virtual-outbound/
           - text: Dataplane
             url: /generated/resources/proxy_dataplane/
-            src: /.repos/kuma/app/docs/dev/generated/resources/proxy_dataplane/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/proxy_dataplane/
           - text: ZoneEgress
             url: /generated/resources/proxy_zoneegress/
-            src: /.repos/kuma/app/docs/dev/generated/resources/proxy_zoneegress/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/proxy_zoneegress/
           - text: ZoneIngress
             url: /generated/resources/proxy_zoneingress/
-            src: /.repos/kuma/app/docs/dev/generated/resources/proxy_zoneingress/
+            src: /.repos/kuma/app/docs/2.0.x/generated/resources/proxy_zoneingress/
       - text: Commands
         items:
           - text: kuma-cp
             url: /generated/cmd/kuma-cp/kuma-cp/
-            src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-cp/kuma-cp/
+            src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-cp/kuma-cp/
           - text: kuma-dp
             url: /generated/cmd/kuma-dp/kuma-dp/
-            src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-dp/kuma-dp/
+            src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-dp/kuma-dp/
           - text: kumactl
             url: /generated/cmd/kumactl/kumactl/
-            src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl/
+            src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl/
       - text: Kuma-cp configuration reference
         url: /generated/kuma-cp
-        src: /.repos/kuma/app/docs/dev/generated/kuma-cp
+        src: /.repos/kuma/app/docs/2.0.x/generated/kuma-cp
 unlisted:
   # Kuma CP
   - url: /generated/cmd/kuma-cp/kuma-cp_migrate/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-cp/kuma-cp_migrate/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-cp/kuma-cp_migrate/
   - url: /generated/cmd/kuma-cp/kuma-cp_migrate_up/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-cp/kuma-cp_migrate_up/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-cp/kuma-cp_migrate_up/
   - url: /generated/cmd/kuma-cp/kuma-cp_run/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-cp/kuma-cp_run/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-cp/kuma-cp_run/
   - url: /generated/cmd/kuma-cp/kuma-cp_version/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-cp/kuma-cp_version/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-cp/kuma-cp_version/
   - url: /generated/cmd/kuma-dp/kuma-dp_run/
     # Kuma DP
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-dp/kuma-dp_run/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-dp/kuma-dp_run/
   - url: /generated/cmd/kuma-dp/kuma-dp_version/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kuma-dp/kuma-dp_version/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kuma-dp/kuma-dp_version/
   # kumactl
   - url: /generated/cmd/kumactl/kumactl_apply/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_apply/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_apply/
   - url: /generated/cmd/kumactl/kumactl_completion/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_completion/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_completion/
   - url: /generated/cmd/kumactl/kumactl_completion_bash/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_completion_bash/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_completion_bash/
   - url: /generated/cmd/kumactl/kumactl_completion_fish/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_completion_fish/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_completion_fish/
   - url: /generated/cmd/kumactl/kumactl_completion_zsh/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_completion_zsh/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_completion_zsh/
   - url: /generated/cmd/kumactl/kumactl_config/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config/
   - url: /generated/cmd/kumactl/kumactl_config_control-planes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config_control-planes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config_control-planes/
   - url: /generated/cmd/kumactl/kumactl_config_control-planes_add/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config_control-planes_add/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config_control-planes_add/
   - url: /generated/cmd/kumactl/kumactl_config_control-planes_list/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config_control-planes_list/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config_control-planes_list/
   - url: /generated/cmd/kumactl/kumactl_config_control-planes_remove/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config_control-planes_remove/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config_control-planes_remove/
   - url: /generated/cmd/kumactl/kumactl_config_control-planes_switch/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config_control-planes_switch/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config_control-planes_switch/
   - url: /generated/cmd/kumactl/kumactl_config_view/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_config_view/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_config_view/
   - url: /generated/cmd/kumactl/kumactl_delete/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_delete/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_delete/
   - url: /generated/cmd/kumactl/kumactl_generate/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate/
   - url: /generated/cmd/kumactl/kumactl_generate_dataplane-token/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate_dataplane-token/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate_dataplane-token/
   - url: /generated/cmd/kumactl/kumactl_generate_signing-key/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate_signing-key/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate_signing-key/
   - url: /generated/cmd/kumactl/kumactl_generate_tls-certificate/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate_tls-certificate/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate_tls-certificate/
   - url: /generated/cmd/kumactl/kumactl_generate_user-token/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate_user-token/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate_user-token/
   - url: /generated/cmd/kumactl/kumactl_generate_zone-ingress-token/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate_zone-ingress-token/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate_zone-ingress-token/
   - url: /generated/cmd/kumactl/kumactl_generate_zone-token/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_generate_zone-token/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_generate_zone-token/
   - url: /generated/cmd/kumactl/kumactl_get/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get/
   - url: /generated/cmd/kumactl/kumactl_get_circuit-breaker/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_circuit-breaker/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_circuit-breaker/
   - url: /generated/cmd/kumactl/kumactl_get_circuit-breakers/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_circuit-breakers/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_circuit-breakers/
   - url: /generated/cmd/kumactl/kumactl_get_dataplane/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_dataplane/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_dataplane/
   - url: /generated/cmd/kumactl/kumactl_get_dataplanes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_dataplanes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_dataplanes/
   - url: /generated/cmd/kumactl/kumactl_get_external-service/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_external-service/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_external-service/
   - url: /generated/cmd/kumactl/kumactl_get_external-services/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_external-services/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_external-services/
   - url: /generated/cmd/kumactl/kumactl_get_fault-injection/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_fault-injection/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_fault-injection/
   - url: /generated/cmd/kumactl/kumactl_get_fault-injections/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_fault-injections/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_fault-injections/
   - url: /generated/cmd/kumactl/kumactl_get_global-secret/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_global-secret/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_global-secret/
   - url: /generated/cmd/kumactl/kumactl_get_global-secrets/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_global-secrets/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_global-secrets/
   - url: /generated/cmd/kumactl/kumactl_get_healthcheck/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_healthcheck/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_healthcheck/
   - url: /generated/cmd/kumactl/kumactl_get_healthchecks/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_healthchecks/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_healthchecks/
   - url: /generated/cmd/kumactl/kumactl_get_mesh/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_mesh/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_mesh/
   - url: /generated/cmd/kumactl/kumactl_get_meshaccesslog/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshaccesslog/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshaccesslog/
   - url: /generated/cmd/kumactl/kumactl_get_meshaccesslogs/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshaccesslogs/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshaccesslogs/
   - url: /generated/cmd/kumactl/kumactl_get_meshes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshes/
   - url: /generated/cmd/kumactl/kumactl_get_meshgateway/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshgateway/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshgateway/
   - url: /generated/cmd/kumactl/kumactl_get_meshgatewayroute/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshgatewayroute/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshgatewayroute/
   - url: /generated/cmd/kumactl/kumactl_get_meshgatewayroutes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshgatewayroutes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshgatewayroutes/
   - url: /generated/cmd/kumactl/kumactl_get_meshgateways/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshgateways/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshgateways/
   - url: /generated/cmd/kumactl/kumactl_get_meshtrace/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtrace/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshtrace/
   - url: /generated/cmd/kumactl/kumactl_get_meshtraces/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtraces/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshtraces/
   - url: /generated/cmd/kumactl/kumactl_get_meshtrafficpermission/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtrafficpermission/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshtrafficpermission/
   - url: /generated/cmd/kumactl/kumactl_get_meshtrafficpermissions/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtrafficpermissions/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_meshtrafficpermissions/
   - url: /generated/cmd/kumactl/kumactl_get_proxytemplate/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_proxytemplate/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_proxytemplate/
   - url: /generated/cmd/kumactl/kumactl_get_proxytemplates/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_proxytemplates/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_proxytemplates/
   - url: /generated/cmd/kumactl/kumactl_get_rate-limit/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_rate-limit/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_rate-limit/
   - url: /generated/cmd/kumactl/kumactl_get_rate-limits/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_rate-limits/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_rate-limits/
   - url: /generated/cmd/kumactl/kumactl_get_retries/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_retries/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_retries/
   - url: /generated/cmd/kumactl/kumactl_get_retry/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_retry/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_retry/
   - url: /generated/cmd/kumactl/kumactl_get_secret/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_secret/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_secret/
   - url: /generated/cmd/kumactl/kumactl_get_secrets/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_secrets/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_secrets/
   - url: /generated/cmd/kumactl/kumactl_get_timeout/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_timeout/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_timeout/
   - url: /generated/cmd/kumactl/kumactl_get_timeouts/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_timeouts/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_timeouts/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-log/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-log/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-log/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-logs/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-logs/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-logs/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-permission/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-permission/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-permission/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-permissions/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-permissions/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-permissions/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-route/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-route/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-route/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-routes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-routes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-routes/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-trace/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-trace/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-trace/
   - url: /generated/cmd/kumactl/kumactl_get_traffic-traces/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_traffic-traces/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_traffic-traces/
   - url: /generated/cmd/kumactl/kumactl_get_virtual-outbound/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_virtual-outbound/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_virtual-outbound/
   - url: /generated/cmd/kumactl/kumactl_get_virtual-outbounds/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_virtual-outbounds/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_virtual-outbounds/
   - url: /generated/cmd/kumactl/kumactl_get_zone/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_zone/ 
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_zone/ 
   - url: /generated/cmd/kumactl/kumactl_get_zone-ingress/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_zone-ingress/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_zone-ingress/
   - url: /generated/cmd/kumactl/kumactl_get_zone-ingresses/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_zone-ingresses/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_zone-ingresses/
   - url: /generated/cmd/kumactl/kumactl_get_zoneegress/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_zoneegress/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_zoneegress/
   - url: /generated/cmd/kumactl/kumactl_get_zoneegresses/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_zoneegresses/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_zoneegresses/
   - url: /generated/cmd/kumactl/kumactl_get_zones/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_get_zones/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_get_zones/
   - url: /generated/cmd/kumactl/kumactl_inspect/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect/
   - url: /generated/cmd/kumactl/kumactl_inspect_circuit-breaker/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_circuit-breaker/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_circuit-breaker/
   - url: /generated/cmd/kumactl/kumactl_inspect_dataplane/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_dataplane/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_dataplane/
   - url: /generated/cmd/kumactl/kumactl_inspect_dataplanes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_dataplanes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_dataplanes/
   - url: /generated/cmd/kumactl/kumactl_inspect_fault-injection/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_fault-injection/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_fault-injection/
   - url: /generated/cmd/kumactl/kumactl_inspect_healthcheck/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_healthcheck/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_healthcheck/
   - url: /generated/cmd/kumactl/kumactl_inspect_meshaccesslog/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshaccesslog/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_meshaccesslog/
   - url: /generated/cmd/kumactl/kumactl_inspect_meshes/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshes/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_meshes/
   - url: /generated/cmd/kumactl/kumactl_inspect_meshgateway/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshgateway/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_meshgateway/
   - url: /generated/cmd/kumactl/kumactl_inspect_meshtrace/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshtrace/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_meshtrace/
   - url: /generated/cmd/kumactl/kumactl_inspect_meshtrafficpermission/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshtrafficpermission/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_meshtrafficpermission/
   - url: /generated/cmd/kumactl/kumactl_inspect_proxytemplate/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_proxytemplate/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_proxytemplate/
   - url: /generated/cmd/kumactl/kumactl_inspect_rate-limit/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_rate-limit/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_rate-limit/
   - url: /generated/cmd/kumactl/kumactl_inspect_retry/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_retry/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_retry/
   - url: /generated/cmd/kumactl/kumactl_inspect_services/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_services/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_services/
   - url: /generated/cmd/kumactl/kumactl_inspect_timeout/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_timeout/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_timeout/
   - url: /generated/cmd/kumactl/kumactl_inspect_traffic-log/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_traffic-log/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_traffic-log/
   - url: /generated/cmd/kumactl/kumactl_inspect_traffic-permission/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_traffic-permission/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_traffic-permission/
   - url: /generated/cmd/kumactl/kumactl_inspect_traffic-route/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_traffic-route/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_traffic-route/
   - url: /generated/cmd/kumactl/kumactl_inspect_traffic-trace/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_traffic-trace/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_traffic-trace/
   - url: /generated/cmd/kumactl/kumactl_inspect_zone-ingresses/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_zone-ingresses/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_zone-ingresses/
   - url: /generated/cmd/kumactl/kumactl_inspect_zoneegress/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_zoneegress/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_zoneegress/
   - url: /generated/cmd/kumactl/kumactl_inspect_zoneegresses/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_zoneegresses/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_zoneegresses/
   - url: /generated/cmd/kumactl/kumactl_inspect_zoneingress/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_zoneingress/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_zoneingress/
   - url: /generated/cmd/kumactl/kumactl_inspect_zones/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_zones/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_inspect_zones/
   - url: /generated/cmd/kumactl/kumactl_install/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install/
   - url: /generated/cmd/kumactl/kumactl_install_control-plane/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_control-plane/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_control-plane/
   - url: /generated/cmd/kumactl/kumactl_install_crds/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_crds/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_crds/
   - url: /generated/cmd/kumactl/kumactl_install_demo/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_demo/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_demo/
   - url: /generated/cmd/kumactl/kumactl_install_gateway/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_gateway/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_gateway/
   - url: /generated/cmd/kumactl/kumactl_install_gateway_kong-enterprise/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_gateway_kong-enterprise/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_gateway_kong-enterprise/
   - url: /generated/cmd/kumactl/kumactl_install_gateway_kong/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_gateway_kong/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_gateway_kong/
   - url: /generated/cmd/kumactl/kumactl_install_logging/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_logging/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_logging/
   - url: /generated/cmd/kumactl/kumactl_install_metrics/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_metrics/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_metrics/
   - url: /generated/cmd/kumactl/kumactl_install_observability/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_observability/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_observability/
   - url: /generated/cmd/kumactl/kumactl_install_tracing/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_tracing/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_tracing/
   - url: /generated/cmd/kumactl/kumactl_install_transparent-proxy/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_install_transparent-proxy/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_install_transparent-proxy/
   - url: /generated/cmd/kumactl/kumactl_uninstall/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_uninstall/
   - url: /generated/cmd/kumactl/kumactl_uninstall_ebpf/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall_ebpf/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_uninstall_ebpf/
   - url: /generated/cmd/kumactl/kumactl_uninstall_transparent-proxy/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall_transparent-proxy/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_uninstall_transparent-proxy/
   - url: /generated/cmd/kumactl/kumactl_version/
-    src: /.repos/kuma/app/docs/dev/generated/cmd/kumactl/kumactl_version/
+    src: /.repos/kuma/app/docs/2.0.x/generated/cmd/kumactl/kumactl_version/


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Update the Kuma src file paths in the Mesh 2.0 nav to point at the 2.0.x folder.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
We are currently pointing to the /dev folder in the nav and that folder will change into the /2.0.x folder when the release happens. 
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
**NOTE:** This won't work until after the Mesh team has turned the /dev folder into the /2.0.x folder. 
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
