### PR TITLE
Kong Mesh QA: Intro, getting started, and install

### DIFF
--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -4,12 +4,10 @@ generate: true
 items:
   - title: Introduction
     icon: /assets/images/icons/documentation/icn-flag.svg
-    url: /mesh/2.0.x/
-    absolute_url: true
     items:
       - text: Introduction to Kong Mesh
-        url: /introduction/what-is-kong-mesh/
-        src: /.repos/kuma/app/docs/dev/introduction/what-is-kuma/
+        url: /mesh/2.0.x/
+        absolute_url: true
       - text: What is Service Mesh?
         url: /introduction/what-is-a-service-mesh/
         src: /.repos/kuma/app/docs/dev/introduction/what-is-a-service-mesh/
@@ -19,9 +17,6 @@ items:
       - text: Deployments
         url: /introduction/deployments/
         src: /.repos/kuma/app/docs/dev/introduction/deployments/
-      - text: Enterprise
-        url: /introduction/enterprise/
-        src: /.repos/kuma/app/docs/dev/introduction/enterprise/
       - text: Version support policy
         url: /support-policy/
       - text: Stability
@@ -50,7 +45,7 @@ items:
         url: /installation/ecs
       - text: Amazon Linux
         url: /installation/amazonlinux/
-      - text: Debian
+      - text: Red Hat
         url: /installation/redhat/
       - text: CentOS
         url: /installation/centos/

--- a/app/_includes/md/mesh/install-universal-run.md
+++ b/app/_includes/md/mesh/install-universal-run.md
@@ -36,10 +36,10 @@ but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-
 <!-- links -->
 {% if_version gte:2.0.x %}
 [deployments]: /mesh/{{page.kong_version}}/introduction/deployments/
-[backends]: /mesh/{{page.kong_version}}/explore/backends/
+[backends]: /mesh/{{page.kong_version}}/documentation/configuration/
 {% endif_version %}
 
 {% if_version lte:1.9.x %}
 [deployments]: https://kuma.io/docs/latest/introduction/deployments/
-[backends]: https://kuma.io/docs/latest/explore/backends/
+[backends]: https://kuma.io/docs/latest/documentation/configuration/
 {% endif_version %}

--- a/app/_redirects
+++ b/app/_redirects
@@ -615,6 +615,9 @@
 /mesh/latest/features/windows/ /mesh/latest/installation/windows/
 /mesh/:version/policies/introduction/  /mesh/:version/policies/
 /mesh/latest/policies/introduction/    /mesh/latest/policies/
+/mesh/:version/introduction/how-kong-mesh-works/#kuma-vs-xyz  /mesh/:version/introduction/how-kong-mesh-works/#kong-mesh-vs-xyz
+/mesh/:version/introduction/what-is-kong-mesh   /mesh/:version/
+/install/:version/  /mesh/:version/install/
 
 
 # ABOUT

--- a/app/_redirects
+++ b/app/_redirects
@@ -614,7 +614,6 @@
 /mesh/*/features/windows/     /mesh/latest/installation/windows/
 /mesh/latest/features/windows/ /mesh/latest/installation/windows/
 /mesh/:version/policies/introduction/  /mesh/:version/policies/
-/mesh/latest/policies/introduction/    /mesh/latest/policies/
 /mesh/:version/introduction/how-kong-mesh-works/#kuma-vs-xyz  /mesh/:version/introduction/how-kong-mesh-works/#kong-mesh-vs-xyz
 /mesh/:version/introduction/what-is-kong-mesh   /mesh/:version/
 /install/:version/  /mesh/:version/install/

--- a/src/mesh/features/kds-auth.md
+++ b/src/mesh/features/kds-auth.md
@@ -4,7 +4,7 @@ title: Multi-zone authentication
 
 To add to the security of your deployments, Kong Mesh provides authentication of zone control planes to the global control plane.
 Authentication is based on the Zone Token which is also used to authenticate the zone proxy.
-See [zone proxy authentication][zoneproxy] to learn about token characteristics, revocation, rotation, and more.
+See [zone proxy authentication][zone-proxy] to learn about token characteristics, revocation, rotation, and more.
 {{site.mesh_product_name}} introduces additional `cp` scope. Only tokens with `cp` scope can be used to authenticate with the zone control plane.
 
 ## Set up tokens

--- a/src/mesh/features/rbac.md
+++ b/src/mesh/features/rbac.md
@@ -96,7 +96,7 @@ spec:
         name: backend
     - targetRef:
         kind: MeshSubset
-        tags: 
+        tags:
         - name: k8s.kuma.io/namespace
           value: kuma-demo
 ```
@@ -116,7 +116,7 @@ rules:
         name: backend
   - targetRef:
       kind: MeshSubset
-      tags: 
+      tags:
       - name: k8s.kuma.io/namespace
         value: kuma-demo
 ```
@@ -1008,7 +1008,7 @@ For this example to work, you must either run the control plane with `KUMA_API_S
 {% endnavtab %}
 {% endnavtabs %}
 {% endnavtab %}
-{% endnavtabs %}óļ
+{% endnavtabs %}
 
 ## Multi-zone
 

--- a/src/mesh/index.md
+++ b/src/mesh/index.md
@@ -138,6 +138,13 @@ hybrid Kubernetes/VMs:
 <br>
 Learn more about the [standalone and multi-zone deployment modes][deployments].
 
+Example of a multi-zone deployment for multiple Kubernetes clusters, or a
+hybrid Kubernetes/VM cluster:
+
+<center>
+  <img src="/assets/images/diagrams/gslides/kuma_multizone.svg" alt="Kuma service mesh multi zone deployment" style="padding-top: 20px; padding-bottom: 10px;">
+</center>
+
 ## Support policy
 Kong primarily follows a [semantic versioning](https://semver.org/) (SemVer)
 model for its products.
@@ -147,7 +154,7 @@ For the latest version support information for
 
 ## Contribute
 
-You can contribute to the development of {{site.mesh_product_name}} by contributing to [Kuma](https://kuma.io/). 
+You can contribute to the development of {{site.mesh_product_name}} by contributing to [Kuma](https://kuma.io/).
 For more information, see the [contribution guide](https://kuma.io/docs/latest/contribute/introduction/#community).
 
 <!-- links -->

--- a/src/mesh/installation/kubernetes.md
+++ b/src/mesh/installation/kubernetes.md
@@ -65,7 +65,8 @@ $ kumactl install control-plane --license-path=/path/to/license.json | kubectl a
 ```
 
 {:.note}
-> **Note**: {{site.mesh_product_name}} also has UBI images. To use these images instead checkout the [UBI documentation](../../features/ubi-images).
+> **Note**: {{site.mesh_product_name}} also has UBI images.
+To use these images instead, check out the [UBI documentation](/mesh/{{page.kong_version}}/features/ubi-images).
 
 Where `/path/to/license.json` is the path to a valid {{site.mesh_product_name}}
 license file on the file system.


### PR DESCRIPTION
### Summary
Removed two topics copied from Kuma:
*  `/.repos/kuma/app/docs/dev/introduction/what-is-kuma/`: This topic is an intro to Kuma specifically. Our intro to Kong Mesh already covers everything + more. The only thing I grabbed from this topic was the multizone example deployment diagram.
* `/.repos/kuma/app/docs/dev/introduction/enterprise/`: This is basically an advertisement for Kong Mesh from the Kuma perspective, and doesn't make sense to leave in the nav.

Other stuff:
* Fixed Red Hat link that was accidentally named Debian
* Fixed links
* Added some redirects (need to test with latest)

### Reason
QA for Kong Mesh 2.0

### Testing
Netlify