### PR TITLE
QA for Policies in Mesh 2.0

### DIFF
--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -191,6 +191,9 @@ items:
       - text: How Kong Mesh chooses the right policy to apply
         url: /policies/how-kong-mesh-chooses-the-right-policy-to-apply/
         src: /.repos/kuma/app/docs/dev/policies/how-kuma-chooses-the-right-policy-to-apply/
+      - text: Policy matching
+        url: /policies/matching/
+        src: /.repos/kuma/app/docs/dev/policies/matching/
       - text: Protocol support in Kong Mesh
         url: /policies/protocol-support-in-kong-mesh/
         src: /.repos/kuma/app/docs/dev/policies/protocol-support-in-kuma/
@@ -268,7 +271,7 @@ items:
         url: /features/acmpca
       - text: cert-manager Private CA
         url: /features/cert-manager
-      - text: OPAPolicy Support
+      - text: OPA policy support
         url: /features/opa
       - text: Multi-zone authentication
         url: /features/kds-auth

--- a/app/_redirects
+++ b/app/_redirects
@@ -614,10 +614,12 @@
 /mesh/*/features/windows/     /mesh/latest/installation/windows/
 /mesh/latest/features/windows/ /mesh/latest/installation/windows/
 /mesh/:version/policies/introduction/  /mesh/:version/policies/
+/policies/  /mesh/:version/policies/   
 /mesh/:version/introduction/how-kong-mesh-works/#kuma-vs-xyz  /mesh/:version/introduction/how-kong-mesh-works/#kong-mesh-vs-xyz
 /mesh/:version/introduction/what-is-kong-mesh   /mesh/:version/
 /install/:version/  /mesh/:version/install/
 /mesh/:version/documentation/introduction/  /mesh/:version/
+/mesh/:version/policies/protocol-support-in-kuma/  /mesh/:version/policies/protocol-support-in-kong-mesh/
 
 # ABOUT
 /about/faq                 https://konghq.com/faqs/


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

- OPA Policy support in sidebar needed a space between OPA and policy
- Found a few links to just "/policies", so I redirected them.
- /mesh/2.0.x/policies/protocol-support-in-kuma was a 404 on the new MeshTrace (beta) page and I don't know why it wasn't transformed to "kong-mesh". I just added a temp redirect.
- Found a 404 to a "Policy matching" page that was unlisted in Kuma, so I added it to the nav in Mesh. 

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Result of QA 
### Testing
<!-- How can your reviewers test your change? How did you test it? -->

- Test redirects
- From the MeshTrace (beta) page, test the link in "You must explicitly specify the protocol for each service and data plane proxy you want to enable tracing for." and "If you don’t understand this table you should read matching docs."

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
