### PR TITLE
[FTI-4430] mtls-auth plugin supports sending ca dn in ssl handshake essage

### DIFF
--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -44,6 +44,7 @@ role_endpoint
 role_entity
 search_by_username
 search_by_username
+send_ca_dn
 ssl_client_verify
 ssl_server_name
 start_cmd

--- a/.github/styles/kongplugins/dictionary.txt
+++ b/.github/styles/kongplugins/dictionary.txt
@@ -16,6 +16,7 @@ DAOs
 Datadog
 DPP
 DPPs
+DNs
 Equinix
 Fargate
 Github

--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -250,7 +250,7 @@ certificate selection. Setting `config.send_ca_dn` to `true` will add the
 ca certificates configured in the `config.ca_certificate` to the list(s) of
 the corresponding SNIs.
 
-As memtioned above in section [Client certificate request](#Client certificate request),
+As mentioned above in section [Client certificate request](#Client certificate request),
 due to the phase gap, Kong does not know the route information in the
 `ssl_certificate_by_lua` phase, which is decided in the later `access` phase.
 Therefore Kong builds an in-memory map of SNIs. The CA DN list will eventually

--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -155,8 +155,7 @@ params:
       value_in_examples:
       datatype: boolean
       description: |
-        Send the DN(Distinguished Name)s of the configured CA list in TLS
-        handshake message.
+        Sends the distinguished names (DN) of the configured CA list in the TLS handshake message.
 ---
 
 ## Usage
@@ -240,40 +239,39 @@ curl -X POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certifi
 {% endnavtabs %}
 The `id` value returned can now be used for mTLS plugin configurations or consumer mappings.
 
-### Sending the CA DN(Distinguished Name)s during TLS handshake
+{% if_plugin_version gte:3.1.x %}
+### Sending the CA DNs during TLS handshake
 
-By default, Kong won't send CA DN list during TLS handshake. More specifically,
+By default, {{site.base_gateway}} won't send the CA DN list during the TLS handshake. More specifically,
 the `certificate_authorities` in the CertificateRequest message is empty.
 
 In some cases, the client may need this `certificate_authorities` to guide
 certificate selection. Setting `config.send_ca_dn` to `true` will add the
-ca certificates configured in the `config.ca_certificate` to the list(s) of
+CA certificates configured in the `config.ca_certificate` to the lists of
 the corresponding SNIs.
 
-As mentioned above in section [Client certificate request](#Client certificate request),
-due to the phase gap, Kong does not know the route information in the
+As mentioned in [Client certificate request](#client-certificate-request),
+due to the phase gap, {{site.base_gateway}} doesn't know the route information in the
 `ssl_certificate_by_lua` phase, which is decided in the later `access` phase.
-Therefore Kong builds an in-memory map of SNIs. The CA DN list will eventually
-be associated to the SNIs. If multiple `mtls-auth` plugins with different
+Therefore {{site.base_gateway}} builds an in-memory map of SNIs. The CA DN list will eventually
+be associated with the SNIs. If multiple `mtls-auth` plugins with different
 `config.ca_certificate` are associated to the same SNI, the CA DNs will be
-merged. Specifically,
+merged. For example:
 
-- When the plugin is enabled in **global** Workspace scope, the CA DNs will be
-  associated to a special SNI "\*"
-- When the plugin is applied at the **service** level, the CA DNs will be
-  associated to every SNI of every route to this service. If a route has no
-  SNIs been set, then the CA DNs will be associated to a special SNI "\*"
-- When the plugin is applied at the **route** level, the CA DNs will be
-  associated to every SNI configured on this route. If the route has no SNIs
-  been set, then the CA DNs will be associated to a special SNI "\*"
+- When the plugin is enabled in the **global** Workspace scope, the CA DNs 
+  are associated with a special SNI, "\*".
+- When the plugin is applied at the **service** level, the CA DNs are
+  associated with every SNI of every route to this service. If a route has no
+  SNIs set, then the CA DNs are associated with a special SNI, "\*".
+- When the plugin is applied at the **route** level, the CA DNs are
+  associated with every SNI configured on this route. If the route has no SNIs set, then the CA DNs are associated with a special SNI, "\*".
 
-During mTLS handshake, if the client sends a SNI in the ClientHello message and
-the SNI is found in the in-memory map of SNIs, then the corresponding CA DN list
-will be sent in CertificatRequest message.
+During the mTLS handshake, if the client sends a SNI in the ClientHello message and
+the SNI is found in the in-memory map of SNIs, then the corresponding CA DN list is sent in CertificatRequest message.
 
-If the client sends no SNIs in the ClientHello message or the SNI sent is
-unknown to Kong, then the CA DN list associated with "\*" will be sent. (Only
-when client certificate is requested.)
+If the client doesn't send SNIs in the ClientHello message or the SNI sent is
+unknown to {{site.base_gateway}}, then the CA DN list associated with "\*" is sent only when the client certificate is requested.
+{% endif_plugin_version %}
 
 ### Create manual mappings between certificate and consumer object
 


### PR DESCRIPTION
### Summary

Adds a new option `config.send_ca_dn` to the mtls-auth plugin. 
The new option will enable the ability to send ca dn in the TLS handshake message.

Related PR: [Kong/kong-ee#3890](https://github.com/Kong/kong-ee/pull/3890)

### Reason

FTI-4430

### Testing
