### PR TITLE
Add Deck Windows installation instructions

### DIFF
--- a/src/deck/installation.md
+++ b/src/deck/installation.md
@@ -36,15 +36,16 @@ $ sudo cp /tmp/deck /usr/local/bin/
 ```
 {% endif_version %}
 
+{% if_version lte:1.12.x %}
+
 ## Windows
 
-If you are Windows, you can either use the compressed archive from
+If you are on Windows, you can either use the compressed archive from
 the Github [release page](https://github.com/kong/deck/releases)
 or install using **CMD** by entering the target installation folder and downloading a compressed archive, which contains the binary:
 
-{% if_version leq:1.12.x %}
 ```shell
-curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_linux_amd64.tar.gz -o deck.tar.gz
+curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_windows_amd64.tar.gz -o deck.tar.gz
 mkdir deck
 tar -xf deck.tar.gz -C deck
 powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + $pwd + '\deck', 'User')"

--- a/src/deck/installation.md
+++ b/src/deck/installation.md
@@ -28,15 +28,11 @@ If you are Linux, you can either use the Debian or RPM archive from
 the Github [release page](https://github.com/kong/deck/releases)
 or install by downloading a compressed archive, which contains the binary:
 
-{% if_version leq:1.12.x %}
 ```shell
 $ curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
-{% endif_version %}
-
-{% if_version lte:1.12.x %}
 
 ## Windows
 
@@ -49,9 +45,7 @@ curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{
 mkdir deck
 tar -xf deck.tar.gz -C deck
 powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + $pwd + '\deck', 'User')"
-
 ```
-{% endif_version %}
 
 ## Docker image
 

--- a/src/deck/installation.md
+++ b/src/deck/installation.md
@@ -36,6 +36,22 @@ $ sudo cp /tmp/deck /usr/local/bin/
 ```
 {% endif_version %}
 
+## Windows
+
+If you are Windows, you can either use the compressed archive from
+the Github [release page](https://github.com/kong/deck/releases)
+or install using **CMD** by entering the target installation folder and downloading a compressed archive, which contains the binary:
+
+{% if_version leq:1.12.x %}
+```shell
+curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_linux_amd64.tar.gz -o deck.tar.gz
+mkdir deck
+tar -xf deck.tar.gz -C deck
+powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + $pwd + '\deck', 'User')"
+
+```
+{% endif_version %}
+
 ## Docker image
 
 If your workflow requires a Docker image, then you can use `kong/deck` Docker

--- a/src/deck/installation.md
+++ b/src/deck/installation.md
@@ -44,7 +44,7 @@ or install using **CMD** by entering the target installation folder and download
 curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_windows_amd64.tar.gz -o deck.tar.gz
 mkdir deck
 tar -xf deck.tar.gz -C deck
-powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + $pwd + '\deck', 'User')"
+powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + [System.IO.Directory]::GetCurrentDirectory() + '\deck', 'User')"
 ```
 
 ## Docker image


### PR DESCRIPTION
### Summary

Add Deck Windows installation instructions using CMD.

As of [Windows 10 Build 17063](https://learn.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows), tar and curl are now packaged by default in the OS.

Used PowerShell to add to environment path since SETX has a 1024 characters limit and could truncate the values.

### Reason
Make Deck setup on Windows easier

### Testing

```
curl -sL https://github.com/kong/deck/releases/download/v1.15.1/deck_1.15.1_windows_amd64.tar.gz -o deck.tar.gz
mkdir deck
tar -xvzf deck.tar.gz -C deck
```
The following command can be used to add the directory to the PATH. If this is not desired can be removed.
`powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + $pwd + '\deck', 'User')"`

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
