### PR TITLE
Replace web url inline instead of appending the config to the file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -426,11 +426,11 @@ function build_site(steps, append) {
   append = append || [];
 
   if (process.env.JEKYLL_ENV == "preview") {
-    var linksWebOverride = `
-links:
-  web: ${process.env.DEPLOY_PRIME_URL}
-`;
-    fs.appendFileSync("./jekyll.yml", linksWebOverride);
+    var configFilePath = "./jekyll.yml";
+    var doc = fs.readFileSync(configFilePath, "utf8");
+    var newDoc = doc.replace(/  web: https:\/\/docs.konghq.com/, `  web: ${process.env.DEPLOY_PRIME_URL}`);
+
+    fs.writeFileSync(configFilePath, newDoc);
   }
 
   // These are the steps that always run for every build


### PR DESCRIPTION
### Summary
The previous code overrode the whole `links` config breaking the `download` links.
This replaces the link inline so everything else keeps working as expected. 

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
* [Download links](https://deploy-preview-4720--kongdocs.netlify.app/mesh/latest/installation/kubernetes/#1-download-kong-mesh) work 
* the url for the file in [this code snippet](https://deploy-preview-4720--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/using-gateway-api/#traffic-splitting-with-httproute) work