### PR TITLE
docs(plugins): add WebSocket protocols to supported plugins

### DIFF
--- a/app/_hub/kong-inc/basic-auth/_index.md
+++ b/app/_hub/kong-inc/basic-auth/_index.md
@@ -23,6 +23,8 @@ params:
     - https
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/file-log/_index.md
+++ b/app/_hub/kong-inc/file-log/_index.md
@@ -30,6 +30,8 @@ params:
     - tcp
     - tls
     - udp
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: path

--- a/app/_hub/kong-inc/hmac-auth/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/_index.md
@@ -27,6 +27,8 @@ params:
     - https
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/http-log/_index.md
+++ b/app/_hub/kong-inc/http-log/_index.md
@@ -26,6 +26,8 @@ params:
     - udp
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: http_endpoint

--- a/app/_hub/kong-inc/kafka-log/_index.md
+++ b/app/_hub/kong-inc/kafka-log/_index.md
@@ -20,6 +20,13 @@ kong_version_compatibility:
 params:
   name: kafka-log
   dbless_compatible: 'yes'
+  protocols:
+    - http
+    - https
+    - grpc
+    - grpcs
+    - ws
+    - wss
   config:
     - name: bootstrap_servers
       required: true

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -32,6 +32,8 @@ params:
     - https
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/key-auth/_index.md
+++ b/app/_hub/kong-inc/key-auth/_index.md
@@ -30,6 +30,8 @@ params:
     - https
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -33,6 +33,8 @@ params:
     - https
     - gprc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: ldap_host

--- a/app/_hub/kong-inc/ldap-auth/_index.md
+++ b/app/_hub/kong-inc/ldap-auth/_index.md
@@ -64,6 +64,8 @@ params:
     - https
     - gprc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: hide_credentials

--- a/app/_hub/kong-inc/loggly/_index.md
+++ b/app/_hub/kong-inc/loggly/_index.md
@@ -26,6 +26,8 @@ params:
     - udp
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -34,6 +34,8 @@ params:
     - https
     - grpc
     - grpcs
+    - ws
+    - wss
   yaml_examples: false
   konnect_examples: false
   dbless_compatible: 'no'

--- a/app/_hub/kong-inc/serverless-functions/_index.md
+++ b/app/_hub/kong-inc/serverless-functions/_index.md
@@ -37,6 +37,8 @@ params:
   protocols:
     - http
     - https
+    - ws
+    - wss
   dbless_compatible: partially
   dbless_explanation: |
     The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.

--- a/app/_hub/kong-inc/syslog/_index.md
+++ b/app/_hub/kong-inc/syslog/_index.md
@@ -26,6 +26,8 @@ params:
     - udp
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: successful_severity

--- a/app/_hub/kong-inc/tcp-log/_index.md
+++ b/app/_hub/kong-inc/tcp-log/_index.md
@@ -26,6 +26,8 @@ params:
     - udp
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/udp-log/_index.md
+++ b/app/_hub/kong-inc/udp-log/_index.md
@@ -26,6 +26,8 @@ params:
     - udp
     - grpc
     - grpcs
+    - ws
+    - wss
   dbless_compatible: 'yes'
   config:
     - name: host


### PR DESCRIPTION
### Summary

This adds WebSocket protocols (`ws` and `wss`) to all the plugins that support them. All of the auth-related plugins have been supported since 3.0. The logging plugins are newly-supported in 3.1.

### Reason

FT-3544

### Testing

View the plugin pages and check the `Compatible protocols` section in the bottom right.