### PR TITLE
feat(vault-auth): secrets engine v2 compatibility

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -554,6 +554,7 @@ kongmap
 konnect_examples
 konnect_icon
 kty
+kv
 kv_path
 latency_metrics
 latency_gateway

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -116,7 +116,7 @@ service, you must add the new consumer to an allowed group. See
 ### Create a Vault
 
 {:.note}
-> Vault Auth plugin only works with HashiCorp Vault KV Secrets Engine - Version 1.
+> Up until version `3.0.x`, Vault Auth plugin is only compatible with HashiCorp Vault KV Secrets Engine - Version 1. Version `3.1.x` of the Vault Auth plugin added support for HashiCorp Vault KV Secrets Engine - Version 2.
 
 A Vault object represents the connection between Kong and a Vault server. It defines the connection and authentication information used to communicate with the Vault API. This allows different instances of the `vault-auth` plugin to communicate with different Vault servers, providing a flexible deployment and consumption model.
 
@@ -134,7 +134,8 @@ curl -X POST http://localhost:8001/vault-auth \
   --form protocol=http \
   --form host=127.0.0.1 \
   --form port=8200 \
-  --form vault_token=<token>
+  --form vault_token=<token> \
+  --form kv=<secret_version>
 ```
 
 ```json
@@ -149,11 +150,13 @@ HTTP/1.1 201 Created
   "name": "kong-auth",
   "port": 8200,
   "updated_at": 1605288799,
-  "id": "c22198a3-cf54-428b-bed2-59c1f3760823"
+  "id": "c22198a3-cf54-428b-bed2-59c1f3760823",
+  "kv": "v2"
 }
 ```
 
-This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a version 1 KV secrets engine has been enabled at `kong-auth`. Vault KV secrets engine documentation is available via the [Vault documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html).
+`<secret_version>` can be configured with the values `v1` or `v2`, which correspond to KV secrets engines version 1 and 2 respectively. 
+This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a version 1 or 2 KV secrets engine has been enabled at `kong-auth`. Vault KV secrets engine documentation is available via the Vault documentation for [version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html) and [version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2).
 
 ### Create an Access/Secret Token Pair
 
@@ -259,7 +262,7 @@ When reading a token from Vault, Kong will search the responding KV value for th
 
 ### Extra-Kong Token Pairs
 
-Kong can read access/token secret pairs that have been created directly in Vault, outside of the Kong Admin API. Currently `vault-auth` supports creating and reading credentials based on the Vault v1 KV engine. Create Vault KV secret values must contain the following fields:
+Kong can read access/token secret pairs that have been created directly in Vault, outside of the Kong Admin API. Create Vault KV secret values must contain the following fields:
 
 ```
 {
@@ -274,7 +277,7 @@ Kong can read access/token secret pairs that have been created directly in Vault
 }
 ```
 
-Additional fields within the secret are ignored. The key must be the `access_token` value; this is the identifier by which Kong queries the Vault API to fetch the credential data. See the [Vault documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html) for further information on the KV v1 secrets engine.
+Additional fields within the secret are ignored. The key must be the `access_token` value; this is the identifier by which Kong queries the Vault API to fetch the credential data. See the Vault documentation for [version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html) or [version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2) for further information on the KV secrets engine.
 
 `vault-auth` token pairs can be created with the Vault HTTP API or the `vault write` command:
 
@@ -294,6 +297,8 @@ EOF
 ---
 
 ## Changelog
+**{{site.base_gateway}} 3.1.x**
+* Added support for KV secrets engine v2
 
 **{{site.base_gateway}} 2.8.1.3**
 

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -115,8 +115,17 @@ service, you must add the new consumer to an allowed group. See
 
 ### Create a Vault
 
+{% if_plugin_version lte:3.0.x %}
 {:.note}
-> Up until version `3.0.x`, Vault Auth plugin is only compatible with HashiCorp Vault KV Secrets Engine - Version 1. Version `3.1.x` of the Vault Auth plugin added support for HashiCorp Vault KV Secrets Engine - Version 2.
+> Vault Auth plugin only works with HashiCorp Vault KV Secrets Engine - Version 1.
+
+{% endif_plugin_version %}
+
+{% if_plugin_version gte:3.1.x %}
+
+The Vault plugin supports HashiCorp Vault KV Secrets Engine versions 1 and 2.
+
+{% endif_plugin_version %}
 
 A Vault object represents the connection between Kong and a Vault server. It defines the connection and authentication information used to communicate with the Vault API. This allows different instances of the `vault-auth` plugin to communicate with different Vault servers, providing a flexible deployment and consumption model.
 
@@ -126,6 +135,7 @@ in a vault. References must follow a [specific format](/gateway/latest/kong-ente
 
 Vault objects can be created via the following HTTP request:
 
+{% if_plugin_version gte:3.1.x %}
 ```bash
 curl -X POST http://localhost:8001/vault-auth \
   --header 'Content-Type: multipart/form-data' \
@@ -155,8 +165,42 @@ HTTP/1.1 201 Created
 }
 ```
 
-`<secret_version>` can be configured with the values `v1` or `v2`, which correspond to KV secrets engines version 1 and 2 respectively. 
+`<secret_version>` can be configured with the values `v1` or `v2`, which correspond to KV secrets engines version 1 and 2 respectively.
 This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a version 1 or 2 KV secrets engine has been enabled at `kong-auth`. Vault KV secrets engine documentation is available via the Vault documentation for [version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html) and [version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2).
+
+{% endif_plugin_version %}
+
+{% if_plugin_version lte:3.0.x %}
+```bash
+curl -X POST http://localhost:8001/vault-auth \
+  --header 'Content-Type: multipart/form-data' \
+  --form name=kong-auth \
+  --form mount=kong-auth \
+  --form protocol=http \
+  --form host=127.0.0.1 \
+  --form port=8200 \
+  --form vault_token=<token>
+```
+
+```json
+HTTP/1.1 201 Created
+
+{
+  "host": "127.0.0.1",
+  "created_at": 1605288799,
+  "vault_token": "<token>",
+  "mount": "kong-auth",
+  "protocol": "http",
+  "name": "kong-auth",
+  "port": 8200,
+  "updated_at": 1605288799,
+  "id": "c22198a3-cf54-428b-bed2-59c1f3760823"
+}
+```
+
+This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a version 1 KV secrets engine has been enabled at `kong-auth`. Vault KV secrets engine documentation is available via the [Vault documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html).
+
+{% endif_plugin_version %}
 
 ### Create an Access/Secret Token Pair
 
@@ -262,6 +306,12 @@ When reading a token from Vault, Kong will search the responding KV value for th
 
 ### Extra-Kong Token Pairs
 
+{% if_plugin_version lte:3.0.x %}
+
+Currently `vault-auth` supports creating and reading credentials based on the Vault v1 KV engine.
+
+{% endif_plugin_version %}
+
 Kong can read access/token secret pairs that have been created directly in Vault, outside of the Kong Admin API. Create Vault KV secret values must contain the following fields:
 
 ```
@@ -277,7 +327,9 @@ Kong can read access/token secret pairs that have been created directly in Vault
 }
 ```
 
-Additional fields within the secret are ignored. The key must be the `access_token` value; this is the identifier by which Kong queries the Vault API to fetch the credential data. See the Vault documentation for [version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html) or [version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2) for further information on the KV secrets engine.
+Additional fields within the secret are ignored. The key must be the `access_token` value; this is the identifier by which Kong queries the Vault API to fetch the credential data. See the Vault documentation for [version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html)
+{% if_plugin_version gte:3.1.x %} or [version 2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2) {% endif_plugin_version %}
+for further information on the KV secrets engine.
 
 `vault-auth` token pairs can be created with the Vault HTTP API or the `vault write` command:
 


### PR DESCRIPTION
### Summary
Update user facing documentation for the vault-auth plugin new functionality (support for kv engine v2), coming with Kong EE 3.1.0

### Reason
https://konghq.atlassian.net/browse/FT-2904

[DOCU-2772]

[DOCU-2772]: https://konghq.atlassian.net/browse/DOCU-2772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ