### PR TITLE
Add OIDC to list of sample enterprise plugins

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,12 +4,32 @@ on:
     types: [synchronize, ready_for_review, opened]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if manual review has been performed
+        uses: actions/github-script@v6
+        id: labels
+        with:
+          result-encoding: string
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+            return labels.map(l => l.name).includes('ci:manual-approve:linting')
+    outputs:
+      result: ${{ steps.labels.outputs.result }}
   prettier:
+    needs: check
+    if: needs.check.outputs.result == 'false'
     name: Prettier
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -25,6 +45,8 @@ jobs:
             app/_assets/**
       - run: npx prettier --check ${{ steps.changed-files.outputs.all_changed_files }}
   rubocop:
+    needs: check
+    if: needs.check.outputs.result == 'false'
     name: Rubocop
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -52,6 +74,8 @@ jobs:
         run: |
           bundle exec rubocop app
   vale:
+    needs: check
+    if: needs.check.outputs.result == 'false'
     name: Vale
     runs-on: ubuntu-latest
     steps:

--- a/src/gateway/kong-enterprise/index.md
+++ b/src/gateway/kong-enterprise/index.md
@@ -16,6 +16,7 @@ It offers exclusive versions of OSS plugins like the [Rate Limiting Advanced plu
 
 Kong Enterprise also natively supports gRPC and REST, WebSockets, and integrates with Apollo GraphQL server and Apache Kafka services. These plugins can be leveraged to provide advanced connectivity features and solutions to {{site.base_gateway}} such as:
 
+* [OpenID Connect (OIDC)](/hub/kong-inc/openid-connect/)
 * [Event gateways with Kafka](/hub/kong-inc/kafka-upstream/)
 * [GraphQL](/hub/kong-inc/graphql-proxy-cache-advanced/)
 * [Mocking](/hub/kong-inc/mocking/)

--- a/src/gateway/kong-enterprise/index.md
+++ b/src/gateway/kong-enterprise/index.md
@@ -11,7 +11,9 @@ It is the only solution that helps you accelerate your cloud journey by managing
 ## Enterprise Plugins
 
 Kong Enterprise offers access to 400+ out-of-box enterprise and community plugins. 
-It offers exclusive versions of OSS plugins like the [Rate-Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/) with added functionality such as the use of consumer groups, and database specific strategy. 
+It offers exclusive versions of OSS plugins like the [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/) with added functionality such as the use of consumer groups, and database specific strategy. It also provides Enterprise-exclusive functionality, such as authentication with 
+[OpenID Connect](/hub/kong-inc/openid-connect/), which lets you standardize identity provider (IdP) integrations.
+
 Kong Enterprise also natively supports gRPC and REST, WebSockets, and integrates with Apollo GraphQL server and Apache Kafka services. These plugins can be leveraged to provide advanced connectivity features and solutions to {{site.base_gateway}} such as:
 
 * [Event gateways with Kafka](/hub/kong-inc/kafka-upstream/)


### PR DESCRIPTION
### Summary
Add OIDC to enterprise plugins section on overview page.

### Reason
OIDC is our most popular/most used Enterprise plugin, so it should be mentioned in the Enterprise overview doc.

### Testing
Netlify