### PR TITLE
Add missing beta docs to Policies section

### DIFF
--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -259,6 +259,12 @@ items:
       - text: MeshTrace (Beta)
         url: /policies/meshtrace/
         src: /.repos/kuma/app/docs/2.0.x/policies/meshtrace/
+      - text: MeshAccessLog (Beta)
+        url: /policies/meshaccesslog/
+        src: /.repos/kuma/app/docs/2.0.x/policies/meshaccesslog/
+      - text: MeshTrafficPermission (Beta)
+        url: /policies/meshtrafficpermission/
+        src: /.repos/kuma/app/docs/2.0.x/policies/meshtrafficpermission/
   - title: Enterprise Features
     icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
     items:


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Charly let me know that we were missing the following two docs in the Mesh nav that currently exist in the Kuma nav:

- https://kuma.io/docs/2.0.x/policies/meshaccesslog/
- https://kuma.io/docs/2.0.x/policies/meshtrafficpermission/

I added these docs back in and double checked that no other docs were missing from the nav.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Docs existed in Kuma nav but not Mesh nav.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Check that the following pages work in the Netlify preview:

- /policies/meshaccesslog/
- /policies/meshtrafficpermission/

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
