### PR TITLE
doc(kic) update aws-lambda service note

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -375,11 +375,20 @@ will be thrown.
 #### Use a fake upstream service
 
 When using the AWS Lambda plugin, the response will be returned by the plugin
-itself without proxying the request to any upstream service. This means that
-a service's `host`, `port`, and `path` properties will be ignored, but must
-still be specified for the entity to be validated by Kong. The `host` property
-in particular must either be an IP address, or a hostname that gets resolved by
-your nameserver.
+itself without proxying the request to any upstream service. The service
+configured for a route is ignored when using this plugin.
+
+Versions of {{site.ce_product_name}} prior to 2.x require a service on all
+routes. Even though the service will not be used, you must configure a
+placeholder service for routes using this plugin. Versions after 2.x allow you
+to omit service configuration.
+
+When using {{site.kic_product_name}}, Kubernetes Ingresses require a Service.
+Even on {{site.ce_product_name}} versions that support empty services, you will
+still need to configure a placeholder Service for the Ingress. An [ExternalName
+Service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname)
+for an unresolvable domain (for example, `fake.example`) will satisfy this
+requirement without requiring a Deployment associated with the Service.
 
 #### Response plugins
 


### PR DESCRIPTION
### Summary
Updates aws-lambda note about interactions with Kong services:

- Modern Kong versions support null services. The version listed (2.x) isn't entirely correct, but I'm using it regardless since 1.x is quite old at this point and configuring a service on versions that don't require it doesn't hurt anything. 1.x support was complicated by the old Kong mesh implementation and it's simpler to leave the old recommendation in place for them instead of checking for inconsistencies with the current configuration needs.
- Added recommendation for creating a KIC placeholder Service. KIC still requires a service because of Kubernetes configuration requirements.

### Reason
Was missing, requested in https://discuss.konghq.com/t/kong-aws-lambda-plugin-applied-to-an-ingress/10790/2

### Testing
None.
<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
