### PR TITLE
docs(plugin): Add SAML plugin documentation

### DIFF
--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -45,6 +45,7 @@ role_entity
 search_by_username
 search_by_username
 ssl_client_verify
+ssl_server_name
 start_cmd
 stream_listen
 stringified

--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -10,6 +10,7 @@ bazgineer
 bazgineer
 callees
 callees
+charset
 consumer_id
 dao
 daos

--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -18,10 +18,12 @@ datastores
 endpoint_key
 foogineer
 if_version
+included_status_codes
 kuma
 max_args
 max_headers
 metatable
+myapikey
 narr
 ngx
 ngx_stream_proxy_module
@@ -33,6 +35,7 @@ params
 proxy_listen
 proxy_ssl
 qux
+random_status_code
 real_ip_header
 real_ip_recursive
 resty

--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -16,6 +16,7 @@ daos
 datastore
 datastores
 endpoint_key
+escape_path
 foogineer
 if_version
 included_status_codes

--- a/.github/styles/kongplugins/dictionary.txt
+++ b/.github/styles/kongplugins/dictionary.txt
@@ -21,6 +21,7 @@ Fargate
 Github
 Goroutine
 Grafana
+Hao
 HTTPie
 Istio
 Istio

--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -553,7 +553,7 @@ items:
       - text: Targets
         url: /admin-api/#target-object
       - text: Vaults
-        url: /admin-api/#vaults-entity
+        url: /admin-api/#vaults-object
       - text: Licenses
         url: /admin-api/licenses/reference
       - text: Workspaces

--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -1,0 +1,587 @@
+product: gateway
+release: 3.1.x
+generate: true
+assume_generated: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    items:
+      - text: Overview of Kong Gateway
+        url: /gateway/3.1.x/
+        absolute_url: true
+      - text: Version Support Policy
+        url: /support-policy
+      - text: Stability
+        url: /stability
+      - text: Release Notes
+        url: /gateway/changelog
+        absolute_url: true
+      - text: Key Concepts
+        items:
+          - text: Services
+            url: /key-concepts/services
+          - text: Routes
+            items:
+              - text: Overview
+                url: /key-concepts/routes
+              - text: Configure Routes with Expressions
+                url: /key-concepts/routes/expressions
+          - text: Upstreams
+            url: /key-concepts/upstreams
+          - text: Plugins
+            url: /key-concepts/plugins
+          # - text: Manage Kong Gateway with decK
+          #   url: /key-concepts/manage-kong-with-deck
+      - text: How Kong Works
+        items:
+          - text: Routing Traffic
+            url: /how-kong-works/routing-traffic
+          - text: Load Balancing
+            url: /how-kong-works/load-balancing
+          - text: Health Checks and Circuit Breakers
+            url: /how-kong-works/health-checks
+          - text: Kong Performance Testing
+            url: /how-kong-works/performance-testing
+      - text: Glossary
+        url: /glossary
+
+  - title: Get Started with Kong
+    icon: /assets/images/icons/documentation/icn-learning.svg
+    items:
+      - text: Get Kong
+        url: /get-started/
+      - text: Services and Routes
+        url: /get-started/services-and-routes
+      - text: Rate Limiting
+        url: /get-started/rate-limiting
+      - text: Proxy Caching
+        url: /get-started/proxy-caching
+      - text: Key Authentication
+        url: /get-started/key-authentication
+      - text: Load-Balancing
+        url: /get-started/load-balancing
+  - title: Kong in Production
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    items:
+      - text: Deployment Topologies
+        items:
+          - text: Overview
+            url: /production/deployment-topologies/
+          - text: Hybrid Mode
+            items:
+            - text: Overview
+              url: /production/deployment-topologies/hybrid-mode/
+            - text: Deploy Kong Gateway in Hybrid mode
+              url: /production/deployment-topologies/hybrid-mode/setup
+          - text: DB-less Deployment
+            url: /production/deployment-topologies/db-less-and-declarative-config
+          - text: Traditional
+            url: /production/deployment-topologies/traditional
+      - text: Installation Options
+        items:
+          - text: Overview
+            url: /install/
+          - text: Kubernetes
+            items:
+              - text: Helm
+                url: /install/kubernetes/helm-quickstart
+              - text: OpenShift with Helm
+                url: /install/kubernetes/openshift
+              - text: kubectl apply
+                url: /install/kubernetes/kubectl
+              - text: Kubernetes Deployment Options
+                url: /install/kubernetes/deployment-options
+          - text: Docker
+            items:
+              - text: Using docker run
+                url: /install/docker
+              - text: Build your own Docker images
+                url: /install/docker/build-custom-images/
+          - text: Linux
+            items:
+              - text: Supported Distributions
+                url: /install/linux/os-support
+              - text: Amazon Linux
+                url: /install/linux/amazon-linux
+              - text: Debian
+                url: /install/linux/debian
+              - text: Red Hat
+                url: /install/linux/rhel
+              - text: Ubuntu
+                url: /install/linux/ubuntu
+          - text: macOS
+            url: /install/macos
+      - text: Running Kong
+        items:
+          - text: Running Kong as a non-root user
+            url: /production/running-kong/kong-user
+          - text: Securing the Admin API
+            url: /production/running-kong/secure-admin-api
+          - text: Using systemd
+            url: /production/running-kong/systemd
+      - text: Access Control
+        items:
+          - text: Start Kong Gateway Securely
+            url: /production/access-control/start-securely
+          - text: Programatically Creating Admins
+            url: /production/access-control/register-admin-api
+          - text: Enabling RBAC
+            url: /production/access-control/enable-rbac
+      - text: Licenses
+        items:
+          - text: Overview
+            url: /licenses/
+          - text: Download your License
+            url: /licenses/download
+          - text: Deploy Enterprise License
+            url: /licenses/deploy
+          - text: Using the License API
+            url: /licenses/examples
+          - text: Monitor Licenses Usage
+            url: /licenses/report
+      - text: Networking
+        items:
+          - text: Default Ports
+            url: /production/networking/default-ports
+          - text: DNS Considerations
+            url: /production/networking/dns-considerations
+          - text: Network and Firewall
+            url: /production/networking/firewall
+      - text: Kong Configuration File
+        url: /production/kong-conf
+      - text: Environment Variables
+        url: /production/environment-variables
+      - text: Embedding Kong in Open Resty
+        url: /production/kong-openresty
+      - text: Serving a Website and APIs from Kong
+        url: /production/website-api-serving
+      - text: Monitoring
+        items:
+          - text: Overview
+            url: /production/monitoring/
+          - text: Prometheus
+            url: /production/monitoring/prometheus
+          - text: StatsD
+            url: /production/monitoring/statsd
+          - text: Datadog
+            url: /production/monitoring/datadog
+      - text: Tracing
+        items:
+          - text: Overview
+            url: /production/tracing/
+          - text: Writing a Custom Trace Exporter
+            url: /production/tracing/write-custom-trace-exporter
+          - text: Tracing API Reference
+            url: /production/tracing/api
+      - text: Resource Sizing Guidelines
+        url: /production/sizing-guidelines
+      - text: Security Update Process
+        url: /production/security-update-process
+      - text: Blue-Green Deployments
+        url: /production/blue-green
+      - text: Canary Deployments
+        url: /production/canary
+      - text: Clustering Reference
+        url: /production/clustering
+      - text: Logging Reference
+        url: /production/logging
+      - text: Upgrade and Migration
+        items:
+          - text: Upgrade Kong Gateway
+            url: /upgrade/
+          - text: Migrate from OSS to Enterprise
+            url: /migrate-ce-to-ke/
+  - title: Kong Enterprise
+    icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
+    items:
+      - text: Overview
+        url: /kong-enterprise/
+      - text: Kong Vitals
+        items:
+          - text: Overview
+            url: /kong-enterprise/analytics/
+          - text: Metrics
+            url: /kong-enterprise/analytics/metrics
+          - text: Reports
+            url: /kong-enterprise/analytics/reports
+          - text: Analytics with InfluxDB
+            url: /kong-enterprise/analytics/influx-strategy
+          - text: Analytics with Prometheus
+            url: /kong-enterprise/analytics/prometheus-strategy
+          - text: Estimate Analytics Storage in PostgreSQL
+            url: /kong-enterprise/analytics/estimates
+      - text: Secrets Management
+        items:
+          - text: Overview
+            url: /kong-enterprise/secrets-management/
+          - text: Getting Started
+            url: /kong-enterprise/secrets-management/getting-started
+          - text: Advanced Usage
+            url: /kong-enterprise/secrets-management/advanced-usage
+          - text: Backends
+            items:
+              - text: Overview
+                url: /kong-enterprise/secrets-management/backends
+              - text: Environment Variables
+                url: /kong-enterprise/secrets-management/backends/env
+              - text: AWS Secrets Manager
+                url: /kong-enterprise/secrets-management/backends/aws-sm
+              - text: Google Secrets Manager
+                url: /kong-enterprise/secrets-management/backends/gcp-sm
+              - text: Hashicorp Vault
+                url: /kong-enterprise/secrets-management/backends/hashicorp-vault
+          - text: How-To
+            items:
+              - text: Securing the Database with AWS Secrets Manager
+                url: /kong-enterprise/secrets-management/how-to/aws-secrets-manager
+          - text: Reference Format
+            url: /kong-enterprise/secrets-management/reference-format
+      - text: Dynamic Plugin Ordering
+        items:
+          - text: Overview
+            url: /kong-enterprise/plugin-ordering/
+          - text: Get Started with Dynamic Plugin Ordering
+            url: /kong-enterprise/plugin-ordering/get-started
+      - text: Dev Portal
+        items:
+          - text: Overview
+            url: /kong-enterprise/dev-portal/
+          - text: Enable the Dev Portal
+            url: /kong-enterprise/dev-portal/enable
+          - text: Publish an OpenAPI Spec
+            url: /kong-enterprise/dev-portal/publish-spec
+          - text: Structure and File Types
+            url: /kong-enterprise/dev-portal/structure-and-file-types
+          - text: Themes Files
+            url: /kong-enterprise/dev-portal/themes
+          - text: Working with Templates
+            url: /kong-enterprise/dev-portal/working-with-templates
+          - text: Using the Editor
+            url: /kong-enterprise/dev-portal/using-the-editor
+          - text: Authentication and Authorization
+            items:
+              - text: Basic Auth
+                url: /kong-enterprise/dev-portal/authentication/basic-auth
+              - text: Key Auth
+                url: /kong-enterprise/dev-portal/authentication/key-auth
+              - text: OIDC
+                url: /kong-enterprise/dev-portal/authentication/oidc
+              - text: Sessions
+                url: /kong-enterprise/dev-portal/authentication/sessions
+              - text: Adding Custom Registration Fields
+                url: /kong-enterprise/dev-portal/authentication/adding-registration-fields
+              - text: Manage Developers
+                url: /kong-enterprise/dev-portal/authentication/managing-developers
+              - text: Developer Roles and Content Permissions
+                url: /kong-enterprise/dev-portal/authentication/developer-permissions
+          - text: Application Registration
+            items:
+              - text: Authorization Provider Strategy
+                url: /kong-enterprise/dev-portal/applications/auth-provider-strategy
+              - text: Enable Application Registration
+                url: /kong-enterprise/dev-portal/applications/enable-application-registration
+              - text: Enable Key Authentication for Application Registration
+                url: /kong-enterprise/dev-portal/applications/enable-key-auth-plugin
+              - text: Enable External Authentication
+                items:
+                  - text: External OAuth2 Support
+                    url: /kong-enterprise/dev-portal/authentication/3rd-party-oauth
+                  - text: Set up Okta and Kong for External Oauth
+                    url: /kong-enterprise/dev-portal/authentication/okta-config
+                  - text: Set up Azure AD and Kong for External Authentication
+                    url: /kong-enterprise/dev-portal/authentication/azure-oidc-config
+              - text: Manage Applications
+                url: /kong-enterprise/dev-portal/applications/managing-applications
+          - text: Customize Dev Portal
+            items:
+              - text: Theme Editing
+                url: /kong-enterprise/dev-portal/customize/theme-editing
+              - text: Migrating Templates Between Workspaces
+                url: /kong-enterprise/dev-portal/customize/migrating-templates
+              - text: Markdown Rendering Module
+                url: /kong-enterprise/dev-portal/customize/markdown-extended
+              - text: Customizing Portal Emails
+                url: /kong-enterprise/dev-portal/customize/emails
+              - text: Adding and Using JavaScript Assets
+                url: /kong-enterprise/dev-portal/customize/adding-javascript-assets
+              - text: Single Page App in Dev Portal
+                url: /kong-enterprise/dev-portal/customize/single-page-app
+              - text: Alternate OpenAPI Renderer
+                url: /kong-enterprise/dev-portal/customize/alternate-openapi-renderer
+          - text: SMTP
+            url: /kong-enterprise/dev-portal/smtp
+          - text: Workspaces
+            url: /kong-enterprise/dev-portal/workspaces
+          - text: Helpers CLI
+            url: /kong-enterprise/dev-portal/cli
+          - text: Portal API
+            url: /kong-enterprise/dev-portal/portal-api
+      - text: Audit Logging
+        url: /kong-enterprise/audit-log
+      - text: Keyring and Data Encryption
+        url: /kong-enterprise/db-encryption
+      - text: Workspaces
+        url: /kong-enterprise/workspaces
+      - text: Consumer Groups
+        url: /kong-enterprise/consumer-groups
+      - text: Event Hooks
+        url: /kong-enterprise/event-hooks
+      - text: FIPS 140-2
+        url: /kong-enterprise/fips-support
+  - title: Kong Manager
+    icon: /assets/images/icons/documentation/icn-manager-color.svg
+    items:
+      - text: Overview
+        url: /kong-manager/
+      - text: Enable Kong Manager
+        url: /kong-manager/enable
+      - text: Get Started with Kong Manager
+        items:
+          - text: Services and Routes
+            url: /kong-manager/get-started/services-and-routes
+          - text: Rate Limiting
+            url: /kong-manager/get-started/rate-limiting
+          - text: Proxy Caching
+            url: /kong-manager/get-started/proxy-caching
+          - text: Authentication with Consumers
+            url: /kong-manager/get-started/consumers
+          - text: Load Balancing
+            url: /kong-manager/get-started/load-balancing
+      - text: Authentication and Authorization
+        items:
+          - text: Overview
+            url: /kong-manager/auth/
+          - text: Create a Super Admin
+            url: /kong-manager/auth/super-admin
+          - text: Workspaces and Teams
+            url: /kong-manager/auth/workspaces-and-teams
+          - text: Reset Passwords and RBAC Tokens
+            url: /kong-manager/auth/reset-password
+          - text: Basic Auth
+            url: /kong-manager/auth/basic
+          - text: LDAP
+            items:
+              - text: Configure LDAP
+                url: /kong-manager/auth/ldap/configure
+              - text: LDAP Service Directory Mapping
+                url: /kong-manager/auth/ldap/service-directory-mapping
+          - text: OIDC
+            items:
+              - text: Configure OIDC
+                url: /kong-manager/auth/oidc/configure
+              - text: OIDC Authenticated Group Mapping
+                url: /kong-manager/auth/oidc/mapping
+          - text: Sessions
+            url: /kong-manager/auth/sessions
+          - text: RBAC
+            items:
+            - text: Overview
+              url: /kong-manager/auth/rbac
+            - text: Enable RBAC
+              url: /kong-manager/auth/rbac/enable
+            - text: Add a Role and Permissions
+              url: /kong-manager/auth/rbac/add-role
+            - text: Create a User
+              url: /kong-manager/auth/rbac/add-user
+            - text: Create an Admin
+              url: /kong-manager/auth/rbac/add-admin
+      - text: Networking Configuration
+        url: /kong-manager/networking
+      - text: Workspaces
+        url: /kong-manager/workspaces
+      - text: Sending Email
+        url: /kong-manager/configuring-to-send-email
+
+  - title: Develop Custom Plugins
+    icon: /assets/images/icons/documentation/icn-dev-portal-color.svg
+    items:
+      - text: Overview
+        url: /plugin-development/
+      - text: File Structure
+        url: /plugin-development/file-structure
+      - text: Implementing Custom Logic
+        url: /plugin-development/custom-logic
+      - text: Plugin Configuration
+        url: /plugin-development/configuration
+      - text: Accessing the Data Store
+        url: /plugin-development/access-the-datastore
+      - text: Storing Custom Entities
+        url: /plugin-development/custom-entities
+      - text: Caching Custom Entities
+        url: /plugin-development/entities-cache
+      - text: Extending the Admin API
+        url: /plugin-development/admin-api
+      - text: Writing Tests
+        url: /plugin-development/tests
+      - text: (un)Installing your Plugin
+        url: /plugin-development/distribution
+      - text: Plugin Development Kit
+        items:
+        - text: Overview
+          url: /plugin-development/pdk/
+        - text: kong.client
+          url: /plugin-development/pdk/kong.client
+        - text: kong.client.tls
+          url: /plugin-development/pdk/kong.client.tls
+        - text: kong.cluster
+          url: /plugin-development/pdk/kong.cluster
+        - text: kong.ctx
+          url: /plugin-development/pdk/kong.ctx
+        - text: kong.ip
+          url: /plugin-development/pdk/kong.ip
+        - text: kong.log
+          url: /plugin-development/pdk/kong.log
+        - text: kong.nginx
+          url: /plugin-development/pdk/kong.nginx
+        - text: kong.node
+          url: /plugin-development/pdk/kong.node
+        - text: kong.request
+          url: /plugin-development/pdk/kong.request
+        - text: kong.response
+          url: /plugin-development/pdk/kong.response
+        - text: kong.router
+          url: /plugin-development/pdk/kong.router
+        - text: kong.service
+          url: /plugin-development/pdk/kong.service
+        - text: kong.service.request
+          url: /plugin-development/pdk/kong.service.request
+        - text: kong.service.response
+          url: /plugin-development/pdk/kong.service.response
+        - text: kong.table
+          url: /plugin-development/pdk/kong.table
+        - text: kong.tracing
+          url: /plugin-development/pdk/kong.tracing
+        - text: kong.vault
+          url: /plugin-development/pdk/kong.vault
+
+        - text: kong.websocket.client
+          url: /plugin-development/pdk/kong.websocket.client
+
+        - text: kong.websocket.upstream
+          url: /plugin-development/pdk/kong.websocket.upstream
+
+      - text: Plugins in Other Languages
+        items:
+          - text: Go
+            url: /plugin-development/pluginserver/go
+          - text: Javascript
+            url: /plugin-development/pluginserver/javascript
+          - text: Python
+            url: /plugin-development/pluginserver/python
+          - text: Running Plugins in Containers
+            url: /plugin-development/pluginserver/plugins-kubernetes
+  - title: Kong Plugins
+    icon: /assets/images/icons/documentation/icn-api-plugins-color.svg
+    items:
+      - text: Overview
+        url: /kong-plugins/
+      - text: Authentication
+        items:
+          - text: Open ID Connect Plugin
+            items:
+              - text: Overview
+                url: /kong-plugins/authentication/oidc/
+              - text: OpenID Connect with Curity
+                url: /kong-plugins/authentication/oidc/curity
+              - text: OpenID Connect with Azure AD
+                url: /kong-plugins/authentication/oidc/azure-ad
+              - text: OpenID Connect with Google
+                url: /kong-plugins/authentication/oidc/google
+              - text: OpenID Connect with Okta
+                url: /kong-plugins/authentication/oidc/okta
+              - text: OpenID Connect with Auth0
+                url: /kong-plugins/authentication/oidc/auth0
+              - text: OpenID Connect with Cognito
+                url: /kong-plugins/authentication/oidc/cognito
+          - text: Authentication Reference
+            url: /kong-plugins/authentication/reference
+          - text: Allow Multiple Authentication Plugins
+            url: /kong-plugins/authentication/allowing-multiple-authentication-methods/
+      - text: Rate Limiting Plugin
+        url: /kong-plugins/rate-limiting/algorithms/rate-limiting
+        #items:
+          #- text: Overview
+            #url: /kong-plugins/rate-limiting/ commenting these lines out for 3.0
+            #url: /kong-plugins/rate-limiting/algorithms/rate-limiting
+          #- text: Algorithms
+           # items:
+            #  - text: Configuring sliding-window
+             #   url:  /kong-plugins/rate-limiting/algorithms/rate-limiting
+              #- text: Configuring Fixed bucket
+               # url: /kong-plugins/rate-limiting/algorithms/fixed-bucket
+      - text: Request Transformer
+        items:
+          - text: Add a Body Value
+            url: /kong-plugins/request-transformer/add-body-value
+
+      - text: GraphQL
+        url: /kong-plugins/graphql
+      - text: gRPC
+        items:
+        - text: gRPC Plugins
+          url: /kong-plugins/grpc
+        - text: Configure a gRPC service
+          url: /kong-plugins/configuring-a-grpc-service
+
+  - title: Admin API
+    icon: /assets/images/icons/documentation/icn-admin-api-color.svg
+    items:
+      - text: Overview
+        url: /admin-api/
+      - text: Information Routes
+        url: /admin-api/#information-routes
+      - text: Health Routes
+        url: /admin-api/#health-routes
+      - text: Tags
+        url: /admin-api/#tags
+      - text: Services
+        url: /admin-api/#service-object
+      - text: Routes
+        url: /admin-api/#route-object
+      - text: Consumers
+        url: /admin-api/#consumer-object
+      - text: Plugins
+        url: /admin-api/#plugin-object
+      - text: Certificates
+        url: /admin-api/#certificate-object
+      - text: CA Certificates
+        url: /admin-api/#ca-certificate-object
+      - text: SNIs
+        url: /admin-api/#sni-object
+      - text: Upstreams
+        url: /admin-api/#upstream-object
+      - text: Targets
+        url: /admin-api/#target-object
+      - text: Vaults
+        url: /admin-api/#vaults-entity
+      - text: Licenses
+        url: /admin-api/licenses/reference
+      - text: Workspaces
+        url: /admin-api/workspaces/reference
+      - text: RBAC
+        url: /admin-api/rbac/reference
+      - text: Admins
+        url: /admin-api/admins/reference
+      - text: Developers
+        url: /admin-api/developers/reference
+      - text: Consumer Groups
+        url: /admin-api/consumer-groups/reference
+      - text: Event Hooks
+        url: /admin-api/event-hooks/reference
+      - text: Keyring and Data Encryption
+        url: /admin-api/db-encryption
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: kong.conf
+        url: /reference/configuration
+      - text: Injecting Nginx Directives
+        url: /reference/nginx-directives
+      - text: CLI
+        url: /reference/cli
+      - text: Performance Testing Framework
+        url: /reference/performance-testing-framework
+      - text: Router Expressions Language
+        url: /reference/router-expressions-language
+      - text: FAQ
+        url: /reference/faq

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -196,6 +196,21 @@
     pcre: 8.45
   lua_doc: true
 -
+  release: "3.1.x"
+  ee-version: "3.1.0.0"
+  ce-version: "3.1.0"
+  edition: "gateway"
+  luarocks_version: "3.0.0-0"
+  dependencies:
+    luajit: "2.1-20220411"
+    luarocks: "3.9.1"
+    postgres: "9.5+"
+    openresty: "1.21.4.1"
+    openssl: "1.1.1.q"
+    libyaml: "0.2.5"
+    pcre: 8.45
+  lua_doc: true
+-
   release: "2.1.x"
   version: "2.1"
   edition: "getting-started-guide"

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -154,7 +154,10 @@ the `eab_kid` or `eab_hmac_key`:
         "auth": null,
         "port": 6379,
         "database": 0,
-        "host": "127.0.0.1"
+        "host": "127.0.0.1",
+        "ssl": false,
+        "ssl_verify": false,
+        "ssl_server_name": null
       },
        "consul": {
           "host": "127.0.0.1",
@@ -506,6 +509,13 @@ own certificate.
 ---
 
 ## Changelog
+
+{% if_plugin_version gte:3.1.x %}
+**{{site.base_gateway}}  3.1.x**
+
+* Added the `config.storage_config.redis.ssl`, `config.storage_config.redis.ssl_verify`, and `config.storage_config.redis.ssl_server_name` configuration parameters.
+
+{% endif_plugin_version %}
 
 {% if_plugin_version gte:3.0.x %}
 

--- a/app/_hub/kong-inc/basic-auth/_index.md
+++ b/app/_hub/kong-inc/basic-auth/_index.md
@@ -40,8 +40,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
   extra: |
     Once applied, any user with a valid credential can access the Service.
     To restrict usage to only some of the authenticated users, also add the

--- a/app/_hub/kong-inc/hmac-auth/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/_index.md
@@ -49,8 +49,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string    
       description: |
-        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails. If empty (default), the request fails with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: validate_request_body
       required: true
       default: '`false`'

--- a/app/_hub/kong-inc/jwt/_index.md
+++ b/app/_hub/kong-inc/jwt/_index.md
@@ -76,8 +76,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string      
       description: |
-        An optional string (consumer uuid) value to use as an anonymous consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. The anonymous value must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -80,10 +80,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string
       description: |
-        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails. If empty (default),
-        the request will fail with an authentication failure `4xx`. Note that this value
-        must refer to the consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: run_on_preflight
       required: false
       default: '`true`'

--- a/app/_hub/kong-inc/key-auth/_index.md
+++ b/app/_hub/kong-inc/key-auth/_index.md
@@ -78,10 +78,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string
       description: |
-        An optional string (Consumer UUID) value to use as an anonymous Consumer if authentication fails.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
-        must refer to the Consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -126,11 +126,19 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      value_in_examples: null
+      datatype: string
       description: |
-        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the
-        request will fail with an authentication failure `4xx`.
-
-        **Note:** The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: header_type
       required: false
       default: '`ldap`'

--- a/app/_hub/kong-inc/ldap-auth/_index.md
+++ b/app/_hub/kong-inc/ldap-auth/_index.md
@@ -142,10 +142,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string
       description: |
-        An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
-
-        **Note:** The value must refer to the Consumer `id` attribute that is internal to Kong, **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request fails with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: header_type
       required: false
       default: '`ldap`'

--- a/app/_hub/kong-inc/mocking/_index.md
+++ b/app/_hub/kong-inc/mocking/_index.md
@@ -37,9 +37,10 @@ params:
     - https
   dbless_compatible: 'yes'
   dbless_explanation: |
-    Use the `api_specification` config for DB-less or hybrid mode. Attach the spec contents directly
+    {:.note}
+    > Use the `api_specification` config for DB-less or hybrid mode. Attach the spec contents directly
     instead of uploading to the Dev Portal. The API spec is configured directly in the plugin.
-  examples: false
+  examples: true
   config:
     - name: api_specification_filename
       required: semi
@@ -94,76 +95,124 @@ params:
       description: |
         Randomly selects one example and returns it. This parameter requires the spec to have multiple examples configured.
       minimum_version: "2.7.x"
+    - name: included_status_codes
+      required: false
+      default: null
+      datatype: array of integers
+      description: |
+        A global list of the HTTP status codes that can only be selected and returned.
+      minimum_version: "3.1.x"
+    - name: random_status_code
+      required: false
+      default: false
+      datatype: boolean
+      description: |
+        Determines whether to randomly select an HTTP status code from the responses of the corresponding API method.
+        The default value is `false`, which means the minimum HTTP status code is always selected and returned.
+      minimum_version: "3.1.x"
   extra: |
 
     Depending on the Kong Gateway deployment mode, set either the `api_specification_filename`
     or the `api_specification` parameter. The plugin requires a spec to work.
 ---
 
-## Configuration
+## Behavioral Headers
 
-### Enable the plugin on a service
+Behavioral headers allow you to change the behavior of the Mocking plugin for the individual request without changing the configuration.
 
-Configure this plugin on a [service](/gateway/latest/admin-api/#service-object):
+### X-Kong-Mocking-Delay
 
-```bash
-curl -X POST http://<admin-hostname>:8001/services/<service>/plugins \
-  --data "name=mocking" \
-  --data "config.api_specification_filename=multipleexamples.json" \
-  --data "config.random_delay=true" \
-  --data "config.max_delay_time=1" \
-  --data "config.min_delay_time=0.01"
+The `X-Kong-Mocking-Delay` header tells the plugin how many milliseconds to delay before responding. The delay value must be between `0`(inclusive) and `10000`(inclusive), otherwise it returns a `400` error.
+
+```
+HTTP/1.1 400 Bad Request
+
+{
+    "message": "Invalid value for X-Kong-Mocking-Delay. The delay value should between 0 and 10000ms"
+}
 ```
 
-The `<service>` is the id or name of the service that this plugin configuration will target.
+### X-Kong-Mocking-Example-Id
 
-### Enable the plugin on a route
+The `X-Kong-Mocking-Example-Id` header tells the plugin which response example is used when the endpoint has multiple examples for a single status code.
 
-Configure this plugin on a [route](/gateway/latest/admin-api/#route-object):
+OpenAPI 3.0 allows you to define multiple examples in a single MIME type. The following example has two candidate examples: `Hao` and `Sasha`.
 
-```bash
-curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
-   --data "name=mocking" \
-   --data "config.api_specification_filename=multipleexamples.json" \
-   --data "config.random_delay=true" \
-   --data "config.max_delay_time=1" \
-   --data "config.min_delay_time=0.01"
-   ```
-
-The `<route>` is the id or name of the route that this plugin configuration will target.
-
-### Enable the plugin on a consumer
-
-Configure this plugin on a [consumer](/gateway/latest/admin-api/#consumer-object):
-
-```bash
-curl -X POST http://<admin-hostname>:8001/consumers/<consumer>/plugins \
-  --data "name=mocking"  \
-  --data "config.api_specification_filename=multipleexamples.json" \
-  --data "config.random_delay=true" \
-  --data "config.max_delay_time=1" \
-  --data "config.min_delay_time=0.001"
+```yaml
+paths:
+  /query_user:
+    get:
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              examples:
+                Jessica:
+                  value:
+                    id: 10
+                    name: Hao
+                Ron:
+                  value:
+                    id: 20
+                    name: Sasha
 ```
 
-The `<consumer>` is the id or username of the consumer that this plugin configuration will target.
 
-You can combine `consumer.id`, `service.id`, or `route.id` within the same request to further narrow the scope of the plugin.
-
-### Enable the plugin globally
-
-A plugin that is not associated to any service, route, or consumer is considered global, and
-will run on every request. Read the [Plugin Reference](/gateway/latest/admin-api/#add-plugin) and the
-[Plugin Precedence](/gateway/latest/admin-api/#precedence) sections for more information.
-
-Configure this plugin globally:
+Makes a request to choose a specific example to respond to:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/plugins/ \
-    --data "name=mocking"  \
-    --data "config.api_specification_filename=multipleexamples.json" \
-    --data "config.random_delay=true" \
-    --data "config.max_delay_time=1" \
-    --data "config.min_delay_time=0.001"
+curl -X GET http://HOSTNAME:8000/query_user -H "X-Kong-Mocking-Example-Id: Sasha"
+```
+
+Response:
+
+```
+{
+    "id": 20,
+    "name": "Sasha"
+}
+```
+
+### X-Kong-Mocking-Status-Code
+
+By default, the plugin chooses the minimum status code that is defined in the corresponding method.
+
+The `X-Kong-Mocking-Status-Code` header allows requests to change the default status code selection behavior by specifying a status code that is defined in the corresponding method. 
+
+```yaml
+paths:
+  /ping:
+    get:
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              example:
+                message: '200'
+        '500':
+          description: '500'
+          content:
+            application/json:
+              example:
+                message: '500'
+```
+
+Makes a request to choose a specific status code to respond to:
+
+```bash
+curl -i -X GET http://HOSTNAME:8000/ping -H "X-Kong-Mocking-Status-Code: 500"
+```
+
+Response:
+
+```
+HTTP/1.1 500 Internal Server Error
+
+{
+    "message": "500"
+}
 ```
 
 ## Tutorial Example
@@ -906,6 +955,14 @@ ensure you set the actual URL for your service so that the response can be recei
 ---
 
 ## Changelog
+
+**{{site.base_gateway}} 3.1.x**
+
+* Added `config.included_status_codes`, `config.random_status_codes` configuration parameters for status code selection.
+* Added behavioral headers feature.
+* $ref and schema support.
+* Added MIME types priority match support.
+
 
 **{{site.base_gateway}} 2.7.x**
 

--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -27,6 +27,14 @@ params:
   config:
     - name: anonymous
       required: false
+      default: null
+      datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
       datatype: string
       description: |
         An optional string (consumer UUID) value to use as an "anonymous" consumer if authentication fails.
@@ -34,6 +42,7 @@ params:
         `HTTP 495` if the client presented a certificate that is not acceptable, or `HTTP 496` if the client failed
         to present certificate as requested. Please note that this value must refer to the consumer `id`
         attribute, which is internal to Kong, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: consumer_by
       required: false
       default: '`[ "username", "custom_id" ]`'

--- a/app/_hub/kong-inc/oauth2-introspection/_index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/_index.md
@@ -95,8 +95,17 @@ params:
       default: null
       value_in_examples: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      value_in_examples: null
+      datatype: string
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure 4xx.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails. If empty (default), the request fails with an authentication failure `4xx`.
+      maximum_version: "3.0.0"
     - name: run_on_preflight
       required: false
       default: true

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -125,8 +125,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string      
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request fails with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: global_credentials
       required: true
       default: '`false`'

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -176,10 +176,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"  
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string      
       description: |
-        Let unauthenticated requests pass or skip the plugin if another authentication plugin
-        has already authenticated the request by setting the value to anonymous Consumer.
-        The value can be a UUID or a username.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - group: General Settings
       description: Parameters for settings that affect different grants and flows.
     - name: preserve_query_args

--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -35,9 +35,11 @@ params:
       value_in_examples: null
       datatype: Set of string elements
       description: |
-        List of allowed content types. The value can be configured with the `charset` parameter(e.g. `application/json; charset=UTF-8`).
-        <br>**Note:** Body validation is only done for `application/json` and skipped for any other allowed content types.
-        
+        List of allowed content types. The value can be configured with the `charset` parameter. For example, `application/json; charset=UTF-8`.
+        <br>**Note:** 
+        Body validation is only done for `application/json` and skipped for any other allowed content types. 
+        Only one parameter is supported at the most. If a request is sending more than one parameter with the Content-Type header, only the first parameter is evaluated and the rest are truncated. Note that `application/json` doesn't match with `application/json; charset=UTF-8`.
+        The type, subtype, parameter names, and the value of the charset parameter are not case sensitive based on the RFC explanation.
     - name: version
       required: true
       default: kong

--- a/app/_hub/kong-inc/request-validator/_index.md
+++ b/app/_hub/kong-inc/request-validator/_index.md
@@ -35,8 +35,9 @@ params:
       value_in_examples: null
       datatype: Set of string elements
       description: |
-        List of allowed content types. <br>**Note:** Body validation is only
-        done for `application/json` and skipped for any other allowed content types.
+        List of allowed content types. The value can be configured with the `charset` parameter(e.g. `application/json; charset=UTF-8`).
+        <br>**Note:** Body validation is only done for `application/json` and skipped for any other allowed content types.
+        
     - name: version
       required: true
       default: kong

--- a/app/_hub/kong-inc/response-ratelimiting/_index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/_index.md
@@ -172,6 +172,26 @@ params:
       default: '`0`'
       datatype: number
       description: 'When using the `redis` policy, this property specifies Redis database to use.'
+    - name: redis_ssl
+      minimum_version: "3.1.x"
+      required: true
+      default: '`false`'
+      datatype: boolean
+      description: |
+        When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.
+    - name: redis_ssl_verify
+      minimum_version: "3.1.x"
+      required: true
+      default: '`false`'
+      datatype: boolean
+      description: |
+        When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.
+    - name: redis_server_name
+      minimum_version: "3.1.x"
+      required: false
+      datatype: string
+      description: |
+        When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI) 
 ---
 
 ## Configuring Quotas
@@ -237,6 +257,10 @@ X-RateLimit-Remaining-Images: 0
 
 ---
 ## Changelog
+
+**{{site.base_gateway}}  3.1.x**
+
+* Added the `redis_ssl`, `redis_ssl_verify`, and `redis_server_name` configuration parameters.
 
 **{{site.base_gateway}} 2.8.x**
 

--- a/app/_hub/kong-inc/route-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/_index.md
@@ -38,6 +38,13 @@ params:
       datatype: string
       description: |
         Updates the upstream request Port with given value/template. Note that the port as set may be overridden again by DNS resolution (in case of SRV records,or an Upstream) One of `config.path` or `config.host` or `config.port` must be specified.
+    - name: escape_path
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        If set to true, the path is escaped after being transformed.
+      minimum_version: "3.1.0"
 ---
 
 _NOTE_: The advanced label is only attached because this is an Enterprise-only

--- a/app/_hub/kong-inc/saml/_index.md
+++ b/app/_hub/kong-inc/saml/_index.md
@@ -1,0 +1,464 @@
+---
+name: SAML
+publisher: Kong Inc.
+version: 3.1.0
+desc: Provides SAML v2.0 authentication and authorization between a Service Provider (Kong) and an Identity Provider
+description: |
+  Security Assertion Markup Language (SAML) is an open standard for exchanging authentication and authorization data between an identity provider and a service provider.
+
+  The SAML specification defines three roles:
+
+  * The principal, generally a user
+  * The identity provider (IdP)
+  * The service provider (SP)
+
+  The Kong SAML plugin acts as the SP and is responsible for initiating a login to the IdP. In SAML terminology, this is called a SP Initiated Login.
+
+  The minimum configuration required is:
+
+  - Certificate [idp_certificate]
+    The SP needs to obtain the public certificate from the IdP to validate the signature. The certificate is stored on the SP side and used whenever a SAML response arrives.
+  - ACS Endpoint [assertion_consumer_path]
+    This is the endpoint provided by the SP where SAML responses are posted. The SP needs to provide this information to the IdP.
+  - IdP Sign-in URL [idp_sso_url]
+    This is the endpoint on the IdP side where SAML requests are posted. The SP needs to obtain this information from the IdP.
+  - Issuer [issuer]
+    Unique identifier of the IdP application.
+
+  The plugin supports Microsoft Azure Active Directory. See https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/auth-saml for further information on SAML authentication with Azure AD.
+
+enterprise: true
+plus: true
+type: plugin
+categories:
+  - security
+kong_version_compatibility:
+  enterprise_edition:
+    compatible:
+      - 3.x
+params:
+  name: saml
+  service_id: true
+  route_id: true
+  consumer_id: false
+  protocols:
+    - http
+    - https
+  dbless_compatible: 'yes'
+  config:
+    - name: assertion_consumer_path
+      required: true
+      datatype: url
+      default: null
+      value_in_examples: <acs-uri>
+      description: |
+        The is the relative path that the SAML IdP provider will use when responding with an authenication response.
+    - name: idp_sso_url
+      required: true
+      datatype: url
+      default: null
+      value_in_examples: <sso-uri>
+      description: |
+        The Sign Sign On URL exposed by the IdP provider. This is where SAML requests are posted. The IdP will provide this information.
+    - name: idp_certificate
+      required: true
+      datatype: string
+      default: null
+      referenceable: true
+      description: |
+        The public certificate provided by the IdP. This is used to validate responses from the IdP.
+    - name: encryption_key
+      required: false
+      datatype: string
+      default: null
+      referenceable: true
+      description: |
+        The private encrytion key required to decrypt encrypted assertions.
+    - name: request_is_signed
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        Indicates if the plugin should sign requests. If set to true, then `request_signing_key` and `request_signing_certificate` values will be required.
+    - name: request_signing_key
+      required: false
+      datatype: string
+      default: null
+      referenceable: true
+      description: |
+        The private key for signing requests.
+    - name: request_signing_certificate
+      required: false
+      datatype: string
+      default: null
+      referenceable: true
+      description: |
+        The certificate for signing requests.
+    - name: request_signature_method
+      required: false
+      datatype: string
+      default: '"SHA256"'
+      description: |
+        The signature method for signing Authn requests. Options are:
+        - `SHA256`
+        - `SHA384`
+        - `SHA512`
+    - name: request_digest_algorithm
+      required: false
+      datatype: string
+      default: '"SHA256"'
+      description: |
+        The digest algorithm to use for Authn requests:
+        - `SHA256`
+        - `SHA1`
+    - name: response_signature_method
+      required: false
+      datatype: string
+      default: '"SHA256"'
+      description: |
+        The algorithm to use for validating signatures in SAML responses. Options are:
+        - `SHA256`
+        - `SHA384`
+        - `SHA512`
+    - name: response_digest_algorithm
+      required: false
+      datatype: string
+      default: '"SHA256"'
+      description: |
+        The algorithm to use for verify digest in SAML responses:
+        - `SHA256`
+        - `SHA1`
+    - name: issuer
+      required: true
+      datatype: string
+      default: null
+      description: |
+        Unique identifier of the IdP application. Formatted as a URL containing information about the IdP so the SP can validate that the SAML assertions it receives are issued from the correct IdP.
+    - name: nameid_format
+      required: false
+      datatype: string
+      default: '"EmailAddress"'
+      description: |
+        The requested NameId format. Options are:
+        - `Unspecified`
+        - `EmailAddress`
+        - `Persistent`
+        - `Transient`.
+    - name: disable_signature_validation
+      required: false
+      datatype: boolean
+      default: false
+      description: |
+        Disable signature validation in SAML responses.
+    - group: Session Cookie
+      description: Parameters used with the session cookie authentication.
+    - name: session_cookie_name
+      required: false
+      default: '"session"'
+      datatype: string
+      description: The session cookie name.
+    - name: session_cookie_lifetime
+      required: false
+      default: 3600
+      datatype: integer
+      description: The session cookie lifetime in seconds.
+    - name: session_cookie_idletime
+      required: false
+      default: null
+      datatype: integer
+      description: The session cookie idle time in seconds.
+    - name: session_cookie_renew
+      required: false
+      default: 600
+      datatype: integer
+      description: The session cookie renew time.
+    - name: session_cookie_path
+      required: false
+      default: '"/"'
+      datatype: string
+      description: The session cookie Path flag.
+    - name: session_cookie_domain
+      required: false
+      default: null
+      datatype: string
+      description: The session cookie Domain flag.
+    - name: session_cookie_samesite
+      required: false
+      default: '"Lax"'
+      datatype: string
+      description: |
+        Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks:
+        - `Strict`: Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.
+        - `Lax`: Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (for example, when following a link).
+        - `None`: Cookies will be sent in all contexts, for example in responses to both first-party and cross-origin requests. If SameSite=None is set, the cookie Secure attribute must also be set (or the cookie will be blocked)
+        - `off`: Do not set the Same-Site flag.
+    - name: session_cookie_httponly
+      required: false
+      default: true
+      datatype: boolean
+      description: 'Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.'
+    - name: session_cookie_secure
+      required: false
+      default: (from the request scheme)
+      datatype: boolean
+      description: |
+        Cookie is only sent to the server when a request is made with the https: scheme (except on localhost),
+        and therefore is more resistant to man-in-the-middle attacks.
+    - name: session_cookie_maxsize
+      required: false
+      default: 4000
+      datatype: integer
+      description: The maximum size of each cookie chunk in bytes.
+    - group: Session Settings
+    - name: session_secret
+      required: false
+      default: '(auto-generated is no value supplied)'
+      datatype: string
+      encrypted: true
+      value_in_examples: <session-secret>
+      referenceable: true
+      description: |
+        The session secret.
+    - name: session_strategy
+      required: false
+      default: '"default"'
+      datatype: string
+      description: |
+        The session strategy:
+        - `default`:  reuses session identifiers over modifications (but can be problematic with single-page applications with a lot of concurrent asynchronous requests)
+        - `regenerate`: generates a new session identifier on each modification and does not use expiry for signature verification (useful in single-page applications or SPAs)
+    - name: session_compressor
+      required: false
+      default: '"none"'
+      datatype: string
+      description: |
+        The session strategy:
+        - `none`: no compression
+        - `zlib`: use zlib to compress cookie data
+    - name: session_storage
+      required: false
+      default: '"cookie"'
+      datatype: string
+      description: |
+        The session storage for session data:
+        - `cookie`: stores session data with the session cookie (the session cannot be invalidated or revoked without changing session secret, but is stateless, and doesn't require a database)
+        - `memcache`: stores session data in memcached
+        - `redis`: stores session data in Redis
+    - name: reverify
+      required: false
+      default: false
+      datatype: boolean
+      description: Specifies whether to always verify tokens stored in the session.
+    - group: Session Settings for Memcached
+    - name: session_memcache_prefix
+      required: false
+      default: '"sessions"'
+      datatype: string
+      description: The memcached session key prefix.
+    - name: session_memcache_socket
+      required: false
+      default: null
+      datatype: string
+      description: The memcached unix socket path.
+    - name: session_memcache_host
+      required: false
+      default: '"127.0.0.1"'
+      datatype: string
+      description: The memcached host.
+    - name: session_memcache_port
+      required: false
+      default: 11211
+      datatype: integer
+      description: The memcached port.
+    - group: Session Settings for Redis
+    - name: session_redis_prefix
+      required: false
+      default: '"sessions"'
+      datatype: string
+      description: The Redis session key prefix.
+    - name: session_redis_socket
+      required: false
+      default: null
+      datatype: string
+      description: The Redis unix socket path.
+    - name: session_redis_host
+      required: false
+      default: '"127.0.0.1"'
+      datatype: string
+      description: The Redis host
+    - name: session_redis_port
+      required: false
+      default: 6379
+      datatype: integer
+      description: The Redis port.
+    - name: session_redis_username
+      required: false
+      default: null
+      datatype: string
+      referenceable: true
+      description: |
+        Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired.
+        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
+    - name: session_redis_password
+      required: false
+      default: (from kong)
+      encrypted: true
+      datatype: string
+      referenceable: true
+      description: |
+        Password to use for Redis connection when the `redis` session storage is defined.
+        If undefined, no AUTH commands are sent to Redis.
+    - name: session_redis_connect_timeout
+      required: false
+      default: (from kong)
+      datatype: integer
+      description: The Redis connection timeout in milliseconds.
+    - name: session_redis_read_timeout
+      required: false
+      default: (from kong)
+      datatype: integer
+      description: The Redis read timeout in milliseconds.
+    - name: session_redis_send_timeout
+      required: false
+      default: (from kong)
+      datatype: integer
+      description: The Redis send timeout in milliseconds.
+    - name: session_redis_ssl
+      required: false
+      default: false
+      datatype: boolean
+      description: Use SSL/TLS for Redis connection.
+    - name: session_redis_ssl_verify
+      required: false
+      default: false
+      datatype: boolean
+      description: Verify Redis server certificate.
+    - name: session_redis_server_name
+      required: false
+      default: null
+      datatype: string
+      description: The SNI used for connecting the Redis server.
+    - name: session_redis_cluster_nodes
+      required: false
+      default: null
+      datatype: array of host records
+      description: |
+        The Redis cluster node host. Takes an array of host records, with
+        either `ip` or `host`, and `port` values.
+    - name: session_redis_cluster_maxredirections
+      required: false
+      default: null
+      datatype: integer
+      description: The Redis cluster maximum redirects.
+---
+
+## Kong Configuration
+
+### Create an Anonymous Consumer:
+
+```bash
+http -f put :8001/consumers/anonymous
+```
+```http
+HTTP/1.1 200 OK
+```
+```json
+{
+    "created_at": 1667352450,
+    "custom_id": null,
+    "id": "bec9d588-073d-4491-b210-1d07099bfcde",
+    "tags": null,
+    "type": 0,
+    "username": "anonymous",
+    "username_lower": null
+}
+```
+
+### Create a Service
+
+```bash
+http -f put :8001/services/saml-service url=https://httpbin.org/anything
+```
+```http
+HTTP/1.1 200 OK
+```
+```json
+{
+    "id": "5fa9e468-0007-4d7e-9aeb-49ca9edd6ccd",
+    "name": "saml-service",
+    "protocol": "https",
+    "host": "httpbin.org",
+    "port": 443,
+    "path": "/anything"
+}
+```
+
+### Create a Route
+
+```bash
+http -f put :8001/services/saml-service/routes/saml-route paths=/saml
+```
+```http
+HTTP/1.1 200 OK
+```
+```json
+{
+    "id": "ac1e86bd-4bce-4544-9b30-746667aaa74a",
+    "name": "saml-route",
+    "paths": [ "/saml" ]
+}
+```
+
+### Setup Microsoft AzureAD 
+
+1. Create a SAML Enterprise Application. Refer to https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/add-application-portal for further information.
+2. Note the `Identifier (Entity ID)` and and `Sign on URL` parameters
+3. For the `Reply URL (Assertion Consumer Service URL)`, use "https://<proxy_host>:<proxy_port>/saml/consume"
+4. Assign users to the SAML Enterprise Application
+
+### Create a Plugin on a Service
+
+Validation of the SAML response Assertion is disabled in the plugin configuration below. This configuration should not be used in a production environment.
+
+Replace `Kong_Anonymous_Consumer_UUID` below with the Anonymous Consumer UUID. 
+Replace `Azure_Identity_ID` with the value of `Identity (Entity ID)` from the Single sign-on - Basic SAML Configuration from the Manage sectio of the Microsoft AzureAD Enterprise Application.
+Replace `AzureAD_Sign_on_URL` with the value of `Sign on URL` from the Single sign-on - Basic SAML Configuration from the Manage sectio of the Microsoft AzureAD Enterprise Application.
+
+```bash
+http -f post :8001/services/saml-service/plugins                                                  \
+  name=saml                                                                                       \
+  config.anonymous=Kong_Anonymous_Consumer_UUID                                                   \
+  service.name=saml-service                                                                       \
+  config.issuer=AzureAD_Identity_ID                                                               \
+  config.idp_sso_url=AzureAD_Sign_on_URL                                                          \
+  config.assertion_consumer_path=/consume                                                         \
+  config.disable_signature_validation=true
+```
+```http
+HTTP/1.1 200 OK
+```
+```json
+{
+    "id": "a8655ba0-de99-48fc-b52f-d7ed030a755c",
+    "name": "saml",
+    "service": {
+        "id": "5fa9e468-0007-4d7e-9aeb-49ca9edd6ccd"
+    },
+    "config": {
+        "assertion_consumer_path": "/consume",
+        "disable_signature_validation": true,
+        "idp_sso_url": "https://login.microsoftonline.com/f177c1d6-50cf-49e0-818a-a0585cbafd8d/saml2",
+        "issuer": "https://samltoolkit.azurewebsites.net/kong_saml",
+        ...
+    }
+}
+```
+
+### Test the SAML plugin
+
+1. Using a browser, go to the URL "https://<proxy-host>:8443/saml" 
+2. The browser is redirected to the AzureAD Sign in page. Enter the user credentials of a user configured in AzureAD
+3. If user credentials are valid, the brower will be redirected to https://httpbin.org/anything
+4. If the user credentials are invalid, a 401 Unauthorized HTTP Status code is returned
+
+

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -56,10 +56,18 @@ params:
       required: false
       default: null
       datatype: string
+      description:
+        An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
+      minimum_version: "3.1.0"
+    - name: anonymous
+      required: false
+      default: null
+      datatype: string
       description: |
-        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`.
-
-        **Note:** This value must refer to the Consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+        An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
+        If empty (default), the request fails with an authentication failure `4xx`. Note that this value
+        must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
+      maximum_version: "3.0.0"
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/advanced-usage.md
@@ -45,7 +45,7 @@ This lets you drop the configuration from environment variables and query argume
 {vault://my-env-vault/my-secret-config-value}
 ```
 
-For more information, see the section on the [Vaults entity](#vaults-entity).
+For more information, see the section on the [Vaults entity](/admin-api/#vaults-object).
 
 ## Vaults CLI
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -158,6 +158,12 @@ defaults:
       version-index: 3
 
   - scope:
+      path: "gateway/3.1.x/"
+    values:
+      layout: "docs-v2"
+      version-index: 4
+
+  - scope:
       path: "about"
     values:
       layout: "about"

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -159,6 +159,12 @@ defaults:
       version-index: 3
 
   - scope:
+      path: "gateway/3.1.x/"
+    values:
+      layout: "docs-v2"
+      version-index: 4
+
+  - scope:
       path: "about"
     values:
       layout: "about"

--- a/src/gateway/kong-enterprise/secrets-management/advanced-usage.md
+++ b/src/gateway/kong-enterprise/secrets-management/advanced-usage.md
@@ -44,7 +44,7 @@ This lets you drop the configuration from environment variables and query argume
 {vault://my-env-vault/my-secret-config-value}
 ```
 
-For more information, see the section on the [Vaults entity](#vaults-entity).
+For more information, see the section on the [Vaults entity](/admin-api/#vaults-object).
 
 ## Vaults CLI
 


### PR DESCRIPTION
### Summary
Add user facing documentation for the new SAML v2.0 plugin available in the Kong EE 3.1.0 release

### Reason
https://konghq.atlassian.net/browse/FT-1821

### Testing
Todo
