### PR TITLE
[fix] Support policy table issue

### DIFF
--- a/app/_includes/md/support-policy.md
+++ b/app/_includes/md/support-policy.md
@@ -41,6 +41,7 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.0.x.x |  2022-08-31   |     2024-08-30      |      2025-08-30       |
 |  2.8.x.x |  2022-03-02   |     2023-08-24      |      2024-08-24       |
 |  2.7.x.x |  2021-12-16   |     2023-02-24      |      2023-08-24       |
 |  2.6.x.x |  2021-10-14   |     2023-02-24      |      2023-08-24       |

--- a/src/gateway/support-policy.md
+++ b/src/gateway/support-policy.md
@@ -4,7 +4,6 @@ badge: enterprise
 content-type: reference
 ---
 
-The support for {{site.ee_product_name}} software versions is explained in this topic.
 
 {% include_cached /md/support-policy.md %}
 

--- a/src/gateway/support-policy.md
+++ b/src/gateway/support-policy.md
@@ -8,7 +8,7 @@ The support for {{site.ee_product_name}} software versions is explained in this 
 
 {% include_cached /md/support-policy.md %}
 
-## See als
+## See also
 
 * [Version support policy for {{site.mesh_product_name}}](/mesh/latest/support-policy)
 * [Version support policy for {{site.kic_product_name}}](/kubernetes-ingress-controller/latest/support-policy)

--- a/src/gateway/support-policy.md
+++ b/src/gateway/support-policy.md
@@ -8,36 +8,7 @@ The support for {{site.ee_product_name}} software versions is explained in this 
 
 {% include_cached /md/support-policy.md %}
 
-## Version support for {{site.base_gateway}} (Enterprise)
-
-| Version  | Released Date | End of Full Support | End of Sunset Support |
-|:--------:|:-------------:|:-------------------:|:---------------------:|
-|  3.0.x.x |  2022-08-31   |     2024-08-30      |      2025-08-30       |
-|  2.8.x.x |  2022-03-02   |     2023-08-24      |      2024-08-24       |
-|  2.7.x.x |  2021-12-16   |     2023-02-24      |      2023-08-24       |
-|  2.6.x.x |  2021-10-14   |     2023-02-24      |      2023-08-24       |
-|  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |
-|  2.4.x.x |  2021-05-18   |     2022-08-24      |      2023-08-24       |  
-|  2.3.x.x |  2021-02-11   |     2022-08-24      |      2023-08-24       |
-|  2.2.x.x |  2020-11-17   |     2022-08-24      |      2023-08-24       |
-|  2.1.x.x |  2020-08-25   |     2022-08-24      |      2023-08-24       |
-|  1.5.x.x |  2020-04-10   |     2021-04-09      |      2022-04-09       |
-|  1.3.x.x |  2019-11-05   |     2020-11-04      |      2021-11-04       |
-|   0.36   |  2019-08-05   |     2020-08-04      |      2021-08-04       |
-|   0.35   |  2019-05-16   |     2020-05-15      |      2020-11-15       |
-|   0.34   |  2018-11-19   |     2019-11-18      |      2020-11-18       |
-|   0.33   |  2018-07-11   |     2019-06-10      |      2020-06-10       |
-|   0.32   |  2018-05-22   |     2019-05-21      |      2020-05-21       |
-|   0.31   |  2018-03-13   |     2019-03-12      |      2020-03-12       |
-|   0.30   |  2018-01-22   |     2019-01-21      |      2020-01-21       |
-
-> *Table 1: Version Support for {{site.ee_product_name}}*
-
-## Additional terms
-- The above is a summary only and is qualified by Kong’s [Support and Maintenance Policy](https://konghq.com/supportandmaintenancepolicy).
-- The above applies to Kong standard software builds only.
-
-## See also
+## See als
 
 * [Version support policy for {{site.mesh_product_name}}](/mesh/latest/support-policy)
 * [Version support policy for {{site.kic_product_name}}](/kubernetes-ingress-controller/latest/support-policy)


### PR DESCRIPTION
### Summary
There are 2 sections of Version support for Kong Gateway (Enterprise), one showing up to 2.8.x one up to 3.0.x
* Removed extra table
* Updated the table to include 3.0.x
