### PR TITLE
fix typo

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -1,4 +1,5 @@
 ACLs
+acl
 Alertmanager
 Amberflo
 Arya

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -1,5 +1,4 @@
 ACLs
-acl
 Alertmanager
 Amberflo
 Arya
@@ -70,6 +69,7 @@ Valero
 Vue
 Wireshark
 Zipkin
+acl
 admin's
 allowlist
 anonymized
@@ -232,6 +232,7 @@ opa
 openresty
 outbounds
 passthrough
+pdk
 pdks
 perf
 performant

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -63,6 +63,7 @@ Styra
 Syslog
 Terraform
 Terraform's
+UIs
 Unicode
 Valero
 Vue
@@ -321,7 +322,6 @@ transpiled
 truthy
 ttl
 txt
-UIs
 udpingress
 unary
 uncheck
@@ -336,6 +336,8 @@ unprocessable
 unpublish
 unregister
 unregistering
+unshorten
+unshortened
 updated_at
 upsert
 upstream

--- a/app/enterprise/2.4.x/plugin-development/custom-logic.md
+++ b/app/enterprise/2.4.x/plugin-development/custom-logic.md
@@ -123,7 +123,7 @@ that a plugin doesn't need to provide functions for all phases.
 
 ```lua
 local CustomHandler = {
-  VERSION  = "1.0.0"
+  VERSION  = "1.0.0",
   PRIORITY = 10
 }
 

--- a/app/enterprise/2.4.x/plugin-development/custom-logic.md
+++ b/app/enterprise/2.4.x/plugin-development/custom-logic.md
@@ -185,7 +185,7 @@ end
 ```
 
 The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
-It can be be split into several Lua files (also called *modules*).
+It can be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
 
 For example, the following plugin splits the functionality into three files.
@@ -237,7 +237,7 @@ execute various gateway operations in a way that is guaranteed to be
 forward-compatible with future releases of {{site.ee_product_name}}.
 
 When you are trying to implement some logic that needs to interact with {{site.ee_product_name}}
-(such as retrieving request headers, producing a response from a plugin, or ogging
+(such as retrieving request headers, producing a response from a plugin, or logging
 some error or debug information), you should consult the [Plugin Development
 Kit Reference][pdk].
 

--- a/app/enterprise/2.5.x/plugin-development/custom-logic.md
+++ b/app/enterprise/2.5.x/plugin-development/custom-logic.md
@@ -123,7 +123,7 @@ that a plugin doesn't need to provide functions for all phases.
 
 ```lua
 local CustomHandler = {
-  VERSION  = "1.0.0"
+  VERSION  = "1.0.0",
   PRIORITY = 10
 }
 

--- a/app/enterprise/2.5.x/plugin-development/custom-logic.md
+++ b/app/enterprise/2.5.x/plugin-development/custom-logic.md
@@ -185,7 +185,7 @@ end
 ```
 
 The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
-It can be be split into several Lua files (also called *modules*).
+It can be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
 
 For example, the following plugin splits the functionality into three files.
@@ -237,7 +237,7 @@ execute various gateway operations in a way that is guaranteed to be
 forward-compatible with future releases of {{site.ee_product_name}}.
 
 When you are trying to implement some logic that needs to interact with {{site.ee_product_name}}
-(such as retrieving request headers, producing a response from a plugin, or ogging
+(such as retrieving request headers, producing a response from a plugin, or logging
 some error or debug information), you should consult the [Plugin Development
 Kit Reference][pdk].
 

--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -175,7 +175,7 @@ end
 ```
 
 The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
-It can be be split into several Lua files (also called *modules*).
+It can be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
 
 For example, the following plugin splits the functionality into three files.

--- a/app/gateway/2.6.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.6.x/plugin-development/custom-logic.md
@@ -113,7 +113,7 @@ that a plugin doesn't need to provide functions for all phases.
 
 ```lua
 local CustomHandler = {
-  VERSION  = "1.0.0"
+  VERSION  = "1.0.0",
   PRIORITY = 10
 }
 

--- a/app/gateway/2.7.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.7.x/plugin-development/custom-logic.md
@@ -200,7 +200,7 @@ You don't need to add a `:new()` method or call any of the `CustomHandler.super.
 methods.
 
 The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
-It can be be split into several Lua files (also called *modules*).
+It can be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
 
 For example, the following plugin splits the functionality into three files.

--- a/app/gateway/2.8.x/plugin-development/custom-logic.md
+++ b/app/gateway/2.8.x/plugin-development/custom-logic.md
@@ -200,7 +200,7 @@ You don't need to add a `:new()` method or call any of the `CustomHandler.super.
 methods.
 
 The plugin's logic doesn't need to be all defined inside the `handler.lua` file.
-It can be be split into several Lua files (also called *modules*).
+It can be split into several Lua files (also called *modules*).
 The `handler.lua` module can use `require` to include other modules in your plugin.
 
 For example, the following plugin splits the functionality into three files.


### PR DESCRIPTION
This PR is based on https://github.com/Kong/docs.konghq.com/pull/4613 
- Adds a comma to this section: 
```
local CustomHandler = {
  VERSION  = "1.0.0",
  PRIORITY = 10,
}
```
for versions 2.5, 2.5, 2.6. 
Comma exists for other versions. 