### PR TITLE
Konnect: Renaming the default runtime group

### DIFF
--- a/app/konnect/runtime-manager/runtime-groups/index.md
+++ b/app/konnect/runtime-manager/runtime-groups/index.md
@@ -26,11 +26,10 @@ manage runtime instances and their configuration in any groupings you want.
 
 ## Default runtime group
 
-The default runtime group is the foundational group in {{site.konnect_short_name}}. Every
-organization starts with one default group.
+The default runtime group is the foundational group in {{site.konnect_short_name}}.
+Every region in every organization starts with one default group.
 
-This group can't be renamed or deleted, and its status as the default
-group can't be changed.
+This group can't be deleted, and its status as the default group can't be changed.
 
 ### Application registration in the Dev Portal
 
@@ -88,7 +87,7 @@ entity-specific permissions.
 
 ## Runtime group dashboard
 
-For each runtime group, you can view traffic, error rate, and {{site.base_gateway}} service analytics for instances in a runtime group. This allows you to see how much of a runtime group is used. You can also select the time frame of analytics that you want to display. 
+For each runtime group, you can view traffic, error rate, and {{site.base_gateway}} service analytics for instances in a runtime group. This allows you to see how much of a runtime group is used. You can also select the time frame of analytics that you want to display.
 
 [Runtime group dashboard &rarr;](/konnect/runtime-manager/runtime-groups/dashboard)
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -11,6 +11,12 @@ services. [Try it today!](https://cloud.konghq.com/quick-start)
 
 ## November 2022
 
+### 2022.11.08
+
+**Editing the default runtime group**
+: You can now edit the name of the default runtime group.
+The group still retains its status as the default group, and can't be deleted.
+
 ### 2022.11.01
 
 **Konnect APIs for identity management**
@@ -22,7 +28,7 @@ services. [Try it today!](https://cloud.konghq.com/quick-start)
 ### 2022.10.27
 
 **Dynamic client registration <span class="badge beta"></span>**
-: Dynamic client registration with Okta is now in public beta. 
+: Dynamic client registration with Okta is now in public beta.
 [Test it out yourself!](/konnect/dev-portal/applications/dynamic-client-registration/okta/)
 
 ### 2022.10.21


### PR DESCRIPTION
### Summary
Remove line from doc about not being able to remove the default runtime group.

Added a short release note with today's date, as we don't know when the functionality was pushed live. 

### Reason
The default runtime group can now we renamed. See https://kongstrong.slack.com/archives/C01888Q7PJ7/p1667941368541619.

### Testing
Netlify