### PR TITLE
decK: add env variable masking flag

### DIFF
--- a/src/deck/reference/deck_diff.md
+++ b/src/deck/reference/deck_diff.md
@@ -24,7 +24,7 @@ deck diff [command-specific flags] [global flags]
 
 {% if_version gte:1.16.x %}
 `--no-mask-deck-env-vars-value`
-:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+:  do not mask `DECK_` environment variable values at diff output. (Default: `false`)
 {% endif_version %}
 
 `--non-zero-exit-code`

--- a/src/deck/reference/deck_diff.md
+++ b/src/deck/reference/deck_diff.md
@@ -22,6 +22,11 @@ deck diff [command-specific flags] [global flags]
 `-h`, `--help`
 :  help for diff (Default: `false`)
 
+{% if_version gte:1.16.x %}
+`--no-mask-deck-env-vars-value`
+:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+{% endif_version %}
+
 `--non-zero-exit-code`
 :  return exit code 2 if there is a diff present,
 exit code 0 if no diff is found,

--- a/src/deck/reference/deck_konnect_diff.md
+++ b/src/deck/reference/deck_konnect_diff.md
@@ -26,6 +26,11 @@ deck konnect diff [command-specific flags] [global flags]
 `-h`, `--help`
 :  help for diff (Default: `false`)
 
+{% if_version gte:1.16.x %}
+`--no-mask-deck-env-vars-value`
+:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+{% endif_version %}
+
 `--include-consumers`
 :  export consumers, associated credentials and any plugins associated with consumers. (Default: `false`)
 

--- a/src/deck/reference/deck_konnect_diff.md
+++ b/src/deck/reference/deck_konnect_diff.md
@@ -28,7 +28,7 @@ deck konnect diff [command-specific flags] [global flags]
 
 {% if_version gte:1.16.x %}
 `--no-mask-deck-env-vars-value`
-:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+:  do not mask `DECK_` environment variable values at diff output. (Default: `false`)
 {% endif_version %}
 
 `--include-consumers`

--- a/src/deck/reference/deck_konnect_sync.md
+++ b/src/deck/reference/deck_konnect_sync.md
@@ -26,6 +26,11 @@ deck konnect sync [command-specific flags] [global flags]
 `--include-consumers`
 :  export consumers, associated credentials and any plugins associated with consumers. (Default: `false`)
 
+{% if_version gte:1.16.x %}
+`--no-mask-deck-env-vars-value`
+:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+{% endif_version %}
+
 `--parallelism`
 :  Maximum number of concurrent operations. (Default: `100`)
 

--- a/src/deck/reference/deck_konnect_sync.md
+++ b/src/deck/reference/deck_konnect_sync.md
@@ -28,7 +28,7 @@ deck konnect sync [command-specific flags] [global flags]
 
 {% if_version gte:1.16.x %}
 `--no-mask-deck-env-vars-value`
-:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+:  do not mask `DECK_` environment variable values at diff output. (Default: `false`)
 {% endif_version %}
 
 `--parallelism`

--- a/src/deck/reference/deck_reset.md
+++ b/src/deck/reference/deck_reset.md
@@ -30,7 +30,7 @@ deck reset [command-specific flags] [global flags]
 
 {% if_version gte:1.16.x %}
 `--no-mask-deck-env-vars-value`
-:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+:  do not mask `DECK_` environment variable values at diff output. (Default: `false`)
 {% endif_version %}
 
 `--rbac-resources-only`

--- a/src/deck/reference/deck_reset.md
+++ b/src/deck/reference/deck_reset.md
@@ -28,6 +28,11 @@ deck reset [command-specific flags] [global flags]
 `-h`, `--help`
 :  help for reset (Default: `false`)
 
+{% if_version gte:1.16.x %}
+`--no-mask-deck-env-vars-value`
+:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+{% endif_version %}
+
 `--rbac-resources-only`
 :  reset only the RBAC resources (Kong Enterprise only). (Default: `false`)
 

--- a/src/deck/reference/deck_sync.md
+++ b/src/deck/reference/deck_sync.md
@@ -23,6 +23,11 @@ See `db_update_propagation` in `kong.conf`. (Default: `0`)
 `-h`, `--help`
 :  help for sync (Default: `false`)
 
+{% if_version gte:1.16.x %}
+`--no-mask-deck-env-vars-value`
+:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+{% endif_version %}
+
 `--parallelism`
 :  Maximum number of concurrent operations. (Default: `10`)
 

--- a/src/deck/reference/deck_sync.md
+++ b/src/deck/reference/deck_sync.md
@@ -25,7 +25,7 @@ See `db_update_propagation` in `kong.conf`. (Default: `0`)
 
 {% if_version gte:1.16.x %}
 `--no-mask-deck-env-vars-value`
-:  do not mask DECK_ environment variable values at diff output. (Default: `false`)
+:  do not mask `DECK_` environment variable values at diff output. (Default: `false`)
 {% endif_version %}
 
 `--parallelism`


### PR DESCRIPTION
### Summary
Add flag for masking DECK_ environment variable values at diff outputs.

### Reason
https://github.com/Kong/deck/pull/463 is going into 1.16.

### Testing
Netlify

This is a generated doc.