### PR TITLE
Add missing config parameter for AWS secrets vault

### DIFF
--- a/src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -12,6 +12,7 @@ configuring via environment variables.
 export AWS_ACCESS_KEY_ID=<access_key_id>
 export AWS_SECRET_ACCESS_KEY=<secrets_access_key>
 export AWS_REGION=<aws-region>
+export AWS_SESSION_TOKEN=<token>
 ```
 
 Region used by default with references, can also be specified with:

--- a/src/gateway/kong-enterprise/secrets-management/how-to/aws-secrets-manager.md
+++ b/src/gateway/kong-enterprise/secrets-management/how-to/aws-secrets-manager.md
@@ -1,21 +1,21 @@
 ---
-title: "Securing Kong Gateway database credentials with AWS Secrets Manager"
+title: Securing Kong Gateway database credentials with AWS Secrets Manager
 content_type: how-to
 description: "How to keep your {{site.base_gateway}} database credentials secure using AWS Secrets Manager and vault integrations."
 ---
 
 Application secrets include sensitive data like passwords, keys, certifications, tokens, and other items
 which must be secured. [{{site.base_gateway}}](/gateway/{{page.kong_version}}/) supports
-[Secrets Management](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/) 
+[Secrets Management](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/)
 which allows you to store secrets in various secure backend systems and helps you protect them from accidental
 exposure.
 
-Traditionally, {{site.base_gateway}} is configured with static credentials for connecting 
-to its external database. This guide will show you how to configure {{site.base_gateway}} to use 
-[AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html) to 
+Traditionally, {{site.base_gateway}} is configured with static credentials for connecting
+to its external database. This guide will show you how to configure {{site.base_gateway}} to use
+[AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html) to
 read database credentials securely instead the conventional file or environment variable based solutions.
 
-For this guide, you will run the PostgreSQL and {{site.base_gateway}} locally on Docker. 
+For this guide, you will run the PostgreSQL and {{site.base_gateway}} locally on Docker.
 You will create a secret in the AWS Secrets Manager and deploy {{site.base_gateway}} using a vault reference
 to read the value securely.
 
@@ -28,7 +28,7 @@ to read the value securely.
 * The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed and configured. You must be able to configure the gateway environment with [AWS CLI environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) because this is the method that {{site.base_gateway}} uses to connect to the Secrets Manager service.
 
 * [Docker](https://docs.docker.com/get-docker/) installed.
-* [`curl`](https://curl.se/) is required on your system to send 
+* [`curl`](https://curl.se/) is required on your system to send
 requests to the gateway for testing. Most systems come with `curl` pre-installed.
 
 ### Configure {{site.base_gateway}} to use AWS Secrets Manager
@@ -39,7 +39,7 @@ requests to the gateway for testing. Most systems come with `curl` pre-installed
    docker network create kong-net
    ```
 
-1. Configure and run the database: 
+1. Configure and run the database:
 
    ```sh
    docker run -d --name kong-database \
@@ -50,14 +50,14 @@ requests to the gateway for testing. Most systems come with `curl` pre-installed
      postgres:9.6
    ```
 
-   The username and password used above are the PostgreSQL master credentials, *not* the 
+   The username and password used above are the PostgreSQL master credentials, *not* the
    username and password you will use to authorize {{site.base_gateway}} with the database.
-   
+
    {:.note}
-   > **Note:** A production deployment can use [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) 
+   > **Note:** A production deployment can use [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/)
    which supports direct integration with AWS Secrets Manager.
 
-1. Create a username and password for {{site.base_gateway}}'s database and store 
+1. Create a username and password for {{site.base_gateway}}'s database and store
 them in environment variables to use in this guide:
 
    ```sh
@@ -71,7 +71,7 @@ them in environment variables to use in this guide:
    docker exec -it kong-database psql -U admin -c \
      "CREATE USER ${KONG_PG_USER} WITH PASSWORD '${KONG_PG_PASSWORD}'"
    ```
-   
+
    You should see:
    ```sh
    CREATE ROLE
@@ -82,7 +82,7 @@ them in environment variables to use in this guide:
    ```sh
    docker exec -it kong-database psql -U admin -c "CREATE DATABASE kong OWNER ${KONG_PG_USER};"
    ```
-   
+
    You should see:
    ```sh
    CREATE DATABASE
@@ -107,7 +107,7 @@ If you want to update the secret values later, this is the command you would use
 
    {:.note}
    > **Note:** Currently, the `kong migrations` tool does not support Secrets Management, so this
-   step must be done with traditional {{site.base_gateway}} configuration options. In this example, 
+   step must be done with traditional {{site.base_gateway}} configuration options. In this example,
    we are passing the secrets to Docker via the environment.
 
    ```sh
@@ -122,25 +122,25 @@ If you want to update the secret values later, this is the command you would use
 
 1. Launch {{site.base_gateway}} configured to use values it can reference for the
 database username and password. To authorize {{site.base_gateway}} to connect to AWS Secrets Manager,
-you need to provide IAM security credentials via environment variables. 
+you need to provide IAM security credentials via environment variables.
 
-   You specify the database credentials using the standard `KONG_` 
-   [environment variable names](/gateway/{{page.kong_version}}/reference/configuration/#environment-variables), 
-   but instead of providing a static value you use a 
+   You specify the database credentials using the standard `KONG_`
+   [environment variable names](/gateway/{{page.kong_version}}/reference/configuration/#environment-variables),
+   but instead of providing a static value you use a
    [reference value](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/reference-format/).
-   
-   The format looks like this: `{vault://aws/kong-gateway-database/pg_user}`. In this example, 
-   the reference format contains `aws` as the backend vault type, `kong-gateway-database` matches 
-   the name of the secret created earlier, and `pg_user` is the JSON field name you want to reference 
+
+   The format looks like this: `{vault://aws/kong-gateway-database/pg_user}`. In this example,
+   the reference format contains `aws` as the backend vault type, `kong-gateway-database` matches
+   the name of the secret created earlier, and `pg_user` is the JSON field name you want to reference
    in the secret value.
-   
+
    See the
-   [AWS Secrets Manager documentation](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/aws-sm/) 
+   [AWS Secrets Manager documentation](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/aws-sm/)
    for more details.
-   
-   Assuming you have set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` in the current 
+
+   Assuming you have set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `AWS_SESSION_TOKEN` in the current
    environment, start {{site.base_gateway}} like this:
-   
+
    ```sh
    docker run --rm \
      --network=kong-net \
@@ -149,17 +149,18 @@ you need to provide IAM security credentials via environment variables.
      -e "AWS_ACCESS_KEY_ID" \
      -e "AWS_SECRET_ACCESS_KEY" \
      -e "AWS_REGION" \
+     -e "AWS_SESSION_TOKEN" \
      -e "KONG_PG_USER={vault://aws/kong-gateway-database/pg_user}" \
      -e "KONG_PG_PASSWORD={vault://aws/kong-gateway-database/pg_password}" \
      kong/kong-gateway:{{page.kong_version}}
    ```
-   
+
    After a moment, {{site.base_gateway}} should be running, which you can verify with the Admin API:
-   
+
    ```sh
    curl -s localhost:8001
    ```
-   
+
    You should receive a JSON response with various information from {{site.base_gateway}}.
 
 The [Secrets Management documentation](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/)
@@ -174,4 +175,3 @@ contains more information about available backends and configuration details.
   * [Google Secrets Management](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/gcp-sm/)
 * See [Starting Kong Securely](/gateway/{{page.kong_version}}/production/access-control/start-securely/) for more
 security practices with {{site.base_gateway}}
-


### PR DESCRIPTION
### Summary
Adding `AWS_SESSION_TOKEN=<token>` to AWS vault backend config.

### Reason
Missing token value noted in Slack: https://kongstrong.slack.com/archives/C037510LW2X/p1668013808779929?thread_ts=1667993877.584539&cid=C037510LW2X

### Testing
Netlify