### PR TITLE
Add a way to skip generated file checks

### DIFF
--- a/.github/workflows/autogenerated-warning.yml
+++ b/.github/workflows/autogenerated-warning.yml
@@ -3,7 +3,24 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if manual review has been performed
+        uses: actions/github-script@v6
+        id: labels
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+            return labels.map(l => l.name).includes('ci:manual-approve:generated-files')
+    outputs:
+      result: ${{ steps.labels.outputs.result }}
   add-comment:
+    needs: [check]
+    if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -15,9 +32,10 @@ jobs:
           node run.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
-    if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
 
   prevent-merge-if-labeled:
+    needs: [check]
+    if: needs.check.outputs.result == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v2


### PR DESCRIPTION
### Summary
Add support for skipping the generated files check

### Reason
PRs are getting noisy when pushing additional commits to generated files

### Testing
I'm testing on this PR