### PR TITLE
chore: bump decK patch version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -229,7 +229,7 @@
   edition: "deck"
 -
   release: "1.16.x"
-  version: "1.16.0"
+  version: "1.16.1"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Summary
Prep branch for decK patch release.

### Reason
Quick followup fix to 1.16 for an issue with `deck ping`: https://github.com/Kong/deck/commit/4ee5ad69335abe1c14a1a5fb4f3d72250ea519e1

### Testing
Netlify; [installation doc](https://deploy-preview-4752--kongdocs.netlify.app/deck/latest/installation/) should say 1.16.1