### PR TITLE
Clean up CTA form styling and move to stylesheet

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -667,7 +667,7 @@ jQuery(function () {
       .removeClass("note")
       .addClass("warning")
       .prepend(
-        '<span style="color:red;font-weight:800;">There was an error adding your free training. Please try again.</span>'
+        '<span class="cta-error">There was an error adding your free training. Please try again.</span>'
       );
   }
 

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -658,7 +658,7 @@ jQuery(function () {
   // Signup confirmation for nurture campaigns
   if (getParams.signup == "nurture") {
     $("#nurture-signup").html(
-      "Thanks for signing up! Check your emails to see the first step of your learning journey"
+      "Thanks for signing up! Check your emails to see the first step of your learning journey."
     );
   }
 
@@ -667,7 +667,7 @@ jQuery(function () {
       .removeClass("note")
       .addClass("warning")
       .prepend(
-        '<span style="color:red;font-weight:800;">There was an error adding your free training. Please try again</span>'
+        '<span style="color:red;font-weight:800;">There was an error adding your free training. Please try again.</span>'
       );
   }
 

--- a/app/_assets/stylesheets/cta-form.less
+++ b/app/_assets/stylesheets/cta-form.less
@@ -1,0 +1,24 @@
+#nurture-signup {
+  text-align: center;
+
+  p {
+    margin-bottom: 6px;
+    font-weight: 700;
+  }
+
+  form {
+    margin: 0;
+
+    input.button {
+      width: 455px;
+      margin-bottom: 5px;
+      background-color: white;
+    }
+
+    button.button {
+      margin-left: 6px;
+      background-color: #1456cb;
+      color: white;
+    }
+  }
+}

--- a/app/_assets/stylesheets/cta-form.less
+++ b/app/_assets/stylesheets/cta-form.less
@@ -11,6 +11,7 @@
 
     input.button {
       width: 455px;
+      max-width: 100%;
       margin-bottom: 5px;
       background-color: white;
     }

--- a/app/_assets/stylesheets/cta-form.less
+++ b/app/_assets/stylesheets/cta-form.less
@@ -25,7 +25,7 @@
   }
 
   span.cta-error {
-    color:red;
-    font-weight:800;
+    color: red;
+    font-weight: 800;
   }
 }

--- a/app/_assets/stylesheets/cta-form.less
+++ b/app/_assets/stylesheets/cta-form.less
@@ -21,4 +21,9 @@
       color: white;
     }
   }
+
+  span.cta-error {
+    color:red;
+    font-weight:800;
+  }
 }

--- a/app/_assets/stylesheets/cta-form.less
+++ b/app/_assets/stylesheets/cta-form.less
@@ -19,6 +19,7 @@
     button.button {
       margin-left: 6px;
       background-color: #1456cb;
+      border-color: #1456cb;
       color: white;
     }
   }

--- a/app/_assets/stylesheets/index.less
+++ b/app/_assets/stylesheets/index.less
@@ -25,3 +25,4 @@
 @import "compat-form";
 @import "hub-landing-page";
 @import "features-table";
+@import "cta-form";

--- a/src/gateway/index.md
+++ b/src/gateway/index.md
@@ -55,11 +55,11 @@ With {{site.base_gateway}}, users can:
 entire organization.
 
 <blockquote class="note no-icon" id="nurture-signup">
-<p style="margin-bottom: 6px; font-weight: 700">Looking for additional help? Free training and curated content, just for you:</p>
-<form action="http://go.konghq.com/l/392112/2022-09-19/cfr97r" method="post" style="margin:0;">
-<input class="button" style="width: 455px;" name="email" placeholder="you@yourcompany.com" />
-<button class="button" style="margin-left:6px;background-color:#1456cb;color:white;" type="submit">Sign up now</button>
-</form>
+  <p>Looking for additional help? Free training and curated content, just for you:</p>
+  <form action="http://go.konghq.com/l/392112/2022-09-19/cfr97r" method="post">
+    <input class="button" name="email" placeholder="you@yourcompany.com" />
+    <button class="button" type="submit">Sign up now</button>
+  </form>
 </blockquote>
 
 ## Extending the {{site.base_gateway}}


### PR DESCRIPTION
### Summary
* Moving styling out of doc page and into stylesheet as a better practice
* Tweak styling for better UX (smaller screens + better contrast)

Before:

![Screen Shot 2022-11-09 at 2 27 36 PM](https://user-images.githubusercontent.com/54370747/200969987-13793e14-86b1-473c-b047-11b80f23bf3d.png)
![Screen Shot 2022-11-09 at 2 27 30 PM](https://user-images.githubusercontent.com/54370747/200969991-6ad9fdf9-9be5-4558-9fd0-75871ed08c4d.png)

After:
![Screen Shot 2022-11-09 at 2 28 10 PM](https://user-images.githubusercontent.com/54370747/200970024-79bf4e5b-2918-42ad-af3f-816e710d3324.png)
![Screen Shot 2022-11-09 at 2 19 36 PM](https://user-images.githubusercontent.com/54370747/200970027-8311c750-4cf1-4386-9c56-b1f724e8ccca.png)


### Reason
Follow-up to https://github.com/Kong/docs.konghq.com/pull/4534 based on review.

### Testing
Netlify