### PR TITLE
Allow version for protocols

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -611,6 +611,7 @@ minimum_version
 missing_name
 moesif
 mtls_auth_credentials
+myapikey
 navtab
 nbf
 new_body

--- a/app/_hub/_init/my-extension/_index.md
+++ b/app/_hub/_init/my-extension/_index.md
@@ -136,7 +136,9 @@ params: # Metadata about your plugin
   protocols:
     # List of protocols this plugin is compatible with, in array format.
     # Valid values: "http", "https", "tcp", "tls"
-    # Example: ["http", "https"]
+    # Example:
+    # - name: http
+    # - name: https
   dbless_compatible:
     # Degree of compatibility with DB-less mode. Three values allowed:
     # 'yes', 'no' or 'partially'.

--- a/app/_hub/amberflo/kong-plugin-amberflo/_index.md
+++ b/app/_hub/amberflo/kong-plugin-amberflo/_index.md
@@ -41,8 +41,8 @@ params:
   service_id: true
   route_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   dbless_explanation: The plugin is compatible with any with DB-less mode, including `local`, `cluster`, and `redis`.
   config:

--- a/app/_hub/flash/set-dynamic-upstream-host/_index.md
+++ b/app/_hub/flash/set-dynamic-upstream-host/_index.md
@@ -32,7 +32,9 @@ params:
   service_id: true
   route_id: false
   consumer_id: false
-  protocols: ["http", "https"]
+  protocols:
+    - name: http
+    - name: https
   dbless_compatible: true
     
   config:

--- a/app/_hub/kong-inc/acl/_index.md
+++ b/app/_hub/kong-inc/acl/_index.md
@@ -25,8 +25,8 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and ACLs can be created with declarative configuration.

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -19,12 +19,12 @@ params:
   route_id: false
   consumer_id: false
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: account_email
@@ -223,7 +223,7 @@ services:
     routes:
       - name: acme-dummy
         protocols:
-          - http
+          - name: http
         paths:
           - /.well-known/acme-challenge
 plugins:

--- a/app/_hub/kong-inc/application-registration/_index.md
+++ b/app/_hub/kong-inc/application-registration/_index.md
@@ -53,10 +53,10 @@ params:
   route_id: false
   konnect_examples: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'no'
   config:
     - name: auto_approve

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -20,8 +20,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: aws_key

--- a/app/_hub/kong-inc/azure-functions/_index.md
+++ b/app/_hub/kong-inc/azure-functions/_index.md
@@ -21,8 +21,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: functionname

--- a/app/_hub/kong-inc/basic-auth/_index.md
+++ b/app/_hub/kong-inc/basic-auth/_index.md
@@ -19,10 +19,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/bot-detection/_index.md
+++ b/app/_hub/kong-inc/bot-detection/_index.md
@@ -20,8 +20,8 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
 

--- a/app/_hub/kong-inc/correlation-id/_index.md
+++ b/app/_hub/kong-inc/correlation-id/_index.md
@@ -19,8 +19,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: header_name

--- a/app/_hub/kong-inc/cors/_index.md
+++ b/app/_hub/kong-inc/cors/_index.md
@@ -19,8 +19,8 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: origins

--- a/app/_hub/kong-inc/datadog/_index.md
+++ b/app/_hub/kong-inc/datadog/_index.md
@@ -25,6 +25,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/datadog/_index.md
+++ b/app/_hub/kong-inc/datadog/_index.md
@@ -20,14 +20,14 @@ params:
   consumer_id: true
   konnect_examples: false
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/exit-transformer/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/_index.md
@@ -22,8 +22,8 @@ params:
   yaml_examples: false
   konnect_examples: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: functions

--- a/app/_hub/kong-inc/file-log/_index.md
+++ b/app/_hub/kong-inc/file-log/_index.md
@@ -23,13 +23,13 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
-    - tcp
-    - tls
-    - udp
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
+    - name: tcp
+    - name: tls
+    - name: udp
   dbless_compatible: 'yes'
   config:
     - name: path

--- a/app/_hub/kong-inc/grpc-gateway/_index.md
+++ b/app/_hub/kong-inc/grpc-gateway/_index.md
@@ -19,8 +19,8 @@ params:
   name: grpc-gateway
   route_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: proto
@@ -57,7 +57,7 @@ services:
   port: 9000
   routes:
   - protocols:
-    - http
+    - name: http
     paths:
     - /
     plugins:

--- a/app/_hub/kong-inc/grpc-web/_index.md
+++ b/app/_hub/kong-inc/grpc-web/_index.md
@@ -18,8 +18,8 @@ params:
   name: grpc-web
   route_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: proto
@@ -77,7 +77,7 @@ services:
   port: 9000
   routes:
   - protocols:
-    - http
+    - name: http
     paths:
     - /
     plugins:
@@ -151,7 +151,7 @@ services:
   port: 9000
   routes:
   - protocols:
-    - http
+    - name: http
     paths:
     - /
     plugins:

--- a/app/_hub/kong-inc/hmac-auth/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/_index.md
@@ -23,10 +23,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/http-log/_index.md
+++ b/app/_hub/kong-inc/http-log/_index.md
@@ -23,6 +23,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/http-log/_index.md
+++ b/app/_hub/kong-inc/http-log/_index.md
@@ -18,14 +18,14 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: http_endpoint

--- a/app/_hub/kong-inc/ip-restriction/_index.md
+++ b/app/_hub/kong-inc/ip-restriction/_index.md
@@ -19,8 +19,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
 

--- a/app/_hub/kong-inc/jq/_index.md
+++ b/app/_hub/kong-inc/jq/_index.md
@@ -44,8 +44,8 @@ params:
   yaml_examples: false
   konnect_examples: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: null
   examples: false
   config:

--- a/app/_hub/kong-inc/jwt-signer/_index.md
+++ b/app/_hub/kong-inc/jwt-signer/_index.md
@@ -29,10 +29,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: realm

--- a/app/_hub/kong-inc/jwt/_index.md
+++ b/app/_hub/kong-inc/jwt/_index.md
@@ -29,10 +29,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and JWT secrets can be created with declarative configuration.

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -28,10 +28,10 @@ params:
   consumer_id: false
   konnect_examples: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/key-auth/_index.md
+++ b/app/_hub/kong-inc/key-auth/_index.md
@@ -26,10 +26,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -29,10 +29,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - gprc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: ldap_host

--- a/app/_hub/kong-inc/ldap-auth/_index.md
+++ b/app/_hub/kong-inc/ldap-auth/_index.md
@@ -60,10 +60,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - gprc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: hide_credentials

--- a/app/_hub/kong-inc/loggly/_index.md
+++ b/app/_hub/kong-inc/loggly/_index.md
@@ -23,6 +23,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/loggly/_index.md
+++ b/app/_hub/kong-inc/loggly/_index.md
@@ -18,14 +18,14 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/mocking/_index.md
+++ b/app/_hub/kong-inc/mocking/_index.md
@@ -33,8 +33,8 @@ params:
   consumer_id: true
   route_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   dbless_explanation: |
     Use the `api_specification` config for DB-less or hybrid mode. Attach the spec contents directly

--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -19,10 +19,10 @@ params:
   service_id: true
   route_id: true
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: anonymous

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -30,10 +30,10 @@ params:
   route_id: false
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   yaml_examples: false
   konnect_examples: false
   dbless_compatible: 'no'

--- a/app/_hub/kong-inc/opa/_index.md
+++ b/app/_hub/kong-inc/opa/_index.md
@@ -20,8 +20,8 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: opa_protocol

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -135,10 +135,10 @@ params:
   route_id: true
   consumer_id: false
   protocols:
-    - http
-    - https
-    - grpc (depends on the grant)
-    - grpcs (depends on the grant)
+    - name: http
+    - name: https
+    - name: grpc (depends on the grant)
+    - name: grpcs (depends on the grant)
   dbless_compatible: 'yes'
   config:
     - group: Authentication Grants

--- a/app/_hub/kong-inc/opentelemetry/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/_index.md
@@ -19,8 +19,8 @@ params:
   name: opentelemetry
   konnect_examples: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: endpoint

--- a/app/_hub/kong-inc/prometheus/_1.6.0.md
+++ b/app/_hub/kong-inc/prometheus/_1.6.0.md
@@ -18,12 +18,12 @@ params:
   service_id: true
   route_id: false
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   dbless_explanation: |
     The database will always be reported as reachable in Prometheus with DB-less.

--- a/app/_hub/kong-inc/prometheus/_index.md
+++ b/app/_hub/kong-inc/prometheus/_index.md
@@ -17,12 +17,12 @@ params:
   service_id: true
   route_id: false
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   dbless_explanation: |
     The database will always be reported as reachable in Prometheus with DB-less.

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -25,10 +25,10 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: response_code

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -27,10 +27,10 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
   dbless_compatible: partially
   dbless_explanation: |
     The cluster strategy is not supported in DB-less and hybrid modes. For Kong

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -25,8 +25,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: partially
   dbless_explanation: |
     The plugin will run fine with the `local` policy (which doesn't use the database) or

--- a/app/_hub/kong-inc/request-size-limiting/_index.md
+++ b/app/_hub/kong-inc/request-size-limiting/_index.md
@@ -24,8 +24,8 @@ params:
   consumer_id: true
   konnect_examples: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: allowed_payload_size

--- a/app/_hub/kong-inc/request-termination/_index.md
+++ b/app/_hub/kong-inc/request-termination/_index.md
@@ -20,8 +20,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: status_code

--- a/app/_hub/kong-inc/request-transformer/_index.md
+++ b/app/_hub/kong-inc/request-transformer/_index.md
@@ -27,8 +27,8 @@ params:
   consumer_id: true
   konnect_examples: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: http_method

--- a/app/_hub/kong-inc/response-ratelimiting/_index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/_index.md
@@ -54,8 +54,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: partially
   dbless_explanation: |
     The plugin will run fine with the `local` policy (which doesn't use the database) or

--- a/app/_hub/kong-inc/response-transformer/_index.md
+++ b/app/_hub/kong-inc/response-transformer/_index.md
@@ -45,8 +45,8 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   config:
     - name: remove.headers

--- a/app/_hub/kong-inc/serverless-functions/_index.md
+++ b/app/_hub/kong-inc/serverless-functions/_index.md
@@ -35,8 +35,8 @@ params:
   consumer_id: false
   konnect_examples: false
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: partially
   dbless_explanation: |
     The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.

--- a/app/_hub/kong-inc/statsd-advanced/_2.2.x.md
+++ b/app/_hub/kong-inc/statsd-advanced/_2.2.x.md
@@ -41,13 +41,13 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
-    - tcp
-    - tls
-    - udp
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
+    - name: tcp
+    - name: tls
+    - name: udp
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/statsd-advanced/_index.md
+++ b/app/_hub/kong-inc/statsd-advanced/_index.md
@@ -33,13 +33,13 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
-    - tcp
-    - tls
-    - udp
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
+    - name: tcp
+    - name: tls
+    - name: udp
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -28,6 +28,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -23,14 +23,14 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/syslog/_index.md
+++ b/app/_hub/kong-inc/syslog/_index.md
@@ -23,6 +23,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/syslog/_index.md
+++ b/app/_hub/kong-inc/syslog/_index.md
@@ -18,14 +18,14 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: successful_severity

--- a/app/_hub/kong-inc/tcp-log/_index.md
+++ b/app/_hub/kong-inc/tcp-log/_index.md
@@ -23,6 +23,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/tcp-log/_index.md
+++ b/app/_hub/kong-inc/tcp-log/_index.md
@@ -18,14 +18,14 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/tls-handshake-modifier/_index.md
+++ b/app/_hub/kong-inc/tls-handshake-modifier/_index.md
@@ -26,9 +26,9 @@ params:
   consumer_id: false
   route_id: true
   protocols:
-    - https
-    - grpcs
-    - tls
+    - name: https
+    - name: grpcs
+    - name: tls
   dbless_compatible: 'yes'
   konnect_examples: false # need to update this once we verify that this plugin is in Konnect post-3.0 update
   config:

--- a/app/_hub/kong-inc/tls-metadata-headers/_index.md
+++ b/app/_hub/kong-inc/tls-metadata-headers/_index.md
@@ -27,9 +27,9 @@ params:
   consumer_id: false
   route_id: true
   protocols:
-    - https
-    - grpcs
-    - tls
+    - name: https
+    - name: grpcs
+    - name: tls
   dbless_compatible: 'yes'
   konnect_examples: false # need to update this once we verify that this plugin is in Konnect post-3.0 update.
 

--- a/app/_hub/kong-inc/udp-log/_index.md
+++ b/app/_hub/kong-inc/udp-log/_index.md
@@ -23,6 +23,7 @@ params:
     - name: tcp
     - name: tls
     - name: tls_passthrough
+      minimum_version: "2.7.x"
     - name: udp
     - name: grpc
     - name: grpcs

--- a/app/_hub/kong-inc/udp-log/_index.md
+++ b/app/_hub/kong-inc/udp-log/_index.md
@@ -18,14 +18,14 @@ params:
   route_id: true
   consumer_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/upstream-timeout/_index.md
+++ b/app/_hub/kong-inc/upstream-timeout/_index.md
@@ -24,8 +24,8 @@ params:
   consumer_id: false
   route_id: true
   protocols:
-    - http
-    - https
+    - name: http
+    - name: https
   dbless_compatible: yes
   config:
     - name: connect_timeout

--- a/app/_hub/kong-inc/zipkin/_index.md
+++ b/app/_hub/kong-inc/zipkin/_index.md
@@ -19,13 +19,13 @@ params:
   consumer_id: true
   konnect_examples: false
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   config:
     - name: local_service_name

--- a/app/_hub/moesif/kong-plugin-moesif/_index.md
+++ b/app/_hub/moesif/kong-plugin-moesif/_index.md
@@ -86,14 +86,14 @@ params:
   consumer_id: true
   route_id: true
   protocols:
-    - http
-    - https
-    - tcp
-    - tls
-    - tls_passthrough
-    - udp
-    - grpc
-    - grpcs
+    - name: http
+    - name: https
+    - name: tcp
+    - name: tls
+    - name: tls_passthrough
+    - name: udp
+    - name: grpc
+    - name: grpcs
   dbless_compatible: 'yes'
   dbless_explanation: The plugin is compatible with any with DB-less mode including `local`, `cluster`, and `redis`
   config:

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -363,7 +363,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
           <td>
               {% for protocol in page.params.protocols %}
                 <div class="protocol">
-                  <code>{{ protocol }}</code>
+                  <code>{{ protocol.name }}</code>
                 </div>
               {% endfor %}
           </td>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -361,11 +361,11 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
         <tr>
           <td>Compatible protocols</td>
           <td>
-              {% for protocol in page.params.protocols %}
+              {% for protocol in page.params.protocols %}{% if_plugin_version gte:protocol.minimum_version lte:protocol.maximum_version %}
                 <div class="protocol">
                   <code>{{ protocol.name }}</code>
                 </div>
-              {% endfor %}
+              {% endif_plugin_version %}{% endfor %}
           </td>
         </tr>
         {% endif %}


### PR DESCRIPTION
### Summary
Adds the ability to add protocol support on specific versions

### Reason
WS and WSS were added in 3.0+

### Testing
Tested locally with the following config on Basic Auth:


```
   protocols:
     - name: http
     - name: https
       minimum_version: 3.0.x
     - name: grpc
     - name: grpcs
       minimum_version: 2.5.x
       maximum_version: 2.7.x
```