### PR TITLE
[FTI-3281] add an option `config.disable_penalty` to rate-limiting-advanced plugin

### DIFF
--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -16,6 +16,7 @@ dao
 daos
 datastore
 datastores
+disable_penalty
 endpoint_key
 escape_path
 foogineer

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -398,6 +398,17 @@ params:
         group override, but does not clear the list of consumer groups.
         You can then flip `enforce_consumer_groups` to `true` to re-enforce the
         groups.
+    - name: disable_penalty
+      minimum_version: "3.1.x"
+      required: false
+      default: false
+      value_in_examples: null
+      datatype: boolean
+      description: |
+        If set to `true`, then won't count the denied requests (status = `429`),
+        while by default all requests including denied ones will be counted.
+        This parameter only has an effect on `sliding` window_type.
+
   extra: |
     **Notes:**
 

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -405,9 +405,7 @@ params:
       value_in_examples: null
       datatype: boolean
       description: |
-        If set to `true`, then won't count the denied requests (status = `429`),
-        while by default all requests including denied ones will be counted.
-        This parameter only has an effect on `sliding` window_type.
+        If set to `true`, this doesn't count denied requests (status = `429`). If set to `false`, all requests, including denied ones, are counted. This parameter only affects the `sliding` window_type.
 
   extra: |
     **Notes:**


### PR DESCRIPTION
### Summary
Adds a new option `config.disable_penalty` to the rate-limiting-advaned plugin. 
If set to `true`, then won't count the denied requests (status = `429`).

Related PR [Kong/kong-ee#3762](https://github.com/Kong/kong-ee/pull/3762)

### Reason
FTI-3281


### Testing
