### PR TITLE
chore(kong-gateway): remove Kong Manager tip in plugin ordering

### DIFF
--- a/src/gateway/kong-enterprise/plugin-ordering/index.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/index.md
@@ -88,12 +88,6 @@ basic mistakes but it can't detect all potentially dangerous configurations.
 If using dynamic ordering, manually test all configurations, and handle this
 feature with care.
 
-### Kong Manager
-
-Kong Manager doesn't support dynamic plugin ordering configuration through the
-UI. Use the Kong Admin API or a declarative configuration file to set
-plugin ordering.
-
 ## See also
 
 Check out the examples in the

--- a/src/gateway/kong-enterprise/plugin-ordering/index.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/index.md
@@ -88,6 +88,13 @@ basic mistakes but it can't detect all potentially dangerous configurations.
 If using dynamic ordering, manually test all configurations, and handle this
 feature with care.
 
+{% if_version lte:3.0.x %}
+### Kong Manager
+
+Kong Manager doesn't support dynamic plugin ordering configuration through the
+UI. Use the Kong Admin API or a declarative configuration file to set
+plugin ordering.
+{% endif_version %}
 ## See also
 
 Check out the examples in the


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

This PR removes the `Kong Manager` section in plugin ordering docs.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Kong Manager 3.1 will support plugin ordering configuration, rendering the removed section obsolete.

Related links:
- https://konghq.atlassian.net/browse/INTF-2878
- https://github.com/Kong/kong-admin/pull/1955

Docs version 3.0 and prior should still keep this section.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
