### PR TITLE
Fix typo in `config.add.querystring` description

### DIFF
--- a/app/_hub/kong-inc/request-transformer/_index.md
+++ b/app/_hub/kong-inc/request-transformer/_index.md
@@ -132,7 +132,7 @@ params:
       datatype: array of string elements
       description: |
         List of `queryname:value` pairs. If and only if the querystring is not already set, set a new
-        querystring with the given value. Ignored if the header is already set.
+        querystring with the given value. Ignored if the querystring is already set.
     - name: add.body
       required: false
       value_in_examples:


### PR DESCRIPTION
### Summary
Fix the description of the config `config.add.querystring` in the [request-transformer](https://docs.konghq.com/hub/kong-inc/request-transformer/) docs page

### Reason
None

### Testing
None