### PR TITLE
chore: uses REPO argument in installer.sh script

### DIFF
--- a/app/mesh/installer.sh
+++ b/app/mesh/installer.sh
@@ -20,6 +20,6 @@
 
 curl -L https://kuma.io/installer.sh | \
   PRODUCT_NAME="Kong Mesh" \
-  REPO_PREFIX="kong-mesh" \
+  REPO="kong/kong-mesh" \
   LATEST_VERSION="https://docs.konghq.com/mesh/latest_version/" \
   sh -


### PR DESCRIPTION
### Summary

Changes the `REPO_PREFIX` argument to `REPO` following changes to the kuma.io/installer.sh changes made in https://github.com/kumahq/kuma-website/pull/1149.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

### Reason

Mirror changes introduced in https://github.com/kumahq/kuma-website/pull/1149.

### Testing

Can be verified by running

```sh
curl https://deploy-preview-4770--kongdocs.netlify.app/mesh/installer.sh | sh -
```
