### PR TITLE
kic: add translation failures troubleshooting

### DIFF
--- a/src/kubernetes-ingress-controller/troubleshooting.md
+++ b/src/kubernetes-ingress-controller/troubleshooting.md
@@ -293,3 +293,60 @@ To enable profiling and access it, set `CONTROLLER_PROFILING=true` in the
 controller container environment (`ingressController.env.profiling: true` using
 the Helm chart), wait for the Deployment to restart, run `kubectl
 port-forward <POD_NAME> 10256:10256`, and visit `http://localhost:10256/debug/pprof/`.
+
+{% if_version gte:2.8.x %}
+## Translation failures
+
+{{site.kic_product_name}} translates Kubernetes resources into {{site.base_gateway}} configuration.
+It implements a set of validation rules that prevent a faulty Kong configuration to be created.
+In most cases, once the validation fails, a causing Kubernetes object is going to get excluded
+from the translation and a corresponding translation, failure is going to be reported for it.
+
+In order to determine if there are any translation failures that you might want to fix, you
+can monitor the `ingress_controller_translation_count` [Prometheus metric](/kubernetes-ingress-controller/{{page.kong_version}}/references/prometheus).
+
+To get a deeper insight into what went wrong during the translation, you might want to look into Kubernetes
+events with a `KongConfigurationTranslationFailed` reason. There's going to be one event created for every
+object that was associated with the failure. An event's message is going to be populated with a human-readable
+explanation of the exact reason for the failure which should help you identify the root cause.
+
+### Example
+In the example, we create a Service with a single port number `80`. In the Ingress definition, we specify a backend
+service that refers to a port number `8080` which does not match the one defined in the Service.
+{{site.kic_product_name}} will skip the affected path and record warning events for both Service and Ingress objects.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  annotations:
+    kubernetes.io/ingress.class: "kong"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 8080 # there's no matching port in my-service
+```
+
+```console
+$ kubectl get events --sort-by='.lastTimestamp' --field-selector=reason=KongConfigurationTranslationFailed
+LAST SEEN   TYPE      REASON                               OBJECT               MESSAGE
+4s          Warning   KongConfigurationTranslationFailed   ingress/my-ingress   can't find port for backend kubernetes service: no suitable port found
+4s          Warning   KongConfigurationTranslationFailed   service/my-service   can't find port for backend kubernetes service: no suitable port found
+```
+{% endif_version %}


### PR DESCRIPTION
### Summary
It adds a section on troubleshooting translation failures in Kubernetes Ingress Controller. 

### Reason

Part of [#3097](https://github.com/Kong/kubernetes-ingress-controller/issues/3097).

### Testing
https://deploy-preview-4772--kongdocs.netlify.app)https://deploy-preview-4772--kongdocs.netlify.app
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
