### PR TITLE
feat(vault,keyring): Propose documentation for proposed Kubernetes Auth mechanism in Kong Enterprise

### DIFF
--- a/src/gateway/kong-enterprise/db-encryption.md
+++ b/src/gateway/kong-enterprise/db-encryption.md
@@ -385,7 +385,7 @@ objects. For information on which plugin fields are encrypted, see
 
 Kong's keyring mechanism can integrate directly with [HashiCorp Vault](https://www.vaultproject.io/) for keyring storage and versioning. In this model, Kong nodes read keyring material directly from a Vault KV secrets engine, rather than generating and disseminating keyring material around the cluster.
 
-To configure Kong to use Vault for keyring storage, set the `keyring_strategy` configuration value to `vault`. Leveraging Vault also requires defining a host, mount point, and token for Vault access. See the Kong configuration reference for more details.
+To configure Kong to use Vault for keyring storage, set the `keyring_strategy` configuration value to `vault`. Leveraging Vault also requires defining a host, mount point, and token or [Kubernetes service account role](https://developer.hashicorp.com/vault/docs/auth/kubernetes) for Vault access. See the Kong configuration reference for more details.
 
 ### Key Format
 
@@ -404,7 +404,12 @@ To provide a new key, add a new version to the Vault secrets engine at the confi
 
 ### Vault Permissions
 
-In order to communicate with Vault, Kong must be provided a Vault token for access. The token must be associated with a policy that allows the `read` and `list` actions on the path where keyring secrets are stored. Kong does not write keyring material to the Vault cluster.
+In order to communicate with Vault, Kong must be provided with either:
+
+* A Vault token
+* A role mapped to the Kubernetes service account of the running pod
+
+The token or Kubernetes auth role must be associated with a policy that allows the `read` and `list` actions on the path where keyring secrets are stored. Kong does not write keyring material to the Vault cluster.
 
 ### Syncing the Keyring
 

--- a/src/gateway/kong-enterprise/db-encryption.md
+++ b/src/gateway/kong-enterprise/db-encryption.md
@@ -407,7 +407,7 @@ To provide a new key, add a new version to the Vault secrets engine at the confi
 In order to communicate with Vault, Kong must be provided with either:
 
 * A Vault token
-* A role mapped to the Kubernetes service account of the running pod
+* A Vault role granted to the Kubernetes service-account of the running pod
 
 The token or Kubernetes auth role must be associated with a policy that allows the `read` and `list` actions on the path where keyring secrets are stored. Kong does not write keyring material to the Vault cluster.
 

--- a/src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -9,13 +9,29 @@ badge: enterprise
 
 ## Environment variables
 
+Using static Vault token authentication:
+
+
 ```bash
 export KONG_VAULT_HCV_PROTOCOL=<protocol(http|https)>
 export KONG_VAULT_HCV_HOST=<hostname>
 export KONG_VAULT_HCV_PORT=<portnumber>
 export KONG_VAULT_HCV_MOUNT=<mountpoint>
 export KONG_VAULT_HCV_KV=<v1|v2>
+export KONG_VAULT_HCV_AUTH_METHOD=token
 export KONG_VAULT_HCV_TOKEN=<tokenstring>
+```
+
+Or, using Kubernetes service-account role authentication:
+
+```bash
+export KONG_VAULT_HCV_PROTOCOL=<protocol(http|https)>
+export KONG_VAULT_HCV_HOST=<hostname>
+export KONG_VAULT_HCV_PORT=<portnumber>
+export KONG_VAULT_HCV_MOUNT=<mountpoint>
+export KONG_VAULT_HCV_KV=<v1|v2>
+export KONG_VAULT_HCV_AUTH_METHOD=kubernetes
+export KONG_VAULT_HCV_KUBE_ROLE=<rolename>
 ```
 
 You can also store this information in an entity.

--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -3595,12 +3595,52 @@ Defines the names of the Vault v2 KV path at which symmetric keys are found.
 
 
 
+### keyring_vault_auth_method
+{:.badge .enterprise}
+
+Defines the authentication mechanism when connecting to the Hashicorp Vault service.
+
+Accepted values are: `token`, or `kubernetes`:
+
+* `token`: Uses the static token defined in the `keyring_vault_token` configuration
+property.
+
+* `kubernetes`: Uses the Kubernetes authentication mechanism, with the running pod's
+mapped service account, to assume the Hashicorp Vault role name that is defined in
+the `keyring_vault_kube_role` configuration property.
+
+**Default:** `token`
+
+
+
 ### keyring_vault_token
 {:.badge .enterprise}
 
 Defines the token value used to communicate with the v2 KV Vault HTTP(S) API.
 
 **Default:** none
+
+
+
+### keyring_vault_kube_role
+{:.badge .enterprise}
+
+Defines the Hashicorp Vault role that will be assumed using the Kubernetes service
+account of the running pod.
+
+`keyring_vault_auth_method` must be set to `kubernetes` for this to activate.
+
+**Default:** `default`
+
+
+
+### keyring_vault_kube_api_token_file
+{:.badge .enterprise}
+
+Defines where the Kubernetes service account token should be read from the pod's
+filesystem, if using a non-standard container platform setup.
+
+**Default:** `/run/secrets/kubernetes.io/serviceaccount/token`
 
 
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Properties and other instructions in relevant to the change proposed in "Kong Enterprise PR 3824".

The feature being added is two parts:

1. Kubernetes Auth Method compatibility when using Kong Keyring
2. Kubernetes Auth Method compatibility when using the Kong Vault Backend "HCV" (Hashicorp Vault)

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

To add the Kubernetes Auth support that some customers require for Hashicorp Vault connections across two different Kong features.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

We will be able to view the changes on Netlify - @tysoekong will be able to confirm that all shell outputs, as in the examples, still correspond to their appearance in the docs preview. @tysoekong will update the examples accordingly.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
