### PR TITLE
Fix broken link checker

### DIFF
--- a/tools/broken-link-checker/lib/src-to-urls.js
+++ b/tools/broken-link-checker/lib/src-to-urls.js
@@ -21,7 +21,7 @@ async function srcToUrls(pattern, src) {
   const navEntries = await loadNavEntries(pattern);
 
   for (const entry of navEntries) {
-    const r = extractNavWithMeta(entry.items, ``, `src/${entry.product}`);
+    let r = extractNavWithMeta(entry.items, ``, `src/${entry.product}`);
 
     // If we provided a specific source, only match that file
     if (src) {


### PR DESCRIPTION
### Summary
Fix broken link checker for items with a `src` entry

### Reason
Builds are currently failing

### Testing
N/A