### PR TITLE
Plugin protocols: fix errors, use new formatting, and set min versions

### DIFF
--- a/app/_hub/SmartParkingTechnology/google-logging/_index.md
+++ b/app/_hub/SmartParkingTechnology/google-logging/_index.md
@@ -30,7 +30,9 @@ params:
   service_id: false
   consumer_id: false
   route_id: false
-  protocols: ["http", "https"]
+  protocols:
+    - name: http
+    - name: https
   dbless_compatible: yes
 
   config:

--- a/app/_hub/inspur/apig-request-transformer/_index.md
+++ b/app/_hub/inspur/apig-request-transformer/_index.md
@@ -1,102 +1,104 @@
---- 
- 
-name: Inspur Request Transformer 
- 
-publisher: Inspur 
- 
-categories: 
-  - transformations 
- 
-type: plugin 
- 
-desc: Kong plugin to transform diversiform requests 
-description: | 
- 
-  Transform the request sent by a client on the fly on Kong, before hitting the upstream server. 
-   
-  The plugin implements parameter transformations and additions of various positions. 
- 
-support_url: https://github.com/cheriL/apig-request-transformer/issues 
- 
-source_code: https://github.com/cheriL/apig-request-transformer 
- 
-license_type: Apache-2.0 
- 
-kong_version_compatibility: 
-  community_edition: 
-    compatible: 
-      - 1.2.x
-      - 1.1.x 
+---
 
- 
-params: 
-  name: apig-request-transformer 
-  api_id: false 
-  service_id: true 
-  consumer_id: false 
-  route_id: true 
-  protocols: ["http", "https"] 
-  dbless_compatible: yes 
-  dbless_explanation: It is recommended to use in dbless mode. 
-  config: 
-    - name: httpMethod 
-      required: true 
-      default: 
-      value_in_examples: POST 
+name: Inspur Request Transformer
+
+publisher: Inspur
+
+categories:
+  - transformations
+
+type: plugin
+
+desc: Kong plugin to transform diversiform requests
+description: |
+
+  Transform the request sent by a client on the fly on Kong, before hitting the upstream server.
+
+  The plugin implements parameter transformations and additions of various positions.
+
+support_url: https://github.com/cheriL/apig-request-transformer/issues
+
+source_code: https://github.com/cheriL/apig-request-transformer
+
+license_type: Apache-2.0
+
+kong_version_compatibility:
+  community_edition:
+    compatible:
+      - 1.2.x
+      - 1.1.x
+
+
+params:
+  name: apig-request-transformer
+  api_id: false
+  service_id: true
+  consumer_id: false
+  route_id: true
+  protocols:
+    - name: http
+    - name: https
+  dbless_compatible: yes
+  dbless_explanation: It is recommended to use in dbless mode.
+  config:
+    - name: httpMethod
+      required: true
+      default:
+      value_in_examples: POST
       description: Changes the HTTP method for the upstream request.
-    - name: backendContentType 
-      required: false 
-      default: 
-      value_in_examples: application/json 
+    - name: backendContentType
+      required: false
+      default:
+      value_in_examples: application/json
       description: Changes Content-Type for the upstream request.
-    - name: requestPath 
-      required: false 
-      default: 
-      value_in_examples: /requestPath/[pageId]/[userId] 
+    - name: requestPath
+      required: false
+      default:
+      value_in_examples: /requestPath/[pageId]/[userId]
       description: It is used with [config.pathParams] to extract values from the request URI.
-    - name: backendPath 
-      required: false 
-      default: 
-      value_in_examples: /servicePath/[pageId]/[userId] 
+    - name: backendPath
+      required: false
+      default:
+      value_in_examples: /servicePath/[pageId]/[userId]
       description: Updates the the path part of the upstream request URI with values.
-    - name: pathParams 
-      required: semi 
-      default: 
-      value_in_examples: ["pageId", "userId"] 
+    - name: pathParams
+      required: semi
+      default:
+      value_in_examples: ["pageId", "userId"]
       description: List of parameters' names of the request URI.
-    - name: replace 
-      required: false 
-      default: 
-      value_in_examples: ["head:h1;query:param1", "path:pageId;query:param2"] 
+    - name: replace
+      required: false
+      default:
+      value_in_examples: ["head:h1;query:param1", "path:pageId;query:param2"]
       description: List of parameter mappings. Replace its old value with the new one at different locations.
-    - name: add 
-      required: false 
-      default: 
-      value_in_examples: ["head:h1:v1", "query:param1:value1"] 
-      description: List of constant parameters. Set a new header or a new querystring with the given value. 
-  extra: 
-    # This is for additional remarks about your configuration. 
-############################################################################### 
-# END YAML DATA 
-# Beneath the next --- use Markdown (redcarpet flavor) and HTML formatting only. 
-# 
-# The remainder of this file is for free-form description, instruction, and 
-# reference matter. 
-# If you include headers, your headers MUST start at Level 2 (parsing to 
-# h2 tag in HTML). Heading Level 2 is represented by ## notation 
-# preceding the header text. Subsequent headings, 
-# if you choose to use them, must be properly nested (eg. heading level 2 may 
-# be followed by another heading level 2, or by heading level 3, but must NOT be 
-# followed by heading level 4) 
-############################################################################### 
-# BEGIN MARKDOWN CONTENT 
---- 
- 
-### Installation 
-Recommended: 
- 
-```bash 
-$ git clone https://github.com/cheriL/apig-request-transformer /opt/kong/plugins 
-$ cd /opt/kong/plugins/apig-request-transformer 
-$ luarocks make 
-``` 
+    - name: add
+      required: false
+      default:
+      value_in_examples: ["head:h1:v1", "query:param1:value1"]
+      description: List of constant parameters. Set a new header or a new querystring with the given value.
+  extra:
+    # This is for additional remarks about your configuration.
+###############################################################################
+# END YAML DATA
+# Beneath the next --- use Markdown (redcarpet flavor) and HTML formatting only.
+#
+# The remainder of this file is for free-form description, instruction, and
+# reference matter.
+# If you include headers, your headers MUST start at Level 2 (parsing to
+# h2 tag in HTML). Heading Level 2 is represented by ## notation
+# preceding the header text. Subsequent headings,
+# if you choose to use them, must be properly nested (eg. heading level 2 may
+# be followed by another heading level 2, or by heading level 3, but must NOT be
+# followed by heading level 4)
+###############################################################################
+# BEGIN MARKDOWN CONTENT
+---
+
+### Installation
+Recommended:
+
+```bash
+$ git clone https://github.com/cheriL/apig-request-transformer /opt/kong/plugins
+$ cd /opt/kong/plugins/apig-request-transformer
+$ luarocks make
+```

--- a/app/_hub/inspur/apig-response-transform/_index.md
+++ b/app/_hub/inspur/apig-response-transform/_index.md
@@ -10,7 +10,7 @@ description: |
 support_url: https://github.com/kakascx/apig-response-transform/issues
 source_code: https://github.com/kakascx/apig-response-transform
 license_type: Apache-2.0
-license_url: https://github.com/kakascx/apig-response-transform/blob/master/LICENSE 
+license_url: https://github.com/kakascx/apig-response-transform/blob/master/LICENSE
 
 kong_version_compatibility:
   community_edition:
@@ -20,27 +20,29 @@ kong_version_compatibility:
 
 
 params:
-  name: apig-response-transform 
+  name: apig-response-transform
   api_id: False
   service_id: True
   consumer_id: False
   route_id: True
-  protocols: ["http","https"]
+  protocols:
+    - name: http
+    - name: https
   dbless_compatible: 'yes'
   dbless_explanation: It is recommended to use in dbless mode.
   config:
     - name: format
       required: true
       default: xml
-      value_in_examples: xml 
+      value_in_examples: xml
       description: |
         Describe the format of the response format.
 ---
-### Installation 
-Recommended: 
- 
-```bash 
-$ git clone https://github.com/kakascx/apig-response-transform /opt/kong/plugins 
-$ cd /opt/kong/plugins/apig-response-transform 
-$ luarocks make 
-``` 
+### Installation
+Recommended:
+
+```bash
+$ git clone https://github.com/kakascx/apig-response-transform /opt/kong/plugins
+$ cd /opt/kong/plugins/apig-response-transform
+$ luarocks make
+```

--- a/app/_hub/kong-inc/basic-auth/_index.md
+++ b/app/_hub/kong-inc/basic-auth/_index.md
@@ -24,7 +24,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/file-log/_index.md
+++ b/app/_hub/kong-inc/file-log/_index.md
@@ -31,7 +31,9 @@ params:
     - name: tls
     - name: udp
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   dbless_compatible: 'yes'
   config:
     - name: path

--- a/app/_hub/kong-inc/hmac-auth/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/_index.md
@@ -28,7 +28,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/http-log/_index.md
+++ b/app/_hub/kong-inc/http-log/_index.md
@@ -28,7 +28,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   dbless_compatible: 'yes'
   config:
     - name: http_endpoint

--- a/app/_hub/kong-inc/kafka-log/_index.md
+++ b/app/_hub/kong-inc/kafka-log/_index.md
@@ -21,12 +21,12 @@ params:
   name: kafka-log
   dbless_compatible: 'yes'
   protocols:
-    - http
-    - https
-    - grpc
-    - grpcs
-    - ws
-    - wss
+    - name: http
+    - name: https
+    - name: grpc
+    - name: grpcs
+    - name: ws
+    - name: wss
   config:
     - name: bootstrap_servers
       required: true

--- a/app/_hub/kong-inc/kafka-log/_index.md
+++ b/app/_hub/kong-inc/kafka-log/_index.md
@@ -26,7 +26,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   config:
     - name: bootstrap_servers
       required: true

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -33,7 +33,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/key-auth/_index.md
+++ b/app/_hub/kong-inc/key-auth/_index.md
@@ -31,7 +31,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: partially
   dbless_explanation: |
     Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -34,7 +34,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: 'yes'
   config:
     - name: ldap_host

--- a/app/_hub/kong-inc/ldap-auth/_index.md
+++ b/app/_hub/kong-inc/ldap-auth/_index.md
@@ -65,7 +65,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: 'yes'
   config:
     - name: hide_credentials

--- a/app/_hub/kong-inc/loggly/_index.md
+++ b/app/_hub/kong-inc/loggly/_index.md
@@ -28,7 +28,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -35,7 +35,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   yaml_examples: false
   konnect_examples: false
   dbless_compatible: 'no'

--- a/app/_hub/kong-inc/serverless-functions/_index.md
+++ b/app/_hub/kong-inc/serverless-functions/_index.md
@@ -38,7 +38,9 @@ params:
     - name: http
     - name: https
     - name: ws
+      minimum_version: "3.0.x"
     - name: wss
+      minimum_version: "3.0.x"
   dbless_compatible: partially
   dbless_explanation: |
     The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.

--- a/app/_hub/kong-inc/syslog/_index.md
+++ b/app/_hub/kong-inc/syslog/_index.md
@@ -28,7 +28,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   dbless_compatible: 'yes'
   config:
     - name: successful_severity

--- a/app/_hub/kong-inc/tcp-log/_index.md
+++ b/app/_hub/kong-inc/tcp-log/_index.md
@@ -28,7 +28,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/udp-log/_index.md
+++ b/app/_hub/kong-inc/udp-log/_index.md
@@ -28,7 +28,9 @@ params:
     - name: grpc
     - name: grpcs
     - name: ws
+      minimum_version: "3.1.x"
     - name: wss
+      minimum_version: "3.1.x"
   dbless_compatible: 'yes'
   config:
     - name: host

--- a/app/_hub/kong-inc/websocket-size-limit/_index.md
+++ b/app/_hub/kong-inc/websocket-size-limit/_index.md
@@ -36,11 +36,13 @@ params:
   route_id: true
   consumer_id: false
   dbless_compatible: 'yes'
-  protocols: ["ws", "wss"]
+  protocols:
+    - name: ws
+    - name: wss
   config:
     - name: client_max_payload
       required: semi
-      value_in_examples: '''1024'''
+      value_in_examples: 1024
       datatype: integer
       default: null
       encrypted: false
@@ -52,7 +54,7 @@ params:
         required.
     - name: upstream_max_payload
       required: semi
-      value_in_examples: '''16384'''
+      value_in_examples: 16384
       datatype: integer
       default: null
       encrypted: false

--- a/app/_hub/kong-inc/websocket-validator/_index.md
+++ b/app/_hub/kong-inc/websocket-validator/_index.md
@@ -36,7 +36,9 @@ params:
   service_id: true
   route_id: true
   consumer_id: false
-  protocols: ["ws", "wss"]
+  protocols:
+    - name: ws
+    - name: wss
   dbless_compatible: 'yes'
   config:
 

--- a/app/_hub/qnap/api-transformer/_index.md
+++ b/app/_hub/qnap/api-transformer/_index.md
@@ -24,22 +24,24 @@ params:
   service_id: True
   consumer_id: False
   route_id: True
-  protocols: ["http", "https"] 
-  dbless_compatible: yes 
+  protocols:
+    - name: http
+    - name: https
+  dbless_compatible: yes
   config:
     - name: request_transformer
       required: 'yes'
       default:
       value_in_examples: /home/foo/api_xxx/req_transformer.lua
       description: |
-        The .lua script to be used for the transformation. 
+        The .lua script to be used for the transformation.
         Available OpenResty variables and utils: [Check README](https://github.com/qnap-dev/kong-plugin-api-transformer#for-developer){:target="_blank"}{:rel="noopener noreferrer"}
     - name: response_transformer
       required: 'yes'
       default:
       value_in_examples: /home/foo/api_xxx/resp_transformer.lua
       description: |
-        The .lua script to be used for the transformation. 
+        The .lua script to be used for the transformation.
         Available OpenResty variables and utils: [Check README](https://github.com/qnap-dev/kong-plugin-api-transformer#for-developer){:target="_blank"}{:rel="noopener noreferrer"}
     - name: http_200_always
       required: 'no'
@@ -49,20 +51,20 @@ params:
         We may need to use HTTP 200 approach in API error handling in some business cases.
 
 
-############################################################################### 
-# END YAML DATA 
-# Beneath the next --- use Markdown (redcarpet flavor) and HTML formatting only. 
-# 
-# The remainder of this file is for free-form description, instruction, and 
-# reference matter. 
-# If you include headers, your headers MUST start at Level 2 (parsing to 
-# h2 tag in HTML). Heading Level 2 is represented by ## notation 
-# preceding the header text. Subsequent headings, 
-# if you choose to use them, must be properly nested (eg. heading level 2 may 
-# be followed by another heading level 2, or by heading level 3, but must NOT be 
-# followed by heading level 4) 
-############################################################################### 
-# BEGIN MARKDOWN CONTENT 
+###############################################################################
+# END YAML DATA
+# Beneath the next --- use Markdown (redcarpet flavor) and HTML formatting only.
+#
+# The remainder of this file is for free-form description, instruction, and
+# reference matter.
+# If you include headers, your headers MUST start at Level 2 (parsing to
+# h2 tag in HTML). Heading Level 2 is represented by ## notation
+# preceding the header text. Subsequent headings,
+# if you choose to use them, must be properly nested (eg. heading level 2 may
+# be followed by another heading level 2, or by heading level 3, but must NOT be
+# followed by heading level 4)
+###############################################################################
+# BEGIN MARKDOWN CONTENT
 
 ---
 

--- a/app/_hub/reedelk/reedelk-transformer/_index.md
+++ b/app/_hub/reedelk/reedelk-transformer/_index.md
@@ -45,7 +45,9 @@ params:
   service_id: true
   consumer_id: false
   route_id: true
-  protocols: ["http", "https"]
+  protocols:
+    - name: http
+    - name: https
   dbless_compatible: yes
   dbless_explanation:
 
@@ -210,10 +212,10 @@ downstream transformer.
    `Hello World John`
 
 For more information about this example, including testing the IntelliJ Flow
-Designer Plugin workflow with [Insomnia](https://insomnia.rest/){:target="_blank"}{:rel="noopener noreferrer"}, see: 
+Designer Plugin workflow with [Insomnia](https://insomnia.rest/){:target="_blank"}{:rel="noopener noreferrer"}, see:
 * Reedelk [Getting Started](https://www.reedelk.com/documentation/getting-started){:target="_blank"}{:rel="noopener noreferrer"}
 documentation.
-* [Reedelk plugin documentation](https://github.com/reedelk/kong-plugin-reedelk-transformer#kong-reedelk-transformer-plugin-hello-world){:target="_blank"}{:rel="noopener noreferrer"} 
-on GitHub. 
-* [Kong Reedelk Transformer Plugin Demo](https://www.youtube.com/watch?v=c5Aw2XpwKos&amp;feature=youtu.be){:target="_blank"}{:rel="noopener noreferrer"} 
+* [Reedelk plugin documentation](https://github.com/reedelk/kong-plugin-reedelk-transformer#kong-reedelk-transformer-plugin-hello-world){:target="_blank"}{:rel="noopener noreferrer"}
+on GitHub.
+* [Kong Reedelk Transformer Plugin Demo](https://www.youtube.com/watch?v=c5Aw2XpwKos&amp;feature=youtu.be){:target="_blank"}{:rel="noopener noreferrer"}
 video on Youtube.

--- a/app/_hub/seifchen/kong-path-allow/_index.md
+++ b/app/_hub/seifchen/kong-path-allow/_index.md
@@ -34,7 +34,9 @@ params:
   service_id: true
   consumer_id: true
   route_id: true
-  protocols: ["http", "https"]
+  protocols:
+    - name: http
+    - name: https
   dbless_compatible: yes
 
   config:

--- a/app/_hub/yesinteractive/kong-jwt2header/_index.md
+++ b/app/_hub/yesinteractive/kong-jwt2header/_index.md
@@ -19,7 +19,7 @@ description: |
   This plugin converts JWT claims into headers during the rewrite phase. This is useful for:
     * Routing requests by JWT claim, so that Kong's route by header functionality can route the request appropriately.
     * Allowing the upstream service to consume claims as headers.
-  Since this plugin has elements that must run in the Rewrite execution phase, it can only be configured to run globally in a Kong workspace or cluster. 
+  Since this plugin has elements that must run in the Rewrite execution phase, it can only be configured to run globally in a Kong workspace or cluster.
   This plugin can be used in conjunction with other JWT validation/authentication plugins.
 
 support_url: https://github.com/yesinteractive/kong-jwt2header/issues
@@ -39,7 +39,7 @@ kong_version_compatibility:
       - 1.5.x
       - 1.3-x
 
-params: 
+params:
   name: kong-jwt2header
   api_id: false
     # boolean - whether this plugin can be applied to an API [[this needs more]]
@@ -52,7 +52,9 @@ params:
   route_id: false
     # whether this plugin can be applied to a Route.
     # Affects generation of examples and config table.
-  protocols: ["http", "https"]
+  protocols:
+    - name: http
+    - name: https
     # List of protocols this plugin is compatible with.
     # Valid values: "http", "https", "tcp", "tls"
     # Example: ["http", "https"]
@@ -62,7 +64,7 @@ params:
   dbless_explanation: Fully compatible with DB and DB-less (K8s, Declarative) Kong implementations.
     # Optional free-text explanation, usually containing details about the degree of
     # compatibility with DB-less.
-    
+
   config:
     - name: strip_claims
       required: yes

--- a/app/_hub/yesinteractive/kong-log-google/_index.md
+++ b/app/_hub/yesinteractive/kong-log-google/_index.md
@@ -36,7 +36,7 @@ kong_version_compatibility:
       - 1.5.x
       - 1.3-x
 
-params: 
+params:
   name: kong-log-google
   api_id: false
     # boolean - whether this plugin can be applied to an API [[this needs more]]
@@ -49,7 +49,9 @@ params:
   route_id: true
     # whether this plugin can be applied to a Route.
     # Affects generation of examples and config table.
-  protocols: ["http", "https"]
+  protocols:
+    - name: http
+    - name: https
     # List of protocols this plugin is compatible with.
     # Valid values: "http", "https", "tcp", "tls"
     # Example: ["http", "https"]
@@ -59,7 +61,7 @@ params:
   dbless_explanation: Fully compatible with DB and DB-less (K8s, Declarative) Kong implementations.
     # Optional free-text explanation, usually containing details about the degree of
     # compatibility with DB-less.
-    
+
   config:
     - name: tid
       required: yes


### PR DESCRIPTION
### Summary
Updating missed plugins with the new protocols formatting and setting `minimum_version` for the `ws` and `wss` protocols.

### Reason
3.1 release branch build is failing because of some plugin's formatting for the protocols values. Updating all plugins to use the new formatting to avoid further errors.

I'm fairly certain that the main culprit is the Kafka Log plugin, which previously didn't have a protocols key. Field got added in 3.1 with the old formatting.
By the time I'd figured that out, I'd already fixed it in a bunch of other places.

### Testing
Build should succeed. 
