### PR TITLE
docs(consumer_group): add delete api for consumer group configuration

### DIFF
--- a/src/gateway/admin-api/consumer-groups/reference.md
+++ b/src/gateway/admin-api/consumer-groups/reference.md
@@ -404,3 +404,18 @@ HTTP/1.1 201 Created
     "plugin": "rate-limiting-advanced"
 }
 ```
+
+## Delete the configurations for a consumer group
+
+Delete custom rate limiting settings for a consumer group. 
+<div class="endpoint delete">/consumer_groups/{GROUP_NAME|GROUP_ID}/overrides/plugins/rate-limiting-advanced</div>
+
+Attribute                             | Description
+---------:                            | --------    
+`GROUP_NAME|GROUP_ID`<br>*required*   | The name or UUID of the consumer group to configure.
+
+**Response**
+
+```
+HTTP/1.1 204 No Content
+```

--- a/src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/src/gateway/kong-enterprise/consumer-groups/index.md
@@ -449,9 +449,9 @@ http DELETE :8001/consumers/DianaPrince/consumer_groups/JL
 
 ## Delete consumer group configurations
 
-If you still need the consumer group but wanted to delete the configuations, 
-you can delete it. This removes configurations for the consumer group.
-The consumers in the group are not deleted and are still in the consumer group.
+You can also clear the configuration of a consumer group without deleting the consumer group itself.
+
+With this method, the consumers in the group aren't deleted and are still in the consumer group.
 
 1. Delete the consumer group configuration using the following request:
 
@@ -470,7 +470,7 @@ http DELETE :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
 {% endnavtabs %}
 {% endcapture %}
 
-{{ delete_consumer_group_config| indent | replace: " </code>", "</code>" }}
+{{ delete_consumer_group_config | indent | replace: " </code>", "</code>" }}
 
     If successful, you receive see the following response:
     ```
@@ -481,7 +481,7 @@ http DELETE :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
 
 {{ check_group1 | indent | replace: " </code>", "</code>" }}
 
-    Response, notice the plugins object in the response is gone.
+    Response, without a `plugins` object:
 
     ```json
     {

--- a/src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/src/gateway/kong-enterprise/consumer-groups/index.md
@@ -447,6 +447,53 @@ http DELETE :8001/consumers/DianaPrince/consumer_groups/JL
     }
     ```
 
+## Delete consumer group configurations
+
+If you still need the consumer group but wanted to delete the configuations, 
+you can delete it. This removes configurations for the consumer group.
+The consumers in the group are not deleted and are still in the consumer group.
+
+1. Delete the consumer group configuration using the following request:
+
+{% capture delete_consumer_group_config %}
+{% navtabs codeblock %}
+{% navtab cURL %}
+```bash
+curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```bash
+http DELETE :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{{ delete_consumer_group_config| indent | replace: " </code>", "</code>" }}
+
+    If successful, you receive see the following response:
+    ```
+    HTTP/1.1 204 No Content
+    ```
+    
+1. To verify, check the consumer object configuration:
+
+{{ check_group1 | indent | replace: " </code>", "</code>" }}
+
+    Response, notice the plugins object in the response is gone.
+
+    ```json
+    {
+        "consumer_group": {
+            "created_at": 1638917780,
+            "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
+            "name": "JL"
+        }
+    }
+    ```
+
+
 
 ## Delete consumer group
 
@@ -743,3 +790,4 @@ http DELETE :8001/consumers/BarryAllen/consumer_groups
     ```
     HTTP/1.1 204 No Content
     ```
+

--- a/src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/src/gateway/kong-enterprise/consumer-groups/index.md
@@ -459,12 +459,12 @@ With this method, the consumers in the group aren't deleted and are still in the
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
+curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-http DELETE :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced \
+http DELETE :8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
We'd like an API to support deleting the current consumer group configurations.

### Reason
[<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->] FT-3564(https://konghq.atlassian.net/browse/FT-3564)

### Testing
Test by using curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/JL/overrides/plugins/rate-limiting-advanced 

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
