### PR TITLE
chore: Bump plugin versions for 3.1

### DIFF
--- a/app/_hub/kong-inc/jq/versions.yml
+++ b/app/_hub/kong-inc/jq/versions.yml
@@ -1,6 +1,7 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x
   - 2.8.x
   - 2.7.x

--- a/app/_hub/kong-inc/kong-terraform-aws/_index.md
+++ b/app/_hub/kong-inc/kong-terraform-aws/_index.md
@@ -12,39 +12,9 @@ source_code: 'https://github.com/kong/kong-terraform-aws'
 license_type: Apache-2.0
 kong_version_compatibility:
   community_edition:
-    compatible:
-      - 3.0.x
-      - 2.8.x
-      - 2.7.x
-      - 2.6.x
-      - 2.5.x
-      - 2.4.x
-      - 2.3.x
-      - 2.2.x
-      - 2.1.x
-      - 2.0.x
-      - 1.5.x
-      - 1.4.x
-      - 1.3.x
-      - 1.2.x
-      - 1.1.x
-      - 1.0.x
-      - 0.14.x
-      - 0.13.x
+    compatible: true
   enterprise_edition:
-    compatible:
-      - 3.0.x
-      - 2.8.x
-      - 2.7.x
-      - 2.6.x
-      - 2.5.x
-      - 2.4.x
-      - 2.3.x
-      - 2.2.x
-      - 2.1.x
-      - 1.5.x
-      - 1.3-x
-      - 0.36-x
+    compatible: true
 ---
 
 ### Documentation

--- a/app/_hub/kong-inc/mocking/versions.yml
+++ b/app/_hub/kong-inc/mocking/versions.yml
@@ -1,6 +1,7 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x
   - 2.8.x
   - 2.7.x

--- a/app/_hub/kong-inc/opa/versions.yml
+++ b/app/_hub/kong-inc/opa/versions.yml
@@ -1,6 +1,7 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x
   - 2.8.x
   - 2.7.x

--- a/app/_hub/kong-inc/opentelemetry/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/_index.md
@@ -10,11 +10,9 @@ categories:
   - analytics-monitoring
 kong_version_compatibility:
   community_edition:
-    compatible:
-      - 3.0.x
+    compatible: true
   enterprise_edition:
-    compatible:
-      - 3.0.x
+    compatible: true
 params:
   name: opentelemetry
   konnect_examples: false

--- a/app/_hub/kong-inc/opentelemetry/versions.yml
+++ b/app/_hub/kong-inc/opentelemetry/versions.yml
@@ -1,5 +1,6 @@
 strategy: gateway
 releases:
+  - 3.1.x
   - 3.0.x
 overrides:
   3.0.x: 0.1.0

--- a/app/_hub/kong-inc/tls-handshake-modifier/_index.md
+++ b/app/_hub/kong-inc/tls-handshake-modifier/_index.md
@@ -18,8 +18,7 @@ categories:
   - security
 kong_version_compatibility:
   enterprise_edition:
-    compatible:
-      - 3.0.x
+    compatible: true
 params:
   name: tls-handshake-modifier
   service_id: true

--- a/app/_hub/kong-inc/tls-handshake-modifier/versions.yml
+++ b/app/_hub/kong-inc/tls-handshake-modifier/versions.yml
@@ -1,4 +1,5 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x

--- a/app/_hub/kong-inc/tls-metadata-headers/_index.md
+++ b/app/_hub/kong-inc/tls-metadata-headers/_index.md
@@ -19,8 +19,7 @@ categories:
   - security
 kong_version_compatibility:
   enterprise_edition:
-    compatible:
-      - 3.0.x
+    compatible: true
 params:
   name: tls-metadata-headers
   service_id: true

--- a/app/_hub/kong-inc/tls-metadata-headers/versions.yml
+++ b/app/_hub/kong-inc/tls-metadata-headers/versions.yml
@@ -1,4 +1,5 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x

--- a/app/_hub/kong-inc/websocket-size-limit/_index.md
+++ b/app/_hub/kong-inc/websocket-size-limit/_index.md
@@ -21,8 +21,7 @@ description: |
 
 kong_version_compatibility:
   enterprise_edition:
-    compatible:
-      - 3.0.x
+    compatible: true
 
 cloud: true
 

--- a/app/_hub/kong-inc/websocket-size-limit/versions.yml
+++ b/app/_hub/kong-inc/websocket-size-limit/versions.yml
@@ -1,4 +1,5 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x

--- a/app/_hub/kong-inc/websocket-validator/_index.md
+++ b/app/_hub/kong-inc/websocket-validator/_index.md
@@ -22,8 +22,7 @@ description: |
 
 kong_version_compatibility:
   enterprise_edition:
-    compatible:
-      - 3.0.x
+    compatible: true
 
 cloud: true
 

--- a/app/_hub/kong-inc/websocket-validator/versions.yml
+++ b/app/_hub/kong-inc/websocket-validator/versions.yml
@@ -1,4 +1,5 @@
 strategy: gateway
 
 releases:
+  - 3.1.x
   - 3.0.x


### PR DESCRIPTION
### Summary
Bumping plugin versions for any plugins not using `delegate_versions: true`.

### Reason
3.1 release prep.

### Testing
Netlify.

Check some of the bumped plugins:
https://deploy-preview-4786--kongdocs.netlify.app/hub/kong-inc/mocking/
https://deploy-preview-4786--kongdocs.netlify.app/hub/kong-inc/websocket-size-limit/
https://deploy-preview-4786--kongdocs.netlify.app/hub/kong-inc/tls-metadata-headers/
