### PR TITLE
chore(mesh): add set_flag_values_prefix var

### DIFF
--- a/jekyll.yml
+++ b/jekyll.yml
@@ -178,6 +178,7 @@ ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
 mesh_product_name: Kong Mesh
 default_namespace: kong-mesh-system
+set_flag_values_prefix: kuma.
 kic_product_name: Kubernetes Ingress Controller
 konnect_product_name: Kong Konnect
 konnect_short_name: Konnect


### PR DESCRIPTION
### Summary
When there is need to set some value which is kuma specific, it has to be prefixed with a `kuma.` prefix.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Bug found when testing (slack discussion).

- [x] Blocked by: https://github.com/kumahq/kuma-website/pull/1157

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

Check if the ebpf installation instructions are correct at the bottom of `docs/2.0.x/networking/transparent-proxying/#transparent-proxy-with-ebpf-experimental`. The correct value should be:
```shell
kumactl install control-plane \
  --set "kuma.experimental.ebpf.enabled=true" | kubectl apply -f-

```

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
