### PR TITLE
Add a/b test support for the top CTA

### DIFF
--- a/app/_assets/javascripts/ab-test.js
+++ b/app/_assets/javascripts/ab-test.js
@@ -1,0 +1,32 @@
+$(document).ready(function () {
+  // Top right CTA
+  const cta = $("#top-cta").text("");
+  const ctaOptions = {
+    incubator: {
+      url: "https://incubator.konghq.com/",
+      text: "Early Access",
+    },
+    sales_demo: {
+      url: "https://konghq.com/contact-sales",
+      text: "Personalized Demo",
+    },
+  };
+
+  let selectedCtaKey = Cookies.get("top_cta");
+  if (!selectedCtaKey) {
+    const ctaKeys = Object.keys(ctaOptions);
+    selectedCtaKey = ctaKeys[Math.floor(Math.random() * ctaKeys.length)];
+    Cookies.set("top_cta", selectedCtaKey, { expires: 1 });
+  }
+
+  const selectedCta = ctaOptions[selectedCtaKey];
+
+  cta
+    .attr("href", selectedCta.url + "?utm_source=docs.konghq.com")
+    .text(selectedCta.text)
+    .click(function () {
+      analytics.track("top_cta_click", selectedCta);
+    });
+
+  // End Top right CTA
+});

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -89,7 +89,7 @@
           <a href="{{site.links.learn}}" class="navbar-item">Kong Academy</a>
         </li>
       </ul>
-      <a href="https://incubator.konghq.com/?utm_source=docs.konghq.com" class="navbar-button">
+      <a id="top-cta" href="https://incubator.konghq.com/?utm_source=docs.konghq.com" class="navbar-button" target="_blank">
         Early Access
       </a>
     </div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ var sources = {
   js: [
     paths.assets + "javascripts/jquery-3.6.0.min.js",
     "node_modules/@segment/analytics-next/dist/umd/standalone.js",
+    "node_modules/js-cookie/dist/js.cookie.js",
     paths.assets + "javascripts/app.js",
     paths.assets + "javascripts/compat-dropdown.js",
     paths.assets + "javascripts/subscribe.js",
@@ -37,7 +38,8 @@ var sources = {
     // uncomment the path to promo-banner.js when adding a new promo banner
     // also uncomment the promo banner sections in app/_assets/stylesheets/header.less and /app/_includes/nav-v2.html -->
     // paths.assets + "javascripts/promo-banner.js",
-    paths.assets + "javascripts/copy-code-snippet-support.js"
+    paths.assets + "javascripts/copy-code-snippet-support.js",
+    paths.assets + "javascripts/ab-test.js"
   ],
   images: paths.assets + "images/**/*",
   manifests: paths.assets + "manifests/**/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "proprietary",
       "dependencies": {
-        "@segment/analytics-next": "1.46.0"
+        "@segment/analytics-next": "1.46.0",
+        "js-cookie": "^3.0.1"
       },
       "devDependencies": {
         "broken-link-checker": "0.7.8",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     ]
   },
   "dependencies": {
-    "@segment/analytics-next": "1.46.0"
+    "@segment/analytics-next": "1.46.0",
+    "js-cookie": "^3.0.1"
   }
 }


### PR DESCRIPTION
### Summary
Add support for A/B testing the top CTA

### Reason
To understand what is resonating with visitors

### Testing
Load the review app and you'll get either the incubator or sales demo CTA. This is randomly selected every 24h.

To see the other CTA, change the `top_cta` cookie to contain either `incubator` or `sales_demo` using developer tools

![CleanShot 2022-11-17 at 11 55 22](https://user-images.githubusercontent.com/59130/202439986-1b48da98-9a37-427f-a103-cacde5120652.png)
