### PR TITLE
[docu-2751] Dynamic log levels

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -187,8 +187,12 @@ items:
         url: /production/canary
       - text: Clustering Reference
         url: /production/clustering
-      - text: Logging Reference
-        url: /production/logging
+      - text: Logging
+        items:
+          - text: Log Reference
+            url: /production/logging/log-reference
+          - text: Customize Gateway Logs
+            url: /production/logging/customize-gateway-logs
       - text: Upgrade and Migration
         items:
           - text: Upgrade Kong Gateway

--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -187,7 +187,14 @@ items:
         url: /production/canary
       - text: Clustering Reference
         url: /production/clustering
-      - text: Logging Reference
+      - text: Logging
+        items:
+          - text: Log Reference
+            url: /production/logging/log-reference
+          - text: Dynamic log level updates
+            url: /production/logging/update-log-level-dynamically
+          - text: Customize Gateway Logs
+            url: /production/logging/customize-gateway-logs
         url: /production/logging
       - text: Upgrade and Migration
         items:

--- a/app/_redirects
+++ b/app/_redirects
@@ -826,3 +826,6 @@
 /gateway/2.8.x/get-started/quickstart/enabling-plugins/                /gateway/latest/key-concepts/plugins/
 /gateway/2.8.x/get-started/quickstart/adding-consumers/               /gateway/latest/get-started/key-authentication
 /gateway/2.8.x/admin-api/rbac/examples/                              /gateway/latest/admin-api/rbac/reference/
+
+# 3.1
+/gateway/latest/production/logging/     /gateway/latest/production/logging/log-reference/

--- a/src/gateway/production/logging.md
+++ b/src/gateway/production/logging.md
@@ -7,7 +7,7 @@ title: Logging Reference
 Log levels are set in [Kong's configuration](/gateway/{{page.kong_version}}/reference/configuration/#log_level). Following are the log levels in increasing order of their severity: `debug`, `info`,
 `notice`, `warn`, `error` and `crit`.
 
-- *`debug`:* It provides debug information about the plugin's run loop and each individual plugin or other components. This should only be used during debugging, the `debug` option, if left on for extended periods of time, can result in excess disk space consumption.
+- *`debug`:* It provides debug information about the plugin's run loop and each individual plugin or other components. This should only be used during debugging. The `debug` option, if left on for extended periods of time, can result in excess disk space consumption.
 - *`info`/`notice`:* Kong does not make a big difference between both these levels. Provides information about normal behavior most of which can be ignored.
 - *`warn`:* To log any abnormal behavior that doesn't result in dropped transactions but requires further investigation, `warn` level should be used.
 - *`error`:* Used for logging errors that result in a request being dropped (for example getting  an HTTP 500 error). The rate of such logs need to be monitored.

--- a/src/gateway/production/logging/customize-gateway-logs.md
+++ b/src/gateway/production/logging/customize-gateway-logs.md
@@ -1,23 +1,10 @@
 ---
-title: Logging Reference
+title: How to Customize Gateway Logs
+content-type: how-to
 ---
 
-## Log Levels
 
-Log levels are set in [Kong's configuration](/gateway/{{page.kong_version}}/reference/configuration/#log_level). Following are the log levels in increasing order of their severity: `debug`, `info`,
-`notice`, `warn`, `error` and `crit`.
-
-- *`debug`:* It provides debug information about the plugin's run loop and each individual plugin or other components. This should only be used during debugging, the `debug` option, if left on for extended periods of time, can result in excess disk space consumption.
-- *`info`/`notice`:* Kong does not make a big difference between both these levels. Provides information about normal behavior most of which can be ignored.
-- *`warn`:* To log any abnormal behavior that doesn't result in dropped transactions but requires further investigation, `warn` level should be used.
-- *`error`:* Used for logging errors that result in a request being dropped (for example getting  an HTTP 500 error). The rate of such logs need to be monitored.
-- *`crit`:* This level is used when Kong is working under critical conditions and not working properly thereby affecting several clients. Nginx also provides `alert` and `emerg` levels but currently Kong doesn't make use of these levels making `crit` the highest severity log level.
-
-`notice` is the default and recommended log level. However if the logs turn out to be too chatty, they can be bumped up to a higher level like `warn`.
-
-## Removing Certain Elements From Your Kong Logs
-
-With new regulations surrounding protecting private data like GDPR, there is a chance you may need to change your logging habits. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your Services. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
+With new regulations surrounding protecting private data like GDPR, there is a chance you may need customize what {{site.base_gateway}} is logging. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your Services. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
 
 For this example, let’s say you want to remove any instances of an email address from your Kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
 

--- a/src/gateway/production/logging/customize-gateway-logs.md
+++ b/src/gateway/production/logging/customize-gateway-logs.md
@@ -1,16 +1,18 @@
 ---
 title: How to Customize Gateway Logs
-content-type: how-to
+content_type: how-to
 ---
 
 
-With new regulations surrounding protecting private data like GDPR, there is a chance you may need customize what {{site.base_gateway}} is logging. If you use Kong as your API Gateway, this can be done in a single location to take effect on all of your Services. This guide will walk you through one approach to accomplishing this, but there are always different approaches for different needs. Please note, these changes will effect the output of the NGINX access logs. This will not have any effect on Kong's logging plugins.
+With regulations for protecting private data like GDPR, you may need to customize what {{site.base_gateway}} is logging. If you use Kong as your API gateway, this can be done in a single location to take effect on all of your services. This guide walks you through one approach to accomplishing this, but there are always different approaches for different needs. 
 
-For this example, let’s say you want to remove any instances of an email address from your Kong logs. The emails addresses may come through in different ways, for example something like `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. In order to keep these from being added to the logs, we will need to use a custom NGINX template.
+These changes affect the output of the NGINX access logs. This doesn't have any effect on Kong's logging plugins.
 
-To start using a custom NGINX template, first get a copy of our template. This can be found in the [Configuration Property reference](/gateway/{{page.kong_version}}/reference/configuration/#custom-nginx-templates-embedding-kong) or copied from below
+For this example, let’s say you want to remove any instances of an email address from your Kong logs. The email addresses may come through in different ways, for example `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. To keep all of these formats from being added to the logs, you need to use a custom NGINX template.
 
-```
+First, make a copy of {{site.base_gateway}}'s NGINX template. This template can be found in the [Configuration Property reference](/gateway/{{page.kong_version}}/reference/configuration/#custom-nginx-templates-embedding-kong) or copied from below:
+
+```nginx
 # ---------------------
 # custom_nginx.template
 # ---------------------
@@ -42,11 +44,11 @@ http {
 }
 ```
 
-In order to control what is placed in the logs, we will be using the NGINX map module in our template. For more detailed information abut the map directive, please see [this guide](http://nginx.org/en/docs/http/ngx_http_map_module.html). This will create a new variable whose value depends on values of one or more of the source variables specified in the first parameter. The format is:
+To control what is placed in the logs, you can use the [NGINX map module](https://nginx.org/en/docs/http/ngx_http_map_module.html) in the template. This creates a new variable whose value depends on values of one or more of the source variables specified in the first parameter. The format is:
 
-```
+```nginx
 
-map $paramater_to_look_at $variable_name {
+map $parameter_to_look_at $variable_name {
     pattern_to_look_for 0;
     second_pattern_to_look_for 0;
 
@@ -54,9 +56,9 @@ map $paramater_to_look_at $variable_name {
 }
 ```
 
-For this example, we will be mapping a new variable called `keeplog` which is dependent on certain values appearing in the `$request_uri`. We will be placing our map directive right at the start of the http block; this must be before `include 'nginx-kong.conf';`. For our example, we will add something along the lines of:
+For this example, map a new variable called `keeplog`, which is dependent on values appearing in the `$request_uri`. Place the map directive at the start of the `http` block, before `include 'nginx-kong.conf';`:
 
-```
+```nginx
 map $request_uri $keeplog {
     ~.+\@.+\..+ 0;
     ~/servicename/v2/verify 0;
@@ -66,24 +68,27 @@ map $request_uri $keeplog {
 }
 ```
 
-You’ll probably notice that each of those lines start with a tilde. This is what tells NGINX to use RegEx when evaluating the line. We have three things to look for in this example:
+Notice that each of the lines in the example start with a tilde. This is what tells NGINX to use RegEx when evaluating the line. There are three things to look for in this example:
 - The first line uses regex to look for any email address in the `x@y.z` format
-- The second line looks for any part of the URI which is `/servicename/v2/verify`
-- The third line looks at any part of the URI which contains `/v3/verify`
+- The second line looks for any part of the URI that contains `/servicename/v2/verify`
+- The third line looks at any part of the URI that contains `/v3/verify`
 
-Because all of those have a value of something other than `0`, if a request has one of those elements, it will not be added to the log.
+Because all of these patterns have a value of something other than `0`, if a request has any of those elements, it will not be added to the log.
 
-Now, we need to set the log format for what we will keep in the logs. We will use the `log_format` module and assign our new logs a name of `show_everything`. The contents of the log can be customized for you needs, but for this example, I will simply change everything back to the Kong standards. To see the full list of options you can use, please refer to [this guide](https://nginx.org/en/docs/http/ngx_http_core_module.html#variables).
+Now, use the `log_format` module to set the log format for what {{site.base_gateway}} keeps in the logs. 
 
-```
+The contents of the log can be customized for your needs. For the purpose of this example, you can assign the new logs with the name `show_everything` and  simply set everything to the Kong default standards. 
+To see the full list of options, refer to the [NGINX core module variables reference](https://nginx.org/en/docs/http/ngx_http_core_module.html#variables).
+
+```nginx
 log_format show_everything '$remote_addr - $remote_user [$time_local] '
     '$request_uri $status $body_bytes_sent '
     '"$http_referer" "$http_user_agent"';
 ```
 
-Now, our custom NGINX template is all ready to be used. If you have been following along, your file should now be look like this:
+Now, the custom NGINX template is ready to be used. If you have been following along, your file should look like this:
 
-```
+```nginx
 # ---------------------
 # custom_nginx.template
 # ---------------------
@@ -120,12 +125,14 @@ http {
 }
 ```
 
-The last thing we need to do is tell Kong to use the newly created log, `show_everything`. To do this, we will be altering the Kong variable `proxy_access_log` by either editing `etc/kong/kong.conf` or using an environmental variable `KONG_PROXY_ACCESS_LOG`. You will want to mend the default location to show:
+The last thing you need to do is tell {{site.base_gateway}} to use the newly created log, `show_everything`. To do this, alter the Kong variable `proxy_access_log` by either editing `etc/kong/kong.conf` or using the environmental variable `KONG_PROXY_ACCESS_LOG`. Adjust the default location to the following:
 
 ```
 proxy_access_log=logs/access.log show_everything if=$keeplog
 ```
 
-The final step in the process to make all the changes take effect is to restart Kong. You can use the `kong restart` command to do so.
+Restart {{site.base_gateway}} to make all the changes take effect. You can use the `kong restart` command.
 
-Now, any requests made with an email address in it will no longer be logged. Of course, we can use this logic to remove anything we want from the logs on a conditional manner.
+Now, any request made with an email address in it will no longer be logged. 
+
+You can use this logic to remove anything you want from the logs in a conditional manner.

--- a/src/gateway/production/logging/customize-gateway-logs.md
+++ b/src/gateway/production/logging/customize-gateway-logs.md
@@ -10,7 +10,7 @@ These changes affect the output of the NGINX access logs. This doesn't have any 
 
 For this example, let’s say you want to remove any instances of an email address from your Kong logs. The email addresses may come through in different ways, for example `/servicename/v2/verify/alice@example.com` or `/v3/verify?alice@example.com`. To keep all of these formats from being added to the logs, you need to use a custom NGINX template.
 
-First, make a copy of {{site.base_gateway}}'s NGINX template. This template can be found in the [Configuration Property reference](/gateway/{{page.kong_version}}/reference/configuration/#custom-nginx-templates-embedding-kong) or copied from below:
+First, make a copy of {{site.base_gateway}}'s NGINX template. This template can be found in the [Nginx directives reference](/gateway/{{page.kong_version}}/reference/nginx-directives/#custom-nginx-templates-and-embedding-kong-gateway/) or copied from below:
 
 ```nginx
 # ---------------------

--- a/src/gateway/production/logging/log-reference.md
+++ b/src/gateway/production/logging/log-reference.md
@@ -1,0 +1,25 @@
+---
+title: Logging Reference
+content-type: reference
+---
+
+## Log Levels
+
+Log levels are set in [Kong's configuration](/gateway/{{page.kong_version}}/reference/configuration/#log_level). Following are the log levels in increasing order of their severity: `debug`, `info`,
+`notice`, `warn`, `error` and `crit`.
+
+- *`debug`:* It provides debug information about the plugin's run loop and each individual plugin or other components. This should only be used during debugging, the `debug` option, if left on for extended periods of time, can result in excess disk space consumption.
+- *`info`/`notice`:* Kong does not make a big difference between both these levels. Provides information about normal behavior most of which can be ignored.
+- *`warn`:* To log any abnormal behavior that doesn't result in dropped transactions but requires further investigation, `warn` level should be used.
+- *`error`:* Used for logging errors that result in a request being dropped (for example getting  an HTTP 500 error). The rate of such logs need to be monitored.
+- *`crit`:* This level is used when Kong is working under critical conditions and not working properly thereby affecting several clients. Nginx also provides `alert` and `emerg` levels but currently Kong doesn't make use of these levels making `crit` the highest severity log level.
+
+`notice` is the default and recommended log level. However if the logs turn out to be too chatty, they can be bumped up to a higher level like `warn`.
+
+
+## More Information
+
+* [Remove elements from {{site.base_gateway}} logs](/gateway/latest/logging/customize-gateway-logs/).
+{% if_version gte:3.1.x %}
+* [Dynamic log level updates](/gateway/latest/logging/update-log-level-dynamically)
+{% endif_version %}

--- a/src/gateway/production/logging/log-reference.md
+++ b/src/gateway/production/logging/log-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Logging Reference
-content-type: reference
+content_type: reference
 ---
 
 ## Log Levels

--- a/src/gateway/production/logging/log-reference.md
+++ b/src/gateway/production/logging/log-reference.md
@@ -19,7 +19,7 @@ Log levels are set in [Kong's configuration](/gateway/{{page.kong_version}}/refe
 
 ## More Information
 
-* [Remove elements from {{site.base_gateway}} logs](/gateway/latest/logging/customize-gateway-logs/).
+* [Remove elements from {{site.base_gateway}} logs](/gateway/{{page.kong_version}}/production/logging/customize-gateway-logs/)
 {% if_version gte:3.1.x %}
-* [Dynamic log level updates](/gateway/latest/logging/update-log-level-dynamically)
+* [Dynamic log level updates](/gateway/{{page.kong_version}}/production/logging/update-log-level-dynamically/)
 {% endif_version %}

--- a/src/gateway/production/logging/update-log-level-dynamically.md
+++ b/src/gateway/production/logging/update-log-level-dynamically.md
@@ -1,14 +1,15 @@
 ---
 title: Dynamic Log Level Updates
-content-type: reference
+content_type: reference
 ---
 
 
-With {{site.base_gateway}} 3.1, you can now change the log level of {{site.base_gateway}} dynamically, without restarting {{site.base_gateway}} using the Admin API. This set of endpoints can be protected using [RBAC](/gateway/latest/admin-api/rbac/reference/#add-a-role-endpoint-permission) and changes in log level are reflected in the [audit log](/gateway/latest/kong-enterprise/audit-log/).
+You can change the log level of {{site.base_gateway}} dynamically, without restarting {{site.base_gateway}}, using the Admin API. This set of endpoints can be protected using [RBAC](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#add-a-role-endpoint-permission) and changes in log level are reflected in the [audit log](/gateway/{{page.kong_version}}/kong-enterprise/audit-log/).
 
 The log level change is propagated to all NGINX worker nodes, including the newly spawned workers.
 
-Care must be taken when changing the log level of a node to `debug` in a production environment because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as `notice`.
+{:.important}
+> Be careful when changing the log level of a node to `debug` in a production environment, because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as `notice`.
 
 
 ## View current log level
@@ -20,28 +21,29 @@ curl --request GET \
   --url http://localhost:8001/debug/node/log-level/ 
 ```
 
-If you have the appropriate permissions, this request will return information about your current log level: 
+If you have the appropriate permissions, this request returns information about your current log level: 
 
-```bash
+```json
 {
     "message": "log level: notice"
 }
 ```
+
 {:.note}
 > It is currently not possible to change the log level of the data plane or DB-less nodes. 
 
 ## Modify the log level for an individual {{site.base_gateway}} node
 
-To change the log level of an individual node, issue a `PUT` request passing the desired `node` and [`log-level`](/gateway/production/logging/log-reference/) as path parameters: 
+To change the log level of an individual node, issue a `PUT` request passing the desired `node` and [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) as path parameters: 
 
 ```bash
 curl --request PUT \
   --url http://localhost:8001/debug/node/log-level/notice 
 ```
 
-If you have the appropriate permissions and the request was successful you will receive a `200` response code and the following response body: 
+If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body: 
 
-```bash
+```json
 {
 	"message": "log level changed"
 }
@@ -49,16 +51,16 @@ If you have the appropriate permissions and the request was successful you will 
 
 ## Change the log level of the {{site.base_gateway}} cluster
 
-To change the log level of every node in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter: 
+To change the log level of every node in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) specified as a path parameter: 
 
 ```bash
 curl --request PUT \
   --url http://localhost:59191/debug/cluster/log-level/notice
 ```
 
-If you have the appropriate permissions and the request was successful you will receive a `200` response code and the following response body:
+If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body:
 
-```bash
+```json
 {
 	"message": "log level changed"
 }
@@ -66,20 +68,20 @@ If you have the appropriate permissions and the request was successful you will 
 
 ### Manage new nodes in the cluster
 
-To ensure that the log level of new nodes that are added to the cluster remain in sync the other nodes in the cluster, change the `log_level` entry in [`kong.conf`](/gateway/latest/reference/configuration/#log_level) to `KONG_LOG_LEVEL`. This setting allows new nodes to join the cluster with the same log level as all existing nodes.
+To ensure that the log level of new nodes that are added to the cluster remain in sync the other nodes in the cluster, change the `log_level` entry in [`kong.conf`](/gateway/{{page.kong_version}}/reference/configuration/#log_level) to `KONG_LOG_LEVEL`. This setting allows new nodes to join the cluster with the same log level as all existing nodes.
 
 ## Change the log level of all control plane {{site.base_gateway}} nodes
 
-To change the log level of the control plane nodes in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter:
+To change the log level of the control plane nodes in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) specified as a path parameter:
 
 ```bash
 curl --request PUT \
   --url http://localhost:59191/debug/cluster/control-planes-nodes/log-level/notice
 ```
 
-If you have the appropriate permissions and the request was successful you will receive a `200` response code and the following response body:
+If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body:
 
-```bash
+```json
 {
 	"message": "log level changed"
 }

--- a/src/gateway/production/logging/update-log-level-dynamically.md
+++ b/src/gateway/production/logging/update-log-level-dynamically.md
@@ -6,6 +6,10 @@ content-type: reference
 
 With {{site.base_gateway}} 3.1, you can now change the log level of {{site.base_gateway}} dynamically, without restarting {{site.base_gateway}} using the Admin API. This set of endpoints can be protected using [RBAC](/gateway/latest/admin-api/rbac/reference/#add-a-role-endpoint-permission) and changes in log level are reflected in the [audit log](/gateway/latest/kong-enterprise/audit-log/).
 
+The log level change is propagated to all NGINX worker nodes, including the newly spawned workers.
+
+Care must be taken when changing the log level of a node to `debug` in a production environment because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as `notice`.
+
 
 ## View current log level
 
@@ -28,7 +32,7 @@ If you have the appropriate permissions, this request will return information ab
 
 ## Modify the log level for an individual {{site.base_gateway}} node
 
-To change the log level of an individual node, issue a `POST` request passing the desired `node` and [`log-level`](/gateway/production/logging/log-reference/) as path parameters: 
+To change the log level of an individual node, issue a `PUT` request passing the desired `node` and [`log-level`](/gateway/production/logging/log-reference/) as path parameters: 
 
 ```bash
 curl --request PUT \
@@ -45,7 +49,7 @@ If you have the appropriate permissions and the request was successful you will 
 
 ## Change the log level of the {{site.base_gateway}} cluster
 
-To change the log level of every node in your cluster, issue a `POST` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter: 
+To change the log level of every node in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter: 
 
 ```bash
 curl --request PUT \
@@ -66,7 +70,7 @@ To ensure that the log level of new nodes that are added to the cluster remain i
 
 ## Change the log level of all control plane {{site.base_gateway}} nodes
 
-To change the log level of the control plane nodes in your cluster, issue a `POST` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter:
+To change the log level of the control plane nodes in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter:
 
 ```bash
 curl --request PUT \

--- a/src/gateway/production/logging/update-log-level-dynamically.md
+++ b/src/gateway/production/logging/update-log-level-dynamically.md
@@ -14,7 +14,7 @@ The log level change is propagated to all NGINX worker nodes, including the newl
 
 ## View current log level
 
-To view the log level of an individual node issue a `GET` request passing the desired `node` as a path parameter: 
+To view the log level of an individual node, issue a `GET` request passing the desired `node` as a path parameter: 
 
 ```bash
 curl --request GET \

--- a/src/gateway/production/logging/update-log-level-dynamically.md
+++ b/src/gateway/production/logging/update-log-level-dynamically.md
@@ -1,0 +1,83 @@
+---
+title: Dynamic Log Level Updates
+content-type: reference
+---
+
+
+With {{site.base_gateway}} 3.1, you can now change the log level of {{site.base_gateway}} dynamically, without restarting {{site.base_gateway}} using the Admin API. This set of endpoints can be protected using [RBAC](/gateway/latest/admin-api/rbac/reference/#add-a-role-endpoint-permission) and changes in log level are reflected in the [audit log](/gateway/latest/kong-enterprise/audit-log/).
+
+
+## View current log level
+
+To view the log level of an individual node issue a `GET` request passing the desired `node` as a path parameter: 
+
+```bash
+curl --request GET \
+  --url http://localhost:8001/debug/node/log-level/ 
+```
+
+If you have the appropriate permissions, this request will return information about your current log level: 
+
+```bash
+{
+    "message": "log level: notice"
+}
+```
+{:.note}
+> It is currently not possible to change the log level of the data plane or DB-less nodes. 
+
+## Modify the log level for an individual {{site.base_gateway}} node
+
+To change the log level of an individual node, issue a `POST` request passing the desired `node` and [`log-level`](/gateway/production/logging/log-reference/) as path parameters: 
+
+```bash
+curl --request PUT \
+  --url http://localhost:8001/debug/node/log-level/notice 
+```
+
+If you have the appropriate permissions and the request was successful you will receive a `200` response code and the following response body: 
+
+```bash
+{
+	"message": "log level changed"
+}
+```
+
+## Change the log level of the {{site.base_gateway}} cluster
+
+To change the log level of every node in your cluster, issue a `POST` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter: 
+
+```bash
+curl --request PUT \
+  --url http://localhost:59191/debug/cluster/log-level/notice
+```
+
+If you have the appropriate permissions and the request was successful you will receive a `200` response code and the following response body:
+
+```bash
+{
+	"message": "log level changed"
+}
+```
+
+### Manage new nodes in the cluster
+
+To ensure that the log level of new nodes that are added to the cluster remain in sync the other nodes in the cluster, change the `log_level` entry in [`kong.conf`](/gateway/latest/reference/configuration/#log_level) to `KONG_LOG_LEVEL`. This setting allows new nodes to join the cluster with the same log level as all existing nodes.
+
+## Change the log level of all control plane {{site.base_gateway}} nodes
+
+To change the log level of the control plane nodes in your cluster, issue a `POST` request with the desired [`log-level`](/gateway/production/logging/log-reference/) specified as a path parameter:
+
+```bash
+curl --request PUT \
+  --url http://localhost:59191/debug/cluster/control-planes-nodes/log-level/notice
+```
+
+If you have the appropriate permissions and the request was successful you will receive a `200` response code and the following response body:
+
+```bash
+{
+	"message": "log level changed"
+}
+```
+


### PR DESCRIPTION
### Summary 
https://konghq.atlassian.net/browse/DOCU-2751


Documents new feature and covers the following cases:
- ~~The user should not leave any node with debug log level for too long otherwise it would be too verbose, could fill the disk quickly~~
- ~~Exercise the GET endpoint often to get current log level~~
- ~~The root (/) endpoint will show current, up-to-date information about the log level considering the ones changed by the API proposed in this document~~
- Traditional nodes and CP nodes
    - ~~Change log level of individual traditional node~~
    - ~~Broadcast log level change to all traditional nodes~~
- ~~The new APIs can be RBAC protected~~
- ~~Changes to the API can be reflected in the audit logs~~
-  ~~It’s currently not possible to change the log level of DP and DB-less nodes~~
- ~~Currently, when the user dynamically changes the log level for the entire cluster and if a new node joins a cluster, the new node will run at the old log level, not at the dynamically log level that was previously set for the entire cluster. To work around that, make sure the new node starts with the proper level by setting the startup kong.conf setting “KONG_LOG_LEVEL”.~~
- ~~The log level change is propagated to all workers~~

Also in this PR
- Split existing log reference doc into two docs. 
- Added redirect. 
