### PR TITLE
[DOCU-2783] Plugin ordering in Kong Manager

### DIFF
--- a/src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -131,9 +131,10 @@ ordering:
     ```
 
 {% endnavtab %}
-
-{% if_version gte:3.1.x %}
 {% navtab Kong Manager UI %}
+
+{:.note}
+> **Note:** Kong Manager support for dynamic plugin ordering is available starting in {{site.base_gateway}} 3.1.x.
 
 1. In Kong Manager, open the **default** workspace.
 2. From the menu, open **Plugins**, then click **Install Plugin**.
@@ -155,8 +156,6 @@ ordering:
 The rate limiting plugin now limits the amount of requests against all services and routes in the default workspace *before* {{site.base_gateway}} requests authentication.
 
 {% endnavtab %}
-{% endif_version %}
-
 {% endnavtabs %}
 
 ## Authentication after request transformation
@@ -262,9 +261,10 @@ ordering:
     ```
 
 {% endnavtab %}
-
-{% if_version gte:3.1.x %}
 {% navtab Kong Manager UI %}
+
+{:.note}
+> **Note:** Kong Manager support for dynamic plugin ordering is available starting in {{site.base_gateway}} 3.1.x.
 
 1. In Kong Manager, open the **default** workspace.
 2. From the menu, open **Plugins**, then click **Install Plugin**.
@@ -279,6 +279,4 @@ ordering:
 
 The basic authentication plugin now requests authentication after the request is transformed.
 {% endnavtab %}
-{% endif_version %}
-
 {% endnavtabs %}

--- a/src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -133,7 +133,24 @@ ordering:
 {% endnavtab %}
 {% navtab Kong Manager UI %}
 
-1. In Kong Manager, ?
+1. In Kong Manager, open the **default** workspace.
+2. From the menu, open **Plugins**, then click **Install Plugin**.
+3. Find the **Rate Limiting** plugin, then click **Enable**.
+4. Apply the plugin as **Global**, which means the rate limiting applies to all requests, including every service and route in the workspace.
+5. Complete only the following fields with the following parameters.
+    1. config.minute: `5`
+    2. config.policy: `local`
+    3. config.limit_by: `ip`
+    
+    Besides the above fields, there may be others populated with default values. For this example, leave the rest of the fields as they are.
+6. Click **Install**.
+7. From the **Rate Limiting** plugin page, click the **Ordering** tab.
+8. Click **Add ordering**.
+9. For **Before access**, click **Add plugin**.
+10. Choose **Key Auth** from the **Plugin 1** dropdown menu.
+11. Click **Update**.
+
+The rate limiting plugin now limits the amount of requests against all services and routes in the default workspace *before* {{site.base_gateway}} requests authentication.
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -243,6 +260,17 @@ ordering:
 {% endnavtab %}
 {% navtab Kong Manager UI %}
 
-1. In Kong Manager, ?
+1. In Kong Manager, open the **default** workspace.
+2. From the menu, open **Plugins**, then click **Install Plugin**.
+3. Find the **Basic Authentication** plugin, then click **Enable**.
+4. Apply the plugin as **Global**, which means the rate limiting applies to all requests, including every service and route in the workspace.
+6. Click **Install**.
+7. From the **Basic Authentication** plugin page, click the **Ordering** tab.
+8. Click **Add ordering**.
+9. For **After access**, click **Add plugin**.
+10. Choose **Request Transformer** from the **Plugin 1** dropdown menu.
+11. Click **Update**.
+
+The basic authentication plugin now requests authentication after the request is transformed.
 {% endnavtab %}
 {% endnavtabs %}

--- a/src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -131,6 +131,8 @@ ordering:
     ```
 
 {% endnavtab %}
+
+{% if_version gte:3.1.x %}
 {% navtab Kong Manager UI %}
 
 1. In Kong Manager, open the **default** workspace.
@@ -153,6 +155,8 @@ ordering:
 The rate limiting plugin now limits the amount of requests against all services and routes in the default workspace *before* {{site.base_gateway}} requests authentication.
 
 {% endnavtab %}
+{% endif_version %}
+
 {% endnavtabs %}
 
 ## Authentication after request transformation
@@ -258,6 +262,8 @@ ordering:
     ```
 
 {% endnavtab %}
+
+{% if_version gte:3.1.x %}
 {% navtab Kong Manager UI %}
 
 1. In Kong Manager, open the **default** workspace.
@@ -273,4 +279,6 @@ ordering:
 
 The basic authentication plugin now requests authentication after the request is transformed.
 {% endnavtab %}
+{% endif_version %}
+
 {% endnavtabs %}

--- a/src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -131,6 +131,11 @@ ordering:
     ```
 
 {% endnavtab %}
+{% navtab Kong Manager UI %}
+
+1. In Kong Manager, ?
+
+{% endnavtab %}
 {% endnavtabs %}
 
 ## Authentication after request transformation
@@ -235,5 +240,9 @@ ordering:
     deck sync
     ```
 
+{% endnavtab %}
+{% navtab Kong Manager UI %}
+
+1. In Kong Manager, ?
 {% endnavtab %}
 {% endnavtabs %}

--- a/src/gateway/kong-enterprise/plugin-ordering/index.md
+++ b/src/gateway/kong-enterprise/plugin-ordering/index.md
@@ -4,11 +4,11 @@ badge: enterprise
 content_type: explanation
 ---
 
-The order in which plugins are executed in Kong is determined by their
+The order in which plugins are executed in {{site.base_gateway}} is determined by their
 `static priority`. As the name suggests, this value is _static_ and can't be
  easily changed by the user.
 
-You can override the priority for any Kong plugin using each plugin's
+You can override the priority for any {{site.base_gateway}} plugin using each plugin's
 `ordering` field. This determines plugin ordering during the `access` phase,
 and lets you create _dynamic_ dependencies between plugins.
 
@@ -95,6 +95,14 @@ Kong Manager doesn't support dynamic plugin ordering configuration through the
 UI. Use the Kong Admin API or a declarative configuration file to set
 plugin ordering.
 {% endif_version %}
+
+{% if_version gte:3.1.x %}
+### Kong Manager
+
+Kong Manager also supports dynamic plugin ordering configuration through the
+UI. For more information, see [Get Started with Dynamic Plugin Ordering](/gateway/{{page.kong_version}}/kong-enterprise/plugin-ordering/get-started)
+{% endif_version %}
+
 ## See also
 
 Check out the examples in the


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Added instructions for how to configure plugin ordering with Kong Manager. This is for Gateway 3.1. 
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
DOCU-2783
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Go to: KM tabs in `/gateway/latest/kong-enterprise/plugin-ordering/get-started/`

Questions for writer reviewers:

- I originally created a "Plugin Ordering" subsection in the Kong Manager section of the docs for this info, but I was mostly copying what was in the Kong Enterprise "Plugin Ordering" subsection, so I figured I'd just add it there. Does this work, or should this live in Kong Manager? I thought maybe at one point we ripped out KM instructions during 3.0 and moved them to the KM section.
- I know this is documenting the UI, but I think it's okay here because it's focused on teaching the user how plugin ordering works with an example vs. generic plugin ordering instructions. Thoughts?

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
