### PR TITLE
[DOCU-2779] Allow root path to be specified for Kong Manager

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -14,7 +14,7 @@ no_version: true
 #### Core
 
 * **Kong Manager**:
-* You can now specify the root path for Kong Manager, for example: `localhost:8445/manager`. This allows you to proxy all traffic through {{site.base_gateway}}, for example, you can proxy both API and Kong Manager traffic from one port. In addtion, using the new Kong Manager root path allows you to add plugins to control access to Kong Manager. For more information, see [Enable Kong Manager](/gateway/latest/kong-manager/enable/).
+* You can now configure the root path for Kong Manager, for example: `localhost:8445/manager`. This allows you to proxy all traffic through {{site.base_gateway}}. For example, you can proxy both API and Kong Manager traffic from one port. In addtion, using the new Kong Manager root path allows you to add plugins to control access to Kong Manager. For more information, see [Enable Kong Manager](/gateway/latest/kong-manager/enable/).
 
 
 ## 3.0.1.0

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -4,6 +4,18 @@ no_version: true
 ---
 
 <!-- vale off -->
+## 3.1.0.0
+**Release Date** 2022/12/xx
+
+### Features
+
+### Fixes
+
+#### Core
+
+* **Kong Manager**:
+* You can now specify the root path for Kong Manager, for example: `localhost:8445/manager`. This allows you to proxy all traffic through {{site.base_gateway}}, for example, you can proxy both API and Kong Manager traffic from one port. In addtion, using the new Kong Manager root path allows you to add plugins to control access to Kong Manager. For more information, see [Enable Kong Manager](/gateway/latest/kong-manager/enable/).
+
 
 ## 3.0.1.0
 **Release Date** 2022/11/02

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -14,7 +14,7 @@ no_version: true
 #### Core
 
 * **Kong Manager**:
-* You can now configure the root path for Kong Manager, for example: `localhost:8445/manager`. This allows you to proxy all traffic through {{site.base_gateway}}. For example, you can proxy both API and Kong Manager traffic from one port. In addtion, using the new Kong Manager root path allows you to add plugins to control access to Kong Manager. For more information, see [Enable Kong Manager](/gateway/latest/kong-manager/enable/).
+* You can now configure the base path for Kong Manager, for example: `localhost:8445/manager`. This allows you to proxy all traffic through {{site.base_gateway}}. For example, you can proxy both API and Kong Manager traffic from one port. In addtion, using the new Kong Manager base path allows you to add plugins to control access to Kong Manager. For more information, see [Enable Kong Manager](/gateway/latest/kong-manager/enable/).
 
 
 ## 3.0.1.0

--- a/src/gateway/kong-manager/enable.md
+++ b/src/gateway/kong-manager/enable.md
@@ -10,16 +10,17 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
 {% navtabs %}
 {% navtab Docker %}
 
-1. Set the [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) property in the ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)) configuration file to the DNS or IP address of your system, then restart {{site.base_gateway}} for the setting to take effect. For example:
+1. Set the [`KONG_ADMIN_GUI_PATH`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_path) and [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) properties in the ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)) configuration file to the DNS or IP address of your system, then restart {{site.base_gateway}} for the setting to take effect. For example:
 
     ```bash
-    echo "-e 'KONG_ADMIN_GUI_URL=http://localhost:8002/manager' \
+    echo "-e 'KONG_ADMIN_GUI_PATH=/manager' \
+    'KONG_ADMIN_GUI_URL=http://localhost:8002/manager' \
     kong reload exit" | docker exec -i KONG_CONTAINER_ID /bin/sh
     ```
 
     Replace `KONG_CONTAINER_ID` with the ID of your Docker container.
 
-2. Access Kong Manager on port `8002`.
+2. Access Kong Manager on port `8002` at the path you specified in `KONG_ADMIN_GUI_PATH`.
 
 {% endnavtab %}
 {% navtab Linux (kong.conf) %}
@@ -28,6 +29,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
   in the `kong.conf` configuration file to the DNS, or IP address, of your system. For example:
 
     ```
+    admin_gui_path = /manager
     admin_gui_url = http://localhost:8002/manager
     ```
 
@@ -39,7 +41,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
     kong restart -c {PATH_TO_KONG.CONF_FILE}
     ```
 
-3. Access Kong Manager on port `8002`.
+3. Access Kong Manager on port `8002` at the path you specified in `KONG_ADMIN_GUI_PATH`.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/src/gateway/kong-manager/enable.md
+++ b/src/gateway/kong-manager/enable.md
@@ -41,7 +41,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
     kong restart -c {PATH_TO_KONG.CONF_FILE}
     ```
 
-3. Access Kong Manager on port `8002` at the path you specified in `KONG_ADMIN_GUI_PATH`.
+3. Access Kong Manager on port `8002` at the path you specified in `admin_gui_path`.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/src/gateway/kong-manager/enable.md
+++ b/src/gateway/kong-manager/enable.md
@@ -13,7 +13,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
 1. Set the [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url) property in the ([`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)) configuration file to the DNS or IP address of your system, then restart {{site.base_gateway}} for the setting to take effect. For example:
 
     ```bash
-    echo "-e 'KONG_ADMIN_GUI_URL=http://localhost:8002' \
+    echo "-e 'KONG_ADMIN_GUI_URL=http://localhost:8002/manager' \
     kong reload exit" | docker exec -i KONG_CONTAINER_ID /bin/sh
     ```
 
@@ -28,7 +28,7 @@ or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
   in the `kong.conf` configuration file to the DNS, or IP address, of your system. For example:
 
     ```
-    admin_gui_url = http://localhost:8002
+    admin_gui_url = http://localhost:8002/manager
     ```
 
     This setting needs to resolve to a network path that can reach the operating system (OS) host.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Edited the `admin_gui_url` examples with the new root path for Kong Manager. Also added an entry to the changelog.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
DOCU-2779
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Go to:

- /gateway/latest/kong-manager/enable
- The release notes

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
