### PR TITLE
DOCU-2809 

### DIFF
--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -63,4 +63,4 @@ for the following parameters:
     cluster_telemetry_server_name = example.us.tp0.konghq.com
     ```
 {:.note}
-> **Note:** Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json] for the list of IPs associated to regional hostnames. You can also subscribe to [ https://ip-addresses.origin.konghq.com/rss] for updates.  
+> **Note**: Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json](https://ip-addresses.origin.konghq.com/ip-addresses.json) for the list of IPs associated to regional hostnames. You can also subscribe to [https://ip-addresses.origin.konghq.com/rss](https://ip-addresses.origin.konghq.com/rss) for updates.  

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -62,5 +62,6 @@ for the following parameters:
     cluster_telemetry_endpoint = example.us.tp0.konghq.com:443
     cluster_telemetry_server_name = example.us.tp0.konghq.com
     ```
+
 {:.note}
 > **Note**: Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json](https://ip-addresses.origin.konghq.com/ip-addresses.json) for the list of IPs associated to regional hostnames. You can also subscribe to [https://ip-addresses.origin.konghq.com/rss](https://ip-addresses.origin.konghq.com/rss) for updates.  

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -62,3 +62,5 @@ for the following parameters:
     cluster_telemetry_endpoint = example.us.tp0.konghq.com:443
     cluster_telemetry_server_name = example.us.tp0.konghq.com
     ```
+{:.note}
+> **Note:** Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json] for the list of IPs associated to regional hostnames. You can also subscribe to [ https://ip-addresses.origin.konghq.com/rss] for updates.  


### PR DESCRIPTION
Document Konnect's static IP list endpoint for different Konnect geos

### Summary
adds https://ip-addresses.origin.konghq.com/ip-addresses.json for the list of IPs, and https://ip-addresses.origin.konghq.com/rss for the rss feed with updates.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
