### PR TITLE
doc(kic) deprecate KongIngress for 2.8

### DIFF
--- a/src/kubernetes-ingress-controller/guides/routing-by-header.md
+++ b/src/kubernetes-ingress-controller/guides/routing-by-header.md
@@ -1,0 +1,299 @@
+---
+title: Routing by Header
+---
+
+In addition to URL components, {{site.base_gateway}} can route HTTP requests
+using request header values. This guide will walk through creating routes that
+use the same URL, but send traffic to different upstream services based on the
+requests' headers.
+
+## Installation
+
+Follow the [deployment](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview) documentation to install
+the {{site.kic_product_name}} on your Kubernetes cluster.
+
+## Test connectivity to {{site.base_gateway}}
+
+This guide assumes that the `PROXY_IP` environment variable is
+set to contain the IP address or URL pointing to {{site.base_gateway}}.
+Follow one of the
+[deployment guides](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview) to configure this environment variable.
+
+If everything is setup correctly, making a request to {{site.base_gateway}} should return
+a HTTP `404` status code.
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -i $PROXY_IP
+```
+{% endnavtab %}
+{% navtab Response %}
+```bash
+HTTP/1.1 404 Not Found
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+Content-Length: 48
+Server: kong/1.2.1
+
+{"message":"no Route matched with those values"}
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+This is expected because {{site.base_gateway}} does not yet know how to proxy the request.
+
+## Install an example service
+
+We will start by installing the echo service and increasing its replica count:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl apply -f https://bit.ly/echo-service
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+service/echo created
+deployment.apps/echo created
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl patch deploy echo --patch '{"spec": {"replicas": 2}}'
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```
+deployment.apps/echo patched
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Setup Ingress
+
+Let's expose the echo service outside the Kubernetes cluster
+by defining an Ingress:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+echo "
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: demo-a
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: echo
+            port:
+              number: 80
+" | kubectl apply -f -
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+ingress.networking.k8s.io/demo-a created
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Test the echo service:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -i $PROXY_IP/foo
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: echoserver
+X-Kong-Upstream-Latency: 2
+X-Kong-Proxy-Latency: 1
+Via: kong/1.2.1
+
+Hostname: echo-d778ffcd8-n9bss
+
+Pod Information:
+  node name:	gke-harry-k8s-dev-default-pool-bb23a167-8pgh
+  pod name:	echo-d778ffcd8-n9bss
+  pod namespace:	default
+  pod IP:	10.60.0.4
+
+Server values:
+  server_version=nginx: 1.12.2 - lua: 10010
+
+Request Information:
+  client_address=10.60.1.10
+  method=GET
+  real path=/foo
+  query=
+  request_version=1.1
+  request_scheme=http
+  request_uri=http://35.233.170.67:8080/foo
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Adding header rules to the Ingress
+
+The `konghq.com/headers.*` annotation controls the `headers` field on {{site.base_gateway}}
+routes generated from Ingress resources. When set, these headers must be
+present with a specific value for a request to match a route.
+
+The header name is configured by replacing the `*` in the example above with a
+header name. The `konghq.com/headers.x-split` and `konghq.com/headers.x-legacy`
+annotations indicate allowed values for the `x-split` and `x-legacy` headers,
+respectively. To start, add one of these to the `demo-a` Ingress:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl annotate ingress demo-a konghq.com/headers.x-split=alpha
+```
+{% endnavtab %}
+{% navtab Response %}
+```
+ingress.networking.k8s.io/demo-a annotated
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Requests will no longer match the route:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -s $PROXY_IP/foo
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+{"message":"no Route matched with those values"}
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Add another Ingress
+
+To demonstrate header routing, add another Ingress with a rule for the same
+path as `demo-a`:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+echo "
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: demo-b
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: echo
+            port:
+              number: 80
+" | kubectl apply -f -
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+ingress.networking.k8s.io/demo-b created
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+This Ingress will accept a different set of values for `x-split` and
+will require an `x-legacy` header:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+kubectl annotate ingress demo-b konghq.com/headers.x-split=bravo,charlie
+kubectl annotate ingress demo-b konghq.com/headers.x-legacy=enabled
+```
+{% endnavtab %}
+{% navtab Response %}
+```
+ingress.networking.k8s.io/demo-b annotated
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Send requests with headers
+
+Add headers to your requests to make your requests match routes again.
+You'll be able to access both routes depending on which header you use:
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -sv $PROXY_IP/foo -H "kong-debug: 1" -H "x-split: alpha" 2>&1 | grep -i kong-route-name
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+< Kong-Route-Name: default.demo-a.00
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -sv $PROXY_IP/foo -H "kong-debug: 1" -H "x-split: bravo" -H "x-legacy: enabled"  2>&1 | grep -i kong-route-name
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+< Kong-Route-Name: default.demo-b.00
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{% navtabs codeblock %}
+{% navtab Command %}
+```bash
+curl -sv $PROXY_IP/foo -H "kong-debug: 1" -H "x-split: charlie" -H "x-legacy: enabled"  2>&1 | grep -i kong-route-name
+```
+{% endnavtab %}
+
+{% navtab Response %}
+```bash
+< Kong-Route-Name: default.demo-b.00
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Note that `demo-b` requires _both_ headers, but matches any of the
+individual values configured for a given header.

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -22,7 +22,7 @@ proxy behavior.
 
 {:.note}
 > As of version 2.8, KongIngress sections other than `upstream` are
-> [deprecatedi](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
+> [deprecated](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
 > All settings in the `proxy` and `route` sections are now available with
 > dedicated annotations, and these annotations will become the only means of
 > configuring those settings in a future release. For example, if you had set

--- a/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -5,6 +5,8 @@ title: Using KongIngress resource
 In this guide, we will learn how to use KongIngress resource to control
 proxy behavior.
 
+{% if_version lte:2.7.x %}
+
 {:.note}
 > **Note:** Many fields available on KongIngress are also available as
 > [annotations](/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations).
@@ -14,6 +16,27 @@ proxy behavior.
 > annotation value will take precedence over a KongIngress value if both set
 > the same setting. This guide focuses on settings that can only be set using
 > KongIngress.
+
+{% endif_version %}
+{% if_version gte:2.8.x %}
+
+{:.note}
+> As of version 2.8, KongIngress sections other than `upstream` are
+> [deprecatedi](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
+> All settings in the `proxy` and `route` sections are now available with
+> dedicated annotations, and these annotations will become the only means of
+> configuring those settings in a future release. For example, if you had set
+> `proxy.connect_timeout: 30000` in a KongIngress and applied an
+> `konghq.com/override` annotation for that KongIngress to a Service, you will
+> need to instead apply a `konghq.com/connect-timeout: 30000` annotation to the
+> Service.
+> 
+> The `upstream` section of KongIngress will be replaced with [a new
+> resource](https://github.com/Kong/kubernetes-ingress-controller/issues/3174),
+> but this is still in development and `upstream` is not officially
+> deprecated yet.
+
+{% endif_version %}
 
 ## Installation
 
@@ -341,6 +364,14 @@ KongIngress reference](/kubernetes-ingress-controller/{{page.kong_version}}/refe
 for the health check fields.
 
 ## Use KongIngress with Ingress resource
+
+{% if_version gte:2.8.x %}
+{:.note}
+> As of version 2.8, this configuration is deprecated in favor of the
+> `konghq.com/headers` annotation. The [Routing by Header](/kubernetes-ingress-controller/{{page.kong_version}}/guides/routing-by-header)
+> guide covers the modern version of this configuration.
+
+{% endif_version %}
 
 Kong can match routes based on request headers. For example, you can have two
 separate routes for `/foo`, one that matches requests which include an

--- a/src/kubernetes-ingress-controller/references/annotations.md
+++ b/src/kubernetes-ingress-controller/references/annotations.md
@@ -12,18 +12,27 @@ Following annotations are supported on Ingress resources:
 | Annotation name | Description |
 |-----------------|-------------|
 | REQUIRED [`kubernetes.io/ingress.class`](#kubernetesioingressclass) | Restrict the Ingress rules that Kong should satisfy |
-| [`konghq.com/plugins`](#konghqcomplugins) | Run plugins for specific Ingress. |
-| [`konghq.com/protocols`](#konghqcomprotocols) | Set protocols to handle for each Ingress resource. |
-| [`konghq.com/preserve-host`](#konghqcompreserve-host) | Pass the `host` header as is to the upstream service. |
-| [`konghq.com/strip-path`](#konghqcomstrip-path) | Strip the path defined in Ingress resource and then forward the request to the upstream service. |
-| [`konghq.com/https-redirect-status-code`](#konghqcomhttps-redirect-status-code) | Set the HTTPS redirect status code to use when an HTTP request is received. |
-| [`konghq.com/regex-priority`](#konghqcomregex-priority) | Set the route's regex priority. |
-| [`konghq.com/methods`](#konghqcommethods) | Set methods matched by this Ingress. |
-| [`konghq.com/snis`](#konghqcomsnis) | Set SNI criteria for routes created from this Ingress. |
-| [`konghq.com/request-buffering`](#konghqcomrequest-buffering) | Set request buffering on routes created from this Ingress. |
-| [`konghq.com/response-buffering`](#konghqcomresponse-buffering) | Set response buffering on routes created from this Ingress. |
-| [`konghq.com/host-aliases`](#konghqcomhostaliases) | Additional hosts for routes created from this Ingress's rules. |
-| [`konghq.com/override`](#konghqcomoverride) | Control other routing attributes via `KongIngress` resource. |
+| [`konghq.com/plugins`](#konghqcomplugins) | Run plugins for specific Ingress |
+| [`konghq.com/protocols`](#konghqcomprotocols) | Set protocols to handle for each Ingress resource |
+| [`konghq.com/preserve-host`](#konghqcompreserve-host) | Pass the `host` header as is to the upstream service |
+| [`konghq.com/strip-path`](#konghqcomstrip-path) | Strip the path defined in Ingress resource and then forward the request to the upstream service |
+| [`konghq.com/https-redirect-status-code`](#konghqcomhttps-redirect-status-code) | Set the HTTPS redirect status code to use when an HTTP request is received |
+| [`konghq.com/regex-priority`](#konghqcomregex-priority) | Set the route's regex priority |
+| [`konghq.com/methods`](#konghqcommethods) | Set methods matched by this Ingress |
+| [`konghq.com/snis`](#konghqcomsnis) | Set SNI criteria for routes created from this Ingress |
+| [`konghq.com/request-buffering`](#konghqcomrequest-buffering) | Set request buffering on routes created from this Ingress |
+| [`konghq.com/response-buffering`](#konghqcomresponse-buffering) | Set response buffering on routes created from this Ingress |
+| [`konghq.com/host-aliases`](#konghqcomhostaliases) | Additional hosts for routes created from this Ingress's rules |
+
+{%- if_version lte:2.7.x -%}
+| [`konghq.com/override`](#konghqcomoverride) | Control other routing attributes via KongIngress resource |
+{%- endif_version -%}
+
+{%- if_version gte:2.8.x %}
+| [`konghq.com/override`](#konghqcomoverride) | (Deprecated, replace with per-setting annotations) Control other routing attributes with a KongIngress resource |
+| [`konghq.com/path-handling`](#konghqcompathhandling) | Sets the path handling algorithm |
+| [`konghq.com/headers.*`](#konghqcomheaders) | Set header values required to match rules in this Ingress |
+{%- endif_version %}
 
 `kubernetes.io/ingress.class` is normally required, and its value should match
 the value of the `--ingress-class` controller argument (`kong` by default).
@@ -39,8 +48,19 @@ Following annotations are supported on Service resources:
 | [`konghq.com/path`](#konghqcompath) | HTTP Path that is always prepended to each request that is forwarded to a Kubernetes service |
 | [`konghq.com/client-cert`](#konghqcomclient-cert) | Client certificate and key pair Kong should use to authenticate itself to a specific Kubernetes service |
 | [`konghq.com/host-header`](#konghqcomhost-header) | Set the value sent in the `Host` header when proxying requests upstream |
-| [`konghq.com/override`](#konghqcomoverride) | Fine grained routing and load-balancing |
 | [`ingress.kubernetes.io/service-upstream`](#ingresskubernetesioservice-upstream) | Offload load-balancing to kube-proxy or sidecar |
+
+{%- if_version lte:2.7.x -%}
+| [`konghq.com/override`](#konghqcomoverride) | Fine grained routing and load-balancing |
+{%- endif_version -%}
+
+{%- if_version gte:2.8.x -%}
+| [`konghq.com/override`](#konghqcomoverride) | (Deprecated for non-upstream fields, replace with per-setting annotations) Control load balancing behavior with a KongIngress resource |
+| [`konghq.com/connect-timeout`](#konghqcomconnecttimeout) | Set the timeout for completing a TCP connection |
+| [`konghq.com/read-timeout`](#konghqcomreadtimeout) | Set the timeout for receiving an HTTP response after sending a request |
+| [`konghq.com/write-timeout`](#konghqcomwritetimeout) | Set the timeout for writing data |
+| [`konghq.com/retries`](#konghqcomretries) | Set the number of times to retry requests that failed |
+{%- endif_version %}
 
 ## KongConsumer resource
 
@@ -427,6 +447,24 @@ Results in two routes:
 
 > Available since controller 0.8
 
+{% if_version gte:2.8.x -%}
+{:.note}
+> As of version 2.8, KongIngress sections other than `upstream` are
+> [deprecatedi](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
+> All settings in the `proxy` and `route` sections are now available with
+> dedicated annotations, and these annotations will become the only means of
+> configuring those settings in a future release. For example, if you had set
+> `proxy.connect_timeout: 30000` in a KongIngress and applied an
+> `konghq.com/override` annotation for that KongIngress to a Service, you will
+> need to instead apply a `konghq.com/connect-timeout: 30000` annotation to the
+> Service.
+> 
+> The `upstream` section of KongIngress will be replaced with [a new
+> resource](https://github.com/Kong/kubernetes-ingress-controller/issues/3174),
+> but this is still in development and `upstream` is not officially
+> deprecated yet.
+{% endif_version %}
+
 This annotation can associate a KongIngress resource with
 an Ingress or a Service resource.
 It serves as a way to bridge the gap between a sparse Ingress API in Kubernetes
@@ -509,6 +547,8 @@ konghq.com/host-header: "test.example.com"
 
 ### ingress.kubernetes.io/service-upstream
 
+> Available since controller 0.6
+
 By default, the {{site.kic_product_name}} distributes traffic amongst all the
 Pods of a Kubernetes `Service` by forwarding the requests directly to
 Pod IP addresses. One can choose the load-balancing strategy to use
@@ -534,4 +574,59 @@ annotations:
   ingress.kubernetes.io/service-upstream: "true"
 ```
 
-You need {{site.kic_product_name}} >= 0.6 for this annotation.
+{% if_version gte:2.8.x %}
+### konghq.com/path-handling
+
+> Available since controller 2.8
+
+Sets the [path handling algorithm](/gateway/latest/admin-api/#path-handling-algorithms),
+which controls how {{site.base_gateway}} combines the service and route `path`
+fields (the Service's [path annotation](#konghqcompath) value and Ingress
+rule's `path` field) are combined into the path sent upstream.
+
+### konghq.com/headers.*
+
+> Available since controller 2.8
+
+Sets header values that are required for requests to match rules in an Ingress.
+
+Unlike most annotations, `konghq.com/headers.*` includes part of the
+configuration in the annotation name. The string after the `.` in the
+annotation name is the header, and the value is a CSV of allowed header values.
+
+For example, setting `konghq.com/headers.x-routing: alpha,bravo` will only
+match requests that include an `x-routing` header whose value is either `alpha`
+or `bravo`.
+
+### konghq.com/connect-timeout
+
+> Available since controller 2.8
+
+Sets the connect timeout, in milliseconds. For example, setting this annotation
+to `60000` will instruct the proxy to wait up to 60 seconds to complete the
+initial TCP connection to the upstream service.
+
+### konghq.com/read-timeout
+
+> Available since controller 2.8
+
+Sets the read timeout, in milliseconds. For example, setting this annotation
+to `60000` will instruct the proxy to wait up to 60 seconds after sending a
+request before timing out and returning a 504 response to the client.
+
+### konghq.com/write-timeout
+
+> Available since controller 2.8
+
+Sets the write timeout, in milliseconds. For example, setting this annotation
+to `60000` will instruct the proxy to wait up to 60 seconds without writing
+data before closing a kept-alive connection.
+
+### konghq.com/retries
+
+> Available since controller 2.8
+
+Sets the max retries on a request. For example, setting this annotation to `3`
+will re-send the request up to three times if it encounters a failure, such as
+a timeout.
+{% endif_version %}

--- a/src/kubernetes-ingress-controller/references/annotations.md
+++ b/src/kubernetes-ingress-controller/references/annotations.md
@@ -450,7 +450,7 @@ Results in two routes:
 {% if_version gte:2.8.x -%}
 {:.note}
 > As of version 2.8, KongIngress sections other than `upstream` are
-> [deprecatedi](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
+> [deprecated](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
 > All settings in the `proxy` and `route` sections are now available with
 > dedicated annotations, and these annotations will become the only means of
 > configuring those settings in a future release. For example, if you had set

--- a/src/kubernetes-ingress-controller/references/custom-resources.md
+++ b/src/kubernetes-ingress-controller/references/custom-resources.md
@@ -9,10 +9,9 @@ Following CRDs enables users to declaratively configure all aspects of Kong:
 
 - [**KongPlugin**](#kongplugin): This resource corresponds to
   the [Plugin][kong-plugin] entity in Kong.
-- [**KongIngress**](#kongingress): This resource provides fine-grained control
-  over all aspects of proxy behaviour like routing, load-balancing,
-  and health checking. It serves as an "extension" to the Ingress resources
-  in Kubernetes.
+- [**KongIngress**](#kongingress): {% if_version gte:2.8.x -%}**(Partially deprecated)**{% endif_version %}This resource provides fine-grained control over all aspects of proxy
+  behaviour like routing, load-balancing, and health checking. It serves as an
+  "extension" to the Ingress resources in Kubernetes.
 - [**KongConsumer**](#kongconsumer):
   This resource maps to the [Consumer][kong-consumer] entity in Kong.
 - [**TCPIngress**](#tcpingress):
@@ -243,6 +242,8 @@ meaning it will be executed for every request that is proxied via Kong.
 
 ## KongIngress
 
+{% if_version lte:2.7.x -%}
+
 {:.note}
 > **Note:** Many fields available on KongIngress are also available as
 > [annotations](/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations).
@@ -251,6 +252,26 @@ meaning it will be executed for every request that is proxied via Kong.
 > available, it is the preferred means of configuring that setting, and the
 > annotation value will take precedence over a KongIngress value if both set
 > the same setting.
+{% endif_version %}
+{% if_version gte:2.8.x -%}
+
+{:.note}
+> As of version 2.8, KongIngress sections other than `upstream` are
+> [deprecatedi](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
+> All settings in the `proxy` and `route` sections are now available with
+> dedicated annotations, and these annotations will become the only means of
+> configuring those settings in a future release. For example, if you had set
+> `proxy.connect_timeout: 30000` in a KongIngress and applied an
+> `konghq.com/override` annotation for that KongIngress to a Service, you will
+> need to instead apply a `konghq.com/connect-timeout: 30000` annotation to the
+> Service.
+> 
+> Plans are to replace the `upstream` section of KongIngress with [a new
+> resource](https://github.com/Kong/kubernetes-ingress-controller/issues/3174),
+> but this is still in development and `upstream` is not yet officially
+> deprecated.
+
+{% endif_version %}
 
 Ingress resource spec in Kubernetes can define routing policies
 based on HTTP Host header and paths.

--- a/src/kubernetes-ingress-controller/references/custom-resources.md
+++ b/src/kubernetes-ingress-controller/references/custom-resources.md
@@ -257,7 +257,7 @@ meaning it will be executed for every request that is proxied via Kong.
 
 {:.note}
 > As of version 2.8, KongIngress sections other than `upstream` are
-> [deprecatedi](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
+> [deprecated](https://github.com/Kong/kubernetes-ingress-controller/issues/3018).
 > All settings in the `proxy` and `route` sections are now available with
 > dedicated annotations, and these annotations will become the only means of
 > configuring those settings in a future release. For example, if you had set


### PR DESCRIPTION
### Summary
Add deprecation notices for KongIngress if the KIC version is 2.8 or higher.

Add a new guide for routing by header using annotations.

Add new 2.8 annotations to annotations reference.

Kind of in limbo before we have a 2.8 to add. The existing guides are fine to go in as-is, since the new content won't go live until there's a 2.8, but until then the header routing guide is an orphan--no nav content to add it to yet.

### Reason

Related to https://github.com/Kong/kubernetes-ingress-controller/issues/3017 and https://github.com/Kong/kubernetes-ingress-controller/issues/3174

### Testing

Waiting on Netlify for formatting validation.

Partial testing of the new header annotations guide against nightly.