### PR TITLE
add docs for keys and key-sets entities

### DIFF
--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -584,6 +584,8 @@ items:
         url: /reference/nginx-directives
       - text: CLI
         url: /reference/cli
+      - text: Key management
+        url: /reference/key-management
       - text: Performance Testing Framework
         url: /reference/performance-testing-framework
       - text: Router Expressions Language

--- a/app/_redirects
+++ b/app/_redirects
@@ -621,7 +621,7 @@
 /mesh/*/features/windows/     /mesh/latest/installation/windows/
 /mesh/latest/features/windows/ /mesh/latest/installation/windows/
 /mesh/:version/policies/introduction/  /mesh/:version/policies/
-/policies/  /mesh/:version/policies/   
+/policies/  /mesh/:version/policies/
 /mesh/:version/introduction/how-kong-mesh-works/#kuma-vs-xyz  /mesh/:version/introduction/how-kong-mesh-works/#kong-mesh-vs-xyz
 /mesh/:version/introduction/what-is-kong-mesh   /mesh/:version/
 /install/:version/  /mesh/:version/install/

--- a/src/gateway/reference/key-management.md
+++ b/src/gateway/reference/key-management.md
@@ -52,8 +52,7 @@ Both formats carry the same base information, such as the public or private key 
 
 ### Create a key using the JWK format and associate it with a Key Set
 
-1. Create a Key Set:
-
+Create a Key Set:
 
 {% navtabs codeblock %}
 {% navtab cURL %}
@@ -74,19 +73,19 @@ http -f PUT :8001/key-sets \
 {% endnavtab %}
 {% endnavtabs %}
 
-  Result:
+Result:
 
-  ``` json
-  {
-    "created_at": 1669029622,
-    "id": "2033cb3d-ef3b-4f6d-8395-bc3c2d5a0e4f",
-    "name": "my-set",
-    "tags": null,
-    "updated_at": 1669029622
+``` json
+{
+  "created_at": 1669029622,
+  "id": "2033cb3d-ef3b-4f6d-8395-bc3c2d5a0e4f",
+  "name": "my-set",
+  "tags": null,
+  "updated_at": 1669029622
   }
 ```
 
-1. Create a key and associate it with the Key Set:
+Create a key and associate it with the Key Set:
 
 {% navtabs codeblock %}
 {% navtab cURL %}
@@ -97,7 +96,6 @@ curl -i -X POST http://HOSTNAME:8001/keys  \
   --data jwk='{"kty":"RSA","kid":"42","use":"enc","n":"pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w","e":"AQAB","d":"ksDmucdMJXkFGZxiomNHnroOZxe8AmDLDGO1vhs-POa5PZM7mtUPonxwjVmthmpbZzla-kg55OFfO7YcXhg-Hm2OWTKwm73_rLh3JavaHjvBqsVKuorX3V3RYkSro6HyYIzFJ1Ek7sLxbjDRcDOj4ievSX0oN9l-JZhaDYlPlci5uJsoqro_YrE0PRRWVhtGynd-_aWgQv1YzkfZuMD-hJtDi1Im2humOWxA4eZrFs9eG-whXcOvaSwO4sSGbS99ecQZHM2TcdXeAs1PvjVgQ_dKnZlGN3lTWoWfQP55Z7Tgt8Nf1q4ZAKd-NlMe-7iqCFfsnFwXjSiaOa2CRGZn-Q","p":"4A5nU4ahEww7B65yuzmGeCUUi8ikWzv1C81pSyUKvKzu8CX41hp9J6oRaLGesKImYiuVQK47FhZ--wwfpRwHvSxtNU9qXb8ewo-BvadyO1eVrIk4tNV543QlSe7pQAoJGkxCia5rfznAE3InKF4JvIlchyqs0RQ8wx7lULqwnn0","q":"ven83GM6SfrmO-TBHbjTk6JhP_3CMsIvmSdo4KrbQNvp4vHO3w1_0zJ3URkmkYGhz2tgPlfd7v1l2I6QkIh4Bumdj6FyFZEBpxjE4MpfdNVcNINvVj87cLyTRmIcaGxmfylY7QErP8GFA-k4UoH_eQmGKGK44TRzYj5hZYGWIC8","dp":"lmmU_AG5SGxBhJqb8wxfNXDPJjf__i92BgJT2Vp4pskBbr5PGoyV0HbfUQVMnw977RONEurkR6O6gxZUeCclGt4kQlGZ-m0_XSWx13v9t9DIbheAtgVJ2mQyVDvK4m7aRYlEceFh0PsX8vYDS5o1txgPwb3oXkPTtrmbAGMUBpE","dq":"mxRTU3QDyR2EnCv0Nl0TCF90oliJGAHR9HJmBe__EjuCBbwHfcT8OG3hWOv8vpzokQPRl5cQt3NckzX3fs6xlJN4Ai2Hh2zduKFVQ2p-AF2p6Yfahscjtq-GY9cB85NxLy2IXCC0PF--Sq9LOrTE9QV988SJy_yUrAjcZ5MmECk","qi":"ldHXIrEmMZVaNwGzDF9WG8sHj2mOZmQpw9yrjLK9hAsmsNr5LTyqWAqJIYZSwPTYWhY4nu2O0EY9G9uYiqewXfCKw_UngrJt8Xwfq1Zruz0YY869zPN4GiE9-9rzdZB33RBw8kIOquY3MK74FMwCihYx_LiU2YTHkaoJ3ncvtvg"}' \
   --data kid=42 \
   --data set.name=my-set
-
 ```
 
 {% endnavtab %}
@@ -109,56 +107,55 @@ http -f PUT :8001/keys \
   jwk='{"kty":"RSA","kid":"42","use":"enc","n":"pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w","e":"AQAB","d":"ksDmucdMJXkFGZxiomNHnroOZxe8AmDLDGO1vhs-POa5PZM7mtUPonxwjVmthmpbZzla-kg55OFfO7YcXhg-Hm2OWTKwm73_rLh3JavaHjvBqsVKuorX3V3RYkSro6HyYIzFJ1Ek7sLxbjDRcDOj4ievSX0oN9l-JZhaDYlPlci5uJsoqro_YrE0PRRWVhtGynd-_aWgQv1YzkfZuMD-hJtDi1Im2humOWxA4eZrFs9eG-whXcOvaSwO4sSGbS99ecQZHM2TcdXeAs1PvjVgQ_dKnZlGN3lTWoWfQP55Z7Tgt8Nf1q4ZAKd-NlMe-7iqCFfsnFwXjSiaOa2CRGZn-Q","p":"4A5nU4ahEww7B65yuzmGeCUUi8ikWzv1C81pSyUKvKzu8CX41hp9J6oRaLGesKImYiuVQK47FhZ--wwfpRwHvSxtNU9qXb8ewo-BvadyO1eVrIk4tNV543QlSe7pQAoJGkxCia5rfznAE3InKF4JvIlchyqs0RQ8wx7lULqwnn0","q":"ven83GM6SfrmO-TBHbjTk6JhP_3CMsIvmSdo4KrbQNvp4vHO3w1_0zJ3URkmkYGhz2tgPlfd7v1l2I6QkIh4Bumdj6FyFZEBpxjE4MpfdNVcNINvVj87cLyTRmIcaGxmfylY7QErP8GFA-k4UoH_eQmGKGK44TRzYj5hZYGWIC8","dp":"lmmU_AG5SGxBhJqb8wxfNXDPJjf__i92BgJT2Vp4pskBbr5PGoyV0HbfUQVMnw977RONEurkR6O6gxZUeCclGt4kQlGZ-m0_XSWx13v9t9DIbheAtgVJ2mQyVDvK4m7aRYlEceFh0PsX8vYDS5o1txgPwb3oXkPTtrmbAGMUBpE","dq":"mxRTU3QDyR2EnCv0Nl0TCF90oliJGAHR9HJmBe__EjuCBbwHfcT8OG3hWOv8vpzokQPRl5cQt3NckzX3fs6xlJN4Ai2Hh2zduKFVQ2p-AF2p6Yfahscjtq-GY9cB85NxLy2IXCC0PF--Sq9LOrTE9QV988SJy_yUrAjcZ5MmECk","qi":"ldHXIrEmMZVaNwGzDF9WG8sHj2mOZmQpw9yrjLK9hAsmsNr5LTyqWAqJIYZSwPTYWhY4nu2O0EY9G9uYiqewXfCKw_UngrJt8Xwfq1Zruz0YY869zPN4GiE9-9rzdZB33RBw8kIOquY3MK74FMwCihYx_LiU2YTHkaoJ3ncvtvg"}' \
   kid=42 \
   set.name=my-set
-
 ```
 
 {% endnavtab %}
 {% endnavtabs %}
 
-  Result:
+Result:
 
-  ```json
-  {
-          "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
-          "jwk":
-                  { kty":"RSA",
-                    "kid":"42",
-                    "use":"enc",
-                    ..."},
-          "created_at":1669029250,
-          "updated_at":1669029250,
-          "name":"my-first-jwk",
-          "tags":null,
-          "set":
-                  { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
-          "kid":"42",
-          "pem":null
+```json
+{
+  "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
+  "jwk":
+          { kty":"RSA",
+            "kid":"42",
+            "use":"enc",
+            ..."},
+  "created_at":1669029250,
+  "updated_at":1669029250,
+  "name":"my-first-jwk",
+  "tags":null,
+  "set":
+          { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
+  "kid":"42",
+  "pem":null
   }
-  ```
+```
 
 ### Create a Key using the PEM format and associate with a Key Set
 
 
-1. Create a Key Set:
+Create a Key Set:
   
-  {% navtabs codeblock %}
-  {% navtab cURL %}
+{% navtabs codeblock %}
+{% navtab cURL %}
 
-  ```bash
-  curl -i -X PUT http://HOSTNAME:8001/key-sets  \
-    --data name=my-other-set \
-  ```
+```bash
+curl -i -X PUT http://HOSTNAME:8001/key-sets  \
+  --data name=my-other-set \
+```
 
-  {% endnavtab %}
-  {% navtab HTTPie %}
+{% endnavtab %}
+{% navtab HTTPie %}
 
-  ```bash
-  http -f PUT :8001/key-sets \
-    name=my-other-set \
-  ```
+```bash
+http -f PUT :8001/key-sets \
+  name=my-other-set \
+```
 
-  {% endnavtab %}
-  {% endnavtabs %}
+{% endnavtab %}
+{% endnavtabs %}
 
 Result:
 
@@ -169,10 +166,10 @@ Result:
   "name": "my-other-set",
   "tags": null,
   "updated_at": 1669029622
-}
+  }
 ```
 
-1. Create a PEM-encoded key and associate it with the Key Set:
+Create a PEM-encoded key and associate it with the Key Set:
 
 {% navtabs codeblock %}
 {% navtab cURL %}
@@ -184,7 +181,6 @@ curl -i -X POST http://HOSTNAME:8001/keys  \
   --data pem.public_key=@path/to/public_key.pem
   --data kid=23 \
   --data set.name=my-other-set
-
 ```
 
 {% endnavtab %}
@@ -203,22 +199,22 @@ http -f PUT :8001/keys \
 {% endnavtab %}
 {% endnavtabs %}
 
-  Result:
+Result:
 
-  ```json
-  {
-          "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
-          "jwk": null
-          "pem": {
-                  "public_key": "----BEGIN...",
-                  "private_key": "----BEGIN...."
-          }
-          "created_at":1669029250,
-          "updated_at":1669029250,
-          "name":"my-first-pem-key",
-          "tags":null,
-          "set":
-                  { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
-          "kid":"23",
+```json
+{
+  "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
+  "jwk": null
+  "pem": {
+          "public_key": "----BEGIN...",
+          "private_key": "----BEGIN...."
   }
-  ```
+  "created_at":1669029250,
+  "updated_at":1669029250,
+  "name":"my-first-pem-key",
+  "tags":null,
+  "set":
+          { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
+  "kid":"23",
+  }
+```

--- a/src/gateway/reference/key-management.md
+++ b/src/gateway/reference/key-management.md
@@ -1,9 +1,8 @@
 ---
 title: Key and Key Set Management in Kong Gateway
 content_type: reference
+badge: free
 ---
-
-Note that this is an OSS feature.
 
 
 This page describes {{site.base_gateway}}'s capabilities to manage asymmetric keys and key-sets in {{site.base_gateway}}.

--- a/src/gateway/reference/key-management.md
+++ b/src/gateway/reference/key-management.md
@@ -1,0 +1,229 @@
+---
+title: Key and Key Set Management in Kong Gateway
+content_type: reference
+---
+
+Note that this is an OSS feature.
+
+
+This page describes Kong Gateway's capabilities to manage asymmetric keys and key-sets in {{site.base_gateway}}.
+
+
+### Keys and Key Sets
+
+For some operations it is required to have access to public and/or private keys. This document describes how to achieve that with Kong Gateway.
+
+
+### Use cases
+
+Some Kong plugins offer a custom endpoint to configure JSON Web Keys today. This new endpoint aims to replace the custom endpoints for each plugin with this, a more generic endpoint. Affected plugins will gradually receive supported. TODO: table below where all plugins that _could_ use this feature and whether they already have support for it.
+
+
+| plugin name    | keys/key-sets support |
+|----------------|-----------------------|
+| openid-connect | no                    |
+| jwt-signer     | no                    |
+| jwt            | no                    |
+| jwe-decrypt    | yes                   |
+
+### Keys
+
+The generic `Keys` endpoint allows you to store asymmetric keys (public and or private key, note that also only a public key or only a private key can be stored) in different formats (ref to Formats section maybe?). A freely configurable `kid` string is required to identify the key. The `kid` attribute is a common way to identify the key that should be used to verify or decrypt a token in the JWT world but could be used in other scenarios where identifying a key is required.
+
+
+### Key Sets
+
+You can assign one or many keys to a key-set. This can be useful to logically group multiple keys. (A group of keys used for a specific application or service). Key-sets are also the preferred way to expose keys to plugins. (meaning; telling plugins where to look for keys -or- have a scoping mechanism to restrict plugins to just _some_ keys.). You will find instructions in the respective plugins docs on how to configure them using a key-set.
+Note: Deleting a Key-set will remove all associated keys.
+
+
+### Formats
+
+Currently there is support for two common formats
+
+* JWK
+* PEM
+
+Note that the formats carry the same base information (public and/or private key exponents) but may allow to specify additional meta information. (JWK carries more information than PEM/DER). This means that one keypair can have multiple different representations (JWK, PEM) while being the same key.
+
+
+### Examples
+
+
+#### Create a Key using the JWK format and associate it with a Key Set.
+
+TODO: Also add a reference to a the admin api for keys/keysets
+
+First create a Key-set
+
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X PUT http://HOSTNAME:8001/key-sets  \
+  --data name=my-set \
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http -f PUT :8001/key-sets \
+  name=my-set \
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+``` json
+{
+  "created_at": 1669029622,
+  "id": "2033cb3d-ef3b-4f6d-8395-bc3c2d5a0e4f",
+  "name": "my-set",
+  "tags": null,
+  "updated_at": 1669029622
+}
+```
+
+
+Now create a Key and associate it with the just created set.
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X POST http://HOSTNAME:8001/keys  \
+  --data name=my-first-jwk \
+  --data jwk='{"kty":"RSA","kid":"42","use":"enc","n":"pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w","e":"AQAB","d":"ksDmucdMJXkFGZxiomNHnroOZxe8AmDLDGO1vhs-POa5PZM7mtUPonxwjVmthmpbZzla-kg55OFfO7YcXhg-Hm2OWTKwm73_rLh3JavaHjvBqsVKuorX3V3RYkSro6HyYIzFJ1Ek7sLxbjDRcDOj4ievSX0oN9l-JZhaDYlPlci5uJsoqro_YrE0PRRWVhtGynd-_aWgQv1YzkfZuMD-hJtDi1Im2humOWxA4eZrFs9eG-whXcOvaSwO4sSGbS99ecQZHM2TcdXeAs1PvjVgQ_dKnZlGN3lTWoWfQP55Z7Tgt8Nf1q4ZAKd-NlMe-7iqCFfsnFwXjSiaOa2CRGZn-Q","p":"4A5nU4ahEww7B65yuzmGeCUUi8ikWzv1C81pSyUKvKzu8CX41hp9J6oRaLGesKImYiuVQK47FhZ--wwfpRwHvSxtNU9qXb8ewo-BvadyO1eVrIk4tNV543QlSe7pQAoJGkxCia5rfznAE3InKF4JvIlchyqs0RQ8wx7lULqwnn0","q":"ven83GM6SfrmO-TBHbjTk6JhP_3CMsIvmSdo4KrbQNvp4vHO3w1_0zJ3URkmkYGhz2tgPlfd7v1l2I6QkIh4Bumdj6FyFZEBpxjE4MpfdNVcNINvVj87cLyTRmIcaGxmfylY7QErP8GFA-k4UoH_eQmGKGK44TRzYj5hZYGWIC8","dp":"lmmU_AG5SGxBhJqb8wxfNXDPJjf__i92BgJT2Vp4pskBbr5PGoyV0HbfUQVMnw977RONEurkR6O6gxZUeCclGt4kQlGZ-m0_XSWx13v9t9DIbheAtgVJ2mQyVDvK4m7aRYlEceFh0PsX8vYDS5o1txgPwb3oXkPTtrmbAGMUBpE","dq":"mxRTU3QDyR2EnCv0Nl0TCF90oliJGAHR9HJmBe__EjuCBbwHfcT8OG3hWOv8vpzokQPRl5cQt3NckzX3fs6xlJN4Ai2Hh2zduKFVQ2p-AF2p6Yfahscjtq-GY9cB85NxLy2IXCC0PF--Sq9LOrTE9QV988SJy_yUrAjcZ5MmECk","qi":"ldHXIrEmMZVaNwGzDF9WG8sHj2mOZmQpw9yrjLK9hAsmsNr5LTyqWAqJIYZSwPTYWhY4nu2O0EY9G9uYiqewXfCKw_UngrJt8Xwfq1Zruz0YY869zPN4GiE9-9rzdZB33RBw8kIOquY3MK74FMwCihYx_LiU2YTHkaoJ3ncvtvg"}' \
+  --data kid=42 \
+  --data set.name=my-set
+
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http -f PUT :8001/keys \
+  name=my-first-jwk \
+  jwk='{"kty":"RSA","kid":"42","use":"enc","n":"pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w","e":"AQAB","d":"ksDmucdMJXkFGZxiomNHnroOZxe8AmDLDGO1vhs-POa5PZM7mtUPonxwjVmthmpbZzla-kg55OFfO7YcXhg-Hm2OWTKwm73_rLh3JavaHjvBqsVKuorX3V3RYkSro6HyYIzFJ1Ek7sLxbjDRcDOj4ievSX0oN9l-JZhaDYlPlci5uJsoqro_YrE0PRRWVhtGynd-_aWgQv1YzkfZuMD-hJtDi1Im2humOWxA4eZrFs9eG-whXcOvaSwO4sSGbS99ecQZHM2TcdXeAs1PvjVgQ_dKnZlGN3lTWoWfQP55Z7Tgt8Nf1q4ZAKd-NlMe-7iqCFfsnFwXjSiaOa2CRGZn-Q","p":"4A5nU4ahEww7B65yuzmGeCUUi8ikWzv1C81pSyUKvKzu8CX41hp9J6oRaLGesKImYiuVQK47FhZ--wwfpRwHvSxtNU9qXb8ewo-BvadyO1eVrIk4tNV543QlSe7pQAoJGkxCia5rfznAE3InKF4JvIlchyqs0RQ8wx7lULqwnn0","q":"ven83GM6SfrmO-TBHbjTk6JhP_3CMsIvmSdo4KrbQNvp4vHO3w1_0zJ3URkmkYGhz2tgPlfd7v1l2I6QkIh4Bumdj6FyFZEBpxjE4MpfdNVcNINvVj87cLyTRmIcaGxmfylY7QErP8GFA-k4UoH_eQmGKGK44TRzYj5hZYGWIC8","dp":"lmmU_AG5SGxBhJqb8wxfNXDPJjf__i92BgJT2Vp4pskBbr5PGoyV0HbfUQVMnw977RONEurkR6O6gxZUeCclGt4kQlGZ-m0_XSWx13v9t9DIbheAtgVJ2mQyVDvK4m7aRYlEceFh0PsX8vYDS5o1txgPwb3oXkPTtrmbAGMUBpE","dq":"mxRTU3QDyR2EnCv0Nl0TCF90oliJGAHR9HJmBe__EjuCBbwHfcT8OG3hWOv8vpzokQPRl5cQt3NckzX3fs6xlJN4Ai2Hh2zduKFVQ2p-AF2p6Yfahscjtq-GY9cB85NxLy2IXCC0PF--Sq9LOrTE9QV988SJy_yUrAjcZ5MmECk","qi":"ldHXIrEmMZVaNwGzDF9WG8sHj2mOZmQpw9yrjLK9hAsmsNr5LTyqWAqJIYZSwPTYWhY4nu2O0EY9G9uYiqewXfCKw_UngrJt8Xwfq1Zruz0YY869zPN4GiE9-9rzdZB33RBw8kIOquY3MK74FMwCihYx_LiU2YTHkaoJ3ncvtvg"}' \
+  kid=42 \
+  set.name=my-set
+
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+```json
+{
+        "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
+        "jwk":
+                { kty":"RSA",
+                  "kid":"42",
+                  "use":"enc",
+                  ..."},
+        "created_at":1669029250,
+        "updated_at":1669029250,
+        "name":"my-first-jwk",
+        "tags":null,
+        "set":
+                { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
+        "kid":"42",
+        "pem":null
+}
+```
+
+#### Create a Key using PEM format and associate with key-set
+
+
+Create a Key-Set first.
+
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X PUT http://HOSTNAME:8001/key-sets  \
+  --data name=my-other-set \
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http -f PUT :8001/key-sets \
+  name=my-other-set \
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+``` json
+{
+  "created_at": 1669029622,
+  "id": "2033cb3d-ef3b-4f6d-8395-bc3c2d5a0e4f",
+  "name": "my-other-set",
+  "tags": null,
+  "updated_at": 1669029622
+}
+```
+
+
+Now create a PEM encoded key and associate it with the just created set.
+
+{% navtabs codeblock %}
+{% navtab cURL %}
+
+```bash
+curl -i -X POST http://HOSTNAME:8001/keys  \
+  --data name=my-first-pem-key \
+  --data pem.private_key=@path/to/private_key.pem
+  --data pem.public_key=@path/to/public_key.pem
+  --data kid=23 \
+  --data set.name=my-other-set
+
+```
+
+{% endnavtab %}
+{% navtab HTTPie %}
+
+```bash
+http -f PUT :8001/keys \
+  name=my-first-jwk \
+  kid=23 \
+  set.name=my-other-set \
+  pem.private_key=@path/to/private_key.pem \
+  pem.public_key=@path/to/public_key.pem \
+  -f
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Result:
+
+```json
+{
+        "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
+        "jwk": null
+        "pem": {
+                "public_key": "----BEGIN...",
+                "private_key": "----BEGIN...."
+        }
+        "created_at":1669029250,
+        "updated_at":1669029250,
+        "name":"my-first-pem-key",
+        "tags":null,
+        "set":
+                { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
+        "kid":"23",
+}
+```

--- a/src/gateway/reference/key-management.md
+++ b/src/gateway/reference/key-management.md
@@ -6,55 +6,54 @@ content_type: reference
 Note that this is an OSS feature.
 
 
-This page describes Kong Gateway's capabilities to manage asymmetric keys and key-sets in {{site.base_gateway}}.
+This page describes {{site.base_gateway}}'s capabilities to manage asymmetric keys and key-sets in {{site.base_gateway}}.
 
-
-### Keys and Key Sets
-
-For some operations it is required to have access to public and/or private keys. This document describes how to achieve that with Kong Gateway.
+For some operations, access to public and private keys is required. This document also describes how to grant access to those keys using {{site.base_gateway}}.
 
 
 ### Use cases
 
-Some Kong plugins offer a custom endpoint to configure JSON Web Keys today. This new endpoint aims to replace the custom endpoints for each plugin with this, a more generic endpoint. Affected plugins will gradually receive supported. TODO: table below where all plugins that _could_ use this feature and whether they already have support for it.
+Some {{site.base_gateway}} plugins offer a custom endpoint to configure JSON Web Keys. The new generic endpoint replaces the custom endpoints for each plugin. The following table lists the plugins that support the new endpoint:  
 
 
-| plugin name    | keys/key-sets support |
-|----------------|-----------------------|
-| openid-connect | no                    |
-| jwt-signer     | no                    |
-| jwt            | no                    |
-| jwe-decrypt    | yes                   |
+| Plugin                                         | Keys/Key Sets supported |
+| ---------------------------------------------- | --------------------- |
+| [OpenID Connect](/hub/kong-inc/openid-connect) | No                    |
+| [JWT Signer](/hub/kong-inc/jwt-signer)         | No                    |
+| [JWT](/hub/kong-inc/jwt)                       | No                    |
+| [JWE Decrypt](/hub/kong-inc/jwe-decrypt)       | Yes                   |
 
-### Keys
+### Keys endpoint
 
-The generic `Keys` endpoint allows you to store asymmetric keys (public and or private key, note that also only a public key or only a private key can be stored) in different formats (ref to Formats section maybe?). A freely configurable `kid` string is required to identify the key. The `kid` attribute is a common way to identify the key that should be used to verify or decrypt a token in the JWT world but could be used in other scenarios where identifying a key is required.
-
-
-### Key Sets
-
-You can assign one or many keys to a key-set. This can be useful to logically group multiple keys. (A group of keys used for a specific application or service). Key-sets are also the preferred way to expose keys to plugins. (meaning; telling plugins where to look for keys -or- have a scoping mechanism to restrict plugins to just _some_ keys.). You will find instructions in the respective plugins docs on how to configure them using a key-set.
-Note: Deleting a Key-set will remove all associated keys.
+The generic `Keys` endpoint allows you to store asymmetric keys, either a public or private key, as a JWK or PEM. A configurable `kid` string is required to identify the key. The `kid` attribute is a common way to identify the key that should be used to verify or decrypt a token, but it can be used in other scenarios when you must identify a key.
 
 
-### Formats
+### Key Sets endpoint
 
-Currently there is support for two common formats
+You can assign one or many keys to a JSON Web Key Set. This can be useful to logically group multiple keys to use for a specific application or service. Key Sets are also the preferred way to expose keys to plugins because they tell the plugin where to look for keys or have a scoping mechanism to restrict plugins to just _some_ keys.
+
+See the following plugins documentation for more information about how to configure them using a Key Set:
+* [OpenID Connect](/hub/kong-inc/openid-connect)
+* [JWT Signer](/hub/kong-inc/jwt-signer)
+* [JWT](/hub/kong-inc/jwt)                       
+* [JWE Decrypt](/hub/kong-inc/jwe-decrypt)
+
+{:.note}
+> **Note:** Deleting a Key Set will remove all associated keys.
+
+
+### Key formats
+
+Currently two common formats are supported:
 
 * JWK
 * PEM
 
-Note that the formats carry the same base information (public and/or private key exponents) but may allow to specify additional meta information. (JWK carries more information than PEM/DER). This means that one keypair can have multiple different representations (JWK, PEM) while being the same key.
+Both formats carry the same base information, such as the public or private key exponents, but may allow you to specify additional meta information. For example, the JWK format carries more information than PEM. This means that one key pair can have multiple different representations (JWK or PEM) while being the same key.
 
+### Create a key using the JWK format and associate it with a Key Set
 
-### Examples
-
-
-#### Create a Key using the JWK format and associate it with a Key Set.
-
-TODO: Also add a reference to a the admin api for keys/keysets
-
-First create a Key-set
+1. Create a Key Set:
 
 
 {% navtabs codeblock %}
@@ -76,20 +75,19 @@ http -f PUT :8001/key-sets \
 {% endnavtab %}
 {% endnavtabs %}
 
-Result:
+  Result:
 
-``` json
-{
-  "created_at": 1669029622,
-  "id": "2033cb3d-ef3b-4f6d-8395-bc3c2d5a0e4f",
-  "name": "my-set",
-  "tags": null,
-  "updated_at": 1669029622
-}
+  ``` json
+  {
+    "created_at": 1669029622,
+    "id": "2033cb3d-ef3b-4f6d-8395-bc3c2d5a0e4f",
+    "name": "my-set",
+    "tags": null,
+    "updated_at": 1669029622
+  }
 ```
 
-
-Now create a Key and associate it with the just created set.
+1. Create a key and associate it with the Key Set:
 
 {% navtabs codeblock %}
 {% navtab cURL %}
@@ -118,51 +116,50 @@ http -f PUT :8001/keys \
 {% endnavtab %}
 {% endnavtabs %}
 
-Result:
+  Result:
 
-```json
-{
-        "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
-        "jwk":
-                { kty":"RSA",
-                  "kid":"42",
-                  "use":"enc",
-                  ..."},
-        "created_at":1669029250,
-        "updated_at":1669029250,
-        "name":"my-first-jwk",
-        "tags":null,
-        "set":
-                { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
-        "kid":"42",
-        "pem":null
-}
-```
+  ```json
+  {
+          "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
+          "jwk":
+                  { kty":"RSA",
+                    "kid":"42",
+                    "use":"enc",
+                    ..."},
+          "created_at":1669029250,
+          "updated_at":1669029250,
+          "name":"my-first-jwk",
+          "tags":null,
+          "set":
+                  { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
+          "kid":"42",
+          "pem":null
+  }
+  ```
 
-#### Create a Key using PEM format and associate with key-set
-
-
-Create a Key-Set first.
+### Create a Key using the PEM format and associate with a Key Set
 
 
-{% navtabs codeblock %}
-{% navtab cURL %}
+1. Create a Key Set:
+  
+  {% navtabs codeblock %}
+  {% navtab cURL %}
 
-```bash
-curl -i -X PUT http://HOSTNAME:8001/key-sets  \
-  --data name=my-other-set \
-```
+  ```bash
+  curl -i -X PUT http://HOSTNAME:8001/key-sets  \
+    --data name=my-other-set \
+  ```
 
-{% endnavtab %}
-{% navtab HTTPie %}
+  {% endnavtab %}
+  {% navtab HTTPie %}
 
-```bash
-http -f PUT :8001/key-sets \
-  name=my-other-set \
-```
+  ```bash
+  http -f PUT :8001/key-sets \
+    name=my-other-set \
+  ```
 
-{% endnavtab %}
-{% endnavtabs %}
+  {% endnavtab %}
+  {% endnavtabs %}
 
 Result:
 
@@ -176,8 +173,7 @@ Result:
 }
 ```
 
-
-Now create a PEM encoded key and associate it with the just created set.
+1. Create a PEM-encoded key and associate it with the Key Set:
 
 {% navtabs codeblock %}
 {% navtab cURL %}
@@ -208,22 +204,22 @@ http -f PUT :8001/keys \
 {% endnavtab %}
 {% endnavtabs %}
 
-Result:
+  Result:
 
-```json
-{
-        "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
-        "jwk": null
-        "pem": {
-                "public_key": "----BEGIN...",
-                "private_key": "----BEGIN...."
-        }
-        "created_at":1669029250,
-        "updated_at":1669029250,
-        "name":"my-first-pem-key",
-        "tags":null,
-        "set":
-                { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
-        "kid":"23",
-}
-```
+  ```json
+  {
+          "id":"92a245af-8cb6-4175-b3a9-9383cbb9848f",
+          "jwk": null
+          "pem": {
+                  "public_key": "----BEGIN...",
+                  "private_key": "----BEGIN...."
+          }
+          "created_at":1669029250,
+          "updated_at":1669029250,
+          "name":"my-first-pem-key",
+          "tags":null,
+          "set":
+                  { "id":"cb5b5df8-0161-4fdf-a2ce-cefc9481d5f9"},
+          "kid":"23",
+  }
+  ```


### PR DESCRIPTION
### Summary

Add a new reference for `key-management` that describes how `keys` and `key-sets` are used alongside examples.

This is an OSS feature.

### Reason

https://konghq.atlassian.net/browse/DOCU-2786


Things to do before merging:

- [x] the "Reference" section doesn't feel suited. It _is_ a core entity but not as frequently used as routes/services etc. It's probably somewhere alongside "Certificates".
- [x] There is a lot of unformatted/unformulated text in the PR. This needs to be adapted to the style of writing used across this document
- [x] Missing links and references to other sections