### PR TITLE
Fix HCV mount name in Result object

### DIFF
--- a/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
+++ b/app/gateway/2.8.x/plan-and-deploy/security/secrets-management/backends/hashicorp-vault.md
@@ -70,7 +70,7 @@ Result:
     "config": {
         "host": "localhost",
         "kv": "v2",
-        "mount": "vault",
+        "mount": "secret",
         "port": 8200,
         "protocol": "https",
         "token": "<mytoken>"

--- a/src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -68,7 +68,7 @@ Result:
     "config": {
         "host": "localhost",
         "kv": "v2",
-        "mount": "vault",
+        "mount": "secret",
         "port": 8200,
         "protocol": "https",
         "token": "<mytoken>"


### PR DESCRIPTION
### Summary

Fixing HCV Vault `mount` name in the Response object to be consistent with the name in the Request object

