### PR TITLE
Update plugin versions and compatibility table

### DIFF
--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -109,7 +109,7 @@
       network_config_opts: All
       notes: --
       url: /hub/kong-inc/openid-connect
-    
+
     - name: SAML
       free: no
       plus: Yes
@@ -203,14 +203,6 @@
       network_config_opts: All
       notes: --
       url: /hub/kong-inc/acl
-    
-    - name: AppDynamics
-      free: no
-      plus: no
-      enterprise: Yes
-      network_config_opts: All
-      notes: --
-      url: /hub/kong-inc/app-dynamics
 
     - name: Canary
       free: No
@@ -245,6 +237,22 @@
         In DB-less and hybrid modes, the <code>cluster</code> config strategy
         is not supported. Use <code>redis</code> instead.
       url: /hub/kong-inc/graphql-rate-limiting-advanced
+
+    - name: Mocking
+      free: No
+      plus: Yes
+      enterprise: Yes
+      network_config_opts: All
+      notes: --
+      url: /hub/kong-inc/mocking
+
+    - name: OAS Validation
+      free: No
+      plus: Yes
+      enterprise: Yes
+      network_config_opts: All
+      notes: --
+      url: /hub/kong-inc/oas-validation/
 
     - name: Proxy Caching
       free: Yes
@@ -356,13 +364,14 @@
       notes: --
       url: /hub/kong-inc/websocket-validator
 
-    - name: Mocking
+    - name: XML Threat Protection
       free: No
-      plus: Yes
+      plus: No
       enterprise: Yes
       network_config_opts: All
       notes: --
-      url: /hub/kong-inc/mocking
+      url: /hub/kong-inc/xml-threat-protection/
+
 
 - category:
   name: Serverless
@@ -405,6 +414,14 @@
 - category:
   name: Analytics and Monitoring
   plugins:
+    - name: AppDynamics
+      free: No
+      plus: No
+      enterprise: Yes
+      network_config_opts: All
+      notes: --
+      url: /hub/kong-inc/app-dynamics
+
     - name: Datadog
       free: Yes
       plus: Yes

--- a/app/_hub/kong-inc/app-dynamics/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/_index.md
@@ -12,7 +12,7 @@ description: |
   The plugin utilizes the
   [AppDynamics C/C++ Application Agent and SDK](https://docs.appdynamics.com/pages/viewpage.action?pageId=42583435),
   which must be downloaded and installed on the machine or within the
-  container running {{site.base_gateway}}. Please refer to the
+  container running Kong Gateway. Refer to the
   [AppDynamics SDK documentation](https://docs.appdynamics.com/) for platform support information.
 enterprise: true
 type: plugin
@@ -50,8 +50,8 @@ Alternatively, the `LD_LIBRARY_PATH` environment variable can be set
 to the directory containing the `libappdynamics.so` file when
 starting {{site.base_gateway}}.
 
-If the AppDymanics plugin is enabled but the `libappdynamics.so` file cannot be loaded, {{site.base_gateway}} will refuse to start. 
-You will receive an error message like this: 
+If the AppDymanics plugin is enabled but the `libappdynamics.so` file cannot be loaded, {{site.base_gateway}} will refuse to start.
+You will receive an error message like this:
 
 ```
 kong/plugins/app-dynamics/appdynamics.lua:74: libappdynamics.so: cannot open shared object file: No such file or directory
@@ -61,14 +61,13 @@ kong/plugins/app-dynamics/appdynamics.lua:74: libappdynamics.so: cannot open sha
 
 The AppDynamics plugin is configured through environment variables
 that need to be set when {{site.base_gateway}} is started. The environment
-variables used by the plugin are shown in the table below. Note that
-if an environment variable listed in the table does not have a `default` value, the value must be set, or the plugin may not operate correctly.
+variables used by the plugin are shown in the table below.
 
 {:.note}
-> if an environment variable listed in the table does not have a `default` value, you must set the value for that variable, or the plugin may not operate correctly.
+> If an environment variable listed in the table does not have a `default` value, you must set the value for that variable, or the plugin may not operate correctly.
 
 The AppDynamics plugin makes use of the AppDynamics C/C++ SDK to send
-information to the AppDynamics controller. Please refer to the
+information to the AppDynamics controller. Refer to the
 [AppDynamics C/C++ SDK documentation](https://docs.appdynamics.com/appd/21.x/21.12/en/application-monitoring/install-app-server-agents/c-c++-sdk/use-the-c-c++-sdk)
 for more information about the configuration parameters.
 
@@ -95,7 +94,7 @@ for more information about the configuration parameters.
 #### Possible values for the `KONG_APPD_LOGGING_LEVEL` parameter
 
 The `KONG_APPD_LOGGING_LEVEL` environment variable is a numeric value that controls the desired logging level.
-Each value corresponds to a specific level: 
+Each value corresponds to a specific level:
 
 | Value | Name | Description |
 |--|--|--|

--- a/app/_hub/kong-inc/app-dynamics/versions.yml
+++ b/app/_hub/kong-inc/app-dynamics/versions.yml
@@ -1,4 +1,4 @@
 strategy: gateway
 
 releases:
-  - 3.1.x
+  minimum_version: '3.1.x'

--- a/app/_hub/kong-inc/oas-validation/versions.yml
+++ b/app/_hub/kong-inc/oas-validation/versions.yml
@@ -1,4 +1,4 @@
 strategy: gateway
 
 releases:
-  - 3.1.x
+  minimum_version: '3.1.x'

--- a/app/_hub/kong-inc/saml/versions.yml
+++ b/app/_hub/kong-inc/saml/versions.yml
@@ -1,4 +1,4 @@
 strategy: gateway
 
 releases:
-  - 3.1.x
+  minimum_version: '3.1.x'

--- a/app/_hub/kong-inc/xml-threat-protection/versions.yml
+++ b/app/_hub/kong-inc/xml-threat-protection/versions.yml
@@ -1,4 +1,4 @@
 strategy: gateway
 
 releases:
-  - 3.1.x
+  minimum_version: '3.1.x'


### PR DESCRIPTION
### Summary
* Following the changes made in https://github.com/Kong/docs.konghq.com/pull/4810, setting the `minimum_version` for plugins introduced in 3.1.x
* Adding OAS validation and XML threat protection plugins to compatibility table
  * Minor fixes to table: moving Mocking plugin up for alphabetical order, and moving AppDynamics from the Traffic category to the Analytics and Monitoring category
* Minor edits to AppDynamics plugin: 
  * Variables can't be used in plugin doc front matter (yaml section)
  * Duplicate note
  * Removed some "please"s

### Reason
See above.

### Testing
Netlify.