### PR TITLE
Update KongVersions to fetch the file relative to the site's source

### DIFF
--- a/app/_plugins/generators/plugin_single_source/kong_versions.rb
+++ b/app/_plugins/generators/plugin_single_source/kong_versions.rb
@@ -4,12 +4,18 @@ module PluginSingleSource
   class KongVersions
     GATEWAY_VERSIONS = %w[gateway gateway-oss enterprise].freeze
 
-    def self.gateway
-      new.gateway
+    def self.gateway(site)
+      new(site).gateway
     end
 
     def self.to_semver(version)
       version.gsub('-x', '.x').gsub(/\.x/, '.0')
+    end
+
+    attr_reader :site
+
+    def initialize(site)
+      @site = site
     end
 
     def gateway
@@ -20,7 +26,9 @@ module PluginSingleSource
     end
 
     def versions
-      @versions ||= SafeYAML.load(File.read('app/_data/kong_versions.yml'))
+      @versions ||= SafeYAML.load(
+        File.read(File.join(site.source, '_data/kong_versions.yml'))
+      )
     end
   end
 end

--- a/app/_plugins/generators/plugin_single_source/plugin/versioned.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/versioned.rb
@@ -41,7 +41,7 @@ module PluginSingleSource
         raise ArgumentError, '`releases` must have a `minimum_version` version set' unless min
 
         KongVersions
-          .gateway
+          .gateway(site)
           .select { |v| Gem::Version.new(v) >= Gem::Version.new(min) }
           .select { |v| max.nil? || Gem::Version.new(v) <= Gem::Version.new(max) }
       end

--- a/spec/app/_plugins/generators/plugin_single_source/kong_versions_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/kong_versions_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe PluginSingleSource::KongVersions do
       allow(File).to receive(:read).and_call_original
       allow(File)
         .to receive(:read)
-        .with('app/_data/kong_versions.yml')
+        .with(File.join(site.source, '_data/kong_versions.yml'))
         .and_return(yaml)
     end
 
     it 'returns the `release` for each gateway version and replaces `-x` with `x`' do
-      expect(described_class.gateway).to match_array(['2.1.x', '2.1.0.x', '2.2.x', '3.0.x'])
+      expect(described_class.gateway(site)).to match_array(['2.1.x', '2.1.0.x', '2.2.x', '3.0.x'])
     end
   end
 


### PR DESCRIPTION
### Summary
Update KongVersions to fetch the file relative to the site's source
It was making the specs fail because it was using the file under app/_data instead of the fixtures.

Fixes https://github.com/Kong/docs.konghq.com/pull/4814

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
