### PR TITLE
Clarify minimum_version in plugin template [skip ci]

### DIFF
--- a/app/_hub/_init/my-extension/versions.yml
+++ b/app/_hub/_init/my-extension/versions.yml
@@ -5,3 +5,5 @@ strategy: gateway
 
 releases:
   minimum_version: 3.0.x
+  # Set the version that your plugin is introduced in. This will generate a doc
+  # for every subsequent gateway version, starting with the one you specify.


### PR DESCRIPTION
### Summary
Adding a comment to describe `minimum_version`.

### Reason
To avoid confusion from plugin authors.

### Testing
N/A; attempting to skip netlify.