### PR TITLE
Add links to content templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All pull requests for these docs should be opened in the [Kong/kong](https://git
 
 For [Gateway Enterprise configuration reference](https://docs.konghq.com/gateway/latest/reference/configuration), open an issue on this repo and we'll update the docs.
 
-* **Community is a priority for us**. Before submitting an issue or pull request, make sure to review our [Contributing Guide](https://docs.konghq.com/contributing/).
+* **Community is a priority for us**. Before submitting an issue or pull request, make sure to review our [Contributing Guide](https://docs.konghq.com/contributing/) and our [documentation templates](https://github.com/Kong/docs.konghq.com/tree/main/docs/templates).
 
 * We are currently accepting plugin submissions to our plugin hub from trusted technical partners, on a limited basis. For more information, see the [Kong Partners page](https://konghq.com/partners/).
 

--- a/app/contributing/index.md
+++ b/app/contributing/index.md
@@ -45,6 +45,7 @@ Before you change anything except for typos or grammatical errors, explore these
 * Our set of [markdown rules](/contributing/markdown-rules) for making your content work with our Jekyll implementation. Specifies how you must
 work with certain kinds of content - includes, variables, new pages.
 * Our [list of Kong-specific terms](/contributing/terms). Includes product names and other terms the Kong docs use in specific ways.
+* Our [documentation templates](https://github.com/Kong/docs.konghq.com/tree/main/docs/templates). You can use these templates to create new documentation pages. 
 
 ### Build locally
 

--- a/app/contributing/index.md
+++ b/app/contributing/index.md
@@ -4,6 +4,8 @@ no_version: true
 layout: 'docs-v2'
 ---
 
+<!-- vale off -->
+
 Hello, and welcome! Thanks for thinking about contributing to the Kong documentation.
 
 This section of the docs is here to help you help us, so read on to learn how to ask questions and help effectively.

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -56,6 +56,17 @@ All files in `src` are formatted with Prettier. Prose in `app` has not been bulk
   - **Important:** Information that the reader really needs to pay attention to, otherwise things won't work.
 For more information about formatting admonitions see [markdown-rules](/contributing/markdown-rules/#admonitions).
 
+## Content types
+
+At Kong, we use the four following standard content types when we write our documentation:
+
+- [Explanation](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/explanation-template.md): Documentation that is understanding-oriented because it clarifies and discuss a particular topic.
+- [How-to](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/how-to-template.md): Documentation that is goal-oriented and prescriptive that takes readers through the steps to complete a real-world problem.
+- [Reference](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/reference-template.md): Documentation that explains the technology, like API or command line documentation.
+- [Tutorial](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/tutorial-template.md): Documentation that help users learn about a topic by going step-by-step through a series of tasks.
+
+Every documentation page should fit one of these four content types.
+
 ## Punctuation rules
 
 - Commas and periods always go inside quotation marks, and colons and semicolons (dashes as well) go outside.

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -60,10 +60,10 @@ For more information about formatting admonitions see [markdown-rules](/contribu
 
 At Kong, we use the four following standard content types when we write our documentation:
 
-- [Explanation](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/explanation-template.md): Documentation that is understanding-oriented because it clarifies and discuss a particular topic.
-- [How-to](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/how-to-template.md): Documentation that is goal-oriented and prescriptive that takes readers through the steps to complete a real-world problem.
+- [Explanation](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/explanation-template.md): Documentation that is understanding-oriented because it clarifies and discusses a particular topic.
+- [How-to](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/how-to-template.md): Documentation that is goal-oriented and prescriptive and that takes readers through the steps to complete a real-world problem.
 - [Reference](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/reference-template.md): Documentation that explains the technology, like API or command line documentation.
-- [Tutorial](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/tutorial-template.md): Documentation that help users learn about a topic by going step-by-step through a series of tasks.
+- [Tutorial](https://github.com/Kong/docs.konghq.com/blob/main/docs/templates/tutorial-template.md): Documentation that helps users learn about a topic by going step-by-step through a series of tasks.
 
 Every documentation page should fit one of these four content types.
 


### PR DESCRIPTION
Signed-off-by: Diana <75819066+cloudjumpercat@users.noreply.github.com>

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Added links to the new content templates in various contributing guides for docs.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Added links so that it's easier to locate our templates for contributors.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
TBD
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
