### PR TITLE
(docs)mesh remove operator feature

### DIFF
--- a/app/_data/tables/features/mesh.yml
+++ b/app/_data/tables/features/mesh.yml
@@ -102,11 +102,6 @@ features:
       - name: Containers, Kubernetes & OpenShift
         kuma: true
         mesh: true
-      - name: Kubernetes Operator
-        tooltip: |
-          Allows you to simplify the operational cost of running Kong Mesh on Kubernetes by providing a native Kubernetes operator to fully manage the deployment, upgrades, and roll outs of a cluster on Kubernetes.
-        kuma: false
-        mesh: true
       - name: Virtual Machine Support
         kuma: true
         mesh: true


### PR DESCRIPTION
### Summary
Removes the 'operator' feature in the mesh overview

### Reason
Bug / incorrect information

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
