### PR TITLE
Fix link to key management page on JWE Decrypt plugin

### DIFF
--- a/app/_hub/kong-inc/jwe-decrypt/_index.md
+++ b/app/_hub/kong-inc/jwe-decrypt/_index.md
@@ -55,7 +55,7 @@ params:
 
 ## Manage keys and Key Sets
 
-For more information, see [Key and Key Set Management in Kong Gateway](/gateway/{{page.kong_version}}/reference/key-management/).
+For more information, see [Key and Key Set Management in Kong Gateway](/gateway/latest/reference/key-management/).
 
 
 ## Supported Content Encryption Algorithms


### PR DESCRIPTION
Signed-off-by: Diana <75819066+cloudjumpercat@users.noreply.github.com>

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Fixed a broken link to the new Key management page that was on the JWE decrypt plugin doc.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
The link had `{{page.kong_version}}` in it, but it looks like plugin docs only use `/latest` links?
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Go to the JWE decrypt plugin page and test out the link to the Key Management page. The link should work, but I just wanted to verify that using `/latest` is correct.
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
