### PR TITLE
chore: Plugin priority 3.1 updates

### DIFF
--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -449,7 +449,7 @@ zipkin                      | 100000
 exit-transformer            | 9999
 bot-detection               | 2500
 cors                        | 2000
-jwt-decrypt                 | 1999
+jwe-decrypt                 | 1999
 session                     | 1900
 oauth2-introspection        | 1700
 acme                        | 1705

--- a/src/gateway/plugin-development/custom-logic.md
+++ b/src/gateway/plugin-development/custom-logic.md
@@ -443,11 +443,13 @@ The current order of execution for the bundled plugins is:
 Plugin                      | Priority
 ----------------------------|----------
 pre-function                | 1000000
+app-dynamics                | 999999
 correlation-id              | 100001 <!--  CE priority is 1, EE priority is 100001 -->
 zipkin                      | 100000
 exit-transformer            | 9999
 bot-detection               | 2500
 cors                        | 2000
+jwt-decrypt                 | 1999
 session                     | 1900
 oauth2-introspection        | 1700
 acme                        | 1705
@@ -467,6 +469,7 @@ jwt-signer                  | 1020
 request-validator           | 999
 websocket-size-limit        | 999
 websocket-validator         | 999
+xml-threat-protection       | 999
 grpc-gateway                | 998
 tls-handshake-modifier      | 997
 tls-metadata-headers        | 996
@@ -479,6 +482,8 @@ rate-limiting               | 910
 rate-limiting-advanced      | 910
 graphql-rate-limiting-advanced | 902
 response-ratelimiting       | 900
+saml                        | 900
+oas-validation              | 850
 route-by-header             | 850
 jq                          | 811
 request-transformer-advanced | 802


### PR DESCRIPTION
### Summary
Adding new plugins to plugin priority table in custom plugin dev doc.
Also checked the priorities of all existing plugins; no changes have happened in 3.1.

Guide for checking plugin priority [here](https://konghq.atlassian.net/wiki/spaces/KD/pages/2673541151/Check+plugin+priority+list). Instead of running 3.1 though, I just pulled the repo and searched through the `plugins` and `plugins-ee` directories, then compared priorities with existing table.

### Reason
New plugins.

### Testing
Netlify. Note that these changes are in the Enterprise tab, not the OSS/Free tab.

https://deploy-preview-4833--kongdocs.netlify.app/gateway/latest/plugin-development/custom-logic/#kong-plugins