### PR TITLE
docs(kic): add compatibilities of router flavors of Kong

### DIFF
--- a/app/_data/docs_nav_kic_2.7.x.yml
+++ b/app/_data/docs_nav_kic_2.7.x.yml
@@ -142,6 +142,8 @@ items:
         url: /references/plugin-compatibility
       - text: Version Compatibility
         url: /references/version-compatibility
+      - text: Supported Kong Router Flavors
+        url: /references/supported-router-flavors
       - text: Troubleshooting
         url: /troubleshooting
       - text: Prometheus Metrics

--- a/src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -2,7 +2,6 @@
 title: Supported Kong Router Flavors
 ---
 
-## Supported Kong Router Flavors
 
 {{site.base_gateway}} (open-source and enterprise edition) includes an [expression-based router][gateway-expression-router] in versions 3.0 and later. 
 The router can be configured in the following [modes][gateway-router-flavor]:

--- a/src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -1,0 +1,27 @@
+---
+title: Supported Kong Router Flavors
+---
+
+## Supported Kong Router Flavors
+
+{{site.base_gateway}} (open-source and enterprise edition) includes an [expression-based router][gateway-expression-router] in versions 3.0 and later. 
+The router can be configured in the following [modes][gateway-router-flavor]:
+
+- `traditional`: uses the pre-3.0 router.
+- `traditional_compatible`: uses the expression based router, but the router configuration interface remains the same as `traditional`.
+- `expression`: uses the expression-based router, and expressions must be provided in the router configuration interface.
+
+The compatibilities of router flavors between different {{site.kic_product_name}} versions and {{site.base_gateway}} are shown in the following table.
+{{site.kic_product_name}} in versions 2.6.x and lower does not support {{site.base_gateway}} 3.0 and later, so the version of {{site.kic_product_name}} begins at 2.7.x.
+
+| {{site.kic_product_name}}            | 2.7.x                           |
+|:-------------------------------------|:-------------------------------:|
+| Kong 3.0.x  `traditional`            |  <i class="fa fa-check"></i>    |     
+| Kong 3.0.x  `traditional_compatible` |  <i class="fa fa-times"></i>(*) | 
+| Kong 3.0.x  `expression`             |  <i class="fa fa-times"></i>    |
+
+(*) Most use cases are supported. Regexes with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
+may not be accepted when {{site.base_gateway}} 3.0 is configured to use the `traditional_compatible` router.
+
+[gateway-expression-router]:/gateway/latest/key-concepts/routes/expressions/
+[gateway-router-flavor]:/gateway/latest/reference/configuration/#router_flavor


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Add compatibility table to show which kong router flavors are supported in KIC.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

fixes [kuberneres-ingress-controller#3187](https://github.com/Kong/kubernetes-ingress-controller/issues/3187)

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

https://deploy-preview-4834--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/supported-router-flavors/

### Special Notes

Kong 3.0.x `traditional_compatible` router is not fully supported in KIC because `traditional_compatible` router does not support some routes supported in `traditional` router. How should we mark it in the compatibility table?
- use a :heavy_check_mark: and add annotations to tell the incompatibilities
- use a :negative_squared_cross_mark: and add annotations to tell that most cases are supported (now this is used)
- use a symbol other than these two, or tell by text such as `Not Fully Supported`

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
