### PR TITLE
Runtime group API Konnect (#4812)

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -214,6 +214,11 @@
           absolute_url: true
         - text: Identity Integration Guide
           url: /api/identity-management/identity-integration
+    - text: Runtime Groups API
+      items:
+        - text: API Documentation
+          url: https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/
+          absolute_url: true
     - text: Reference
       items:
         - text: Filtering

--- a/app/konnect/api/filtering.md
+++ b/app/konnect/api/filtering.md
@@ -176,4 +176,6 @@ expected results are:
 
 ## API reference documentation
 
-* [Identity Management API](https://developer.konghq.com/spec/5175b87f-bfae-40f6-898d-82d224387f9b/d0e13745-db5c-42d5-80ae-ef803104f5ce) - Interface for management of users, teams, team memberships and role assignments.
+* [Identity Management API Documentation](https://developer.konghq.com/spec/5175b87f-bfae-40f6-898d-82d224387f9b/d0e13745-db5c-42d5-80ae-ef803104f5ce) - Interface for managing users, teams, team memberships and role assignments.
+
+* [Runtime Groups API Documentation](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/) - Interface for managing runtime groups and certificates.

--- a/app/konnect/api/index.md
+++ b/app/konnect/api/index.md
@@ -26,6 +26,7 @@ The recommended method of authentication for {{site.konnect_short_name}} is [Per
 
 * [Identity Management API](https://developer.konghq.com/spec/5175b87f-bfae-40f6-898d-82d224387f9b/d0e13745-db5c-42d5-80ae-ef803104f5ce) - Interface for management of users, teams, team memberships and role assignments.
 
+* [Runtime Groups API](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/) - Interface for managing runtime groups and certificates.
 
 
 ## More information

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -9,6 +9,11 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services. [Try it today!](https://cloud.konghq.com/quick-start)
 
+## December 2022
+
+**Runtime Groups API**
+: Konnect APIs for runtime groups are now available for external consumption. This set of APIs allow organizations to create and manage runtime groups and manage CP/DP certificates. [View API documentation](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/).
+
 ## November 2022
 
 ### 2022.11.21


### PR DESCRIPTION
This PR is to be merged by Hayden. It contains the Runtime groups API links in the konnect docs. 

##note

This link 
https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/ 

Should resolve before this PR is merged. This link will only work if you publish the runtime group API documentation service in the Kong Konnect organization. Instructions [here](https://konghq.atlassian.net/wiki/spaces/KD/pages/2926739460/Adding+Updating+the+Konnect+API+docs). 