### PR TITLE
[docu-2777] Konnect release notes for GW 3.1

### DIFF
--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -17,6 +17,7 @@ data plane.
 
 |                                | {{site.konnect_saas}} | First supported patch version
 |--------------------------------|:---------------------:|-----------------------------
+| {{site.ee_product_name}} 3.1.x | <i class="fa fa-check"></i>    | 3.1.0.0
 | {{site.ee_product_name}} 3.0.x | <i class="fa fa-check"></i>    | 3.0.0.0
 | {{site.ee_product_name}} 2.8.x | <i class="fa fa-check"></i>    | 2.8.0.0
 | {{site.ee_product_name}} 2.7.x | <i class="fa fa-check"></i>    | 2.7.0.0

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -15,7 +15,7 @@ services. [Try it today!](https://cloud.konghq.com/quick-start)
 : {{site.konnect_short_name}} users can now use Kong Gateway 3.1 with {{site.konnect_short_name}}. This allows {{site.konnect_short_name}} users to get access to the new capabilities and improvements added to {{site.base_gateway}} 3.1 core platforms. 
 
 **Support for all {{site.base_gateway}} 3.1 plugins**
-: {{site.konnect_short_name}} users can now take advantage of the the entire plugin suite offered alongside {{site.base_gateway}} 3.1. For more information about the available plugins review our [compatibility documentation](/compatibility/#plugin-compatibility)
+: {{site.konnect_short_name}} users can now take advantage of the the entire plugin suite offered alongside {{site.base_gateway}} 3.1. For more information about the available plugins review our [compatibility documentation](/konnect/compatibility/#plugin-compatibility)
 
 ## November 2022
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -12,10 +12,10 @@ services. [Try it today!](https://cloud.konghq.com/quick-start)
 ## December 2022
 
 **{{site.base_gateway}} 3.1 support**
-: {{site.konnect_short_name}} users can now use Kong Gateway 3.1 with {{site.konnect_short_name}}. This allows {{site.konnect_short_name}} users to get access to the new capabilities and improvements added to {{site.base_gateway}} 3.1 core platforms. 
+: {{site.konnect_short_name}} users can now use {{site.base_gateway}} 3.1 with {{site.konnect_short_name}}. This allows {{site.konnect_short_name}} users to access the new capabilities and improvements added to {{site.base_gateway}} 3.1 core platforms. 
 
 **Support for all {{site.base_gateway}} 3.1 plugins**
-: {{site.konnect_short_name}} users can now take advantage of the the entire plugin suite offered alongside {{site.base_gateway}} 3.1. For more information about the available plugins review our [compatibility documentation](/konnect/compatibility/#plugin-compatibility)
+: {{site.konnect_short_name}} users can now take advantage of the the entire plugin suite offered alongside {{site.base_gateway}} 3.1. For more information about the available plugins. review our [compatibility documentation](/konnect/compatibility/#plugin-compatibility).
 
 **Runtime Groups API**
 : Konnect APIs for runtime groups are now available for external consumption. This set of APIs allow organizations to create and manage runtime groups and manage CP/DP certificates. [View API documentation](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/).

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -9,6 +9,14 @@ an application that lets you manage configuration for multiple runtimes
 from a single, cloud-based control plane, and provides a catalog of all deployed
 services. [Try it today!](https://cloud.konghq.com/quick-start)
 
+## December 2022
+
+**{{site.base_gateway}} 3.1 support**
+: {{site.konnect_short_name}} users can now use Kong Gateway 3.1 with {{site.konnect_short_name}}. This allows {{site.konnect_short_name}} users to get access to the new capabilities and improvements added to {{site.base_gateway}} 3.1 core platforms. 
+
+**Support for all {{site.base_gateway}} 3.1 plugins**
+: {{site.konnect_short_name}} users can now take advantage of the the entire plugin suite offered alongside {{site.base_gateway}} 3.1. For more information about the available plugins review our [compatibility documentation](/compatibility/#plugin-compatibility)
+
 ## November 2022
 
 ### 2022.11.21


### PR DESCRIPTION
Konnect users can now use the Kong Gateway 3.1 with Konnect. 
https://konghq.atlassian.net/browse/DOCU-2777

This needs to be cherry-picked into release 3.1 