### PR TITLE
[DOCU-2757] CP/DP forward proxy config

### DIFF
--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -151,6 +151,8 @@ items:
             url: /production/networking/dns-considerations
           - text: Network and Firewall
             url: /production/networking/firewall
+          - text: CP/DP Communication through a Forward Proxy
+            url: /production/networking/cp-dp-proxy
       - text: Kong Configuration File
         url: /production/kong-conf
       - text: Environment Variables

--- a/src/gateway/production/networking/cp-dp-proxy.md
+++ b/src/gateway/production/networking/cp-dp-proxy.md
@@ -32,7 +32,7 @@ only use this option if any component is explicitly configured to use the proxy.
 `proxy_server` is in HTTPS. Set to `on` if using HTTPS (default), or `off` if
 using HTTP.
 
-* `cluster_use_proxy`: Tell the cluster to use HTTP CONNECT proxy support for
+* `cluster_use_proxy`: Tells the cluster to use HTTP CONNECT proxy support for
 hybrid mode connections. If turned on, {{site.base_gateway}} will use the
 URL defined in `proxy_server` to connect.
 

--- a/src/gateway/production/networking/cp-dp-proxy.md
+++ b/src/gateway/production/networking/cp-dp-proxy.md
@@ -1,5 +1,6 @@
 ---
 title: Control Plane and Data Plane Communication through a Forward Proxy
+content_type: reference
 ---
 
 If your control plane and data planes run on different sides of a firewall
@@ -7,7 +8,7 @@ that runs external communications through a proxy, you can configure
 {{site.base_gateway}} to authenticate with the proxy server and allow
 traffic through.
 
-{{site.base_gateway}} only supports HTTP CONNECT proxies.
+{{site.base_gateway}} only supports [HTTP CONNECT](https://httpwg.org/specs/rfc9110.html#CONNECT) proxies. 
 
 {:.important}
 > This feature does not support mTLS termination.
@@ -31,14 +32,14 @@ only use this option if any component is explicitly configured to use the proxy.
 `proxy_server` is in HTTPS. Set to `on` if using HTTPS (default), or `off` if
 using HTTP.
 
-* `lua_ssl_trusted_certificate` (*Optional*): If using HTTPS, you can also
-specify a custom certificate authority with `lua_ssl_trusted_certificate`. If
-using the [system default CA](src/gateway/reference/configuration/#lua_ssl_trusted_certificate),
-you don't need to change this value.
-
 * `cluster_use_proxy`: Tell the cluster to use HTTP CONNECT proxy support for
 hybrid mode connections. If turned on, {{site.base_gateway}} will use the
 URL defined in `proxy_server` to connect.
+
+* `lua_ssl_trusted_certificate` (*Optional*): If using HTTPS, you can also
+specify a custom certificate authority with `lua_ssl_trusted_certificate`. If
+using the [system default CA](/gateway/reference/configuration/#lua_ssl_trusted_certificate),
+you don't need to change this value.
 
 Reload {{site.base_gateway}} for the connection to take effect:
 

--- a/src/gateway/production/networking/cp-dp-proxy.md
+++ b/src/gateway/production/networking/cp-dp-proxy.md
@@ -1,0 +1,47 @@
+---
+title: Control Plane and Data Plane Communication through a Forward Proxy
+---
+
+If your control plane and data planes run on different sides of a firewall
+that runs external communications through a proxy, you can configure
+{{site.base_gateway}} to authenticate with the proxy server and allow
+traffic through.
+
+{{site.base_gateway}} only supports HTTP CONNECT proxies.
+
+{:.important}
+> This feature does not support mTLS termination.
+
+## Set up forward proxy connection
+
+In [`kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/),
+configure the following parameters:
+
+```
+proxy_server = http(s)://<username>:<password>@<proxy-host>:<proxy-port>
+proxy_server_tls_verify = on/off
+cluster_use_proxy = on
+lua_ssl_trusted_certificate = system | <certificate> | <path-to-cert>
+```
+
+* `proxy_server`: Proxy server defined as a URL. {{site.base_gateway}} will
+only use this option if any component is explicitly configured to use the proxy.
+
+* `proxy_server_tls_verify`: Toggles server certificate verification if
+`proxy_server` is in HTTPS. Set to `on` if using HTTPS (default), or `off` if
+using HTTP.
+
+* `lua_ssl_trusted_certificate` (*Optional*): If using HTTPS, you can also
+specify a custom certificate authority with `lua_ssl_trusted_certificate`. If
+using the [system default CA](src/gateway/reference/configuration/#lua_ssl_trusted_certificate),
+you don't need to change this value.
+
+* `cluster_use_proxy`: Tell the cluster to use HTTP CONNECT proxy support for
+hybrid mode connections. If turned on, {{site.base_gateway}} will use the
+URL defined in `proxy_server` to connect.
+
+Reload {{site.base_gateway}} for the connection to take effect:
+
+```
+kong reload
+```


### PR DESCRIPTION
### Summary
Doc for setting up a forward proxy connection between CP and DP.

I can't really test this, so I can't verify that this is correct. Need some SME help.

Outstanding questions @dndx:
* From design doc: "Customers need to ensure their proxy does not MITM or mutate the certificate used by Kong DP when connecting to CP" - How do you verify this? 
* What special info do we need for Konnect here?
* From design doc: "We should document roughly how many connections each Kong DP will open to the CP, so that user knows how much proxy servers are needed to support a given number of Kong deployments." - how would you estimate this number?

### Reason
https://konghq.atlassian.net/browse/DOCU-2757

### Testing
https://deploy-preview-4846--kongdocs.netlify.app/gateway/latest/production/networking/cp-dp-proxy/