### PR TITLE
DOCU-2818 changelog 2.8.2.2

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -896,6 +896,16 @@ openid-connect
 * Bumped `lodash` for Dev Portal from 4.17.11 to 4.17.21
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 
+## 2.8.2.2
+**Release Date** 2022/12/01
+
+### Fixes 
+
+#### Core
+
+* Fixed the timer error `lua_max_running_timers are not enough`.
+
+
 ## 2.8.2.1
 **Release Date** 2022/11/21
 
@@ -920,8 +930,6 @@ openid-connect
 * **Dev Portal**: Fixed an issue where Dev Portal response examples weren't rendered when media type was vendor-specific.
 
 #### Core
-
-* Fixed the timer error `lua_max_running_timers are not enough`.
 
 * Targets with a weight of `0` are no longer included in health checks, and checking their status via the `upstreams/<upstream>/health` endpoint results in the status `HEALTHCHECK_OFF`.
 Previously, the `upstreams/<upstream>/health` endpoint was incorrectly reporting targets with `weight=0` as `HEALTHY`, and the health check was reporting the same targets as `UNDEFINED`.


### PR DESCRIPTION
### Summary
update changelog to reflect the fix the timer error in Core was not part of 2.8.2.1 and instead is releasing as this patch. 

### Reason
DOCU-2818

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
