### PR TITLE
changes to upgrade guidance

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -896,6 +896,16 @@ openid-connect
 * Bumped `lodash` for Dev Portal from 4.17.11 to 4.17.21
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 
+## 2.8.2.2
+**Release Date** 2022/12/01
+
+### Fixes 
+
+#### Core
+
+* Fixed the timer error `lua_max_running_timers are not enough`.
+
+
 ## 2.8.2.1
 **Release Date** 2022/11/21
 
@@ -920,8 +930,6 @@ openid-connect
 * **Dev Portal**: Fixed an issue where Dev Portal response examples weren't rendered when media type was vendor-specific.
 
 #### Core
-
-* Fixed the timer error `lua_max_running_timers are not enough`.
 
 * Targets with a weight of `0` are no longer included in health checks, and checking their status via the `upstreams/<upstream>/health` endpoint results in the status `HEALTHCHECK_OFF`.
 Previously, the `upstreams/<upstream>/health` endpoint was incorrectly reporting targets with `weight=0` as `HEALTHY`, and the health check was reporting the same targets as `UNDEFINED`.

--- a/src/deck/installation.md
+++ b/src/deck/installation.md
@@ -28,13 +28,24 @@ If you are Linux, you can either use the Debian or RPM archive from
 the Github [release page](https://github.com/kong/deck/releases)
 or install by downloading a compressed archive, which contains the binary:
 
-{% if_version leq:1.12.x %}
 ```shell
 $ curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
-{% endif_version %}
+
+## Windows
+
+If you are on Windows, you can either use the compressed archive from
+the Github [release page](https://github.com/kong/deck/releases)
+or install using **CMD** by entering the target installation folder and downloading a compressed archive, which contains the binary:
+
+```shell
+curl -sL https://github.com/kong/deck/releases/download/v{{page.version}}/deck_{{page.version}}_windows_amd64.tar.gz -o deck.tar.gz
+mkdir deck
+tar -xf deck.tar.gz -C deck
+powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + [System.IO.Directory]::GetCurrentDirectory() + '\deck', 'User')"
+```
 
 ## Docker image
 

--- a/src/gateway/upgrade.md
+++ b/src/gateway/upgrade.md
@@ -21,10 +21,8 @@ The upgrade to 3.0.x is a **major** upgrade.
 The lowest version that Kong 3.0.x supports migrating from is 2.1.x.
 
 {:.important}
-> **Important**: Blue-green migration in traditional mode for versions below 2.8.2 to 3.0.x is not supported.
-The upcoming 2.8.2 release will include blue-green migration support. If you want
-to perform migrations for traditional mode with no downtime, please wait for the upcoming 2.8.2 patch release,
-upgrade to 2.8.2, [then migrate to 3.0.x](#migrate-db).
+> **Important**: Blue-green migration in traditional mode for versions below 2.8.2 to 3.0.x is not supported. The upcoming 2.8.2 release will include blue-green migration support. If you want
+to perform migrations for traditional mode with no downtime, please upgrade to 2.8.2, [then migrate to 3.0.x](#migrate-db).
 
 While you can upgrade directly to the latest version, be aware of any
 breaking changes between the 2.x and 3.x series noted in this document
@@ -51,9 +49,12 @@ Amazon Linux 1 and Debian 8 (Jessie) containers and packages are deprecated and 
 #### Blue-green deployments
 
 **Traditional mode**: Blue-green upgrades from versions of 2.8.1 and below to 3.0.0 are not currently supported.
-This is a known issue planned to be fixed in the next 2.8 release. When that version is released, 2.x users should upgrade to that version before beginning a blue-green upgrade to 3.0.
+This is fixed in the 2.8.2 release. 2.x users should upgrade to that version before beginning a blue-green upgrade to 3.0.
 
 **Hybrid mode**: See the [upgrade instructions](#migrate-db) below.
+
+{:.important}
+> **Important**: The legacy hybrid configuration protocol has been removed in favor of [the wRPC protocol introduced in 3.0.0.0](/gateway/changelog/#hybrid-mode). Strictly speaking, this is not a breaking change, but it does have the side effect that rolling upgrades from 2.8.x.y to 3.1.0.0 are not supported. You must upgrade to 3.0.x.y before you can perform a rolling upgrade to 3.1.0.0.  
 
 ### Dependencies
 
@@ -418,9 +419,6 @@ Once you have migrated to 2.8.x, you can follow the instructions in the section
 below to migrate to 3.0.x.
 
 ### Upgrade from 2.8.x (x>=2) to 3.0.x for traditional mode
-
-{:.note}
-> These instructions will only work once 2.8.2 is available.
 
 1. Clone your database.
 2. Download 3.0.x, and configure it to point to the cloned data store.


### PR DESCRIPTION
DOCU-2811: change statements that were referring to 2.8.2 as upcoming to available (Important admonition re blue/green migration , statement in the Upgrade considerations/ Deployment/ Blue-green deployments, and removes the Info admonition in the Upgrade from 2.8.x section)

Adds Important admonition in Upgrade considerations/Deployment section related to FT-3587 that rolling upgrades from 2.8.x.y to 3.1.0.0 are not supported.

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
