### PR TITLE
docs(fips) add new fips distros - FT-3310

### DIFF
--- a/src/gateway/install/linux/rhel.md
+++ b/src/gateway/install/linux/rhel.md
@@ -29,6 +29,10 @@ Install {{site.base_gateway}} on RHEL from the command line.
 ```bash
 curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-3.x-rhel-%{rhel}/Packages/k/kong-enterprise-edition-{{page.versions.ee}}.rhel%{rhel}.amd64.rpm")
 ```
+For the FIPS package (only supported in RHEL 8):
+```
+curl -Lo kong-enterprise-edition-fips-{{page.versions.ee}}.rpm $( rpm --eval "{{ site.links.download }}/gateway-3.x-rhel-%{rhel}/Packages/k/kong-enterprise-edition-fips-{{page.versions.ee}}.rhel%{rhel}.amd64.rpm")
+```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
@@ -92,6 +96,10 @@ Install the YUM repository from the command line.
 {% navtab Kong Gateway %}
 ```bash
 sudo yum install kong-enterprise-edition-{{page.versions.ee}}
+```
+For the FIPS package (only supported in RHEL 8):
+```
+sudo yum install kong-enterprise-edition-fips-{{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}

--- a/src/gateway/install/linux/ubuntu.md
+++ b/src/gateway/install/linux/ubuntu.md
@@ -36,6 +36,10 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 ```bash
 curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
 ```
+For the FIPS package (only supported in Ubuntu 20.04 and Ubuntu 22.04):
+```
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong-enterprise-edition-fips/kong-enterprise-edition-fips_{{page.versions.ee}}_amd64.deb"
+```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
@@ -117,6 +121,10 @@ Install the APT repository from the command line.
 {% navtab Kong Gateway %}
 ```bash
 sudo apt install -y kong-enterprise-edition={{page.versions.ee}}
+```
+For the FIPS package (only supported in Ubuntu 20.04 and Ubuntu 22.04):
+```
+sudo apt install -y kong-enterprise-edition-fips={{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}

--- a/src/gateway/kong-enterprise/fips-support.md
+++ b/src/gateway/kong-enterprise/fips-support.md
@@ -6,21 +6,17 @@ content_type: reference
 
 The Federal Information Processing Standard (FIPS) 140-2 is a federal standard defined by the National Institute of Standards and Technology. It specifies the security requirements that must be satisfied by a cryptographic module. The FIPS {{site.base_gateway}} package is FIPS 140-2 compliant. Compliance means that the software has met all of the rules of FIPS 140-2, but has not been submitted to a NIST testing lab for validation.
 
-{{site.ee_product_name}} provides a FIPS 140-2 compliant package for **Ubuntu 20.04**. This package provides compliance for the core {{site.base_gateway}} product only. 
+{{site.ee_product_name}} provides a FIPS 140-2 compliant package for **Ubuntu 20.04**, **Ubuntu 22.04**, and **RHEL 8**. Those packages provide compliance for the core {{site.base_gateway}} product only.
 
 The package replaces the primary library in {{site.base_gateway}}, OpenSSL, with [BoringSSL](https://boringssl.googlesource.com/boringssl/), which at its core uses the FIPS 140-2 validated BoringCrypto for cryptographic operations.
 
 {:.note}
 >**Note**: As of {{site.base_gateway}} 3.0, {{site.base_gateway}} plugins can't be considered FIPS-compliant. Future {{site.base_gateway}} releases aim to support plugins as well as distributions other than Ubuntu 20.04, such as RHEL. 
 
-## Installing the {{site.base_gateway}} FIPS compliant Ubuntu package
+## Installing the {{site.base_gateway}} FIPS compliant packages
 
-The only supported {{site.base_gateway}} distribution is based on Ubuntu 20.04 and can be installed with the package distinctively named `kong-enterprise-edition-fips`.
 
-To install the {{site.base_gateway}} FIPS package use:
-
-    apt install kong-enterprise-edition-fips
-
+{{site.base_gateway}} supports **Ubuntu 20.04**, **Ubuntu 22.04**, and **RHEL 8** kong-enterprise-edition-fips`. Install instructions can be found at the [Installation Options page](/gateway/latest/install/linux). Note that the FIPS package for each of these distributions is named `kong-enterprise-edition-fips`.
 
 ### Configure FIPS
 


### PR DESCRIPTION
### Summary

This is an attempt at better structuring the FIPS docs; instead of replicating install instructions over at the FIPS docs page, point to the Install page, where FIPS-specific instructions are added.

### Reason

FT-3310.
