### PR TITLE
Gateway 2.8.2.2: Expand the changelog entry for the timer fix and bump 2.8.x version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -153,7 +153,7 @@
     pcre: "8.45"
   lua_doc: true
 - release: "2.8.x"
-  ee-version: "2.8.2.1"
+  ee-version: "2.8.2.2"
   ce-version: "2.8.3"
   edition: "gateway"
   luarocks_version: "2.5.1-0"

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -897,7 +897,7 @@ openid-connect
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 
 ## 2.8.2.2
-**Release Date** 2022/12/02
+**Release Date** 2022/12/01
 
 ### Fixes
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -897,14 +897,27 @@ openid-connect
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 
 ## 2.8.2.2
-**Release Date** 2022/12/01
+**Release Date** 2022/12/02
 
-### Fixes 
+### Fixes
 
 #### Core
 
-* Fixed the timer error `lua_max_running_timers are not enough`.
+Timer issue fixes:
+* Added batch queues for the Datadog and StatsD plugins to reduce timer usage,
+fixing a `lua_max_running_timers are not enough` timer error.
 
+    Whenever a request was processed, a new running timer was instantly
+    created during the log phase. This was causing a shortage
+    of timers under heavy traffic and led to unpredictable consequences, where
+    internal timers were killed randomly and couldn't recover automatically.
+    This would then trigger a `lua_max_running_timers are not enough` timer
+    error and cause data planes to crash.
+
+    [#9521](https://github.com/Kong/kong/pull/9521)
+
+* Fixed a timer leak that occurred whenever the generic messaging protocol
+connection would break in hybrid mode.
 
 ## 2.8.2.1
 **Release Date** 2022/11/21


### PR DESCRIPTION
### Summary
* Bump release version
* Update release date
* expand description of timer issues based on ticket + PRs

### Reason
Comment in https://github.com/Kong/docs.konghq.com/pull/4849#discussion_r1037458945.
Release date has changed and version needs bumping.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
