### PR TITLE
[DOCU-2827] 3.1 fast-follow: Amazon Linux 2022 support

### DIFF
--- a/app/_data/tables/os_support.yml
+++ b/app/_data/tables/os_support.yml
@@ -196,9 +196,9 @@
   enterprise_versions:
     first_version: 3.1.x
     last_version: null
-  oss: false
+  oss: true
   oss_versions:
-    first_version: null
+    first_version: 3.1.x
     last_version: null
   status: active
   deprecation_date: null

--- a/app/_data/tables/os_support.yml
+++ b/app/_data/tables/os_support.yml
@@ -179,3 +179,15 @@
   status: active
   deprecation_date: null
   eol_link: null
+- name: Amazon Linux 2022
+  enterprise: true
+  enterprise_versions:
+    first_version: 3.1.x
+    last_version: null
+  oss: false
+  oss_versions:
+    first_version: null
+    last_version: null
+  status: active
+  deprecation_date: null
+  eol_link: null

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -79,6 +79,10 @@ see [Key management](/gateway/latest/reference/key-management/).
 - Add batch queue into the Datadog and StatsD plugins to reduce timer usage.
   [#9521](https://github.com/Kong/kong/pull/9521)
 
+### OS support
+
+- Kong Gateway now supports Amazon Linux 2022 with Enterprise packages.
+
 ### PDK
 
 - Extend `kong.client.tls.request_client_certificate` to support setting


### PR DESCRIPTION
Signed-off-by: Diana <75819066+cloudjumpercat@users.noreply.github.com>

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Added Amazon Linux 2022 to the changelog and table of supported OS.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
DOCU-2827
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
- View the changelog
- View /gateway/latest/os-support/ to see if Amazon Linux 2022 is listed there
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
