### PR TITLE
[DOCU-2815] 3.1 Plugin updates

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -302,6 +302,7 @@ cookie_lifetime
 cookie_name
 cookie_names
 cookie_path
+cookie_persistent
 cookie_renew
 cookie_samesite
 cookie_secure
@@ -387,6 +388,8 @@ enforce_headers
 enterprise_edition
 entityproperty
 entityname
+error_code
+error_message
 event_queue_size
 example_pass
 example_user
@@ -776,6 +779,7 @@ resource_attributes
 response_body_masks
 response_buffering
 response_code
+response_header_for_traceid
 response_header_masks
 response_if_media_type
 response_if_status_code

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -509,15 +509,13 @@ Have fun leveraging the power of AWS Lambda in Kong!
 
 ## Changelog
 
-{% if_plugin_version gte:3.0.x %}
+**{{site.base_gateway}} 3.1.x**
+* Added a `requestContext` field into `awsgateway_compatible` input data.
+  [#9380](https://github.com/Kong/kong/pull/9380)
 
 **{{site.base_gateway}} 3.0.x**
 * The `proxy_scheme` configuration parameter has been removed from the plugin.
 * The plugin now allows both `aws_region` and `host` to be set at the same time.
-
-{% endif_plugin_version %}
-
-{% if_plugin_version gte:2.8.x %}
 
 **{{site.base_gateway}} 2.8.x**
 * The `proxy_scheme` configuration parameter is deprecated and planned to be
@@ -525,29 +523,15 @@ removed in 3.x.x.
 * {{site.base_gateway}} 2.8.1.3: Added support for cross account invocation
 through configuration properties `aws_assume_role_arn` and `aws_role_session_name`.
 
-{% endif_plugin_version %}
-
-{% if_plugin_version gte:2.7.x %}
-
 **{{site.base_gateway}} 2.7.x**
 * Starting with {{site.base_gateway}} 2.7.0.0, if keyring encryption is enabled,
  the `config.aws_key` and `config.aws_secret` parameter values will be encrypted.
 
-{% endif_plugin_version %}
-
-{% if_plugin_version gte:2.6.x %}
-
 **{{site.base_gateway}} 2.6.x**
 * The AWS region can now be set with the environment variables: `AWS_REGION` or `AWS_DEFAULT_REGION`.
 
-{% endif_plugin_version %}
-
-{% if_plugin_version gte:2.2.x %}
-
 **{{site.base_gateway}} 2.2.x**
 * Added support for `isBase64Encoded` flag in Lambda function responses.
-
-{% endif_plugin_version %}
 
 **{{site.base_gateway}} 2.1.x**
 * Added `host` configuration to allow for custom Lambda endpoints.

--- a/app/_hub/kong-inc/basic-auth/_index.md
+++ b/app/_hub/kong-inc/basic-auth/_index.md
@@ -46,7 +46,7 @@ params:
       datatype: string
       description:
         An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -55,7 +55,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
   extra: |
     Once applied, any user with a valid credential can access the Service.
     To restrict usage to only some of the authenticated users, also add the

--- a/app/_hub/kong-inc/hmac-auth/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/_index.md
@@ -55,7 +55,7 @@ params:
       datatype: string
       description:
         An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -64,7 +64,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: validate_request_body
       required: true
       default: '`false`'

--- a/app/_hub/kong-inc/jwt/_index.md
+++ b/app/_hub/kong-inc/jwt/_index.md
@@ -78,7 +78,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -87,7 +87,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -86,7 +86,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -95,7 +95,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: run_on_preflight
       required: false
       default: '`true`'

--- a/app/_hub/kong-inc/key-auth/_index.md
+++ b/app/_hub/kong-inc/key-auth/_index.md
@@ -84,7 +84,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -93,7 +93,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/ldap-auth-advanced/_index.md
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_index.md
@@ -132,7 +132,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -142,7 +142,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: header_type
       required: false
       default: '`ldap`'

--- a/app/_hub/kong-inc/ldap-auth/_index.md
+++ b/app/_hub/kong-inc/ldap-auth/_index.md
@@ -148,7 +148,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -157,7 +157,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request fails with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: header_type
       required: false
       default: '`ldap`'

--- a/app/_hub/kong-inc/mtls-auth/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/_index.md
@@ -31,7 +31,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -42,7 +42,7 @@ params:
         `HTTP 495` if the client presented a certificate that is not acceptable, or `HTTP 496` if the client failed
         to present certificate as requested. Please note that this value must refer to the consumer `id`
         attribute, which is internal to Kong, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: consumer_by
       required: false
       default: '`[ "username", "custom_id" ]`'

--- a/app/_hub/kong-inc/oauth2-introspection/_index.md
+++ b/app/_hub/kong-inc/oauth2-introspection/_index.md
@@ -97,7 +97,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -105,7 +105,7 @@ params:
       datatype: string
       description: |
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails. If empty (default), the request fails with an authentication failure `4xx`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: run_on_preflight
       required: false
       default: true

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -131,7 +131,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -140,7 +140,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request fails with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: global_credentials
       required: true
       default: '`false`'

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -178,7 +178,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"  
+      minimum_version: "3.1.x"  
     - name: anonymous
       required: false
       default: null
@@ -187,7 +187,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request will fail with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - group: General Settings
       description: Parameters for settings that affect different grants and flows.
     - name: preserve_query_args

--- a/app/_hub/kong-inc/opentelemetry/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/_index.md
@@ -28,14 +28,30 @@ params:
       description: |
         The full HTTP(S) endpoint that Kong Gateway should send OpenTelemetry spans to.
         The endpoint must be a [OTLP/HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp) endpoint.
-    - name: headers
+
+    - name: headers # old version of headers parameter without 'referenceable' attribute
+      maximum_version: "3.0.x"
       required: false
       datatype: map
       value_in_examples:
         - X-Auth-Token:secret-token
       description: |
         The custom headers to be added in the HTTP request sent to the OTLP server.
-        It's useful to add the authentication headers (token) for the APM backend.
+        This setting is useful for adding the authentication headers (token)
+        for the APM backend.
+
+    - name: headers  # current version of headers parameter
+      minimum_version: "3.1.x"
+      referenceable: true
+      required: false
+      datatype: map
+      value_in_examples:
+        - X-Auth-Token:secret-token
+      description: |
+        The custom headers to be added in the HTTP request sent to the OTLP server.
+        This setting is useful for adding the authentication headers (token)
+        for the APM backend.
+
     - name: resource_attributes
       required: false
       datatype: map
@@ -281,3 +297,10 @@ Span #6 name=balancer try #1 duration=0.99328ms attributes={"net.peer.ip":"104.2
 - May impact the performance of {{site.base_gateway}}.
   It's recommended to set the sampling rate (`opentelemetry_tracing_sampling_rate`)
   via Kong configuration file when using the OpenTelemetry plugin.
+
+## Changelog
+
+**{{site.base_gateway}} 3.1.x**
+* The `headers` field is now marked as referenceable, which means it can be securely stored as a
+[secret](/gateway/latest/kong-enterprise/secrets-management/)
+in a vault.

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -72,7 +72,7 @@ params:
         - `service` (The `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.)
         - `header` (The `header_name` configuration must be provided.)
         - `path` (The `path` configuration must be provided.)
-        
+
         If the entity value for aggregating the limits cannot be determined, the system falls back to `ip`.
     - name: header_name
       required: semi
@@ -170,6 +170,22 @@ params:
       datatype: integer
       description: |
         When using the `redis` policy, this property specifies the Redis database to use.
+    - name: error_code
+      minimum_version: "3.1.x"
+      required: false
+      default: 429
+      datatype: number
+      description: |
+        Set a custom error code to return when the rate limit is exceeded.
+    - name: error_message
+      minimum_version: "3.1.x"
+      required: false
+      default: rate limit exceeded
+      datatype: string
+      description: |
+        Set a custom error message to return when the rate limit is exceeded.
+
+
   extra: '<div class="alert alert-warning"> <strong>Note:</strong> At least one limit (`second`, `minute`, `hour`, `day`, `month`, `year`) must be configured. Multiple limits can be configured. </div>'
 ---
 
@@ -268,6 +284,10 @@ selected header was not sent by the client or the configured service was not fou
 ---
 
 ## Changelog
+
+**{{site.base_gateway}} 3.1.x**
+* Added the ability to customize the error code and message with
+the configuration parameters `error_code` and `error_message`.
 
 **{{site.base_gateway}} 2.8.x**
 

--- a/app/_hub/kong-inc/route-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/_index.md
@@ -44,7 +44,7 @@ params:
       default: false
       description: |
         If set to true, the path is escaped after being transformed.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
 ---
 
 _NOTE_: The advanced label is only attached because this is an Enterprise-only

--- a/app/_hub/kong-inc/session/_index.md
+++ b/app/_hub/kong-inc/session/_index.md
@@ -7,7 +7,7 @@ description: |
   through the Kong API Gateway. It provides configuration and management for
   session data storage, encryption, renewal, expiry, and sending browser cookies.
   It is built using
-  <a href="https://github.com/bungle/lua-resty-session">lua-resty-session</a>.
+  [lua-resty-session](https://github.com/bungle/lua-resty-session).
 
   For information about configuring and using the Sessions plugin with the Dev
   Portal, see [Sessions in the Dev Portal](/gateway/latest/developer-portal/configuration/authentication/sessions/#configuration-to-use-the-sessions-plugin-with-the-dev-portal).
@@ -103,6 +103,14 @@ params:
       default: 10
       datatype: number
       description: The duration in seconds after which an old session’s TTL is updated that an old cookie is discarded.
+    - name: cookie_persistent
+      minimum_version: "3.1.x"
+      required: false
+      default: false
+      datatype: boolean
+      description: |
+        Allows the browser to persist cookies even if the browser is closed.
+        By default, cookies are not persisted across browser restarts.
     - name: storage
       required: false
       default: cookie
@@ -427,6 +435,11 @@ _not_ a problem during session renewal period as renew happens in `access` phase
 ---
 
 ## Changelog
+
+**{{site.base_gateway}} 3.1.x**
+*  Added the new configuration parameter `cookie_persistent`, which allows the
+browser to persist cookies even if the browser is closed. This defaults to `false`,
+which means cookies are not persisted across browser restarts.
 
 **{{site.base_gateway}} 2.7.x**
 

--- a/app/_hub/kong-inc/vault-auth/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_index.md
@@ -58,7 +58,7 @@ params:
       datatype: string
       description:
         An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.
-      minimum_version: "3.1.0"
+      minimum_version: "3.1.x"
     - name: anonymous
       required: false
       default: null
@@ -67,7 +67,7 @@ params:
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request fails with an authentication failure `4xx`. Note that this value
         must refer to the consumer `id` attribute that is internal to Kong Gateway, and **not** its `custom_id`.
-      maximum_version: "3.0.0"
+      maximum_version: "3.0.x"
     - name: run_on_preflight
       required: true
       default: '`true`'

--- a/app/_hub/kong-inc/zipkin/_index.md
+++ b/app/_hub/kong-inc/zipkin/_index.md
@@ -212,6 +212,16 @@ params:
       datatype: number
       description: The timeout, in milliseconds, between two
         successive read operations when receiving a response from the Zipkin server.
+    - name: response_header_for_traceid
+      minimum_version: "3.1.x"
+      required: false
+      default: null
+      value_in_examples: null
+      datatype: string
+      description: |
+        Set a header name to append to responses. This header name
+        is sent to the client, making it possible to trace the ID of the
+        correlated request.
 
 ---
 ## How it Works
@@ -288,6 +298,9 @@ For more information, read the [Kong blog post](https://konghq.com/blog/tracing-
 
 ## Changelog
 
+**{{site.base_gateway}} 3.1.x**
+* Added the parameter `response_header_for_traceid`.
+
 **{{site.base_gateway}} 3.0.x**
 
 * Added support for including the HTTP path in the span name with the
@@ -301,8 +314,8 @@ For more information, read the [Kong blog post](https://konghq.com/blog/tracing-
 
 **{{site.base_gateway}} 2.7.x**
 
-* Added a new parameter: `local_service_name`
-* Added a new `ignore` option for the `header_type` parameter
+* Added a new parameter: `local_service_name`.
+* Added a new `ignore` option for the `header_type` parameter.
 
 **{{site.base_gateway}} 2.5.x**
 * The plugin now includes the following tags: `kong.route`, `kong.service_name`, and `kong.route_name`.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -150,7 +150,7 @@ see [Key management](/gateway/latest/reference/key-management/).
 - [**OPA**](/hub/kong-inc/opa/) (`OPA`)
   - Added the `include_uri_captures_in_opa_input` field. When this field is set to true, the [regex capture groups](/gateway/latest/reference/proxy/#using-regex-in-paths) captured on the Kong Gateway route's path field in the current request (if any) are included as input to OPA.
 
-- [**Proxy Cache**](/hub/kong-inc/proxy-cache/) (`proxy-cache`)
+- [**Proxy Cache Advanced**](/hub/kong-inc/proxy-cache-advanced/) (`proxy-cache-advanced`)
   - Added support for integrating with Redis clusters through the `config.redis.cluster_addresses` configuration property.
 
 - [**Rate Limiting**](/hub/kong-inc/rate-limiting/) (`rate-limiting`)
@@ -184,7 +184,7 @@ see [Key management](/gateway/latest/reference/key-management/).
 - [**Session**](/hub/kong-inc/session/) (`session`)
   - Added new config `cookie_persistent`, which allows the browser to persist
   cookies even if the browser is closed. This defaults to `false` which means
-  cookies are not persisted across browser restarts. 
+  cookies are not persisted across browser restarts.
   Thanks [@tschaume](https://github.com/tschaume)
   for this contribution!
   [#8187](https://github.com/Kong/kong/pull/8187)
@@ -367,9 +367,9 @@ requests to `wss` for `wss`-only routes for parity with HTTP/HTTPS.
 
 ### Hybrid mode
 
-- The legacy hybrid configuration protocol has been removed in favor of the wRPC protocol 
-introduced in 3.0.0.0. Rolling upgrades from 2.8.x.y to 3.1.0.0 are not supported. 
-Operators must upgrade to 3.0.x.x before they can perform a rolling upgrade to 3.1.0.0. 
+- The legacy hybrid configuration protocol has been removed in favor of the wRPC protocol
+introduced in 3.0.0.0. Rolling upgrades from 2.8.x.y to 3.1.0.0 are not supported.
+Operators must upgrade to 3.0.x.x before they can perform a rolling upgrade to 3.1.0.0.
   [#9740](https://github.com/Kong/kong/pull/9740)
 
 ## 3.0.1.0


### PR DESCRIPTION
### Summary
Documenting the following plugin updates from 3.1 changelog:

- Zipkin: Added response_header_for_traceid field in Zipkin plugin.
  The plugin will set the corresponding header in the response
  if the field is specified with a string value.

- Rate Limiting: The HTTP status code and response body for rate-limited
requests can now be customized. 

- AWS Lambda: Added requestContext field into awsgateway_compatible input data

- Authentication plugins: The anonymous field can now be configured as the username of the consumer.
  This field allows you to configure a string to use as an “anonymous” consumer if authentication fails.
  - _fixed the min and max versions to display the anonymous parameter correctly_

- Session: Added new config `cookie_persistent`, which allows the browser to persist
cookies even if the browser is closed. This defaults to false which means
cookies are not persisted across browser restarts. 

- OpenTelemetry: Added referenceable attribute to the headers field
that could be stored in vaults. 

- Proxy Cache Advanced: Added support for integrating with Redis clusters through the `config.redis.cluster_addresses` configuration property.
   - _this one just needed to have the changelog entry fixed to point to the correct plugin_

### Reason

Documenting plugin updates discovered during changelog review.

https://konghq.atlassian.net/browse/DOCU-2815

### Testing
Plugins:
[Session](https://deploy-preview-4863--kongdocs.netlify.app/hub/kong-inc/session/)
[Rate limiting](https://deploy-preview-4863--kongdocs.netlify.app/hub/kong-inc/rate-limiting/)
[AWS Lambda](https://deploy-preview-4863--kongdocs.netlify.app/hub/kong-inc/aws-lambda/)
[OpenTelemetry](https://deploy-preview-4863--kongdocs.netlify.app/hub/kong-inc/opentelemetry/)
[Zipkin](https://deploy-preview-4863--kongdocs.netlify.app/hub/kong-inc/zipkin/)

Also check a couple of auth plugins to make sure that the `anonymous` consumer changes between 3.0 and 3.1.