### PR TITLE
doc(kic) change support of GWAPI into changelog format

### DIFF
--- a/src/kubernetes-ingress-controller/references/gateway-api-support.md
+++ b/src/kubernetes-ingress-controller/references/gateway-api-support.md
@@ -14,7 +14,7 @@ overrides:
 The {{site.kic_product_name}} supports the following resources and features in the
 [Gateway API](https://gateway-api.sigs.k8s.io/). By default:
 
-- Core features are supported. If a core feature is not supported in the any
+- Core features are supported. If a core feature is not supported in any
   of the released versions yet, it will be listed in `Unsupported` section.
 - Extended features are not supported. If an extended feature is supported in 
   any of the released versions, it will be listed in the section of the 
@@ -40,7 +40,7 @@ The {{site.kic_product_name}} supports the following resources and features in t
 ### v2.4.x
 
 - Supported weights of `BackendRefs`. Multiple `BackendRefs` with a round-robin load-balancing strategy 
-  is applied by default across the `Endpoints` or the `Services`. configuring weights of `BackendRefs`
+  is applied by default across the `Endpoints` or the `Services`. Configuring weights of `BackendRefs`
   can allow you to fine-tune the load-balancing between those backend services.
 
 ### v2.6.x

--- a/src/kubernetes-ingress-controller/references/gateway-api-support.md
+++ b/src/kubernetes-ingress-controller/references/gateway-api-support.md
@@ -14,82 +14,68 @@ overrides:
 The {{site.kic_product_name}} supports the following resources and features in the
 [Gateway API](https://gateway-api.sigs.k8s.io/). By default:
 
-- Core features are supported. If a core feature is not supported in the
-  current version, it will be listed in `Unsupported Core Features`.
+- Core features are supported. If a core feature is not supported in the any
+  of the released versions yet, it will be listed in `Unsupported` section.
 - Extended features are not supported. If an extended feature is supported in 
-  current version, it will be listed in `Supported Extended Features`.
+  any of the released versions, it will be listed in the section of the 
+  first version that support the feature.
 
 ## Gateways and GatewayClasses
 
-### Supported Versions
+### v2.2.x
 
-{% if_version gte: 2.6.x %}
-- `v1beta1`
-{% endif_version %}
-{% if_version lte: 2.5.x %}
-- `v1alpha2`
-{% endif_version %}
+- Supported `v1alpha2` version of Gateways and GatewayClasses.
+
+### v2.6.x
+
+- Supported `v1beta1` version of Gateways and GatewayClasses, and removed support of `v1alpha2` version of Gateways and GatewayClasses.
 
 ## HTTP Routes
 
-{{site.kic_product_name}}'s implementation of `HTTPRoute` supports multiple `BackendRefs` with a
-round-robin load-balancing strategy applied by default across the
-`Endpoints` or the `Services`. `BackendRefs` weights are now supported
-to allow you to fine-tune the load-balancing between those backend services.
+### v2.2.x
 
-### Supported Versions
+- Supported `v1alpha2` version of HTTPRoute.
+- Supported extended feature: supported `method` in route matches.
 
-{% if_version gte: 2.6.x %}
-- `v1beta1`
-{% endif_version %}
-{% if_version lte: 2.5.x %}
-- `v1alpha2`
-{% endif_version %}
+### v2.4.x
 
-### Supported Extended Features
-- Supports `method` in route matches.
+- Supported weights of `BackendRefs`. Multiple `BackendRefs` with a round-robin load-balancing strategy 
+  is applied by default across the `Endpoints` or the `Services`. configuring weights of `BackendRefs`
+  can allow you to fine-tune the load-balancing between those backend services.
 
-### Unsupported Core Features
+### v2.6.x
+
+- Supported `v1beta1` version of HTTPRoute and removed support of `v1alpha2` version of HTTPRoute.
+
+### Unsupported
 - Does not support `queryParam` in route matches.
 - Does not support `requestRedirect` in filters.
 
 ## TCP Routes
 
-The {{site.kic_product_name}}'s implementation of `TCPRoute` supports multiple `BackendRefs` in
-`TCPRoute` resources for load balancing.
+### v2.4.x
 
-### Supported Versions
-- `v1alpha2`
+- Supported `v1alpha2` of TCPRoute.
 
 ## UDP Routes
 
-The {{site.kic_product_name}}'s implementation of `UDPRoute` supports multiple `BackendRefs` in
-`UDPRoute` resources for load balancing.
+### v2.4.x
 
-### Supported Versions
-- `v1alpha2`
+- Supported `v1alpha2` of UDPRoute.
 
 ## TLS Routes
 
-### Supported Versions
-- `v1alpha2`
+### v2.4.x
 
-{% if_version gte:2.6.x %}
-## Reference Grants
+- Supported `v1alpha2` of TLSRoute.
 
-Kong implementation supports `ReferenceGrant` to allow routes to
-reference backends in other namespaces in `BackendRefs`.
+## Reference Grants and Reference Policies
 
-### Supported Versions
-- `v1alpha2`
-{% endif_version %}
+### v2.4.x
 
-{% if_version gte:2.4.x lte:2.5.x %}
-## Reference Policies
+- Supported `v1alpha2` version of ReferencePolicy to allow routes to
+  reference backends in other namespaces in `BackendRefs`.
 
-The {{site.kic_product_name}}'s implementation supports using `ReferencePolicy` to allow routes to
-reference backends in other namespaces in `BackendRefs`.
+### v2.6.x
 
-### Supported Versions
-- `v1alpha2`
-{% endif_version %}
+- Supported `v1alpha2` version of ReferenceGrant and removed support of ReferencePolicy.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

change docs for support of gateway API in KIC into changedog format to provide a clearer view of "what version of KIC supports what features in gateway API". 

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

fixes https://github.com/Kong/kubernetes-ingress-controller/issues/3215
possibly another way to fix https://github.com/Kong/kubernetes-ingress-controller/issues/3173

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

https://deploy-preview-4869--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/gateway-api-support/

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
