### PR TITLE
docs(rate-limiting-advanced): add suggestions on namespace field in DB-less mode

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -37,7 +37,8 @@ params:
     Gateway in DB-less or hybrid mode, use the `redis` strategy.
 
     {:.note}
-    > **Note**: When using DB-less mode, it is recommended to have the `namespace` field configured manually instead of auto-generating.
+    > **Note**: We recommend setting `namespace` to a static value in DB-less mode.
+    > The `namespace` will be regenerated on every configuration change if not explicitly set, resetting counters to zero.
 
   config:
     - name: limit
@@ -100,9 +101,10 @@ params:
       datatype: string
       description: |
         The rate limiting library namespace to use for this plugin instance. Counter
-        data and sync configuration is shared in a namespace. Note that in DB-less mode,
-        this field will be generated automatically on every configuration change, so it
-        is recommended to be set to a unique value to keeps it stable in DB-less mode.
+        data and sync configuration is shared in a namespace.
+
+        In DB-less mode, this field will be generated automatically on every configuration change.
+        We recommended setting `namespace` explicitly when using DB-less mode.
     - name: strategy # old version of param description
       maximum_version: "2.8.x"
       required: true

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -35,6 +35,10 @@ params:
   dbless_explanation: |
     The cluster strategy is not supported in DB-less and hybrid modes. For Kong
     Gateway in DB-less or hybrid mode, use the `redis` strategy.
+
+    {:.note}
+    > **Note**: When using DB-less mode, it is recommended to have the `namespace` field configured manually instead of auto-generating.
+
   config:
     - name: limit
       required: true
@@ -96,8 +100,9 @@ params:
       datatype: string
       description: |
         The rate limiting library namespace to use for this plugin instance. Counter
-        data and sync configuration is shared in a namespace.
-
+        data and sync configuration is shared in a namespace. Note that in DB-less mode,
+        this field will be generated automatically on every configuration change, so it
+        is recommended to be set to a unique value to keeps it stable in DB-less mode.
     - name: strategy # old version of param description
       maximum_version: "2.8.x"
       required: true


### PR DESCRIPTION
### Summary

docs(rate-limiting-advanced): add suggestions on the namespace field in DB-less mode

This PR adds some suggestions to guide users manually setting `namespace` field in the rate-limiting-advanced plugin when using DB-less mode.

### Reason

The `namespace` field is an auto field and will be generated every time when new plugins are created. In DB-less mode, when a new configuration is pushed to the gateway instance, new entities will be created, which will result in the change of `namespace` value, thus may cause precision loss on the rate-limit couting.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

### Ref

This fixes part of the problem in [FTI-4549](https://konghq.atlassian.net/browse/FTI-4549)

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
