### PR TITLE
Remove privileged worker from 3.1

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -71,8 +71,6 @@ see [Key management](/gateway/latest/reference/key-management/).
 
 ### Performance
 
-- Data plane's connection to control plane is moved to a privileged worker process.
-  [#9432](https://github.com/Kong/kong/pull/9432)
 - Increase the default value of `lua_regex_cache_max_entries`. A warning will be thrown
   when there are too many regex routes and `router_flavor` is `traditional`.
   [#9624](https://github.com/Kong/kong/pull/9624)


### PR DESCRIPTION
Signed-off-by: Diana <75819066+cloudjumpercat@users.noreply.github.com>

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Removed the mention of the privileged worker from the 3.1 release notes. 
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
The changes for this were reverted due to performance issues, but will be included in a later release.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->
View the Gateway changelog.
<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
