### PR TITLE
Add "External plugin performance" back

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -479,6 +479,8 @@ items:
             url: /plugin-development/pluginserver/python
           - text: Running Plugins in Containers
             url: /plugin-development/pluginserver/plugins-kubernetes
+          - text: External Plugin Performance
+            url: /plugin-development/pluginserver/performance
   - title: Kong Plugins
     icon: /assets/images/icons/documentation/icn-api-plugins-color.svg
     items:

--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -485,6 +485,8 @@ items:
             url: /plugin-development/pluginserver/python
           - text: Running Plugins in Containers
             url: /plugin-development/pluginserver/plugins-kubernetes
+          - text: External Plugin Performance
+            url: /plugin-development/pluginserver/performance
   - title: Kong Plugins
     icon: /assets/images/icons/documentation/icn-api-plugins-color.svg
     items:

--- a/app/_redirects
+++ b/app/_redirects
@@ -501,6 +501,7 @@
 /gateway-oss/2.6.x/external-plugins/    /gateway/2.6.x/reference/external-plugins
 /gateway-oss/2.7.x/external-plugins/    /gateway/2.7.x/reference/external-plugins
 /gateway-oss/latest/external-plugins/   /gateway/latest/reference/external-plugins
+/gateway/3.0.x/reference/external-plugins/#performance-for-external-plugins /gateway/3.0.x/plugin-development/pluginserver/performance
 /enterprise/2.6.x/systemd/              /gateway/2.6.x/plan-and-deploy/systemd
 /enterprise/2.7.x/systemd/              /gateway/2.7.x/plan-and-deploy/systemd
 /enterprise/latest/systemd/             /gateway/latest/plan-and-deploy/systemd

--- a/src/gateway/plugin-development/pluginserver/performance.md
+++ b/src/gateway/plugin-development/pluginserver/performance.md
@@ -1,0 +1,23 @@
+---
+title: External plugin performance
+content_type: reference
+---
+
+Depending on implementation details, Go plugins are able to use multiple CPU cores
+and so perform best on a multi-core system. JavaScript plugins are currently
+single-core only and there's no dedicated plugin server support.
+Python plugins can use a dedicated plugin server to span workload to
+multiple CPU cores as well.
+
+Unlike Lua plugins where invoking PDK functions are handled in local processes,
+calling PDK functions in external plugins implies inter-process communications and so is a
+relatively expensive operation. Because of the expense of calling PDK functions in external plugins, the performance of Kong using external plugins is
+highly related to the number of IPC (inter-process communication) calls in each request.
+
+The following graph demonstrates the correlation between performance and count of IPC
+calls per request. Numbers of RPS and latency are removed as they are dependent on
+hardware and to avoid confusion.
+
+<center><img title="RPS" src="/assets/images/docs/external-plugins/rps.png"/></center>
+
+<center><img title="Latency" src="/assets/images/docs/external-plugins/latency.png"/></center>


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
Added "External plugin performance" back to the 3.0 and 3.1 nav. I just added this to the `release/gateway-3.1` branch because it would need to be added to the 3.1 nav anyways.
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
Looks like the page was unintentionally removed during our IA rework in 3.0. 
### Testing
<!-- How can your reviewers test your change? How did you test it? -->

- View the page /plugin-development/pluginserver/performance
- See if the redirect works correctly

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
