### PR TITLE
docs(aws-lambda): add new `https` config field in aws-lambda plugin

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -198,6 +198,7 @@ params:
       description: |
         The TCP port that the plugin uses to connect to the server.
     - name: https
+      minimum_version: "3.2.x"
       required: false
       default: true
       datatype: boolean

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -197,6 +197,11 @@ params:
       datatype: integer
       description: |
         The TCP port that the plugin uses to connect to the server.
+    - name: https
+      required: false
+      default: true
+      datatype: boolean
+      description: Whether to use HTTPS to connect with the AWS Lambda Function service endpoint. This is useful for local test scenarios by using the [AWS SAM CLI tool](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
     - name: keepalive
       required: true
       default: '`60000`'


### PR DESCRIPTION
### Summary

This PR adds the documentation of the new `https` config field in the aws-lambda plugin, which supports scheme config on the lambda service API endpoint.

This will be a Kong Gateway 3.2 feature.

### Reason
[FTI-4484](https://konghq.atlassian.net/browse/FTI-4484)

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
