### PR TITLE
Update NLB guide to preserve IP address on EKS using AWS Load Balancer Controller strategy

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
+++ b/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
@@ -84,28 +84,31 @@ You can use `ExternalTrafficPolicy: Local` to preserve the Client IP address.
 
 ### EKS
 
-You have two options:
+You have three options:
 
-- L4 Load Balancer
-  In this case, you need to use the Proxy Protocol method to preserve Client IP
-  address.
+- L4 Network Load Balancer, with [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller)
+  In this case, you can use the Proxy Protocol method to preserve Client IP
+  address together with `ExternalTrafficPolicy: Cluster`.
+- L4 in-tree Network Load Balancer with the `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation
+  In this case you need to use `ExternalTrafficPolicy: Local` to preserve the Client IP address.
 - L7 Load Balancer
   In this case, you need to use the HTTP headers method to preserve the Client
   IP address.
 
-The recommend Load Balancer type for AWS is NLB.
-You can choose the type of Load Balancer using the following annotation:
+The recommended Load Balancer type for AWS is the Network Load Balancer deployed with AWS Load Balancer Controller.
+You can choose this type of Load Balancer using the following annotations:
 
 ```
-service.beta.kubernetes.io/aws-load-balancer-type: nlb
+service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+service.beta.kubernetes.io/aws-load-balancer-type: "external"
+service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
 ```
 
-Other useful annotations for AWS are:
+To enable proxy protocol with the AWS Load Balancer Controller, you need to set the following annotations:
 
 ```
-service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 ```
 
-A complete list can be found
-[here](https://gist.github.com/mgoodness/1a2926f3b02d8e8149c224d25cc57dc1).
+A list of annotations for the AWS Load Balancer Controller can be found
+[here](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/).

--- a/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
+++ b/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
@@ -86,12 +86,12 @@ You can use `ExternalTrafficPolicy: Local` to preserve the Client IP address.
 
 You have three options:
 
-- L4 Network Load Balancer, with [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller)
+- L4 Network Load Balancer, with [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller): 
   In this case, you can use the Proxy Protocol method to preserve Client IP
   address together with `ExternalTrafficPolicy: Cluster`.
-- L4 in-tree Network Load Balancer with the `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation
+- L4 in-tree Network Load Balancer with the `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation: 
   In this case you need to use `ExternalTrafficPolicy: Local` to preserve the Client IP address.
-- L7 Load Balancer
+- L7 Load Balancer: 
   In this case, you need to use the HTTP headers method to preserve the Client
   IP address.
 

--- a/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
+++ b/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
@@ -87,15 +87,15 @@ You can use `ExternalTrafficPolicy: Local` to preserve the Client IP address.
 You have three options:
 
 - L4 Network Load Balancer, with [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller): 
-  In this case, you can use the Proxy Protocol method to preserve Client IP
+  In this case, you can use the Proxy Protocol method to preserve the client IP
   address together with `ExternalTrafficPolicy: Cluster`.
-- L4 in-tree Network Load Balancer with the `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation: 
-  In this case you need to use `ExternalTrafficPolicy: Local` to preserve the Client IP address.
+- L4 in-tree network Load Balancer with the `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation: 
+  In this case you need to use `ExternalTrafficPolicy: Local` to preserve the client IP address.
 - L7 Load Balancer: 
   In this case, you need to use the HTTP headers method to preserve the Client
   IP address.
 
-The recommended Load Balancer type for AWS is the Network Load Balancer deployed with AWS Load Balancer Controller.
+The recommended Load Balancer type for AWS is the Network Load Balancer deployed with the AWS Load Balancer Controller. 
 You can choose this type of Load Balancer using the following annotations:
 
 ```

--- a/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
+++ b/app/_src/kubernetes-ingress-controller/guides/preserve-client-ip.md
@@ -92,7 +92,7 @@ You have three options:
 - L4 in-tree network Load Balancer with the `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation: 
   In this case you need to use `ExternalTrafficPolicy: Local` to preserve the client IP address.
 - L7 Load Balancer: 
-  In this case, you need to use the HTTP headers method to preserve the Client
+  In this case, you need to use the HTTP headers method to preserve the client
   IP address.
 
 The recommended Load Balancer type for AWS is the Network Load Balancer deployed with the AWS Load Balancer Controller. 


### PR DESCRIPTION
### Summary
HI this PR address some outdated informations on the page `preserving client ip adress`. It adds informations on the AWS Load Balancer Controller instead of using the in-tree one.

The AWS Load Balancer Controller is a more complete approach on EKS to manage Load Balancers, network and application. 

### Reason
The reason behind this PR is to update the page and remove the wrong information that proxy protocol can be enabled on a `in-tree` `nlb` load balancer.

### Testing
To test the annotations/Load Balancers, you need an EKS cluster with the AWS Load Balancer Controller deployed.

To install the AWS Load Balancer Controller on an EKS cluster you can follow the official docs or use the kustomize package and terraform module included in this repository https://github.com/sighupio/fury-kubernetes-aws 

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->

review:tech:
