### PR TITLE
Fix plugins regeneration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ build: ruby-version-check
 clean:
 	-rm -rf dist
 	-rm -rf app/.jekyll-cache
+	-rm app/.jekyll-metadata
 
 # Runs tests
 test:

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -1,44 +1,35 @@
-{% assign path_array = extn.path | split: "/" %}
-{% assign filename = path_array | last %}
-{% assign extn_slug = path_array[2] %}
-{% assign extn_publisher = path_array[1] %}
-{% capture extn_id %}{{ extn_publisher }}_{{ extn_slug }}{% endcapture %}
-  {% if include.header_icon %}
-    {% assign header_icon = include.header_icon %}
-  {% else %}
-    {% capture header_icon %}/assets/images/icons/hub/{{ extn_id }}.png{% endcapture %}
-  {% endif %}
-  {% assign extn_slug_array = extn_slug | split: "-" %}
-  <div class="card-group {{ extn.type }} {{ extn.categories | join: ' ' }} {%
-    if extn_publisher == 'kong-inc' %}pub-konghq {%
-      if extn.kong_version_compatibility.enterprise_edition.compatible != nil %}ee-compat {% endif %}{%
-        if extn.plus or extn.kong_version_compatibility.community_edition.compatible != nil %}{%
-          unless extn.cloud == false %}plus {% endunless %}{% endif %}{%
-            if extn.enterprise %}enterprise {%
-              else %}open-source {% endif %}{%
-                unless extn.cloud == false %} konnect-cloud{% endunless %}{%
-                else %}pub-not-konghq pub-{{extn_publisher}}{% endif %}">
-    <div class="plugin-card">
-      <a href="{{ extn.url | remove: 'index.html' }}" title="{{ extn.name }}: {{ extn.desc }}">
-        <div>
-          <div class="name-desc">
-            {% if extn.plus and extn_publisher == 'kong-inc' %}
-            <span class="plugin-badge plus"></span>{% endif %}
-            {% if extn.enterprise and extn_publisher == 'kong-inc' %}
-            <span class="plugin-badge enterprise"></span> {% endif %}
-            <img class="card-img-top" src="{{ header_icon }}" alt="" />
-            <p class="plugin-name">{{ extn.name }}</p>
-            <p class="plugin-desc">{{ extn.desc }}</p>
-          </div>
-          <div class="publisher">
-            Support by:<br>
-            {% if extn_publisher == "kong-inc" %}
-              {% include svgs.html img='team-kong-icon' %}
-            {% else %}
-              {{ extn.publisher }}
-            {% endif %}
-          </div>
+{% assign extn_publisher = extn.extn_publisher %}
+
+<div class="card-group {{ extn.type }} {{ extn.categories | join: ' ' }} {%
+  if extn_publisher == 'kong-inc' %}pub-konghq {%
+    if extn.kong_version_compatibility.enterprise_edition.compatible != nil %}ee-compat {% endif %}{%
+      if extn.plus or extn.kong_version_compatibility.community_edition.compatible != nil %}{%
+        unless extn.cloud == false %}plus {% endunless %}{% endif %}{%
+          if extn.enterprise %}enterprise {%
+            else %}open-source {% endif %}{%
+              unless extn.cloud == false %} konnect-cloud{% endunless %}{%
+              else %}pub-not-konghq pub-{{extn_publisher}}{% endif %}">
+  <div class="plugin-card">
+    <a href="{{ extn.url | remove: 'index.html' }}" title="{{ extn.name }}: {{ extn.desc }}">
+      <div>
+        <div class="name-desc">
+          {% if extn.plus and extn_publisher == 'kong-inc' %}
+          <span class="plugin-badge plus"></span>{% endif %}
+          {% if extn.enterprise and extn_publisher == 'kong-inc' %}
+          <span class="plugin-badge enterprise"></span> {% endif %}
+          <img class="card-img-top" src="{{ extn.extn_icon }}" alt="" />
+          <p class="plugin-name">{{ extn.name }}</p>
+          <p class="plugin-desc">{{ extn.desc }}</p>
         </div>
-      </a>
-    </div>
+        <div class="publisher">
+          Support by:<br>
+          {% if extn_publisher == "kong-inc" %}
+            {% include svgs.html img='team-kong-icon' %}
+          {% else %}
+            {{ extn.publisher }}
+          {% endif %}
+        </div>
+      </div>
+    </a>
   </div>
+</div>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -10,12 +10,9 @@ breadcrumbs:
 {% unless page.type == "concept" %}
 {% if page.type == "plugin" or page.type == "integration" %}
 
-
-{% assign path_array = page.path | split: "/" %}
-{% assign extn_slug = path_array[2] %}
-{% assign extn_publisher = path_array[1] %}
+{% assign extn_slug = page.extn_slug %}
+{% assign extn_publisher = page.extn_publisher %}
 {% assign extn_data = site.data.extensions[extn_publisher][extn_slug] %}
-
 {% capture params_table %}
 <table>
   <thead>
@@ -135,18 +132,10 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
 {% assign extn_type = site.extensions.types | where: "slug", page.type %}
 {% assign extn_type = extn_type[0]['name'] %}
 
-{% capture extn_id %}{{ extn_publisher }}_{{ extn_slug }}{% endcapture %}
-{% capture extn_icon %}/assets/images/icons/hub/{{ extn_id }}.png{% endcapture %}
-
-{% assign extn_filename = path_array | last %}
 {% assign extn_versions = extn_data['releases'] %}
 {% if extn_versions %}
   {% assign extn_latest = extn_versions | first %}
-  {% unless extn_filename == "index.md" %}
-    {% assign extn_release = extn_filename | remove: ".md" %}
-  {% else %}
-    {% assign extn_release = extn_versions | first %}
-  {% endunless %}
+  {% assign extn_release = page.extn_release %}
 {% endif %}
 {% endunless %}
 
@@ -155,18 +144,18 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
 
 <div class="page page-extension-profile">
   {% if page.header_icon or page.header_title %}
-    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs type=extn_type name=page.header_title img=page.header_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
+    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.header_title img=page.header_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% elsif page.type == concept %}
-    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
+    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.title img=page.header_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% else %}
-    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=extn_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_filename=extn_filename extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
+    {% include_cached header.html is_latest=page.is_latest id=page.id url=page.url breadcrumbs=page.breadcrumbs name=page.name img=page.extn_icon plus=page.plus enterprise=page.enterprise cloud=page.cloud publisher=page.publisher extn_versions=extn_versions extn_publisher=extn_publisher extn_slug=extn_slug %}
   {% endif %}
 
   <div class="container">
 
     {% capture full_content %}
     {% if page.type == "plugin" or page.type == "integration" %}
-      {% unless path_array contains "kong-inc" %}
+      {% unless extn_publisher == "kong-inc" %}
         <div class="alert alert-info blue" role="alert">
           Community {{ extn_type | capitalize }}: This plugin is <b>developed, tested, and maintained</b> by a third-party contributor.
         </div>
@@ -287,7 +276,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
           <a href="/hub"><i class="fa fa-chevron-left"></i>Back to Kong Plugin Hub</a>
         </p>
         <p>
-          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{page.path | replace: "index", "_index" }}">
+          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ page.source_file }}">
             <img src="/assets/images/logos/logo-github.svg" alt="github-edit-page"/>Edit this page</a>
         </p>
         <p>

--- a/app/_plugins/generators/plugin_single_source/single_source_page.rb
+++ b/app/_plugins/generators/plugin_single_source/single_source_page.rb
@@ -13,9 +13,6 @@ module PluginSingleSource
 
       permalink_name = is_latest ? 'index' : version
 
-      # Make sure the source path is still index.md to generate the extension listing
-      @path = File.join(site.source, Generator::PLUGINS_FOLDER, plugin.dir, "#{permalink_name}.md")
-
       # Set self.ext and self.basename by extracting information from the page filename
       process("#{version}.md")
 
@@ -37,10 +34,6 @@ module PluginSingleSource
       @data['canonical_url'] = "/hub/#{plugin.dir}/" unless is_latest
       @data['seo_noindex'] = true unless is_latest
 
-      # We need to set the path so that some of the conditionals in templates
-      # continue to work.
-      @data['path'] = "_hub/#{plugin.dir}/#{permalink_name}.md"
-
       # The plugin hub uses version.html as the filename unless it's the most
       # recent version, in which case it uses index
       @data['permalink'] = "#{@dir}/"
@@ -48,6 +41,17 @@ module PluginSingleSource
 
       # Set the layout if it's not already provided
       @data['layout'] = 'extension' unless data['layout']
+
+      @data['source_file'] = source_path
+      @data['extn_slug'] = plugin.name
+      @data['extn_publisher'] = plugin.vendor
+      @data['extn_icon'] = @data['header_icon'] || "/assets/images/icons/hub/#{plugin.vendor}_#{plugin.name}.png"
+      @data['extn_release'] = version
+
+      # Needed so that regeneration works for single sourced pages
+      # It must be set to the source file
+      # Also, @path MUST NOT be set, it falls back to @relative_path
+      @relative_path = File.expand_path(source_path, site.source)
     end
   end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/single_source_page_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/single_source_page_spec.rb
@@ -22,15 +22,22 @@ RSpec.describe PluginSingleSource::SingleSourcePage do
       let(:is_latest) { true }
 
       it 'sets the corresponding attributes' do
-        expect(subject.instance_variable_get(:@path)).to eq(File.expand_path('_hub/acme/jwt-signer/index.md', site.source))
         expect(subject.instance_variable_get(:@dir)).to eq('hub/acme/jwt-signer')
+        expect(subject.instance_variable_get(:@relative_path))
+          .to eq(File.join(site.source, '_hub/acme/jwt-signer/_index.md'))
+
         expect(subject.data['version']).to eq('3.0.x')
         expect(subject.data['is_latest']).to eq(true)
         expect(subject.data['canonical_url']).to be_nil
         expect(subject.data['seo_noindex']).to be_nil
-        expect(subject.data['path']).to eq('_hub/acme/jwt-signer/index.md')
         expect(subject.data['permalink']).to eq('hub/acme/jwt-signer/')
         expect(subject.data['layout']).to eq('extension')
+
+        expect(subject.data['source_file']).to eq('_hub/acme/jwt-signer/_index.md')
+        expect(subject.data['extn_slug']).to eq('jwt-signer')
+        expect(subject.data['extn_publisher']).to eq('acme')
+        expect(subject.data['extn_icon']).to eq('/assets/images/icons/hub/acme_jwt-signer.png')
+        expect(subject.data['extn_release']).to eq('3.0.x')
       end
     end
 
@@ -40,15 +47,47 @@ RSpec.describe PluginSingleSource::SingleSourcePage do
       let(:is_latest) { false }
 
       it 'sets the corresponding attributes' do
-        expect(subject.instance_variable_get(:@path)).to eq(File.expand_path('_hub/acme/jwt-signer/2.8.x.md', site.source))
         expect(subject.instance_variable_get(:@dir)).to eq('hub/acme/jwt-signer')
+        expect(subject.instance_variable_get(:@relative_path))
+          .to eq(File.join(site.source, '_hub/acme/jwt-signer/_index.md'))
+
         expect(subject.data['version']).to eq('2.8.x')
         expect(subject.data['is_latest']).to eq(false)
         expect(subject.data['canonical_url']).to eq('/hub/acme/jwt-signer/')
         expect(subject.data['seo_noindex']).to eq(true)
-        expect(subject.data['path']).to eq('_hub/acme/jwt-signer/2.8.x.md')
         expect(subject.data['permalink']).to eq('hub/acme/jwt-signer/2.8.x.html')
         expect(subject.data['layout']).to eq('extension')
+
+        expect(subject.data['source_file']).to eq('_hub/acme/jwt-signer/_index.md')
+        expect(subject.data['extn_slug']).to eq('jwt-signer')
+        expect(subject.data['extn_publisher']).to eq('acme')
+        expect(subject.data['extn_icon']).to eq('/assets/images/icons/hub/acme_jwt-signer.png')
+        expect(subject.data['extn_release']).to eq('2.8.x')
+      end
+
+      context 'when there is a specific file for a particular version' do
+        let(:source) { '_2.2.x' }
+        let(:version) { '2.2.x' }
+        let(:is_latest) { false }
+
+        it 'sets the corresponding attributes' do
+          expect(subject.instance_variable_get(:@dir)).to eq('hub/acme/jwt-signer')
+          expect(subject.instance_variable_get(:@relative_path))
+            .to eq(File.join(site.source, '_hub/acme/jwt-signer/_2.2.x.md'))
+
+          expect(subject.data['version']).to eq('2.2.x')
+          expect(subject.data['is_latest']).to eq(false)
+          expect(subject.data['canonical_url']).to eq('/hub/acme/jwt-signer/')
+          expect(subject.data['seo_noindex']).to eq(true)
+          expect(subject.data['permalink']).to eq('hub/acme/jwt-signer/2.2.x.html')
+          expect(subject.data['layout']).to eq('extension')
+
+          expect(subject.data['source_file']).to eq('_hub/acme/jwt-signer/_2.2.x.md')
+          expect(subject.data['extn_slug']).to eq('jwt-signer')
+          expect(subject.data['extn_publisher']).to eq('acme')
+          expect(subject.data['extn_icon']).to eq('/assets/images/icons/hub/acme_jwt-signer.png')
+          expect(subject.data['extn_release']).to eq('2.2.x')
+        end
       end
     end
   end

--- a/spec/app/_plugins/generators/plugin_single_source_generator_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source_generator_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe PluginSingleSource::Generator do
       subject
 
       expect(site.data['ssg_hub'].map(&:path)).to match_array([
-        '_hub/acme/jq/index.md', '_hub/acme/jwt-signer/index.md', '_hub/acme/kong-plugin/index.md'
+        File.join(site.source, '_hub/acme/jq/_index.md'),
+        File.join(site.source, '_hub/acme/jwt-signer/_index.md'),
+        File.join(site.source, '_hub/acme/kong-plugin/_index.md')
       ])
     end
 


### PR DESCRIPTION
### Summary
[Related Jira ticket](https://konghq.atlassian.net/browse/DOCU-2828)
Fixes plugin pages re-generation so that they are re-built whenever the corresponding source file changes or its layout/ includes does.

This also removes some conditionals and calculations done in the templates and does them in ruby.
Fixes `Edit this page` link on plugin pages that have a source file for specific versions, e.g. [this one](https://deploy-preview-4884--kongdocs.netlify.app//hub/kong-inc/jwt-signer/2.2.x.html)

### Reason
Plugin pages were being re-generated on every file change, even if the change wasn't related.


### Testing
* Modify one of the plugin source files and check that the corresponding page is re-built
* Modify the layout and check that all the plugin pages are re-built
* Modify any file that is not related and check that the plugins are not re-built 

https://user-images.githubusercontent.com/715229/206397588-ee45ffb5-33ed-4973-9ae2-53b17d4c77e6.mov



