### PR TITLE
SAML plugin can be attached to consumers

### DIFF
--- a/app/_hub/kong-inc/saml/_index.md
+++ b/app/_hub/kong-inc/saml/_index.md
@@ -94,7 +94,7 @@ params:
   name: saml
   service_id: true
   route_id: true
-  consumer_id: false
+  consumer_id: true
   protocols:
     - name: http
     - name: https


### PR DESCRIPTION
### Summary

The SAML plugin can now be attached to consumers.

### Reason

There was no technical reason to disallow attaching the plugin to consumers, so it is now permitted.

KAG-207