### PR TITLE
feat(status_listen) support HTTP/2 protocol (FTI-4546)

### DIFF
--- a/src/gateway/reference/configuration.md
+++ b/src/gateway/reference/configuration.md
@@ -765,10 +765,12 @@ The following suffix can be specified for each pair:
 
 - `ssl` will require that all connections made through a particular
   address/port be made with TLS enabled.
+- `http2` will allow for clients to open HTTP/2 connections to
+   Kong's proxy server.
 
 This value can be set to `off`, disabling the Status API for this node.
 
-Example: `status_listen = 0.0.0.0:8100`
+Example: `status_listen = 0.0.0.0:8100 ssl http2`
 
 **Default:** `off`
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

`status_listen` API does not support HTTP/2.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

To support HTTP/2.

### Testing

Refer to <https://github.com/Kong/kong/pull/9919>.

<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
