### PR TITLE
[FTI-2972] bump the default `pg_ssl_version` to `tlsv1_2` and update the accepted values

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -1456,7 +1456,7 @@ name   | description  | default
 **pg_database** | The database name to connect to. | `kong`
 **pg_schema** | The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance. | none
 **pg_ssl** | Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one. | `off`
-**pg_ssl_version** | When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1`, `tlsv1_2`, or `tlsv1_3`. | `tlsv1`
+**pg_ssl_version** | When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3` or `any`. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`. | `tlsv1_2`
 **pg_ssl_required** | When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections. | `off`
 **pg_ssl_verify** | Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority. | `off`
 **pg_ssl_cert** | The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set. | none

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -1456,7 +1456,7 @@ name   | description  | default
 **pg_database** | The database name to connect to. | `kong`
 **pg_schema** | The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance. | none
 **pg_ssl** | Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one. | `off`
-**pg_ssl_version** | When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3` or `any`. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`. | `tlsv1_2`
+**pg_ssl_version** | When using SSL between Kong and PostgreSQL, the version of TLS to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or `any`. When `any` is set, the client negotiates the highest version with the server, which can't be lower than `tlsv1_1`. | `tlsv1_2`
 **pg_ssl_required** | When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections. | `off`
 **pg_ssl_verify** | Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority. | `off`
 **pg_ssl_cert** | The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set. | none


### PR DESCRIPTION
## Summary
- bump default `pg_ssl_version` to `tlsv1_2`

TLS versions lower than `tlsv1_2` are already deprecated and considered insecure. And since PostgreSQL 12.x+ a default minimum ssl version is added `ssl_min_protocol_version = 'TLSv1.2'`.

- constrain the valid values of this config

Currently it accepts any strings. Constrain it to accept only `tlsv1_1`, `tlsv1_2`, `tlsv1_3` or `any`. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`. Note our pgmoon has removed tlsv1 support. https://github.com/Kong/pgmoon/commit/2f2b028b960f5a4a4052d3ec0d5ef12774a3d3da

## Reasons
https://github.com/Kong/kong-ee/pull/4151
FTI-2972