### PR TITLE
docs(redis) redis.username cannot be 'default'

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -251,7 +251,7 @@ params:
       referenceable: true
       description: |
         Username to use for Redis connection when the `redis` strategy is defined and ACL authentication is desired.
-        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
+        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. Note that you can not set it as *default*.
     - name: redis.password
       required: semi
       default: null

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -251,7 +251,7 @@ params:
       referenceable: true
       description: |
         Username to use for Redis connection when the `redis` strategy is defined and ACL authentication is desired.
-        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. Note that you can not set it as *default*.
+        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. This can not be set to **default**.
     - name: redis.password
       required: semi
       default: null

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -132,7 +132,7 @@ params:
       datatype: string
       referenceable: true
       description: |
-        When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired. This requires Redis v6.0.0+. Note that you can not set it as *default*.
+        When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired. This requires Redis v6.0.0+. This can not be set to **default**.
     - name: redis_password
       minimum_version: "2.7.x"
       required: false

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -132,7 +132,7 @@ params:
       datatype: string
       referenceable: true
       description: |
-        When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.
+        When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired. This requires Redis v6.0.0+. Note that you can not set it as *default*.
     - name: redis_password
       minimum_version: "2.7.x"
       required: false


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

`redis.username` cannot be *default*. The Doc may confuse customers.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Required by Redis 6+.

<!-- ### Testing -->
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->

Fix _[FTI-4151]_

[FTI-4151]: https://konghq.atlassian.net/browse/FTI-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ