### PR TITLE
docs(key-auth): key ttl does not work with db-less or hybrid mode

### DIFF
--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -54,7 +54,9 @@
       plus: Yes
       enterprise: Yes
       network_config_opts: All
-      notes: --
+      notes: |
+        The time-to-live (ttl) does not work in hybrid mode. This setting
+        determines the length of time a credential remains valid.
       url: /hub/kong-inc/key-auth
 
     - name: Key Auth Encrypted


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

key ttl does not work with DB-less or hybrid mode.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Doc may confuse customers.

<!-- ### Testing -->
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->

Fix #_[FTI-4512]_
