### PR TITLE
StatsD Plugin: Converts ordered list to unordered list for non-instruction list

### DIFF
--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -171,19 +171,19 @@ Field         | Description                                             | Dataty
 
 ### Metric behaviors
 
-1.  By default, all metrics get logged.
-2.  Metric with `stat_type` set to `counter` or `gauge` must have `sample_rate` defined as well.
-3.  `unique_users` metric only works with `stat_type` as `set`.
+* By default, all metrics get logged.
+* Metric with `stat_type` set to `counter` or `gauge` must have `sample_rate` defined as well.
+* `unique_users` metric only works with `stat_type` as `set`.
 {% if_plugin_version lte:2.8.x %}
-4.  `status_count`, `status_count_per_user` and `request_per_user` work only with `stat_type`  as `counter`.
-5.  `status_count_per_user`, `request_per_user` and `unique_users` must have `customer_identifier` defined.
+* `status_count`, `status_count_per_user` and `request_per_user` work only with `stat_type`  as `counter`.
+* `status_count_per_user`, `request_per_user` and `unique_users` must have `customer_identifier` defined.
 {% endif_plugin_version %}
 {% if_plugin_version gte:3.0.x %}
-4.  `status_count`, `status_count_per_user`, `status_count_per_user_per_route` and `request_per_user` work only with `stat_type` as `counter`.
-5.  `shdict_usage` work only with `stat_type` as `gauge`.
-6.  `status_count_per_user`, `request_per_user`, `unique_users` and `status_count_per_user_per_route` must have `customer_identifier` defined.
-7.  All metrics can optionally configure `service_identifier`; by default it's set to `service_name_or_host`.
-8.  `status_count_per_workspace` must have `workspace_identifier` defined.
+* `status_count`, `status_count_per_user`, `status_count_per_user_per_route` and `request_per_user` work only with `stat_type` as `counter`.
+* `shdict_usage` work only with `stat_type` as `gauge`.
+* `status_count_per_user`, `request_per_user`, `unique_users` and `status_count_per_user_per_route` must have `customer_identifier` defined.
+* All metrics can optionally configure `service_identifier`; by default it's set to `service_name_or_host`.
+* `status_count_per_workspace` must have `workspace_identifier` defined.
 {% endif_plugin_version %}
 
 


### PR DESCRIPTION
### Summary
Formerlly, this list was ordered, but it was not intended to be step by step instructions

### Reason
It's a fix

### Testing
Built docs locally and manually validated the new list

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
