### PR TITLE
refactor(portal-cli): clarify details about variables

### DIFF
--- a/app/_src/gateway/kong-enterprise/dev-portal/cli.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/cli.md
@@ -33,9 +33,6 @@ Now, from the root folder of the templates repo, you can run:
 
 ```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
 
-or, including environment variables:
-```KONG_ADMIN_URL=<kong_admin_base_url> KONG_ADMIN_TOKEN=<kong_admin_token> portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
-
 Where `<command>` is one of:
 
 * `config`   Output or change configuration of the portal on the given

--- a/app/_src/gateway/kong-enterprise/dev-portal/cli.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/cli.md
@@ -24,7 +24,8 @@ master branch locally.
 Next, edit `workspaces/default/cli.conf.yaml` to set the workspace `kong_admin_url` and `kong_admin_token`
 to match your setup.
 
-You can also override the values set in `workspaces/default/cli.conf.yaml` by using the environment variables `KONG_ADMIN_URL` and `KONG_ADMIN_TOKEN`.
+You can also override the values set in `workspaces/default/cli.conf.yaml` by using the environment variables
+`KONG_ADMIN_URL` and `KONG_ADMIN_TOKEN`.
 
 Make sure Kong is running and portal is on.
 
@@ -46,6 +47,16 @@ Where `<command>` is one of:
 * `wipe`     Deletes all content and themes from upstream workspace
 
 Where `<workspace>` indicates the directory/workspace pairing you would like to operate on.
+
+You can set environment variables to override the values in the `workspaces/default/cli.conf.yaml` file:
+
+```sh
+KONG_ADMIN_URL=<kong_admin_base_url> \
+KONG_ADMIN_TOKEN=<kong_admin_token> \
+portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>
+```
+
+Where `<kong_admin_base_url>` is the location of the Kong Admin API that manages the developer portal and `<kong_admin_token>` is an RBAC token that has access to the manage the portal.
 
 #### For `deploy`
 - Add `-W` or `--watch` to make changes reactive.

--- a/app/_src/gateway/kong-enterprise/dev-portal/cli.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/cli.md
@@ -53,7 +53,7 @@ KONG_ADMIN_TOKEN=<kong_admin_token> \
 portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>
 ```
 
-Where `<kong_admin_base_url>` is the location of the Kong Admin API that manages the developer portal and `<kong_admin_token>` is an RBAC token that has access to the manage the portal.
+Where `<kong_admin_base_url>` is the location of the Kong Admin API that manages the developer portal and `<kong_admin_token>` is an RBAC token that has access to manage the portal.
 
 #### For `deploy`
 - Add `-W` or `--watch` to make changes reactive.

--- a/app/_src/gateway/kong-enterprise/dev-portal/cli.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/cli.md
@@ -21,14 +21,19 @@ this project is to make a higher quality CLI tool over the initial sync script.
 The easiest way to start is by cloning the [portal-templates repo][templates]
 master branch locally.
 
-Next, edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token`
+Next, edit `workspaces/default/cli.conf.yaml` to set the workspace `kong_admin_url` and `kong_admin_token`
 to match your setup.
+
+You can also override the values set in `workspaces/default/cli.conf.yaml` by using the environment variables `KONG_ADMIN_URL` and `KONG_ADMIN_TOKEN`.
 
 Make sure Kong is running and portal is on.
 
 Now, from the root folder of the templates repo, you can run:
 
 ```portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
+
+or, including environment variables:
+```KONG_ADMIN_URL=<kong_admin_base_url> KONG_ADMIN_TOKEN=<kong_admin_token> portal [-h,--help] [--config PATH] [-v,--verbose] <command> <workspace>```
 
 Where `<command>` is one of:
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
This clarifies how you can use variables for `kong_admin_url` and `kong_admin_token` when using the [kong-portal-cli](https://github.com/Kong/kong-portal-cli) to manage [kong-portal-templates](https://github.com/Kong/kong-portal-templates/).

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
This was brought up as unclear by a team member.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
