### PR TITLE
Fix quotes in cert-manager example for KIC

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/cert-manager.md
+++ b/app/_src/kubernetes-ingress-controller/guides/cert-manager.md
@@ -178,8 +178,8 @@ spec:
           podTemplate:
              metadata:
                annotations:
-                 kuma.io/sidecar-injection: "false"   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
-                 sidecar.istio.io/inject: "false"  # If using Istio, disable sidecar injection
+                 kuma.io/sidecar-injection: 'false'   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
+                 sidecar.istio.io/inject: 'false'  # If using Istio, disable sidecar injection
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -179,8 +179,8 @@ spec:
           podTemplate:
              metadata:
                annotations:
-                 kuma.io/sidecar-injection: "false"   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
-                 sidecar.istio.io/inject: "false"  # If using Istio, disable sidecar injection
+                 kuma.io/sidecar-injection: 'false'   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
+                 sidecar.istio.io/inject: 'false'  # If using Istio, disable sidecar injection
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```

--- a/app/kubernetes-ingress-controller/2.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/cert-manager.md
@@ -179,8 +179,8 @@ spec:
           podTemplate:
              metadata:
                annotations:
-                 kuma.io/sidecar-injection: "false"   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
-                 sidecar.istio.io/inject: "false"  # If using Istio, disable sidecar injection
+                 kuma.io/sidecar-injection: 'false'   # If ingress is running in Kuma/Kong Mesh, disable sidecar injection
+                 sidecar.istio.io/inject: 'false'  # If using Istio, disable sidecar injection
           class: kong" | kubectl apply -f -
 clusterissuer.cert-manager.io/letsencrypt-prod configured
 ```


### PR DESCRIPTION
### Summary
Copy/paste didn't work as double quotes were used in the YAML manifest _and_ the `echo` command. Swap to single quotes in the manifest

### Reason
Enable copy/paste for consumers

### Testing
I deployed a `cert-manager` instance using the guide on a GKE cluster
