### PR TITLE
Makes the PDK file structure slightly more consistent

### DIFF
--- a/app/_src/gateway/plugin-development/file-structure.md
+++ b/app/_src/gateway/plugin-development/file-structure.md
@@ -97,7 +97,7 @@ master each one of them.
 
 | Module name            | Required   | Description
 |:-----------------------|------------|------------
-| [admin-api.lua](https://github.com/Kong/kong/blob/master/autodoc/admin-api/data/admin-api.lua)          | No         | Defines a list of endpoints to be available in the Admin API to interact with the custom entities handled by your plugin.
+| [api.lua](https://github.com/Kong/kong/blob/master/autodoc/admin-api/data/admin-api.lua)          | No         | Defines a list of endpoints to be available in the Admin API to interact with the custom entities handled by your plugin.
 | [daos.lua](https://github.com/Kong/kong/blob/master/kong/plugins/basic-auth/daos.lua)        | No         | Defines a list of DAOs (Database Access Objects) that are abstractions of custom entities needed by your plugin and stored in the data store.
 | [handler.lua](https://github.com/Kong/kong/blob/master/kong/plugins/basic-auth/handler.lua)     | Yes        | An interface to implement. Each function is to be run by Kong at the desired moment in the lifecycle of a request / connection.
 | [migrations/*.lua](https://github.com/Kong/kong/tree/master/kong/plugins/basic-auth/migrations) | No         | The database migrations (e.g. creation of tables). Migrations are only necessary when your plugin has to store custom entities in the database and interact with them through one of the DAOs defined by [daos.lua](https://github.com/Kong/kong/blob/master/kong/plugins/basic-auth/daos.lua).


### PR DESCRIPTION
### Summary

The table at the bottom of the page lists filenames the plugin developer should use And the descriptions below go into more detail on each file The table and the descriptions are inconsistent regarding the API interface filename

I looked at existing plugins, and there seems to be a standard to use api.lua and not admin-api.lua despite that being the name of the referenced autodoc file.

I suggest we make the filename in the description match the filename in the table so the developer knows what to name their file.

### Reason
To make the PDK more consistent for the reader

### Testing
Built the docs locally and viewed the result manually

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
