### PR TITLE
Make `vale`, actually `reviewdog` fail on error

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           # path where vale checks checking only modified files.
           filter_mode: file
+          fail_on_error: true
           vale_flags: "--glob=!app/_src/.repos/kuma/**"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -88,5 +88,6 @@ jobs:
           filter_mode: file
           fail_on_error: true
           vale_flags: "--glob=!app/_src/.repos/kuma/**"
+          reporter: github-pr-review
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Summary
Related [Jira ticket](https://konghq.atlassian.net/browse/DOCU-2841)
Make `reviewdog` fail when an error was found.

### Reason
Currently, `reviewdog` returns with an exit code of 0, even [if it finds errors.](https://github.com/reviewdog/reviewdog#exit-codes) This leads us to believe that the check passes, when in fact it does not. When we moved the docs from src/ to app/_src it [reported](https://github.com/Kong/docs.konghq.com/runs/10075252384) over 9k errors.

