### PR TITLE
[Release] decK version 1.17

### DIFF
--- a/app/_data/docs_nav_deck_1.17.x.yml
+++ b/app/_data/docs_nav_deck_1.17.x.yml
@@ -1,0 +1,87 @@
+product: deck
+release: 1.17.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    url: /deck/1.17.x/
+    absolute_url: true
+    items:
+      - text: Terminology
+        url: /terminology
+      - text: Architecture
+        url: /design-architecture
+      - text: Compatibility Promise
+        url: /compatibility-promise
+
+  - title: Changelog
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: https://github.com/kong/deck/blob/main/CHANGELOG.md
+    absolute_url: true
+
+  - title: Installation
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    url: /installation
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Getting Started with decK
+        url: /guides/getting-started
+      - text: Backup and Restore
+        url: /guides/backup-restore
+      - text: Upgrade to Kong Gateway 3.x
+        url: /3.0-upgrade
+      - text: Configuration as Code and GitOps
+        url: /guides/ci-driven-configuration
+      - text: Distributed Configuration
+        url: /guides/distributed-configuration
+      - text: Best Practices
+        url: /guides/best-practices
+      - text: Using decK with Kong Gateway (Enterprise)
+        url: /guides/kong-enterprise
+      - text: Using decK with Konnect
+        url: /guides/konnect
+      - text: Run decK with Docker
+        url: /guides/run-with-docker
+      - text: Using Multiple Files to Store Configuration
+        url: /guides/multi-file-state
+      - text: De-duplicate Plugin Configuration
+        url: /guides/deduplicate-plugin-configuration
+      - text: Set Up Object Defaults
+        url: /guides/defaults
+      - text: Security
+        items:
+          - text: Overview
+            url: /guides/security
+          - text: Secret Management with decK
+            url: /guides/vaults
+          - text: Using Environment Variables with decK
+            url: /guides/environment-variables
+
+  - title: decK CLI Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: /reference/deck
+    items:
+      - text: deck completion
+        url: /reference/deck_completion
+      - text: deck convert
+        url: /reference/deck_convert
+      - text: deck diff
+        url: /reference/deck_diff
+      - text: deck dump
+        url: /reference/deck_dump
+      - text: deck ping
+        url: /reference/deck_ping
+      - text: deck reset
+        url: /reference/deck_reset
+      - text: deck sync
+        url: /reference/deck_sync
+      - text: deck validate
+        url: /reference/deck_validate
+      - text: deck version
+        url: /reference/deck_version
+
+  - title: FAQ
+    icon: /assets/images/icons/documentation/icn-faq-color.svg
+    url: /faqs

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -248,6 +248,10 @@
   version: "1.16.1"
   edition: "deck"
 -
+  release: "1.17.x"
+  version: "1.17.1"
+  edition: "deck"
+-
   release: "1.0.x"
   version: "1.0.4"
   edition: "mesh"

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -249,7 +249,7 @@
   edition: "deck"
 -
   release: "1.17.x"
-  version: "1.17.1"
+  version: "1.17.0"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
This PR bumps the decK version to from 1.16 to 1.17. 

Autodocs do not need to be run for decK 1.17