### PR TITLE
fix(nav) add file access permissions link to nav

### DIFF
--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -598,6 +598,8 @@ items:
         url: /reference/nginx-directives
       - text: CLI
         url: /reference/cli
+      - text: File Permissions Reference
+        url: /reference/file-access-permissions
       - text: Key management
         url: /reference/key-management
       - text: Performance Testing Framework


### PR DESCRIPTION
### Summary
This somehow got removed in 3.1 docs.
