### PR TITLE
kic: add docs for annotation 

### DIFF
--- a/app/_src/kubernetes-ingress-controller/references/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/references/annotations.md
@@ -16,6 +16,7 @@ Following annotations are supported on Ingress resources:
 | [`konghq.com/protocols`](#konghqcomprotocols) | Set protocols to handle for each Ingress resource |
 | [`konghq.com/preserve-host`](#konghqcompreserve-host) | Pass the `host` header as is to the upstream service |
 | [`konghq.com/strip-path`](#konghqcomstrip-path) | Strip the path defined in Ingress resource and then forward the request to the upstream service |
+| [`ingress.kubernetes.io/force-ssl-redirect`](#ingresskubernetesioforce-ssl-redirect) | Force non-SSL requests to be redirected to SSL. |
 | [`konghq.com/https-redirect-status-code`](#konghqcomhttps-redirect-status-code) | Set the HTTPS redirect status code to use when an HTTP request is received |
 | [`konghq.com/regex-priority`](#konghqcomregex-priority) | Set the route's regex priority |
 | [`konghq.com/methods`](#konghqcommethods) | Set methods matched by this Ingress |
@@ -288,6 +289,15 @@ Sample usage:
 ```yaml
 konghq.com/preserve-host: "true"
 ```
+
+### ingress.kubernetes.io/force-ssl-redirect
+
+> Available since controller 0.10
+
+This annotation is used to enforce requests to redirected to SSL protocol
+(HTTPS or GRPCS). The default status code for requests need to be redirected
+is 302. This code can be configured by annotation konghq.com/https-redirect-status-code[#konghqcomhttps-redirect-status-code].
+
 
 ### konghq.com/https-redirect-status-code
 

--- a/app/_src/kubernetes-ingress-controller/references/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/references/annotations.md
@@ -19,16 +19,17 @@ Following annotations are supported on Ingress resources:
 | [`ingress.kubernetes.io/force-ssl-redirect`](#ingresskubernetesioforce-ssl-redirect) | Force non-SSL requests to be redirected to SSL. |
 | [`konghq.com/https-redirect-status-code`](#konghqcomhttps-redirect-status-code) | Set the HTTPS redirect status code to use when an HTTP request is received |
 | [`konghq.com/regex-priority`](#konghqcomregex-priority) | Set the route's regex priority |
+{%- if_version gte:2.7.x -%}
+| [`konghq.com/regex-prefix`](#konghqcomregex-prefix) | Prefix of path to annotate that the path is a regex match, other than default `/~` |
+{%- endif_version -%}
 | [`konghq.com/methods`](#konghqcommethods) | Set methods matched by this Ingress |
 | [`konghq.com/snis`](#konghqcomsnis) | Set SNI criteria for routes created from this Ingress |
 | [`konghq.com/request-buffering`](#konghqcomrequest-buffering) | Set request buffering on routes created from this Ingress |
 | [`konghq.com/response-buffering`](#konghqcomresponse-buffering) | Set response buffering on routes created from this Ingress |
 | [`konghq.com/host-aliases`](#konghqcomhostaliases) | Additional hosts for routes created from this Ingress's rules |
-
 {%- if_version lte:2.7.x -%}
 | [`konghq.com/override`](#konghqcomoverride) | Control other routing attributes via KongIngress resource |
 {%- endif_version -%}
-
 {%- if_version gte:2.8.x %}
 | [`konghq.com/override`](#konghqcomoverride) | (Deprecated, replace with per-setting annotations) Control other routing attributes with a KongIngress resource |
 | [`konghq.com/path-handling`](#konghqcompathhandling) | Sets the path handling algorithm |
@@ -294,9 +295,9 @@ konghq.com/preserve-host: "true"
 
 > Available since controller 0.10
 
-This annotation is used to enforce requests to redirected to SSL protocol
-(HTTPS or GRPCS). The default status code for requests need to be redirected
-is 302. This code can be configured by annotation konghq.com/https-redirect-status-code[#konghqcomhttps-redirect-status-code].
+This annotation is used to enforce requests to be redirected to SSL protocol
+(HTTPS or GRPCS). The default status code for requests that need to be 
+redirected is 302. This code can be configured by annotation `konghq.com/https-redirect-status-code`[#konghqcomhttps-redirect-status-code].
 
 
 ### konghq.com/https-redirect-status-code
@@ -583,6 +584,21 @@ on a Service resource in Kubernetes, (please note the quotes around `true`):
 annotations:
   ingress.kubernetes.io/service-upstream: "true"
 ```
+
+{% if_version gte:2.7.x %}
+### konghq.com/regex-prefix
+
+> Available since controller 2.7
+
+Sets the prefix of regex matched path to be some string other than `/~`. In
+Kong 3.0 and later, paths with regex match must start with `~`, so in 
+ingresses, `/~` prefix used by default to annotate that the path is using
+regex match. If the annotation is set, paths with the specified prefix is
+considered as paths with regex match and will be translated to `~` started
+path in Kong. For example, if an ingress has annotation 
+`konghq.com/regex-prefix: "/@"`, paths started with `/@` are considered as 
+paths using regex match. See: [upgrade-to-kong3x](/kubernetes-ingress-controller/latest/guides/upgreade-kong-3x)
+{% endif_version %}
 
 {% if_version gte:2.8.x %}
 ### konghq.com/path-handling


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Add the introduction of missing annotation `ingress.kubernetes.io/force-ssl-redirect`.  

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
fixes https://github.com/Kong/kubernetes-ingress-controller/issues/3260.
### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
https://deploy-preview-4943--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/annotations
