### PR TITLE
Updating how to pass env variables

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
@@ -34,6 +34,9 @@ This allows you to reference the secrets separately:
 {vault://env/pg-creds/password}
 ```
 
+{:.note}
+> While adding the environment variable inside using helm, make sure the varible which is been passed has kong- appended to it as this is been appended to all the environment variable by default.
+
 ## Configuration via vaults entity
 
 {:.note}

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
@@ -35,7 +35,7 @@ This allows you to reference the secrets separately:
 ```
 
 {:.note}
-> While adding the environment variable inside using helm, make sure the varible which is been passed has kong- appended to it as this is been appended to all the environment variable by default.
+> When adding an environment variable with Helm, ensure that the variable being passed has `kong-` appended to it. 
 
 ## Configuration via vaults entity
 


### PR DESCRIPTION
Adding a note to simplify the usage of env variable which are been appended inside env section of kong helm deployment

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
