### PR TITLE
Remake: Konnect externalized API Spec PR 

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -251,6 +251,7 @@
             url: /api/runtime-groups-config/#vaults-entity
         - text: API Spec
           url: https://developer.konghq.com/spec/3c38bff8-3b7b-4323-8e2e-690d35ef97e0/16adcd15-493a-49b2-ad53-8c73891e29bf
+          absolute_url: true
     - text: Reference
       items:
         - text: Filtering

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -249,6 +249,8 @@
             url: /api/runtime-groups-config/#target-object
           - text: Vaults
             url: /api/runtime-groups-config/#vaults-entity
+        - text: API Spec
+          url: https://developer.konghq.com/spec/3c38bff8-3b7b-4323-8e2e-690d35ef97e0/16adcd15-493a-49b2-ad53-8c73891e29bf
     - text: Reference
       items:
         - text: Filtering


### PR DESCRIPTION
There were too many changes to https://github.com/Kong/docs.konghq.com/pull/4898 which made 
 https://github.com/Kong/docs.konghq.com/pull/4931 fall out of sync. This PR contains only the link the API spec since #4898 has been merged already this PR will be much easier to use. **This is still for Hayden to merge if he can finish the API spec**.