### PR TITLE
kic: update support of router flavors

### DIFF
--- a/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -13,11 +13,14 @@ The router can be configured in the following [modes][gateway-router-flavor]:
 The compatibilities of router flavors between different {{site.kic_product_name}} versions and {{site.base_gateway}} are shown in the following table.
 {{site.kic_product_name}} in versions 2.6.x and lower does not support {{site.base_gateway}} 3.0 and later, so the version of {{site.kic_product_name}} begins at 2.7.x.
 
-| {{site.kic_product_name}}            | 2.7.x                           |
-|:-------------------------------------|:-------------------------------:|
-| Kong 3.0.x  `traditional`            |  <i class="fa fa-check"></i>    |     
-| Kong 3.0.x  `traditional_compatible` |  <i class="fa fa-times"></i>(*) | 
-| Kong 3.0.x  `expression`             |  <i class="fa fa-times"></i>    |
+| {{site.kic_product_name}}            | 2.7.x                           | 2.8.x
+|:-------------------------------------|:-------------------------------:|:-------------------------------:|
+| Kong 3.0.x  `traditional`            |  <i class="fa fa-check"></i>    | <i class="fa fa-check"></i> | 
+| Kong 3.0.x  `traditional_compatible` |  <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | 
+| Kong 3.0.x  `expression`             |  <i class="fa fa-times"></i>    | <i class="fa fa-times"></i>  | 
+| Kong 3.1.x  `traditional`            |  <i class="fa fa-check"></i>    |  <i class="fa fa-check"></i> |    
+| Kong 3.1.x  `traditional_compatible` |  <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | 
+| Kong 3.1.x  `expression`             |  <i class="fa fa-times"></i>    | <i class="fa fa-times"></i> |
 
 (*) Most use cases are supported. Regexes with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
 may not be accepted when {{site.base_gateway}} 3.0 is configured to use the `traditional_compatible` router.


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

update supported router flavors in KIC for KIC 2.8 and Kong 3.1.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

fixes https://github.com/Kong/kubernetes-ingress-controller/issues/3290

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

https://deploy-preview-4949--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/supported-router-flavors/

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
