### PR TITLE
Update Rate Limiting Plugin docs to add subdomain

### DIFF
--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -69,6 +69,7 @@ params:
         - `consumer`
         - `credential`
         - `ip`
+        - `subdomain` (The first part of your hostname eg. `<subdomain>.domain.com` will rate limit by subdomain.)
         - `service` (The `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.)
         - `header` (The `header_name` configuration must be provided.)
         - `path` (The `path` configuration must be provided.)


### PR DESCRIPTION
### Summary
Update the docs for the rate limiting plugin to mention the ability to rate limit by subdomain.

### Reason
https://github.com/Kong/kong/pull/9965

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
