### PR TITLE
fix(nav): add debug routes to nav sidebar

### DIFF
--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -549,6 +549,8 @@ items:
         url: /admin-api/#information-routes
       - text: Health Routes
         url: /admin-api/#health-routes
+      - text: Debug Routes
+        url: /admin-api/#debug-routes
       - text: Tags
         url: /admin-api/#tags
       - text: Services

--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -549,10 +549,10 @@ items:
         url: /admin-api/#information-routes
       - text: Health Routes
         url: /admin-api/#health-routes
-      - text: Debug Routes
-        url: /admin-api/#debug-routes
       - text: Tags
         url: /admin-api/#tags
+      - text: Debug Routes
+        url: /admin-api/#debug-routes
       - text: Services
         url: /admin-api/#service-object
       - text: Routes


### PR DESCRIPTION
The debug routes don’t show up in the nav sidebar: https://docs.konghq.com/gateway/latest/admin-api/#debug-routes

Fix https://konghq.atlassian.net/browse/DOCU-2883