### PR TITLE
Use site.data.kong_latest_gateway.ee-version in Konnect

### DIFF
--- a/app/konnect/runtime-manager/runtime-instances/gateway-runtime-docker.md
+++ b/app/konnect/runtime-manager/runtime-instances/gateway-runtime-docker.md
@@ -85,7 +85,7 @@ $ docker run -d --name kong-dp \
   -e "KONG_VITALS=off" \
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly \
   -p 8000:8000 \
-  kong/kong-gateway:3.0.0.0
+  kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
 ```
 {% endnavtab %}
 {% navtab Windows PowerShell %}
@@ -105,7 +105,7 @@ docker run -d --name kong-dp `
   -e "KONG_VITALS=off" `
   --mount type=bind,source="$(pwd)",target={PATH_TO_KEYS_AND_CERTS},readonly `
   -p 8000:8000 `
-  kong/kong-gateway:3.0.0.0
+  kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Summary
Use site.data.kong_latest_gateway.ee-version rather than a hardcoded version in Konnect docs

### Reason
The docs will automatically update when new versions are released (this assumes compatibility on day zero, which should be a baseline)

### Testing
/konnect/runtime-manager/runtime-instances/gateway-runtime-docker/