### PR TITLE
Redirect moved file for KIC Gateway API guide

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -46,6 +46,9 @@
 /kubernetes-ingress-controller-beta/   /kubernetes-ingress-controller/
 /kubernetes-ingress-controller-beta/*  /kubernetes-ingress-controller/:splat
 
+# KIC GENERAL
+/kubernetes-ingress-controller/:version/guides/using-gateway-api/ /kubernetes-ingress-controller/:version/guides/getting-started/
+
 # ENTERPRISE GATEWAY
 /enterprise/latest/introduction       /enterprise/
 /enterprise/2.3.x/introduction        /enterprise/


### PR DESCRIPTION
### Summary
Add a redirect for a guide that no longer exists. If the file exists on disk (e.g. pre-2.7) then the redirect does not take effect.

### Reason
The Gateway API guide has been refactored in KIC 2.7 and 2.8.

### Testing
/kubernetes-ingress-controller/2.6.x/guides/using-gateway-api/ does not redirect
/kubernetes-ingress-controller/2.7.x/guides/using-gateway-api/ redirects