### PR TITLE
New kong.conf directives for Prometheus plugin

### DIFF
--- a/app/_hub/kong-inc/prometheus/_1.6.0.md
+++ b/app/_hub/kong-inc/prometheus/_1.6.0.md
@@ -363,7 +363,7 @@ allow access to the `/metrics` endpoint to Prometheus:
 * Adds new directives in `kong.conf` to enable or disable high cardinality metrics.
   * `prometheus_plugin_status_code_metrics`: enables or disables reporting the HTTP/Stream status codes per service/route.
   * `prometheus_plugin_latency_metrics`: enables or disables reporting the latency added by Kong, request time and upstream latency.
-  * `prometheus_plugin_bandwidth_metrics`: enables or disables reporting the bandwith consumed by service/route.
+  * `prometheus_plugin_bandwidth_metrics`: enables or disables reporting the bandwidth consumed by service/route.
   * `prometheus_plugin_upstream_health_metrics`: enables or disables reporting the upstream health status.
 
 **{{site.base_gateway}} 2.8.x**

--- a/app/_hub/kong-inc/prometheus/_1.6.0.md
+++ b/app/_hub/kong-inc/prometheus/_1.6.0.md
@@ -359,6 +359,13 @@ allow access to the `/metrics` endpoint to Prometheus:
 * Plugin version bumped to 3.0.0
 * The `node_id` label was added to memory metrics.
 
+**{{site.base_gateway}} (Enterprise) 2.8.3.2**
+* Adds new directives in `kong.conf` to enable or disable high cardinality metrics.
+  * `prometheus_plugin_status_code_metrics`: enables or disables reporting the HTTP/Stream status codes per service/route.
+  * `prometheus_plugin_latency_metrics`: enables or disables reporting the latency added by Kong, request time and upstream latency.
+  * `prometheus_plugin_bandwidth_metrics`: enables or disables reporting the bandwith consumed by service/route.
+  * `prometheus_plugin_upstream_health_metrics`: enables or disables reporting the upstream health status.
+
 **{{site.base_gateway}} 2.8.x**
 * Adds a new metric:
   * `kong_nginx_timers` (gauge): total number of Nginx timers, in Running or Pending state.

--- a/app/_hub/kong-inc/prometheus/_index.md
+++ b/app/_hub/kong-inc/prometheus/_index.md
@@ -310,6 +310,13 @@ allow access to the `/metrics` endpoint to Prometheus:
 * Plugin version bumped to 3.0.0
 * The `node_id` label was added to memory metrics.
 
+**{{site.base_gateway}} (Enterprise) 2.8.3.2**
+* Adds new directives in `kong.conf` to enable or disable high cardinality metrics.
+  * `prometheus_plugin_status_code_metrics`: enables or disables reporting the HTTP/Stream status codes per service/route.
+  * `prometheus_plugin_latency_metrics`: enables or disables reporting the latency added by Kong, request time and upstream latency.
+  * `prometheus_plugin_bandwidth_metrics`: enables or disables reporting the bandwith consumed by service/route.
+  * `prometheus_plugin_upstream_health_metrics`: enables or disables reporting the upstream health status.
+
 **{{site.base_gateway}} 2.8.x**
 * Adds a new metric:
   * `kong_nginx_timers` (gauge): total number of Nginx timers, in Running or Pending state.

--- a/app/_hub/kong-inc/prometheus/_index.md
+++ b/app/_hub/kong-inc/prometheus/_index.md
@@ -314,7 +314,7 @@ allow access to the `/metrics` endpoint to Prometheus:
 * Adds new directives in `kong.conf` to enable or disable high cardinality metrics.
   * `prometheus_plugin_status_code_metrics`: enables or disables reporting the HTTP/Stream status codes per service/route.
   * `prometheus_plugin_latency_metrics`: enables or disables reporting the latency added by Kong, request time and upstream latency.
-  * `prometheus_plugin_bandwidth_metrics`: enables or disables reporting the bandwith consumed by service/route.
+  * `prometheus_plugin_bandwidth_metrics`: enables or disables reporting the bandwidth consumed by service/route.
   * `prometheus_plugin_upstream_health_metrics`: enables or disables reporting the upstream health status.
 
 **{{site.base_gateway}} 2.8.x**


### PR DESCRIPTION
### Summary

Changelog entry of new `kong.conf` directives added for the Prometheus plugin.

### Reason

New directives were added so users can enable or disable some metrics in the Prometheus plugin. You can read more about why this change is needed in FTI-4460. 

I added a non-standard version section for the new feature as it is being released only for a specific version of Kong EE. Please let me know if there is a correct/better way of documenting this.

### Testing

More details in:
Kong/kong-ee#4222
Kong/kong-ee#4189
Kong/kong-ee#4220
FTI-4460

<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
