### PR TITLE
python pdk doc improvements

### DIFF
--- a/app/_src/gateway/plugin-development/pluginserver/python.md
+++ b/app/_src/gateway/plugin-development/pluginserver/python.md
@@ -64,7 +64,7 @@ You can implement custom logic during the following phases using the same functi
 The presence of the `response` handler automatically enables the buffered proxy mode.
 
 {:.note}
-> **Notes:** a positional argument is required in the definition of phase handler method.
+> **Notes:** a positional argument is required in the definition of phase handler method. In the example below, the positional argument is called `kong`. The positional argument can be used as the PDK function's root object, which means that you can call specific PDK function by using this argment, like `kong.log.info` or `kong.request.get_header`.
 
 ### Type hints
 
@@ -80,7 +80,7 @@ class Plugin(object):
         host, err = kong.request.get_header("host")
 ```
 
-{:.warning}
+{:.important}
 > **Warning:** classes and functions in the `kong_pdk.pdk.kong` module cannot be used directly because they're only used for type hints. To call PDK functions, you need to use the `kong` object which is passed as the phase handler's parameter. Please keep in mind that if you want to call PDK functions outside of the phase handler, you'll also need to pass the `kong` object to your outer code.
 
 Below is an example of using the PDK functions outside of the `Plugin` class:

--- a/app/_src/gateway/plugin-development/pluginserver/python.md
+++ b/app/_src/gateway/plugin-development/pluginserver/python.md
@@ -64,7 +64,7 @@ You can implement custom logic during the following phases using the same functi
 The presence of the `response` handler automatically enables the buffered proxy mode.
 
 {:.note}
-> **Notes:** a positional argument is required in the definition of phase handler method. In the example below, the positional argument is called `kong`. The positional argument can be used as the PDK function's root object, which means that you can call specific PDK function by using this argument, like `kong.log.info` or `kong.request.get_header`.
+> **Notes:** A positional argument is required in the definition of the phase handler method. In the example below, the positional argument is called `kong`. The positional argument can be used as the PDK function's root object, which means that you can call specific PDK functions by using this argument, like `kong.log.info` or `kong.request.get_header`.
 
 ### Type hints
 
@@ -81,9 +81,9 @@ class Plugin(object):
 ```
 
 {:.important}
-> **Warning:** classes and functions in the `kong_pdk.pdk.kong` module cannot be used directly because they're only used for type hints. To call PDK functions, you need to use the `kong` object which is passed as the phase handler's parameter. Please keep in mind that if you want to call PDK functions outside of the phase handler, you'll also need to pass the `kong` object to your outer code.
+> **Warning:** Classes and functions in the `kong_pdk.pdk.kong` module cannot be used directly because they're only used for type hints. To call PDK functions,  use the `kong` object that is passed as the phase handler's parameter. Keep in mind that if you want to call PDK functions outside of the phase handler, you also need to pass the `kong` object to your outer code.
 
-Below is an example of using the PDK functions outside of the `Plugin` class:
+Here is an example of using the PDK functions outside of the `Plugin` class:
 
 ```python
 import kong_pdk.pdk.kong as kong
@@ -136,7 +136,7 @@ pluginserver_my_plugin_query_cmd = /path/to/my-plugin --dump
 pluginserver_other_one_query_cmd = /path/to/other-one --dump
 ```
 
-If you want to open verbose logging, pass an `-v` argument to the start command line:
+If you want to open verbose logging, pass the `-v` argument to the `start` command line:
 
 ```
 pluginserver_my_plugin_start_cmd = /path/to/my-plugin.py -v

--- a/app/_src/gateway/plugin-development/pluginserver/python.md
+++ b/app/_src/gateway/plugin-development/pluginserver/python.md
@@ -64,7 +64,7 @@ You can implement custom logic during the following phases using the same functi
 The presence of the `response` handler automatically enables the buffered proxy mode.
 
 {:.note}
-> **Notes:** a positional argument is required in the definition of phase handler method. In the example below, the positional argument is called `kong`. The positional argument can be used as the PDK function's root object, which means that you can call specific PDK function by using this argment, like `kong.log.info` or `kong.request.get_header`.
+> **Notes:** a positional argument is required in the definition of phase handler method. In the example below, the positional argument is called `kong`. The positional argument can be used as the PDK function's root object, which means that you can call specific PDK function by using this argument, like `kong.log.info` or `kong.request.get_header`.
 
 ### Type hints
 

--- a/app/_src/gateway/plugin-development/pluginserver/python.md
+++ b/app/_src/gateway/plugin-development/pluginserver/python.md
@@ -136,7 +136,7 @@ pluginserver_my_plugin_query_cmd = /path/to/my-plugin --dump
 pluginserver_other_one_query_cmd = /path/to/other-one --dump
 ```
 
-If you want to open verbose logging, pass an `-v` argument to the start cmd line:
+If you want to open verbose logging, pass an `-v` argument to the start command line:
 
 ```
 pluginserver_my_plugin_start_cmd = /path/to/my-plugin.py -v


### PR DESCRIPTION
### Summary
Multiple improvements to the Python PDK server document.

- Trailing whitespace removed
- Add a note to reflect the necessity of positional argument in phase handler
- Add a warning and example code to show the correct way to call PDK function
- Verbose logging content

### Reason
[FTI-4601](https://konghq.atlassian.net/browse/FTI-4601), try to clear up some misunderstanding in the usage of Python PDK

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->


[FTI-4601]: https://konghq.atlassian.net/browse/FTI-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTI-4601]: https://konghq.atlassian.net/browse/FTI-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ