### PR TITLE
add datadog & statsd plugin missing doc

### DIFF
--- a/app/_hub/kong-inc/datadog/_index.md
+++ b/app/_hub/kong-inc/datadog/_index.md
@@ -164,6 +164,10 @@ Field           | Description                                           | Dataty
 
 ## Changelog
 
+**{{site.base_gateway}} 3.1.x**
+* Added support for managing queues and connection retries when sending messages to the upstream with 
+the `queue_size`,`flush_timeout`, and `retry_count` configuration parameters. 
+
 **{{site.base_gateway}} 2.7.x**
 * Added support for the `distribution` metric type.
 * Allow service, consumer, and status tags to be customized through the configuration parameters `service_name_tag`, `consumer_tag`, and `status_tag`.

--- a/app/_hub/kong-inc/datadog/_index.md
+++ b/app/_hub/kong-inc/datadog/_index.md
@@ -74,6 +74,27 @@ params:
       default: consumer
       datatype: string
       description: String to be attached as tag of the consumer.
+    - name: flush_timeout
+      required: true
+      default: '`2`'
+      value_in_examples: 2
+      datatype: number
+      description: |
+        Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.
+      minimum_version: "3.1.x"
+    - name: retry_count
+      required: true
+      default: 10
+      value_in_examples: 10
+      datatype: integer
+      description: Number of times to retry when sending data to the upstream server.
+      minimum_version: "3.1.x"
+    - name: queue_size
+      required: true
+      default: 1
+      datatype: integer
+      description: Maximum number of log entries to be sent on each message to the upstream server.
+      minimum_version: "3.1.x"
 ---
 
 ## Metrics

--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -215,6 +215,10 @@ Field         | Description                                             | Dataty
 ---
 ## Changelog
 
+**{{site.base_gateway}} 3.1.x**
+* Added support for managing queues and connection retries when sending messages to the upstream with 
+the `queue_size`,`flush_timeout`, and `retry_count` configuration parameters. 
+
 ### {{site.base_gateway}} 3.0.x
 
 * Merged features of the StatsD Advanced plugin into the StatsD plugin. The StatsD plugin now includes the following:

--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -102,7 +102,28 @@ params:
       default: 'workspace_id'
       datatype: string
       description: The default workspace identifier of metrics. This will take effect when a metric's workspace identifier is omitted. Allowed values are `workspace_id`, `workspace_name`.
-      minimum_version: "3.0.x"   
+      minimum_version: "3.0.x"
+    - name: flush_timeout
+      required: true
+      default: '`2`'
+      value_in_examples: 2
+      datatype: number
+      description: |
+        Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.
+      minimum_version: "3.1.x"
+    - name: retry_count
+      required: true
+      default: 10
+      value_in_examples: 10
+      datatype: integer
+      description: Number of times to retry when sending data to the upstream server.
+      minimum_version: "3.1.x"
+    - name: queue_size
+      required: true
+      default: 1
+      datatype: integer
+      description: Maximum number of log entries to be sent on each message to the upstream server.
+      minimum_version: "3.1.x"
   extra: |
     By default, the plugin sends a packet for each metric it observes. The `udp_packet_size` option
     configures the greatest datagram size the plugin can combine. It should be less than


### PR DESCRIPTION
### Summary

This PR adds missing documentation on the new config fields for datadog & statsd plugins.
Ref: https://github.com/Kong/kong/pull/9521

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
