### PR TITLE
mesh: new policy rbac qualifiers

### DIFF
--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -79,6 +79,30 @@ For policies using the `targetRef` selector. You can specify which `targetRef` k
 
 {% navtabs %}
 {% navtab Kubernetes %}
+{% if_version lte:2.0.x %}
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: AccessRole
+metadata:
+  name: role-1
+spec:
+  rules:
+  - types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If it's empty, access is granted to all types.
+    names: ["res-1"] # List of allowed type names that are granted access. If it's empty, access is granted to resources regardless of the name.
+    mesh: default # Grants access to the resources in the named mesh. It can only be used with the mesh-scoped resources.
+    access: ["CREATE", "UPDATE", "DELETE"] # The action bound to a type.
+    when: # A set of qualifiers to receive access. Only one of them needs to be fulfilled to receive access.
+    - tagetRef: # A condition on the targetRef section in policies 2.0 (like MeshAccessLog or MeshTrace).
+        kind: MeshService
+        name: backend
+    - targetRef:
+        kind: MeshSubset
+        tags:
+        - name: k8s.kuma.io/namespace
+          value: kuma-demo
+```
+{% endif_version %}
+{% if_version gte:2.1.x %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: AccessRole
@@ -102,19 +126,41 @@ spec:
     - targetRef:
         kind: MeshService
         name: web
-      to: # can only be used with policies that have "to" list (like MeshAccessLog)
+      to: # can only be used with policies that have a "to" list (like MeshAccessLog)
         targetRef:
           kind: MeshService
           name: backend
     - targetRef:
         kind: MeshService
         name: web
-      from: # can only be used with policies that have "from" list (like MeshTrafficPermission)
+      from: # can only be used with policies that have a "from" list (like MeshTrafficPermission)
         targetRef:
           kind: Mesh
 ```
+{% endif_version %}
 {% endnavtab %}
 {% navtab Universal %}
+{% if_version lte:2.0.x %}
+```yaml
+type: AccessRole
+name: role-1
+rules:
+- types: ["MeshTrafficPermission", "MeshTrace", "MeshAccessLog"] # List of types that are granted access. If it's empty, access is granted to all types.
+  names: ["res-1"] # List of allowed type names that are granted access. If it's empty, access is granted to resources regardless of the name.
+  mesh: default # Grants access to the resources in the named mesh. It can only be used with the mesh-scoped resources.
+  access: ["CREATE", "UPDATE", "DELETE"] # The action bound to a type.
+  when: # A set of qualifiers to receive access. Only one of them needs to be fulfilled to receive access.
+  - tagetRef: # A condition on the targetRef section in policies 2.0 (like MeshAccessLog or MeshTrace).
+        kind: MeshService
+        name: backend
+  - targetRef:
+      kind: MeshSubset
+      tags:
+      - name: k8s.kuma.io/namespace
+        value: kuma-demo
+```
+{% endif_version %}
+{% if_version gte:2.1.x %}
 ```yaml
 type: AccessRole
 name: role-1
@@ -135,24 +181,26 @@ rules:
   - targetRef:
       kind: MeshService
       name: web
-    to: # can only be used with policies that have "to" list (like MeshAccessLog)
+    to: # can only be used with policies that have a "to" list (like MeshAccessLog)
       targetRef:
         kind: MeshService
         name: backend
   - targetRef:
       kind: MeshService
       name: web
-    from: # can only be used with policies that have "from" list (like MeshTrafficPermission)
+    from: # can only be used with policies that have a "from" list (like MeshTrafficPermission)
       targetRef:
         kind: Mesh
 ```
-
+{% endif_version %}
 {% endnavtab %}
 {% endnavtabs %}
-The Lack of `targetRef`, `from` or `to` means that a user can specify anything in this section.
-For example, `when` element with specific `from` section lets user pick anything for `targetRef` in policy.
+{% if_version gte:2.1.x %}
+The lack of `targetRef`, `from`, or `to` means that a user can specify anything in this section.
+For example, the `when` element with a specific `from` section allows the user to pick anything for `targetRef` in the policy.
 
-If the policy contains multiple `to` elements, you need to specify RBAC qualifier for every single `to` element.
+If the policy contains multiple `to` elements, you must specify an RBAC qualifier for every single `to` element.
+{% endif_version %}
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -99,6 +99,19 @@ spec:
         tags:
         - name: k8s.kuma.io/namespace
           value: kuma-demo
+    - targetRef:
+        kind: MeshService
+        name: web
+      to: # can only be used with policies that have "to" list (like MeshAccessLog)
+        targetRef:
+          kind: MeshService
+          name: backend
+    - targetRef:
+        kind: MeshService
+        name: web
+      from: # can only be used with policies that have "from" list (like MeshTrafficPermission)
+        targetRef:
+          kind: Mesh
 ```
 {% endnavtab %}
 {% navtab Universal %}
@@ -119,9 +132,27 @@ rules:
       tags:
       - name: k8s.kuma.io/namespace
         value: kuma-demo
+  - targetRef:
+      kind: MeshService
+      name: web
+    to: # can only be used with policies that have "to" list (like MeshAccessLog)
+      targetRef:
+        kind: MeshService
+        name: backend
+  - targetRef:
+      kind: MeshService
+      name: web
+    from: # can only be used with policies that have "from" list (like MeshTrafficPermission)
+      targetRef:
+        kind: Mesh
 ```
+
 {% endnavtab %}
 {% endnavtabs %}
+The Lack of `targetRef`, `from` or `to` means that a user can specify anything in this section.
+For example, `when` element with specific `from` section lets user pick anything for `targetRef` in policy.
+
+If the policy contains multiple `to` elements, you need to specify RBAC qualifier for every single `to` element.
 {% endnavtab %}
 {% endnavtabs %}
 


### PR DESCRIPTION
### Summary
Adds information of extra `to` and `from` RBAC qualifiers in incoming Kong Mesh 2.1

### Reason
We introduced new functionality

### Testing
Checked with the preview
