### PR TITLE
Minor fixes to konnect deck onboarding

### DIFF
--- a/app/konnect/getting-started/configure-runtime.md
+++ b/app/konnect/getting-started/configure-runtime.md
@@ -40,7 +40,7 @@ is part of the organization admin team by default.
     Every account starts with one group named `default`. If you have an
     Enterprise subscription, you can create additional custom groups.
 
-1. Click **Add runtime instance**.
+1. Click **New Runtime Instance**.
 
      The page opens to a runtime configuration form with the Docker tab
      selected.

--- a/app/konnect/runtime-manager/runtime-groups/declarative-config.md
+++ b/app/konnect/runtime-manager/runtime-groups/declarative-config.md
@@ -135,7 +135,7 @@ For this example, let's add a new service.
 
     This snippet defines a service named `MyService` pointing to `mockbin.org`.
     The service has one version, and the version gets implemented with the
-    route `/mockpath`, which means that you can access the service by appending
+    route `/mock`, which means that you can access the service by appending
     this route to your proxy URL.
 
     Because you're also enabling the `key-auth` plugin on the route, you need
@@ -152,10 +152,11 @@ For this example, let's add a new service.
     be added to the {{site.konnect_saas}} configuration:
 
     ```sh
-    creating route mockpath
     creating service MyService
+    creating route mockpath
+    creating plugin key-auth for route mockpath
     Summary:
-      Created: 2
+      Created: 3
       Updated: 0
       Deleted: 0
     ```
@@ -170,10 +171,11 @@ For this example, let's add a new service.
     You should see the same output again:
 
     ```sh
-    creating route mockpath
     creating service MyService
+    creating route mockpath
+    creating plugin key-auth for route mockpath
     Summary:
-      Created: 2
+      Created: 3
       Updated: 0
       Deleted: 0
     ```


### PR DESCRIPTION
### Summary

This PR contains very minor fixes to wording and output that differed from what I saw when following the onboarding guide for Konnect and using declarative config with Konnect.

Namely:

- there is no "Add runtime instance" button. It's "New Runtime Instance". I expect this was a change in Konnect at some point.
- The route is set up at `/mock` not `/mockpath` (this is correctly identified [later in the doc](https://github.com/Kong/docs.konghq.com/blob/634e153fa9111543a407f148ba74eb348ea6c46e/app/konnect/runtime-manager/runtime-groups/declarative-config.md?plain=1))
- deck makes 3 objects - the sample output is missing the keyauth plugin

### Reason

It prevents confusion when the docs are consistent with the experience.

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

I was using decK v1.17.0.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
