### PR TITLE
Add placeholders for `kuma` and `kuma/kuma` used in Mesh docs

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -204,3 +204,7 @@ company_name: Kong Inc.
 jekyll-generator-single-source:
   versions_file: '_data/kong_versions.yml'
   docs_nav_folder: '_data'
+
+# Helm commands
+mesh_helm_repo: kong-mesh/kong-mesh
+mesh_helm_install_name: kong-mesh

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -189,3 +189,7 @@ company_name: Kong Inc.
 jekyll-generator-single-source:
   versions_file: '_data/kong_versions.yml'
   docs_nav_folder: '_data'
+
+# Helm commands
+mesh_helm_repo: kong-mesh/kong-mesh
+mesh_helm_install_name: kong-mesh


### PR DESCRIPTION
### Summary
Add placeholders for `helm_repo` and `helm_install_name` that will be used in Mesh docs following [this PR](https://github.com/kumahq/kuma-website/pull/1185).
Once we merge this, I'll create a follow-up PR (or use the github action) that updates the git submodule, which will pick up this change.  

### Reason
Related [Jira ticket](https://konghq.atlassian.net/browse/DOCU-2882) and [Github  Issue](https://github.com/Kong/docs.konghq.com/issues/4960)

HELM commands in [Mesh documentation](https://docs.konghq.com/mesh/latest/deployments/multi-zone/) were still referring to Kuma, e.g.
```
helm install kuma --create-namespace --namespace kong-mesh-system --set controlPlane.mode=global kuma/kuma
```

### Testing
Nothing to test here given that it's not being used at the moment.
