### PR TITLE
Gateway 2.8.2.3: Changelog and parameters

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -153,7 +153,7 @@
     pcre: "8.45"
   lua_doc: true
 - release: "2.8.x"
-  ee-version: "2.8.2.2"
+  ee-version: "2.8.2.3"
   ce-version: "2.8.3"
   edition: "gateway"
   luarocks_version: "2.5.1-0"

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -2065,6 +2065,50 @@ each individual worker.
 
 ---
 
+The following switches enable or disable Prometheus plugin high-cardinality
+metrics. When enabled, these metrics can negatively impact the Gateway
+performance depending on the number of entities configured.
+
+---
+
+#### prometheus_plugin_status_code_metrics
+
+Enables or disables reporting the HTTP/Stream
+status codes per service/route by the
+Prometheus plugin. 
+
+**Default:** `on`
+
+---
+
+#### prometheus_plugin_latency_metrics 
+
+Enables or disables reporting the latency
+added by Kong, request time and upstream
+latency by the Prometheus plugin. 
+
+**Default:** `on`
+
+---
+
+#### prometheus_plugin_bandwidth_metrics
+
+Enables or disables the bandwith consumed by
+service/route reporting by the Prometheus
+plugin. 
+
+**Default:** `on`
+
+---
+
+#### prometheus_plugin_upstream_health_metrics
+
+Enables or disables the upstream health status
+reporting by the Prometheus plugin.
+
+**Default:** `on`.
+
+---
 
 ### Miscellaneous section
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1271,6 +1271,56 @@ openid-connect
 * Bumped `lodash` for Dev Portal from 4.17.11 to 4.17.21
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 
+## 2.8.2.3
+**Release Date** 2023/01/06
+
+### Fixes
+
+#### Enterprise
+
+**Kong Manager:**
+* Fixed a role precedence issue with RBAC. 
+RBAC rules involving deny (negative) rules now correctly take precedence over allow (non-negative) roles.
+* Fixed workspace filtering pagination on the overview page.
+
+#### Core 
+
+* Fixed a router issue where, in an environment with more than 50k routes, attempting to update a route caused a 500 error response.
+* Fixed a timer leak that occurred whenever the generic messaging protocol connection broke in hybrid mode.
+* Fixed a `tlshandshake` method error that occurred when SSL was configured on PostgreSQL, and the Kong Gateway had `stream_listen` configured with a stream proxy. 
+* Fixed an issue that caused segfaults in Kong Gateway running on Amazon Linux 2 with `opentracing` enabled.
+  This was caused by the wrong base image being used for the Amazon Linux 2 package.
+  The Amazon Linux 2 package is now built on an actual Amazon Linux 2 image instead of the shared CentOS-based image.
+
+#### Plugins
+
+* [HTTP Log](/hub/kong-inc/http-log) (`http-log`)
+  * Fixed the `could not update kong admin` internal error caused by empty headers.
+  This error occurred when using this plugin with the Kubernetes Ingress Controller.
+
+* [JWT](/hub/kong-inc/jwt/) (`jwt`)
+  * Fixed an issue where the JWT plugin could potentially forward an unverified token to the upstream. 
+
+* [JWT Signer](/hub/kong-inc/jwt-signer/) (`jwt-signer`)
+  * Fixed the error `attempt to call local 'err' (a string value)`. 
+
+* [Mocking](/hub/kong-inc/mocking) (`mocking`)
+  * Fixed UUID pattern matching. 
+
+* [Prometheus](/hub/kong-inc/prometheus/) (`prometheus`)
+  * Provided options to reduce the plugin's impact on performance.
+  Added new `kong.conf` options to switch high cardinality metrics `on` or `off`: 
+  [`prometheus_plugin_status_code_metrics`](/gateway/2.8.x/reference/configuration/#prometheus_plugin_status_code_metrics), [`prometheus_plugin_latency_metrics`](/gateway/2.8.x/reference/configuration/#prometheus_plugin_latency_metrics), [`prometheus_plugin_bandwidth_metrics`](/gateway/2.8.x/reference/configuration/#prometheus_plugin_bandwidth_metrics), and [`prometheus_plugin_upstream_health_metrics`](/gateway/2.8.x/reference/configuration/#prometheus_plugin_upstream_health_metrics).
+
+* [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced) (`rate-limiting-advanced`)
+  * Fixed a maintenance cycle lock leak in the `kong_locks` dictionary. 
+  Kong Gateway now clears old namespaces from the maintenance cycle schedule when a namespace is updated.
+
+* [Request Transformer](/hub/kong-inc/request-transformer/) (`request-transformer`)
+  * Fixed an issue where empty arrays were being converted to empty objects.
+  Empty arrays are now preserved.
+
+
 ## 2.8.2.2
 **Release Date** 2022/12/01
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1285,7 +1285,7 @@ RBAC rules involving deny (negative) rules now correctly take precedence over al
 
 #### Core 
 
-* Fixed a router issue where, in an environment with more than 50k routes, attempting to update a route caused a 500 error response.
+* Fixed a router issue where, in an environment with more than 50,000 routes, attempting to update a route caused a `500` error response.
 * Fixed a timer leak that occurred whenever the generic messaging protocol connection broke in hybrid mode.
 * Fixed a `tlshandshake` method error that occurred when SSL was configured on PostgreSQL, and the Kong Gateway had `stream_listen` configured with a stream proxy. 
 * Fixed an issue that caused segfaults in Kong Gateway running on Amazon Linux 2 with `opentracing` enabled.


### PR DESCRIPTION
### Summary
* Changelog for 2.8.2.3 based on internal Enterprise changelog.
* Prometheus parameters added from https://github.com/Kong/kong-ee/pull/4220/files. 
  * This is listed as part of the release but is not yet merged, and the release is going out tomorrow. May have to remove it.
  * Will also need to merge (or not merge) https://github.com/Kong/docs.konghq.com/pull/4972 along with this update.

### Reason
https://konghq.atlassian.net/browse/DOCU-2817

### Testing
Netlify

(This is still using the old changelog format, as we haven't settled on everything for the split method yet.)