### PR TITLE
Updated ingress declaration examples to match

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/ingress-versions.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/ingress-versions.md
@@ -121,13 +121,14 @@ metadata:
 spec:
   ingressClassName: kong
   rules:
-  - http:
+  - host: example.com
+    http:
       paths:
-      - path: /testpath
+      - path: /test
         pathType: Prefix
         backend:
           service:
-            name: test
+            name: echo
             port:
               number: 80
 ```


### PR DESCRIPTION


### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

The attributes defined for apiVersion: networking.k8s.io/v1 did not match the one defined for apiVersion: networking.k8s.io/v1beta1. I did my best as a kubernetes novice, but please have someone internal review my changes and make any others necessary.

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

We're updating from k8s 1.21 to 1.22 and need these instructions to know exactly what to do wrt kong

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
