### PR TITLE
Fix db-less badges on log level PUT endpoints

### DIFF
--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -1759,7 +1759,9 @@ HTTP 200 OK
 
 
 ### Set Node Log Level of All Control Plane Nodes
-{:.badge .dbless}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
 
  Change the log level of all Control Plane nodes deployed in Hybrid
  (CP/DP) cluster.
@@ -1808,7 +1810,9 @@ HTTP 200 OK
 ---
 
 ### Set Node Log Level of All Nodes
-{:.badge .dbless}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
 
 Change the log level of all nodes in a cluster.
 
@@ -1882,7 +1886,9 @@ HTTP 200 OK
 ---
 
 ### Set Log Level of A Single Node
-{:.badge .dbless}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
 
 Change the log level of a node.
 


### PR DESCRIPTION
### Summary

Switching db-less badges for log level PUT endpoints to notes saying the API is not available in db-less mode.

### Reason
The endpoints were incorrectly set in the source file. Fixing the source as well: [PR link]

Issue reported on slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1672965868058589

### Testing
Netlify