### PR TITLE
Getting started mention advanced docs

### DIFF
--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -39,8 +39,11 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
 1. Run {{site.base_gateway}} with the `quickstart` script:
 
    ```sh
-   curl -Ls https://get.konghq.com/quickstart | bash -s
+   curl -Ls https://get.konghq.com/quickstart | bash
    ```
+
+   {:.note}
+   > **Note**: The quickstart script runs Kong Gateway Enterprise in Free mode. If you wish to run Kong with a license, you can pass the license to the script via the `KONG_LICENSE_DATA` environment variable: `curl -Ls get.konghq.com/quickstart | bash -s -- -e "KONG_LICENSE_DATA"`. For more advanced usage of the quickstart script, see the [code repository documentation](https://github.com/Kong/get.konghq.com).
 
    This script runs Docker containers for {{site.base_gateway}} and the supporting PostgreSQL database.
    The script also creates a Docker network for those containers to communicate over. Finally, the database is 

--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -43,7 +43,7 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
    ```
 
    {:.note}
-   > **Note**: The quickstart script runs Kong Gateway Enterprise in Free mode. You may run Kong with a license by passing the license to the script via an environment variable. For instructions on this and other advanced usage, see the [code repository documentation](https://github.com/Kong/get.konghq.com).
+   > **Note**: The quickstart script runs {{site.base_gateway}} Enterprise in Free mode. You may run Kong with a license by passing the license to the script via an environment variable. For instructions on this and other advanced usage, see the [code repository documentation](https://github.com/Kong/get.konghq.com).
 
    This script runs Docker containers for {{site.base_gateway}} and the supporting PostgreSQL database.
    The script also creates a Docker network for those containers to communicate over. Finally, the database is 

--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -43,7 +43,7 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
    ```
 
    {:.note}
-   > **Note**: The quickstart script runs Kong Gateway Enterprise in Free mode. If you wish to run Kong with a license, you can pass the license to the script via the `KONG_LICENSE_DATA` environment variable: `curl -Ls get.konghq.com/quickstart | bash -s -- -e "KONG_LICENSE_DATA"`. For more advanced usage of the quickstart script, see the [code repository documentation](https://github.com/Kong/get.konghq.com).
+   > **Note**: The quickstart script runs Kong Gateway Enterprise in Free mode. You may run Kong with a license by passing the license to the script via an environment variable. For instructions on this and other advanced usage, see the [code repository documentation](https://github.com/Kong/get.konghq.com).
 
    This script runs Docker containers for {{site.base_gateway}} and the supporting PostgreSQL database.
    The script also creates a Docker network for those containers to communicate over. Finally, the database is 


### PR DESCRIPTION
### Summary
Minor note addition to the getting started instructions to help guide users to advanced usage of the quickstart script. 

### Reason
This change was at the request of the field who have customers using the script for various cases including running in licensed mode.

### Testing
Built docs locally and viewed


