### PR TITLE
remove note on deck support of consumer groups

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -545,10 +545,6 @@ For guides on working with consumer groups, see the consumer group
 [API reference](/gateway/latest/admin-api/consumer-groups/reference) in
 the Admin API documentation.
 
-{:.note}
-> **Note:** Consumer groups are not supported in declarative configuration with
-decK. If you have consumer groups in your configuration, decK will ignore them.
-
 {% endif_plugin_version %}
 
 ---


### PR DESCRIPTION
deck's support of consumer groups released as part of 1.17.0


