### PR TITLE
Use variable for kong gateway version in Konnect K8s doc

### DIFF
--- a/app/konnect/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
+++ b/app/konnect/runtime-manager/runtime-instances/gateway-runtime-kubernetes.md
@@ -78,7 +78,7 @@ like this:
     ```yaml
     image:
       repository: kong/kong-gateway
-      tag: "3.0.0.0"
+      tag: "{{ site.data.kong_latest_gateway.ee-version }}"
 
     secretVolumes:
     - kong-cluster-cert


### PR DESCRIPTION
Follow up PR to https://github.com/Kong/docs.konghq.com/pull/4970. The kubernetes doc should have the same update.

Preview: https://deploy-preview-5000--kongdocs.netlify.app/konnect/runtime-manager/runtime-instances/gateway-runtime-kubernetes/