### PR TITLE
Remove note about decK support

### DIFF
--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -31,10 +31,6 @@ configuration
 For all possible requests, see the
 [Consumer Groups reference](/gateway/{{page.kong_version}}/admin-api/consumer-groups/reference).
 
-{:.note}
-> **Note:** Consumer groups are not supported in declarative configuration with
-decK. If you have consumer groups in your configuration, decK will ignore them.
-
 ## Set up consumer group
 
 1. Create a consumer group named `Gold`:


### PR DESCRIPTION
Follow up to https://github.com/Kong/docs.konghq.com/pull/4969. 
Removing the note about decK support for consumer groups in one other topic.

Preview: https://deploy-preview-5001--kongdocs.netlify.app/gateway/latest/kong-enterprise/consumer-groups/