### PR TITLE
Clarify redis.username on all plugins that support it

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -177,7 +177,9 @@ params:
       referenceable: true
       description: |
         Username to use for Redis connection when the `redis` strategy is defined and ACL authentication is desired.
-        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
+        If undefined, ACL authentication will not be performed.
+
+         This requires Redis v6.0.0+. The username **cannot** be set to `default`.
       minimum_version: "2.8.x"
     - name: redis.password
       required: semi

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -1096,7 +1096,9 @@ params:
       referenceable: true
       description: |
         Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired.
-        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
+        If undefined, ACL authentication will not be performed.
+
+        This requires Redis v6.0.0+. The username **cannot** be set to `default`.
     - name: session_redis_password
       minimum_version: "2.8.x"
       required: false

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -258,7 +258,9 @@ params:
       referenceable: true
       description: |
         Username to use for Redis connection when the `redis` strategy is defined and ACL authentication is desired.
-        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. This can not be set to **default**.
+        If undefined, ACL authentication will not be performed.
+
+        This requires Redis v6.0.0+. The username **cannot** be set to `default`.
     - name: redis.password
       required: semi
       default: null

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -132,7 +132,9 @@ params:
       datatype: string
       referenceable: true
       description: |
-        When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired. This requires Redis v6.0.0+. This can not be set to **default**.
+        When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired. 
+        
+        This requires Redis v6.0.0+. The username **cannot** be set to `default`.
     - name: redis_password
       minimum_version: "2.7.x"
       required: false

--- a/app/_hub/kong-inc/response-ratelimiting/_index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/_index.md
@@ -156,6 +156,8 @@ params:
       referenceable: true
       description: |
         When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.
+
+        This requires Redis v6.0.0+. The username **cannot** be set to `default`.
     - name: redis_password
       required: false
       datatype: string

--- a/app/_hub/kong-inc/saml/_index.md
+++ b/app/_hub/kong-inc/saml/_index.md
@@ -358,7 +358,9 @@ params:
       referenceable: true
       description: |
         Redis username if the `redis` session storage is defined and ACL authentication is desired.
-        If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+.
+        If undefined, ACL authentication will not be performed.
+
+        This requires Redis v6.0.0+. The username **cannot** be set to `default`.
     - name: session_redis_password
       required: false
       default: (from kong)


### PR DESCRIPTION
Follow-up to https://github.com/Kong/docs.konghq.com/pull/4913. 
The PR only edited the rate limiting plugins, but according to the linked FTI, the username `default` is not supported in Redis 6.0.0+ in general - this is not specific to Kong, so it should apply anywhere that we allow `redis.username`.

@outsinre can you please verify that this change is correct for all of these plugins?