### PR TITLE
Fix plugin GUI examples when using `if_plugin_version`

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -109,7 +109,7 @@ params:
       maximum_version: "2.8.x"
       required: true
       default: cluster
-      value_in_examples: cluster
+      value_in_examples: local
       datatype: string
       description: |
         The rate-limiting strategy to use for retrieving and incrementing the

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -1,6 +1,6 @@
 <!-- Generate Konnect and Kong Manager examples -->
 {% capture config_required_fields_gui %}{%
-  for field in include.params.config %}{% assign capfields = field.name | split: '_' %}{% capture titlecase %}{% for capfield in capfields %}{{ capfield | capitalize }} {% endfor %}{% endcapture %}{%
+  for field in include.params.config %}{% if_plugin_version gte:field.minimum_version lte:field.maximum_version %}{% assign capfields = field.name | split: '_' %}{% capture titlecase %}{% for capfield in capfields %}{{ capfield | capitalize }} {% endfor %}{% endcapture %}{%
     if field.required == true and field.value_in_examples != nil %}{%
       if field.value_in_examples == false or field.value_in_examples == true %}
     * Config.{{ titlecase | rstrip }}: {{ field.value_in_examples | replace: false, "clear checkbox" | replace: true, "select checkbox" }}{%
@@ -21,7 +21,7 @@
           endif %}{%
         endif %}{%
       endif %}{%
-    endif %}{%
+    endif %}{% endif_plugin_version %}{%
   endfor %}{%
 endcapture %}
 


### PR DESCRIPTION
### Summary
Make GUI examples respect `if_plugin_version` - fixes Konnect and KM examples for Rate Limiting Advanced

### Reason
DOCU-2879

### Testing
/hub/kong-inc/rate-limiting-advanced/

You'll see `config.strategy` twice in production, and once on the review app
