### PR TITLE
Helm Chart README moved to official documentation

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -271,6 +271,8 @@ requery
 retryOn
 rockspec
 rockspecs
+rollout
+rollouts
 routable
 ruleset
 runtime

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -251,11 +251,13 @@ export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"h
 kong start
 ```
 
-## DB-Less with Helm (KIC Disabled)
+## DB-less with Helm (KIC disabled)
 
-When deploying Kong in DB-less mode(env.database: "off") and without the Ingress Controller(ingressController.enabled: false), you have to provide a declarative configuration for Kong to run. You can provide an existing ConfigMap (dblessConfig.configMap) or place the whole configuration into values.yaml (dblessConfig.config) parameter. See the example configuration in the default values.yaml for more details. You can use --set-file dblessConfig.config=/path/to/declarative-config.yaml in Helm commands to substitute in a complete declarative config file.
+When deploying {{site.base_gateway}} on Kubernetes in DB-less mode (`env.database: "off"`) and without the Ingress Controller (`ingressController.enabled: false`), you have to provide a declarative configuration for {{site.base_gateway}} to run. You can provide an existing ConfigMap (`dblessConfig.configMap`) or place the whole configuration into a `values.yaml` (`dblessConfig.config`) parameter. See the example configuration in the [default `values.yaml`](https://github.com/Kong/charts/blob/main/charts/kong/values.yaml) for more detail.
 
-Note that externally supplied ConfigMaps are not hashed or tracked in deployment annotations. Subsequent ConfigMap updates will require user-initiated new deployment rollouts to apply the new configuration. You should run kubectl rollout restart deploy after updating externally supplied ConfigMap content.
+Use `--set-file dblessConfig.config=/path/to/declarative-config.yaml` in Helm commands to substitute in a complete declarative config file.
+
+Externally supplied ConfigMaps are not hashed or tracked in deployment annotations. Subsequent ConfigMap updates require user-initiated deployment rollouts to apply the new configuration. Run `kubectl rollout restart deploy` after updating externally supplied ConfigMap content.
 
 ## Using Kong in DB-less mode
 

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -251,6 +251,12 @@ export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"h
 kong start
 ```
 
+## DB-Less with Helm (KIC Disabled)
+
+When deploying Kong in DB-less mode(env.database: "off") and without the Ingress Controller(ingressController.enabled: false), you have to provide a declarative configuration for Kong to run. You can provide an existing ConfigMap (dblessConfig.configMap) or place the whole configuration into values.yaml (dblessConfig.config) parameter. See the example configuration in the default values.yaml for more details. You can use --set-file dblessConfig.config=/path/to/declarative-config.yaml in Helm commands to substitute in a complete declarative config file.
+
+Note that externally supplied ConfigMaps are not hashed or tracked in deployment annotations. Subsequent ConfigMap updates will require user-initiated new deployment rollouts to apply the new configuration. You should run kubectl rollout restart deploy after updating externally supplied ConfigMap content.
+
 ## Using Kong in DB-less mode
 
 There are a number of things to be aware of when using Kong in DB-less


### PR DESCRIPTION
We should include this section of our Helm Chart README in the official documentation. It includes steps to configure a Proxy in Kubernetes with a declarative config when not using a KIC

https://github.com/Kong/charts/tree/main/charts/kong#db-less-deployment

### Summary
Including steps to use a declarative configuration on a Proxy in Kubernetes when the Kong Ingress controller is disabled

### Reason
Steps to perform this are somewhat buried in our Helm Chart README file
