### PR TITLE
Rate Limiting Advanced plugin: Improve config.namespace description

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -393,6 +393,7 @@ error_code
 error_message
 event_queue_size
 example_apikey
+example_namespace
 example_pass
 example_tag
 example_user

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -87,12 +87,23 @@ params:
         entirely and only stores counters in node memory. A value greater than
         0 syncs the counters in that many number of seconds.
     - name: namespace
-      required: false
-      default: random string
-      value_in_examples: null
+      required: semi
+      default: random_auto_generated_string
+      value_in_examples: example_namespace
       datatype: string
       description: |
-        The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is shared in a namespace.
+        The rate limiting library namespace to use for this plugin instance. Counter
+        data and sync configuration is shared in a namespace.
+
+        {:.important}
+        > **Important**: If managing Kong Gateway with **declarative configuration** or running
+        Kong Gateway in **DB-less mode**, set the `namespace` explicitly in your declarative configuration.
+        > <br><br>
+        > If not set, you will run into the following issues:
+        * In DB-less mode, this field will be regenerated automatically on every configuration change.
+        * If applying declarative configuration with decK, decK will automatically fail the update and require a 
+        `namespace` value.
+
     - name: strategy
       required: null
       default: cluster

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -95,16 +95,24 @@ params:
         0 will sync the counters in the specified number of seconds. The minimum
         allowed interval is 0.02 seconds (20ms).
     - name: namespace
-      required: true
+      required: semi
       default: random_auto_generated_string
-      value_in_examples: null
+      value_in_examples: example_namespace
       datatype: string
       description: |
         The rate limiting library namespace to use for this plugin instance. Counter
         data and sync configuration is shared in a namespace.
 
-        In DB-less mode, this field will be generated automatically on every configuration change.
-        We recommended setting `namespace` explicitly when using DB-less mode.
+        {:.important}
+        > **Important**: If managing Kong Gateway with **declarative configuration** or running
+        Kong Gateway in **DB-less mode**, set the `namespace` explicitly in your declarative configuration.
+        > <br><br>
+        > If not set, you will run into the following issues:
+        * In DB-less mode, this field will be regenerated automatically on every configuration change.
+        * If applying declarative configuration with decK, decK will automatically fail the update and require a 
+        `namespace` value.
+
+
     - name: strategy # old version of param description
       maximum_version: "2.8.x"
       required: true


### PR DESCRIPTION
### Summary
Improve description to include DB-less and declarative config info. Also add the value to the autogenerated config examples, since we recommend setting it explicitly for a large portion of users.

### Reason
[Issue raised on Slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1673022359955879).

Explanation of behavior from FTI ticket:
> As you can see from the discussion on this related PR, we are going to not fix this on purpose: this is currently failing because the namespace field is an auto field, meaning that if the user doesn't provide any input, Kong autogenerates it. Since deck is a tool for declarative configuration, we believe this is a good place for deck to fail since not having a namespace and autogenerate it here would mean that decK is not pushing configuration declaratively: a side-effect of this would be that consecutive deployments with a configuration file not including any namespace would result in misleading diffs, since Kong will keep regenerating a namespace each time.

### Testing
https://deploy-preview-5011--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/