### PR TITLE
[DOCU-2880] Plugin konnect examples

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/_index.md
@@ -51,7 +51,7 @@ Alternatively, the `LD_LIBRARY_PATH` environment variable can be set
 to the directory containing the `libappdynamics.so` file when
 starting {{site.base_gateway}}.
 
-If the AppDymanics plugin is enabled but the `libappdynamics.so` file cannot be loaded, {{site.base_gateway}} will refuse to start.
+If the AppDynamics plugin is enabled but the `libappdynamics.so` file cannot be loaded, {{site.base_gateway}} will refuse to start.
 You will receive an error message like this:
 
 ```

--- a/app/_hub/kong-inc/degraphql/_index.md
+++ b/app/_hub/kong-inc/degraphql/_index.md
@@ -15,6 +15,7 @@ kong_version_compatibility:
 params:
   name: degraphql
   service_id: true
+  konnect_examples: false
   dbless_compatible: 'yes'
   config:
     - name: graphql_server_path

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -18,6 +18,7 @@ params:
   name: graphql-rate-limiting-advanced
   service_id: true
   route_id: true
+  konnect_examples: false
   dbless_compatible: partially
   dbless_explanation: |
     The cluster strategy is not supported in DB-less and hybrid modes. For Kong

--- a/app/_hub/kong-inc/tls-handshake-modifier/_index.md
+++ b/app/_hub/kong-inc/tls-handshake-modifier/_index.md
@@ -11,8 +11,8 @@ description: |
   This plugin must be used in conjunction with the TLS Metadata Headers plugin.
 
 enterprise: true
-plus: false # need to update this once we verify that this plugin is in Konnect post-3.0 update
-cloud: false # need to update this once we verify that this plugin is in Konnect post-3.0 update
+plus: false
+cloud: true
 type: plugin
 categories:
   - security
@@ -29,7 +29,6 @@ params:
     - name: grpcs
     - name: tls
   dbless_compatible: 'yes'
-  konnect_examples: false # need to update this once we verify that this plugin is in Konnect post-3.0 update
   config:
     - name: tls_client_certificate
       required: false

--- a/app/_hub/kong-inc/tls-metadata-headers/_index.md
+++ b/app/_hub/kong-inc/tls-metadata-headers/_index.md
@@ -12,8 +12,8 @@ description: |
   Used in conjunction with any plugin which requests a client certificate, such as the mTLS Authentication or TLS Handshake Modifier plugins.
 
 enterprise: true
-plus: false # need to update this once we verify that this plugin is in Konnect post-3.0 update.
-cloud: false # need to update this once we verify that this plugin is in Konnect post-3.0 update.
+plus: false
+cloud: true
 type: plugin
 categories:
   - security
@@ -30,7 +30,6 @@ params:
     - name: grpcs
     - name: tls
   dbless_compatible: 'yes'
-  konnect_examples: false # need to update this once we verify that this plugin is in Konnect post-3.0 update.
 
   config:
     - name: inject_client_cert_details


### PR DESCRIPTION
### Summary
Searched through the doc for plugins that have `cloud: false` but not `konnect_examples: false` and updated them. The plugins noted in the ticket were the only ones.

Also found that the TLS plugins were supposed to have been checked in Konnect in 3.0 and have the examples enabled if they exist. I checked that, they are there, so I enabled examples.

### Reason
Some plugins had Konnect examples even though they're not available in Konnect.

### Testing
Netlify. 
Konnect examples for the graphql plugins should be gone, and the TLS plugins should have Konnect examples.
