### PR TITLE
[DOCU-2900] Add tags to consumer groups examples and reference

### DIFF
--- a/app/_src/gateway/admin-api/consumer-groups/reference.md
+++ b/app/_src/gateway/admin-api/consumer-groups/reference.md
@@ -11,6 +11,8 @@ To use consumer groups for rate limiting, configure the plugin with the
 `enforce_consumer_groups` and `consumer_groups` parameters, then use the
 `/consumer_groups` endpoint to manage the groups.
 
+Consumer groups can be [tagged and filtered by tags](/gateway/{{page.kong_version}}/admin-api/#tags).
+
 For more information and examples of setting up and managing consumer groups, see the
 [Consumer Groups examples](/gateway/{{page.kong_version}}/kong-enterprise/consumer-groups).
 
@@ -35,12 +37,14 @@ HTTP/1.1 200 OK
         {
             "created_at": 1557522650,
             "id": "42b022c1-eb3c-4512-badc-1aee8c0f50b5",
-            "name": "my_group"
+            "name": "my_group",
+            "tags": null
         },
         {
             "created_at": 1637706162,
             "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
-            "name": "my_group2"
+            "name": "my_group2",
+            "tags": null
         }
     ],
     "next": null
@@ -68,7 +72,8 @@ HTTP/1.1 200 OK
     "consumer_group": {
         "created_at": 1638917780,
         "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
-        "name": "JL"
+        "name": "JL",
+        "tags": null
     }
 }
 ```
@@ -135,7 +140,8 @@ HTTP/1.1 200 OK
         {
             "created_at": 1638918476,
             "id": "e2c3f16e-22c7-4ef4-b6e4-ab25c522b339",
-            "name": "JL"
+            "name": "JL",
+            "tags": null,
         }
     ]
 }
@@ -153,6 +159,8 @@ HTTP/1.1 200 OK
 Attribute               | Description
 ---------:              | --------
 `name`<br>*required*    | A unique name for the consumer group you want to create.
+`tags`<br>*optional*    | An optional set of strings associated with the consumer group for grouping and filtering.
+
 
 **Response**
 
@@ -165,6 +173,7 @@ HTTP 201 Created
   "created_at": 1557522650,
   "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
   "name": "JL",
+  "tags": ["tag1", "tag2"]
 }
 ```
 
@@ -175,6 +184,7 @@ HTTP 201 Created
 Attribute                    | Description
 ---------:                   | --------
 `GROUP_NAME`<br>*required*   | A unique name for the consumer group you want to create.
+`tags`<br>*optional*         | An optional set of strings associated with the consumer group for grouping and filtering.
 
 
 **Response**
@@ -188,6 +198,7 @@ HTTP 201 Created
   "created_at": 1557522650,
   "id": "fa6881b2-f49f-4007-9475-577cd21d34f4",
   "name": "JL",
+  "tags": ["tag1", "tag2"]
 }
 ```
 
@@ -235,7 +246,8 @@ HTTP 201 Created
         {
             "created_at": 1638918476,
             "id": "e2c3f16e-22c7-4ef4-b6e4-ab25c522b339",
-            "name": "JL"
+            "name": "JL",
+            "tags": null
         }
     ]
 }

--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -59,7 +59,8 @@ http POST :8001/consumer_groups name=Gold
     {
         "created_at": 1638915521,
         "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
-        "name": "Gold"
+        "name": "Gold",
+        "tags": null
     }
     ```
 
@@ -124,7 +125,8 @@ http POST :8001/consumer_groups/Gold/consumers consumer=Amal
       "consumer_group": {
       "created_at": 1638915521,
       "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
-      "name": "Gold"
+      "name": "Gold",
+      "tags": null
       },
       "consumers": [
         {
@@ -258,7 +260,8 @@ http :8001/consumer_groups/Gold
         "consumer_group": {
             "created_at": 1638915521,
             "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
-            "name": "Gold"
+            "name": "Gold",
+            "tags": null
         },
         "consumers": [
             {
@@ -308,7 +311,8 @@ You can remove a consumer from a group by accessing `/consumers` or
         "consumer_group": {
             "created_at": 1638915521,
             "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
-            "name": "Gold"
+            "name": "Gold",
+            "tags": null
         },
         "consumers": [
             {
@@ -320,7 +324,7 @@ You can remove a consumer from a group by accessing `/consumers` or
             }
         ]
       }
-      ```
+    ```
 
 1. Using the username or ID of the consumer (`Amal` in this example),
 remove the consumer from the group:
@@ -358,7 +362,8 @@ http DELETE :8001/consumer_groups/Gold/consumers/Amal
         "consumer_group": {
             "created_at": 1638917780,
             "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
-            "name": "Gold"
+            "name": "Gold",
+            "tags": null
         }
     }
     ```
@@ -396,7 +401,8 @@ http :8001/consumers/Amal/consumer_groups
             {
                 "created_at": 1638915521,
                 "id": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4",
-                "name": "Gold"
+                "name": "Gold",
+                "tags": null
             }
         ]
     }
@@ -438,7 +444,8 @@ http DELETE :8001/consumers/Amal/consumer_groups/Gold
         "consumer_group": {
             "created_at": 1638917780,
             "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
-            "name": "Gold"
+            "name": "Gold",
+            "tags": null
         }
     }
     ```
@@ -484,7 +491,8 @@ http DELETE :8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced
         "consumer_group": {
             "created_at": 1638917780,
             "id": "be4bcfca-b1df-4fac-83cc-5cf6774bf48e",
-            "name": "Gold"
+            "name": "Gold",
+            "tags": null
         }
     }
     ```
@@ -659,7 +667,8 @@ http POST :8001/consumer_groups/Speedsters/consumers \
         "consumer_group": {
             "created_at": 1639432267,
             "id": "a905151a-5767-40e8-804e-50eec4d0235b",
-            "name": "Speedsters"
+            "name": "Speedsters",
+            "tags": null
         },
         "consumers": [
             {
@@ -752,12 +761,14 @@ http POST :8001/consumers/BarryAllen/consumer_groups \
           {
               "created_at": 1639432267,
               "id": "a905151a-5767-40e8-804e-50eec4d0235b",
-              "name": "Gold"
+              "name": "Gold",
+              "tags": null
           },
           {
               "created_at": 1639436107,
               "id": "2fd2bdd6-690c-4e49-8296-31f55015496d",
-              "name": "Speedsters"
+              "name": "Speedsters",
+              "tags": null
           }
       ]
     }


### PR DESCRIPTION
### Summary
Adding tags to consumer group examples and `tags` attribute entries for creating a consumer group.

### Reason
3.1 fast-follow PR based on https://konghq.atlassian.net/browse/DOCU-2900. 

### Testing
Netlify.

Tested the API, things work, tags appear. Also tested out filtering by tags but didn't want to add an example of that here, since we don't include tag filtering examples in other API docs, and there is a specific doc section for that instead.