### PR TITLE
remove Important warning from the top of the Event Hooks reference page

### DIFF
--- a/app/_src/gateway/admin-api/event-hooks/reference.md
+++ b/app/_src/gateway/admin-api/event-hooks/reference.md
@@ -3,12 +3,6 @@ title: Event Hooks Reference
 badge: enterprise
 ---
 
-{:.important}
-> **Important:** Before you can use event hooks for the first time, Kong needs to be
-reloaded.
-
-{% include_cached /md/enterprise/event-hooks-intro.md %}
-
 {:.note}
 > **Note:** Event hooks do not work with Konnect yet.
 

--- a/app/_src/gateway/admin-api/event-hooks/reference.md
+++ b/app/_src/gateway/admin-api/event-hooks/reference.md
@@ -3,6 +3,8 @@ title: Event Hooks Reference
 badge: enterprise
 ---
 
+{% include_cached /md/enterprise/event-hooks-intro.md %}
+
 {:.note}
 > **Note:** Event hooks do not work with Konnect yet.
 


### PR DESCRIPTION
I don't think that the "Important: Before you can use event hooks for the first time, Kong needs to be reloaded." message at the top of the https://docs.konghq.com/gateway/latest/admin-api/event-hooks/reference/ page is necessary.

Please remove it as per this PR or explain why it should remain. 

For reference, I see it being added in this commit https://github.com/Kong/docs.konghq.com-private/commit/e4a83dd35b0fae58c5eae1ff3a06a409af93dc0e#diff-573438562e7571186a5c5a030162746792c36f46275f591c5157fd55c4343631

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
