### PR TITLE
Add note about seeding super-admin password

### DIFF
--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -45,6 +45,8 @@ The following instructions use [PostgreSQL](http://www.postgresql.org/) as a dat
     ```
 
 2. Run the {{site.base_gateway}} migrations using the following command:
+{:.note}
+> **Note:** If using Enterprise, [we strongly recommend seeding a password for the **Super Admin** user](#seed-super-admin) with the ```kong migrations``` command.
 
     ```bash
     kong migrations bootstrap -c {PATH_TO_KONG.CONF_FILE}

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -44,10 +44,14 @@ The following instructions use [PostgreSQL](http://www.postgresql.org/) as a dat
     CREATE USER kong WITH PASSWORD 'super_secret'; CREATE DATABASE kong OWNER kong;
     ```
 
-2. Run the {{site.base_gateway}} migrations using the following command:
-{:.note}
-> **Note:** If using Enterprise, [we strongly recommend seeding a password for the **Super Admin** user](#seed-super-admin) with the ```kong migrations``` command.
+2. Run one of the following {{site.base_gateway}} migrations:
+    * <span class="badge enterprise"></span> In Enterprise environments, we strongly recommend seeding a password for the **Super Admin** user with the ```kong migrations``` command. This allows you to use RBAC (Role Based Access Control) at a later time, if needed. Create an environment variable with the desired **Super Admin** password and store the password in a safe place:
+    ```bash
+    KONG_PASSWORD={PASSWORD} kong migrations bootstrap -c {PATH_TO_KONG.CONF_FILE}
+    ```
+    > **Important**: Setting your Kong password (`KONG_PASSWORD`) using a value containing four ticks (for example, `KONG_PASSWORD="a''a'a'a'a"`) causes a PostgreSQL syntax error on bootstrap. To work around this issue, do not use special characters in your password.
 
+    * If you aren't using Enterprise, run the following:
     ```bash
     kong migrations bootstrap -c {PATH_TO_KONG.CONF_FILE}
     ```
@@ -79,22 +83,6 @@ Set the `database` option to `off` and the `declarative_config` option to the pa
 ```
 database = off
 declarative_config = {PATH_TO_KONG.CONF_FILE}
-```
-
-## Seed Super Admin
-{:.badge .enterprise}
-
-Setting a password for the **Super Admin** before initial start-up is strongly recommended. This will permit the use of RBAC (Role Based Access Control) at a later time, if needed.
-
-Create an environment variable with the desired **Super Admin** password and store the password in a safe place.
-
-{:.important}
-> **Important**: Setting your Kong password (`KONG_PASSWORD`) using a value containing four ticks (for example, `KONG_PASSWORD="a''a'a'a'a"`) causes a PostgreSQL syntax error on bootstrap. To work around this issue, do not use special characters in your password.
-
-Run migrations to prepare the Kong database, using the following command:
-
-```
-KONG_PASSWORD={PASSWORD} kong migrations bootstrap -c {PATH_TO_KONG.CONF_FILE}
 ```
 
 ## Start {{site.base_gateway}}


### PR DESCRIPTION
### Summary
Added a quick note to encourage Enterprise users to skip to the Seeding Super-Admin password section instead of running the initial ```kong migrations``` command without it.

### Reason
A customer highlighted the concern that if following the documentation in-order as currently defined then it's too late to set the Super-Admin password by the time that section is read. To help users avoid this trap, I felt it was best to highlight the area before a user runs the initial ```kong migrations``` command.
