### PR TITLE
OAS Validation plugin: Not supported in Konnect

### DIFF
--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -260,7 +260,7 @@
       free: No
       plus: Yes
       enterprise: Yes
-      network_config_opts: All
+      network_config_opts: Self-managed classic, DB-less, and hybrid
       notes: --
       url: /hub/kong-inc/oas-validation/
 

--- a/app/_hub/kong-inc/oas-validation/_index.md
+++ b/app/_hub/kong-inc/oas-validation/_index.md
@@ -10,7 +10,8 @@ description: |
   [upgrade your runtimes](/konnect/runtime-manager/upgrade) to at least
   v3.x.
 enterprise: true
-plus: true
+cloud: false
+plus: false
 type: plugin
 categories:
   - traffic-control
@@ -26,6 +27,7 @@ params:
     - name: http
     - name: https
   dbless_compatible: 'yes'
+  konnect_examples: false
   config:
     - name: api_spec
       required: true

--- a/app/_hub/kong-inc/oas-validation/_index.md
+++ b/app/_hub/kong-inc/oas-validation/_index.md
@@ -5,10 +5,6 @@ desc: Validate HTTP requests and responses based on an OpenAPI 3.0 or Swagger AP
 description: |
   Validate HTTP requests and responses based on an API Specification. Supports both Swagger v2 and OpenAPI v3 specifications JSON request and response bodies, with support for schema definitions described using JSON Schema draft v4. For JSON Schema draft 4 type schemas, see the [JSON Schema documentation](https://json-schema.org/) for details on the format and examples.
 
-  {:.note}
-  > To use this plugin in Konnect Cloud,
-  [upgrade your runtimes](/konnect/runtime-manager/upgrade) to at least
-  v3.x.
 enterprise: true
 cloud: false
 plus: false


### PR DESCRIPTION
### Summary
Remove konnect labels and examples from OAS validation plugin.

### Reason
Currently, the OAS Validation plugin is not supported in Konnect. It will be added in an upcoming patch release instead.
See [this conversation](https://kongstrong.slack.com/archives/C01888Q7PJ7/p1673366690845499?thread_ts=1673342450.933209&cid=C01888Q7PJ7) for background.

### Testing
https://deploy-preview-5020--kongdocs.netlify.app/hub/kong-inc/oas-validation/