### PR TITLE
Add missing anchor link on upgrade page 

### DIFF
--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -173,7 +173,7 @@ diff the files to identify any changes, and apply them as needed.
 {% endnavtab %}
 {% endnavtabs %}
 
-## Upgrade from 3.0.x to 3.1.x
+## Upgrade from 3.0.x to 3.1.x {#migrate-db}
 
 ### Traditional mode
 


### PR DESCRIPTION
### Summary
Add an anchor to the migrate/upgrade section. There are links to that anchor, this fixes them.

The link works in previous versions. 

### Reason
Fixes https://github.com/Kong/docs.konghq.com/issues/5019.
### Testing
https://deploy-preview-5021--kongdocs.netlify.app/gateway/latest/upgrade/

Check the link to "database migration" in the sentence "In either case, you can review the upgrade considerations, then follow the database migration instructions."