### PR TITLE
[DOCU-2840] AppDynamics plugin: Prereqs section with platform info

### DIFF
--- a/.github/styles/kongplugins/dictionary.txt
+++ b/.github/styles/kongplugins/dictionary.txt
@@ -134,6 +134,7 @@ flamegraph
 full_name
 gevent
 gibibytes
+glibc
 globbing
 gojira
 grpc

--- a/app/_hub/kong-inc/app-dynamics/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/_index.md
@@ -8,13 +8,17 @@ description: |
   AppDynamics. The plugin reports request and response timestamps and error information to the AppDynamics platform to
   be analyzed in the AppDynamics flow map and correlated with other
   systems participating in handling application API requests.
+  
+  ## Prerequisites
 
-  {:.warning}
-  > The plugin utilizes the
-  > [AppDynamics C/C++ Application Agent and SDK](https://docs.appdynamics.com/pages/viewpage.action?pageId=42583435),
-  > which must be downloaded and installed on the machine or within the
-  > container running Kong Gateway. Refer to the
-  > [AppDynamics SDK documentation](https://docs.appdynamics.com/) for platform support information.
+  Before using the plugin, download and install the [AppDynamics C/C++ Application Agent and SDK](https://docs.appdynamics.com/pages/viewpage.action?pageId=42583435) on the machine or within the container running Kong Gateway. 
+
+  ### Platform support
+  
+  The AppDynamics C SDK supports Linux distributions based on glibc 2.5+. MUSL-based distributions like the Alpine distribution, which is popular for container usage, are not supported. Kong Gateway must be running on a glibc-based distribution like RHEL, CentOS, Debian, or Ubuntu to support this plugin. 
+  
+  See the [AppDynamics C/C++ SDK Supported Environments](https://docs.appdynamics.com/appd/21.x/21.12/en/application-monitoring/install-app-server-agents/c-c++-sdk/c-c++-sdk-supported-environments) document for more information.
+
 enterprise: true
 type: plugin
 categories:


### PR DESCRIPTION
### Summary
Adding a prerequisites section to the AppDynamics plugin with the SDK install info + platform requirements.

### Reason
https://konghq.atlassian.net/browse/DOCU-2840

### Testing
https://deploy-preview-5022--kongdocs.netlify.app/hub/kong-inc/app-dynamics/