### PR TITLE
[DOCU-2212] Zipkin: Document missing parameter default_service_name

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -329,6 +329,7 @@ datatype
 dbless_compatible
 dbless_explanation
 default_header_type
+default_service_name
 default_type
 description
 dest

--- a/app/_hub/kong-inc/zipkin/_index.md
+++ b/app/_hub/kong-inc/zipkin/_index.md
@@ -54,6 +54,13 @@ params:
         How often to sample requests that do not contain trace IDs.
         Set to `0` to turn sampling off, or to `1` to sample **all** requests. The
         value must be between zero (0) and one (1), inclusive.
+    - name: default_service_name
+      required: false
+      default: null
+      datatype: string
+      description: |
+        Set a default service name to override `unknown-service-name` in the 
+        Zipkin spans.
     - name: include_credential
       required: true
       default: true


### PR DESCRIPTION
### Summary
Adding the missing parameter `default_service_name`. 
This parameter was added in a pre-2.1 version, so we don't need to set any conditionals on it.

References: 
* [plugin schema](https://github.com/Kong/kong/blob/master/kong/plugins/zipkin/schema.lua#L55)
* [PR from archived plugin repo](https://github.com/Kong/kong-plugin-zipkin/pull/45)

### Reason
https://konghq.atlassian.net/browse/DOCU-2212

### Testing
Netlify