### PR TITLE
ft(rate-limiting-advanced): allow 'cluster' strategy with 'sync_rate …

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -147,8 +147,9 @@ params:
 
         In DB-less and hybrid modes, the `cluster` config strategy
         is not supported. From `3.0.0.0` onwards, Kong disallows
-        the plugin enablement if `cluster` strategy is set with DB-less
-        or hybrid mode.
+        the plugin enablement if strategy is `cluster` and `sync_rate` is `-1`
+        with DB-less or hybrid mode. From `3.2.0.0` onward, please either
+        use a different strategy or set `sync_rate` as `-1`.
 
         In Konnect, the default strategy is `redis`.
 

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -148,8 +148,8 @@ params:
         In DB-less and hybrid modes, the `cluster` config strategy
         is not supported. From `3.0.0.0` onwards, Kong disallows
         the plugin enablement if strategy is `cluster` and `sync_rate` is `-1`
-        with DB-less or hybrid mode. From `3.2.0.0` onward, please either
-        use a different strategy or set `sync_rate` as `-1`.
+        with DB-less or hybrid mode. From `3.2.0.0` onward, please
+        use a different strategy or set `sync_rate` to `-1`.
 
         In Konnect, the default strategy is `redis`.
 


### PR DESCRIPTION

### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->

Allow sync_rate = -1 with DB-less mode or hybrid mode, even when the default 'cluster' strategy is untouched.
https://konghq.atlassian.net/browse/FTI-4670
### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->

Give customer clear guide.


<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
