### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,9 @@
 
-### Summary 
+### Description
 
-Description: <!-- What did you change and why? -->
+What did you change and why?
  
-<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
-
-Changelog entry, if applicable:
+Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
 
 
 ### Testing instructions
@@ -16,7 +14,9 @@ Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add 
 ### Checklist 
 
 [ ] Review label added
-[ ] Changelog entry (if applicable)
+
+** Release-specific work only **
+[ ] Pointed to correct feature branch (e.g. `release/gateway-3.2`, `release/deck-1.17`)
 
 
 <!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->
@@ -25,7 +25,8 @@ Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add 
 
     review:copyedit: Request for writer review.
     review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
-    review:tech: Request for technical review for a platform change.
+    review:tech: Request for technical review for a docs platform change.
+    review:sme: Request for review from an SME (engineer, PM, etc).
 
 At least one of these labels must be applied to a PR or the build will fail.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,32 @@
-### Summary
-<!-- Description of PR, with any special instructions for your reviewers. -->
 
-### Reason
-<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
-Trello card, etc. -->
+### Summary 
 
-### Testing
-<!-- How can your reviewers test your change? How did you test it? -->
+Description: <!-- What did you change and why? -->
+ 
+<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
 
-<!-- (Optional) Include link to topic in Netlify preview after it's generated 
-(around 10mins after PR is created) -->
+Changelog entry, if applicable:
 
-<!--
 
-!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!
+### Testing instructions
 
-When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:
+Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
+
+
+### Checklist 
+
+[ ] Review label added
+[ ] Changelog entry (if applicable)
+
+
+<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->
+
+<!-- When raising a pull request, indicate what type of review you need with one of the following labels:
 
     review:copyedit: Request for writer review.
     review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
-    review:tech: Request for technical review from an SME.
+    review:tech: Request for technical review for a platform change.
 
 At least one of these labels must be applied to a PR or the build will fail.
 -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add 
 
 ### Checklist 
 
-[ ] Review label added
+[ ] Review label added <!-- (see below) -->
 
 ** Release-specific work only **
 [ ] Pointed to correct feature branch (e.g. `release/gateway-3.2`, `release/deck-1.17`)

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -25,6 +25,7 @@ Grafana
 HTTPie
 Istio
 Istio's
+Jira
 JsonPath
 Keycloak
 Knative

--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -13,3 +13,15 @@ jobs:
           mode: minimum
           count: 1
           labels: "review:tech, review:copyedit, review:general, review:autodoc, review:sme"
+          add_comment: true
+          message: |
+            "Please add at least one of the following review labels to this PR:
+             - `review:copyedit`: Request for writer review.
+             - `review:general`: Review for general accuracy and presentation. 
+               Does the doc work? Does it output correctly?
+             - `review:tech`: Request for technical review for a docs platform change.
+             - `review:sme`: Request for review from an SME (engineer, PM, etc.).
+             
+             Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! 
+             The maintainers will label this PR for you."
+

--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -15,13 +15,13 @@ jobs:
           labels: "review:tech, review:copyedit, review:general, review:autodoc, review:sme"
           add_comment: true
           message: |
-            "Please add at least one of the following review labels to this PR:
+            Please add at least one of the following review labels to this PR:
              - `review:copyedit`: Request for writer review.
              - `review:general`: Review for general accuracy and presentation. 
                Does the doc work? Does it output correctly?
              - `review:tech`: Request for technical review for a docs platform change.
              - `review:sme`: Request for review from an SME (engineer, PM, etc.).
              
-             Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! 
-             The maintainers will label this PR for you."
+             **Note:** Only Kong employees can add labels due to a GitHub limitation. 
+             If you're an OSS contributor, thank you! The maintainers will label this PR for you.
 

--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -15,7 +15,7 @@ jobs:
           labels: "review:tech, review:copyedit, review:general, review:autodoc, review:sme"
           add_comment: true
           message: |
-            Please add at least one of the following review labels to this PR:
+             :warning: Please add at least one of the following review labels to this PR:
              - `review:copyedit`: Request for writer review.
              - `review:general`: Review for general accuracy and presentation. 
                Does the doc work? Does it output correctly?


### PR DESCRIPTION
Attempting to make the PR template clearer.

* Combined the summary and reason sections into one
* Added changelog prompt
* Added checklist - is this useful at all? If we want to use it, what else should be part of this checklist?
* Left the info about labels in. It's a big block block of text that I don't think anyone reads, but the info needs to be there to cover why the builds fail. 
  * Or does it? Should it be a bot comment instead, if someone doesn't add a label?

All feedback and ideas welcome.