### PR TITLE
Updating the kong enterprise documentation

### DIFF
--- a/.github/styles/kong/auto-ignore.txt
+++ b/.github/styles/kong/auto-ignore.txt
@@ -43,6 +43,7 @@ ssl_client_verify
 start_cmd
 stream_listen
 stringified
+tolerations
 trusted_ips
 Gateway
 GatewayClass


### PR DESCRIPTION
Adding content to support deployment of AIO on Kind so that developers can try this on local environments if they want to have a play.

### Summary
I have added documentation to support deployment of Kong Ingress controller with Kong enterprise on Kind.

### Reason
I believe it will help developer try our Kong enterprise locally on their machine with Kind. Not every one will have access to cloud infrastructure to try KIC and Kong enterprise. This hopefuly will give them the opportunity to try the product locally and get an understanding of the components.

### Testing
Follow the steps indicated with `### For kind` heading.

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

!!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!!

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
