### PR TITLE
Add auto-close Kong issues workflow

### DIFF
--- a/.github/workflows/auto-close-kong-issues.yml
+++ b/.github/workflows/auto-close-kong-issues.yml
@@ -1,0 +1,20 @@
+name: Auto Close Org Issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-close-org-issues:
+    name: Auto Close Org Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Close Org Issues
+        uses: mheap/auto-close-org-issues-action@v1
+        with:
+          token: ${{ secrets.ORG_MEMBERS_PAT }}
+          org: Kong
+          message: |
+            Thanks for raising an issue! We track issues raised by Kong employees in Jira.
+
+            Please submit your request in the DOCU project and we'll get it prioritized.
+          keep_open: "Kubernetes Team"


### PR DESCRIPTION
### Summary
Automatically close issues raised by Kong org members

### Reason
We prefer to track employee requests in Jira

### Testing
Tested on a separate repo (it worked!)