### PR TITLE
Update kuma submodule with `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-prerequisites:
 install: ruby-version-check
 	npm ci
 	bundle install
-	git submodule init && git submodule update
+	git submodule update --init
 
 # Using local dependencies, starts a doc site instance on http://localhost:3000.
 run: ruby-version-check

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install-prerequisites:
 install: ruby-version-check
 	npm ci
 	bundle install
+	git submodule init && git submodule update
 
 # Using local dependencies, starts a doc site instance on http://localhost:3000.
 run: ruby-version-check


### PR DESCRIPTION
### Description

Adding `git submodule init && git submodule update` to the `make install` command. People (myself included) keep running into issues where the local submodule ends up out of date and the build fails.

### Testing instructions

Test locally by running `make install`. 
You can temporarily delete the `_src/.repos/kuma` folder first before running it to make sure that the command does pull the submodule.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] Pointed to correct feature branch
