### PR TITLE
[DOCU-2906] OAS validation plugin is bundled with Kong

### DIFF
--- a/app/_hub/kong-inc/oas-validation/_index.md
+++ b/app/_hub/kong-inc/oas-validation/_index.md
@@ -5,6 +5,9 @@ desc: Validate HTTP requests and responses based on an OpenAPI 3.0 or Swagger AP
 description: |
   Validate HTTP requests and responses based on an API Specification. Supports both Swagger v2 and OpenAPI v3 specifications JSON request and response bodies, with support for schema definitions described using JSON Schema draft v4. For JSON Schema draft 4 type schemas, see the [JSON Schema documentation](https://json-schema.org/) for details on the format and examples.
 
+  {:.important .no-icon}
+  > In Kong Gateway versions 3.1.1.0 and 3.1.1.1, this plugin is not enabled by default. Upgrade to 3.1.1.2, or manually [enable the plugin](#enable-the-plugin).
+  
 enterprise: true
 cloud: false
 plus: false
@@ -101,6 +104,16 @@ params:
       description: |
         If set to true, returns a detailed error message for invalid requests & responses. This is useful while testing.
 ---
+
+{% if_plugin_version eq:3.1.x %}
+## Enable the plugin
+
+To enable the plugin, use one of the following methods:
+  * Package install: Set `plugins=bundled,oas-validation` in `kong.conf` before starting Kong
+  * Docker: Set `KONG_PLUGINS=bundled,oas-validation` in the environment
+  * Kubernetes: Set `KONG_PLUGINS=bundled,oas-validation` using [these instructions](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/#modify-configuration)
+
+{% endif_plugin_version %}
 
 ## Tutorial
 

--- a/app/_hub/kong-inc/oas-validation/_index.md
+++ b/app/_hub/kong-inc/oas-validation/_index.md
@@ -6,7 +6,7 @@ description: |
   Validate HTTP requests and responses based on an API Specification. Supports both Swagger v2 and OpenAPI v3 specifications JSON request and response bodies, with support for schema definitions described using JSON Schema draft v4. For JSON Schema draft 4 type schemas, see the [JSON Schema documentation](https://json-schema.org/) for details on the format and examples.
 
   {:.important .no-icon}
-  > In Kong Gateway versions 3.1.1.0 and 3.1.1.1, this plugin is not enabled by default. Upgrade to 3.1.1.2, or manually [enable the plugin](#enable-the-plugin).
+  > In Kong Gateway versions 3.1.0.0-3.1.1.1, this plugin is not enabled by default. Upgrade to 3.1.1.2, or manually [enable the plugin](#enable-the-plugin).
   
 enterprise: true
 cloud: false
@@ -107,6 +107,8 @@ params:
 
 {% if_plugin_version eq:3.1.x %}
 ## Enable the plugin
+
+In Kong Gateway versions 3.1.0.0-3.1.1.1, this plugin is not enabled by default.
 
 To enable the plugin, use one of the following methods:
   * Package install: Set `plugins=bundled,oas-validation` in `kong.conf` before starting Kong

--- a/app/_hub/kong-inc/oas-validation/versions.yml
+++ b/app/_hub/kong-inc/oas-validation/versions.yml
@@ -2,7 +2,3 @@ strategy: gateway
 
 releases:
   minimum_version: '3.1.x'
-
-frontmatter:
-  3.1.x:
-    bundled: false


### PR DESCRIPTION
### Description

OAS validation plugin is bundled with Kong starting in 3.1.1.2. 
* Removing `bundled: false` for this plugin and moving the instructions into a conditional section that will only be visible for 3.1.x
* Adding a banner mentioning the version. 
  * I didn't want to put all of the info in the banner at the top of the page, as that would take over the intro section.

https://konghq.atlassian.net/browse/DOCU-2906

Merge this PR only when 3.1.1.2 goes out.

### Testing instructions

Netlify link: https://deploy-preview-5038--kongdocs.netlify.app/hub/kong-inc/oas-validation/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] Pointed to correct feature branch (e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

