### PR TITLE
FTI-4690: Notes a limitation in Kong 2.8.2.3 in regard to dynamically linked PCRE library

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1322,7 +1322,7 @@ RBAC rules involving deny (negative) rules now correctly take precedence over al
 
 ### Known limitations
 
-A required PCRE library is dynamically linked where prior versions statically linked the library. Depending on the system PCRE version, this may cause regex compliation to fail when routing requests. From 2.8.2.4 and later, Kong will return to statically linking the PCRE library.
+* A required PCRE library is dynamically linked, where prior versions statically linked the library. Depending on the system PCRE version, this may cause regex compilation to fail when routing requests. Starting in 2.8.2.4 and later, Kong Gateway will return to statically linking the PCRE library.
 
 ## 2.8.2.2
 **Release Date** 2022/12/01

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1320,6 +1320,9 @@ RBAC rules involving deny (negative) rules now correctly take precedence over al
   * Fixed an issue where empty arrays were being converted to empty objects.
   Empty arrays are now preserved.
 
+### Known limitations
+
+A required PCRE library is dynamically linked where prior versions statically linked the library. Depending on the system PCRE version, this may cause regex compliation to fail when routing requests. From 2.8.2.4 and later, Kong will return to statically linking the PCRE library.
 
 ## 2.8.2.2
 **Release Date** 2022/12/01


### PR DESCRIPTION
### Description

Clarifies an issue in the changelog with a dynamically linked library in kong release 2.8.2.3

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

