### PR TITLE
Remove Amazon Linux segfaults fix from changelog

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1288,9 +1288,6 @@ RBAC rules involving deny (negative) rules now correctly take precedence over al
 * Fixed a router issue where, in an environment with more than 50,000 routes, attempting to update a route caused a `500` error response.
 * Fixed a timer leak that occurred whenever the generic messaging protocol connection broke in hybrid mode.
 * Fixed a `tlshandshake` method error that occurred when SSL was configured on PostgreSQL, and the Kong Gateway had `stream_listen` configured with a stream proxy. 
-* Fixed an issue that caused segfaults in Kong Gateway running on Amazon Linux 2 with `opentracing` enabled.
-  This was caused by the wrong base image being used for the Amazon Linux 2 package.
-  The Amazon Linux 2 package is now built on an actual Amazon Linux 2 image instead of the shared CentOS-based image.
 
 #### Plugins
 


### PR DESCRIPTION
### Description

Removing amazon linux segfaults fix that didn't make it into the 2.8.2.3 builds. It is being deferred to 2.8.2.4 or 2.8.3.0. 

### Testing instructions

Netlify


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

