### PR TITLE
Add prometheus to supported strategies list

### DIFF
--- a/app/_src/gateway/kong-enterprise/analytics/index.md
+++ b/app/_src/gateway/kong-enterprise/analytics/index.md
@@ -20,10 +20,10 @@ Vitals is enabled by default in {{site.ee_product_name}} and available upon the 
 
 You can use one of the following storage strategies with Vitals:
 * Kong database:
- * PostgresSQL 9.5+
+  * PostgresSQL 9.5+
 * Separate storage engine:
- * InfluxDB
- * Prometheus 
+  * InfluxDB
+  * Prometheus 
 
 ## Guidelines for viewing Vitals
 When using Vitals, note:

--- a/app/_src/gateway/kong-enterprise/analytics/index.md
+++ b/app/_src/gateway/kong-enterprise/analytics/index.md
@@ -12,15 +12,18 @@ Use Kong Vitals (Vitals) to monitor {{site.ee_product_name}} health and performa
 ![Vitals Overview](/assets/images/docs/ee/vitals_overview.png)
 
 ## Prerequisites
-Vitals is enabled by default in {{site.ee_product_name}} and available upon the first login of a Super Admin.
 
+Vitals is enabled by default in {{site.ee_product_name}} and available upon the first login of a Super Admin.
 
 {% include_cached /md/enterprise/cassandra-deprecation.md length='short' kong_version=page.kong_version %}
 
 
-You will need one of the following databases to use Vitals:
-* InfluxDB
-* PostgresSQL 9.5+
+You can use one of the following storage strategies with Vitals:
+* Kong database:
+ * PostgresSQL 9.5+
+* Separate storage engine:
+ * InfluxDB
+ * Prometheus 
 
 ## Guidelines for viewing Vitals
 When using Vitals, note:

--- a/app/gateway/2.8.x/vitals/index.md
+++ b/app/gateway/2.8.x/vitals/index.md
@@ -5,7 +5,7 @@ badge: enterprise
 
 Use Kong Vitals (Vitals) to monitor {{site.ee_product_name}} health and performance, and to understand the microservice API transactions traversing Kong. Vitals uses visual API analytics to see exactly how your APIs and Gateway are performing. Quickly access key statistics, monitor vital signs, and pinpoint anomalies in real time.
 
-* Use Kong Admin API to access Vitals data via endpoints. Additional visualizations, including dashboarding of Vitals data alongside data from other systems, can be achieved using the Vitals API to integrate with common monitoring systems.
+* Use Kong Admin API to access Vitals data via endpoints. Additional visualizations, including creating dashboards of Vitals data alongside data from other systems, can be achieved using the Vitals API to integrate with common monitoring systems.
 
 * Use Kong Manager to view visualizations of Vitals data, including the Workspaces Overview Dashboard, Workspace Charts, Vitals tab, and Status Codes, and to generate CSV Reports.
 

--- a/app/gateway/2.8.x/vitals/index.md
+++ b/app/gateway/2.8.x/vitals/index.md
@@ -12,16 +12,17 @@ Use Kong Vitals (Vitals) to monitor {{site.ee_product_name}} health and performa
 ![Vitals Overview](/assets/images/docs/ee/vitals_overview.png)
 
 ## Prerequisites
-Vitals is enabled by default in {{site.ee_product_name}} and available upon the first login of a Super Admin.
 
+Vitals is enabled by default in {{site.ee_product_name}} and available upon the first login of a Super Admin.
 
 {% include_cached /md/enterprise/cassandra-deprecation.md %}
 
-
-You will need one of the following databases to use Vitals:
-* InfluxDB
-* PostgresSQL 9.5+
-* Cassandra 2.1+
+You can use one of the following storage strategies with Vitals:
+* Kong database:
+ * PostgresSQL 9.5+
+* Separate storage engine:
+ * InfluxDB
+ * Prometheus 
 
 ## Guidelines for viewing Vitals
 When using Vitals, note:

--- a/app/gateway/2.8.x/vitals/index.md
+++ b/app/gateway/2.8.x/vitals/index.md
@@ -19,10 +19,10 @@ Vitals is enabled by default in {{site.ee_product_name}} and available upon the 
 
 You can use one of the following storage strategies with Vitals:
 * Kong database:
- * PostgresSQL 9.5+
+  * PostgresSQL 9.5+
 * Separate storage engine:
- * InfluxDB
- * Prometheus 
+  * InfluxDB
+  * Prometheus 
 
 ## Guidelines for viewing Vitals
 When using Vitals, note:


### PR DESCRIPTION
### Description

* Added Prometheus to the Vitals/analytics supported strategies list. 
* Rephrased the list to say strategies instead of databases for accuracy.

This has always been true, it was just missing, so I've also updated 2.8.x.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1674117603455889

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

