### PR TITLE
OIDC plugin: Add PKCE to list of supported credentials and grants

### DIFF
--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -13,7 +13,7 @@ description: |
   - Signed [JWT][jwt] access tokens ([JWS][jws])
   - Opaque access tokens
   - Refresh tokens
-  - Authorization code
+  - Authorization code with client secret or PKCE
   - Username and password
   - Client credentials
   - Session cookies


### PR DESCRIPTION
### Description

Added PKCE to list of supported credentials and grants for the OIDC plugin. We have supported it for a long time but have never mentioned in the docs.

I looked into expanding auth code flow examples and decided against it, so that we don't simply repeat the [Auth0 documentation](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce). As far as I can tell, any other config that the customer has to do happens on their end, not in this plugin.
 
Issue reported on [Slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1674238775807409).

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

