### PR TITLE
Fix Typo in the additional abilities listing

### DIFF
--- a/app/_hub/kong-inc/response-transformer/_index.md
+++ b/app/_hub/kong-inc/response-transformer/_index.md
@@ -18,7 +18,7 @@ description: |
 
   * When transforming a JSON payload, transformations are applied to nested JSON objects and
     arrays. This can be turned off and on using the `config.dots_in_keys` configuration parameter.
-    See [Response Transformed Advanced arrays and nested objects](/hub/kong-inc/response-transformer-advanced/#arrays-and-nested-objects).
+    See [Response Transformer Advanced arrays and nested objects](/hub/kong-inc/response-transformer-advanced/#arrays-and-nested-objects).
   * Transformations can be restricted to responses with specific status codes using various
     `config.*.if_status` configuration parameters.
   * JSON body contents can be restricted to a set of allowed properties with


### PR DESCRIPTION
### Description

What did you change and why?
 Fix Typo in the Page for Response Transformer plugin documentation.
![image](https://user-images.githubusercontent.com/116092718/214219973-42256dcf-d501-4cd2-9b21-02cb1c54a496.png)



### Testing instructions

Just open https://docs.konghq.com/hub/kong-inc/response-transformer/ and see if the changes reflected.


### Checklist 

- [X ] Review label added <!-- (see below) -->
- [X ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

