### PR TITLE
Fix indent in release notes

### DIFF
--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -50,9 +50,8 @@ with any of the following backends:
 
 **Runtime Groups API**
 : Konnect APIs for runtime groups are now available for external consumption. This set of APIs allow organizations to create and manage runtime groups and manage CP/DP certificates. [View API documentation](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/).
-## November 2022
 
-### 2022.11.21
+## November 2022
 
 **Application registration support in any runtime group**
 : {{site.konnect_short_name}} now officially supports [app registration to services in both default and non-default runtime groups](/konnect/dev-portal/applications/enable-app-reg/#support-for-any-runtime-group). Portal developers can register their applications to consume services proxied through gateway services in both default and non-default runtime groups.


### PR DESCRIPTION
### Description

Fixing this issue:

![Screenshot 2023-01-24 at 9 26 52 AM](https://user-images.githubusercontent.com/54370747/214364599-f8c096b2-3b59-4a13-b596-dcacf05b78a3.png)

Also removing the date, as we don't post specific dates anymore; looks like it was an accidental leftover.
 
Ran into this when looking through the release notes.

### Testing instructions

Netlify link: https://deploy-preview-5068--kongdocs.netlify.app/konnect/updates/#november-2022


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

