### PR TITLE
chore: Bump deck version to 1.17.2

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -249,7 +249,7 @@
   edition: "deck"
 -
   release: "1.17.x"
-  version: "1.17.0"
+  version: "1.17.2"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Description

Bumped the version for decK. 
1.7.2 was released today: https://github.com/Kong/deck/releases/tag/v1.17.2

Did a quick review of the changelog (https://github.com/Kong/deck/blob/main/CHANGELOG.md#v1172), nothing in there needs doc updates.


### Testing instructions

Netlify link: https://deploy-preview-5069--kongdocs.netlify.app/deck/latest/installation/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

