### PR TITLE
[DOCU-2914] Entities managed by decK

### DIFF
--- a/app/_data/docs_nav_deck_1.17.x.yml
+++ b/app/_data/docs_nav_deck_1.17.x.yml
@@ -59,28 +59,33 @@ items:
           - text: Using Environment Variables with decK
             url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_src/deck/guides/kong-enterprise.md
+++ b/app/_src/deck/guides/kong-enterprise.md
@@ -18,6 +18,8 @@ decK manages only the core proxy entities in {{site.ee_product_name}}. It doesn'
 manage enterprise-only entities such as admins, RBAC permissions, RBAC roles,
 or any entities related to Dev Portal.
 
+For a full list, see the reference for [entities managed by decK](/deck/{{page.kong_version}}/entities).
+
 ## RBAC
 
 If you have authentication and RBAC configured for Kong's Admin API, provide the

--- a/app/_src/deck/guides/kong-enterprise.md
+++ b/app/_src/deck/guides/kong-enterprise.md
@@ -18,7 +18,7 @@ decK manages only the core proxy entities in {{site.ee_product_name}}. It doesn'
 manage enterprise-only entities such as admins, RBAC permissions, RBAC roles,
 or any entities related to Dev Portal.
 
-For a full list, see the reference for [entities managed by decK](/deck/{{page.kong_version}}/entities).
+For a full list, see the reference for [entities managed by decK](/deck/{{page.kong_version}}/reference/entities).
 
 ## RBAC
 

--- a/app/_src/deck/reference/entities.md
+++ b/app/_src/deck/reference/entities.md
@@ -1,0 +1,42 @@
+---
+title: Entities Managed by decK
+content_type: reference
+---
+
+decK manages entity configuration for {{site.base_gateway}}, including all core proxy entities.
+
+It does not manage {{site.base_gateway}} configuration parameters in `kong.conf`, or content and configuration for the Dev Portal.
+
+
+Entity | Managed by decK?
+-------|-----------------
+Services | <i class="fa fa-check"></i>
+Routes | <i class="fa fa-check"></i>
+Consumers | <i class="fa fa-check"></i>
+Plugins | <i class="fa fa-check"></i>
+Certificates |<i class="fa fa-check"></i>
+CA Certificates | <i class="fa fa-check"></i>
+SNIs | <i class="fa fa-check"></i>
+Upstreams | <i class="fa fa-check"></i>
+Targets | <i class="fa fa-check"></i>
+Vaults | <i class="fa fa-check"></i>
+Keys and keysets | <i class="fa fa-times"></i>
+Licenses | <i class="fa fa-times"></i>
+Workspaces | <i class="fa fa-check"></i> <sup>1</sup>
+RBAC: roles and endpoint permissions | <i class="fa fa-check"></i>
+RBAC: groups and admins | <i class="fa fa-times"></i>
+Developers | <i class="fa fa-times"></i>
+Consumer groups | <i class="fa fa-times"></i>
+Event hooks | <i class="fa fa-times"></i>
+Keyring and data encryption | <i class="fa fa-times"></i>
+
+{:.note .no-icon}
+> **\[1\]**: decK can create workspaces and manage entities in a given workspace. 
+However, decK can't delete workspaces, and it can't update multiple workspaces simultaneously.
+See [Manage multiple workspaces](/deck/{{page.kong_version}}/guides/kong-enterprise/#manage-multiple-workspaces) for more information.
+
+Because decK can't manage all of {{site.base_gateway}}'s configuration, you need to make other arrangements for deployment, backup, and restore of unmanaged entities.
+
+This is also the case if the data plane loses connection to the control plane in hybrid mode. 
+The data plane can function in disconnected mode, using a [backup declarative configuration file](/gateway/latest/reference/configuration/#declarative_config). 
+However, this option is not available if you have any of the unmanaged entities configured.


### PR DESCRIPTION
### Description
 
Adding a reference doc for entities managed by decK. This list has already been vetted by an SME.

Questions/considerations for reviewers:
* I turned the decK CLI reference section into a general reference section and nested the CLI ref one level down. Let me know if that seems like a bad idea.
* I wasn't sure if the table format was the way to go for the list - I could simply have two lists, one supported and one unsupported. I like the visual element the table adds but it's not necessary. What do you think?

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

