### PR TITLE
docs(policies): add note about one policy for kong mesh opa

### DIFF
--- a/app/_src/mesh/features/opa.md
+++ b/app/_src/mesh/features/opa.md
@@ -21,6 +21,7 @@ To apply a policy with OPA:
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
 > **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/_src/mesh/features/opa.md
+++ b/app/_src/mesh/features/opa.md
@@ -20,7 +20,7 @@ To apply a policy with OPA:
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
-> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+> **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/_src/mesh/features/opa.md
+++ b/app/_src/mesh/features/opa.md
@@ -18,8 +18,10 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 - Optionally provide custom configuration for the policy agent.
+
+<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/_src/mesh/features/opa.md
+++ b/app/_src/mesh/features/opa.md
@@ -18,10 +18,11 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+{:.note}
+> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
-<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/mesh/1.2.x/features/opa.md
+++ b/app/mesh/1.2.x/features/opa.md
@@ -18,8 +18,10 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 - Optionally provide custom configuration for the policy agent.
+
+<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 ### Inline
 

--- a/app/mesh/1.2.x/features/opa.md
+++ b/app/mesh/1.2.x/features/opa.md
@@ -21,6 +21,7 @@ To apply a policy with OPA:
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
 > **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.2.x/features/opa.md
+++ b/app/mesh/1.2.x/features/opa.md
@@ -18,10 +18,11 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+{:.note}
+> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
-<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 ### Inline
 

--- a/app/mesh/1.2.x/features/opa.md
+++ b/app/mesh/1.2.x/features/opa.md
@@ -20,7 +20,7 @@ To apply a policy with OPA:
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
-> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+> **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.3.x/features/opa.md
+++ b/app/mesh/1.3.x/features/opa.md
@@ -18,8 +18,10 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 - Optionally provide custom configuration for the policy agent.
+
+<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 ### Inline
 

--- a/app/mesh/1.3.x/features/opa.md
+++ b/app/mesh/1.3.x/features/opa.md
@@ -21,6 +21,7 @@ To apply a policy with OPA:
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
 > **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.3.x/features/opa.md
+++ b/app/mesh/1.3.x/features/opa.md
@@ -18,10 +18,11 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA:
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+{:.note}
+> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
-<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 ### Inline
 

--- a/app/mesh/1.3.x/features/opa.md
+++ b/app/mesh/1.3.x/features/opa.md
@@ -20,7 +20,7 @@ To apply a policy with OPA:
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
-> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+> **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.4.x/features/opa.md
+++ b/app/mesh/1.4.x/features/opa.md
@@ -21,6 +21,7 @@ To apply a policy with OPA:
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
 > **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.4.x/features/opa.md
+++ b/app/mesh/1.4.x/features/opa.md
@@ -18,8 +18,10 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA: 
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 - Optionally provide custom configuration for the policy agent.
+
+<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/mesh/1.4.x/features/opa.md
+++ b/app/mesh/1.4.x/features/opa.md
@@ -20,7 +20,7 @@ To apply a policy with OPA:
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
-> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+> **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.4.x/features/opa.md
+++ b/app/mesh/1.4.x/features/opa.md
@@ -18,10 +18,11 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA: 
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+{:.note}
+> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
-<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/mesh/1.5.x/features/opa.md
+++ b/app/mesh/1.5.x/features/opa.md
@@ -21,6 +21,7 @@ To apply a policy with OPA:
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
 > **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.5.x/features/opa.md
+++ b/app/mesh/1.5.x/features/opa.md
@@ -18,8 +18,10 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA: 
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 - Optionally provide custom configuration for the policy agent.
+
+<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/mesh/1.5.x/features/opa.md
+++ b/app/mesh/1.5.x/features/opa.md
@@ -20,7 +20,7 @@ To apply a policy with OPA:
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
-> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+> **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.5.x/features/opa.md
+++ b/app/mesh/1.5.x/features/opa.md
@@ -18,10 +18,11 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA: 
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+{:.note}
+> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
-<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/mesh/1.6.x/features/opa.md
+++ b/app/mesh/1.6.x/features/opa.md
@@ -21,6 +21,7 @@ To apply a policy with OPA:
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
 > **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.6.x/features/opa.md
+++ b/app/mesh/1.6.x/features/opa.md
@@ -18,8 +18,10 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA: 
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide the list of policies with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 - Optionally provide custom configuration for the policy agent.
+
+<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 

--- a/app/mesh/1.6.x/features/opa.md
+++ b/app/mesh/1.6.x/features/opa.md
@@ -20,7 +20,7 @@ To apply a policy with OPA:
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
 - Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
 {:.note}
-> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
+> **Note:** You cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
 

--- a/app/mesh/1.6.x/features/opa.md
+++ b/app/mesh/1.6.x/features/opa.md
@@ -18,10 +18,11 @@ When `OPAPolicy` is applied, the control plane configures:
 To apply a policy with OPA: 
 
 - Specify the group of data plane proxies to apply the policy to with the `selectors` property.
-- Provide a policy<a href="#footnote-1"><sup id="note-return-1">1</sup></a> with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+- Provide a policy with the `conf` property. Policies are defined in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/).
+{:.note}
+> **Note:** As of version 2.1.x, you cannot currently apply multiple OPA policies. This limitation will be addressed in the future.
 - Optionally provide custom configuration for the policy agent.
 
-<span id="footnote-1"><a href="#note-return-1">1</a></span>: You cannot currently apply multiple OPA policies. This limitation will be lifted in the future.
 
 You must also specify the HTTP protocol in your mesh configuration:
 


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Description

> What did you change and why?

We found a bug in OPA that only allows one policy to be defined, multiple policies never worked so we need to backport this.
 
> Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

https://github.com/Kong/kong-mesh/pull/2516

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

