### PR TITLE
Add redirects for mesh

### DIFF
--- a/app/_mesh_redirects
+++ b/app/_mesh_redirects
@@ -1,6 +1,6 @@
 # TODO: Automate this file's generation
 # Generated redirects
-/mesh/:version/overview/ /mesh/:version/overview/what-is-a-service-mesh 301
+/mesh/:version/overview/ /mesh/:version/introduction/what-is-a-service-mesh 301
 /mesh/:version/installation/ /mesh/:version/installation/kubernetes 301
 /mesh/:version/api/ /mesh/:version/reference/http-api 301
 /mesh/:version/documentation/deployments/ /mesh/:version/introduction/deployments 301

--- a/app/_mesh_redirects
+++ b/app/_mesh_redirects
@@ -1,7 +1,7 @@
 # TODO: Automate this file's generation
 # Generated redirects
 /mesh/:version/overview/ /mesh/:version/introduction/what-is-a-service-mesh 301
-/mesh/:version/installation/ /mesh/:version/installation/kubernetes 301
+/mesh/:version/installation/ /mesh/:version/install/ 301
 /mesh/:version/api/ /mesh/:version/reference/http-api 301
 /mesh/:version/documentation/deployments/ /mesh/:version/introduction/deployments 301
 

--- a/app/_mesh_redirects
+++ b/app/_mesh_redirects
@@ -1,0 +1,21 @@
+# TODO: Automate this file's generation
+# Generated redirects
+/mesh/:version/overview/ /mesh/:version/overview/what-is-a-service-mesh 301
+/mesh/:version/installation/ /mesh/:version/installation/kubernetes 301
+/mesh/:version/api/ /mesh/:version/reference/http-api 301
+/mesh/:version/documentation/deployments/ /mesh/:version/introduction/deployments 301
+
+# Policy redirects
+/mesh/:version/policies/circuit-breakers/ /mesh/:version/policies/circuit-breaker/ 301
+/mesh/:version/policies/fault-injections/ /mesh/:version/policies/fault-injection/ 301
+/mesh/:version/policies/health-checks/ /mesh/:version/policies/health-check/ 301
+/mesh/:version/policies/meshgateways/ /mesh/:version/policies/mesh-gateway/ 301
+/mesh/:version/policies/meshgatewayroutes/ /mesh/:version/policies/mesh-gateway-route/ 301
+/mesh/:version/policies/proxytemplates/ /mesh/:version/policies/proxy-template/ 301
+/mesh/:version/policies/rate-limits/ /mesh/:version/policies/rate-limit/ 301
+/mesh/:version/policies/retries/ /mesh/:version/policies/retry/ 301
+/mesh/:version/policies/timeouts/ /mesh/:version/policies/timeout/ 301
+/mesh/:version/policies/traffic-logs/ /mesh/:version/policies/traffic-log/ 301
+/mesh/:version/policies/traffic-routes/ /mesh/:version/policies/traffic-route/ 301
+/mesh/:version/policies/traffic-traces/ /mesh/:version/policies/traffic-trace/ 301
+/mesh/:version/policies/virtual-outbounds/ /mesh/:version/policies/virtual-outbound/ 301

--- a/app/_plugins/generators/alias_generator.rb
+++ b/app/_plugins/generators/alias_generator.rb
@@ -43,6 +43,9 @@ module Jekyll
       # Generate redirect_to from frontmatter redirects
       redirects.concat(frontmatter_aliases)
 
+      # Read existing _mesh_redirects file
+      redirects.concat(mesh_redirects)
+
       # Write out a _redirects file
       site.pages << build_page(redirects)
     end
@@ -87,6 +90,13 @@ module Jekyll
     def existing_redirects
       @existing_redirects ||= File.readlines(
         File.join(@site.source, '_redirects'),
+        chomp: true
+      )
+    end
+
+    def mesh_redirects
+      @mesh_redirects ||= File.readlines(
+        File.join(@site.source, '_mesh_redirects'),
         chomp: true
       )
     end

--- a/spec/app/_plugins/generators/alias_generator_spec.rb
+++ b/spec/app/_plugins/generators/alias_generator_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Jekyll::AliasGenerator do
         expect(redirects).to include("/first-alias/index.html\t/contributing/")
         expect(redirects).to include("/second-alias/index.html\t/contributing/")
       end
+
+      it 'includes mesh_redirects' do
+        expect(redirects).to include('/mesh/:version/policies/circuit-breakers/ /mesh/:version/policies/circuit-breaker/ 301')
+      end
     end
   end
 end

--- a/spec/fixtures/app/_mesh_redirects
+++ b/spec/fixtures/app/_mesh_redirects
@@ -1,0 +1,2 @@
+# Policy redirects
+/mesh/:version/policies/circuit-breakers/ /mesh/:version/policies/circuit-breaker/ 301


### PR DESCRIPTION
### Description

Add some of the redirects we have in Kuma to Kong-Mesh, the new release of Kuma's GUI points to the old urls that's why  we need them. Also, we should definitely automate the generation of this file so that we can update it every time we update kuma, this is a quick and dirty solution we can ship and test before the release.

cc @lahabana 

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

