### PR TITLE
[DOCU-857] Using workspaces in an Admin API request

### DIFF
--- a/app/_includes/md/gateway/admin-api-workspaces.md
+++ b/app/_includes/md/gateway/admin-api-workspaces.md
@@ -1,0 +1,21 @@
+
+Any requests that don't specify a workspace target the `default` workspace.
+
+To target a different workspace, prefix any endpoint with the workspace name or ID:
+
+```sh
+http://<HOSTNAME>:8001/<WORKSPACE_NAME|ID>/<ENDPOINT>
+```
+
+For example, if you don't specify a workspace,
+this request retrieves a list of services from the `default` workspace:
+
+```sh
+curl -i -X GET http://localhost:8001/services
+```
+
+While this request retrieves all services from the workspace `SRE`:
+
+```sh
+curl -i -X GET http://localhost:8001/SRE/services
+```

--- a/app/_src/gateway/admin-api/admin-api-3.0.x.md
+++ b/app/_src/gateway/admin-api/admin-api-3.0.x.md
@@ -828,6 +828,13 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
 
 ---
 
+## Using the API in workspaces 
+{:.badge .enterprise}
+
+{% include_cached /md/gateway/admin-api-workspaces.md %}
+
+---
+
 ## Information Routes
 
 

--- a/app/_src/gateway/admin-api/admin-api-3.0.x.md
+++ b/app/_src/gateway/admin-api/admin-api-3.0.x.md
@@ -640,6 +640,8 @@ vault_data: |
 
 ---
 
+<!-- vale off -->
+
 {{site.base_gateway}} comes with an **internal** RESTful Admin API for administration purposes.
  Requests to the Admin API can be sent to any node in the cluster, and Kong will
  keep the configuration consistent across all nodes.

--- a/app/_src/gateway/admin-api/developers/reference.md
+++ b/app/_src/gateway/admin-api/developers/reference.md
@@ -15,43 +15,6 @@ for bulk developer administration.
 This is not the same as the Dev Portal API [`/developer`](https://developer.konghq.com/spec/3e65edbc-364d-4762-9d3e-f13083e1b534/33cd4595-e389-4c2b-80ee-5275f25e80e1#/developer/get-developer) endpoints,
 which return data on the logged-in developer.
 
-## Using the API in workspaces
-
-Any requests that don't specify a workspace target the `default` workspace.
-To target a different workspace, add `/{WORKSPACE_NAME}/` to the start of any
-endpoint.
-
-For example, if you don't specify a workspace,
-this request retrieves a list of developers from the `default` workspace:
-
-{% navtabs codeblock %}
-{% navtab cURL %}
-```sh
-curl -i -X GET http://localhost:8001/developers
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/developers
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-While this request retrieves all developers from the workspace `SRE`:
-
-{% navtabs codeblock %}
-{% navtab cURL %}
-```sh
-curl -i -X GET http://localhost:8001/SRE/developers
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/SRE/developers
-```
-{% endnavtab %}
-{% endnavtabs %}
-
 ## Developers
 
 ### List all developers

--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -798,7 +798,6 @@ curl -i -X POST http://https://us.api.konghq.com/v2/runtime-groups/{runtime_grou
 * [Runtime Groups API](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/)
 * [Plugin Hub](/hub/)
 
---- 
 ## Nodes
 ### List Runtime Instance Records
 
@@ -1140,6 +1139,13 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
      -F "paths[1]=/path/one" \
      -F "paths[2]=/path/two"
 ```
+
+---
+
+## Using the API in workspaces 
+{:.badge .enterprise}
+
+{% include_cached /md/gateway/admin-api-workspaces.md %}
 
 ---
 

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -362,7 +362,7 @@ Attributes | Description
 
 Can be used with any request method.
 
-Target entities within a specified workspace by adding the workpace name or ID prefix before any entity endpoint.
+Target entities within a specified workspace by adding the workspace name or ID prefix before any entity endpoint.
 
 ```sh
 http://<ADMIN_API_HOSTNAME>:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -5,25 +5,25 @@ badge: enterprise
 workspace_body: |
     Attribute | Description
     ---:| ---
-    `name` | The **Workspace** name.
+    `name` | The workspace name.
 ---
 
 
-{{site.base_gateway}}'s Workspaces feature is configurable through Kong's
+{{site.base_gateway}}'s workspaces feature is configurable through Kong's
 Admin API.
 
-## Workspace Object
-
-The **Workspace** object describes the **Workspace** entity, which has an ID
+The workspace object describes the workspace entity, which has an ID
 and a name.
 
-### Add Workspace
+For workspace use cases and configuration examples, see [Workspace Examples](/gateway/{{page.kong_version}}/kong-enterprise/workspaces/).
+
+## Add workspace
 
 **Endpoint**
 
 <div class="endpoint post">/workspaces/</div>
 
-#### Request Body
+**Request body**
 
 {{ page.workspace_body }}
 
@@ -63,7 +63,7 @@ HTTP 201 Created
 }
 ```
 
-### List Workspaces
+## List workspaces
 
 **Endpoint**
 
@@ -137,7 +137,7 @@ HTTP 200 OK
 }
 ```
 
-### Update or Create a Workspace
+## Update or create a workspace
 
 **Endpoint**
 
@@ -145,20 +145,20 @@ HTTP 200 OK
 
 Attributes | Description
 ---:| ---
-`id`<br>**conditional** | The **Workspaces'** unique ID, if replacing it.*
+`id`<br>**conditional** | The **workspaces'** unique ID, if replacing it.*
 
 * The behavior of `PUT` endpoints is the following: if the request payload **does
-not** contain an entity's primary key (`id` for Workspaces), the entity will be
+not** contain an entity's primary key (`id` for workspaces), the entity will be
 created with the given payload. If the request payload **does** contain an
 entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Request Body
+**Request body**
 
 Attribute | Description
 ---:| ---
-`name` | The **Workspace** name.
+`name` | The workspace name.
 
 **Response**
 
@@ -204,7 +204,7 @@ HTTP 200 OK
 }
 ```
 
-### Retrieve a Workspace
+## Retrieve a workspace
 
 **Endpoint**
 
@@ -212,7 +212,7 @@ HTTP 200 OK
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to retrieve
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to retrieve
 
 **Response**
 
@@ -233,17 +233,17 @@ HTTP 200 OK
 }
 ```
 
-### Retrieve Workspace Metadata
+## Retrieve workspace metadata
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/workspaces/{name or id}/meta</div>
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to retrieve
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -276,7 +276,7 @@ HTTP 200 OK
 }
 ```
 
-### Delete a Workspace
+## Delete a workspace
 
 **Endpoint**
 
@@ -284,10 +284,11 @@ HTTP 200 OK
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to delete
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
 
-**Note:** All entities within a **Workspace** must be deleted before the
-**Workspace** itself can be.
+{:.note}
+> **Note:** All entities within a workspace must be deleted before the
+workspace itself can be.
 
 **Response**
 
@@ -295,7 +296,7 @@ Attributes | Description
 HTTP 204 No Content
 ```
 
-### Update a Workspace
+## Update a workspace
 
 **Endpoint**
 
@@ -303,15 +304,15 @@ HTTP 204 No Content
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to patch
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to patch
 
-#### Request Body
+**Request body**
 
 Attributes | Description
 ---:| ---
-`comment` | A string describing the **Workspace**
+`comment` | A string describing the workspace
 
-The behavior of `PATCH` endpoints prevents the renaming of a **Workspace**.
+The behavior of `PATCH` endpoints prevents the renaming of a workspace.
 
 **Response**
 
@@ -348,6 +349,31 @@ HTTP 200 OK
   "name": "green-team"
 }
 ```
+
+## Access an endpoint within a workspace
+
+**Endpoint**
+
+<div class="endpoint">/{name or id}/{endpoint}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to target.
+
+Can be used with any request method.
+
+Target entities within a specified workspace by adding the workpace name or ID prefix before any entity endpoint.
+
+```sh
+http://<ADMIN_API_HOSTNAME>:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>
+```
+
+For example, to target `services` in the workspace `SRE`:
+
+```sh
+http://localhost:8001/SRE/services
+```
+
 ---
 
 [Admin API]: /gateway/{{page.kong_version}}/admin-api/

--- a/app/_src/gateway/kong-enterprise/workspaces/index.md
+++ b/app/_src/gateway/kong-enterprise/workspaces/index.md
@@ -46,8 +46,6 @@ a specific workspace.
 That said, it's worth noting that the default workspace is a workspace as any
 other, the only difference being that it's created by Kong, at migration time.
 
-(Examples will be shown using the HTTPie HTTP command line client.)
-
 ## Using the API in workspaces
 
 {% include_cached /md/gateway/admin-api-workspaces.md %}
@@ -181,6 +179,9 @@ With this, Teams A, B, and C will have the freedom to operate their `guest`
 consumer independently, choosing authentication plugins or doing any other
 operation that is allowed in the non-workspaced Kong world.
 
+## See also
+
+* [Workspaces API reference](/gateway/{{page.kong_version}}/admin-api/workspaces/reference)
 
 ---
 

--- a/app/_src/gateway/kong-enterprise/workspaces/index.md
+++ b/app/_src/gateway/kong-enterprise/workspaces/index.md
@@ -3,7 +3,7 @@ title: Workspace Examples
 badge: enterprise
 ---
 
-Workspaces provide a way to segment Kong entities—entities in a workspace
+Workspaces provide a way to segment Kong entities. Entities in a workspace
 are isolated from those in other workspaces. That said, entities
 such as Services and Routes have "routing rules", which are pieces of info
 attached to Services or Routes—such as HTTP method, URI, or host—that allow a
@@ -30,10 +30,10 @@ router:
     * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 
-## The Default workspace
+## The default workspace
 
-Kong creates a default workspace—unsurprisingly named `default`—whose goal
-is to group all existing entities in Kong, where "existing entities" refers to:
+Kong starts with a default workspace named `default`. This workspace
+groups all existing entities in Kong:
 
 - Entities that were created in operation in previous versions &amp; in case
 one is migrating from an older Kong version;
@@ -47,6 +47,10 @@ That said, it's worth noting that the default workspace is a workspace as any
 other, the only difference being that it's created by Kong, at migration time.
 
 (Examples will be shown using the HTTPie HTTP command line client.)
+
+## Using the API in workspaces
+
+{% include_cached /md/gateway/admin-api-workspaces.md %}
 
 ## Listing workspaces and its entities
 

--- a/app/gateway/2.8.x/admin-api/index.md
+++ b/app/gateway/2.8.x/admin-api/index.md
@@ -631,6 +631,8 @@ vaults_beta_data: |
 
 ---
 
+<!-- vale off -->
+
 {{site.base_gateway}} comes with an **internal** RESTful Admin API for administration purposes.
  Requests to the Admin API can be sent to any node in the cluster, and Kong will
  keep the configuration consistent across all nodes.

--- a/app/gateway/2.8.x/admin-api/index.md
+++ b/app/gateway/2.8.x/admin-api/index.md
@@ -819,6 +819,13 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
 
 ---
 
+## Using the API in workspaces 
+{:.badge .enterprise}
+
+{% include_cached /md/gateway/admin-api-workspaces.md %}
+
+---
+
 ## Information Routes
 
 

--- a/app/gateway/2.8.x/admin-api/workspaces/examples.md
+++ b/app/gateway/2.8.x/admin-api/workspaces/examples.md
@@ -3,11 +3,6 @@ title: Workspace Examples
 badge: enterprise
 ---
 
-This chapter aims to provide a step-by-step tutorial on how to set up
-workspaces, entities, and see it in action.
-
-## Important Note: Conflicting Services or Routes in workspaces
-
 Workspaces provide a way to segment Kong entities—entities in a workspace
 are isolated from those in other workspaces. That said, entities
 such as Services and Routes have "routing rules", which are pieces of info
@@ -35,10 +30,10 @@ router:
     * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 
-## The Default workspace
+## The default workspace
 
-Kong creates a default workspace—unsurprisingly named `default`—whose goal
-is to group all existing entities in Kong, where "existing entities" refers to:
+Kong starts with a default workspace named `default`. This workspace
+groups all existing entities in Kong:
 
 - Entities that were created in operation in previous versions &amp; in case
 one is migrating from an older Kong version;
@@ -51,7 +46,9 @@ a specific workspace.
 That said, it's worth noting that the default workspace is a workspace as any
 other, the only difference being that it's created by Kong, at migration time.
 
-(Examples will be shown using the httpie HTTP command line client.)
+## Using the API in workspaces 
+
+{% include_cached /md/gateway/admin-api-workspaces.md %}
 
 ## Listing workspaces and its entities
 
@@ -182,6 +179,9 @@ With this, Teams A, B, and C will have the freedom to operate their `guest`
 consumer independently, choosing authentication plugins or doing any other
 operation that is allowed in the non-workspaced Kong world.
 
+## See also
+
+* [Workspaces API reference](/gateway/{{page.kong_version}}/admin-api/workspaces/reference)
 
 ---
 

--- a/app/gateway/2.8.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.8.x/admin-api/workspaces/reference.md
@@ -362,7 +362,7 @@ Attributes | Description
 
 Can be used with any request method.
 
-Target entities within a specified workspace by adding the workpace name or ID prefix before any entity endpoint.
+Target entities within a specified workspace by adding the workspace name or ID prefix before any entity endpoint.
 
 ```sh
 http://<ADMIN_API_HOSTNAME>:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>

--- a/app/gateway/2.8.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.8.x/admin-api/workspaces/reference.md
@@ -5,25 +5,25 @@ badge: enterprise
 workspace_body: |
     Attribute | Description
     ---:| ---
-    `name` | The **Workspace** name.
+    `name` | The workspace name.
 ---
 
 
-{{site.base_gateway}}'s Workspaces feature is configurable through Kong's
+{{site.base_gateway}}'s workspaces feature is configurable through Kong's
 Admin API.
 
-## Workspace Object
-
-The **Workspace** object describes the **Workspace** entity, which has an ID
+The workspace object describes the workspace entity, which has an ID
 and a name.
 
-### Add Workspace
+For workspace use cases and configuration examples, see [Workspace Examples](/gateway/{{page.kong_version}}/admin-api/workspaces/examples).
+
+## Add workspace
 
 **Endpoint**
 
 <div class="endpoint post">/workspaces/</div>
 
-#### Request Body
+**Request body**
 
 {{ page.workspace_body }}
 
@@ -63,7 +63,7 @@ HTTP 201 Created
 }
 ```
 
-### List Workspaces
+## List workspaces
 
 **Endpoint**
 
@@ -137,7 +137,7 @@ HTTP 200 OK
 }
 ```
 
-### Update or Create a Workspace
+## Update or create a workspace
 
 **Endpoint**
 
@@ -145,20 +145,20 @@ HTTP 200 OK
 
 Attributes | Description
 ---:| ---
-`id`<br>**conditional** | The **Workspace's** unique ID, if replacing it.*
+`id`<br>**conditional** | The **workspaces'** unique ID, if replacing it.*
 
 * The behavior of `PUT` endpoints is the following: if the request payload **does
-not** contain an entity's primary key (`id` for Workspaces), the entity will be
+not** contain an entity's primary key (`id` for workspaces), the entity will be
 created with the given payload. If the request payload **does** contain an
 entity's primary key, the payload will "replace" the entity specified by the
 given primary key. If the primary key is **not** that of an existing entity, `404
 NOT FOUND` will be returned.
 
-#### Request Body
+**Request body**
 
 Attribute | Description
 ---:| ---
-`name` | The **Workspace** name.
+`name` | The workspace name.
 
 **Response**
 
@@ -204,7 +204,7 @@ HTTP 200 OK
 }
 ```
 
-### Retrieve a Workspace
+## Retrieve a workspace
 
 **Endpoint**
 
@@ -212,7 +212,7 @@ HTTP 200 OK
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to retrieve
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to retrieve
 
 **Response**
 
@@ -233,17 +233,17 @@ HTTP 200 OK
 }
 ```
 
-### Retrieve Workspace Metadata
+## Retrieve workspace metadata
 
-#### Endpoint
+**Endpoint**
 
 <div class="endpoint get">/workspaces/{name or id}/meta</div>
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to retrieve
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to retrieve
 
-#### Response
+**Response**
 
 ```
 HTTP 200 OK
@@ -276,7 +276,7 @@ HTTP 200 OK
 }
 ```
 
-### Delete a Workspace
+## Delete a workspace
 
 **Endpoint**
 
@@ -284,10 +284,11 @@ HTTP 200 OK
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to delete
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
 
-**Note:** All entities within a **Workspace** must be deleted before the
-**Workspace** itself can be.
+{:.note}
+> **Note:** All entities within a workspace must be deleted before the
+workspace itself can be.
 
 **Response**
 
@@ -295,7 +296,7 @@ Attributes | Description
 HTTP 204 No Content
 ```
 
-### Update a Workspace
+## Update a workspace
 
 **Endpoint**
 
@@ -303,15 +304,15 @@ HTTP 204 No Content
 
 Attributes | Description
 ---:| ---
-`name or id`<br>**required** | The unique identifier **or** the name of the **Workspace** to patch
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to patch
 
-#### Request Body
+**Request body**
 
 Attributes | Description
 ---:| ---
-`comment` | A string describing the **Workspace**
+`comment` | A string describing the workspace
 
-The behavior of `PATCH` endpoints prevents the renaming of a **Workspace**.
+The behavior of `PATCH` endpoints prevents the renaming of a workspace.
 
 **Response**
 
@@ -348,6 +349,31 @@ HTTP 200 OK
   "name": "green-team"
 }
 ```
+
+## Access an endpoint within a workspace
+
+**Endpoint**
+
+<div class="endpoint">/{name or id}/{endpoint}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to target.
+
+Can be used with any request method.
+
+Target entities within a specified workspace by adding the workpace name or ID prefix before any entity endpoint.
+
+```sh
+http://<ADMIN_API_HOSTNAME>:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>
+```
+
+For example, to target `services` in the workspace `SRE`:
+
+```sh
+http://localhost:8001/SRE/services
+```
+
 ---
 
 [Admin API]: /gateway/{{page.kong_version}}/admin-api/


### PR DESCRIPTION
### Description

Adding doc on using the workspace name or ID prefix in requests to the Kong Admin API.
Previously, the info was buried on the Developer API reference page.

Minor clean up, removed HTTPie examples, and reused the info in the Admin API overview and the workspace examples pages. 

Tested all the things locally. Backported through 2.8.x.
 
Tickets:
https://konghq.atlassian.net/browse/DOCU-857
https://konghq.atlassian.net/browse/DOCU-2942
https://konghq.atlassian.net/browse/DOCU-2262
https://konghq.atlassian.net/browse/DOCU-2912

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

