### PR TITLE
Fix autogenerated label action

### DIFF
--- a/.github/workflows/autogenerated-warning.yml
+++ b/.github/workflows/autogenerated-warning.yml
@@ -35,7 +35,7 @@ jobs:
 
   prevent-merge-if-labeled:
     needs: [check]
-    if: needs.check.outputs.result == 'false'
+    if: check.outputs.result == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v3
@@ -44,4 +44,4 @@ jobs:
         with:
           mode: exactly
           count: 0
-          labels: "ci:prevent-merge:generated-files, ci:manual-approve:generated-files"
+          labels: "ci:prevent-merge:generated-files"

--- a/.github/workflows/autogenerated-warning.yml
+++ b/.github/workflows/autogenerated-warning.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           mode: exactly
           count: 0
-          labels: "ci:prevent-merge:generated-files"
+          labels: "ci:prevent-merge:generated-files, ci:manual-approve:generated-files"

--- a/app/_src/gateway/admin-api/admin-api-3.0.x.md
+++ b/app/_src/gateway/admin-api/admin-api-3.0.x.md
@@ -640,8 +640,7 @@ vault_data: |
 
 ---
 
-test
-
+testing one more time
 {{site.base_gateway}} comes with an **internal** RESTful Admin API for administration purposes.
  Requests to the Admin API can be sent to any node in the cluster, and Kong will
  keep the configuration consistent across all nodes.

--- a/app/_src/gateway/admin-api/admin-api-3.0.x.md
+++ b/app/_src/gateway/admin-api/admin-api-3.0.x.md
@@ -640,6 +640,8 @@ vault_data: |
 
 ---
 
+test
+
 {{site.base_gateway}} comes with an **internal** RESTful Admin API for administration purposes.
  Requests to the Admin API can be sent to any node in the cluster, and Kong will
  keep the configuration consistent across all nodes.


### PR DESCRIPTION
### Description

Adding the `ci:manual-approve:generated-files` label to list of labels that should prevent the action from failing the check. 
 
Trying to prevent this from happening, where the action ignores the label and keeps adding the autogen warning to the PR:
![Screenshot 2023-01-26 at 11 01 14 AM](https://user-images.githubusercontent.com/54370747/214925895-3af84f97-e147-4c6a-a866-207d234ec4bc.png)

### Testing instructions

Will test in this PR.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

