### PR TITLE
Update Gatway upgrade doc to include upgrade path for 3.1.1.2

### DIFF
--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -48,12 +48,12 @@ The following table outlines various upgrade path scenarios to 3.1.x depending o
 | 2.x–2.7.2.0 | Traditional | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/) (required for blue/green deployments only), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 2.x–2.7.2.0 | Hybrid | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 2.x–2.7.2.0 | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
-| 2.8.x.x | Traditional | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3112). |
-| 2.8.x.x | Hybrid | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3112). |
-| 2.8.x.x | DB less | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3112). |
-| 3.0.x | Traditional | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
-| 3.0.x | Hybrid | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
-| 3.0.x | DB less | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
+| 2.8.x.x | Traditional | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3113). |
+| 2.8.x.x | Hybrid | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3113). |
+| 2.8.x.x | DB less | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3113). |
+| 3.0.x | Traditional | Yes | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3113). |
+| 3.0.x | Hybrid | Yes | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3113). |
+| 3.0.x | DB less | Yes | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3113). |
 
 ## Upgrade considerations and breaking changes
 

--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -48,6 +48,9 @@ The following table outlines various upgrade path scenarios to 3.1.x depending o
 | 2.x | Traditional | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/) (required for blue/green deployments only), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 2.x | Hybrid | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 2.x | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
+| 2.8.x.x | Traditional | Only if you upgrade to 3.1.1.2 | [Upgrade to 3.1.1.2](#upgrade-from-28xx-to-3112). |
+| 2.8.x.x | Hybrid | Only if you upgrade to 3.1.1.2 | [Upgrade to 3.1.1.2](#upgrade-from-28xx-to-3112). |
+| 2.8.x.x | DB less | Only if you upgrade to 3.1.1.2 | [Upgrade to 3.1.1.2](#upgrade-from-28xx-to-3112). |
 | 3.0.x | Traditional | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 3.0.x | Hybrid | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 3.0.x | DB less | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
@@ -207,3 +210,38 @@ Perform a rolling upgrade of your cluster:
    is going smoothly.
 8. When your traffic is fully migrated to the 3.1.x cluster,
    decommission your old 3.0.x data planes.
+
+## Upgrade from 2.8.x.x to 3.1.1.2 
+
+### Traditional mode
+
+
+1. Clone your database.
+2. Download 3.1.1.2, and configure it to point to the cloned data store.
+   Run `kong migrations up` and `kong migrations finish`.
+3. Start the 3.1.1.2 cluster.
+4. Now both the old (2.8.x.x) and new (3.1.1.2)
+   clusters can now run simultaneously. Start provisioning 3.1.1.2 nodes.
+3. Gradually divert traffic away from your old nodes, and into
+   your 3.1.1.2 cluster. Monitor your traffic to make sure everything
+   is going smoothly.
+4. When your traffic is fully migrated to the 3.1.1.2 cluster,
+   decommission your old nodes.
+
+### Hybrid mode
+
+Perform a rolling upgrade of your cluster:
+
+1. Download 3.1.1.2.
+2. Decommission your existing 2.8.x.x control plane. Your existing 2.8.x.x data
+   planes can continue to handle proxy traffic during this time, even with no 
+   active control plane.
+4. Configure the new 3.1.1.2 control plane to point to the same data store as
+   your old control plane. Run `kong migrations up` and `kong migrations finish`.
+5. Start the new 3.1.1.2 control plane.
+6. Start new 3.1.1.2 data planes.
+7. Gradually divert traffic away from your 2.8.x.x data planes, and into
+   the new 3.1.1.2 data planes. Monitor your traffic to make sure everything
+   is going smoothly.
+8. When your traffic is fully migrated to the 3.1.1.2 cluster,
+   decommission your old 2.8.x.x data planes.

--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -45,12 +45,12 @@ The following table outlines various upgrade path scenarios to 3.1.x depending o
 
 | **Current version** | **Topology** | **Direct upgrade possible?** | **Upgrade path** |
 | ------------------- | ------------ | ---------------------------- | ---------------- |
-| 2.x | Traditional | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/) (required for blue/green deployments only), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
-| 2.x | Hybrid | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
-| 2.x | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
-| 2.8.x.x | Traditional | Only if you upgrade to 3.1.1.2 | [Upgrade to 3.1.1.2](#upgrade-from-28xx-to-3112). |
-| 2.8.x.x | Hybrid | Only if you upgrade to 3.1.1.2 | [Upgrade to 3.1.1.2](#upgrade-from-28xx-to-3112). |
-| 2.8.x.x | DB less | Only if you upgrade to 3.1.1.2 | [Upgrade to 3.1.1.2](#upgrade-from-28xx-to-3112). |
+| 2.x–2.7.2.0 | Traditional | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/) (required for blue/green deployments only), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
+| 2.x–2.7.2.0 | Hybrid | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
+| 2.x–2.7.2.0 | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
+| 2.8.x.x | Traditional | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3112). |
+| 2.8.x.x | Hybrid | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3112). |
+| 2.8.x.x | DB less | Only if you upgrade to 3.1.1.3 | [Upgrade to 3.1.1.3](#upgrade-from-28xx-to-3112). |
 | 3.0.x | Traditional | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 3.0.x | Hybrid | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
 | 3.0.x | DB less | Yes | [Upgrade to 3.1.x](#upgrade-from-30x-to-31x). |
@@ -211,37 +211,37 @@ Perform a rolling upgrade of your cluster:
 8. When your traffic is fully migrated to the 3.1.x cluster,
    decommission your old 3.0.x data planes.
 
-## Upgrade from 2.8.x.x to 3.1.1.2 
+## Upgrade from 2.8.x.x to 3.1.1.3
 
 ### Traditional mode
 
 
 1. Clone your database.
-2. Download 3.1.1.2, and configure it to point to the cloned data store.
+2. Download 3.1.1.3, and configure it to point to the cloned data store.
    Run `kong migrations up` and `kong migrations finish`.
-3. Start the 3.1.1.2 cluster.
-4. Now both the old (2.8.x.x) and new (3.1.1.2)
-   clusters can now run simultaneously. Start provisioning 3.1.1.2 nodes.
+3. Start the 3.1.1.3 cluster.
+4. Now both the old (2.8.x.x) and new (3.1.1.3)
+   clusters can now run simultaneously. Start provisioning 3.1.1.3 nodes.
 3. Gradually divert traffic away from your old nodes, and into
-   your 3.1.1.2 cluster. Monitor your traffic to make sure everything
+   your 3.1.1.3 cluster. Monitor your traffic to make sure everything
    is going smoothly.
-4. When your traffic is fully migrated to the 3.1.1.2 cluster,
+4. When your traffic is fully migrated to the 3.1.1.3 cluster,
    decommission your old nodes.
 
 ### Hybrid mode
 
 Perform a rolling upgrade of your cluster:
 
-1. Download 3.1.1.2.
+1. Download 3.1.1.3.
 2. Decommission your existing 2.8.x.x control plane. Your existing 2.8.x.x data
    planes can continue to handle proxy traffic during this time, even with no 
    active control plane.
-4. Configure the new 3.1.1.2 control plane to point to the same data store as
+4. Configure the new 3.1.1.3 control plane to point to the same data store as
    your old control plane. Run `kong migrations up` and `kong migrations finish`.
-5. Start the new 3.1.1.2 control plane.
-6. Start new 3.1.1.2 data planes.
+5. Start the new 3.1.1.3 control plane.
+6. Start new 3.1.1.3 data planes.
 7. Gradually divert traffic away from your 2.8.x.x data planes, and into
-   the new 3.1.1.2 data planes. Monitor your traffic to make sure everything
+   the new 3.1.1.3 data planes. Monitor your traffic to make sure everything
    is going smoothly.
-8. When your traffic is fully migrated to the 3.1.1.2 cluster,
+8. When your traffic is fully migrated to the 3.1.1.3 cluster,
    decommission your old 2.8.x.x data planes.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -62,6 +62,10 @@ Kong Gateway now triggers an event that allows the Vitals subsystem to be reinit
   - For `/vitals/reports/hostname`, use `/{workspace_name}/vitals/nodes` instead
 
   See the [Vitals documentation](/gateway/latest/kong-enterprise/analytics/#vitals-api) for more detail.
+
+### Upgrades
+
+You can now directly upgrade to {{site.base_gateway}} 3.1.1.2 from 2.8.x.x.
  
 
 ## 3.1.0.0


### PR DESCRIPTION
Signed-off-by: Diana <75819066+cloudjumpercat@users.noreply.github.com>


### Description

**What did you change and why?**
Our current upgrade doc didn't explain that you could directly upgrade from 2.8.x.x to 3.1.1.2, it implied that you could only perform a rolling upgrade. I fixed that doc and also added a note to the release notes about it.

 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
https://kongstrong.slack.com/archives/CDSTDSG9J/p1674772695101839

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

Question for reviewers:

- Does the way I phrased the 2.8.x.x rows in the upgrade table make sense? I'm not 100% sold on how that info is presented.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

