### PR TITLE
docs(meshopa): fix missing container and namespace

### DIFF
--- a/app/_src/mesh/features/meshopa.md
+++ b/app/_src/mesh/features/meshopa.md
@@ -102,6 +102,7 @@ kind: MeshOPA
 mesh: default
 metadata:
   name: mopa-1
+  namespace: kong-mesh-system
 spec:
   targetRef:
     kind: Mesh
@@ -220,6 +221,7 @@ Encoding the policy in a [Secret][secrets] provides some security for policies t
     mesh: default
     metadata:
       name: opa-1
+      namespace: kong-mesh-system
     spec:
       targetRef:
         kind: Mesh
@@ -248,6 +250,7 @@ Encoding the policy in a [Secret][secrets] provides some security for policies t
     mesh: default
     metadata:
       name: opa-1
+      namespace: kong-mesh-system
     spec:
       targetRef:
         kind: Mesh
@@ -371,6 +374,7 @@ kind: MeshOPA
 mesh: default
 metadata:
   name: mopa-1
+  namespace: kong-mesh-system
 spec:
   targetRef:
     kind: Mesh
@@ -434,6 +438,7 @@ kind: MeshOPA
 mesh: default
 metadata:
   name: mopa-1
+  namespace: kong-mesh-system
 spec:
   targetRef:
     kind: Mesh
@@ -492,7 +497,7 @@ The following example shows how to deploy and test a sample MeshOPA policy on Ku
 1.  Make a request from the frontend to the backend:
 
     ```sh
-    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -- curl backend:3001 -v
+    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -c kuma-fe -- curl backend:3001 -v
     ```
 
     The output looks like:
@@ -538,6 +543,7 @@ The following example shows how to deploy and test a sample MeshOPA policy on Ku
     kind: MeshOPA
     mesh: default
     metadata:
+      namespace: kong-mesh-system
       name: mopa-1
     spec:
       targetRef:
@@ -578,7 +584,7 @@ The following example shows how to deploy and test a sample MeshOPA policy on Ku
 1.  Make an invalid request from the frontend to the backend:
 
     ```sh
-    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -- curl backend:3001 -v
+    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -c kuma-fe -- curl backend:3001 -v
     ```
     The output looks like:
 
@@ -616,7 +622,7 @@ The following example shows how to deploy and test a sample MeshOPA policy on Ku
 
     Make the request:
     ```sh
-    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -- curl -H "Authorization: Bearer $ADMIN_TOKEN" backend:3001
+    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -c kuma-fe -- curl -H "Authorization: Bearer $ADMIN_TOKEN" backend:3001
     ```
 
     The output looks like:


### PR DESCRIPTION
### Description

Added missing container to curl command, and namespace


### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)



