### PR TITLE
docs(mesh): added container name to Opapolicy command

### DIFF
--- a/app/_src/mesh/features/opa.md
+++ b/app/_src/mesh/features/opa.md
@@ -474,7 +474,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 1.  Make a request from the frontend to the backend:
 
     ```sh
-    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -- curl backend:3001 -v
+    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -c kuma-fe -- curl backend:3001 -v
     ```
 
     The output looks like:
@@ -561,7 +561,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 1.  Make an invalid request from the frontend to the backend:
 
     ```sh
-    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -- curl backend:3001 -v
+    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -c kuma-fe -- curl backend:3001 -v
     ```
     The output looks like:
 
@@ -599,7 +599,7 @@ The following example shows how to deploy and test a sample OPA Policy on Kubern
 
     Make the request:
     ```sh
-    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -- curl -H "Authorization: Bearer $ADMIN_TOKEN" backend:3001
+    kubectl exec -i -t $(kubectl get pod -l "app=kuma-demo-frontend" -o jsonpath='{.items[0].metadata.name}' -n kuma-demo) -n kuma-demo -c kuma-fe -- curl -H "Authorization: Bearer $ADMIN_TOKEN" backend:3001
     ```
 
     The output looks like:


### PR DESCRIPTION
### Description

Updated docs based on changes to MeshOpa https://github.com/Kong/docs.konghq.com/pull/5091/files, namespace doesn't have to be backported because old policies don't require this.
### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

