### PR TITLE
Postgres outdated version

### DIFF
--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -64,7 +64,7 @@ communicate with each other:
      -e "POSTGRES_USER=kong" \
      -e "POSTGRES_DB=kong" \
      -e "POSTGRES_PASSWORD=kongpass" \
-     postgres:12.2
+     postgres:13
     ```
 
     * `POSTGRES_USER` and `POSTGRES_DB`: Set these values to `kong`. This is

--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -64,7 +64,7 @@ communicate with each other:
      -e "POSTGRES_USER=kong" \
      -e "POSTGRES_DB=kong" \
      -e "POSTGRES_PASSWORD=kongpass" \
-     postgres:9.6
+     postgres:12.2
     ```
 
     * `POSTGRES_USER` and `POSTGRES_DB`: Set these values to `kong`. This is


### PR DESCRIPTION
The version provided in the documentation does not seem to work as its outdated. Hence updated with the version which works currently on setting up the Kong using docker images.


### Description

What did you change and why? Updated the Postgres version from 9.6 to 12.2 which works
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

https://stackoverflow.com/questions/59142544/docker-kong-postgresql-error-failed-to-retrieve-postgresql-server-version-n

### Testing instructions

Netlify link: https://deploy-preview-5103--kongdocs.netlify.app/

Before Change : https://docs.konghq.com/gateway/latest/install/docker/#prepare-the-database
After Change: https://deploy-preview-5103--kongdocs.netlify.app/gateway/latest/install/docker/#prepare-the-database

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

