### PR TITLE
Revert "docs(aws-lambda): add new `https` config field in aws-lambda plugin"

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -198,7 +198,6 @@ params:
       description: |
         The TCP port that the plugin uses to connect to the server.
     - name: https
-      minimum_version: "3.2.x"
       required: false
       default: true
       datatype: boolean

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -197,11 +197,6 @@ params:
       datatype: integer
       description: |
         The TCP port that the plugin uses to connect to the server.
-    - name: https
-      required: false
-      default: true
-      datatype: boolean
-      description: Whether to use HTTPS to connect with the AWS Lambda Function service endpoint. This is useful for local test scenarios by using the [AWS SAM CLI tool](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
     - name: keepalive
       required: true
       default: '`60000`'


### PR DESCRIPTION
Reverts Kong/docs.konghq.com#4877

Hi team, can you help revert this change from the 3.2 changeset? We decide to postpone this change as it needs some more work to be done.