### PR TITLE
PR - Update Hybrid communication protocol to TCP

### DIFF
--- a/app/enterprise/2.5.x/deployment/default-ports.md
+++ b/app/enterprise/2.5.x/deployment/default-ports.md
@@ -16,5 +16,5 @@ By default, Kong Enterprise Gateway listens on the following ports:
 | [`:8446`](/enterprise/{{page.kong_version}}/property-reference/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**. |
 | [`:8004`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. |
 | [`:8447`](/enterprise/{{page.kong_version}}/property-reference/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. |
-| [`:8005`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. |
-| [`:8006`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. |
+| [`:8005`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | TCP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. |
+| [`:8006`](/enterprise/{{page.kong_version}}/deployment/hybrid-mode-setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. |


### PR DESCRIPTION
### Description

What did you change and why?

Update default protocol for Hybrid CP Communications to **TCP instead of HTTP.** 

The feedback from the field was that at first sight they will provisioned Layer 7 LoadBalancer for Hybrid communication since its indicated as HTTP for port 8005 and 8006, which will not work as the config sync between CP and DP required a Layer 4 LoadBalancer passthrough
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc
https://kongstrong.slack.com/archives/CDSTDSG9J/p1675324064493179


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)




