### PR TITLE
[DOCU-2957] Add missing 3.1.1.2 changelog entries

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -28,6 +28,19 @@ This prevented SSL connections from using common root certificate authorities.
   - The Dev Portal API now supports an optional `fields` query parameter on the `/files` endpoint.
   This parameter lets you specify which file object fields should be included in the response.
 
+#### Core 
+
+- When `router_flavor` is `traditional_compatible`, verify routes created using the
+  Expression router instead of the traditional router to ensure created routes
+  are actually compatible.
+  [#10088](https://github.com/Kong/kong/pull/10088)
+  
+-`kong migrations up` now reports routes that are incompatible with the 3.0 router
+  and stops the migration progress so that admins have a chance to adjust them.
+
+  [#10092](https://github.com/Kong/kong/pull/10092)
+  [#10101](https://github.com/Kong/kong/pull/10101)
+
 ### Fixes
 
 #### Enterprise
@@ -44,19 +57,32 @@ This prevented SSL connections from using common root certificate authorities.
   - Fixed an issue where admins with the permission `['create'] /services/*/plugins` couldn't create plugins under a service.
   - Fixed an issue where viewing a consumer group in any workspace other than `default` would cause a `404 Not Found` error. 
 
+#### Core
+
+* Fixed an issue where regexes generated in inso would not work in Kong Gateway. 
+* Bumped `atc-router` to `1.0.2` to address the potential worker crash issue.
+  [#9927](https://github.com/Kong/kong/pull/9927)
+
 #### Hybrid mode
 
 - Fixed an issue where Vitals data was not showing up after a license was deployed using the `/licenses` endpoint.
 Kong Gateway now triggers an event that allows the Vitals subsystem to be reinitialized during license preload.
 - Fixed an issue where the forward proxy between data planes and the control plane didn't support the telemetry port `8006`.
-- Backwards compatibility with 2.8.x.x data planes has been restored. 
+- Reverted the removal of WebSocket protocol support for configuration sync.
+  Backwards compatibility with 2.8.x.x data planes has been restored. 
+  [#10067](https://github.com/Kong/kong/pull/10067) 
 
-### Plugins
+#### Plugins
+
+- [**Datadog**](/hub/kong-inc/datadog/) (`datadog`),[**OpenTelemetry**](/hub/kong-inc/opentelemetry/) (`opentelemetry`), and [**StatsD**](/hub/kong-inc/statsd/) (`statsd`)
+  - Fixed an issue in these plugins' batch queue processing, where metrics would be published multiple times. 
+  This caused a memory leak, where memory usage would grow without limit.
 
 - [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced/) (`rate-limiting-advanced`)
-  - Fixed an issue where the cache expired while the window was still valid.
-   The plugin now requires the cache size to be, at minimum, twice the value of `window_size`.
-
+  - Fixed an issue with the `local` strategy, which was not working correctly when `window_size` was set to `fixed`.
+    The cache would expire while the window was still valid.
+    The plugin now requires the cache size to be, at minimum, twice the value of `window_size`.
+  
 - [**OAS Validation**](/hub/kong-inc/oas-validation) (`oas-validation`)
   - Added the OAS Validation plugin back into the bundled plugins list. The plugin is now available by default
   with no extra configuration necessary through `kong.conf`.


### PR DESCRIPTION
### Description

Changelog for 3.1.1.2 was missing all changes added to core/OSS gateway. 

There is a discrepancy between what the OSS engineering changelog shows, and what actually got pulled into the release on the Enterprise side.

https://konghq.atlassian.net/browse/DOCU-2957

PR can be merged at any time after review.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

