### PR TITLE
PR: Update default protocols for Hybrid communications in Kong 3.0 Production Page

### DIFF
--- a/app/_src/gateway/production/networking/default-ports.md
+++ b/app/_src/gateway/production/networking/default-ports.md
@@ -9,8 +9,8 @@ By default, {{site.base_gateway}} listens on the following ports:
 | [`:8443`](/gateway/{{page.kong_version}}/reference/configuration/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from **Consumers**, and forwards it to upstream **Services**. | All tiers and modes |
 | [`:8001`](/gateway/{{page.kong_version}}/reference/configuration/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
 | [`:8444`](/gateway/{{page.kong_version}}/reference/configuration/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
-| [`:8005`](/gateway/{{page.kong_version}}/production/deployment-topologies/hybrid-mode/setup/)         | HTTP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
-| [`:8006`](/gateway/{{page.kong_version}}/production/deployment-topologies/hybrid-mode/setup/)         | HTTP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | {{site.base_gateway}} Enterprise tier |
+| [`:8005`](/gateway/{{page.kong_version}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
+| [`:8006`](/gateway/{{page.kong_version}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | {{site.base_gateway}} Enterprise tier |
 | [`:8002`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |
 | [`:8445`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | {{site.base_gateway}} free mode |
 | [`:8003`](/gateway/{{page.kong_version}}/reference/configuration/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. | {{site.base_gateway}} Enterprise tier |


### PR DESCRIPTION
### Description

Update default protocol for Hybrid CP Communications to TCP instead of HTTP.

The feedback from the field was that at first sight they will provisioned Layer 7 LoadBalancer for Hybrid communication since its indicated as HTTP for port 8005 and 8006, which will not work as the config sync between CP and DP required a Layer 4 LoadBalancer passthrough

This is a continuation from PR #5112 ,which only updated contents pre Kong Gateway 3.0. This PR will update latest Kong 3.x documentations.

Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc
https://kongstrong.slack.com/archives/CDSTDSG9J/p1675324064493179

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)



