### PR TITLE
Changelog fix: Remove internal implementation info

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -35,7 +35,7 @@ This prevented SSL connections from using common root certificate authorities.
   are actually compatible.
   [#10088](https://github.com/Kong/kong/pull/10088)
   
--`kong migrations up` now reports routes that are incompatible with the 3.0 router
+- `kong migrations up` now reports routes that are incompatible with the 3.0 router
   and stops the migration progress so that admins have a chance to adjust them.
 
   [#10092](https://github.com/Kong/kong/pull/10092)
@@ -79,9 +79,8 @@ Kong Gateway now triggers an event that allows the Vitals subsystem to be reinit
   This caused a memory leak, where memory usage would grow without limit.
 
 - [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced/) (`rate-limiting-advanced`)
-  - Fixed an issue with the `local` strategy, which was not working correctly when `window_size` was set to `fixed`.
-    The cache would expire while the window was still valid.
-    The plugin now requires the cache size to be, at minimum, twice the value of `window_size`.
+  - Fixed an issue with the `local` strategy, which was not working correctly when `window_size` was set to `fixed`, 
+    and the cache would expire while the window was still valid.
   
 - [**OAS Validation**](/hub/kong-inc/oas-validation) (`oas-validation`)
   - Added the OAS Validation plugin back into the bundled plugins list. The plugin is now available by default


### PR DESCRIPTION
### Description

Removed a line from a changelog entry that implied the user had to configure cache size for the RLA plugin. This is not the case - this is something the plugin does intenally. 

Reported on [Slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1675853248681819).

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

