### PR TITLE
Chore: Bump deck version to 1.17.3

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -249,7 +249,7 @@
   edition: "deck"
 -
   release: "1.17.x"
-  version: "1.17.2"
+  version: "1.17.3"
   edition: "deck"
 -
   release: "1.0.x"


### PR DESCRIPTION
### Description

Bumping decK version. Patch release just went out: https://github.com/Kong/deck/blob/main/CHANGELOG.md#v1173

No other doc changes needed.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

