### PR TITLE
fix: kic 2.8 enabled CombinedRoutes by default

### DIFF
--- a/app/_src/kubernetes-ingress-controller/references/feature-gates.md
+++ b/app/_src/kubernetes-ingress-controller/references/feature-gates.md
@@ -25,13 +25,16 @@ Features that reach GA and become stable are removed from this table, but they c
 {% if_version lte: 2.5.x %}
 | Gateway                | `false` | Alpha | 2.2.0 | 2.5.0 |
 {% endif_version %}
-
 {% if_version gte: 2.6.x %}
 | Gateway                | `true`  | Beta  | 2.6.0 | TBD   |
 | GatewayAlpha           | `false` | Alpha | 2.6.0 | TBD   |
 {% endif_version %}
-
+{% if_version lte: 2.7.x %}
 | CombinedRoutes         | `false` | Alpha | 2.4.0 | TBD   |
+{% endif_version %}
+{% if_version gte: 2.8.x %}
+| CombinedRoutes         | `true`  | Beta  | 2.8.0 | TBD   |
+{% endif_version %}
 | IngressClassParameters | `false` | Alpha | 2.6.0 | TBD   |
 
 ### Feature gates details


### PR DESCRIPTION
### Description



KIC 2.8.x has enabled feature gate `CombinedRoutes` by default, so docs should be updated.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
https://deploy-preview-5139--kongdocs.netlify.app/kubernetes-ingress-controller/2.8.x/references/feature-gates/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

