### PR TITLE
[DOCU-2928] Kong-Debug header + configuration reference update

### DIFF
--- a/app/_src/gateway/how-kong-works/routing-traffic.md
+++ b/app/_src/gateway/how-kong-works/routing-traffic.md
@@ -542,9 +542,20 @@ defined URIs, in this order:
 4. `/version`
 
 Routers with a large number of regexes can consume traffic intended for other rules. Regular expressions are much more expensive to build and execute and can't be optimized easily. 
-You can avoid creating complex regular expressions using the [Router Expressions language](/gateway/latest/reference/router-expressions-language). If you see unexpected behavior, sending `Kong-Debug: 1` in your
+You can avoid creating complex regular expressions using the [Router Expressions language](/gateway/latest/reference/router-expressions-language). 
+
+{% if_version lte:3.1.x %}
+If you see unexpected behavior, sending `Kong-Debug: 1` in your
 request headers will indicate the matched route ID in the response headers for
+{% endif_version %}
+
+{% if_version gte:3.2.x %}
+If you see unexpected behavior, use the Kong debug header to help track down the source:
+
+1. In `kong.conf`, set [`allow_debug_header: on`](/gateway/{{page.kong_version}}/reference/configuration/#allow_debug_header).
+1. Send `Kong-Debug: 1` in your request headers to indicate the matched route ID in the response headers for
 troubleshooting purposes.
+{% endif_version %}
 
 As usual, a request must still match a route's `hosts` and `methods` properties
 as well, and {{site.base_gateway}} traverses your routes until it finds one that [matches

--- a/app/_src/gateway/kong-plugins/configuring-a-grpc-service.md
+++ b/app/_src/gateway/kong-plugins/configuring-a-grpc-service.md
@@ -3,276 +3,278 @@ title: Configuring a gRPC Service
 content_type: how-to
 ---
 
-Note: this guide assumes familiarity with gRPC; for learning how to set up
-Kong with an upstream REST API, check out the [Configuring a Service guide][conf-service].
+{:.note}
+> Note: This guide assumes familiarity with gRPC. For learning how to set up
+Kong with an upstream REST API, check out the [Configuring a service guide][conf-service].
 
-Starting with version 1.3, gRPC proxying is natively supported in Kong. In this
-section, you'll learn how to configure Kong to manage your gRPC services. For the
+gRPC proxying is natively supported in Kong. In this guide, you'll learn how 
+to configure Kong to manage your gRPC services. For the
 purpose of this guide, we'll use [`grpcurl`][grpcurl] and [`grpcbin`][grpcbin] - they
 provide a gRPC client and gRPC services, respectively.
 
-We will describe two setups: Single gRPC Service and Route and single gRPC Service
-with multiple Routes. In the former, a single catch-all Route is configured, which
-proxies all matching gRPC traffic to an upstream gRPC service; the latter demonstrates
-how to use a Route per gRPC method.
+The guide sets up two examples:
+*  A single gRPC service and route, with a single catch-all route that proxies all matching 
+gRPC traffic to an upstream gRPC service. 
+* A single gRPC service with multiple routes, demonstrating how to use a route per gRPC method.
 
-In Kong 1.3, gRPC support assumes gRPC over HTTP/2 framing. As such, make sure
-you have at least one HTTP/2 proxy listener (check out the [Configuration Reference][configuration-reference]
-for how to). In this guide, we will assume Kong is listening for HTTP/2 proxy
+In Kong, gRPC support assumes gRPC over HTTP/2 framing. Make sure
+you have at least one [HTTP/2 proxy listener](/gateway/{{page.kong_version}}/reference/configuration/#proxy_listen). 
+
+The following examples assume that Kong is running and listening for HTTP/2 proxy
 requests on port 9080.
 
-## Before you start
+## Single gRPC service and route
 
-You have installed and started {{site.base_gateway}}, either through the [Docker quickstart](/gateway/{{page.kong_version}}/get-started) or a more [comprehensive installation](/gateway/{{page.kong_version}}/install).
+1. Issue the following request to create a gRPC service. 
+    For example, if your gRPC server is listening on `localhost`, port `15002`:
 
-## 1. Single gRPC Service and Route
+    ```bash
+    curl -XPOST localhost:8001/services \
+      --data name=grpc \
+      --data protocol=grpc \
+      --data host=localhost \
+      --data port=15002
+    ```
 
-Issue the following request to create a gRPC Service (assuming your gRPC
-server is listening in localhost, port 15002):
+1. Issue the following request to create a gRPC route:
 
-```bash
-curl -XPOST localhost:8001/services \
-  --data name=grpc \
-  --data protocol=grpc \
-  --data host=localhost \
-  --data port=15002
-```
+    ```bash
+    curl -XPOST localhost:8001/services/grpc/routes \
+      --data protocols=grpc \
+      --data name=catch-all \
+      --data paths=/
+    ```
 
-Issue the following request to create a gRPC route:
-
-```bash
-curl -XPOST localhost:8001/services/grpc/routes \
-  --data protocols=grpc \
-  --data name=catch-all \
-  --data paths=/
-```
-
-Using the [`grpcurl`][grpcurl] command line client, issue the following gRPC
+1. Using the [`grpcurl`][grpcurl] command line client, issue the following gRPC
 request:
 
-```bash
-grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
-  -plaintext localhost:9080 hello.HelloService.SayHello
-```
+    ```bash
+    grpcurl -v -d '{"greeting": "Kong!"}' \
+      -plaintext localhost:9080 hello.HelloService.SayHello
+    ```
 
-The response should resemble the following:
+    The response should resemble the following:
 
-```
-Resolved method descriptor:
-rpc SayHello ( .hello.HelloRequest ) returns ( .hello.HelloResponse );
+    ```
+    Resolved method descriptor:
+    rpc SayHello ( .hello.HelloRequest ) returns ( .hello.HelloResponse );
 
-Request metadata to send:
-(empty)
+    Request metadata to send:
+    (empty)
 
-Response headers received:
-content-type: application/grpc
-date: Tue, 16 Jul 2019 21:37:36 GMT
-server: openresty/1.15.8.1
-via: kong/1.2.1
-x-kong-proxy-latency: 0
-x-kong-upstream-latency: 0
+    Response headers received:
+    content-type: application/grpc
+    date: Tue, 16 Jul 2019 21:37:36 GMT
+    server: openresty/1.15.8.1
+    via: kong/1.2.1
+    x-kong-proxy-latency: 0
+    x-kong-upstream-latency: 0
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response trailers received:
-(empty)
-Sent 1 request and received 1 response
-```
+    Response trailers received:
+    (empty)
+    Sent 1 request and received 1 response
+    ```
 
 Notice that Kong response headers, such as `via` and `x-kong-proxy-latency`, were
 inserted in the response.
 
-## 2. Single gRPC Service with Multiple Routes
+## Single gRPC service with multiple routes
 
-Building on top of the previous example, let's create a few more routes, for
+Building on top of the previous example, let's create a few more routes for
 individual gRPC methods.
 
-The gRPC "HelloService" service being used in this example exposes a few different
-methods, as can be seen in [its protocol buffer file][protobuf]. We will create individual
-routes for its "SayHello" and LotsOfReplies methods.
+In this example, the gRPC `HelloService` service exposes a few different
+methods, as can be seen in its [protocol buffer file][protobuf]. 
 
-Create a Route for "SayHello":
+1. Create individual routes for its `SayHello` and `LotsOfReplies` methods.
 
-```bash
-curl -X POST localhost:8001/services/grpc/routes \
-  --data protocols=grpc \
-  --data paths=/hello.HelloService/SayHello \
-  --data name=say-hello
-```
+    1. Create a route for `SayHello`:
 
-Create a Route for "LotsOfReplies":
+        ```bash
+        curl -X POST localhost:8001/services/grpc/routes \
+          --data protocols=grpc \
+          --data paths=/hello.HelloService/SayHello \
+          --data name=say-hello
+        ```
 
-```bash
-curl -X POST localhost:8001/services/grpc/routes \
-  --data protocols=grpc \
-  --data paths=/hello.HelloService/LotsOfReplies \
-  --data name=lots-of-replies
-```
+    1. Create a route for `LotsOfReplies`:
 
-With this setup, gRPC requests to the "SayHello" method will match the first
-Route, while requests to "LotsOfReplies" will be routed to the latter.
+        ```bash
+        curl -X POST localhost:8001/services/grpc/routes \
+          --data protocols=grpc \
+          --data paths=/hello.HelloService/LotsOfReplies \
+          --data name=lots-of-replies
+        ```
 
-Issue a gRPC request to the "SayHello" method:
+    With this setup, gRPC requests to the `SayHello` method will match the first
+    route, while requests to `LotsOfReplies` will be routed to the latter.
 
-```bash
-grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
-  -H 'kong-debug: 1' -plaintext \
-  localhost:9080 hello.HelloService.SayHello
-```
+{% if_version gte:3.2.x %}
+1. In `kong.conf`, set [`allow_debug_header: on`](/gateway/{{page.kong_version}}/reference/configuration/#allow_debug_header).
+{% endif_version %}
 
-(Notice we are sending a header `kong-debug`, which causes Kong to insert
-debugging information in response headers.)
+1. Issue a gRPC request to the `SayHello` method:
 
-The response should look like:
+    ```bash
+    grpcurl -v -d '{"greeting": "Kong!"}' \
+      -H 'kong-debug: 1' -plaintext \
+      localhost:9080 hello.HelloService.SayHello
+    ```
 
-```
-Resolved method descriptor:
-rpc SayHello ( .hello.HelloRequest ) returns ( .hello.HelloResponse );
+    Notice that the example sends the header `kong-debug`, which causes Kong to insert
+    debugging information in response headers. 
 
-Request metadata to send:
-kong-debug: 1
+    The response should look like:
 
-Response headers received:
-content-type: application/grpc
-date: Tue, 16 Jul 2019 21:57:00 GMT
-kong-route-id: 390ef3d1-d092-4401-99ca-0b4e42453d97
-kong-service-id: d82736b7-a4fd-4530-b575-c68d94c3493a
-kong-service-name: s1
-server: openresty/1.15.8.1
-via: kong/1.2.1
-x-kong-proxy-latency: 0
-x-kong-upstream-latency: 0
+    ```
+    Resolved method descriptor:
+    rpc SayHello ( .hello.HelloRequest ) returns ( .hello.HelloResponse );
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Request metadata to send:
+    kong-debug: 1
 
-Response trailers received:
-(empty)
-Sent 1 request and received 1 response
-```
+    Response headers received:
+    content-type: application/grpc
+    date: Tue, 16 Jul 2019 21:57:00 GMT
+    kong-route-id: 390ef3d1-d092-4401-99ca-0b4e42453d97
+    kong-service-id: d82736b7-a4fd-4530-b575-c68d94c3493a
+    kong-service-name: s1
+    server: openresty/1.15.8.1
+    via: kong/1.2.1
+    x-kong-proxy-latency: 0
+    x-kong-upstream-latency: 0
 
-Notice the Route ID should refer to the first route we created.
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Similarly, let's issue a request to the "LotsOfReplies" gRPC method:
+    Response trailers received:
+    (empty)
+    Sent 1 request and received 1 response
+    ```
 
-```bash
-grpcurl -v -d '{"greeting": "Kong 1.3!"}' \
-  -H 'kong-debug: 1' -plaintext \
-  localhost:9080 hello.HelloService.LotsOfReplies
-```
+    Notice the route ID should refer to the first route we created.
 
-The response should look like the following:
+1. Similarly, let's issue a request to the `LotsOfReplies` gRPC method:
 
-```
-Resolved method descriptor:
-rpc LotsOfReplies ( .hello.HelloRequest ) returns ( stream .hello.HelloResponse );
+    ```bash
+    grpcurl -v -d '{"greeting": "Kong!"}' \
+      -H 'kong-debug: 1' -plaintext \
+      localhost:9080 hello.HelloService.LotsOfReplies
+    ```
 
-Request metadata to send:
-kong-debug: 1
+    The response should look like the following:
 
-Response headers received:
-content-type: application/grpc
-date: Tue, 30 Jul 2019 22:21:40 GMT
-kong-route-id: 133659bb-7e88-4ac5-b177-bc04b3974c87
-kong-service-id: 31a87674-f984-4f75-8abc-85da478e204f
-kong-service-name: grpc
-server: openresty/1.15.8.1
-via: kong/1.2.1
-x-kong-proxy-latency: 14
-x-kong-upstream-latency: 0
+    ```
+    Resolved method descriptor:
+    rpc LotsOfReplies ( .hello.HelloRequest ) returns ( stream .hello.HelloResponse );
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Request metadata to send:
+    kong-debug: 1
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response headers received:
+    content-type: application/grpc
+    date: Tue, 30 Jul 2019 22:21:40 GMT
+    kong-route-id: 133659bb-7e88-4ac5-b177-bc04b3974c87
+    kong-service-id: 31a87674-f984-4f75-8abc-85da478e204f
+    kong-service-name: grpc
+    server: openresty/1.15.8.1
+    via: kong/1.2.1
+    x-kong-proxy-latency: 14
+    x-kong-upstream-latency: 0
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response contents:
-{
-  "reply": "hello Kong 1.3!"
-}
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Response trailers received:
-(empty)
-Sent 1 request and received 10 responses
-```
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-Notice that the `kong-route-id` response header now carries a different value
-and refers to the second Route created in this page.
+    Response contents:
+    {
+      "reply": "hello Kong!"
+    }
 
-**Note:**
-Some gRPC clients (typically CLI clients) issue ["gRPC Reflection Requests"][grpc-reflection]
+    Response trailers received:
+    (empty)
+    Sent 1 request and received 10 responses
+    ```
+
+    Notice that the `kong-route-id` response header now carries a different value
+    and refers to the second Route created in this page.
+
+{:.note}
+> **Note:**
+> Some gRPC clients (typically CLI clients) issue ["gRPC Reflection Requests"][grpc-reflection]
 as a means of determining what methods a server exports and how those methods are called.
-Said requests have a particular path; for example, `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo`
-is a valid reflection path. As with any proxy request, Kong needs to know how to
-route these; in the current example, they would be routed to the catch-all route
-(whose path is `/`, matching any path). If no route matches the gRPC reflection
-request, Kong will respond, as expected, with a `404 Not Found` response.
+> These requests have a particular path. For example, `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo` is a valid reflection path. 
+> As with any proxy request, Kong needs to know how to route these requests. 
+> In the current example, they would be routed to the catch-all route whose path is `/`, matching any path. 
+> If no route matches the gRPC reflection request, Kong will respond, as expected, with a `404 Not Found` response.
 
-## 3. Enabling Plugins
+## Enabling plugins
 
-Kong 1.3 gRPC support is compatible with Logging and Observability plugins; for
-example, let's try out the [File Log][file-log] plugin with gRPC.
+Let's try out the [File Log][file-log] plugin with gRPC.
 
-Issue the following request to enable File Log on the "SayHello" route:
+1. Issue the following request to enable the File Log plugin on the `SayHello` route:
 
-```bash
-curl -X POST localhost:8001/routes/say-hello/plugins \
-  --data name=file-log \
-  --data config.path=grpc-say-hello.log
-```
+    ```bash
+    curl -X POST localhost:8001/routes/say-hello/plugins \
+      --data name=file-log \
+      --data config.path=grpc-say-hello.log
+    ```
 
-Follow the output of the log as gRPC requests are made to "SayHello":
+1. Follow the output of the log as gRPC requests are made to `SayHello`:
 
-```
-tail -f grpc-say-hello.log
-{"latencies":{"request":8,"kong":5,"proxy":3},"service":{"host":"localhost","created_at":1564527408,"connect_timeout":60000,"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","protocol":"grpc","name":"grpc","read_timeout":60000,"port":15002,"updated_at":1564527408,"write_timeout":60000,"retries":5},"request":{"querystring":{},"size":"46","uri":"\/hello.HelloService\/SayHello","url":"http:\/\/localhost:9080\/hello.HelloService\/SayHello","headers":{"host":"localhost:9080","content-type":"application\/grpc","kong-debug":"1","user-agent":"grpc-go\/1.20.0-dev","te":"trailers"},"method":"POST"},"client_ip":"127.0.0.1","tries":[{"balancer_latency":0,"port":15002,"balancer_start":1564527732522,"ip":"127.0.0.1"}],"response":{"headers":{"kong-route-id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","content-type":"application\/grpc","connection":"close","kong-service-name":"grpc","kong-service-id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","kong-route-name":"say-hello","via":"kong\/1.2.1","x-kong-proxy-latency":"5","x-kong-upstream-latency":"3"},"status":200,"size":"298"},"route":{"id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","updated_at":1564527431,"protocols":["grpc"],"created_at":1564527431,"service":{"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c"},"name":"say-hello","preserve_host":false,"regex_priority":0,"strip_path":false,"paths":["\/hello.HelloService\/SayHello"],"https_redirect_status_code":426},"started_at":1564527732516}
-{"latencies":{"request":3,"kong":1,"proxy":1},"service":{"host":"localhost","created_at":1564527408,"connect_timeout":60000,"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","protocol":"grpc","name":"grpc","read_timeout":60000,"port":15002,"updated_at":1564527408,"write_timeout":60000,"retries":5},"request":{"querystring":{},"size":"46","uri":"\/hello.HelloService\/SayHello","url":"http:\/\/localhost:9080\/hello.HelloService\/SayHello","headers":{"host":"localhost:9080","content-type":"application\/grpc","kong-debug":"1","user-agent":"grpc-go\/1.20.0-dev","te":"trailers"},"method":"POST"},"client_ip":"127.0.0.1","tries":[{"balancer_latency":0,"port":15002,"balancer_start":1564527733555,"ip":"127.0.0.1"}],"response":{"headers":{"kong-route-id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","content-type":"application\/grpc","connection":"close","kong-service-name":"grpc","kong-service-id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","kong-route-name":"say-hello","via":"kong\/1.2.1","x-kong-proxy-latency":"1","x-kong-upstream-latency":"1"},"status":200,"size":"298"},"route":{"id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","updated_at":1564527431,"protocols":["grpc"],"created_at":1564527431,"service":{"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c"},"name":"say-hello","preserve_host":false,"regex_priority":0,"strip_path":false,"paths":["\/hello.HelloService\/SayHello"],"https_redirect_status_code":426},"started_at":1564527733554}
-```
+    ```
+    tail -f grpc-say-hello.log
+    {"latencies":{"request":8,"kong":5,"proxy":3},"service":{"host":"localhost","created_at":1564527408,"connect_timeout":60000,"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","protocol":"grpc","name":"grpc","read_timeout":60000,"port":15002,"updated_at":1564527408,"write_timeout":60000,"retries":5},"request":{"querystring":{},"size":"46","uri":"\/hello.HelloService\/SayHello","url":"http:\/\/localhost:9080\/hello.HelloService\/SayHello","headers":{"host":"localhost:9080","content-type":"application\/grpc","kong-debug":"1","user-agent":"grpc-go\/1.20.0-dev","te":"trailers"},"method":"POST"},"client_ip":"127.0.0.1","tries":[{"balancer_latency":0,"port":15002,"balancer_start":1564527732522,"ip":"127.0.0.1"}],"response":{"headers":{"kong-route-id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","content-type":"application\/grpc","connection":"close","kong-service-name":"grpc","kong-service-id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","kong-route-name":"say-hello","via":"kong\/1.2.1","x-kong-proxy-latency":"5","x-kong-upstream-latency":"3"},"status":200,"size":"298"},"route":{"id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","updated_at":1564527431,"protocols":["grpc"],"created_at":1564527431,"service":{"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c"},"name":"say-hello","preserve_host":false,"regex_priority":0,"strip_path":false,"paths":["\/hello.HelloService\/SayHello"],"https_redirect_status_code":426},"started_at":1564527732516}
+    {"latencies":{"request":3,"kong":1,"proxy":1},"service":{"host":"localhost","created_at":1564527408,"connect_timeout":60000,"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","protocol":"grpc","name":"grpc","read_timeout":60000,"port":15002,"updated_at":1564527408,"write_timeout":60000,"retries":5},"request":{"querystring":{},"size":"46","uri":"\/hello.HelloService\/SayHello","url":"http:\/\/localhost:9080\/hello.HelloService\/SayHello","headers":{"host":"localhost:9080","content-type":"application\/grpc","kong-debug":"1","user-agent":"grpc-go\/1.20.0-dev","te":"trailers"},"method":"POST"},"client_ip":"127.0.0.1","tries":[{"balancer_latency":0,"port":15002,"balancer_start":1564527733555,"ip":"127.0.0.1"}],"response":{"headers":{"kong-route-id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","content-type":"application\/grpc","connection":"close","kong-service-name":"grpc","kong-service-id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c","kong-route-name":"say-hello","via":"kong\/1.2.1","x-kong-proxy-latency":"1","x-kong-upstream-latency":"1"},"status":200,"size":"298"},"route":{"id":"e49f2df9-3e8e-4bdb-8ce6-2c505eac4ab6","updated_at":1564527431,"protocols":["grpc"],"created_at":1564527431,"service":{"id":"74a95d95-fbe4-4ddb-a448-b8faf07ece4c"},"name":"say-hello","preserve_host":false,"regex_priority":0,"strip_path":false,"paths":["\/hello.HelloService\/SayHello"],"https_redirect_status_code":426},"started_at":1564527733554}
+    ```
 
 [enabling-plugins]: /gateway/{{page.kong_version}}/get-started/enabling-plugins
 [conf-service]: /gateway/{{page.kong_version}}/get-started/services-and-routes

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -1386,7 +1386,7 @@ be kept open indefinitely.
 
 Enable the `Kong-Debug` header function.
 
-if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name`
+If it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name`
 `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client
 request header `Kong-Debug: 1` is present.
 

--- a/autodoc-conf-ee/run.lua
+++ b/autodoc-conf-ee/run.lua
@@ -140,7 +140,7 @@ infd:close()
 
 local parsed = assert(parser.parse(lines))
 
-local outpath = "src/gateway/reference/configuration.md"
+local outpath = "app/_src/gateway/reference/configuration.md"
 local outfd = assert(io.open(outpath, "w+"))
 
 outfd:write(data.header)
@@ -210,6 +210,9 @@ for _, section in ipairs(parsed) do
         write("{:.badge .enterprise}")
 
       elseif string.match(var.name, "cluster_telemetry") then
+        write("{:.badge .enterprise}")
+
+      elseif string.match(var.name, "cluster_fallback") then
         write("{:.badge .enterprise}")
 
       elseif string.match(var.name, "rbac") then


### PR DESCRIPTION
### Description

* Add new parameters to the Configuration Reference.
  * Compared the Enterprise and OSS versions of kong.conf.default and labelled Enterprise features accordingly
  * Had to make a copy of the Postgres table for 3.2.x, couldn't get version conditionals to work right without breaking the table - I think it's because I had to use both `lte` and `gte` one after the other.
* Searched for and updated any instances of the kong-debug header, adding a step to first enable sending debugging info.
  * As part of this, cleaned up the very outdated gRPC service guide, which was mentioning Kong 1.3 everywhere.

Did not add a changelog/breaking change entry. This will be added in a separate changelog PR.
 
Ticket: https://konghq.atlassian.net/browse/DOCU-2928


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

