### PR TITLE
cleanup alpine Dockerfile

### DIFF
--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -111,15 +111,9 @@ FROM alpine:latest
 COPY kong.apk.tar.gz /tmp/kong.apk.tar.gz
 
 RUN set -ex; \
-    apk add bash curl ca-certificates; \
-    arch="$(apk --print-arch)"; \
-    case "${arch}" in \
-      x86_64) export ARCH='amd64'; KONG_SHA256=$KONG_AMD64_SHA ;; \
-      aarch64) export ARCH='arm64'; KONG_SHA256=$KONG_ARM64_SHA ;; \
-    esac; \
     apk add --no-cache --virtual .build-deps tar gzip \
     && tar -C / -xzf /tmp/kong.apk.tar.gz \
-    && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zlib zlib-dev bash \
+    && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zlib zlib-dev bash curl ca-certificates \
     && adduser -S kong \
     && addgroup -S kong \
     && mkdir -p "/usr/local/kong" \


### PR DESCRIPTION


### Description

This provides two minor cleanups to the Alpine Dockerfile:

- remove unused `$arch`, `$ARCH`, `$KONG_SHA256` environment variables (probably those have been used earlier to download+verify the kong archive using curl?)
- merge apk add lines (bash already installed anyway below)

### Testing instructions

Netlify link: https://deploy-preview-5153--kongdocs.netlify.app/gateway/latest/install/docker/build-custom-images/


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->


<sup>Jens Erat <jens.erat@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>