### PR TITLE
Explain the session_cookie_renew property in more detail

### DIFF
--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -953,7 +953,7 @@ params:
       required: false
       default: 600
       datatype: integer
-      description: The number of seconds prior to the `session_cookie_lifetime` the session cookie will be renewed.
+      description: The number of seconds prior to the `session_cookie_lifetime` that the session cookie will be renewed.
     - name: session_cookie_path
       required: false
       default: '"/"'

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -953,7 +953,7 @@ params:
       required: false
       default: 600
       datatype: integer
-      description: The session cookie renew time.
+      description: The number of seconds prior to the `session_cookie_lifetime` the session cookie will be renewed.
     - name: session_cookie_path
       required: false
       default: '"/"'


### PR DESCRIPTION
### Description

Clarified the session_cookie_renew property as it was pointed out by a customer that it wasn't clear this property was how many seconds prior to the lifetime expiration before being renewed.

### Checklist 

- [x] Review label added
- [x] PR pointed to correct branch