### PR TITLE
[DOCU-2920] Changelog for Gateway 3.2

### DIFF
--- a/app/_hub/kong-inc/canary/_index.md
+++ b/app/_hub/kong-inc/canary/_index.md
@@ -26,6 +26,7 @@ params:
     - name: grpcs
   config:
     - name: start
+      maximum_version: "3.1.x"
       required: semi
       default: null
       value_in_examples: null
@@ -33,6 +34,19 @@ params:
       description: |
         Future time in seconds since epoch, when the canary release will start.
         Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`.
+
+    - name: start
+      minimum_version: "3.2.x"
+      default: current timestamp
+      value_in_examples: null
+      datatype: number
+      description: |
+        Future time in seconds since epoch, when the canary release will start.
+        Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`.
+
+        If no value is set for the `start` field, it defaults to the 
+        timestamp of the moment that the plugin instance is created.
+
     - name: duration
       required: null
       default: 3600
@@ -220,6 +234,9 @@ target. For this configuration to take effect, the following conditions must be 
 ---
 
 ## Changelog
+
+**{{site.base_gateway}} 3.2.x**
+* The `start` field now defaults to the current timestamp.
 
 **{{site.base_gateway}} 2.8.x**
 * Added the `canary_by_header_name` configuration parameter.

--- a/app/_hub/kong-inc/opentelemetry/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/_index.md
@@ -15,6 +15,9 @@ kong_version_compatibility:
     compatible: true
 params:
   name: opentelemetry
+  service_id: true
+  route_id: true
+  consumer_id: true
   konnect_examples: false
   protocols:
     - name: http
@@ -330,6 +333,9 @@ Span #6 name=balancer try #1 duration=0.99328ms attributes={"net.peer.ip":"104.2
 {% endif_plugin_version %}
 
 ## Changelog
+
+**{{site.base_gateway}} 3.2.x**
+* This plugin can now be scoped to individual services, routes, and consumers.
 
 **{{site.base_gateway}} 3.1.x**
 * The `headers` field is now marked as referenceable, which means it can be securely stored as a

--- a/app/_src/gateway/how-kong-works/load-balancing.md
+++ b/app/_src/gateway/how-kong-works/load-balancing.md
@@ -168,8 +168,16 @@ to this target it will query the nameserver again.
 
 ### Balancing algorithms
 
-The ring-balancer supports the following load balancing algorithms: `round-robin`,
-`consistent-hashing`, `least-connections`, and `latency`. By default, a ring-balancer
+The ring-balancer supports the following load balancing algorithms:
+* `round-robin`
+* `consistent-hashing`
+* `least-connections`
+{% if_version gte:3.2.x %}
+* `latency`
+{% endif_version %}
+
+
+By default, a ring-balancer
 uses the `round-robin` algorithm, which provides a well-distributed weighted
 round-robin over the targets.
 
@@ -200,9 +208,13 @@ The `consistent-hashing` algorithm is based on _Consistent Hashing_, which ensur
 a change in its targets (adding, removing, failing, or changing weights), only
 the minimum number of hashing losses occur. This maximizes upstream cache hits.
 
-The `latency` algorithm is based on peak EWMA(exponentially weighted moving average), which ensures that the balancer selects the upstream target
+{% if_version gte:3.2.x %}
+
+The `latency` algorithm is based on peak EWMA (exponentially weighted moving average), which ensures that the balancer selects the upstream target
 by lowest latency (`upstream_response_time`). This latency is not only TCP connect time, but also includes
 body response time. In the `latency` algorithm, the latency is the service response latency because it describes the combined score of service load and network latency. This balancer algorithm is suitable for a single type upstream service. If the backend service has different requests with different body types (for example, video data, audio data, or text data), it causes the `latency` algorithm loss load balancing function. Before using the `latency` algorithm, make sure that the QPS of your requests is as large as possible because sharing data between multiple workers in Nginx is difficult and this algorithm only stores data on a single worker. So, the more requests there are, the more data Kong will uncover and the more `latency` balanced it will be.
+
+{% endif_version %}
 
 The ring-balancer also supports the `least-connections` algorithm, which selects
 the target with the lowest number of connections, weighted by the Target's

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -6,6 +6,263 @@ no_version: true
 <!-- vale off -->
 
 
+## 3.2.0.0
+**Release Date** 2023/02/15
+
+### Breaking changes and deprecations
+
+* The default PostgreSQL SSL version has been bumped to TLS 1.2. In `kong.conf`:
+   
+    * The default [`pg_ssl_version`](/gateway/latest/reference/configuration/#postgres-settings)
+    is now `tlsv1_2`.
+    * Constrained the valid values of this configuration option to only accept the following: `tlsv1_1`, `tlsv1_2`, `tlsv1_3` or `any`.
+
+    This mirrors the setting `ssl_min_protocol_version` in PostgreSQL 12.x and onward. 
+    See the [PostgreSQL documentation](https://postgresqlco.nf/doc/en/param/ssl_min_protocol_version/)
+    for more information about that parameter.
+
+    To use the default setting in `kong.conf`, verify that your Postgres server supports TLS 1.2 or higher versions, or set the TLS version yourself. 
+    TLS versions lower than `tlsv1_2` are already deprecated and considered insecure from PostgreSQL 12.x onward.
+  
+* Added the [`allow_debug_header`](/gateway/latest/reference/configuration/#allow_debug_header) 
+configuration property to `kong.conf` to constrain the `Kong-Debug` header for debugging. This option defaults to `off`.
+
+    If you were previously relying on the `Kong-Debug` header to provide debugging information, set `allow_debug_header: on` to continue doing so.
+* Deprecated Alpine Linux images and packages. 
+    
+    Alpine images and packages will continue to be available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
+
+* [**JWT plugin**](/hub/kong-inc/jwt/) (`jwt`)
+    
+    * The JWT plugin now denies any request that has different tokens in the JWT token search locations.
+      [#9946](https://github.com/Kong/kong/pull/9946)
+
+* [**Session plugin**](/hub/kong-inc/session/) (`session`)
+    * For sessions to work as expected in this version, all nodes must run Kong Gateway 3.2.x or later.
+    For that reason, we recommend that during upgrades, proxy nodes with mixed versions run for
+    as little time as possible. During that time, the invalid sessions could cause failures and partial downtime.
+    
+        All existing sessions are invalidated when upgrading to this version.
+        [#10199](https://github.com/Kong/kong/pull/10199)
+
+### Features
+
+#### Core
+
+* When `router_flavor` is `traditional_compatible`, Kong Gateway verifies routes created 
+  using the expression router instead of the traditional router to ensure created routes
+  are compatible.
+  [#9987](https://github.com/Kong/kong/pull/9987)
+* In DB-less mode, the `/config` API endpoint can now flatten all schema validation
+  errors into a single array using the optional `flatten_errors` query parameter.
+  [#10161](https://github.com/Kong/kong/pull/10161)
+* The upstream entity now has a new load balancing algorithm option: [`latency`](/gateway/latest/how-kong-works/load-balancing/#balancing-algorithms).
+  This algorithm chooses a target based on the response latency of each target
+  from prior requests.
+  [#9787](https://github.com/Kong/kong/pull/9787)
+* The Nginx `charset` directive can now be configured with Nginx directive injections.
+    Set it in Kong Gateway's configuration with [`nginx_http_charset`](/gateway/latest/reference/configuration/#nginx_http_charset)
+    [#10111](https://github.com/Kong/kong/pull/10111)
+* The services upstream TLS configuration is now extended to the stream subsystem.
+  [#9947](https://github.com/Kong/kong/pull/9947)
+* Added the new configuration parameter [`ssl_session_cache_size`](/gateway/latest/reference/configuration/#ssl_session_cache_size), 
+which lets you set the Nginx directive `ssl_session_cache`.
+  This configuration parameter defaults to `10m`.
+  
+  Thanks [Michael Kotten](https://github.com/michbeck100) for contributing this change.
+  [#10021](https://github.com/Kong/kong/pull/10021)
+
+#### Enterprise
+
+* Added two debugging endpoints to the Admin API:
+    * `/debug/profiling/cpu`: Instruction-based and timer-based Lua VM CPU profiling.
+    * `/debug/profiling/gc-snapshot`: Lua GC heap snapshot.
+
+##### Kong Manager
+
+* Improved the editor for expression fields. Any fields using the expression router now have syntax highlighting, autocomplete, and route validation.
+* Improved audit logs by adding `rbac_user_name` and `request_source`. 
+By combining the data in the new `request_source` field with the `path` field, you can now determine login and logout events from the logs.
+* License information can now be copied or downloaded into a file from Kong Manager. 
+* Kong Manager now supports the `POST` method for OIDC-based authentication.
+* Keys and key sets can now be configured in Kong Manager.
+* Optimized the color scheme for `http` method badges.
+
+#### Plugins
+
+* **Plugin entity**: Added an optional `instance_name` field, which identifies a
+  particular plugin entity.
+  [#10077](https://github.com/Kong/kong/pull/10077)
+
+* [**New plugin: Datadog Tracing**](/hub/kong-inc/datadog-tracing) (`datadog-tracing`)
+  * The Datadog Tracing plugin integrates Kong Gateway with the Datadog Application Performance Monitoring (APM) platform so that proxy requests handled by Kong Gateway can be identified and analyzed in Datadog.
+
+* [**Zipkin**](/hub/kong-inc/zipkin/) (`zipkin`)
+  * Added support for setting the durations of Kong phases as span tags
+  through the configuration property `phase_duration_flavor`.
+  [#9891](https://github.com/Kong/kong/pull/9891)
+
+* [**HTTP Log**](/hub/kong-inc/http-log/) (`http-log`)
+  * The `headers` configuration parameter is now referenceable, which means it can be securely stored in a vault.
+  [#9948](https://github.com/Kong/kong/pull/9948)
+
+* [**AWS Lambda**](/hub/kong-inc/aws-lambda/) (`aws-lambda`)
+  * Added the configuration parameter `aws_imds_protocol_version`, which
+  lets you select the IMDS protocol version.
+  This option defaults to `v1` and can be set to `v2` to enable IMDSv2.
+  [#9962](https://github.com/Kong/kong/pull/9962)
+
+* [**OpenTelemetry**](/hub/kong-inc/opentelemetry/) (`opentelemetry`)
+  * This plugin can now be scoped to individual services, routes, and consumers.
+  [#10096](https://github.com/Kong/kong/pull/10096)
+
+* [**StatsD**](/hub/kong-inc/statsd/) (`statsd`)
+  * Added the `tag_style` configuration parameter, which allows the plugin 
+  to send metrics with [tags](https://github.com/prometheus/statsd_exporter#tagging-extensions).
+  The parameter defaults to `nil`, which means that no tags are added to the metrics.
+  [#10118](https://github.com/Kong/kong/pull/10118)
+  
+* [**Session**](/hub/kong-inc/session/) (`session`), [OpenID Connect](/hub/kong-inc/openid-connect/) (`openid-connect`), and [**SAML**](/hub/kong-inc/saml) (`saml`).
+
+  * These plugins now use `lua-resty-session` v4.0.0. 
+  
+    With this library update, these plugin have new session functionalities, including: configuring audiences to manage multiple sessions in a single cookie, global timeout, and persistent cookies.
+    [#10199](https://github.com/Kong/kong/pull/10199)
+
+* [**GraphQL Rate Limiting Advanced**](/hub/kong-inc/graphql-rate-limiting-advanced/) (`graphql-rate-limiting-advanced`) and [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced/) (`rate-limiting-advanced`)
+    * In hybrid and DB-less modes, these plugins now support `sync_rate = -1` with any strategy, including the default `cluster` strategy.
+
+* [**OPA**](/hub/kong-inc/opa/) (`opa`)
+    * This plugin can now handle custom messages from the OPA server.
+
+* [**Canary**](/hub/kong-inc/canary/) (`canary`)
+    * Added a default value for the `start` field in the canary plugin. 
+    If not set, the start time defaults to the current timestamp.
+
+### Fixes
+
+#### Core 
+
+* Added back PostgreSQL `FLOOR` function when calculating `ttl`, so the returned `ttl` is always a whole integer.
+  [#9960](https://github.com/Kong/kong/pull/9960)
+* Exposed PostreSQL connection pool configuration.
+  [#9603](https://github.com/Kong/kong/pull/9603)
+* **Nginx template**: Do not add the default charset to the `Content-Type` response header when upstream response doesn't contain it.
+  [#9905](https://github.com/Kong/kong/pull/9905)
+* Fixed an issue where, after a valid declarative configuration was loaded,
+  the configuration hash was incorrectly set to the value `00000000000000000000000000000000`.
+  [#9911](https://github.com/Kong/kong/pull/9911)
+* Updated the batch queues module so that queues no longer grow without bounds if
+  their consumers fail to process the entries. Instead, old batches are now dropped
+  and an error is logged.
+  [#10247](https://github.com/Kong/kong/pull/10247)
+* Fixed an issue where `X-Kong-Upstream-Status` couldn't be emitted when a response was buffered.
+  [#10056](https://github.com/Kong/kong/pull/10056)
+* Improved the error message for invalid JWK entries.
+  [#9904](https://github.com/Kong/kong/pull/9904)
+
+#### Enterprise
+
+* Fixed an issue where the forward proxy between the data plane and the control plane didn't support telemetry port 8006.
+* Fix the PostgreSQL mTLS error `bad client cert type`. 
+* Fixed issues with the Admin API's `/licenses` endpoint:
+    * The Enterprise license wasn't being picked up by other nodes in a cluster.
+    * Vitals routes weren't accessible.
+    * Vitals wasn't showing up in hybrid mode.
+
+##### Vitals
+
+* Fixed an issue where Vitals wasn't tracking the status codes of service-less routes.
+* Fixed the Admin API error `/vitals/reports/:entity_type is not available`.
+
+##### Kong Manager
+
+* Fixed an issue where `404 Not Found` errors were triggered while updating the service, route, or consumer bound to a scoped plugin.
+* Moved the `tags` field out of the advanced fields section for certificate, route, and upstream configuration pages. 
+The tags field is now visible without needing to expand to see all fields.
+* Improved the user interface for Keys and Key Sets entities. 
+* Fixed a role precedence issue with RBAC. RBAC rules involving deny (negative) rules now correctly take precedence over allow (non-negative) roles.
+* You can now add tags for consumer groups in Kong Manager.
+* Fixed an issue where the plugin **Copy JSON** button didn't copy the full configuration.
+* Fixed an issue where the password reset form didn't check for matching passwords and allowed mismatched passwords to be submitted.
+* Added a link to the upgrade prompt for Konnect or Enterprise. 
+ 
+#### Plugins
+
+* Fixed an issue where the `redis.username` configuration parameter didn't work for the following plugins:
+    * GraphQL Rate Limiting Advanced
+    * Proxy Cache Advanced
+    * Rate Limiting Advanced
+
+    These plugins now accept Redis username and password authentication.
+
+* [**Zipkin**](/hub/kong-inc/zipkin/) (`zipkin`)
+  * Fixed an issue where the global plugin's sample ratio overrode the route-specific ratio.
+  [#9877](https://github.com/Kong/kong/pull/9877)
+
+* [**JWT**](/hub/kong-inc/jwt/) (`jwt`)
+  * This plugin now denies requests that have different tokens in the JWT token search locations. 
+  
+    Thanks Jackson 'Che-Chun' Kuo from Latacora for reporting this issue.
+    [#9946](https://github.com/Kong/kong/pull/9946)
+
+* [**Datadog**](/hub/kong-inc/datadog/) (`datadog`),[**OpenTelemetry**](/hub/kong-inc/opentelemetry/) (`opentelemetry`), and [**StatsD**](/hub/kong-inc/statsd/) (`statsd`)
+  * Fixed an issue in these plugins' batch queue processing, where metrics would be published multiple times. 
+  This caused a memory leak, where memory usage would grow without limit.
+  [#10052](https://github.com/Kong/kong/pull/10052) [#10044](https://github.com/Kong/kong/pull/10044)
+
+* [**OpenTelemetry**](/hub/kong-inc/opentelemetry/) (`opentelemetry`)
+  *  Fixed non-compliances to specification:
+    * For `http.uri` in spans, the field is now the full HTTP URI.
+      [#10036](https://github.com/Kong/kong/pull/10036)
+    * `http.status_code` is now present on spans for requests that have a status code.
+      [#10160](https://github.com/Kong/kong/pull/10160)
+    * `http.flavor` is now a string value, not a double.
+      [#10160](https://github.com/Kong/kong/pull/10160)
+  
+* [**OAuth2**](/hub/kong-inc/oauth2/) (`oauth2`)
+  * `refresh_token_ttl` is now limited to a range between `0` and `100000000` by the schema validator. 
+  Previously, numbers that were too large caused requests to fail.
+  [#10068](https://github.com/Kong/kong/pull/10068)
+
+ * [**OpenID Connect**](/hub/kong-inc/openid-connect/) (`openid-connect`)
+  * Fixed a bug where it was not possible to specify an anonymous consumer by name.
+    [#4377](https://github.com/Kong/kong-ee/pull/4377)
+
+* [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced/) (`rate-limiting-advanced`)
+  * Matched the plugin's behavior to the Rate Limiting plugin.
+    When an `HTTP 429` status code was returned, rate limiting related headers were missed from the PDK module `kong.response.exit()`. 
+    This made the plugin incompatible with other Kong components like the Exit Transformer plugin.
+
+* [**Response Transformer**](/hub/kong-inc/response-transformer/) (`response-transformer`)
+  * Fixed an issue where the `allow.json` configuration parameter couldn't use nested JSON object and array syntax.
+
+* [**Mocking**](/hub/kong-inc/mocking/) (`mocking`)
+  * Fixed UUID pattern matching. 
+
+### Dependencies
+
+* Bumped`lua-resty-openssl` from 0.8.15 to 0.8.17
+* Bumped `libexpat` from 2.4.9 to 2.5.0
+* Bumoed `kong-openid-connect` from v2.5.0 to v2.5.2
+* Bumped `openssl` from 1.1.1q to 1.1.1t
+* `libyaml` is no longer built with Kong Gateway. System `libyaml` is used instead.
+* Bumped `luarocks` from 3.9.1 to 3.9.2
+  [#9942](https://github.com/Kong/kong/pull/9942)
+* Bumped `atc-router` from 1.0.1 to 1.0.5
+  [#9925](https://github.com/Kong/kong/pull/9925)
+  [#10143](https://github.com/Kong/kong/pull/10143)
+  [#10208](https://github.com/Kong/kong/pull/10208)
+* Bumped `lua-resty-openssl` from 0.8.15 to 0.8.17
+  [#9583](https://github.com/Kong/kong/pull/9583)
+  [#10144](https://github.com/Kong/kong/pull/10144)
+* Bumped `lua-kong-nginx-module` from 0.5.0 to 0.5.1
+  [#10181](https://github.com/Kong/kong/pull/10181)
+* Bumped `lua-resty-session` from 3.10 to 4.0.0
+  [#10199](https://github.com/Kong/kong/pull/10199)
+  [#10230](https://github.com/Kong/kong/pull/10230)
+
+
 ## 3.1.1.3
 **Release Date** 2023/01/30
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -78,8 +78,8 @@ which lets you set the Nginx directive `ssl_session_cache`.
 #### Enterprise
 
 * Added two debugging endpoints to the Admin API:
-    * `/debug/profiling/cpu`: Instruction-based and timer-based Lua VM CPU profiling.
-    * `/debug/profiling/gc-snapshot`: Lua GC heap snapshot.
+    * [`/debug/profiling/cpu`](/gateway/latest/admin-api/#get-state-of-the-cpu-profiling): Instruction-based and timer-based Lua VM CPU profiling.
+    * [`/debug/profiling/gc-snapshot`](/gateway/latest/admin-api/#get-the-state-of-gc-snapshot): Lua GC heap snapshot.
 
 #### Kong Manager
 
@@ -125,7 +125,7 @@ By combining the data in the new `request_source` field with the `path` field, y
   The parameter defaults to `nil`, which means that no tags are added to the metrics.
   [#10118](https://github.com/Kong/kong/pull/10118)
   
-* [**Session**](/hub/kong-inc/session/) (`session`), [OpenID Connect](/hub/kong-inc/openid-connect/) (`openid-connect`), and [**SAML**](/hub/kong-inc/saml) (`saml`).
+* [**Session**](/hub/kong-inc/session/) (`session`), [**OpenID Connect**](/hub/kong-inc/openid-connect/) (`openid-connect`), and [**SAML**](/hub/kong-inc/saml) (`saml`).
 
   * These plugins now use `lua-resty-session` v4.0.0. 
   
@@ -144,7 +144,8 @@ By combining the data in the new `request_source` field with the `path` field, y
     
     
 * **Improved Plugin Documentation**
-    * Updated the plugin compatibility information for more clarity on [supported network protocols](/hub/plugins/compatibility/#protocols) and on [entity scopes](/hub/plugins/compatibility/#scopes) 
+    * Split the plugin compatibility table into a [technical compatibility page](/hub/plugins/compatibility/) and a [license tiers](hub/plugins/license-tiers) page. 
+    * Updated the plugin compatibility information for more clarity on [supported network protocols](/hub/plugins/compatibility/#protocols) and on [entity scopes](/hub/plugins/compatibility/#scopes). 
     * Revised docs for the following plugins to include examples:
       * [CORS](/hub/kong-inc/cors/)
       * [File Log](/hub/kong-inc/file-log/)
@@ -154,8 +155,8 @@ By combining the data in the new `request_source` field with the `path` field, y
       * [OpenID Connect](/hub/kong-inc/openid-connect/)
       * [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced/)
       * [SAML](/hub/kong-inc/saml/)
-       * [StatsD](/hub/kong-inc/statsd/)
-       * [StatsD advanced](/hub/kong-inc/statsd-advanced/)
+      * [StatsD](/hub/kong-inc/statsd/)
+      * [StatsD advanced](/hub/kong-inc/statsd-advanced/)
   
 
 ### Fixes
@@ -166,7 +167,7 @@ By combining the data in the new `request_source` field with the `path` field, y
   [#9960](https://github.com/Kong/kong/pull/9960)
 * Exposed PostreSQL connection pool configuration.
   [#9603](https://github.com/Kong/kong/pull/9603)
-* **Nginx template**: Do not add the default charset to the `Content-Type` response header when upstream response doesn't contain it.
+* **Nginx template**: The default charset is no longer added to the `Content-Type` response header when the upstream response doesn't contain it.
   [#9905](https://github.com/Kong/kong/pull/9905)
 * Fixed an issue where, after a valid declarative configuration was loaded,
   the configuration hash was incorrectly set to the value `00000000000000000000000000000000`.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -71,7 +71,6 @@ configuration property to `kong.conf` to constrain the `Kong-Debug` header for d
 * Added the new configuration parameter [`ssl_session_cache_size`](/gateway/latest/reference/configuration/#ssl_session_cache_size), 
 which lets you set the Nginx directive `ssl_session_cache`.
   This configuration parameter defaults to `10m`.
-  
   Thanks [Michael Kotten](https://github.com/michbeck100) for contributing this change.
   [#10021](https://github.com/Kong/kong/pull/10021)
 
@@ -163,7 +162,7 @@ By combining the data in the new `request_source` field with the `path` field, y
 
 #### Core 
 
-* Added back PostgreSQL `FLOOR` function when calculating `ttl`, so the returned `ttl` is always a whole integer.
+* Added back PostgreSQL `FLOOR` function when calculating `ttl`, so `ttl` is always returned as a whole integer.
   [#9960](https://github.com/Kong/kong/pull/9960)
 * Exposed PostreSQL connection pool configuration.
   [#9603](https://github.com/Kong/kong/pull/9603)

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -81,7 +81,7 @@ which lets you set the Nginx directive `ssl_session_cache`.
     * `/debug/profiling/cpu`: Instruction-based and timer-based Lua VM CPU profiling.
     * `/debug/profiling/gc-snapshot`: Lua GC heap snapshot.
 
-##### Kong Manager
+#### Kong Manager
 
 * Improved the editor for expression fields. Any fields using the expression router now have syntax highlighting, autocomplete, and route validation.
 * Improved audit logs by adding `rbac_user_name` and `request_source`. 
@@ -144,7 +144,7 @@ By combining the data in the new `request_source` field with the `path` field, y
     
     
 * **Improved Plugin Documentation**
-    * Updated the plugin compatibility information for more clarity on [supported network protocols] (/hub/plugins/compatibility/#protocols) and on [entity scopes](/hub/plugins/compatibility/#scopes) 
+    * Updated the plugin compatibility information for more clarity on [supported network protocols](/hub/plugins/compatibility/#protocols) and on [entity scopes](/hub/plugins/compatibility/#scopes) 
     * Revised docs for the following plugins to include examples:
       * [CORS](/hub/kong-inc/cors/)
       * [File Log](/hub/kong-inc/file-log/)

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -79,7 +79,7 @@ which lets you set the Nginx directive `ssl_session_cache`.
 * Added two debugging endpoints to the Admin API:
     * [`/debug/profiling/cpu`](/gateway/latest/admin-api/#get-state-of-the-cpu-profiling): Instruction-based and timer-based Lua VM CPU profiling.
     * [`/debug/profiling/gc-snapshot`](/gateway/latest/admin-api/#get-the-state-of-gc-snapshot): Lua GC heap snapshot.
-
+* The OpenID Connect, Key Authentication - Encrypted, and JWT Signer plugins are now [FIPS 140-2 compliant](/gateway/latest/kong-enterprise/fips-support/). If you are migrating from {{site.base_gateway}} 3.1 to 3.2 in FIPS mode and are using the key-auth-enc plugin, you should send [PATCH or POST requests](/hub/kong-inc/key-auth-enc/#create-a-key) to all existing key-auth-enc credentials to re-hash them in SHA256.
 #### Kong Manager
 
 * Improved the editor for expression fields. Any fields using the expression router now have syntax highlighting, autocomplete, and route validation.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -141,6 +141,22 @@ By combining the data in the new `request_source` field with the `path` field, y
 * [**Canary**](/hub/kong-inc/canary/) (`canary`)
     * Added a default value for the `start` field in the canary plugin. 
     If not set, the start time defaults to the current timestamp.
+    
+    
+* **Improved Plugin Documentation**
+    * Updated the plugin compatibility information for more clarity on [supported network protocols] (/hub/plugins/compatibility/#protocols) and on [entity scopes](/hub/plugins/compatibility/#scopes) 
+    * Revised docs for top plugins to include examples:
+      * [CORS](/hub/kong-inc/cors/)
+      * [File Log](/hub/kong-inc/file-log/)
+      * [HTTP Log](/hub/kong-inc/http-log/)
+      * [JWT Signer](/hub/kong-inc/jwt-signer/)
+      * [Key Auth](/hub/kong-inc/key-auth/)
+      * [OpenID Connect](/hub/kong-inc/openid-connect/)
+      * [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced/)
+      * [SAML](/hub/kong-inc/saml/)
+       * [StatsD](/hub/kong-inc/statsd/)
+       * [StatsD advanced](/hub/kong-inc/statsd-advanced/)
+  
 
 ### Fixes
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -40,7 +40,7 @@ configuration property to `kong.conf` to constrain the `Kong-Debug` header for d
     * The JWT plugin now denies any request that has different tokens in the JWT token search locations.
       [#9946](https://github.com/Kong/kong/pull/9946)
 
-* [**Session plugin**](/hub/kong-inc/session/) (`session`)
+* [**Session**](/hub/kong-inc/session/) (`session`), [**OpenID Connect**](/hub/kong-inc/openid-connect/) (`openid-connect`), and [**SAML**](/hub/kong-inc/saml) (`saml`) plugins
     * For sessions to work as expected in this version, all nodes must run Kong Gateway 3.2.x or later.
     For that reason, we recommend that during upgrades, proxy nodes with mixed versions run for
     as little time as possible. During that time, the invalid sessions could cause failures and partial downtime.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -155,7 +155,6 @@ By combining the data in the new `request_source` field with the `path` field, y
       * [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced/)
       * [SAML](/hub/kong-inc/saml/)
       * [StatsD](/hub/kong-inc/statsd/)
-      * [StatsD advanced](/hub/kong-inc/statsd-advanced/)
   
 
 ### Fixes

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -52,7 +52,7 @@ configuration property to `kong.conf` to constrain the `Kong-Debug` header for d
 
 #### Core
 
-* When `router_flavor` is `traditional_compatible`, Kong Gateway verifies routes created 
+* When `router_flavor` is set to`traditional_compatible`, Kong Gateway verifies routes created 
   using the expression router instead of the traditional router to ensure created routes
   are compatible.
   [#9987](https://github.com/Kong/kong/pull/9987)
@@ -98,7 +98,7 @@ By combining the data in the new `request_source` field with the `path` field, y
   [#10077](https://github.com/Kong/kong/pull/10077)
 
 * [**New plugin: Datadog Tracing**](/hub/kong-inc/datadog-tracing) (`datadog-tracing`)
-  * The Datadog Tracing plugin integrates Kong Gateway with the Datadog Application Performance Monitoring (APM) platform so that proxy requests handled by Kong Gateway can be identified and analyzed in Datadog.
+  * The Datadog Tracing plugin integrates Kong Gateway with the Datadog Application Performance Monitoring (APM) platform so that proxy requests handled by Kong Gateway can be identified and analyzed by Datadog.
 
 * [**Zipkin**](/hub/kong-inc/zipkin/) (`zipkin`)
   * Added support for setting the durations of Kong phases as span tags
@@ -145,7 +145,7 @@ By combining the data in the new `request_source` field with the `path` field, y
     
 * **Improved Plugin Documentation**
     * Updated the plugin compatibility information for more clarity on [supported network protocols] (/hub/plugins/compatibility/#protocols) and on [entity scopes](/hub/plugins/compatibility/#scopes) 
-    * Revised docs for top plugins to include examples:
+    * Revised docs for the following plugins to include examples:
       * [CORS](/hub/kong-inc/cors/)
       * [File Log](/hub/kong-inc/file-log/)
       * [HTTP Log](/hub/kong-inc/http-log/)

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -9,7 +9,13 @@ no_version: true
 ## 3.2.0.0
 **Release Date** 2023/02/15
 
-### Breaking changes and deprecations
+### Deprecations
+
+* Deprecated Alpine Linux images and packages. 
+    
+    Kong is announcing our intent to remove support for Alpine images and packages later this year. These images and packages are available in 3.2 and will continue to be available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
+
+### Breaking changes
 
 * The default PostgreSQL SSL version has been bumped to TLS 1.2. In `kong.conf`:
    
@@ -28,9 +34,6 @@ no_version: true
 configuration property to `kong.conf` to constrain the `Kong-Debug` header for debugging. This option defaults to `off`.
 
     If you were previously relying on the `Kong-Debug` header to provide debugging information, set `allow_debug_header: on` to continue doing so.
-* Deprecated Alpine Linux images and packages. 
-    
-    Alpine images and packages will continue to be available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
 
 * [**JWT plugin**](/hub/kong-inc/jwt/) (`jwt`)
     


### PR DESCRIPTION
### Description

Changelog for Gateway 3.2 release.
Compiled from OSS CHANGELOG.md, Enterprise CHANGELOG.md, and Enterprise changelog wiki page.

When going through changelog entries, found and added/fixed the following:
* New default value for Canary plugin's `start` parameter
* Consumer, route, and service scope support for OpenTelemetry plugin
* Missing `if_version` tags in load balancing doc for new `latency` algorithm.

We are also missing docs for two other things: `instance_name` in plugins and new audit log entries. 
Both of these items are logged in tickets and tagged as Gateway 3.2 fast-follow.

https://konghq.atlassian.net/browse/DOCU-2920

### Testing instructions

Netlify link: https://deploy-preview-5159--kongdocs.netlify.app/gateway/changelog/

❗Reviewers:
* Please make sure that any features you worked on are covered in this changelog.
* Check links manually, since the link checker isn't working.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

