### PR TITLE
[DOCU-2983] Plugin instance name + spacing fixes

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -24,45 +24,71 @@ breadcrumbs:
   <tbody>
     <tr>
       <td><code>name</code>
-        <br><i>required</i>
-        <br><br><strong>Type: </strong>string</td>
+        <p><i>required</i></p>
+        <p><strong>Type: </strong>string</p>
+      </td>
       <td>The name of the plugin, in this case <code>{{ page.params.name }}</code>.</td>
     </tr>
+
+    {% if_plugin_version gte:3.2.x %}
+    <tr>
+      <td><code>instance_name</code>
+        <p><i>optional</i></p>
+        <p><strong>Type: </strong>string</p>
+      </td>
+      <td>
+        <p>An optional custom name to identify an instance of the plugin, for example <code>{{ page.params.name }}_my-service</code>.</p> 
+        <p>Useful when running the same plugin in multiple contexts, for example, on multiple services.</p>
+      </td>
+    </tr>
+    {% endif_plugin_version %}
 
     {% if page.params.service_id %}
       <tr>
         <td><code>service.name</code> or <code>service.id</code>
-        {% if page.params.global == false %}
-        <br><i>required</i>
-        {% endif %}
-          <br><br><strong>Type: </strong>string</td>
-        <td>The name or ID of the service the plugin targets.
-          <br><br>Set one of these parameters if adding the plugin to a service through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          <br><br> Not required if using <code>/services/SERVICE_NAME|SERVICE_ID/plugins</code>. </td>
+          {% if page.params.global == false %}
+          <p><i>required</i></p>
+          {% else %}
+          <p><i>optional</i></p>
+          {% endif %}
+          <p><strong>Type: </strong>string</p>
+        </td>
+        <td>
+          <p>The name or ID of the service the plugin targets.</p>
+          <p>Set one of these parameters if adding the plugin to a service through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a></p>
+          <p> Not required if using <code>/services/SERVICE_NAME|SERVICE_ID/plugins</code>.</p> </td>
       </tr>
     {% endif %}
     {% if page.params.route_id %}
       <tr>
         <td><code>route.name</code> or <code>route.id</code>
-          <br><br><strong>Type: </strong>string</td>
-        <td>The name or ID of the route the plugin targets.
-          <br><br>Set one of these parameters if adding the plugin to a route through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          <br><br>Not required if using <code>/routes/ROUTE_NAME|ROUTE_ID/plugins</code>. </td>
+          <p><i>optional</i></p>
+          <p><strong>Type: </strong>string</p>
+        </td>
+        <td>
+          <p>The name or ID of the route the plugin targets.</p>
+          <p>Set one of these parameters if adding the plugin to a route through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a></p>
+          <p>Not required if using <code>/routes/ROUTE_NAME|ROUTE_ID/plugins</code>.</p></td>
       </tr>
     {% endif %}
     {% if page.params.consumer_id %}
       <tr>
         <td><code>consumer.name</code> or <code>consumer.id</code>
-          <br><br><strong>Type: </strong>string</td>
-        <td>The name or ID of the consumer the plugin targets.
-          <br><br>Set one of these parameters if adding the plugin to a consumer through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          <br><br>Not required if using <code>/consumers/CONSUMER_NAME|CONSUMER_ID/plugins</code>.</td>
+          <p><i>optional</i></p>
+          <p><br><strong>Type: </strong>string</p>
+        </td>
+        <td>
+          <p>The name or ID of the consumer the plugin targets.</p>
+          <p>Set one of these parameters if adding the plugin to a consumer through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a></p>
+          <p>Not required if using <code>/consumers/CONSUMER_NAME|CONSUMER_ID/plugins</code>.</p></td>
       </tr>
     {% endif %}
       <tr>
         <td><code>enabled</code>
-          <br><br><strong>Type: </strong>boolean
-          <br><br><strong>Default value: </strong><code>true</code></td>
+          <p><i>optional</i></p>
+          <p><strong>Type: </strong>boolean</p>
+          <p><strong>Default value: </strong><code>true</code></p>
+        </td>
         <td>Whether this plugin will be applied.</td>
       </tr>
     {% if page.params.api_id %}
@@ -81,11 +107,11 @@ breadcrumbs:
       {% else %}
       <tr>
         <td><code>config.{{ field.name }}</code>
-          {% if field.required == true %}<br><em>required</em>{% endif %}
-          {% if field.required == false %}<br><em>optional</em>{% endif %}
-          {% if field.required == "semi" %}<br><em>semi-optional</em>{% endif %}
-          {% if field.datatype != nil %}<br><br><strong>Type: </strong>{{ field.datatype | markdownify | strip_html }}{% endif %}
-          {% if field.default != nil %}<br><br><strong>Default value: </strong><code>{{ field.default | markdownify | strip_html }}</code>{% endif %}
+          {% if field.required == true %}<p><em>required</em></p>{% endif %}
+          {% if field.required == false %}<p><em>optional</em></p>{% endif %}
+          {% if field.required == "semi" %}<p><em>semi-optional</em></p>{% endif %}
+          {% if field.datatype != nil %}<p><strong>Type: </strong>{{ field.datatype | markdownify | strip_html }}</p>{% endif %}
+          {% if field.default != nil %}<p><strong>Default value: </strong><code>{{ field.default | markdownify | strip_html }}</code></p>{% endif %}
         </td>
         <td>
           <br>{{ field.description | markdownify }}

--- a/app/hub/plugins/compatibility.md
+++ b/app/hub/plugins/compatibility.md
@@ -217,7 +217,7 @@ simply tools to help you deploy {{ site.base_gateway }} in various environments.
 
 ## Scopes
 
-Plugins can be scoped or global (unscoped):
+Plugins can be scoped or global (without scope):
 * Scoped plugin: Plugin applied to a specific service, route, or consumer.
 * Global plugin: Plugin applies either to your entire environment, or if running {{site.ee_product_name}}, your entire workspace.
 

--- a/app/hub/plugins/compatibility.md
+++ b/app/hub/plugins/compatibility.md
@@ -258,7 +258,11 @@ See the following table for plugins and their compatible scopes:
         {% endif %}
       </td>
       <td style="text-align: center"> 
+        {% if extn.params.global == false %}
+        <i class="fa fa-times"></i>
+        {% else %}
         <i class="fa fa-check"></i>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
### Description

Added plugin `instance_name` to the plugin table. Every plugin has this field now.
Validated against a 3.2 KM instance, all plugins do indeed have this field.

Also fixed some format issues with the layout:
* Fixed plugin table spacing. We were using `br` tags instead of `p` tags for some reason.
* Added `optional` tags for optional parameters. These are already set for anything in `config.` but were missing from the `service_*`, `route_*`, `consumer_*`, and `enabled` parameters.
* Added a `false` option for global scope support. There is one plugin that doesn't support being applied globally, which I discovered when editing the layout.

https://konghq.atlassian.net/browse/DOCU-2983
### Testing instructions

Netlify links:

* Check any plugin for the `instance_name` param, for example: https://deploy-preview-5164--kongdocs.netlify.app/hub/kong-inc/basic-auth/. This should only appear in 3.2.x.
* In the scopes table, the Application Registration plugin should have an X in the global column: https://deploy-preview-5164--kongdocs.netlify.app/hub/plugins/compatibility/#scopes

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

