### PR TITLE
docs(rate-limiting): remove wrongly placed information

### DIFF
--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -69,7 +69,7 @@ params:
         - `consumer`
         - `credential`
         - `ip`
-        - `service` (The `service.id` or `service.name` configuration must be provided if you're adding the plugin to a service through the top-level `/plugins` endpoint.)
+        - `service`
         - `header` (The `header_name` configuration must be provided.)
         - `path` (The `path` configuration must be provided.)
 


### PR DESCRIPTION
### Description

Remove an information that, put that way, is redundant and confusing. The values `service.id` and `service.name` are not related with the configuration of the parameter `limit_by`, which can be set even when the plugin is configured globally.

### Checklist 

- [X] Review label added
- [X] PR pointed to correct branch
