### PR TITLE
[DOCU-2982] Audit log updates for 3.2

### DIFF
--- a/app/_data/docs_nav_gateway_3.0.x.yml
+++ b/app/_data/docs_nav_gateway_3.0.x.yml
@@ -582,6 +582,8 @@ items:
         url: /admin-api/event-hooks/reference
       - text: Keyring and Data Encryption
         url: /admin-api/db-encryption
+      - text: Audit Logs
+        url: /admin-api/audit-logs
   - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
     items:

--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -593,6 +593,8 @@ items:
         url: /admin-api/event-hooks/reference
       - text: Keyring and Data Encryption
         url: /admin-api/db-encryption
+      - text: Audit Logs
+        url: /admin-api/audit-logs
   - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
     items:

--- a/app/_data/docs_nav_gateway_3.2.x.yml
+++ b/app/_data/docs_nav_gateway_3.2.x.yml
@@ -611,6 +611,8 @@ items:
         url: /admin-api/event-hooks/reference
       - text: Keyring and Data Encryption
         url: /admin-api/db-encryption
+      - text: Audit Logs
+        url: /admin-api/audit-logs
   - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
     items:

--- a/app/_src/gateway/admin-api/audit-logs.md
+++ b/app/_src/gateway/admin-api/audit-logs.md
@@ -1,0 +1,104 @@
+---
+title: Audit Logs
+badge: enterprise
+---
+
+You can access request and database audit logs through the Admin API.
+
+For usage examples, see [Audit Logging in {{site.base_gateway}}](/gateway/{{page.kong_version}}/kong-enterprise/audit-log/).
+
+## List audit logs
+
+### List request audit logs
+
+**Endpoint**
+
+<div class="endpoint get">/audit/requests</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+Example response generated for checking the `/status` endpoint without RBAC enabled:
+
+{% if_version lte:3.1.x %}
+```json
+{
+    "data": [
+        {
+            "client_ip": "127.0.0.1",
+            "method": "GET",
+            "path": "/status",
+            "payload": null,
+            "rbac_user_id": null,
+            "removed_from_payload": null,
+            "request_id": "OjOcUBvt6q6XJlX3dd6BSpy1uUkTyctC",
+            "request_timestamp": 1676424547,
+            "signature": null,
+            "status": 200,
+            "ttl": 2591997,
+            "workspace": "1065b6d6-219f-4002-b3e9-334fc3eff46c"
+        }
+    ],
+    "total": 1
+}
+```
+{% endif_version %}
+
+{% if_version gte:3.2.x %}
+```json
+{
+    "data": [
+        {
+            "client_ip": "127.0.0.1",
+            "method": "GET",
+            "path": "/status",
+            "payload": null,
+            "rbac_user_id": null,
+            "rbac_user_name": null,
+            "removed_from_payload": null,
+            "request_id": "OjOcUBvt6q6XJlX3dd6BSpy1uUkTyctC",
+            "request_source": null,
+            "request_timestamp": 1676424547,
+            "signature": null,
+            "status": 200,
+            "ttl": 2591997,
+            "workspace": "1065b6d6-219f-4002-b3e9-334fc3eff46c"
+        }
+    ],
+    "total": 1
+}
+```
+{% endif_version %}
+
+### List database audit logs
+
+**Endpoint**
+
+<div class="endpoint get">/audit/objects</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+Example response for a consumer creation log entry:
+```json
+{
+    "data": [
+        {
+            "dao_name": "consumers",
+            "entity": "{\"created_at\":1542131418000,\"id\":\"16787ed7-d805-434a-9cec-5e5a3e5c9e4f\",\"username\":\"bob\",\"type\":0}",
+            "entity_key": "16787ed7-d805-434a-9cec-5e5a3e5c9e4f",
+            "expire": 1544723418009,
+            "id": "7ebabee7-2b09-445d-bc1f-2092c4ddc4be",
+            "operation": "create",
+            "request_id": "59fpTWlpUtHJ0qnAWBzQRHRDv7i5DwK2"
+        },
+  ],
+  "total": 1
+}
+```

--- a/app/_src/gateway/kong-enterprise/audit-log.md
+++ b/app/_src/gateway/kong-enterprise/audit-log.md
@@ -269,8 +269,7 @@ The `method` and `path` fields correspond either to a login or logout event:
 
 You may want to ignore audit log generation for certain Admin API
 requests, such as requests to the `/status` endpoint for
-health checking, or to ignore requests for a given path prefix 
-(for example, a given workspace). 
+health checking, or to ignore requests to a specific path prefix, for example, a given workspace.
 
 Use the `audit_log_ignore_methods` and
 `audit_log_ignore_paths` configuration options:

--- a/app/_src/gateway/kong-enterprise/audit-log.md
+++ b/app/_src/gateway/kong-enterprise/audit-log.md
@@ -1,9 +1,9 @@
 ---
-title: Admin API Audit Log
+title: Audit Logging in Kong Gateway
 badge: enterprise
 ---
 
-{{site.base_gateway}} provides a granular logging facility on its Admin API. This
+{{site.base_gateway}} provides a granular logging facility through its Admin API. This
 allows cluster administrators to keep detailed track of changes made to the
 cluster configuration throughout its lifetime, aiding in compliance efforts and
 providing valuable data points during forensic investigations. Generated audit
@@ -11,9 +11,8 @@ log trails are [Workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/r
 providing Kong operators a deep and wide look into changes happening within
 the cluster.
 
-## Getting Started
-
-Audit logging is disabled by default. It is configured via the Kong configuration (e.g. `kong.conf`):
+## Enable audit logging
+Audit logging is disabled by default. Configure it through {{site.base_gateway}} configuration in `kong.conf`:
 
 ```bash
 audit_log = on # audit logging is enabled
@@ -30,24 +29,31 @@ export KONG_AUDIT_LOG=off
 As with other Kong configurations, changes take effect on `kong reload` or `kong
 restart`.
 
-## Request Audits
+## Request audits
 
-### Generating and Viewing Audit Logs
+### Generating and viewing audit logs
 
 Audit logging provides granular details of each HTTP request that was handled by
-Kong's Admin API. Audit log data is written to Kong's back database. As a result,
+Kong's Admin API. Audit log data is written to Kong's database. As a result,
 request audit logs are available via the Admin API (in addition to via direct
-database query). For example, consider a query to the Admin API to the `/status`
+database query). 
+
+For example, consider a query to the Admin API to the `/status`
 endpoint:
 
+```sh
+http :8001/status
 ```
-vagrant@ubuntu-xenial:/kong$ http :8001/status
+
+You get the following response:
+
+```sh
 HTTP/1.1 200 OK
 Access-Control-Allow-Origin: *
 Connection: keep-alive
 Content-Type: application/json; charset=utf-8
 Date: Tue, 13 Nov 2018 17:32:47 GMT
-Server: kong/0.34-enterprise-edition
+Server: kong/ kong/{{page.versions.ee}}-enterprise-edition
 Transfer-Encoding: chunked
 X-Kong-Admin-Request-ID: ZuUfPfnxNn7D2OTU6Xi4zCnQkavzMUNM
 
@@ -55,6 +61,16 @@ X-Kong-Admin-Request-ID: ZuUfPfnxNn7D2OTU6Xi4zCnQkavzMUNM
     "database": {
         "reachable": true
     },
+    
+    "memory": {
+        "lua_shared_dicts": {
+            ...
+        },
+         "workers_lua_vms": [
+            ...
+         ]
+    }
+
     "server": {
         "connections_accepted": 1,
         "connections_active": 1,
@@ -68,16 +84,20 @@ X-Kong-Admin-Request-ID: ZuUfPfnxNn7D2OTU6Xi4zCnQkavzMUNM
 ```
 
 The above interaction with the Admin API generates a correlating entry in
-the audit log table. Querying the audit log via Admin API returns the details of the interaction above:
+the audit log table. Querying the audit log via the Admin API returns the details of the previous interaction:
 
-```
+```sh
 http :8001/audit/requests
+```
+
+{% if_version lte:3.1.x %}
+```sh
 HTTP/1.1 200 OK
 Access-Control-Allow-Origin: *
 Connection: keep-alive
 Content-Type: application/json; charset=utf-8
 Date: Tue, 13 Nov 2018 17:35:24 GMT
-Server: kong/0.34-enterprise-edition
+Server: kong/{{page.versions.ee}}-enterprise-edition
 Transfer-Encoding: chunked
 X-Kong-Admin-Request-ID: VXgMG1Y3rZKbjrzVYlSdLNPw8asVwhET
 
@@ -88,17 +108,55 @@ X-Kong-Admin-Request-ID: VXgMG1Y3rZKbjrzVYlSdLNPw8asVwhET
             "method": "GET",
             "path": "/status",
             "payload": null,
-            "request_id": "ZuUfPfnxNn7D2OTU6Xi4zCnQkavzMUNM",
-            "request_timestamp": 1581617463,
+            "rbac_user_id": null,
+            "removed_from_payload": null,
+            "request_id": "OjOcUBvt6q6XJlX3dd6BSpy1uUkTyctC",
+            "request_timestamp": 1676424547,
             "signature": null,
             "status": 200,
-            "ttl": 2591995,
-            "workspace": "0da4afe7-44ad-4e81-a953-5d2923ce68ae"
+            "ttl": 2591997,
+            "workspace": "1065b6d6-219f-4002-b3e9-334fc3eff46c"
         }
     ],
     "total": 1
 }
 ```
+{% endif_version %}
+
+{% if_version gte:3.2.x %}
+```sh
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Connection: keep-alive
+Content-Type: application/json; charset=utf-8
+Date: Tue, 13 Nov 2018 17:35:24 GMT
+Server: kong/{{page.versions.ee}}-enterprise-edition
+Transfer-Encoding: chunked
+X-Kong-Admin-Request-ID: VXgMG1Y3rZKbjrzVYlSdLNPw8asVwhET
+
+{
+    "data": [
+        {
+            "client_ip": "127.0.0.1",
+            "method": "GET",
+            "path": "/status",
+            "payload": null,
+            "rbac_user_id": null,
+            "rbac_user_name": null,
+            "removed_from_payload": null,
+            "request_id": "OjOcUBvt6q6XJlX3dd6BSpy1uUkTyctC",
+            "request_source": null,
+            "request_timestamp": 1676424547,
+            "signature": null,
+            "status": 200,
+            "ttl": 2591997,
+            "workspace": "1065b6d6-219f-4002-b3e9-334fc3eff46c"
+        }
+    ],
+    "total": 1
+}
+```
+{% endif_version %}
 
 Note the value of the `request_id` field. This is tied to the
 `X-Kong-Admin-Request-ID` response header received in the first transaction.
@@ -111,11 +169,13 @@ solutions, or other remote services for duplication and inspection.
 
 ### Workspaces and RBAC
 
-Audit log entries are written with an awareness of the requested Workspace, and
+Audit log entries are written with an awareness of the requested workspace, and
 the RBAC user (if present). When RBAC is enforced, the RBAC user's UUID will be
-written to the `rbac_user_id` field in the audit log entry:
+written to the `rbac_user_id` field in the audit log entry, and the username 
+will be written to the `rbac_user_name` field:
 
-```
+{% if_version lte:3.1.x %}
+```json
 {
     "data": [
         {
@@ -135,16 +195,85 @@ written to the `rbac_user_id` field in the audit log entry:
     "total": 1
 }
 ```
+{% endif_version %}
 
-Note also the presence of the `workspace` field. This is the UUID of the Workspace with which the request was associated.
+{% if_version gte:3.2.x %}
+```json
+{
+    "data": [
+        {
+            "client_ip": "127.0.0.1",
+            "method": "GET",
+            "path": "/status",
+            "payload": null,
+            "rbac_user_id": "2e959b45-0053-41cc-9c2c-5458d0964331",
+            "rbac_user_name": "admin",
+            "request_id": "QUtUa3RMbRLxomqcL68ilOjjl68h56xr",
+            "request_source": "kong-manager",
+            "request_timestamp": 1581617463,
+            "signature": null,
+            "status": 200,
+            "ttl": 2591995,
+            "workspace": "0da4afe7-44ad-4e81-a953-5d2923ce68ae"
+        }
+    ],
+    "total": 1
+}
+```
+{% endif_version %}
 
-### Limiting Audit Log Generation
+Note the presence of the `workspace` field. This is the UUID of the workspace with which the request is associated.
 
-It may be desirable to ignore audit log generation for certain Admin API
-requests such as innocuous requests to the `/status` endpoint for
-health checking or to ignore requests for a given path prefix (e.g. a given
-Workspace). To this end, the `audit_log_ignore_methods` and
-`audit_log_ignore_paths` configuration options are presented:
+{% if_version gte:3.2.x %}
+
+### Kong Manager authentication
+
+You can track login and logout events for the Kong Manager through 
+the `path`, `method`, and `request_source` audit log fields.
+
+For example, review the following audit log entry:
+
+
+```json
+{
+    "data": [
+        {
+            "client_ip": "127.0.0.1",
+            "method": "GET",
+            "path": "/auth",
+            "payload": null,
+            "rbac_user_id": "2e959b45-0053-41cc-9c2c-5458d0964331",
+            "rbac_user_name": "admin",
+            "request_id": "QUtUa3RMbRLxomqcL68ilOjjl68h56xr",
+            "request_source": "kong-manager",
+            "request_timestamp": 1581617463,
+            "signature": null,
+            "status": 200,
+            "ttl": 2591995,
+            "workspace": "0da4afe7-44ad-4e81-a953-5d2923ce68ae"
+        }
+    ],
+    "total": 1
+}
+```
+
+The `request_source` field tells you that the action occurred in Kong Manager.
+
+The `method` and `path` fields correspond either to a login or logout event:
+* Login event: `"method": "GET"`, `"path": "/auth"`
+* Logout event: `"method": "DELETE"`, `"path": "/auth?session_logout=true"`
+
+{% endif_version %}
+
+### Limiting audit log generation
+
+You may want to ignore audit log generation for certain Admin API
+requests, such as requests to the `/status` endpoint for
+health checking, or to ignore requests for a given path prefix 
+(for example, a given workspace). 
+
+Use the `audit_log_ignore_methods` and
+`audit_log_ignore_paths` configuration options:
 
 ```bash
 audit_log_ignore_methods = GET,OPTIONS
@@ -155,7 +284,8 @@ audit_log_ignore_paths = /foo,/status,^/services,/routes$,/one/.+/two,/upstreams
 
 The values of `audit_log_ignore_paths` are matched via a Perl-compatible regular expression.
 
-For example, when `audit_log_ignore_paths = /foo,/status,^/services,/routes$,/one/.+/two,/upstreams/`, the following request paths do not generate an audit-log entry in the database:
+For example, when `audit_log_ignore_paths = /foo,/status,^/services,/routes$,/one/.+/two,/upstreams/`, 
+the following request paths do not generate an audit log entry in the database:
 
 - `/status`
 - `/status/`
@@ -179,34 +309,27 @@ The following request paths generate an audit log entry in the database:
 - `/routes/`
 - `/upstreams`
 
-### Audit Log Retention
+## Database audits
 
-Request audit records are kept in the database for a duration defined by the
-`audit_log_record_ttl` [Kong configuration property](/gateway/{{page.kong_version}}/reference/configuration/#audit_log_record_ttl).
-Records in the database older than `audit_log_record_ttl` seconds are automatically
-purged. In Cassandra databases, record deletion is handled automatically via the
-Cassandra TTL mechanism. In Postgres databases, records are purged via the stored
-procedure that is executed on insert into the record database. Thus, request
-audit records may exist in the database longer than the configured TTL, if no new
-records are inserted to the audit table following the expiration timestamp.
+### Generating and viewing audit logs
 
-## Database Audits
-
-### Generating and Viewing Audit Logs
-
-In addition to Admin API request data, Kong will generate granular audit log
+In addition to Admin API request data, Kong can generate granular audit log
 entries for all insertions, updates, and deletions to the cluster database.
 Database update audit logs are also associated with Admin API request unique
-IDs. Consider the following request to create a Consumer:
+IDs. Consider the following request to create a consumer:
 
-```
+```sh
 http :8001/consumers username=bob
+```
+
+Response:
+```sh
 HTTP/1.1 201 Created
 Access-Control-Allow-Origin: *
 Connection: keep-alive
 Content-Type: application/json; charset=utf-8
 Date: Tue, 13 Nov 2018 17:50:18 GMT
-Server: kong/0.34-enterprise-edition
+Server: kong/{{page.versions.ee}}-enterprise-edition
 Transfer-Encoding: chunked
 X-Kong-Admin-Request-ID: 59fpTWlpUtHJ0qnAWBzQRHRDv7i5DwK2
 
@@ -223,14 +346,17 @@ As seen before, a request audit log is generated with details about the request.
 Note the presence of the `payload` field, recorded when the request body is
 present:
 
-```
+```sh
 http :8001/audit/requests
+```
+
+```sh
 HTTP/1.1 200 OK
 Access-Control-Allow-Origin: *
 Connection: keep-alive
 Content-Type: application/json; charset=utf-8
 Date: Tue, 13 Nov 2018 17:52:41 GMT
-Server: kong/0.34-dev-enterprise-edition
+Server: kong/{{page.versions.ee}}-dev-enterprise-edition
 Transfer-Encoding: chunked
 X-Kong-Admin-Request-ID: SpPaxLTkDNndzKaYiWuZl3xrxDUIiGRR
 
@@ -256,14 +382,18 @@ X-Kong-Admin-Request-ID: SpPaxLTkDNndzKaYiWuZl3xrxDUIiGRR
 Additionally, audit logs are generated to track the creation of the
 database entity:
 
-```
+```sh
 http :8001/audit/objects
+```
+
+Response:
+```sh
 HTTP/1.1 200 OK
 Access-Control-Allow-Origin: *
 Connection: keep-alive
 Content-Type: application/json; charset=utf-8
 Date: Tue, 13 Nov 2018 17:53:27 GMT
-Server: kong/0.34-dev-enterprise-edition
+Server: kong/{{page.versions.ee}}-dev-enterprise-edition
 Transfer-Encoding: chunked
 X-Kong-Admin-Request-ID: ZKra3QT0d3eJKl96jOUXYueLumo0ck8c
 
@@ -289,9 +419,9 @@ entity body itself, its database primary key, and the type of operation
 performed (`create`, `update`, or `delete`). Note also the associated
  `request_id` field.
 
-### Limiting Audit Log Generation
+### Limiting audit log generation
 
-As with request audit logs, it may be desirable to skip generation of audit logs
+As with request audit logs, you may want to skip generation of audit logs
 for certain database tables. This is configurable via the
 `audit_log_ignore_tables` Kong config option:
 
@@ -300,18 +430,23 @@ audit_log_ignore_tables = consumers
 # do not generate database audit logs for changes to the consumers table
 ```
 
-### Audit Log Retention
+## Audit log retention
 
-Database audit records are kept in the database for a duration defined by the
-`audit_log_record_ttl` [Kong configuration property](/gateway/{{page.kong_version}}/reference/configuration/#audit_log_record_ttl).
-Records in the database older than `audit_log_record_ttl` seconds are automatically
-purged. In Cassandra databases, record deletion is handled automatically via the
-Cassandra TTL mechanism. In Postgres databases, records are purged via the stored
-procedure that is executed on insert into the record database. Thus, database
-audit records may exist in the database longer than the configured TTL, if no new
-records are inserted to the audit table following the expiration timestamp.
+Audit log records are kept in the database for a duration defined by the
+[`audit_log_record_ttl`](/gateway/{{page.kong_version}}/reference/configuration/#audit_log_record_ttl)
+Kong configuration property. Records in the database older than `audit_log_record_ttl` 
+seconds are automatically purged. 
 
-## Digital Signatures
+PostgreSQL and Cassandra handle record deletion in different ways:
+* In Cassandra databases, record deletion is handled automatically via the
+Cassandra TTL mechanism. 
+* In PostgreSQL databases, records are purged via the stored
+procedure that is executed on insert into the record database. 
+
+Therefore, request audit records may exist in the database longer than the configured TTL, 
+if no new records are inserted to the audit table following the expiration timestamp.
+
+## Digital signatures
 
 To provide non-repudiation, audit logs may be signed with a private RSA key. When
 enabled, a lexically sorted representation of each audit log entry is signed by
@@ -319,179 +454,137 @@ the defined private key; the signature is stored in an additional field within
 the record itself. The public key should be stored elsewhere and can be used
 later to validate the signature of the record.
 
-### Setting Up Log Signing
+### Setting up log signing
 
-Generate a private key via the `openssl` tool:
+1. Generate a private key via the `openssl` tool:
 
-```bash
-openssl genrsa -out private.pem 2048
-```
+    ```sh
+    openssl genrsa -out private.pem 2048
+    ```
 
-Extract the public key for future audit verification:
+1. Extract the public key for future audit verification:
 
-```
-openssl rsa -in private.pem -outform PEM -pubout -out public.pem
-```
+    ```sh
+    openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+    ```
 
-Configure Kong to sign audit log records:
+1. Configure Kong to sign audit log records:
 
-```
-audit_log_signing_key = /path/to/private.pem
-```
+    ```
+    audit_log_signing_key = /path/to/private.pem
+    ```
 
-Audit log entries will now contain a field `signature`:
+1. Audit log entries will now contain the field `signature`:
 
-```
-{
-    "client_ip": "127.0.0.1",
-    "method": "GET",
-    "path": "/status",
-    "payload": null,
-    "request_id": "Ka2GeB13RkRIbMwBHw0xqe2EEfY0uZG0",
-    "request_timestamp": 1581617463,
-    "signature": "l2LWYaRIHfXglFa5ehFc2j9ijfERazxisKVtJnYa+QUz2ckcytxfOLuA4VKEWHgY7cCLdn5C7uRJzE6es5V2SoOV59NOpskkr5lTt9kzao64UEw5UNOdeZYZKwyhG9Ge7IsxTK6haW0iG3a9dHqlKlwvnHZTbFM8TUV/umg8sJ1QJ/5ivXecbyHYtD5luKAI6oEgIdZPtQexRkwxlzvfR8lzeC/dDc2slSrjWRbBxNFlgfRKhDdVzVzgu8pEucgKggu67PKLkJ+bQEkxX1+Yg3czIpJyC3t6cgoggb0UNtBq1uUpswe0wdueKh6G5Gzz6XrmOjlv7zSz4gtVyEHZgg==",
-    "status": 200,
-    "ttl": 2591995,
-    "workspace": "fd51ce6e-59c0-4b6b-b991-aa708a9ff4d2"
-}
-```
+    {% if_version lte:3.1.x %}
+    ```json
+    {
+        "client_ip": "127.0.0.1",
+        "method": "GET",
+        "path": "/status",
+        "payload": null,
+        "request_id": "Ka2GeB13RkRIbMwBHw0xqe2EEfY0uZG0",
+        "request_timestamp": 1581617463,
+        "signature": "l2LWYaRIHfXglFa5ehFc2j9ijfERazxisKVtJnYa+QUz2ckcytxfOLuA4VKEWHgY7cCLdn5C7uRJzE6es5V2SoOV59NOpskkr5lTt9kzao64UEw5UNOdeZYZKwyhG9Ge7IsxTK6haW0iG3a9dHqlKlwvnHZTbFM8TUV/umg8sJ1QJ/5ivXecbyHYtD5luKAI6oEgIdZPtQexRkwxlzvfR8lzeC/dDc2slSrjWRbBxNFlgfRKhDdVzVzgu8pEucgKggu67PKLkJ+bQEkxX1+Yg3czIpJyC3t6cgoggb0UNtBq1uUpswe0wdueKh6G5Gzz6XrmOjlv7zSz4gtVyEHZgg==",
+        "status": 200,
+        "ttl": 2591995,
+        "workspace": "fd51ce6e-59c0-4b6b-b991-aa708a9ff4d2"
+    }
+    ```
+    {% endif_version %}
 
-### Validating Signatures
+    {% if_version gte:3.2.x %}
+    ```json
+    {
+        "client_ip": "127.0.0.1",
+        "method": "GET",
+        "path": "/status",
+        "payload": null,
+        "rbac_user_id": "2e959b45-0053-41cc-9c2c-5458d0964331",
+        "rbac_user_name": null,
+        "request_id": "Ka2GeB13RkRIbMwBHw0xqe2EEfY0uZG0",
+        "request_source": null,
+        "request_timestamp": 1581617463,
+        "signature": "l2LWYaRIHfXglFa5ehFc2j9ijfERazxisKVtJnYa+QUz2ckcytxfOLuA4VKEWHgY7cCLdn5C7uRJzE6es5V2SoOV59NOpskkr5lTt9kzao64UEw5UNOdeZYZKwyhG9Ge7IsxTK6haW0iG3a9dHqlKlwvnHZTbFM8TUV/umg8sJ1QJ/5ivXecbyHYtD5luKAI6oEgIdZPtQexRkwxlzvfR8lzeC/dDc2slSrjWRbBxNFlgfRKhDdVzVzgu8pEucgKggu67PKLkJ+bQEkxX1+Yg3czIpJyC3t6cgoggb0UNtBq1uUpswe0wdueKh6G5Gzz6XrmOjlv7zSz4gtVyEHZgg==",
+        "status": 200,
+        "ttl": 2591995,
+        "workspace": "fd51ce6e-59c0-4b6b-b991-aa708a9ff4d2"
+    }
+    ```
+    {% endif_version %}
+
+### Validating signatures
 
 To verify record signatures, use the `openssl` utility, or other cryptographic
 tools that are capable of validating RSA digital signatures.
 
 Signatures are generated using a 256-bit SHA digest. The following example
-demonstrates how to verify the audit log record shown above. First, store the
+demonstrates how to verify the audit log record shown above. 
+
+1. First, store the
 record signature on disk after stripping the Base64
 encoding:
 
-```bash
-cat <<EOF | base64 -d > record_signature
-> l2LWYaRIHfXglFa5ehFc2j9ijfERazxisKVtJnYa+QUz2ckcytxfOLuA4VKEWHgY7cCLdn5C7uRJzE6es5V2SoOV59NOpskkr5lTt9kzao64UEw5UNOdeZYZKwyhG9Ge7IsxTK6haW0iG3a9dHqlKlwvnHZTbFM8TUV/umg8sJ1QJ/5ivXecbyHYtD5luKAI6oEgIdZPtQexRkwxlzvfR8lzeC/dDc2slSrjWRbBxNFlgfRKhDdVzVzgu8pEucgKggu67PKLkJ+bQEkxX1+Yg3czIpJyC3t6cgoggb0UNtBq1uUpswe0wdueKh6G5Gzz6XrmOjlv7zSz4gtVyEHZgg==
-> EOF
-```
+    ```bash
+    cat <<EOF | base64 -d > record_signature
+    > l2LWYaRIHfXglFa5ehFc2j9ijfERazxisKVtJnYa+QUz2ckcytxfOLuA4VKEWHgY7cCLdn5C7uRJzE6es5V2SoOV59NOpskkr5lTt9kzao64UEw5UNOdeZYZKwyhG9Ge7IsxTK6haW0iG3a9dHqlKlwvnHZTbFM8TUV/umg8sJ1QJ/5ivXecbyHYtD5luKAI6oEgIdZPtQexRkwxlzvfR8lzeC/dDc2slSrjWRbBxNFlgfRKhDdVzVzgu8pEucgKggu67PKLkJ+bQEkxX1+Yg3czIpJyC3t6cgoggb0UNtBq1uUpswe0wdueKh6G5Gzz6XrmOjlv7zSz4gtVyEHZgg==
+    > EOF
+    ```
 
-Next, the audit record must be transformed into its canonical format used for
+1. Next, the audit record must be transformed into its canonical format used for
 signature generation. This transformation requires serializing the record into
 a string format that can be verified. The format is a lexically-sorted,
 pipe-delimited string of each audit log record part, _without_ the `signature`,
 `ttl`, or `expire` fields. The following is a canonical
 implementation written in Lua:
 
-```lua
-local cjson = require "cjson"
-local pl_sort = require "pl.tablex".sort
+    ```lua
+    local cjson = require "cjson"
+    local pl_sort = require "pl.tablex".sort
 
-local function serialize(data)
-  local p = {}
+    local function serialize(data)
+    local p = {}
 
-  data.signature = nil
-  data.expire = nil
-  data.ttl = nil
+    data.signature = nil
+    data.expire = nil
+    data.ttl = nil
 
-  for k, v in pl_sort(data) do
-    if type(v) == "table" then
-      p[#p + 1] = serialize(v)
-    elseif v ~= cjson.null then
-      p[#p + 1] = v
+    for k, v in pl_sort(data) do
+        if type(v) == "table" then
+        p[#p + 1] = serialize(v)
+        elseif v ~= cjson.null then
+        p[#p + 1] = v
+        end
     end
-  end
 
-  return p
-end
+    return p
+    end
 
-table.concat(serialize(data), "|")
-```
+    table.concat(serialize(data), "|")
+    ```
 
-For example, the canonical format of the audit record above is:
+    For example, the canonical format of the audit record above is:
 
-```
-cat canonical_record.txt
-127.0.0.1|1544724298663|GET|/status|Ka2GeB13RkRIbMwBHw0xqe2EEfY0uZG0|1542132298664|200|fd51ce6e-59c0-4b6b-b991-aa708a9ff4d2
-```
+    ```
+    cat canonical_record.txt
+    127.0.0.1|1544724298663|GET|/status|Ka2GeB13RkRIbMwBHw0xqe2EEfY0uZG0|1542132298664|200|fd51ce6e-59c0-4b6b-b991-aa708a9ff4d2
+    ```
 
-<div class="alert alert-warning">
-Ensure that the contents of the canonical record file on disk match the expected
-canonical record format exactly. The presence of any additional bytes, such as
-a trailing newline `\n`, will cause a validation failure in the next step.
-</div>
+    {:.important}
+    > Ensure that the contents of the canonical record file on disk match the expected
+    canonical record format exactly. The presence of any additional bytes, such as
+    a trailing newline `\n`, will cause a validation failure in the next step.
 
-Once these two elements are in place, the signature can be verified:
+1. Once these two elements are in place, the signature can be verified:
 
-```bash
-openssl dgst -sha256 -verify public.pem -signature record_signature canonical_record.txt
-Verified OK
-```
+    ```bash
+    openssl dgst -sha256 -verify public.pem -signature record_signature canonical_record.txt
+    Verified OK
+    ```
 
----
+## More information
 
-## Reference
-
-### API Reference
-
-#### List Request Audit Logs
-
-##### Endpoint
-
-<div class="endpoint get">/audit/requests</div>
-
-##### Response
-
-```
-HTTP 200 OK
-```
-
-```json
-{
-    "data": [
-        {
-            "client_ip": "127.0.0.1",
-            "method": "GET",
-            "path": "/status",
-            "payload": null,
-            "request_id": "ZuUfPfnxNn7D2OTU6Xi4zCnQkavzMUNM",
-            "request_timestamp": 1581617463,
-            "signature": null,
-            "status": 200,
-            "ttl": 2591995,
-            "workspace": "0da4afe7-44ad-4e81-a953-5d2923ce68ae"
-        }
-    ],
-    "total": 1
-}
-```
-
-#### List Database Audit Logs
-
-##### Endpoint
-
-<div class="endpoint get">/audit/objects</div>
-
-##### Response
-
-```
-HTTP 200 OK
-```
-
-```json
-{
-    "data": [
-        {
-            "dao_name": "consumers",
-            "entity": "{\"created_at\":1542131418000,\"id\":\"16787ed7-d805-434a-9cec-5e5a3e5c9e4f\",\"username\":\"bob\",\"type\":0}",
-            "entity_key": "16787ed7-d805-434a-9cec-5e5a3e5c9e4f",
-            "expire": 1544723418009,
-            "id": "7ebabee7-2b09-445d-bc1f-2092c4ddc4be",
-            "operation": "create",
-            "request_id": "59fpTWlpUtHJ0qnAWBzQRHRDv7i5DwK2"
-        },
-  ],
-  "total": 1
-}
-```
-
-### Configuration Reference
-
-See the [Data & Admin Audit](/gateway/{{page.kong_version}}/reference/configuration/#data--admin-audit)
+* For {{site.base_gateway}} `kong.conf` options, 
+see the [Data & Admin Audit](/gateway/{{page.kong_version}}/reference/configuration/#data--admin-audit-section)
 section of the Configuration Property Reference.
+* For the `/audit` API reference, see [Audit Logs](/gateway/{{page.kong_version}}/admin-api/audit-logs/).


### PR DESCRIPTION
### Description

Document new log entries and update audit logging doc. Tested everything in a local 3.2 Gateway instance.

* The new feature is documented in the "Kong Manager authentication" section in the "Audit Logging in Kong Gateway" doc. I also went through the code examples and added the new fields wherever relevant.
  * ❗ Reviewers - you only need to look closely at this new "Kong Manager authentication" section. Nothing else is new.

* The rest of (and majority) of this PR is quality-of-life improvements to the doc: standardization, cleanup, split the admin API reference into the Admin API doc section (I had no idea we had an `/audit` endpoint until today!).

https://konghq.atlassian.net/browse/DOCU-2982

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

