### PR TITLE
Gateway 3.2: QA edits

### DIFF
--- a/app/_src/gateway/admin-api/licenses/reference.md
+++ b/app/_src/gateway/admin-api/licenses/reference.md
@@ -232,7 +232,7 @@ HTTP 200 OK
         }
     ],
     "db_version": "postgres 9.6.19",
-    "kong_version": "2.7.0.0",
+    "kong_version": "{{page.versions.ee}}",
     "license_key": "ASDASDASDASDASDASDASDASDASD_ASDASDA",
     "rbac_users": 0,
     "services_count": 0,
@@ -261,7 +261,7 @@ HTTP 200 OK
         }
     ],
     "db_version": "postgres 9.6.19",
-    "kong_version": "2.7.0.0",
+    "kong_version": "{{page.versions.ee}}",
     "license_key": "UNLICENSED",
     "rbac_users": 0,
     "services_count": 0,

--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -74,7 +74,7 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
    Access-Control-Allow-Origin: *
    Content-Length: 11063
    X-Kong-Admin-Latency: 6
-   Server: kong/{{page.kong_version}}
+   Server: kong/{{page.versions.ce}}
    ```
 
 1. Evaluate the {{site.base_gateway}} configuration:

--- a/app/_src/gateway/licenses/examples.md
+++ b/app/_src/gateway/licenses/examples.md
@@ -158,7 +158,7 @@ http GET :8001/license/report
         }
     ],
     "db_version": "postgres 9.6.19",
-    "kong_version": "2.7.0.0",
+    "kong_version": "{{page.versions.ee}}",
     "license_key": "ASDASDASDASDASDASDASDASDASD_ASDASDA",
     "rbac_users": 0,
     "services_count": 0,
@@ -182,7 +182,7 @@ http GET :8001/license/report
         }
     ],
     "db_version": "postgres 9.6.19",
-    "kong_version": "2.7.0.0",
+    "kong_version": "{{page.versions.ee}}",
     "license_key": "UNLICENSED",
     "rbac_users": 0,
     "services_count": 0,

--- a/app/_src/gateway/licenses/report.md
+++ b/app/_src/gateway/licenses/report.md
@@ -40,7 +40,7 @@ Connection: keep-alive
 Content-Length: 814
 Content-Type: application/json; charset=utf-8
 Date: Mon, 06 Dec 2021 12:04:28 GMT
-Server: kong/2.7.0.1-enterprise-edition
+Server: kong/{{page.versions.ee}}-enterprise-edition
 Vary: Origin
 X-Kong-Admin-Request-ID: R1jmopI6fjkOLdOuPJVLEmGh4sCLMpSY
 {
@@ -68,7 +68,7 @@ X-Kong-Admin-Request-ID: R1jmopI6fjkOLdOuPJVLEmGh4sCLMpSY
     }
   ],
    "db_version": "postgres 9.6.24",
-   "kong_version": "2.7.0.1-enterprise-edition",
+   "kong_version": "{{page.versions.ee}}-enterprise-edition",
    "license_key": "KONGLICENSEKEY_NOTVALIDFORREAL_USAGE",
    "rbac_users": 0,
    "services_count": 27,

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -74,7 +74,7 @@ Connection: keep-alive
 Content-Length: 6342
 Content-Type: application/json; charset=utf-8
 Date: Wed, 27 Mar 2019 15:24:58 GMT
-Server: kong/{{page.kong_version}}
+Server: kong/{{page.versions.ce}}
 {
     "configuration:" {
        ...
@@ -82,7 +82,7 @@ Server: kong/{{page.kong_version}}
        ...
     },
     ...
-    "version": "{{page.kong_version}}"
+    "version": "{{page.versions.ce}}"
 }
 ```
 
@@ -105,7 +105,7 @@ Connection: keep-alive
 Content-Length: 23
 Content-Type: application/json; charset=utf-8
 Date: Wed, 27 Mar 2019 15:30:02 GMT
-Server: kong/2.1.0
+Server: kong/{{page.versions.ce}}
 
 {
     "data": [],

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
@@ -3,17 +3,17 @@ title: Hybrid Mode Overview
 ---
 
 Traditionally, Kong has always required a database, to store configured 
-entities such as Routes, Services, and Plugins.
-
-
-Hybrid mode also known as control plane / data plane separation (CP/DP).
+entities such as routes, services, and plugins. Hybrid mode,
+also known as control plane / data plane separation (CP/DP), removes the
+need for a database on every node.
 
 In this mode, Kong nodes in a cluster are split into two roles: control plane
 (CP), where configuration is managed and the Admin API is served from; and data
 plane (DP), which serves traffic for the proxy. Each DP node is connected to one
-of the CP nodes. Instead of accessing the database contents directly in the
-traditional deployment method, the DP nodes maintain connection with CP nodes,
-and receive the latest configuration.
+of the CP nodes, and only the CP nodes are directly connected to a database.
+
+Instead of accessing the database contents directly, the DP nodes maintain a 
+connection with CP nodes to receive the latest configuration.
 
 ![Hybrid mode topology](/assets/images/docs/ee/deployment/deployment-hybrid-2.png)
 


### PR DESCRIPTION
### Description

More QA edits, building on https://github.com/Kong/docs.konghq.com/pull/5166.

Using `{{page.version.ee}}` and `{{page.version.ce}}` instead to `{{page.kong_version}}` to use the real version name (eg 3.2.0.0) instead of the truncated one (eg 3.2.x).

Also finish the edit to the hybrid mode intro started in https://github.com/Kong/docs.konghq.com/pull/5166.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

