### PR TITLE
feat(key-auth-enc): support TTL of credentials (FTI-4066)

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/_index.md
@@ -235,11 +235,12 @@ keyauth_credentials:
 
 The fields/parameters work as follows:
 
-Field/parameter     | Description
----                 | ---
-`{USERNAME_OR_ID}` |  The `id` or `username` property of the [consumer][consumer-object] entity to associate the credentials to.
+Field/parameter      | Description
+---                  | ---
+`{USERNAME_OR_ID}`   | The `id` or `username` property of the [consumer][consumer-object] entity to associate the credentials to.
 `tags`<br>*optional* | You can optionally assign a list of tags to your `key`.
-`key`<br>*optional* | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
+`ttl`<br>*optional*  | The number of seconds the key is going to be valid. If missing or set to zero, the TTL of the key is unlimited. If present, the value must be an integer between 0 and 100000000. Currently, it is incompatible with DB-less mode or Hybrid mode.
+`key`<br>*optional*  | You can optionally set your own unique `key` to authenticate the client. If missing, the plugin will generate one.
 
 ### Make a request with the key
 


### PR DESCRIPTION
### Description

The `key-auth-enc` plugin nows support `ttl` for credentials. See [FTI-4066.](https://konghq.atlassian.net/browse/FTI-4066).

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

