### PR TITLE
oauth2_update

### DIFF
--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -188,7 +188,7 @@ params:
 In order to use the plugin, you first need to create a consumer to associate one or more credentials to. The Consumer represents a developer using the upstream service.
 
 <div class="alert alert-warning">
-    <strong>Note</strong>: This plugin requires a database in order to work effectively. It *does not* work on DB-Less mode.
+    <strong>Note</strong>: This plugin requires a database in order to work effectively. It <strong>does not</strong> work on DB-Less or hybrid mode.
 </div>
 
 ### Endpoints


### PR DESCRIPTION
Added hybrid mode alongside DB-less where the OAuth 2.0 Authentication plugin isn't compatible


### Description

What did you change and why?
DB-less mode is the only one that was listed as being incompatible. Added hybrid mode as another deployment methodology where this plugin doesn't work.

Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
Plugin compatibility [link](https://docs.konghq.com/hub/plugins/compatibility/) mentions both DB-less and hybrid under OAuth 2.0 Notes.

### Testing instructions

N/A


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.

At least one of these labels must be applied to a PR or the build will fail.
-->

