### PR TITLE
release 3.2/datadog services routes

### DIFF
--- a/app/_hub/kong-inc/datadog-tracing/_index.md
+++ b/app/_hub/kong-inc/datadog-tracing/_index.md
@@ -142,11 +142,11 @@ The top level span has the following attributes:
 - `http.scheme`: HTTP scheme (http or https)
 - `http.flavor`: HTTP version
 - `net.peer.ip`: Client IP address
-- `kong.route_id`: Id of the {{site.base_gateway}} Route matched by the request
-- `kong.route_name`: Name of the {{site.base_gateway}} Route matched by the request (if available)
-- `kong.service_id`: Id of the {{site.base_gateway}} Service matched by the request (if available)
-- `kong.service_name`: Name of the {{site.base_gateway}} Service matched by the request (if available)
-- `kong.consumer`: Id of the {{site.base_gateway}} Consumer authenticated by the request (if available)
+- `kong.route_id`: Id of the {{site.base_gateway}} route matched by the request
+- `kong.route_name`: Name of the {{site.base_gateway}} route matched by the request (if available)
+- `kong.service_id`: Id of the {{site.base_gateway}} service matched by the request (if available)
+- `kong.service_name`: Name of the {{site.base_gateway}} service matched by the request (if available)
+- `kong.consumer`: Id of the {{site.base_gateway}} consumer authenticated by the request (if available)
 
 
 ### Propagation

--- a/app/_hub/kong-inc/datadog-tracing/_index.md
+++ b/app/_hub/kong-inc/datadog-tracing/_index.md
@@ -142,6 +142,12 @@ The top level span has the following attributes:
 - `http.scheme`: HTTP scheme (http or https)
 - `http.flavor`: HTTP version
 - `net.peer.ip`: Client IP address
+- `kong.route_id`: Id of the {{site.base_gateway}} Route matched by the request
+- `kong.route_name`: Name of the {{site.base_gateway}} Route matched by the request (if available)
+- `kong.service_id`: Id of the {{site.base_gateway}} Service matched by the request (if available)
+- `kong.service_name`: Name of the {{site.base_gateway}} Service matched by the request (if available)
+- `kong.consumer`: Id of the {{site.base_gateway}} Consumer authenticated by the request (if available)
+
 
 ### Propagation
 


### PR DESCRIPTION
The datadog-tracing plugin was missing some attributes on the root span it generates. This documents those missing attributes.