### PR TITLE
Add Konnect support to the OAS plugin

### DIFF
--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -260,6 +260,7 @@
       free: No
       plus: Yes
       enterprise: Yes
+      konnect: Yes
       network_config_opts: Self-managed classic, DB-less, and hybrid
       notes: --
       url: /hub/kong-inc/oas-validation/

--- a/app/_hub/kong-inc/oas-validation/_index.md
+++ b/app/_hub/kong-inc/oas-validation/_index.md
@@ -9,7 +9,7 @@ description: |
   > In Kong Gateway versions 3.1.0.0-3.1.1.1, this plugin is not enabled by default. Upgrade to 3.1.1.2, or manually [enable the plugin](#enable-the-plugin).
   
 enterprise: true
-cloud: false
+cloud: true
 plus: false
 type: plugin
 categories:
@@ -26,7 +26,7 @@ params:
     - name: http
     - name: https
   dbless_compatible: 'yes'
-  konnect_examples: false
+  konnect_examples: true
   config:
     - name: api_spec
       required: true


### PR DESCRIPTION
### Description

What did you change and why?
   I enabled Konnect support in the OAS plugin docs, so it displays Konnect instructions as well as info that it is available in Konnect in the sidebar. 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-2947

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

