### PR TITLE
Update docs_nav_gateway_3.2.x.yml

### DIFF
--- a/app/_data/docs_nav_gateway_3.2.x.yml
+++ b/app/_data/docs_nav_gateway_3.2.x.yml
@@ -11,7 +11,7 @@ items:
         absolute_url: true
       - text: Support
         items:
-          - text: Gateway Support
+          - text: Version Support Policy
             url: /support
           - text: Third Party Dependencies
             url: /support/third-party


### PR DESCRIPTION
Updating the nav label (but not the URL) to be Version Support Policy; new LTS policy is additive to the policy, so makes sense to keep consistent.


### Description

Nav label from Gateway Support > Version Support Policy
 
Updates [DOCU-2980](https://konghq.atlassian.net/browse/DOCU-2980) deliverable for 3.2 release, along with https://github.com/Kong/docs.konghq.com/pull/5178


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



[DOCU-2980]: https://konghq.atlassian.net/browse/DOCU-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ