### PR TITLE
[DOCU-2945] Konnect + Gateway 3.2 - Datadog EE plugin

### DIFF
--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -498,6 +498,7 @@
       free: No
       plus: No
       enterprise: Yes
+      konnect: Yes
       network_config_opts: All
       notes: --
       url: /hub/kong-inc/datadog-tracing


### PR DESCRIPTION
### Description

What did you change and why?

- I added that Konnect was supported for the Datadog tracing plugin. 

 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-2945

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
❗ Reviewers: check that Datadog Tracing displays on the plugin compatibility page and that Konnect has a check for it.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

