### PR TITLE
[DOCU-2270] Remove drafts for entity sharing

### DIFF
--- a/app/konnect/org-management/teams-and-roles/index.md
+++ b/app/konnect/org-management/teams-and-roles/index.md
@@ -46,26 +46,6 @@ If two roles provide access to the same entity, the role with more access
 takes effect. For example, if you have the Service Admin and Service Deployer
 roles on the same service, the Service Admin role takes precedence.
 
-<!-- (SHARING IS NOT YET AVAILABLE)
-### Entity and role sharing
-
-An Organization Admin can share any role or entity with any user in the
-organization.
-
-Any user with the Service Admin or Runtime Group Admin role can
-share services that they have access to, with
-users with the same role or lesser.
-
-For example, if you have a Service Admin role:
-* You can share that service with any other user through the Service Hub.
-* Because you have admin access, you can choose to share the service with users that possess any other
-level of access: creator, deployer, viewer, etc.
-
-You can [share any service](/konnect/servicehub/manage-services/#share-service)
-through the Service Hub, or
-[share any runtime group](/konnect/runtime-manager/runtime-groups/manage/#share-runtime-group)
-through the Runtime Manager. -->
-
 ## Get started with access management
 
 * Manage resource access in your organization

--- a/app/konnect/servicehub/manage-services.md
+++ b/app/konnect/servicehub/manage-services.md
@@ -52,25 +52,6 @@ Edit any of the following:
 * **Service description**: Click **Edit** next to the description, make your edits, then click the checkmark to save.
 * **Labels**: Click **Edit** next to the labels, make your edits, then click **Save**.
 
-<!-- SHARING IS NOT YET AVAILABLE
-## Share a service
-
-If you have a Service Admin or Organization Admin role, you can share any
-service that you have access to.
-
-For more information, see [Manage Teams, Roles, and Users](/konnect/org-management/teams-and-roles/#entity-and-role-sharing).
-
-1. In the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.com/servicehub), select a service from the list.
-
-1. Click **Share service**.
-
-1. Select a user or team to share the service with.
-
-1. Select a role to grant to the user or team.
-
-1. Click **Share service** to save.
--->
-
 ## Delete a service
 
 Deleting a service permanently removes it and all of its service versions, implementations, routes, and plugins from the Service Hub.


### PR DESCRIPTION
### Description

During the lead up to helium, we had originally planned on an entity sharing feature. This feature was documented and ready to go on most fronts, but was rolled back. It is now being completely removed from the roadmap and codebase.

Removing draft docs, which currently exist in commented-out form in a couple of konnect topics.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

