### PR TITLE
Remove last bits of old `/apis` endpoint

### DIFF
--- a/app/_hub/kong-inc/jwt-signer/_2.2.x.md
+++ b/app/_hub/kong-inc/jwt-signer/_2.2.x.md
@@ -27,7 +27,6 @@ kong_version_compatibility:
 
 params:
   name: jwt-signer
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: false

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -290,7 +290,7 @@ Response:
       "credential_id": "2c74324f-fa2d-434b-b6de-bd138652158f",
       "scope": "email",
       "id": "610740e5-700a-45f0-889a-5c7f0422c48d",
-      "api_id": "898dfc5f-20f9-4315-a028-2ecb0193f834",
+      "service_id": "898dfc5f-20f9-4315-a028-2ecb0193f834",
       "token_type": "bearer"
     },
     {
@@ -300,14 +300,14 @@ Response:
       "credential_id": "2c74324f-fa2d-434b-b6de-bd138652158f",
       "scope": "email",
       "id": "edff2fc7-1634-4fb5-b714-de9435531e10",
-      "api_id": "898dfc5f-20f9-4315-a028-2ecb0193f834",
+      "service_id": "898dfc5f-20f9-4315-a028-2ecb0193f834",
       "token_type": "bearer"
     }
   ]
 }
 ```
 
-`credential_id` is the ID of the OAuth application at `kong:8001/consumers/{consumer_id}/oauth2` and `api_id` or `service_id` is the API or service that the token is valid for.
+`credential_id` is the ID of the OAuth application at `kong:8001/consumers/{consumer_id}/oauth2` and `service_id` is the API or service that the token is valid for.
 
 Note that `expires_in` is static and does not decrement based on elapsed time: you must add it to `created_at` to calculate when the token will expire.
 

--- a/app/_hub/kong-inc/statsd-advanced/_1.3-x.md
+++ b/app/_hub/kong-inc/statsd-advanced/_1.3-x.md
@@ -31,7 +31,6 @@ kong_version_compatibility:
 
 params:
   name: statsd-advanced
-  api_id: true
   service_id: true
   route_id: true
   consumer_id: true

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -253,7 +253,6 @@ HTTP 200 OK
 {
   "counts": {
     "acls": 1,
-    "apis": 1,
     "basicauth_credentials": 1,
     "consumers": 1234,
     "files": 41,

--- a/app/gateway/2.6.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.6.x/admin-api/workspaces/reference.md
@@ -253,7 +253,6 @@ HTTP 200 OK
 {
   "counts": {
     "acls": 1,
-    "apis": 1,
     "basicauth_credentials": 1,
     "consumers": 1234,
     "files": 41,

--- a/app/gateway/2.7.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.7.x/admin-api/workspaces/reference.md
@@ -253,7 +253,6 @@ HTTP 200 OK
 {
   "counts": {
     "acls": 1,
-    "apis": 1,
     "basicauth_credentials": 1,
     "consumers": 1234,
     "files": 41,

--- a/app/gateway/2.8.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.8.x/admin-api/workspaces/reference.md
@@ -253,7 +253,6 @@ HTTP 200 OK
 {
   "counts": {
     "acls": 1,
-    "apis": 1,
     "basicauth_credentials": 1,
     "consumers": 1234,
     "files": 41,


### PR DESCRIPTION
### Description

Fixes issue https://github.com/Kong/docs.konghq.com/issues/5106.

Removing `/apis` endpoint, which was deprecated before 1.0.

### Testing instructions

Netlify:

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

