### PR TITLE
Fix the upgrade path for 2.8.x traditional and DBless

### DIFF
--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -66,15 +66,15 @@ The following table outlines various upgrade path scenarios to {{page.kong_versi
 | 2.x–2.7.x | Traditional | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/) (required for blue/green deployments only), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
 | 2.x–2.7.x | Hybrid | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
 | 2.x–2.7.x | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
-| 2.8.x | Traditional | No | [Upgrade to 3.1.1.3](#migrate-db), and then [upgrade to 3.2.x](#migrate-db). |
+| 2.8.x | Traditional | No | [Upgrade to 3.2.x](#migrate-db). |
 | 2.8.x | Hybrid | No | [Upgrade to 3.1.1.3](#migrate-db), and then [upgrade to 3.2.x](#migrate-db). |
-| 2.8.x | DB less | No | [Upgrade to 3.1.1.3](#migrate-db), and then [upgrade to 3.2.x](#migrate-db). |
+| 2.8.x | DB less | No | [Ugrade to 3.2.x](#migrate-db). |
 | 3.0.x | Traditional | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | Hybrid | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | DB less | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.1.x | Traditional | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.1.0.x-3.1.1.2 | Hybrid | No | [Upgrade to 3.1.1.3](#migrate-db), and then [upgrade to 3.2.x](#migrate-db). |
-| 3.1.1.3 | Hybrid | Yes | [upgrade to 3.2.x](#migrate-db) |
+| 3.1.1.3 | Hybrid | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.1.x | DB less | Yes | [Upgrade to 3.2.x](#migrate-db). |
 
 {% endif_version %}

--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -66,9 +66,9 @@ The following table outlines various upgrade path scenarios to {{page.kong_versi
 | 2.x–2.7.x | Traditional | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/) (required for blue/green deployments only), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
 | 2.x–2.7.x | Hybrid | No | [Upgrade to 2.8.2.x](/gateway/2.8.x/install-and-run/upgrade-enterprise/), then [upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
 | 2.x–2.7.x | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
-| 2.8.x | Traditional | No | [Upgrade to 3.2.x](#migrate-db). |
+| 2.8.x | Traditional | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 2.8.x | Hybrid | No | [Upgrade to 3.1.1.3](#migrate-db), and then [upgrade to 3.2.x](#migrate-db). |
-| 2.8.x | DB less | No | [Ugrade to 3.2.x](#migrate-db). |
+| 2.8.x | DB less | Yes | [Ugrade to 3.2.x](#migrate-db). |
 | 3.0.x | Traditional | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | Hybrid | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | DB less | Yes | [Upgrade to 3.2.x](#migrate-db). |

--- a/app/_src/gateway/upgrade-31x.md
+++ b/app/_src/gateway/upgrade-31x.md
@@ -68,7 +68,7 @@ The following table outlines various upgrade path scenarios to {{page.kong_versi
 | 2.x–2.7.x | DB less | No | [Upgrade to 3.0.x](/gateway/3.0.x/upgrade/), and then [upgrade to 3.2.x](#migrate-db). |
 | 2.8.x | Traditional | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 2.8.x | Hybrid | No | [Upgrade to 3.1.1.3](#migrate-db), and then [upgrade to 3.2.x](#migrate-db). |
-| 2.8.x | DB less | Yes | [Ugrade to 3.2.x](#migrate-db). |
+| 2.8.x | DB less | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | Traditional | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | Hybrid | Yes | [Upgrade to 3.2.x](#migrate-db). |
 | 3.0.x | DB less | Yes | [Upgrade to 3.2.x](#migrate-db). |


### PR DESCRIPTION
### Description

What did you change and why?

-  After talking with Michael Martin, he confirmed that in 2.8.x, traditional and DB less can both go directly to 3.2.x. Hybrid still must do the indirect route however.

Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: /gateway/latest/upgrade/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

