### PR TITLE
Release/deck 1.18.1 and 1.19.0

### DIFF
--- a/app/_data/docs_nav_deck_1.18.x.yml
+++ b/app/_data/docs_nav_deck_1.18.x.yml
@@ -1,0 +1,92 @@
+product: deck
+release: 1.18.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    url: /deck/1.18.x/
+    absolute_url: true
+    items:
+      - text: Terminology
+        url: /terminology
+      - text: Architecture
+        url: /design-architecture
+      - text: Compatibility Promise
+        url: /compatibility-promise
+
+  - title: Changelog
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: https://github.com/kong/deck/blob/main/CHANGELOG.md
+    absolute_url: true
+
+  - title: Installation
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    url: /installation
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Getting Started with decK
+        url: /guides/getting-started
+      - text: Backup and Restore
+        url: /guides/backup-restore
+      - text: Upgrade to Kong Gateway 3.x
+        url: /3.0-upgrade
+      - text: Configuration as Code and GitOps
+        url: /guides/ci-driven-configuration
+      - text: Distributed Configuration
+        url: /guides/distributed-configuration
+      - text: Best Practices
+        url: /guides/best-practices
+      - text: Using decK with Kong Gateway (Enterprise)
+        url: /guides/kong-enterprise
+      - text: Using decK with Konnect
+        url: /guides/konnect
+      - text: Run decK with Docker
+        url: /guides/run-with-docker
+      - text: Using Multiple Files to Store Configuration
+        url: /guides/multi-file-state
+      - text: De-duplicate Plugin Configuration
+        url: /guides/deduplicate-plugin-configuration
+      - text: Set Up Object Defaults
+        url: /guides/defaults
+      - text: Security
+        items:
+          - text: Overview
+            url: /guides/security
+          - text: Secret Management with decK
+            url: /guides/vaults
+          - text: Using Environment Variables with decK
+            url: /guides/environment-variables
+
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+
+  - title: FAQ
+    icon: /assets/images/icons/documentation/icn-faq-color.svg
+    url: /faqs

--- a/app/_data/docs_nav_deck_1.19.x.yml
+++ b/app/_data/docs_nav_deck_1.19.x.yml
@@ -1,0 +1,92 @@
+product: deck
+release: 1.19.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    url: /deck/1.19.x/
+    absolute_url: true
+    items:
+      - text: Terminology
+        url: /terminology
+      - text: Architecture
+        url: /design-architecture
+      - text: Compatibility Promise
+        url: /compatibility-promise
+
+  - title: Changelog
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: https://github.com/kong/deck/blob/main/CHANGELOG.md
+    absolute_url: true
+
+  - title: Installation
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    url: /installation
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Getting Started with decK
+        url: /guides/getting-started
+      - text: Backup and Restore
+        url: /guides/backup-restore
+      - text: Upgrade to Kong Gateway 3.x
+        url: /3.0-upgrade
+      - text: Configuration as Code and GitOps
+        url: /guides/ci-driven-configuration
+      - text: Distributed Configuration
+        url: /guides/distributed-configuration
+      - text: Best Practices
+        url: /guides/best-practices
+      - text: Using decK with Kong Gateway (Enterprise)
+        url: /guides/kong-enterprise
+      - text: Using decK with Konnect
+        url: /guides/konnect
+      - text: Run decK with Docker
+        url: /guides/run-with-docker
+      - text: Using Multiple Files to Store Configuration
+        url: /guides/multi-file-state
+      - text: De-duplicate Plugin Configuration
+        url: /guides/deduplicate-plugin-configuration
+      - text: Set Up Object Defaults
+        url: /guides/defaults
+      - text: Security
+        items:
+          - text: Overview
+            url: /guides/security
+          - text: Secret Management with decK
+            url: /guides/vaults
+          - text: Using Environment Variables with decK
+            url: /guides/environment-variables
+
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+
+  - title: FAQ
+    icon: /assets/images/icons/documentation/icn-faq-color.svg
+    url: /faqs

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -252,6 +252,14 @@
   version: "1.17.3"
   edition: "deck"
 -
+  release: "1.18.x"
+  version: "1.18.1"
+  edition: "deck"
+-
+  release: "1.19.x"
+  version: "1.19.0"
+  edition: "deck"
+-
   release: "1.0.x"
   version: "1.0.4"
   edition: "mesh"

--- a/app/_src/deck/guides/defaults-v2.md
+++ b/app/_src/deck/guides/defaults-v2.md
@@ -2,6 +2,8 @@
 title: Set Up Object Defaults
 content_type: how-to
 ---
+<!--old version of topic; for the current version, see defaults.md -->
+
 Use object defaults to enforce a set of standard values and avoid
 repetition in your configuration.
 

--- a/app/_src/deck/guides/defaults.md
+++ b/app/_src/deck/guides/defaults.md
@@ -299,20 +299,9 @@ the {{site.base_gateway}}, set all possible default values for an object in your
 
 Use the Kong Admin API `/schemas` endpoint to find default values:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://localhost:8001/schemas/routes
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/schemas/routes
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 In your `kong.yaml` file, set the default values you want to use across all Routes.
 For example:
@@ -346,20 +335,9 @@ For documentation on all available properties, see the
 
 Use the Kong Admin API `/schemas` endpoint to find default values:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://localhost:8001/schemas/services
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/schemas/services
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 In your `kong.yaml` file, set the default values you want to use across all
 Services. For example:
@@ -384,20 +362,9 @@ For documentation on all available properties, see the
 
 Use the Kong Admin API `/schemas` endpoint to find default values:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://localhost:8001/schemas/upstreams
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/schemas/upstreams
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 In your `kong.yaml` file, set the default values you want to use across all
 Upstreams. For example:
@@ -481,20 +448,9 @@ For documentation on all available properties, see the
 
 Use the Kong Admin API `/schemas` endpoint to find default values:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://localhost:8001/schemas/targets
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/schemas/targets
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 In your `kong.yaml` file, set the default values you want to use across all
 Targets. For example:
@@ -513,20 +469,9 @@ For all available properties, see the
 
 Use the Kong Admin API `/schemas` endpoint to find default values:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i http://localhost:8001/schemas/plugins/<plugin-name>
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/schemas/plugins/<plugin-name>
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 decK doesn't support setting custom default values for the plugin object.
 

--- a/app/_src/deck/guides/defaults.md
+++ b/app/_src/deck/guides/defaults.md
@@ -509,6 +509,28 @@ For all available properties, see the
 [Target object](/gateway/latest/admin-api/#target-object) documentation.
 
 {% endnavtab %}
+{% navtab Plugins %}
+
+Use the Kong Admin API `/schemas` endpoint to find default values:
+
+<!-- codeblock tabs -->
+{% navtabs codeblock %}
+{% navtab cURL %}
+```sh
+curl -i http://localhost:8001/schemas/plugins/<plugin-name>
+```
+{% endnavtab %}
+{% navtab HTTPie %}
+```sh
+http :8001/schemas/plugins/<plugin-name>
+```
+{% endnavtab %}
+{% endnavtabs %}
+<!-- end codeblock tabs -->
+
+decK doesn't support setting custom default values for the plugin object.
+
+{% endnavtab %}
 {% endnavtabs %}
 
 ## See also

--- a/app/_src/deck/guides/konnect.md
+++ b/app/_src/deck/guides/konnect.md
@@ -117,7 +117,7 @@ decK automatically uses the credentials from `$HOME/.deck.yaml` in any subsequen
 ```sh
 deck ping
 
-Successfully Konnected as MyName (Konnect Org)!
+Successfully Konnected to the Example-Name organization!
 ```
 {% if_version gte:1.14.x %}
 ### Authenticate using a personal access token

--- a/app/konnect/getting-started/import.md
+++ b/app/konnect/getting-started/import.md
@@ -47,7 +47,7 @@ When you provide any {{site.konnect_short_name}} flags, decK targets the `cloud.
     user associated with the account:
 
     ```sh
-    Successfully Konnected as Some Name (Org Name)!
+    Successfully Konnected to the Example-Name organization!
     ```
 
     You can also use decK with {{site.konnect_short_name}} more securely by storing

--- a/app/konnect/runtime-manager/runtime-groups/declarative-config.md
+++ b/app/konnect/runtime-manager/runtime-groups/declarative-config.md
@@ -52,7 +52,7 @@ If the connection is successful, the terminal displays the full name of the user
 associated with the account:
 
 ```sh
-Successfully Konnected as Some Name (Org Name)!
+Successfully Konnected to the Example-Name organization!
 ```
 
 You can also use decK with {{site.konnect_short_name}} more securely by storing


### PR DESCRIPTION
### Description

Added decK 1.19.0, which we just released yesterday, and 1.18.1, which came out a couple of weeks ago. 

Both releases are very small and require little to no doc updates; see changelog: https://github.com/Kong/deck/blob/main/CHANGELOG.md#v1190

The plugin tab on the defaults guide page is not a new feature, it's just an addition of a missing tab.
 
### Testing instructions

Netlify link: https://deploy-preview-5197--kongdocs.netlify.app/deck/latest/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

