### PR TITLE
add  VERSION  field

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/setting-up-custom-plugins.md
+++ b/app/_src/kubernetes-ingress-controller/guides/setting-up-custom-plugins.md
@@ -21,6 +21,7 @@ $ mkdir myheader && cd myheader
 $ echo 'local MyHeader = {}
 
 MyHeader.PRIORITY = 1000
+MyHeader.VERSION = "1.0.0"
 
 function MyHeader:header_filter(conf)
   -- do custom logic here


### PR DESCRIPTION

### Description

Plugins MUST now have a valid PRIORITY (integer) and VERSION (“x.y.z” format) field in their handler.lua file, otherwise the plugin will fail to load. #8836
