### PR TITLE
[DOCU-2837] Fix OpenTelemetry plugin example

### DIFF
--- a/app/_hub/kong-inc/opentelemetry/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/_index.md
@@ -262,6 +262,9 @@ The following is an example for adding a custom span using {{site.base_gateway}}
 
       -- Append attributes
       span:set_attribute("custom.attribute", "custom value")
+      
+      -- Close the span
+      span:finish()
     ```
 
 2. Apply the Lua code using the `post-function` plugin using a cURL file upload:


### PR DESCRIPTION
### Description

According to issue reporter, the span must be closed, otherwise you get a 400.
https://konghq.atlassian.net/browse/DOCU-2837


### Testing instructions

Netlify link: https://deploy-preview-5207--kongdocs.netlify.app/hub/kong-inc/opentelemetry/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

