### PR TITLE
[DOCU-2985] Mention document_objects as not managed by decK

### DIFF
--- a/app/_src/deck/reference/entities.md
+++ b/app/_src/deck/reference/entities.md
@@ -10,7 +10,7 @@ It does not manage {{site.base_gateway}} configuration parameters in `kong.conf`
 
 Entity | Managed by decK?
 -------|-----------------
-Services | <i class="fa fa-check"></i>
+Services | <i class="fa fa-check"></i> <sup>1</sup>
 Routes | <i class="fa fa-check"></i>
 Consumers | <i class="fa fa-check"></i>
 Plugins | <i class="fa fa-check"></i>
@@ -22,7 +22,7 @@ Targets | <i class="fa fa-check"></i>
 Vaults | <i class="fa fa-check"></i>
 Keys and key sets | <i class="fa fa-times"></i>
 Licenses | <i class="fa fa-times"></i>
-Workspaces | <i class="fa fa-check"></i> <sup>1</sup>
+Workspaces | <i class="fa fa-check"></i> <sup>2</sup>
 RBAC: roles and endpoint permissions | <i class="fa fa-check"></i>
 RBAC: groups and admins | <i class="fa fa-times"></i>
 Developers | <i class="fa fa-times"></i>
@@ -31,7 +31,11 @@ Event hooks | <i class="fa fa-times"></i>
 Keyring and data encryption | <i class="fa fa-times"></i>
 
 {:.note .no-icon}
-> **\[1\]**: decK can create workspaces and manage entities in a given workspace. 
+> **\[1\]**: decK doesn't manage documents (`document_objects`) related to services, which means they are not included in dump/sync actions.
+If you attempt to delete a service that has an associated document via decK, it will fail.
+[Manage service documents directly](/gateway/latest/kong-enterprise/dev-portal/applications/managing-applications/#add-a-document-to-your-service) through Kong Manager. 
+> <br><br>
+> **\[2\]**: decK can create workspaces and manage entities in a given workspace. 
 However, decK can't delete workspaces, and it can't update multiple workspaces simultaneously.
 See [Manage multiple workspaces](/deck/{{page.kong_version}}/guides/kong-enterprise/#manage-multiple-workspaces) for more information.
 


### PR DESCRIPTION
### Description

Added a note for `document_objects` as being the one sub-entity for services that isn't managed by decK.

**Note:** We also don't have the `document_objects` entity documented in our Admin API doc; in fact, it's purposely not generated, if you look at `admin_api.lua`: https://github.com/Kong/kong-ee/blame/master/autodoc/admin-api/data/admin-api.lua#L1177
It looks like there was a start to a project to add EE endpoints to the Admin API doc, and it stalled.
I think we should wait to revisit that until we have a spec.
 
https://konghq.atlassian.net/browse/DOCU-2985


### Testing instructions

Netlify link: https://deploy-preview-5209--kongdocs.netlify.app/deck/latest/reference/entities/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

