### PR TITLE
[DOCU-2820][DOCU-2753] Improve license expiration description

### DIFF
--- a/app/_src/gateway/licenses/index.md
+++ b/app/_src/gateway/licenses/index.md
@@ -51,7 +51,7 @@ the Admin GUI in Kong Manager.
 
 ## License expiration
 
-Licenses expire at 00:00 on the date of expiration, relative to the timezone the machine is running in.
+Licenses expire at 00:00 on the date of expiration, relative to the time zone the machine is running in.
 
 Kong Manager displays a banner with a license expiration warning starting at 15 days before expiration.
 Expiration warnings also appear in [{{site.base_gateway}} logs](#license-expiration-logs).

--- a/app/_src/gateway/licenses/index.md
+++ b/app/_src/gateway/licenses/index.md
@@ -59,7 +59,7 @@ When a license expires, {{site.base_gateway}} behaves as follows:
 * Kong Manager and its configuration are accessible and may be changed, however any [Enterprise-specific features](/gateway/{{page.kong_version}}/kong-enterprise) become read-only.
 * The Admin API is not accessible until the license is either renewed or the subscription is downgraded to free mode.
 * Proxy traffic, including traffic using Enterprise plugins, continues to be processed as if the license had not expired.
-* Other Enterprise features, such as the Developer Portal, are not accessible.
+* Other Enterprise features, such as the Dev Portal, are not accessible.
 
 If you downgrade to free mode, the Admin API will be unlocked, but Enterprise features such Dev Portal, 
 Enterprise plugins, and others will no longer be accessible.

--- a/app/_src/gateway/licenses/index.md
+++ b/app/_src/gateway/licenses/index.md
@@ -66,6 +66,8 @@ When a license expires, {{site.base_gateway}} behaves as follows:
 If you downgrade to free mode, the Admin API will be unlocked, but Enterprise features such Dev Portal, 
 Enterprise plugins, and others will no longer be accessible.
 
+To upload a new license, see [Deploy an Enterprise License](/gateway/{{page.kong_version}}/licenses/deploy/).
+
 ### License expiration logs
 
 {{site.base_gateway}} logs the license expiration date on the following schedule:

--- a/app/_src/gateway/licenses/index.md
+++ b/app/_src/gateway/licenses/index.md
@@ -51,14 +51,18 @@ the Admin GUI in Kong Manager.
 
 ## License expiration
 
-When a license expires, you will still have access to your {{site.base_gateway}}
-and its configuration. Any Enterprise-specific features will be locked, and
-the Admin API will not be accessible until the license is either renewed or the
-subscription is downgraded to the free mode.
+Kong Manager displays a banner with a license expiration warning starting at 15 days before expiration.
+Expiration warnings also appear in [{{site.base_gateway}} logs](#license-expiration-logs).
 
-In the event of a downgrade, the Admin API will be unlocked, but Enterprise
-features such Dev Portal, Enterprise plugins, and others will no
-longer be accessible.
+When a license expires, {{site.base_gateway}} behaves as follows:
+
+* Kong Manager and its configuration are accessible and may be changed, however any [Enterprise-specific features](/gateway/{{page.kong_version}}/kong-enterprise) become read-only.
+* The Admin API is not accessible until the license is either renewed or the subscription is downgraded to free mode.
+* Proxy traffic, including traffic using Enterprise plugins, continues to be processed as if the license had not expired.
+* Other Enterprise features, such as the Developer Portal, are not accessible.
+
+If you downgrade to free mode, the Admin API will be unlocked, but Enterprise features such Dev Portal, 
+Enterprise plugins, and others will no longer be accessible.
 
 ### License expiration logs
 

--- a/app/_src/gateway/licenses/index.md
+++ b/app/_src/gateway/licenses/index.md
@@ -51,6 +51,8 @@ the Admin GUI in Kong Manager.
 
 ## License expiration
 
+Licenses expire at 00:00 on the date of expiration, relative to the timezone the machine is running in.
+
 Kong Manager displays a banner with a license expiration warning starting at 15 days before expiration.
 Expiration warnings also appear in [{{site.base_gateway}} logs](#license-expiration-logs).
 


### PR DESCRIPTION
### Description

Better license expiration description. Currently, the license expiration behavior is hard to understand.
Include the exact time at which the license expires.

https://konghq.atlassian.net/browse/DOCU-2820
https://konghq.atlassian.net/browse/DOCU-2753


### Testing instructions

Netlify link: https://deploy-preview-5212--kongdocs.netlify.app/gateway/latest/licenses/#license-expiration


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

