### PR TITLE
[DOCU-2588] Reference topic for labels in Konnect

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -281,3 +281,9 @@
       items:
         - text: Filtering
           url: /api/filtering
+
+- title: Reference
+  icon: /assets/images/icons/documentation/icn-references-color.svg
+  items:
+    - text: Labels
+      url: /reference/labels

--- a/app/konnect/reference/labels.md
+++ b/app/konnect/reference/labels.md
@@ -8,10 +8,10 @@ Labels are `key:value` pairs. They are case sensitive attributes associated with
 A maximum of 5 user-defined labels are allowed on each resource.
 
 **Key requirements:**
-* Keys must be 63 characters or less, beginning and ending with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
+* Keys must be 63 characters or less, beginning and ending with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumeric characters in between.
 * Keys must not start with `kong`, `konnect`, `insomnia`, `mesh`, `kic` or `_`. These strings are reserved for Kong.
 * Keys are case-sensitive.
 
 **Value requirements:**
-* Values must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
+* Values must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumeric characters in between.
 * Values must not be empty.

--- a/app/konnect/reference/labels.md
+++ b/app/konnect/reference/labels.md
@@ -1,0 +1,17 @@
+---
+title: Labels
+content_type: reference
+---
+
+Labels are `key:value` pairs. They are case sensitive attributes associated with entities. Labels allow an organization to specify metadata on an entity that can be used for filtering an entity list or for searching across entity types.
+
+A maximum of 10 user-defined labels are allowed on each resource.
+
+**Key requirements:**
+* Keys must be 63 characters or less, beginning and ending with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
+* Keys must not start with `kong`, `konnect`, `insomnia`, `mesh`, `kic` or `_`. These strings are reserved for Kong.
+* Keys are case-sensitive.
+
+**Value requirements:**
+* Values must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
+* Values must not be empty.

--- a/app/konnect/reference/labels.md
+++ b/app/konnect/reference/labels.md
@@ -5,7 +5,7 @@ content_type: reference
 
 Labels are `key:value` pairs. They are case sensitive attributes associated with entities. Labels allow an organization to specify metadata on an entity that can be used for filtering an entity list or for searching across entity types.
 
-A maximum of 10 user-defined labels are allowed on each resource.
+A maximum of 5 user-defined labels are allowed on each resource.
 
 **Key requirements:**
 * Keys must be 63 characters or less, beginning and ending with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.

--- a/app/konnect/reference/labels.md
+++ b/app/konnect/reference/labels.md
@@ -3,7 +3,10 @@ title: Labels
 content_type: reference
 ---
 
-Labels are `key:value` pairs. They are case sensitive attributes associated with entities. Labels allow an organization to specify metadata on an entity that can be used for filtering an entity list or for searching across entity types.
+Labels are `key:value` pairs. They are case-sensitive attributes associated with entities. 
+Labels allow an organization to specify metadata on an entity that can be used for filtering an entity list or for searching across entity types.
+
+For example, you might use the label `location:us-west`, where `location` is the key and the `us-west` is the value.
 
 A maximum of 5 user-defined labels are allowed on each resource.
 
@@ -13,5 +16,6 @@ A maximum of 5 user-defined labels are allowed on each resource.
 * Keys are case-sensitive.
 
 **Value requirements:**
-* Values must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumeric characters in between.
+* Values must be 63 characters or less, beginning and ending with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumeric characters in between.
 * Values must not be empty.
+* Values are **not** case-sensitive.

--- a/app/konnect/servicehub/manage-services.md
+++ b/app/konnect/servicehub/manage-services.md
@@ -39,7 +39,8 @@ From the {% konnect_icon servicehub %} [**Service Hub**](https://cloud.konghq.co
     For example, you might set `location:us-west`, where `location` is the key
     and the `us-west` is the value.
 
-    These labels are customizable, you can set them to any value.
+    These labels are customizable. 
+    See the [Labels](/konnect/reference/labels) reference for more information on label formatting.
 
 1. Click **Save**.
 


### PR DESCRIPTION
### Description

Adding a reference section in Konnect nav with a Labels reference topic.
I put it into a general reference section because labels are used in multiple places (runtime manager, service hub) and there's no central shared section that it fits into otherwise.

https://konghq.atlassian.net/browse/DOCU-2588

Will need to make a follow-up update in Flycode once this PR is merged to update the doc URL in the UI.
 
### Testing instructions

Netlify link: https://deploy-preview-5213--kongdocs.netlify.app/konnect/reference/labels/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

