### PR TITLE
Fix Konnect nav link for vaults

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -273,7 +273,7 @@
           - text: Targets
             url: /api/runtime-groups-config/#target-object
           - text: Vaults
-            url: /api/runtime-groups-config/#vaults-entity
+            url: /api/runtime-groups-config/#vaults-object
         - text: API Spec
           url: https://developer.konghq.com/spec/3c38bff8-3b7b-4323-8e2e-690d35ef97e0/16adcd15-493a-49b2-ad53-8c73891e29bf
           absolute_url: true


### PR DESCRIPTION
### Description

Header was changed to "Vaults Object", but the nav link wasn't. Fixing that.


### Testing instructions

Netlify link: 
https://deploy-preview-5224--kongdocs.netlify.app/konnect/api/runtime-groups-config/#vaults-object


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

