### PR TITLE
Fix: Disable icon expanding on install overview

### DIFF
--- a/app/_src/gateway/install/index.md
+++ b/app/_src/gateway/install/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installation Options
+disable_image_expand: true
 ---
 
 Kong can be installed on many different systems. From bare metal, to virtual machines, and cloud native Kubernetes environments, Kong is a low-demand, high-performing API gateway.


### PR DESCRIPTION
### Description

There's currently a bug on this page that expands the icons of each image whenever you click a link. Disabling that.

![Screenshot 2023-03-01 at 8 58 27 AM (2)](https://user-images.githubusercontent.com/54370747/222209788-162d4803-fe28-47e2-a03b-945925f11cdb.png)

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

