### PR TITLE
fix(getting-started) app reg is now on all runtimes

### DIFF
--- a/app/konnect/getting-started/app-registration.md
+++ b/app/konnect/getting-started/app-registration.md
@@ -12,8 +12,7 @@ legal agreements API.
 
 ## Prerequisites
 
-* You have a {{site.konnect_short_name}} service with at least one version in the `default` runtime group.
-Application registration is not supported for custom runtime groups.
+* You have a {{site.konnect_short_name}} service with at least one version.
 
 * You have [published the {{site.konnect_short_name}} service to the Dev Portal](/konnect/getting-started/publish-service/).
 

--- a/app/konnect/getting-started/app-registration.md
+++ b/app/konnect/getting-started/app-registration.md
@@ -102,6 +102,9 @@ In this topic, you:
 * Created an application through the Dev Portal and registered it against your service
 * Generated an API key for the application and made a call using this key
 
+You can learn more about [application registration](/konnect/dev-portal/applications/enable-app-reg/) 
+in the {{site.konnect_saas}} Dev Portal documentation.
+
 For next steps, check out some of the other things you can do in
 {{site.konnect_saas}}:
 


### PR DESCRIPTION
### Description

This information is stale, so I deleted the sentence. More detail is in https://docs.konghq.com/konnect/dev-portal/applications/enable-app-reg/#support-for-any-runtime-group, maybe a link should be added?


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

