### PR TITLE
fix: align examples to behaviour of add.headers

### DIFF
--- a/app/_hub/kong-inc/response-transformer/_index.md
+++ b/app/_hub/kong-inc/response-transformer/_index.md
@@ -151,7 +151,7 @@ similar for Services.
 ```bash
 curl -X POST http://localhost:8001/routes/{route}/plugins \
   --data "name=response-transformer" \
-  --data "config.add.headers[1]=h1:v1" \
+  --data "config.add.headers[1]=h1:v2" \
   --data "config.add.headers[2]=h2:v1"
 ```
 {% endnavtab %}
@@ -163,7 +163,7 @@ plugins:
   route: {route}
   config:
     add:
-      headers: ["h1:v1", "h2:v2"]
+      headers: ["h1:v2", "h2:v1"]
 ```
 
 {% endnavtab %}
@@ -190,7 +190,7 @@ plugins:
 ```bash
 curl -X POST http://localhost:8001/routes/{route}/plugins \
   --data "name=response-transformer" \
-  --data "config.add.headers=h1:v1,h2:v2"
+  --data "config.add.headers=h1:v2,h2:v1"
 ```
 
 <table>


### PR DESCRIPTION
> Ignored if the header is already set.

Use `v2` to highlight fact that `v2` is ignored because header already set


### Description

Docs


