### PR TITLE
Replace KIC bitly links with links we control

### DIFF
--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -67,18 +67,20 @@ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```sh
-kubectl apply -f https://bit.ly/k4k8s-enterprise-install
-kubectl apply -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{page.kong_version | replace: ".x" ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab Kubernetes (OSS) %}
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x" ".0" }}/deploy/single/all-in-one-dbless.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift %}
 ```sh
 oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x" ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -67,20 +67,20 @@ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{page.kic_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{page.kic_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab Kubernetes (OSS) %}
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless.yaml
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/{{page.kic_version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/v{{page.kic_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift %}
 ```sh
-oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
-oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kic_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/v{{page.kic_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -68,19 +68,19 @@ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% navtab Kubernetes %}
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{page.kong_version | replace: ".x" ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab Kubernetes (OSS) %}
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless.yaml
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x" ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift %}
 ```sh
 oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
-oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x" ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/v{{page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -68,16 +68,17 @@ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% navtab Kubernetes %}
 ```sh
 kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+kubectl apply -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab Kubernetes (OSS) %}
 ```sh
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift %}
 ```sh
-oc create -f https://bit.ly/k4k8s-enterprise-install
+oc create -f https://github.com/Kong/kubernetes-ingress-controller/blob/{{page.kong_version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

Try and move the KIC manifest links off bitly.

### Testing instructions

Yes.

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)