### PR TITLE
fix(correlation-id): example log correct header

### DIFF
--- a/app/_hub/kong-inc/correlation-id/_index.md
+++ b/app/_hub/kong-inc/correlation-id/_index.md
@@ -120,7 +120,7 @@ To edit your Nginx parameters, do the following:
    log_format customformat '$remote_addr - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent  '
                  '"$http_referer" "$http_user_agent" '
-                 'Kong-Request-ID="$sent_http_Kong_Request_ID"';
+                 'Kong-Request-ID="$http_Kong_Request_ID"';
    ```
 
 1. Use your custom log format for the proxy access log phase. Locate the following line:


### PR DESCRIPTION

### Description

the `sent_` prefixed headers are the headers returned by kong to the client. Without that prefix, it will refer to the header sent to the backend. Since the former ones are only available if the "echo to client" checkbox is ticked, this is the safer option for the example.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

