### PR TITLE
Backport deck entities topic to avoid broken links

### DIFF
--- a/app/_data/docs_nav_deck_1.10.x.yml
+++ b/app/_data/docs_nav_deck_1.10.x.yml
@@ -50,38 +50,43 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.11.x.yml
+++ b/app/_data/docs_nav_deck_1.11.x.yml
@@ -49,38 +49,43 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.12.x.yml
+++ b/app/_data/docs_nav_deck_1.12.x.yml
@@ -53,38 +53,43 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.13.x.yml
+++ b/app/_data/docs_nav_deck_1.13.x.yml
@@ -51,38 +51,43 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.14.x.yml
+++ b/app/_data/docs_nav_deck_1.14.x.yml
@@ -51,28 +51,33 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.15.x.yml
+++ b/app/_data/docs_nav_deck_1.15.x.yml
@@ -53,28 +53,33 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.16.x.yml
+++ b/app/_data/docs_nav_deck_1.16.x.yml
@@ -59,28 +59,33 @@ items:
           - text: Using Environment Variables with decK
             url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.7.x.yml
+++ b/app/_data/docs_nav_deck_1.7.x.yml
@@ -47,36 +47,41 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.8.x.yml
+++ b/app/_data/docs_nav_deck_1.8.x.yml
@@ -50,38 +50,43 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg

--- a/app/_data/docs_nav_deck_1.9.x.yml
+++ b/app/_data/docs_nav_deck_1.9.x.yml
@@ -50,38 +50,43 @@ items:
       - text: Using environment variables with decK
         url: /guides/environment-variables
 
-  - title: decK CLI Reference
+  - title: Reference
     icon: /assets/images/icons/documentation/icn-references-color.svg
-    url: /reference/deck
     items:
-      - text: deck completion
-        url: /reference/deck_completion
-      - text: deck convert
-        url: /reference/deck_convert
-      - text: deck diff
-        url: /reference/deck_diff
-      - text: deck dump
-        url: /reference/deck_dump
-      - text: deck ping
-        url: /reference/deck_ping
-      - text: deck reset
-        url: /reference/deck_reset
-      - text: deck sync
-        url: /reference/deck_sync
-      - text: deck validate
-        url: /reference/deck_validate
-      - text: deck version
-        url: /reference/deck_version
-      - text: deck konnect
-        url: /reference/deck_konnect
-      - text: deck konnect diff
-        url: /reference/deck_konnect_diff
-      - text: deck konnect dump
-        url: /reference/deck_konnect_dump
-      - text: deck konnect ping
-        url: /reference/deck_konnect_ping
-      - text: deck konnect sync
-        url: /reference/deck_konnect_sync
+      - text: Entities Managed by decK
+        url: /reference/entities
+
+      - text: decK CLI reference
+        url: /reference/deck
+        items:
+          - text: deck completion
+            url: /reference/deck_completion
+          - text: deck convert
+            url: /reference/deck_convert
+          - text: deck diff
+            url: /reference/deck_diff
+          - text: deck dump
+            url: /reference/deck_dump
+          - text: deck ping
+            url: /reference/deck_ping
+          - text: deck reset
+            url: /reference/deck_reset
+          - text: deck sync
+            url: /reference/deck_sync
+          - text: deck validate
+            url: /reference/deck_validate
+          - text: deck version
+            url: /reference/deck_version
+          - text: deck konnect
+            url: /reference/deck_konnect
+          - text: deck konnect diff
+            url: /reference/deck_konnect_diff
+          - text: deck konnect dump
+            url: /reference/deck_konnect_dump
+          - text: deck konnect ping
+            url: /reference/deck_konnect_ping
+          - text: deck konnect sync
+            url: /reference/deck_konnect_sync
 
   - title: FAQ
     icon: /assets/images/icons/documentation/icn-faq-color.svg


### PR DESCRIPTION
### Description

Adding 
```
     - text: Entities Managed by decK
        url: /reference/entities
```
To all single-sourced decK navs. The topic applies the whole way back.
This way, we avoid broken links in earlier versions (eg the broken link to "Entities Managed by decK" here: https://docs.konghq.com/deck/1.16.x/guides/backup-restore/). 

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

