### PR TITLE
fix(kic): fix bit.ly links

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -34,12 +34,15 @@ Istio's
 Jira
 JsonPath
 Keycloak
+knative
 Knative
 Knative's
 Knatives
 Kong/kong
 Konnect
 Kuma
+kustomizations
+kustomize
 Kustomize
 Loggly
 Lua's

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -350,5 +350,5 @@
   version: "2.7.0"
   edition: "kubernetes-ingress-controller"
 - release: "2.8.x"
-  version: "2.8.0"
+  version: "2.8.1"
   edition: "kubernetes-ingress-controller"

--- a/app/_redirects
+++ b/app/_redirects
@@ -36,8 +36,8 @@
 /enterprise/2.5.x/deployment/using-kong-for-kubernetes/    /kubernetes-ingress-controller/
 /enterprise/latest/deployment/using-kong-for-kubernetes/   /kubernetes-ingress-controller/
 /enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes/  /enterprise/2.1.x/deployment/installation/kong-for-kubernetes/
-/enteprise/2.1.x/kong-for-kubernetes/install  /gateway/latest/install-and-run/kubernetes
-/enteprise/2.1.x/kong-for-kubernetes/install-on-kubernetes    /gateway/latest/install-and-run/kubernetes
+/enterprise/2.1.x/kong-for-kubernetes/install  /gateway/latest/install-and-run/kubernetes
+/enterprise/2.1.x/kong-for-kubernetes/install-on-kubernetes    /gateway/latest/install-and-run/kubernetes
 /enterprise/2.1.x/kong-for-kubernetes/  /gateway/latest/install-and-run/kubernetes
 /enterprise/2.1.x/kong-for-kubernetes/deployment-options  /gateway/latest/install-and-run/kubernetes
 

--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -67,17 +67,17 @@ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 {% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```sh
-kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab Kubernetes (OSS) %}
 ```sh
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift %}
 ```sh
-oc create -f https://bit.ly/k4k8s-enterprise-install
+oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/kubernetes-ingress-controller/deployment/aks.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/_src/kubernetes-ingress-controller/deployment/eks.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/_src/kubernetes-ingress-controller/deployment/gke.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/_src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/_src/kubernetes-ingress-controller/deployment/kong-enterprise.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/_src/kubernetes-ingress-controller/deployment/minikube.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-dbless.yaml
+kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/_src/kubernetes-ingress-controller/guides/cert-manager.md
+++ b/app/_src/kubernetes-ingress-controller/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/_src/kubernetes-ingress-controller/guides/using-kong-with-knative.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,

--- a/app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.1.x/deployment/installation/kong-for-kubernetes.md
@@ -85,12 +85,12 @@ The steps in this section show you how to install Kong for Kubernetes Enterprise
 {% navtabs codeblock %}
 {% navtab kubectl %}
 ```sh
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```sh
-$ oc create -f https://bit.ly/k4k8s-enterprise-install
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.2.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.2.x/deployment/installation/kong-for-kubernetes.md
@@ -85,12 +85,12 @@ The steps in this section show you how to install Kong for Kubernetes Enterprise
 {% navtabs codeblock %}
 {% navtab kubectl %}
 ```sh
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```sh
-$ oc create -f https://bit.ly/k4k8s-enterprise-install
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-for-kubernetes.md
@@ -94,12 +94,12 @@ The steps in this section show you how to install Kong for Kubernetes Enterprise
 {% navtabs codeblock %}
 {% navtab kubectl %}
 ```sh
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```sh
-$ oc create -f https://bit.ly/k4k8s-enterprise-install
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.4.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.4.x/deployment/installation/kong-for-kubernetes.md
@@ -94,12 +94,12 @@ The steps in this section show you how to install Kong for Kubernetes Enterprise
 {% navtabs codeblock %}
 {% navtab kubectl %}
 ```sh
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```sh
-$ oc create -f https://bit.ly/k4k8s-enterprise-install
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/enterprise/2.5.x/deployment/installation/kong-for-kubernetes.md
+++ b/app/enterprise/2.5.x/deployment/installation/kong-for-kubernetes.md
@@ -94,12 +94,12 @@ The steps in this section show you how to install Kong for Kubernetes Enterprise
 {% navtabs codeblock %}
 {% navtab kubectl %}
 ```sh
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```sh
-$ oc create -f https://bit.ly/k4k8s-enterprise-install
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway-oss/2.1.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.1.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.2.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.2.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.3.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.3.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.4.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.4.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.5.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.5.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -56,17 +56,17 @@ oc new-project kong
 
     ```sh
     ## Kong Gateway on Kubernetes native
-    kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
     ```
 
     ```sh
     ## Kong Gateway on OpenShift
-    oc create -f https://bit.ly/k4k8s-enterprise-install
+    oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
     ```
 
     ```sh
     ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://bit.ly/kong-ingress-dbless
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
     ```
 
     This might take a few minutes.

--- a/app/gateway/2.7.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.7.x/install-and-run/kubernetes.md
@@ -56,17 +56,17 @@ oc new-project kong
 
     ```sh
     ## Kong Gateway on Kubernetes native
-    kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
     ```
 
     ```sh
     ## Kong Gateway on OpenShift
-    oc create -f https://bit.ly/k4k8s-enterprise-install
+    oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
     ```
 
     ```sh
     ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://bit.ly/kong-ingress-dbless
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
     ```
 
     This might take a few minutes.

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -56,17 +56,17 @@ oc new-project kong
 
     ```sh
     ## Kong Gateway on Kubernetes native
-    kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
     ```
 
     ```sh
     ## Kong Gateway on OpenShift
-    oc create -f https://bit.ly/k4k8s-enterprise-install
+    oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
     ```
 
     ```sh
     ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://bit.ly/kong-ingress-dbless
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
     ```
 
     This might take a few minutes.

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/1.0.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -153,7 +153,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/1.1.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -153,7 +153,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/1.2.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -153,7 +153,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/1.3.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -153,7 +153,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -151,7 +151,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/2.1.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -151,7 +151,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/aks.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/aks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Azure Kubernetes Service (AKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/eks.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/eks.md
@@ -17,7 +17,7 @@ title: Kong Ingress on Elastic Kubernetes Service (EKS)
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/gke.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/gke.md
@@ -72,7 +72,7 @@ subjects:
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/k4k8s-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/k4k8s-enterprise.md
@@ -50,7 +50,7 @@ Execute the following to install Kong for Kubernetes Enterprise using YAML
 manifests:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml-enterprise-install
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 
 It takes a few minutes the first time this setup is done.

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://bit.ly/kong-ingress-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/minikube.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/minikube.md
@@ -27,7 +27,7 @@ title: Kong Ingress on Minikube
 Deploy the {{site.kic_product_name}} using `kubectl`:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.konghq.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.konghq.com created

--- a/app/kubernetes-ingress-controller/2.2.x/guides/cert-manager.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/cert-manager.md
@@ -26,7 +26,7 @@ This tutorial was written using Google Kubernetes Engine.
 Execute the following to install the Ingress Controller:
 
 ```bash
-$ kubectl create -f https://bit.ly/k4k8s
+$ kubectl create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 namespace/kong created
 customresourcedefinition.apiextensions.k8s.io/kongplugins.configuration.example.com created
 customresourcedefinition.apiextensions.k8s.io/kongconsumers.configuration.example.com created

--- a/app/kubernetes-ingress-controller/2.2.x/guides/using-kong-with-knative.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/using-kong-with-knative.md
@@ -32,7 +32,7 @@ This will install the resources that are required to run Knative.
 Next, install the {{site.kic_product_name}}:
 
 ```
-kubectl apply -f https://bit.ly/k4k8s
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless.yaml
 ```
 
 You can choose to install a different flavor, like using a database,
@@ -151,7 +151,7 @@ Via: kong/1.4.3
 Hello Go Sample v1!
 ```
 
-The request is served by Knative and from the response HTTP headeres,
+The request is served by Knative and from the response HTTP headers,
 we can tell that the request was proxied by Kong.
 
 The first request will also take longer to complete as Knative will spin

--- a/archive/enterprise/1.3-x/kong-for-kubernetes/install.md
+++ b/archive/enterprise/1.3-x/kong-for-kubernetes/install.md
@@ -65,7 +65,7 @@ $ oc create secret generic kong-enterprise-license --from-file=./license -n kong
 ### Step 2. Deploy Kong for Kubernetes Enterprise
 
 ```
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 The initial setup might take a few minutes.
 
@@ -86,7 +86,7 @@ kong-proxy   LoadBalancer   10.63.254.78   35.233.198.16   80:32697/TCP,443:3236
 On OpenShift:
 
 ```
-$ oc create -f https://bit.ly/k4k8s-enterprise
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 The initial setup might take a few minutes.
 

--- a/archive/enterprise/1.5.x/kong-for-kubernetes/install.md
+++ b/archive/enterprise/1.5.x/kong-for-kubernetes/install.md
@@ -65,7 +65,7 @@ The steps in this section show you how to install Kong for Kubernetes Enterprise
 {% navtabs %}
 {% navtab kubectl %}
 ```
-$ kubectl apply -f https://bit.ly/k4k8s-enterprise
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 The initial setup might take a few minutes.
 
@@ -85,7 +85,7 @@ kong-proxy   LoadBalancer   10.63.254.78   35.233.198.16   80:32697/TCP,443:3236
 {% endnavtab %}
 {% navtab OpenShift oc %}
 ```
-$ oc create -f https://bit.ly/k4k8s-enterprise
+$ oc create -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.version }}/deploy/single/all-in-one-dbless-k4k8s-enterprise.yaml
 ```
 The initial setup might take a few minutes.
 

--- a/archive/gateway-oss/1.4.x/kong-for-kubernetes/install.md
+++ b/archive/gateway-oss/1.4.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment. 

--- a/archive/gateway-oss/1.5.x/kong-for-kubernetes/install.md
+++ b/archive/gateway-oss/1.5.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment. 

--- a/archive/gateway-oss/2.0.x/kong-for-kubernetes/install.md
+++ b/archive/gateway-oss/2.0.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://bit.ly/kong-ingress-dbless
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.


### PR DESCRIPTION
### Description

KIC 2.9 introduced a breaking change in its manifests and since we don't have control over bit.ly links let's replace them with long github links pointing to particular tag's manifests.

This PR uses a hidden gem: `site.data.kong_latest_KIC.version` (on gateway pages where we don't have access to particular KIC version since we don't map Gateway versions to KIC versions) and also `{{ page.version }}`.

It also bumps KIC 2.8.0 to 2.8.1.

This aims to solve: https://github.com/Kong/kubernetes-ingress-controller/issues/3650

I wanted to change less in this PR but vale forced me to fix all the typos 😓 

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


