### PR TITLE
fixed the url for OSS

### DIFF
--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -72,7 +72,7 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-contr
 {% endnavtab %}
 {% navtab Kubernetes (OSS) %}
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 {% endnavtab %}
 {% navtab OpenShift %}


### PR DESCRIPTION
fixed the kubectl apply URL with prefix v

### Description

What did you change and why? There is a typo in the URL which is navigating to page Not Found
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

https://discuss.konghq.com/t/incorrect-url-to-all-in-one-dbless-yaml-oss-version/11267

### Testing instructions

Netlify link: https://deploy-preview-5261--kongdocs.netlify.app/


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

