### PR TITLE
Datadog plugin fix: add enterprise tag

### DIFF
--- a/app/_hub/kong-inc/datadog-tracing/_index.md
+++ b/app/_hub/kong-inc/datadog-tracing/_index.md
@@ -10,6 +10,7 @@ description: |
   be analyzed using Datadog's Request Flow Map, and also correlated with other
   systems handling API requests.
 type: plugin
+enterprise: true
 categories:
   - analytics-monitoring
 kong_version_compatibility:


### PR DESCRIPTION
### Description

Adding missing Enterprise tag for Datadog Tracing plugin.

Issue reported in Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1678200127324889

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

