### PR TITLE
Fix top-cta link

### DIFF
--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -89,7 +89,7 @@
           <a href="{{site.links.learn}}" class="navbar-item">Kong Academy</a>
         </li>
       </ul>
-      <a id="top-cta" href="https://incubator.konghq.com/?utm_source=docs.konghq.com" class="navbar-button" target="_blank">
+      <a id="top-cta" href="https://konghq.com/contact-sales?utm_source=docs.konghq.com" class="navbar-button" target="_blank">
         Get A Demo
       </a>
       <a id="konnect-cta" href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=docs-top-nav" class="navbar-button" target="_blank">


### PR DESCRIPTION
### Description

What did you change and why?
 
Fix cta link, the url was being replaced in the [A/B test script](https://github.com/Kong/docs.konghq.com/commit/c567f615dbda1c88a4e6a0e1946f3d42e1928be6#diff-e6cf23c02e7353eb5dd94f2ccfd70a56df997e15454f12fbaf439e49bf7efcbf) 


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

