### PR TITLE
Fix KIC install links

### DIFF
--- a/app/gateway-oss/2.1.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.1.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.2.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.2.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.3.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.3.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.4.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.4.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway-oss/2.5.x/kong-for-kubernetes/install.md
+++ b/app/gateway-oss/2.5.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -66,7 +66,7 @@ oc new-project kong
 
     ```sh
     ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
     ```
 
     This might take a few minutes.

--- a/app/gateway/2.7.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.7.x/install-and-run/kubernetes.md
@@ -66,7 +66,7 @@ oc new-project kong
 
     ```sh
     ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
     ```
 
     This might take a few minutes.

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -66,7 +66,7 @@ oc new-project kong
 
     ```sh
     ## Kong Gateway (OSS) on Kubernetes native
-    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
     ```
 
     This might take a few minutes.

--- a/app/kubernetes-ingress-controller/1.0.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.0.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.1.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.1.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.2.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.2.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/1.3.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/1.3.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/2.0.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.0.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/2.1.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.1.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/app/kubernetes-ingress-controller/2.2.x/deployment/kong-enterprise.md
+++ b/app/kubernetes-ingress-controller/2.2.x/deployment/kong-enterprise.md
@@ -56,7 +56,7 @@ Ingress Controller.
 ## Install
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
 It takes a little while to bootstrap the database.

--- a/archive/gateway-oss/1.4.x/kong-for-kubernetes/install.md
+++ b/archive/gateway-oss/1.4.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment. 

--- a/archive/gateway-oss/1.5.x/kong-for-kubernetes/install.md
+++ b/archive/gateway-oss/1.5.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment. 

--- a/archive/gateway-oss/2.0.x/kong-for-kubernetes/install.md
+++ b/archive/gateway-oss/2.0.x/kong-for-kubernetes/install.md
@@ -20,7 +20,7 @@ Use one of the following installation methods to install Kong for Kubernetes:
 To deploy Kong via `kubectl`, use:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/single/all-in-one-dbless.yaml
 ```
 
 > Important! This is not a production-grade deployment.


### PR DESCRIPTION
### Description

Fixing links that were missing the `v` prefix for the KIC version. 
Contributor caught one of them here: https://github.com/Kong/docs.konghq.com/pull/5261

Expanding on the fix - didn't think to search the whole site in the original PR, but there are a lot more broken links than just that one.

@pmalek I'm throwing this one on `main`, you might want to update the 2.9 branch after this.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

