### PR TITLE
Typo in Configure Data Plane Resilience

### DIFF
--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -85,7 +85,7 @@ kong-dp-exporter:
     environment:
       <<: *other-kong-envs
       KONG_CLUSTER_FALLBACK_CONFIG_STORAGE: gcs://test-bucket/
-      KONG_CLUSTER_FALLBACK_CONFIG_IMPORT: "on"
+      KONG_CLUSTER_FALLBACK_CONFIG_EXPORT: "on"
       GCP_SERVICE_ACCOUNT: <GCP_JSON_STRING_WRITE>
 ```
 


### PR DESCRIPTION
### Description

Typo in Configure Data Plane Resilience
 
As we exporting into GCP bucket, the environment variable should be `EXPORT` instead of `IMPORT`. Other options of storage i.e AWS S3 uses `EXPORT` too.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

