### PR TITLE
fix(kic): router_flavor mode

### DIFF
--- a/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -8,7 +8,7 @@ The router can be configured in the following [modes][gateway-router-flavor]:
 
 - `traditional`: uses the pre-3.0 router.
 - `traditional_compatible`: uses the expression based router, but the router configuration interface remains the same as `traditional`.
-- `expression`: uses the expression-based router, and expressions must be provided in the router configuration interface.
+- `expressions`: uses the expression-based router, and expressions must be provided in the router configuration interface.
 
 The compatibilities of router flavors between different {{site.kic_product_name}} versions and {{site.base_gateway}} are shown in the following table.
 {{site.kic_product_name}} in versions 2.6.x and lower does not support {{site.base_gateway}} 3.0 and later, so the version of {{site.kic_product_name}} begins at 2.7.x.
@@ -17,10 +17,10 @@ The compatibilities of router flavors between different {{site.kic_product_name}
 |:-------------------------------------|:-------------------------------:|:-------------------------------:|
 | Kong 3.0.x  `traditional`            |  <i class="fa fa-check"></i>    | <i class="fa fa-check"></i> | 
 | Kong 3.0.x  `traditional_compatible` |  <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | 
-| Kong 3.0.x  `expression`             |  <i class="fa fa-times"></i>    | <i class="fa fa-times"></i>  | 
+| Kong 3.0.x  `expressions`            |  <i class="fa fa-times"></i>    | <i class="fa fa-times"></i>  | 
 | Kong 3.1.x  `traditional`            |  <i class="fa fa-check"></i>    |  <i class="fa fa-check"></i> |    
 | Kong 3.1.x  `traditional_compatible` |  <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | 
-| Kong 3.1.x  `expression`             |  <i class="fa fa-times"></i>    | <i class="fa fa-times"></i> |
+| Kong 3.1.x  `expressions`            |  <i class="fa fa-times"></i>    | <i class="fa fa-times"></i> |
 
 (*) Most use cases are supported. Regexes with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
 may not be accepted when {{site.base_gateway}} 3.0 is configured to use the `traditional_compatible` router.


### PR DESCRIPTION
### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

As per the [source code](https://github.com/Kong/kong-ee/blob/master/kong/conf_loader/init.lua#L507), the accepted values for `router_flavor` are `"traditional"`, `"traditional_compatible"` and `"expressions"`, not `"expression"`.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

