### PR TITLE
feat(proxy-cache): add ignore_uri_case to configuring cache-key uri to be handled as lowercase

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -488,6 +488,7 @@ idp_sso_url
 idtoken
 if_plugin_version
 ignore_signature
+ignore_uri_case
 include_body_in_opa_input
 include_cached
 include_consumer_in_opa_input

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -86,6 +86,13 @@ params:
       datatype: boolean
       description: |
         When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
+    - name: cache_lowercase_uri
+      required: false
+      default: false
+      value_in_examples: null
+      datatype: boolean
+      description: |
+        When enabled, the incoming request will be lowercase before fed into the Cache-Key calculation.
     - name: storage_ttl
       required: false
       default: null

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -86,7 +86,7 @@ params:
       datatype: boolean
       description: |
         When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
-    - name: cache_lowercase_uri
+    - name: ignore_uri_case
       required: false
       default: false
       value_in_examples: null

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -92,7 +92,7 @@ params:
       value_in_examples: null
       datatype: boolean
       description: |
-        When enabled, the incoming request will be lowercase before fed into the Cache-Key calculation.
+        When enabled, the incoming request will be lowercase before feeding into the Cache-Key calculation.
     - name: storage_ttl
       required: false
       default: null

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -86,13 +86,6 @@ params:
       datatype: boolean
       description: |
         When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
-    - name: ignore_uri_case
-      required: false
-      default: false
-      value_in_examples: null
-      datatype: boolean
-      description: |
-        When enabled, the incoming request will be lowercase before feeding into the Cache-Key calculation.
     - name: storage_ttl
       required: false
       default: null

--- a/app/_hub/kong-inc/proxy-cache/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/_index.md
@@ -93,7 +93,7 @@ params:
       value_in_examples: null
       datatype: boolean
       description: |
-        When enabled, the incoming request will be lowercase before feeding into the Cache-Key calculation.
+        If set to `true`, requests will be cached while ignoring case sensitivity in the URI.
     - name: storage_ttl
       required: false
       default: null

--- a/app/_hub/kong-inc/proxy-cache/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/_index.md
@@ -87,7 +87,7 @@ params:
       datatype: boolean
       description: |
         When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
-    - name: cache_lowercase_uri
+    - name: ignore_uri_case
       required: false
       default: false
       value_in_examples: null

--- a/app/_hub/kong-inc/proxy-cache/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/_index.md
@@ -93,7 +93,7 @@ params:
       value_in_examples: null
       datatype: boolean
       description: |
-        When enabled, the incoming request will be lowercase before fed into the Cache-Key calculation.
+        When enabled, the incoming request will be lowercase before feeding into the Cache-Key calculation.
     - name: storage_ttl
       required: false
       default: null

--- a/app/_hub/kong-inc/proxy-cache/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/_index.md
@@ -87,6 +87,13 @@ params:
       datatype: boolean
       description: |
         When enabled, respect the Cache-Control behaviors defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2).
+    - name: cache_lowercase_uri
+      required: false
+      default: false
+      value_in_examples: null
+      datatype: boolean
+      description: |
+        When enabled, the incoming request will be lowercase before fed into the Cache-Key calculation.
     - name: storage_ttl
       required: false
       default: null


### PR DESCRIPTION
### Description

This PR adds documentation of `ignore_uri_case` parameter in the cache-proxy plugin added with PR https://github.com/Kong/kong/pull/10453.

### Testing instructions

Netlify link: https://deploy-preview-5270--kongdocs.netlify.app


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`release/gateway-3.3`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

