### PR TITLE
[DOCU-3031] Split RM troubleshooting topic

### DIFF
--- a/app/konnect/runtime-manager/runtime-instances/install.md
+++ b/app/konnect/runtime-manager/runtime-instances/install.md
@@ -17,7 +17,7 @@ For more information, see [Control Plane and Data Plane Communication through a 
 
 We recommend running one major version (2.x or 3.x) of a runtime instance per
 runtime group, unless you are in the middle of version upgrades to the data plane.
-Mixing versions may cause [compatibility issues](/konnect/runtime-manager/troubleshoot/#version-compatibility).
+Mixing versions may cause [compatibility issues](/konnect/runtime-manager/version-compatibility).
 
 <!-- Runtime Manager provides pre-populated templates for AWS and Azure that you can create your runtime instances in any of these clouds directly from {{site.konnect_short_name}}. -->
 

--- a/app/konnect/runtime-manager/runtime-instances/upgrade.md
+++ b/app/konnect/runtime-manager/runtime-instances/upgrade.md
@@ -9,7 +9,7 @@ method for high availability, as the new node starts processing data before the
 old node is removed. It is the cleanest and safest way to upgrade with no
 proxy downtime.
 
-We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane. Mixing versions may cause [compatibility issues](/konnect/runtime-manager/troubleshoot/#version-compatibility).
+We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane. Mixing versions may cause [compatibility issues](/konnect/runtime-manager/version-compatibility).
 
 {:.important}
 > **Important:** Upgrading a runtime instance version isn't supported for runtime instances created in cloud providers, such as AWS and Azure.

--- a/app/konnect/runtime-manager/troubleshoot.md
+++ b/app/konnect/runtime-manager/troubleshoot.md
@@ -5,10 +5,14 @@ content_type: how-to
 
 ## Out of sync runtime instance
 
+**Problem**
+
 Occasionally, a {{site.base_gateway}} runtime instance might get out of sync
 with the {{site.konnect_short_name}} control plane. If this happens, you will
 see the status `Out of sync` on the Runtime Instances page, meaning the control
 plane can't communicate with the instance.
+
+**Solution**
 
 Troubleshoot the issue using the following methods:
 
@@ -37,8 +41,12 @@ If you are unable to resolve sync issues using the above methods, contact
 
 ## Missing functionality
 
+**Problem**
+
 If a {{site.konnect_short_name}} feature isn’t working on your runtime instance,
 the version may be out of date.
+
+**Solution**
 
 Verify that your instance versions are up to date:
 
@@ -57,46 +65,4 @@ instance may need [upgrading](/konnect/runtime-manager/runtime-instances/upgrade
 If your version is up to date but the feature still isn't working, contact
 [Kong Support](https://support.konghq.com/).
 
-## Version compatibility
-
-We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane.
-
-If you mix major runtime instance versions, the control plane will support the least common subset of configurations across all the versions connected to the {{site.konnect_short_name}} control plane.
-For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configurations that can be used by the 2.8.1.3 runtime instance.
-
-If you experience compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
-
-Possible compatibility errors:
-
-{% assign errors = site.data.tables.version_errors_konnect %}
-
-<table>
-  <thead>
-      <th>Error code</th>
-      <th>Severity</th>
-      <th>Description</th>
-      <th>Resolution</th>
-      <th class="width=25%">References</th>
-  </thead>
-<tbody>
-  {% for message in errors.messages %}
-      <tr>
-        <td>
-          {{ message.ID | markdownify }}
-        </td>
-        <td>
-          {{ message.Severity | markdownify }}
-        </td>
-        <td>
-          {{ message.Description | markdownify }}
-        </td>
-        <td>
-          {{ message.Resolution | markdownify }}
-        </td>
-        <td>
-          {{ message.DocumentationURL | markdownify }}
-        </td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
+## Compatibility errors appear in the runtime instances list

--- a/app/konnect/runtime-manager/troubleshoot.md
+++ b/app/konnect/runtime-manager/troubleshoot.md
@@ -64,5 +64,3 @@ instance may need [upgrading](/konnect/runtime-manager/runtime-instances/upgrade
 
 If your version is up to date but the feature still isn't working, contact
 [Kong Support](https://support.konghq.com/).
-
-## Compatibility errors appear in the runtime instances list

--- a/app/konnect/runtime-manager/version-compatibility.md
+++ b/app/konnect/runtime-manager/version-compatibility.md
@@ -2,3 +2,45 @@
 title: Version Compatibility in Runtime Groups
 content_type: reference
 ---
+
+We recommend running one major version (2.x or 3.x) of a runtime instance per runtime group, unless you are in the middle of version upgrades to the data plane.
+
+If you mix major runtime instance versions, the control plane will support the least common subset of configurations across all the versions connected to the {{site.konnect_short_name}} control plane.
+For example, if you are running 2.8.1.3 on one runtime instance and 3.0.0.0 on another, the control plane will only push configurations that can be used by the 2.8.1.3 runtime instance.
+
+If you experience compatibility errors, [upgrade your data planes](/konnect/runtime-manager/runtime-instances/upgrade) to match the version of the highest-versioned runtime instance in your runtime group.
+
+Possible compatibility errors:
+
+{% assign errors = site.data.tables.version_errors_konnect %}
+
+<table>
+  <thead>
+      <th>Error code</th>
+      <th>Severity</th>
+      <th>Description</th>
+      <th>Resolution</th>
+      <th class="width=25%">References</th>
+  </thead>
+<tbody>
+  {% for message in errors.messages %}
+      <tr>
+        <td>
+          {{ message.ID | markdownify }}
+        </td>
+        <td>
+          {{ message.Severity | markdownify }}
+        </td>
+        <td>
+          {{ message.Description | markdownify }}
+        </td>
+        <td>
+          {{ message.Resolution | markdownify }}
+        </td>
+        <td>
+          {{ message.DocumentationURL | markdownify }}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
### Description

Splitting the runtime manager troubleshooting topic into two: general troubleshooting and version compatibility, to make the version compatibility info more discoverable.

https://konghq.atlassian.net/browse/DOCU-3031

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

