### PR TITLE
Fix absolute links in link checker

### DIFF
--- a/tools/broken-link-checker/lib/src-to-urls.js
+++ b/tools/broken-link-checker/lib/src-to-urls.js
@@ -32,10 +32,12 @@ async function srcToUrls(pattern, src) {
 
     urls = urls.concat(
       r.map((u) => {
-        const url = u.is_absolute ? "" : u.url;
+        const prefix = u.is_absolute
+          ? ""
+          : `/${entry.product}/${entry.release}`;
         return {
           source: src,
-          url: `/${entry.product}/${entry.release}${url}`,
+          url: `${prefix}${u.url}`,
         };
       })
     );


### PR DESCRIPTION
### Description

Any absolute URL would resolve to `/<product>/<release>` in the previous fix. This inverts the logic so that the URL is used rather than the prefix.

It previously worked as `url == prefix` for index pages (which is what I set out to fix)

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

