### PR TITLE
docs(mesh): don't refer to Kuma in UBI instructions

### DIFF
--- a/app/_src/mesh/features/ubi-images.md
+++ b/app/_src/mesh/features/ubi-images.md
@@ -29,14 +29,14 @@ kumactl install control plane \
 {% endnavtab %}
 {% navtab Helm %}
 ```sh
-helm install kuma \
-  --namespace kuma-system \
+helm install kong-mesh \
+  --namespace kong-mesh-system \
   --set kuma.controlPlane.image.repository=ubi-kuma-cp \
   --set kuma.dataPlane.image.repository=ubi-kuma-dp \
   --set kuma.dataPlane.image.repository=ubi-kuma-dp \
   --set kuma.dataPlane.initImage.repository=ubi-kuma-dp \
   --set kuma.kumactl.image.repository=ubi-kumactl \
-  kuma/kuma
+  kong-mesh/kong-mesh
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/mesh/1.6.x/features/ubi-images.md
+++ b/app/mesh/1.6.x/features/ubi-images.md
@@ -29,14 +29,14 @@ kumactl install control plane \
 {% endnavtab %}
 {% navtab Helm %}
 ```sh
-helm install kuma \
-  --namespace kuma-system \
+helm install kong-mesh \
+  --namespace kong-mesh-system \
   --set kuma.controlPlane.image.repository=ubi-kuma-cp \
   --set kuma.dataPlane.image.repository=ubi-kuma-dp \
   --set kuma.dataPlane.image.repository=ubi-kuma-dp \
   --set kuma.dataPlane.initImage.repository=ubi-kuma-dp \
   --set kuma.kumactl.image.repository=ubi-kumactl \
-  kuma/kuma
+  kong-mesh/kong-mesh
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

This is about KM and the values are for the KM chart, see the Helm install instructions otherwise (release is called `kong-mesh`, NS is `kong-mesh-system`, etc).

### Testing instructions

[Rendered](https://deploy-preview-5278--kongdocs.netlify.app/mesh/latest/features/ubi-images/#usage)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

