### PR TITLE
Add a note about integrating Kong Manager with MFA

### DIFF
--- a/app/_src/gateway/kong-manager/auth/index.md
+++ b/app/_src/gateway/kong-manager/auth/index.md
@@ -31,7 +31,9 @@ In addition to the authentication plugins above, the
 is required when RBAC is enabled. It sends HTTP cookies to authenticate
 client requests and maintain session information.
 
-Note: Kong Manager does not directly offer 2FA, MFA, OTP or captcha/Recaptcha. However, if you configured Kong manager to use OIDC auth https://docs.konghq.com/gateway/latest/kong-manager/auth/oidc/configure/ then you could provide MFA etc via the OIDC provider.
+{:.note}
+> **Note:** Kong Manager does not directly offer 2FA, MFA, OTP, CAPTCHA, or reCAPTCHA. 
+However, if you configure Kong Manager to use [OIDC authentication](/gateway/{{page.kong_version}}/kong-manager/auth/oidc/configure/), then you can provide secondary authentication via your OIDC provider.
 
 The **Sessions plugin** (configured with `admin_gui_session_conf`) requires a secret and is configured securely by default.
 * Under all circumstances, the `secret` must be manually set to a string.

--- a/app/_src/gateway/kong-manager/auth/index.md
+++ b/app/_src/gateway/kong-manager/auth/index.md
@@ -31,6 +31,8 @@ In addition to the authentication plugins above, the
 is required when RBAC is enabled. It sends HTTP cookies to authenticate
 client requests and maintain session information.
 
+Note: Kong Manager does not directly offer 2FA, MFA, OTP or captcha/Recaptcha. However, if you configured Kong manager to use OIDC auth https://docs.konghq.com/gateway/latest/kong-manager/auth/oidc/configure/ then you could provide MFA etc via the OIDC provider.
+
 The **Sessions plugin** (configured with `admin_gui_session_conf`) requires a secret and is configured securely by default.
 * Under all circumstances, the `secret` must be manually set to a string.
 * If using HTTP instead of HTTPS, `cookie_secure` must be manually set to `false`.


### PR DESCRIPTION
### Description

What did you change and why?
 
I added this note: 
"Kong Manager does not directly offer 2FA, MFA, OTP or captcha/Recaptcha. However, if you configured Kong manager to use OIDC auth https://docs.konghq.com/gateway/latest/kong-manager/auth/oidc/configure/ then you could provide MFA etc via the OIDC provider."

As per this KB article: https://support.konghq.com/support/s/article/How-can-I-integrate-2FA-MFA-OTP-or-captcha-recaptcha-with-Kong-Manager 

It's not an uncommon question from customers, hence we created the KB above. 
However, perhaps it's better suited as a note in the docs, hence this PR. 


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)




