### PR TITLE
[DOCU-2506] Style guide updates

### DIFF
--- a/app/_data/docs_nav_contributing.yml
+++ b/app/_data/docs_nav_contributing.yml
@@ -1,4 +1,3 @@
-# to do: Heather will fill this out
 - title: Contribution guidelines
   icon: /assets/images/icons/documentation/icn-references-color.svg
   url: /
@@ -10,6 +9,10 @@
       url: /style-guide
     - text: Word choice and naming
       url: /word-choice
+    - text: Notes and other notices
+      url: /notices
+    - text: Documenting user interfaces
+      url: /user-interfaces
     - text: Contribution templates
       url: /contribution-templates
     - text: Plugin documentation
@@ -40,10 +43,3 @@
       url: /community-expectations
     - text: Hackathons
       url: /hackathons
-# - title: Plugin docs
-#   icon: /assets/images/icons/documentation/icn-references-color.svg
-#   url: /plugin-docs
-
-# - title: Terms
-#   icon: /assets/images/icons/documentation/icn-references-color.svg
-#   url: /terms

--- a/app/_hub/_init/my-extension/_index.md
+++ b/app/_hub/_init/my-extension/_index.md
@@ -5,7 +5,7 @@
 # Your publisher path is relative to app/_hub/.
 # The path must consist only of alphanumeric characters and hyphens (-).
 #
-# 2. Duplicate the versions.yml file into your new plugin directory.
+# 2. (Kong Inc. internal plugins only) Duplicate the versions.yml file into your new plugin directory.
 # Set the Kong Gateway version that the plugin is being added to.
 
 # 3. Add a 64x64px icon for the plugin to app/_assets/images/icons/hub.
@@ -20,13 +20,13 @@
 # https://github.com/Kong/docs.konghq.com/app/_hub for examples.
 # Remove inapplicable entries and comments as needed.
 
-name: # (required) The name of your extension.
+name: # (required) The name of your plugin.
   # Use capitals and spaces as needed.
-publisher: # (required) The name of the entity publishing this extension.
+publisher: # (required) The name of the entity publishing this plugin.
   # Use capitals and spaces as needed.
   # If you are an individual, you might choose to use your GitHub handle, or your name.
   # If this is being published and supported by a company, please use your company name.
-  # Note that every extension by a given publisher must have the exact same value.
+  # Note that every plugin by a given publisher must have the exact same value.
 
 categories: # (required) Uncomment ONE that applies.
   #- authentication
@@ -101,11 +101,11 @@ cloud: # (Kong Inc plugins only) Boolean
 # Set the subscription tiers that your plugin is restricted to.
 # If your plugin is free/open-source, set `false` for both the enterprise and plus tiers.
 
-enterprise: # (Kong Inc plugins only) Boolean
+enterprise: # (Kong Inc internal plugins only) Boolean
   # Specifies if your plugin is an Enterprise-tier plugin.
   # Set true if only available in Enterprise, or false if available in other tiers.
 
-plus: # (Kong Inc and Konnect only) Boolean
+plus: # (Kong Inc internal and Konnect only) Boolean
   # Specifies if your plugin is a Plus-tier plugin in Konnect.
   # Set true if the plugin is available in the Plus and Enterprise tiers, or false if available for free/in open-source.
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -134,18 +134,36 @@ them using three backticks, or fenced code blocks:
 
 ````
 ```bash
-some code here
+curl -i -X http://some-url \
+  --header 'content-type: application/json' \
+  --data '{"something":"example"}'
 ```
 ````
-
-Include a language whenever possible (in the example above, that language is
-`bash`). This will format your code blocks using language-specific syntax.
 
 You can also create tabbed code blocks, so that users can easily switch to
 their preferred format. See [tabs for code blocks](#tabs-for-code-blocks).
 
-<!-- If you're including placeholders in code blocks, use HTML tags instead of
-backticks. See [editable placeholders](#editable-placeholders-in-code-blocks). -->
+### Code block best practices 
+
+Use the following best practices for code blocks:
+
+* Wrap lines at 80 characters whenever possible. Use the `\` character to wrap a line.
+
+* Include a language (in the example above, that language is
+`bash`). This will format your code blocks using language-specific syntax.
+
+* Preface code examples with an introductory sentence. Use present tense, 
+avoid qualifiers, and end the statement with a colon (`:`). 
+
+  For example:
+
+  <i class="fa fa-check"></i> **Do:** The results should look like this:
+
+  <i class="fa fa-check"></i> **Do:** The output shows all of the connected data plane instances in the cluster:
+
+  <i class="fa times"></i> **Don't:** The results should look _something_ like this:
+
+  <i class="fa times"></i> **Don't:** The output will show...
 
 ## Placeholders
 
@@ -481,60 +499,6 @@ config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
   config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
   {% endnavtab %}
   {% endnavtabs %}
-
-## Admonitions
-
-When you need to highlight important information in some way, you can use an
-admonition. In our docs, we do this with Markdown blockquotes (`>`) and a class:
-
-```
-{:.note}
-> **Note**: Here's a note.
-```
-
-When using admonitions, think about whether the thing you're trying to note is
-_actually_ a note (or warning, or caution), or simply another piece of
-information that fits the flow of the task or content on the page. Avoid
-nesting too many elements inside admonitions, and try to keep them short.
-
-You can set the admonition label to anything you want. For example, you might
-want an `important` note to start with **Protect your password!**.
-
-Set a class on the admonition to display a specific style:
-
-* **Note:** {% raw %}`{:.note}`{% endraw %}
-
-    This is a generic note block that points out useful information that the
-    reader should pay attention to, but won't break anything if it's not followed.
-    If you don't use any class at all, the blockquote element defaults to this style.
-
-    {:.note}
-    > **Note:** Here's some info.
-
-* **Important:** {% raw %}`{:.important}`{% endraw %}
-
-    Use the `important` block for something that the reader really
-    needs to pay attention to, otherwise the thing they're trying to do won't work.
-
-    {:.important}
-    > **Important:** Be cautious about this thing.
-
-* **Warning:** {% raw %}`{:.warning}`{% endraw %}
-
-    Use the `warning` block for any big breaking changes, or for anything
-    irreversible.
-
-    {:.warning}
-    > **Warning:** Everything will break forever if you do this.
-
-* **No icon:** {% raw %}`{:.no-icon}`{% endraw %}
-
-    If you have a situation where you need to use a specific admonition type but
-    the icon doesn't belong, you can hide the icon by setting `no-icon` along
-    with any other admonition class. For example, here's the result of using `{:.warning .no-icon}`:
-
-    {:.warning .no-icon}
-    > This is something that's vital in a special way and the icon doesn't apply.
 
 ## Page-level navigation
 

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -157,13 +157,13 @@ avoid qualifiers, and end the statement with a colon (`:`).
 
   For example:
 
-  <i class="fa fa-check"></i> **Do:** The results should look like this:
+  ✅ **Do:** The results should look like this:
 
-  <i class="fa fa-check"></i> **Do:** The output shows all of the connected data plane instances in the cluster:
+  ✅ **Do:** The output shows all of the connected data plane instances in the cluster:
 
-  <i class="fa times"></i> **Don't:** The results should look _something_ like this:
+  ❌ **Don't:** The results should look _something_ like this:
 
-  <i class="fa times"></i> **Don't:** The output will show...
+  ❌ **Don't:** The output will show...
 
 ## Placeholders
 

--- a/app/contributing/notices.md
+++ b/app/contributing/notices.md
@@ -1,0 +1,87 @@
+---
+title: Notes and other notices
+content_type: reference
+---
+
+Notices are carefully selected, called-out text. 
+They purposely break the flow of text to grab a reader's attention and highlight important information.
+
+Notice types:
+* **Note:** Information concerning behavior that would not be expected, but won't break anything if it's not followed.
+* **Important:** Information that the reader really needs to pay attention to, otherwise things won't work.
+* **Warning:** Information necessary to avoid breaking something or losing data.
+
+You can set the notice label to anything you want. For example, you might
+want an `important` note to start with **Protect your password!**:
+
+{:.important}
+> **Protect your password!**
+> Store your password in a password manager. Never write passwords down on paper, or share them in plaintext.
+
+## Best practices 
+
+* When using notices, think about whether the thing you're trying to note is
+_actually_ a note (or warning, or caution), or simply another piece of
+information that fits the flow of the task or content on the page. 
+* Avoid nesting too many elements inside notices.
+* Keep notices short.
+* Don't stack notices. You never want to place multiple notices one after the other.
+
+## Notice types
+
+Crete a notice with Markdown blockquotes (`>`) and a class to display a specific style:
+
+### Note
+
+This is a generic note block that points out useful information that the
+reader should pay attention to, but won't break anything if it's not followed.
+If you don't use any class at all, the blockquote element defaults to this style.
+
+```
+{:.note}
+> **Note**: Here's some info.
+```
+
+{:.note}
+> **Note:** Here's some info.
+
+### Important
+
+Use the `important` block for something that the reader really
+needs to pay attention to, otherwise the thing they're trying to do won't work.
+
+```
+{:.important}
+> **Important:** Be cautious about this thing.
+```
+
+{:.important}
+> **Important:** Be cautious about this thing.
+
+### Warning 
+
+Use the `warning` block for any big breaking changes, or for anything
+irreversible.
+
+```
+{:.warning}
+> **Warning:** Everything will break forever if you do this.
+```
+
+{:.warning}
+> **Warning:** Everything will break forever if you do this.
+
+
+### No icon
+
+If you have a situation where you need to use a specific notice type but
+the icon doesn't belong, you can hide the icon by setting `no-icon` along
+with any other notice class. For example, here's the result of using `{:.warning .no-icon}`:
+
+```
+{:.warning .no-icon}
+> This is something that's vital in a special way and the icon doesn't apply.
+```
+
+{:.warning .no-icon}
+> This is something that's vital in a special way and the icon doesn't apply.

--- a/app/contributing/notices.md
+++ b/app/contributing/notices.md
@@ -60,7 +60,7 @@ needs to pay attention to, otherwise the thing they're trying to do won't work.
 
 ### Warning 
 
-Use the `warning` block for any big breaking changes, or for anything
+Use the `warning` block for any breaking changes, or for anything
 irreversible.
 
 ```

--- a/app/contributing/plugin-docs.md
+++ b/app/contributing/plugin-docs.md
@@ -6,23 +6,17 @@ Plugin documentation is posted on the [Plugin Hub](/hub/).
 All plugin docs, whether developed by Kong or external contributors,
 follow a [specific template](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/_init/my-extension).
 
-We are currently accepting plugin submissions to our plugin hub from trusted technical partners, on a limited basis. For more information, see the [Kong Partners page](https://konghq.com/partners/).
+We are currently accepting plugin submissions to our plugin hub from trusted technical partners, on a limited basis. 
+For more information, see the [Kong Partners page](https://konghq.com/partners/).
 
 {:.note}
 > The Kong Plugin Hub is a documentation site. We **do not** host plugin source code or downloads.
 
 ## Add a new plugin doc
 
-1. Set up or find your publisher directory:
-  * If you're contributing a plugin developed by Kong, 
- use the existing `_app/_hub/kong-inc` directory.
-  * If you're documenting a plugin created by another company, 
-  create a publisher directory at`_app/_hub/`, such as
- `_app/_hub/company-name`. 
+### Plugins created by Kong Inc
 
-    See other Kong Hub listings for examples of publisher names.
-
-1. Create a subdirectory for your plugin within your publisher directory.
+1. Create a subdirectory for your plugin within the `_app/_hub/kong-inc` directory.
 For example, `_app/_hub/kong-inc/your-plugin`.
 
 1. Copy the `/app/_hub/_init/my-extension/_index.md` and 
@@ -30,6 +24,10 @@ the `/app/_hub/_init/my-extension/versions.yml` files into your plugin's subdire
 
 1. Edit your `_index.md` file based on the guidance in comments in that file.
 You'll also find lots of helpful examples in other plugin doc files.
+
+    If any of your plugin's configuration parameters have default values, 
+    leave the `required` field blank for that parameter.
+    The existence of a default value negates the requirement.
 
 1. Edit your `versions.yml` file with the minimum {{site.base_gateway}} version that this plugin supports.
     This will generate a doc for every subsequent gateway version, 
@@ -44,6 +42,41 @@ should be a square-format PNG file, 120x120 pixels in size.
 
     Add the icon file to `/app/_assets/images/icons/hub/`. 
 
+### Third-party or partner plugins
+
+1. Set up or find your publisher directory.
+
+  If your company has not contributed a plugin to Kong before, 
+  create a publisher directory at`_app/_hub/`, such as
+ `_app/_hub/company-name`. 
+
+    See other Kong Hub listings for examples of publisher names.
+
+1. Create a subdirectory for your plugin within your publisher directory.
+For example, `_app/_hub/kong-inc/your-plugin`.
+
+1. Copy the `/app/_hub/_init/my-extension/_index.md` file into your plugin's subdirectory.
+
+    **Do not** use the `versions.yml` file. 
+    Kong does not maintain multiple versions of third-party plugin docs.
+
+1. Edit your `_index.md` file based on the guidance in comments in that file.
+You'll also find lots of helpful examples in other plugin doc files.
+
+    If any of your plugin's configuration parameters have default values, 
+    leave the `required` field blank for that parameter.
+    The existence of a default value negates the requirement.
+
+1. Plugin icons are required for publication on the Kong plugin hub. Icons
+should be a square-format PNG file, 120x120 pixels in size. 
+
+    The filename of your image should be `publisher_plugin-name` using 
+    the `publisher` and `plugin` name from step 2.
+    For example, `my-company_oas-validation`.
+
+    Add the icon file to `/app/_assets/images/icons/hub/`. 
+
+### Test and submit plugin
 
 1. Run the docs site locally per the instructions in
 the README - you should find your Hub contribution listed at

--- a/app/contributing/plugin-docs.md
+++ b/app/contributing/plugin-docs.md
@@ -16,11 +16,12 @@ For more information, see the [Kong Partners page](https://konghq.com/partners/)
 
 ### Plugins created by Kong Inc
 
-1. Create a subdirectory for your plugin within the `_app/_hub/kong-inc` directory.
+1. Create a subdirectory for your plugin [within the `_app/_hub/kong-inc` directory](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/kong-inc/).
 For example, `_app/_hub/kong-inc/your-plugin`.
 
-1. Copy the `/app/_hub/_init/my-extension/_index.md` and 
-the `/app/_hub/_init/my-extension/versions.yml` files into your plugin's subdirectory.
+1. Copy the [`/app/_hub/_init/my-extension/_index.md` and 
+the `/app/_hub/_init/my-extension/versions.yml`](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/_init/my-extension)
+files into your plugin's subdirectory.
 
 1. Edit your `_index.md` file based on the guidance in comments in that file.
 You'll also find lots of helpful examples in other plugin doc files.
@@ -44,18 +45,19 @@ should be a square-format PNG file, 120x120 pixels in size.
 
 ### Third-party or partner plugins
 
-1. Set up or find your publisher directory.
+1. Set up or find your publisher directory in the [docs repository](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/).
 
-  If your company has not contributed a plugin to Kong before, 
-  create a publisher directory at`_app/_hub/`, such as
- `_app/_hub/company-name`. 
+   If your company has not contributed a plugin to Kong before, 
+   create a publisher directory at`_app/_hub/`, such as
+  `_app/_hub/company-name`. 
 
     See other Kong Hub listings for examples of publisher names.
 
 1. Create a subdirectory for your plugin within your publisher directory.
 For example, `_app/_hub/kong-inc/your-plugin`.
 
-1. Copy the `/app/_hub/_init/my-extension/_index.md` file into your plugin's subdirectory.
+1. Copy the [`/app/_hub/_init/my-extension/_index.md`](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/_init/my-extension)
+ file into your plugin's subdirectory.
 
     **Do not** use the `versions.yml` file. 
     Kong does not maintain multiple versions of third-party plugin docs.

--- a/app/contributing/plugin-docs.md
+++ b/app/contributing/plugin-docs.md
@@ -16,17 +16,17 @@ For more information, see the [Kong Partners page](https://konghq.com/partners/)
 
 ### Plugins created by Kong Inc
 
-1. Create a subdirectory for your plugin [within the `_app/_hub/kong-inc` directory](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/kong-inc/).
+1. Create a subdirectory for the plugin [within the `_app/_hub/kong-inc` directory](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/kong-inc/).
 For example, `_app/_hub/kong-inc/your-plugin`.
 
 1. Copy the [`/app/_hub/_init/my-extension/_index.md` and 
 the `/app/_hub/_init/my-extension/versions.yml`](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/_init/my-extension)
-files into your plugin's subdirectory.
+files into the plugin's subdirectory.
 
 1. Edit your `_index.md` file based on the guidance in comments in that file.
 You'll also find lots of helpful examples in other plugin doc files.
 
-    If any of your plugin's configuration parameters have default values, 
+    If configuration parameters have default values, 
     leave the `required` field blank for that parameter.
     The existence of a default value negates the requirement.
 
@@ -53,7 +53,7 @@ should be a square-format PNG file, 120x120 pixels in size.
 
     See other Kong Hub listings for examples of publisher names.
 
-1. Create a subdirectory for your plugin within your publisher directory.
+1. Create a subdirectory for your plugin within the publisher directory.
 For example, `_app/_hub/kong-inc/your-plugin`.
 
 1. Copy the [`/app/_hub/_init/my-extension/_index.md`](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/_init/my-extension)
@@ -62,10 +62,10 @@ For example, `_app/_hub/kong-inc/your-plugin`.
     **Do not** use the `versions.yml` file. 
     Kong does not maintain multiple versions of third-party plugin docs.
 
-1. Edit your `_index.md` file based on the guidance in comments in that file.
+1. Edit the `_index.md` file based on the guidance in the comments in that file.
 You'll also find lots of helpful examples in other plugin doc files.
 
-    If any of your plugin's configuration parameters have default values, 
+    If configuration parameters have default values, 
     leave the `required` field blank for that parameter.
     The existence of a default value negates the requirement.
 
@@ -76,7 +76,7 @@ should be a square-format PNG file, 120x120 pixels in size.
     the `publisher` and `plugin` name from step 2.
     For example, `my-company_oas-validation`.
 
-    Add the icon file to `/app/_assets/images/icons/hub/`. 
+    Add the icon file to the `/app/_assets/images/icons/hub/` directory. 
 
 ### Test and submit plugin
 

--- a/app/contributing/plugin-docs.md
+++ b/app/contributing/plugin-docs.md
@@ -59,7 +59,7 @@ For example, `_app/_hub/kong-inc/your-plugin`.
 1. Copy the [`/app/_hub/_init/my-extension/_index.md`](https://github.com/Kong/docs.konghq.com/tree/main/app/_hub/_init/my-extension)
  file into your plugin's subdirectory.
 
-    **Do not** use the `versions.yml` file. 
+    **Do not** use the `versions.yml` file that also appears in the template directory.
     Kong does not maintain multiple versions of third-party plugin docs.
 
 1. Edit the `_index.md` file based on the guidance in the comments in that file.

--- a/app/contributing/plugin-docs.md
+++ b/app/contributing/plugin-docs.md
@@ -90,7 +90,9 @@ the README - you should find your Hub contribution listed at
     git push --set-upstream origin [name_of_your_new_branch]
     ```
 
-1. Find [your branch](https://github.com/Kong/docs.konghq.com/branches/yours) and make a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to add your documentation to the Plugin Hub. 
+1. Make a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+against the [docs.konghq.com](https://github.com/Kong/docs.konghq.com/) 
+repository to add your documentation to the Plugin Hub. 
 
 The Kong docs team will review your PR, suggest improvements and adjustments as
 necessary, and once approved, will merge and deploy your Plugin Hub addition!

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -40,7 +40,7 @@ title: Style guide
 
 ## Formatting standards
 
-### Automatic Formatting
+### Automatic formatting
 
 [Prettier](https://prettier.io/) is used to format all prose and code files. There are three ways to meet this standard:
 
@@ -49,16 +49,6 @@ title: Style guide
 * (Maintainers only) Add the `ci:autofix:prettier` label to a Pull Request
 
 All files in `app/_src` are formatted with Prettier. Prose in `app` has not been bulk-formatted and _may_ be formatted as you edit those files
-
-### Admonitions
-
-- Do not stack admonitions, in other words, list several admonitions one after the other.<br/>
-  Admonitions should be carefully selected, called-out text.
-- Admonition types:
-  - **Note:** Information concerning behavior that would not be expected, but won't break anything if it's not followed.
-  - **Warning:** Information necessary to avoid breaking something or losing data.
-  - **Important:** Information that the reader really needs to pay attention to, otherwise things won't work.
-For more information about formatting admonitions see [markdown-rules](/contributing/markdown-rules/#admonitions).
 
 ## Content types
 
@@ -168,23 +158,6 @@ to avoid horizontal scrolling.
 
 - Enclose sample code with single backticks.<br/>
   For example: \`sudo yum install /path/to/package.rpm`
-
-## Screenshots
-
-You can use screenshots to express the capabilities, look and feel, and experience of a feature in situations where exclusively using text would make the documentation harder to understand. We recommend writing the documentation first, **without** using screenshots, and then assessing if a screenshot would enhance the documentation.
-
-Screenshots are used to support documentation and do not _replace_ documentation. In some cases, using wireframes in place of screenshots is easier to maintain. Otherwise, all screenshots must follow these guidelines.
-
-- Screenshots must be taken with browser developer tools.
-- Resolution should be set to **1500x843.75**.
-- Screenshots of UI elements should include only the relevant **panel**. Panels are a container within a UI window which contain multiple related elements.
-- Mouse should not be visible.
-- Emphasis can be added by creating a **square** border around the point of interest. The border must use the color `#0788ad` from the [colors style guide](https://kongponents.netlify.app/style-guide/colors.html).
-- In situations that require it a `1px` black border can be used.
-- **Do not** use GIFs.
-- Limit image file size to ~2MB.
-- Add files to the corresponding product folder by navigating in the repo from `app > _assets > images > docs`.
-- Use lowercase letters and dashes when naming an image file.
 
 ### Icons
 

--- a/app/contributing/user-interfaces.md
+++ b/app/contributing/user-interfaces.md
@@ -1,0 +1,44 @@
+---
+title: Documenting user interfaces
+content_type: reference
+---
+
+ How do you direct users to interact with a UI element? 
+ Do you say “click” or “click on”? 
+ Where do you provide explicit instructions, and where do you condense?
+
+Use carets to describe only context menus, e.g.:
+
+Click Service actions > Add new version.
+
+Click All > Services.
+
+Don’t use plus signs in labels. For example, if the button looks like this: “+ New Plugin”, refer to the button as “New Plugin”.
+
+
+CRUD (create, read, update, delete) tasks:
+Can only exist as part of tutorial/getting-started/how-to 
+Does not exist anywhere else. 
+In cases of escalation, create a troubleshooting doc and add it in. 
+If the area of a screen only has an icon, refer to it by the title of the element + icon. (accessibility). 
+
+Screenshots: 
+Only two levels in Runtime manager -> Certificates 
+
+
+## Screenshots
+
+You can use screenshots to express the capabilities, look and feel, and experience of a feature in situations where exclusively using text would make the documentation harder to understand. We recommend writing the documentation first, **without** using screenshots, and then assessing if a screenshot would enhance the documentation.
+
+Screenshots are used to support documentation and do not _replace_ documentation. In some cases, using wireframes in place of screenshots is easier to maintain. Otherwise, all screenshots must follow these guidelines.
+
+- Screenshots must be taken with browser developer tools.
+- Resolution should be set to **1500x845**.
+- Screenshots of UI elements should include only the relevant **panel**. Panels are a container within a UI window which contain multiple related elements.
+- Mouse should not be visible.
+- Emphasis can be added by creating a **square** border around the point of interest. The border must use the color <span style="color:#0788ad">`#0788ad`</span> from the [colors style guide](https://kongponents.netlify.app/style-guide/colors.html).
+- In situations that require it a `1px` black border can be used.
+- **Do not** use GIFs.
+- Limit image file size to ~2MB.
+- Add files to the corresponding product folder by navigating in the repo from `app > _assets > images > docs`.
+- Use lowercase letters and dashes when naming an image file.

--- a/app/contributing/user-interfaces.md
+++ b/app/contributing/user-interfaces.md
@@ -5,23 +5,40 @@ content_type: reference
 
 ## Documenting interactions with UI elements
 
-When documenting UI instructions, make sure to write them as part of workflows.
-
 As a general rule, we do not directly document CRUD (create, read, update, delete) tasks in the Kong documentation without any context.
+
+When documenting UI instructions, make sure to write them as part of workflows. 
+For example, you might have a multi-section task where you [set up a vault object and use it](/konnect/runtime-manager/vaults/how-to/), part of which walks you through creating the object in the {{site.konnect_short_name}} UI.
 
 {:.note}
 > In cases of escalation around a specific task (for example, users keep struggling to delete a route in Kong Manager), create a troubleshooting doc for that content.
+See the [Dev Portal troubleshooting doc](/konnect/dev-portal/troubleshoot/) for an example.
 
 ## Best practices for referring to UI elements 
 
-* If the area of a screen only has an icon, refer to it by the title of the element + icon. 
-* Use carets to describe only context menus, e.g.:
+* If the area of a screen only has an icon, refer to it by the title of the element and its icon. For example:  
+    
+    ✅  **Do:** Click the {% konnect_icon cogwheel %} settings icon.
 
-    * Click Service actions > Add new version.
-    * Click All > Services.
+* Use carets to only describe context menus. For example:
+    
+    ✅  **Do:** Click **Service actions** > **Add new version**.
+    
+    ✅  **Do:** Click All > **Services**.
+    
+    ❌  **Don't:** Click the **Reports** button > **Latency** tab > **Service** tab.
 
-* Say **Click**; do not say **Click on**
-* Don’t use plus signs in labels. For example, if the button looks like this: `+ New Plugin`, refer to the button as `New Plugin`.
+* Say **Click**; do not say **Click on**. For example:
+    
+    ✅  **Do:** Click the **Reports** button.
+    
+    ❌  **Don't:** Click on the **Reports** button.
+
+* When referring to buttons or other interactable elements that have plus signs, don't use the plus sign in the documentation.
+    
+    ✅  **Do:** New Plugin
+    
+    ❌  **Don't:** + New Plugin
 
 ## Screenshots
 
@@ -35,7 +52,7 @@ Screenshots are used to support documentation and do not _replace_ documentation
 - Mouse should not be visible.
 - **Emphasis on elements in the screenshot:** Create a **rectangular** border around the point of interest. 
 The border must use the color <span style="color:#0788ad">`#0788ad`</span> from the [colors style guide](https://kongponents.netlify.app/style-guide/colors.html).
-- **Screenshot border:** Set the `image-border` class if your screeshot requires a border. You might need to set a border when:
+- **Screenshot border:** Set the `image-border` class if your screenshot requires a border. You might need to set a border when:
     * Panels have a white background and will therefore blend into the surrounding area
     * You want to separate the screenshot clearly from another image
     * It's hard to tell which text belongs to the screenshot and which to the page content

--- a/app/contributing/user-interfaces.md
+++ b/app/contributing/user-interfaces.md
@@ -3,28 +3,25 @@ title: Documenting user interfaces
 content_type: reference
 ---
 
- How do you direct users to interact with a UI element? 
- Do you say “click” or “click on”? 
- Where do you provide explicit instructions, and where do you condense?
+## Documenting interactions with UI elements
 
-Use carets to describe only context menus, e.g.:
+When documenting UI instructions, make sure to write them as part of workflows.
 
-Click Service actions > Add new version.
+As a general rule, we do not directly document CRUD (create, read, update, delete) tasks in the Kong documentation without any context.
 
-Click All > Services.
+{:.note}
+> In cases of escalation around a specific task (for example, users keep struggling to delete a route in Kong Manager), create a troubleshooting doc for that content.
 
-Don’t use plus signs in labels. For example, if the button looks like this: “+ New Plugin”, refer to the button as “New Plugin”.
+## Best practices for referring to UI elements 
 
+* If the area of a screen only has an icon, refer to it by the title of the element + icon. 
+* Use carets to describe only context menus, e.g.:
 
-CRUD (create, read, update, delete) tasks:
-Can only exist as part of tutorial/getting-started/how-to 
-Does not exist anywhere else. 
-In cases of escalation, create a troubleshooting doc and add it in. 
-If the area of a screen only has an icon, refer to it by the title of the element + icon. (accessibility). 
+    * Click Service actions > Add new version.
+    * Click All > Services.
 
-Screenshots: 
-Only two levels in Runtime manager -> Certificates 
-
+* Say **Click**; do not say **Click on**
+* Don’t use plus signs in labels. For example, if the button looks like this: `+ New Plugin`, refer to the button as `New Plugin`.
 
 ## Screenshots
 
@@ -36,8 +33,12 @@ Screenshots are used to support documentation and do not _replace_ documentation
 - Resolution should be set to **1500x845**.
 - Screenshots of UI elements should include only the relevant **panel**. Panels are a container within a UI window which contain multiple related elements.
 - Mouse should not be visible.
-- Emphasis can be added by creating a **square** border around the point of interest. The border must use the color <span style="color:#0788ad">`#0788ad`</span> from the [colors style guide](https://kongponents.netlify.app/style-guide/colors.html).
-- In situations that require it a `1px` black border can be used.
+- **Emphasis on elements in the screenshot:** Create a **rectangular** border around the point of interest. 
+The border must use the color <span style="color:#0788ad">`#0788ad`</span> from the [colors style guide](https://kongponents.netlify.app/style-guide/colors.html).
+- **Screenshot border:** Set the `image-border` class if your screeshot requires a border. You might need to set a border when:
+    * Panels have a white background and will therefore blend into the surrounding area
+    * You want to separate the screenshot clearly from another image
+    * It's hard to tell which text belongs to the screenshot and which to the page content
 - **Do not** use GIFs.
 - Limit image file size to ~2MB.
 - Add files to the corresponding product folder by navigating in the repo from `app > _assets > images > docs`.

--- a/app/contributing/user-interfaces.md
+++ b/app/contributing/user-interfaces.md
@@ -51,7 +51,7 @@ Screenshots are used to support documentation and do not _replace_ documentation
 - Screenshots of UI elements should include only the relevant **panel**. Panels are a container within a UI window which contain multiple related elements.
 - Mouse should not be visible.
 - **Emphasis on elements in the screenshot:** Create a **rectangular** border around the point of interest. 
-The border must use the color <span style="color:#0788ad">`#0788ad`</span> from the [colors style guide](https://kongponents.netlify.app/style-guide/colors.html).
+The border must use the color <span style="color:#0788ad">`#0788ad`</span> from the [colors style guide](https://kongponents.netlify.app/guide/styles/colors.html).
 - **Screenshot border:** Set the `image-border` class if your screenshot requires a border. You might need to set a border when:
     * Panels have a white background and will therefore blend into the surrounding area
     * You want to separate the screenshot clearly from another image

--- a/app/contributing/user-interfaces.md
+++ b/app/contributing/user-interfaces.md
@@ -34,7 +34,7 @@ See the [Dev Portal troubleshooting doc](/konnect/dev-portal/troubleshoot/) for 
     
     ❌  **Don't:** Click on the **Reports** button.
 
-* When referring to buttons or other interactable elements that have plus signs, don't use the plus sign in the documentation.
+* When referring to buttons or other interactive elements that have plus signs, don't use the plus sign in the documentation.
     
     ✅  **Do:** New Plugin
     


### PR DESCRIPTION
### Description

* Topic for user interfaces (draft, will need more work after)
* Third-party plugins
* Split out "admonitions" and called them "notices" (instead; the content was split out and not discoverable before
* Various cleanup and replacements

https://konghq.atlassian.net/browse/DOCU-2506

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

