### PR TITLE
Fix default rate limiting strategy in Konnect

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -306,15 +306,13 @@ params:
       datatype: boolean
       description: |
         Optionally hide informative response headers. Available options: `true` or `false`.
-  extra: |
-    > Note: Redis configuration values are ignored if the `cluster` strategy is used.
-
-    **Notes:**
-
-     * PostgreSQL 9.5+ is required when using the `cluster` strategy with `postgres` as the backing Kong cluster data store. This requirement varies from the PostgreSQL 9.4+ requirement as described in the <a href="/install/source">Kong Community Edition documentation</a>.
-
-     * The `dictionary_name` directive was added to prevent the usage of the `kong` shared dictionary, which could lead to `no memory` errors.
 ---
+
+{:.note}
+> **Notes:**
+  *  Redis configuration values are ignored if the `cluster` strategy is used.
+  * PostgreSQL 9.5+ is required when using the `cluster` strategy with `postgres` as the backing Kong cluster datastore.
+  * The `dictionary_name` directive was added to prevent the usage of the `kong` shared dictionary, which could lead to `no memory` errors.
 
 The **GraphQL Rate Limiting Advanced** plugin is an extension of the
 **Rate Limiting Advanced** plugin and provides rate limiting for
@@ -342,7 +340,7 @@ plugin exposes two strategies: `default` and `node_quantifier`.
 
 The following example queries can be run on this [SWAPI playground].
 
-[SWAPI playground]: https://swapi-graphql.eskerda.now.sh
+[SWAPI playground]: https://swapi-graphql.eskerda.vercel.app/
 
 ### `default`
 
@@ -693,8 +691,8 @@ curl -i -X PATCH http://kong:8001/plugins/{plugin_id} \
 
 * The `redis.username`, `redis.password`, `redis.sentinel_username`, and `redis.sentinel_password`
 configuration fields are now marked as referenceable, which means they can be securely stored as
-[secrets](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started)
-in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format/).
+[secrets](/gateway/latest/kong-enterprise/secrets-management/getting-started/)
+in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/secrets-management/reference-format/).
 
 * Fixed plugin versions in the documentation. Previously, the plugin versions
 were labelled as `1.3-x` and `2.3.x`. They are now updated to align with the

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -340,7 +340,7 @@ plugin exposes two strategies: `default` and `node_quantifier`.
 
 The following example queries can be run on this [SWAPI playground].
 
-[SWAPI playground]: https://swapi-graphql.eskerda.vercel.app/
+[SWAPI playground]: https://swapi-graphql.eskerda.vercel.app
 
 ### `default`
 

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -340,7 +340,7 @@ plugin exposes two strategies: `default` and `node_quantifier`.
 
 The following example queries can be run on this [SWAPI playground].
 
-[SWAPI playground]: https://swapi-graphql.eskerda.vercel.app
+[SWAPI playground]: https://swapi-graphql.eskerda.now.sh
 
 ### `default`
 

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_index.md
@@ -126,8 +126,6 @@ params:
         In DB-less and hybrid modes, the `cluster` config strategy is not
         supported.
 
-        In Konnect, the default strategy is `redis`.
-
         {:.important}
         > There is no local storage strategy. However, you can achieve local
         rate limiting by using a placeholder `strategy` value (either `cluster` or `redis`)

--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -137,10 +137,8 @@ params:
         - `local`: Counters are stored locally in-memory on the node (same effect
            as setting `sync_rate` to `-1`).
 
-        In DB-less and hybrid modes, the `cluster` config strategy
+        In DB-less, hybrid mode, and Konnect, the `cluster` config strategy
         is not supported.
-
-        In Konnect, the default strategy is `redis`.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).
@@ -161,13 +159,13 @@ params:
         - `redis`: Counters are stored on a Redis server and shared
            across the nodes.
 
-        In DB-less and hybrid modes, the `cluster` config strategy
-        is not supported. From `3.0.0.0` onwards, Kong disallows
-        the plugin enablement if strategy is `cluster` and `sync_rate` is `-1`
+        In DB-less, hybrid mode, and Konnect, the `cluster` config strategy
+        is not supported. 
+        
+        From `3.0.0.0` onwards, Kong disallows
+        the plugin enablement if the strategy is `cluster` and `sync_rate` is `-1`
         with DB-less or hybrid mode. From `3.2.0.0` onward, please
         use a different strategy or set `sync_rate` to `-1`.
-
-        In Konnect, the default strategy is `redis`.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).

--- a/app/_hub/kong-inc/rate-limiting-advanced/_v1.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_v1.md
@@ -136,10 +136,8 @@ params:
         - `local`: Counters are stored locally in-memory on the node (same effect
            as setting `sync_rate` to `-1`).
 
-        In DB-less and hybrid modes, the `cluster` config strategy
+        In DB-less, hybrid mode, and Konnect, the `cluster` config strategy
         is not supported.
-
-        In Konnect, the default strategy is `redis`.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).
@@ -160,13 +158,11 @@ params:
         - `redis`: Counters are stored on a Redis server and shared
            across the nodes.
 
-        In DB-less and hybrid modes, the `cluster` config strategy
+        In DB-less, hybrid mode, and Konnect, the `cluster` config strategy
         is not supported. From `3.0.0.0` onwards, Kong disallows
-        the plugin enablement if strategy is `cluster` and `sync_rate` is `-1`
-        with DB-less or hybrid mode. From `3.2.0.0` onward, please
+        the plugin enablement if the strategy is `cluster` and `sync_rate` is `-1`
+        with DB-less or hybrid mode. From `3.2.0.0` onward,
         use a different strategy or set `sync_rate` to `-1`.
-
-        In Konnect, the default strategy is `redis`.
 
         For details on which strategy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -98,11 +98,9 @@ params:
         - `redis`: Counters are stored on a Redis server and shared
         across the nodes.
 
-        In DB-less and hybrid modes, the `cluster` config policy is not supported.
-        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
+        In DB-less, hybrid mode, and Konnect, the `cluster` config policy is not supported.
+        For DB-less mode or Konnect, use one of `redis` or `local`; for hybrid mode, use
         `redis`, or `local` for data planes only.
-
-        In Konnect, the default policy is `redis`.
 
         For details on which policy should be used, refer to the
         [implementation considerations](#implementation-considerations).

--- a/app/_hub/kong-inc/response-ratelimiting/_index.md
+++ b/app/_hub/kong-inc/response-ratelimiting/_index.md
@@ -98,11 +98,9 @@ params:
         - `redis`: Counters are stored on a Redis server and shared
         across the nodes.
 
-        In DB-less and hybrid modes, the `cluster` config policy is not supported.
-        For DB-less mode, use one of `redis` or `local`; for hybrid mode, use
+        In DB-less, hybrid mode, and Konnect, the `cluster` config policy is not supported.
+        For DB-less mode or Konnect, use one of `redis` or `local`; for hybrid mode, use
         `redis`, or `local` for data planes only.
-
-        In Konnect, the default policy is `redis`.
 
         For details on which policy should be used, refer to the
         [implementation considerations](/hub/kong-inc/rate-limiting/#implementation-considerations).

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
@@ -196,8 +196,8 @@ have limitations in hybrid mode:
 (`ttl`), which determines the length of time a credential remains valid, does
 not work in hybrid mode.
 * [**Rate Limiting**](/hub/kong-inc/rate-limiting/), [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced/), and [**Response Rate Limiting**](/hub/kong-inc/response-ratelimiting/):
-These plugins don't support the `cluster` strategy/policy in hybrid mode. One the `local` or `redis` 
-strategies/policies must be used instead.
+These plugins don't support the `cluster` strategy/policy in hybrid mode. One of 
+the `local` or `redis` strategies/policies must be used instead.
 * [**GraphQL Rate Limiting Advanced**](/hub/kong-inc/graphql-rate-limiting-advanced/):
 This plugins doesn't support the `cluster` strategy in hybrid mode. The `redis` 
 strategy must be used instead.

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
@@ -192,13 +192,16 @@ control plane, all plugin configuration has to occur from the CP. Due to this
 setup, and the configuration sync format between the CP and the DP, some plugins
 have limitations in hybrid mode:
 
-* [**Key Auth Encrypted:**](/hub/kong-inc/key-auth-enc/) The time-to-live setting
+* [**Key Auth Encrypted**](/hub/kong-inc/key-auth-enc/): The time-to-live setting
 (`ttl`), which determines the length of time a credential remains valid, does
 not work in hybrid mode.
-* [**Rate Limiting Advanced:**](/hub/kong-inc/rate-limiting-advanced/)
-This plugin does not support the `cluster` strategy in hybrid mode. The `redis`
+* [**Rate Limiting**](/hub/kong-inc/rate-limiting/), [**Rate Limiting Advanced**](/hub/kong-inc/rate-limiting-advanced/), and [**Response Rate Limiting**](/hub/kong-inc/response-ratelimiting/):
+These plugins don't support the `cluster` strategy/policy in hybrid mode. One the `local` or `redis` 
+strategies/policies must be used instead.
+* [**GraphQL Rate Limiting Advanced**](/hub/kong-inc/graphql-rate-limiting-advanced/):
+This plugins doesn't support the `cluster` strategy in hybrid mode. The `redis` 
 strategy must be used instead.
-* [**OAuth 2.0 Authentication:**](/hub/kong-inc/oauth2/) This plugin is not
+* [**OAuth 2.0 Authentication**](/hub/kong-inc/oauth2/): This plugin is not
 compatible with hybrid mode. For its regular workflow, the plugin needs to both
 generate and delete tokens, and commit those changes to the database, which is
 not possible with CP/DP separation.


### PR DESCRIPTION
### Description

Default rate limiting strategy in Konnect is now `local`, the same as in all other places. It no longer needs a special callout.

Change happened in 3.0. This PR is a continuation of https://github.com/Kong/docs.konghq.com/pull/4378, these lines were missed.
 
Also removed any mention of Konnect from the GraphQL Rate Limiting advanced plugin, as this plugin is not supported in Konnect.

Issue called out in Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1678997282969009 and https://kongstrong.slack.com/archives/CDSTDSG9J/p1678951045262189

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

