### PR TITLE
chore(kic): add missing nav section for gateway API in 2.4

### DIFF
--- a/app/_data/docs_nav_kic_2.4.x.yml
+++ b/app/_data/docs_nav_kic_2.4.x.yml
@@ -33,6 +33,8 @@ items:
         url: /concepts/security
       - text: Ingress Resource API Versions
         url: /concepts/ingress-versions
+      - text: Gateway API
+        url: /concepts/gateway-api
   - title: Deployment
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     url: /deployment/overview


### PR DESCRIPTION
### Description

This PR fixes a missing nav section in 2.4 docs. This came up when changing files for 2.9 release: https://github.com/Kong/docs.konghq.com/actions/runs/4448486330/jobs/7811364792#step:5:168

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

