### PR TITLE
GatewayAlpha feature-gate added to grpc guide

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/using-ingress-with-grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-ingress-with-grpc.md
@@ -115,6 +115,10 @@ In this guide, we use
 [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation).
 Ensure that you have it installed on your local system.
 
+## Enable the `GatewayAlpha` feature gate
+
+If you are using the Gateway API, you need to enable the [`GatewayAlpha`](/kubernetes-ingress-controller/{{page.kong_version}}/references/feature-gates) feature gate in the Kubernetes Ingress Controller.
+
 ## Deploy a gRPC test application
 
 Add a gRPC deployment and service:


### PR DESCRIPTION
### Description

The `GRPCRoute` guide has been improved with a new section related to enabling the `GatewayAlpha` feature gate in KIC.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

