### PR TITLE
docs(http-log): plugin schema update for 3.3

### DIFF
--- a/app/_hub/kong-inc/http-log/_index.md
+++ b/app/_hub/kong-inc/http-log/_index.md
@@ -59,7 +59,7 @@ params:
       value_in_examples: null
       datatype: string
       description: |
-        Indicates the type of data sent. The only available option is `application/json`.
+        Indicates the type of data sent. The available options are `application/json` and `application/json; charset=utf-8`.
     - name: timeout
       required: false
       default: '`10000`'

--- a/app/_hub/kong-inc/http-log/_index.md
+++ b/app/_hub/kong-inc/http-log/_index.md
@@ -53,7 +53,17 @@ params:
       description: |
         An optional method used to send data to the HTTP server. Supported values are
         `POST` (default), `PUT`, and `PATCH`.
-    - name: content_type
+    
+    - name: content_type # old param version
+      maximum_version: "3.2.x"
+      required: false
+      default: '`application/json`'
+      value_in_examples: null
+      datatype: string
+      description: |
+        Indicates the type of data sent. The only available option is `application/json`.
+    - name: content_type # current param version
+      minimum_version: "3.3.x"
       required: false
       default: '`application/json`'
       value_in_examples: null
@@ -177,6 +187,10 @@ The log server that receives these messages might require extra headers, such as
 ---
 
 ## Changelog
+
+**{{site.base_gateway}} 3.3.x**
+
+* This plugin now supports the `application/json; charset=utf-8` content type.
 
 **{{site.base_gateway}} 3.0.x**
 


### PR DESCRIPTION
### Description

Added config schema explanation, as per PR https://github.com/Kong/kong/pull/10533

The PR adds just one config option to the restricted list available for http-log's "content_type" schema entry.

Target is for it to end up at this page, upon the next Kong minor release: https://docs.konghq.com/hub/kong-inc/http-log/

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

