### PR TITLE
Add initial draft of Konnect API errors

### DIFF
--- a/app/_data/konnect_errors.yml
+++ b/app/_data/konnect_errors.yml
@@ -1,0 +1,27 @@
+- title: Base Errors
+  description: |
+    The following errors may be returned by any Konnect API. They are primarily related to authentication and request validation and should be handled consistently in your application
+  errors:
+    unauthenticated:
+      title: Unauthenticated
+      description: You must be authenticated to perform this action.
+      resolution: Send a valid Bearer access token in your request 
+      link:
+        url: /konnect/api/#authentication
+        text: Learn more about Authentication
+    unauthorized:
+      title: Unauthorized
+      description: You do not have permission to perform this action.
+      resolution: Speak to your organization administrator to be granted the required permissions
+    not-found:
+      title: Not Found
+      description: The resource requested does not exist, or it is not owned by the organization that the authenticated user belongs to
+      resolution: Check the resource ID provided and try again
+    invalid-request:
+      title: Invalid Request
+      description: Your request was understood, but can't be processed due to invalid data in the payload
+      resolution: See the `invalid_parameters` section of the response for more detailed information
+    conflict:
+      title: Conflict
+      description: The requested action is valid but can't be executed due to the current state on the server
+      resolution: N/A

--- a/app/konnect/api/errors.md
+++ b/app/konnect/api/errors.md
@@ -1,0 +1,41 @@
+---
+title: Konnect API Errors
+content-type: reference
+---
+
+{% for entry in site.data.konnect_errors %}
+
+<h2>{{ entry.title }}</h2>
+
+{{ entry.description }}
+
+<table style="width:100%; display:table;">
+<thead>
+  <tr>
+    <th>Code</th>
+    <th>Information</th>
+  </tr>
+</thead>
+<tbody>
+  {% for e in entry.errors %}
+  {% assign error = e[1] %}
+  <tr id="{{ e[0] }}">
+    <td width="25%">
+      {{ error.title }}
+    </td>
+    <td>
+      <strong>Description:</strong><br />
+      {{ error.description | newline_to_br }}
+      <br /><br />
+      <strong>Resolution:</strong><br />
+      {{ error.resolution | newline_to_br }}
+  
+      {% if error.link %}
+      <br /><br /><a href="{{ error.link.url }}">{{ error.link.text }} &raquo;</a>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</tbody>
+</table>
+{% endfor %}


### PR DESCRIPTION
### Description

Add a page documenting errors from the Konnect API.

This will be used with kongapi.info

kongapi.info/konnect/unauthenticated will be redirected to docs.konghq.com/konnect/api/errors#unauthenticated etc

The `konnect_errors` file will be maintained by Konnect engineering as new errors are added


### Testing instructions

Netlify link: https://deploy-preview-5329--kongdocs.netlify.app/konnect/api/errors/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

