### PR TITLE
Clarified where admin SMTP properties are set in Hybrid deployment

### DIFF
--- a/app/_src/gateway/kong-manager/configuring-to-send-email.md
+++ b/app/_src/gateway/kong-manager/configuring-to-send-email.md
@@ -13,7 +13,7 @@ Emails from Kong Manager require the following configuration through `kong.conf`
 * [`admin_emails_reply_to`](/gateway/{{page.kong_version}}/reference/configuration/#admin_emails_reply_to)
 * [`admin_invitation_expiry`](/gateway/{{page.kong_version}}/reference/configuration/#admin_invitation_expiry)
 
-If running {{site.base_gateway}} in Hybrid deployment mode, these admin SMTP settings are meant to be applied to the Control Plane.
+If running {{site.base_gateway}} in hybrid deployment mode, these admin SMTP settings are meant to be applied to the control plane.
 
 Kong does not check for the validity of email addresses set in the configuration. If the SMTP settings are configured incorrectly, for example if they point to a non-existent email address, Kong Manager will _not_ display an error message.
 

--- a/app/_src/gateway/kong-manager/configuring-to-send-email.md
+++ b/app/_src/gateway/kong-manager/configuring-to-send-email.md
@@ -13,7 +13,7 @@ Emails from Kong Manager require the following configuration through `kong.conf`
 * [`admin_emails_reply_to`](/gateway/{{page.kong_version}}/reference/configuration/#admin_emails_reply_to)
 * [`admin_invitation_expiry`](/gateway/{{page.kong_version}}/reference/configuration/#admin_invitation_expiry)
 
-If running Kong Gateway in Hybrid deployment mode, these admin SMTP settings are meant to be applied to the Control Plane.
+If running {{site.base_gateway}} in Hybrid deployment mode, these admin SMTP settings are meant to be applied to the Control Plane.
 
 Kong does not check for the validity of email addresses set in the configuration. If the SMTP settings are configured incorrectly, for example if they point to a non-existent email address, Kong Manager will _not_ display an error message.
 

--- a/app/_src/gateway/kong-manager/configuring-to-send-email.md
+++ b/app/_src/gateway/kong-manager/configuring-to-send-email.md
@@ -13,11 +13,8 @@ Emails from Kong Manager require the following configuration through `kong.conf`
 * [`admin_emails_reply_to`](/gateway/{{page.kong_version}}/reference/configuration/#admin_emails_reply_to)
 * [`admin_invitation_expiry`](/gateway/{{page.kong_version}}/reference/configuration/#admin_invitation_expiry)
 
-Kong does not check for the validity of email
-addresses set in the configuration. If the SMTP settings are
-configured incorrectly, for example if they point to a non-existent
-email address, Kong Manager will _not_ display an error message.
+If running Kong Gateway in Hybrid deployment mode, these admin SMTP settings are meant to be applied to the Control Plane.
 
-For additional information about SMTP, refer to the
-[general SMTP configuration](/gateway/{{page.kong_version}}/reference/configuration/#general-smtp-configuration)
-shared by Kong Manager and Dev Portal.
+Kong does not check for the validity of email addresses set in the configuration. If the SMTP settings are configured incorrectly, for example if they point to a non-existent email address, Kong Manager will _not_ display an error message.
+
+For additional information about SMTP, refer to the [general SMTP configuration](/gateway/{{page.kong_version}}/reference/configuration/#general-smtp-configuration) shared by Kong Manager and Dev Portal.


### PR DESCRIPTION
### Description

Made it a bit clearer that these properties are aimed to be deployed with the Control Plane configuration in case of Hybrid deployment. This came up as a question from a customer who wasn't sure where to place the configurations, whether it was on the CP or DP.

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
