### PR TITLE
AppDynamics: Set `bundled:false` to default for all versions

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/_index.md
@@ -28,6 +28,7 @@ kong_version_compatibility:
     compatible: null
   enterprise_edition:
     compatible: true
+bundled: false
 params:
   name: app-dynamics
   service_id: true

--- a/app/_hub/kong-inc/app-dynamics/versions.yml
+++ b/app/_hub/kong-inc/app-dynamics/versions.yml
@@ -2,7 +2,3 @@ strategy: gateway
 
 releases:
   minimum_version: '3.1.x'
-
-frontmatter:
-  3.1.x:
-    bundled: false


### PR DESCRIPTION
### Description

The AppDynamics plugin is not going to be bundled with Kong in the foreseeable future, and we shouldn't have to add a new entry for `bundled:false` with every release. Setting it directly in the plugin's front matter will apply it to all versions of the plugin.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

