### PR TITLE
Add the ability to customise the stability banner

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -110,11 +110,19 @@ id: documentation
             {% if page.alpha %}
             <blockquote class="warning no-icon">
               This feature is released as a <a href="/gateway/latest/availability-stages/#tech-preview">tech preview</a> (alpha-quality) and should not be deployed in a production environment.
+
+              {% if page.stability_message %}
+              {{ page.stability_message }}
+              {% endif %}
             </blockquote>
             {% endif %}
             {% if page.beta %}
             <blockquote class="warning no-icon">
               This feature is released as <a href="/gateway/latest/availability-stages/#beta">beta</a> and should not be deployed in a production environment.
+
+              {% if page.stability_message %}
+              {{ page.stability_message }}
+              {% endif %}
             </blockquote>
             {% endif %}
 

--- a/app/_src/kubernetes-ingress-controller/guides/using-multiple-backends.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-multiple-backends.md
@@ -2,6 +2,8 @@
 title: Using multiple backend Services
 content_type: tutorial
 beta: true
+stability_message: |
+  Using multiple backend services will be GA once a non-beta version of the <a href="https://gateway-api.sigs.k8s.io/">Kubernetes Gateway API</a> is available
 ---
 
 ## Overview

--- a/app/_src/kubernetes-ingress-controller/guides/using-multiple-backends.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-multiple-backends.md
@@ -3,7 +3,7 @@ title: Using multiple backend Services
 content_type: tutorial
 beta: true
 stability_message: |
-  Using multiple backend services will be GA once a non-beta version of the <a href="https://gateway-api.sigs.k8s.io/">Kubernetes Gateway API</a> is available
+  Using multiple backend services will be GA once a non-beta version of the <a href="https://gateway-api.sigs.k8s.io/">Kubernetes Gateway API</a> is available.
 ---
 
 ## Overview


### PR DESCRIPTION
### Description

Added the ability to add more information to the stability banner.

### Testing instructions

Netlify link: https://deploy-preview-5348--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/using-multiple-backends/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
