### PR TITLE
Added note about PKCE usage with OIDC plugin

### DIFF
--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -2201,7 +2201,7 @@ for this usage scenario, including the use of session cookies:
 <img src="/assets/images/docs/openid-connect/authorization-code-flow.svg">
 
 {:.info}
-> If PKCE is to be used, the Identity Provider _must_ contain the ```code_challenge_methods_supported``` in the /.well-known/openid-configuration Discovery endpoint response. If it is not included, the PKCE code_challenge will not be sent. The ```code_challenge_methods_supported``` is a requirement for PKCE per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html).
+> If PKCE is to be used, the Identity Provider _must_ contain the ```code_challenge_methods_supported``` object in the ```/.well-known/openid-configuration``` Issuer discovery endpoint response. If it is not included, the PKCE ```code_challenge``` query parameter will not be sent. The ```code_challenge_methods_supported``` is a requirement for PKCE per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html).
 
 #### Patch the Plugin
 

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -2200,8 +2200,8 @@ for this usage scenario, including the use of session cookies:
 
 <img src="/assets/images/docs/openid-connect/authorization-code-flow.svg">
 
-{:.info}
-> If PKCE is to be used, the Identity Provider _must_ contain the ```code_challenge_methods_supported``` object in the ```/.well-known/openid-configuration``` Issuer discovery endpoint response. If it is not included, the PKCE ```code_challenge``` query parameter will not be sent. The ```code_challenge_methods_supported``` is a requirement for PKCE per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html).
+{:.note}
+> If using PKCE, the identity provider *must* contain the `code_challenge_methods_supported` object in the `/.well-known/openid-configuration` issuer discovery endpoint response, as required by [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html). If it is not included, the PKCE `code_challenge` query parameter will not be sent.
 
 #### Patch the Plugin
 

--- a/app/_hub/kong-inc/openid-connect/_index.md
+++ b/app/_hub/kong-inc/openid-connect/_index.md
@@ -2200,6 +2200,9 @@ for this usage scenario, including the use of session cookies:
 
 <img src="/assets/images/docs/openid-connect/authorization-code-flow.svg">
 
+{:.info}
+> If PKCE is to be used, the Identity Provider _must_ contain the ```code_challenge_methods_supported``` in the /.well-known/openid-configuration Discovery endpoint response. If it is not included, the PKCE code_challenge will not be sent. The ```code_challenge_methods_supported``` is a requirement for PKCE per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html).
+
 #### Patch the Plugin
 
 Let's patch the plugin that we created in the [Kong configuration](#kong-configuration) step:


### PR DESCRIPTION
### Description

There was no real information about PKCE requirements if it's needed to be used. Adding more details to show that ```code_challenge_methods_supported``` is a requirement in the IdP response if PKCE is needed to be used in Kong's OIDC plugin. This stems from a customer support case.

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)