### PR TITLE
Update Kong Gateway patch version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -199,8 +199,8 @@
   lua_doc: true
 -
   release: "3.2.x"
-  ee-version: "3.2.1.0"
-  ce-version: "3.2.1"
+  ee-version: "3.2.2.0"
+  ce-version: "3.2.2"
   edition: "gateway"
   luarocks_version: "3.0.0-0"
   dependencies:


### PR DESCRIPTION
### Description

Gateway 3.2.2 is out. The 3.2.1 release isn't available for Alpine


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
