### PR TITLE
docs(oauth2): Warn about Resource Owner Password Credentials Grant

### DIFF
--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -135,7 +135,7 @@ params:
     - name: anonymous
       required: false
       default: null
-      datatype: string      
+      datatype: string
       description: |
         An optional string (consumer UUID) value to use as an anonymous consumer if authentication fails.
         If empty (default), the request fails with an authentication failure `4xx`. Note that this value
@@ -334,13 +334,13 @@ You can use this information on your side to implement additional logic. You can
 ### Client Credentials
 
 The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow works out of the box, without building any authorization page.
-The clients need to use the `/oauth2/token` endpoint to request an access token.  
+The clients need to use the `/oauth2/token` endpoint to request an access token.
 
 You can access the `/oauth2/token` endpoint to retrieve the `access_token` in the following ways:
 
 * Using a POST request, set `Content-Type` to `application/x-www-form-urlencoded` and send the credentials as form data:
 
-    ```bash  
+    ```bash
     curl -i -X POST 'https://example.service.com/oauth2/token' \
       --header 'Content-Type: application/x-www-form-urlencoded' \
       --data-urlencode 'client_id=XXXX' \
@@ -441,13 +441,22 @@ In this flow, the steps that you need to implement are:
 
 ## Resource Owner Password Credentials
 
+
+<div class="alert alert-warning">
+  <strong>Note:</strong>
+  The OAuth2 Security Best Practice explicitly mentions that Resource Owner Password Credentials
+  ["MUST NOT BE USED"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-13#section-3.4)
+  The following section is left here as a reference for supporting legacy systems.
+</div>
+
+
 The [Resource Owner Password Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.3) is a much simpler version of the Authorization Code flow, but it still requires to build an authorization backend (without the frontend) in order to make it work properly.
 
 ![OAuth 2.0 Flow](/assets/images/docs/oauth2/oauth2-flow2.png)
 
-1. On the first request, the client application make a request including some OAuth2 parameters, including `username` and `password` parameters, to your web-application.
+1. On the first request, the client application make a request with some OAuth2 parameters to your web-application.
 
-2. The backend of your web-application will authenticate the `username` and `password` sent by the client, and if successful will add the `provision_key`, `authenticated_userid` and `grant_type` parameters to the parameters originally sent by the client, and it will make a `POST` request to Kong at, on the `/oauth2/token` endpoint of the configured plugin. If an `Authorization` header has been sent by the client, that must be added too. The equivalent of:
+2. The backend of your web-application will add the `provision_key` and `grant_type` parameters to the parameters originally sent by the client, and it will make a `POST` request to Kong at, on the `/oauth2/token` endpoint of the configured plugin. If an `Authorization` header has been sent by the client, that must be added too. The equivalent of:
 
     ```bash
     curl https://your.service.com/oauth2/token \

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -439,24 +439,22 @@ In this flow, the steps that you need to implement are:
 
 ----
 
-## Resource Owner Password Credentials
+## (Legacy systems only) Resource owner password credentials
 
 
-<div class="alert alert-warning">
-  <strong>Note:</strong>
-  The OAuth2 Security Best Practice explicitly mentions that Resource Owner Password Credentials
-  ["MUST NOT BE USED"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-13#section-3.4)
+{:.important}
+ > **Important**: The OAuth2 Security Best Practice explicitly mentions that Resource Owner Password Credentials
+  ["MUST NOT BE USED"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-13#section-3.4).
   The following section is left here as a reference for supporting legacy systems.
-</div>
 
 
 The [Resource Owner Password Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.3) is a much simpler version of the Authorization Code flow, but it still requires to build an authorization backend (without the frontend) in order to make it work properly.
 
 ![OAuth 2.0 Flow](/assets/images/docs/oauth2/oauth2-flow2.png)
 
-1. On the first request, the client application make a request with some OAuth2 parameters to your web-application.
+1. On the first request, the client application makes a request with some OAuth2 parameters to your web application.
 
-2. The backend of your web-application will add the `provision_key` and `grant_type` parameters to the parameters originally sent by the client, and it will make a `POST` request to Kong at, on the `/oauth2/token` endpoint of the configured plugin. If an `Authorization` header has been sent by the client, that must be added too. The equivalent of:
+2. The backend of your web application adds the `provision_key` and `grant_type` parameters to the parameters originally sent by the client, then makes a `POST` request to Kong using the `/oauth2/token` endpoint of the configured plugin. If an `Authorization` header is sent by the client, that must be added too. For example:
 
     ```bash
     curl https://your.service.com/oauth2/token \


### PR DESCRIPTION
### Description

Adds a warn section to Oauth2 Resource Owner Password Credentials Grant
section.

Related with https://github.com/Kong/kong/issues/1752 (that issue advocates for removing username and password, we added a warning for the whole section instead. The alternative would be removing that whole section entirely)

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

