### PR TITLE
[DOCU-3145] Third-party plugin layout adjustments

### DIFF
--- a/app/_hub/imperva/imp-appsec-connector/_index.md
+++ b/app/_hub/imperva/imp-appsec-connector/_index.md
@@ -34,6 +34,7 @@ description: |
   receiver service endpoint though the plugin's configuration, so the API data is 
   kept under the control of the application owner.
 
+enterprise: true
 # (required) extended description.
 # Use YAML pipe notation for extended entries.
 # EXAMPLE long text format (do not use this entry)

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -33,9 +33,9 @@
         {% if include.publisher == "Kong Inc." %}
            {% unless include.cloud == false %}<a href="https://cloud.konghq.com" target="_blank" class="badge konnect" aria-label="compatible with Konnect"></a>{% endunless %}
            {% if include.plus %} <a href="https://konghq.com/pricing" target="_blank" class="badge plus" aria-label="available with plus subscription"></a>{% endif %}
-           {% if include.enterprise %}<a href="https://konghq.com/pricing" target="_blank" class="badge enterprise" aria-label="available with enterprise subscription"></a>{% endif %}
-           {% if include.oss %}<a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source only"></a>{% endif %}
         {% endif %}
+        {% if include.enterprise %}<a href="https://konghq.com/pricing" target="_blank" class="badge enterprise" aria-label="available with enterprise subscription"></a>{% endif %}
+        {% if include.oss %}<a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source only"></a>{% endif %}
         </div>
       </div>
       {% if include.extn_versions %}

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -15,7 +15,7 @@
         <div class="name-desc">
           {% if extn.plus and extn_publisher == 'kong-inc' %}
           <span class="plugin-badge plus"></span>{% endif %}
-          {% if extn.enterprise and extn_publisher == 'kong-inc' %}
+          {% if extn.enterprise %}
           <span class="plugin-badge enterprise"></span> {% endif %}
           <img class="card-img-top" src="{{ extn.extn_icon }}" alt="" />
           <p class="plugin-name">{{ extn.name }}</p>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -149,12 +149,13 @@ breadcrumbs:
 We used to show a compatibility matrix for all plugins. As of Gateway 3.0 (and backported to the 2.x series)
 we pin the plugin version to the Gateway version. These are marked with strategy = gateway
 
-We only want to show the compatibility matrix if the strategy = matrix (which is the default)
+We only want to show the compatibility matrix if the strategy = matrix (which is the default), or if the plugins are third-party.
 {% endcomment %}
-{% unless extn_data['strategy'] == "matrix" %}
-  {% assign compat = false %}
-{% endunless %}
-
+{% if extn_publisher == "kong-inc" %}
+  {% unless extn_data['strategy'] == "matrix" %}
+    {% assign compat = false %}
+  {% endunless %}
+{% endif %}
 {% assign extn_type = site.extensions.types | where: "slug", page.type %}
 {% assign extn_type = extn_type[0]['name'] %}
 
@@ -462,57 +463,30 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
           </tr>
           <tr class="kong-compatibility">
             <td colspan="2">
+            {% if ee_compatible %}
               <ul class="compat-list">
-              {% for v in site.data.kong_versions_gateway reversed %}
-                {% if ee_compatible contains v.release %}
-                  {% unless first_ee %}
-                  <span class="compat-label">{{site.ee_product_name}}</span>{% assign first_ee = true %}
-                  {% endunless %}
+                {% unless first_ee %}
+                    <span class="compat-label">{{site.ee_product_name}}</span>{% assign first_ee = true %}
+                {% endunless %}
+                {% for v in ee_compatible %}
                   <li>
-                  {% if ee_compatible contains v.release %}
-                    <i class="fa fa-check"></i>
-                  {% endif %}{{ v.release }}
+                    <i class="fa fa-check"></i> {{ v }}
                   </li>
-                {% endif %}
-              {% endfor %}
-              {% for v in site.data.kong_versions_ee reversed %}
-                {% if ee_compatible contains v.release %}
-                  {% unless first_ee %}
-                  <span class="compat-label">{{site.ee_product_name}}</span>{% assign first_ee = true %}
-                  {% endunless %}
-                  <li>
-                  {% if ee_compatible contains v.release %}
-                    <i class="fa fa-check"></i>
-                  {% endif %}{{ v.release }}
-                  </li>
-                {% endif %}
-              {% endfor %}
-              </ul><ul class="compat-list">
-              {% for v in site.data.kong_versions_gateway reversed %}
-                {% if ce_compatible contains v.release %}
-                  {% unless first_ce %}
-                    <span class="compat-label">{{site.ce_product_name}}</span>{% assign first_ce = true %}
-                  {% endunless %}
-                  <li>
-                  {% if ce_compatible contains v.release %}
-                    <i class="fa fa-check"></i>
-                  {% endif %}{{ v.release }}
-                  </li>
-                {% endif %}
-              {% endfor %}
-              {% for v in site.data.kong_versions_ce reversed %}
-                {% if ce_compatible contains v.release %}
-                  {% unless first_ce %}
-                    <span class="compat-label">{{site.ce_product_name}}</span>{% assign first_ce = true %}
-                  {% endunless %}
-                  <li>
-                  {% if ce_compatible contains v.release %}
-                    <i class="fa fa-check"></i>
-                  {% endif %}{{ v.release }}
-                  </li>
-                {% endif %}
-              {% endfor %}
+               {% endfor %}
               </ul>
+            {% endif %}
+            {% if ce_compatible %}
+              <ul class="compat-list">
+                {% unless first_ce %}
+                    <span class="compat-label">{{site.ce_product_name}}</span>{% assign first_ce = true %}
+                {% endunless %}
+                {% for v in ce_compatible %}
+                  <li>
+                    <i class="fa fa-check"></i> {{ v }}
+                  </li>
+               {% endfor %}
+              </ul>
+            {% endif %}
             </td>
           </tr>
         {% endif %}

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -184,7 +184,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
     {% if page.type == "plugin" or page.type == "integration" %}
       {% unless extn_publisher == "kong-inc" %}
         <div class="alert alert-info blue" role="alert">
-          Community {{ extn_type | capitalize }}: This plugin is <b>developed, tested, and maintained</b> by a third-party contributor.
+          Partner Plugin: This plugin is <b>developed, tested, and maintained</b> by a third-party contributor.
         </div>
       {% endunless %}
     {% endif %}


### PR DESCRIPTION
### Description

* Enabled the compatible versions list for third party plugins
* Enabled enterprise badges for third-party plugins
* Changed 3rd party banner to read "Partner Plugin" instead of "Community Plugin", based on our new partner plugin program approach.

https://konghq.atlassian.net/browse/DOCU-3145

### Testing instructions

* Test on the Imperva plugin: 
  * https://deploy-preview-5362--kongdocs.netlify.app/hub/ (look at the Imperva tile)
  * https://deploy-preview-5362--kongdocs.netlify.app/hub/imperva/imp-appsec-connector/

* Check any other third-party plugins on the plugin hub to make sure that the version compatibility list appears in the side nav, eg: https://deploy-preview-5362--kongdocs.netlify.app/hub/wallarm/wallarm/ 
* And check that Kong plugins _don't_ have this list.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

