### PR TITLE
Contributing guide: add missing front matter options

### DIFF
--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -29,7 +29,7 @@ Add the tag that most closely resembles the concept, even if it doesn’t perfec
 : Disables the version selector dropdown. Set this on pages that shouldn't be versioned.
 : 
 : Do not use if the page is part of `/contributing/` or `/konnect/`, 
-as both of those doc sets are unversioned by default.
+as both of those doc sets are not versioned by default.
 
 `beta: true` or `alpha: true`
 : Labels the page as beta or alpha; adds a banner to the top of the page. Can use `stability_message` to

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -20,15 +20,28 @@ Plugin Hub docs have specialized front matter elements. See the
 `content_type: how-to | explanation | reference | tutorial`
 : Add a tag to the front matter of each topic that you edit.
 Add the tag that most closely resembles the concept, even if it doesn’t perfectly align with a tag.
+: 
+: See our [contribution templates](/contributing/contribution-templates/) for more information about each content type.
 
 **Optional:**
 
 `no_version: true`
-: Disables the version selector dropdown. Set this on pages that belong to
-doc sets without versions like `/konnect/`.
+: Disables the version selector dropdown. Set this on pages that shouldn't be versioned.
+: 
+: Do not use if the page is part of `/contributing/` or `/konnect/`, 
+as both of those doc sets are unversioned by default.
 
 `beta: true` or `alpha: true`
-: Labels the page as beta or alpha; adds a banner to the top of the page.
+: Labels the page as beta or alpha; adds a banner to the top of the page. Can use `stability_message` to
+add a custom explanation.
+
+`stability_message: <message>`
+: Set a custom message about the stability of a release. Must be used with `beta: true` or `alpha: true`.
+: 
+: Use YAML pipe (`|`) notation if your message extends over one line.
+
+`badge: enterprise | plus | oss | free`
+: Sets a tier badge on the page title.
 
 `disable_image_expand: true`
 : Stops images from expanding in a modal on click. Sets it for the entire page.
@@ -59,6 +72,18 @@ disable_image_expand: true
 ---
 ```
 
+A page with a custom stability banner:
+
+```yaml
+---
+title: Using multiple backend Services
+content_type: tutorial
+beta: true
+stability_message: |
+  Using multiple backend services will be GA once a non-beta version of the 
+  <a href="https://gateway-api.sigs.k8s.io/">Kubernetes Gateway API</a> is available.
+---
+```
 
 ## Variables
 


### PR DESCRIPTION
### Description

Follow-up to https://github.com/Kong/docs.konghq.com/pull/5348. 
Adding the new `stability_banner` option to our contributing docs.

Also adding the `badge` option, which was missing, and a link to more info about `content_type`. 

### Testing instructions

Netlify link: https://deploy-preview-5364--kongdocs.netlify.app/contributing/markdown-rules/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

