### PR TITLE
adding kind install instructions for KIC

### DIFF
--- a/app/_data/docs_nav_kic_2.9.x.yml
+++ b/app/_data/docs_nav_kic_2.9.x.yml
@@ -45,6 +45,8 @@ items:
     items:
       - text: Kong Ingress on Minikube
         url: /deployment/minikube
+      - text: Kong Ingress on Kind
+        url: /deployment/kind
       - text: Kong for Kubernetes
         url: /deployment/k4k8s
       - text: Kong for Kubernetes Enterprise

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -1,0 +1,232 @@
+---
+title: Kong for Kubernetes with Kong Enterprise
+---
+
+This guide walks through setting up the {{site.kic_product_name}} using Kong
+Enterprise. This architecture is described in detail in [this doc](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/k4k8s-with-kong-enterprise).
+
+We assume that we start from scratch and you don't have Kong Enterprise
+deployed. For the sake of simplicity, we will deploy Kong Enterprise and
+its database in Kubernetes itself. You can safely run them outside
+Kubernetes as well.
+
+## Prerequisites
+
+Before we can deploy the {{site.kic_product_name}} with Kong Enterprise,
+we need to satisfy the following prerequisites:
+
+- [Kong Enterprise License secret](#kong-enterprise-license-secret)
+- [Kong Enterprise bootstrap password](#kong-enterprise-bootstrap-password)
+
+In order to create these secrets, let's provision the `kong`
+namespace first:
+
+```bash
+$ kubectl create namespace kong
+namespace/kong created
+```
+
+### Set up Kind cluster
+
+```bash
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+name: kong
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+```
+
+### Kong Enterprise License secret
+
+Kong Enterprise requires a valid license to run.
+As part of sign up for Kong Enterprise, you should have received a license file.
+Save the license file temporarily to disk and execute the following:
+
+```bash
+$ kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
+secret/kong-enterprise-license created
+```
+
+Please note that `-n kong` specifies the namespace in which you are deploying
+  the {{site.kic_product_name}}. If you are deploying in a different namespace,
+  please change this value.
+
+### Kong Enterprise bootstrap password
+
+Next, we need to create a secret containing the password using which we can login into Kong Manager.
+Please replace `cloudnative` with a random password of your choice and note it down.
+
+```bash
+$ kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=cloudnative
+secret/kong-enterprise-superuser-password created
+```
+
+Once these are created, we are ready to deploy Kong Enterprise
+Ingress Controller.
+
+## Install
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml
+```
+
+It takes a little while to bootstrap the database.
+Once bootstrapped, you should see the {{site.kic_product_name}} running with
+Kong Enterprise as its core:
+
+```bash
+$ kubectl get pods -n kong
+NAME                            READY   STATUS      RESTARTS   AGE
+ingress-kong-548b9cff98-n44zj   2/2     Running     0          21s
+kong-migrations-pzrzz           0/1     Completed   0          4m3s
+postgres-0                      1/1     Running     0          4m3s
+```
+
+Apply kind specific patches to forward the hostPorts to the ingress controller, set taint tolerations, and schedule it to the custom labeled node.
+
+```bash
+kubectl patch deployment -n kong ingress-kong -p '{"spec":{"template":{"spec":{"containers":[{"name":"proxy","ports":[{"containerPort":8000,"hostPort":80,"name":"proxy","protocol":"TCP"},{"containerPort":8443,"hostPort":443,"name":"proxy-ssl","protocol":"TCP"}]}],"nodeSelector":{"ingress-ready":"true"},"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Equal","effect":"NoSchedule"},{"key":"node-role.kubernetes.io/master","operator":"Equal","effect":"NoSchedule"}]}}}}'
+```
+
+Apply kind specific patch to change service type to NodePort
+
+```bash
+kubectl patch service -n kong kong-proxy -p '{"spec":{"type":"NodePort"}}'
+kubectl patch service -n kong kong-manager -p '{"spec":{"type":"NodePort"}}'
+kubectl patch service -n kong kong-admin -p '{"spec":{"type":"NodePort"}}'
+```
+
+```bash
+kubectl get services -n kong
+NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
+kong-admin                NodePort    10.96.66.102    <none>        80:30980/TCP                 62m
+kong-manager              NodePort    10.96.244.156   <none>        80:31640/TCP                 62m
+kong-proxy                NodePort    10.96.87.68     <none>        80:31134/TCP,443:32025/TCP   62m
+kong-validation-webhook   ClusterIP   10.96.37.107    <none>        443/TCP                      62m
+postgres                  ClusterIP   10.96.84.4      <none>        5432/TCP                     62m
+```
+
+### Setup Kong Manager
+
+Set up the ingress rules for Admin, Manager and Proxy
+
+```bash
+echo "
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kong-proxy
+  namespace: kong
+spec:
+  ingressClassName: kong
+  rules:
+  - host: kong.127-0-0-1.nip.io
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: kong-proxy
+            port: 
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kong-admin
+  namespace: kong
+spec:
+  ingressClassName: kong
+  rules:
+  - host: admin-api.127-0-0-1.nip.io
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: kong-admin
+            port: 
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kong-manager
+  namespace: kong
+spec:
+  ingressClassName: kong
+  rules:
+  - host: manager.127-0-0-1.nip.io
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: kong-manager
+            port: 
+              number: 80
+" | kubectl apply -f -
+```
+
+Next, if you browse to the IP address or host of the kong-manager service in your Browser, which in our case is <http://manager.127-0-0-1.nip.io/>. Kong Manager should load in your browser. Try logging in to the Manager with the username kong_admin and the password you supplied in the prerequisite, it should fail. The reason being we've not yet told Kong Manager where it can find the Admin API.
+
+Let's set that up. We will take the External IP address of kong-admin service and set the environment variable KONG_ADMIN_API_URI:
+
+We will use the admin.127.nip.io to set up the Admin API
+
+```bash
+kubectl patch deployment -n kong ingress-kong -p "{\"spec\": { \"template\" : { \"spec\" : {\"containers\":[{\"name\":\"proxy\",\"env\": [{ \"name\" : \"KONG_ADMIN_API_URI\", \"value\": \"http://admin-api.127-0-0-1.nip.io\" }]}]}}}}"
+```
+
+It will take a few minutes to roll out the updated deployment and once the new
+`ingress-kong` pod is up and running, you should be able to log into the Kong Manager UI.
+
+As you follow along with other guides on how to use your newly deployed the {{site.kic_product_name}},
+you will be able to browse Kong Manager and see changes reflected in the UI as Kong's
+configuration changes.
+
+## Using Kong for Kubernetes with Kong Enterprise
+
+Let's setup an environment variable to hold the IP address of `kong-proxy` service:
+
+```bash
+export PROXY_IP="proxy.127-0-0-1.nip.io"
+
+curl proxy.127-0-0-1.nip.io/
+{"message":"no Route matched with those values"}%
+
+```
+
+Once you've installed Kong for Kubernetes Enterprise, please follow our
+[getting started](/kubernetes-ingress-controller/{{page.kong_version}}/guides/getting-started) tutorial to learn more.
+
+## Customizing by use-case
+
+The deployment in this guide is a point to start using Ingress Controller.
+Based on your existing architecture, this deployment will require custom
+work to make sure that it needs all of your requirements.
+
+In this guide, there are three load-balancers deployed for each of
+Kong Proxy, Kong Admin and Kong Manager services. It is possible and
+recommended to instead have a single Load balancer and then use DNS names
+and Ingress resources to expose the Admin and Manager services outside
+the cluster.

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -18,14 +18,6 @@ we need to satisfy the following prerequisites:
 - [Kong Enterprise License secret](#kong-enterprise-license-secret)
 - [Kong Enterprise bootstrap password](#kong-enterprise-bootstrap-password)
 
-In order to create these secrets, let's provision the `kong`
-namespace first:
-
-```bash
-$ kubectl create namespace kong
-namespace/kong created
-```
-
 ### Set up Kind cluster
 
 ```bash
@@ -50,6 +42,17 @@ nodes:
     protocol: TCP
 EOF
 ```
+
+### Kong Enterprise namespace
+
+In order to create these secrets, let's provision the `kong`
+namespace first:
+
+```bash
+$ kubectl create namespace kong
+namespace/kong created
+```
+
 
 ### Kong Enterprise License secret
 

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -54,7 +54,7 @@ Run the following, replacing `cloudnative` with a random password of your choice
 kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=cloudnative
 ```
 
-Once these resources have been created, we are ready to deploy {{site.kic_product_name}}.
+Once these resources have been created, you're ready to deploy {{site.kic_product_name}}.
 
 ## Install Kong
 

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -51,7 +51,7 @@ secret to set the default value for the default `kong_admin` user.
 Run the following, replacing `cloudnative` with a random password of your choice and note it down:
 
 ```bash
-$ kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=cloudnative
+kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=cloudnative
 ```
 
 Once these resources have been created, we are ready to deploy {{site.kic_product_name}}.

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -32,7 +32,7 @@ EOF
 Next, create a `kong` namespace for your resources:
 
 ```bash
-$ kubectl create namespace kong
+kubectl create namespace kong
 ```
 
 ### Create a Kong Enterprise License secret (optional)

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -167,7 +167,7 @@ configuration changes.
 
 ## Making a request through the proxy
 
-Finally, let's setup an environment variable to hold the IP address of `kong-proxy` service:
+Let's set up an environment variable to hold the IP address of `kong-proxy` service:
 
 ```bash
 export PROXY_IP="proxy.127-0-0-1.nip.io"

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -161,7 +161,7 @@ It will take a few minutes to roll out the updated deployment. Once the new
 `ingress-kong` pod is up and running, visit `http://manager.127-0-0-1.nip.io` and you should be able to log
 in to the Kong Manager UI.
 
-As you follow along with other guides on how to use your newly deployed the {{site.kic_product_name}},
+As you follow along with other guides on how to use your newly deployed {{site.kic_product_name}},
 you will be able to browse Kong Manager and see changes reflected in the UI as Kong's
 configuration changes.
 

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -5,7 +5,7 @@ title: Kong for Kubernetes with Kong Enterprise
 This guide walks through setting up the {{site.kic_product_name}} with Kong
 Enterprise. This architecture is described in detail in [this doc](/kubernetes-ingress-controller/{{page.kong_version}}/concepts/k4k8s-with-kong-enterprise).
 
-### Set up Kind cluster
+## Set up Kind cluster
 
 First, create a `kind` cluster to deploy {{site.kic_product_name}} to:
 

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -76,8 +76,8 @@ postgres-0                      1/1     Running     0          4m3s
 
 ### Configure your ingress
 
-Kong's Admin API, Kong Manager UI and the proxy will all be exposed on the same port.
-We use Kong to route to the correct internal port based on the `host` provided.
+{{site.base_gateway}}'s Admin API, Kong Manager UI, and the proxy will all be exposed on the same port.
+Use {{site.base_gateway}} to route to the correct internal port based on the `host` provided.
 
 Let's create some `ingress` configurations to enable this:
 

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -64,10 +64,15 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-contr
 
 This may take a few minutes.
 
-Once bootstrapped, you should see the {{site.kic_product_name}} running:
+Once bootstrapped, run `kubectl get pods` to see your running pods:
 
 ```bash
 kubectl get pods -n kong
+```
+
+You should see the {{site.kic_product_name}} running:
+
+```
 NAME                            READY   STATUS      RESTARTS   AGE
 ingress-kong-548b9cff98-n44zj   2/2     Running     0          21s
 kong-migrations-pzrzz           0/1     Completed   0          4m3s

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -143,7 +143,7 @@ spec:
 " | kubectl apply -f -
 ```
 
-Finally, apply the following patch to set the `KONG_ADMIN_API_URI` to the hostname we set in the ingress above:
+Apply the following patch to set the `KONG_ADMIN_API_URI` to the hostname you set in the ingress above:
 
 ```bash
 kubectl patch deployment -n kong ingress-kong -p "{\"spec\": { \"template\" : { \"spec\" : {\"containers\":[{\"name\":\"proxy\",\"env\": [{ \"name\" : \"KONG_ADMIN_API_URI\", \"value\": \"http://admin-api.127-0-0-1.nip.io\" }]}]}}}}"

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -151,7 +151,7 @@ kubectl patch deployment -n kong ingress-kong -p "{\"spec\": { \"template\" : { 
 
 ### Expose the proxy to your host machine
 
-We need to apply some `kind` specific patches to make our proxy accessible on our host machine:
+Apply the following `kind`-specific patches to make the proxy accessible on the host machine:
 
 ```bash
 kubectl patch deployment -n kong ingress-kong -p '{"spec":{"template":{"spec":{"containers":[{"name":"proxy","ports":[{"containerPort":8000,"hostPort":80,"name":"proxy","protocol":"TCP"},{"containerPort":8443,"hostPort":443,"name":"proxy-ssl","protocol":"TCP"}]}]}}}}'

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -29,7 +29,7 @@ nodes:
 EOF
 ```
 
-We're going create our resources in the `kong` namespace. Create this now:
+Next, create a `kong` namespace for your resources:
 
 ```bash
 $ kubectl create namespace kong

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -67,7 +67,7 @@ This may take a few minutes.
 Once bootstrapped, you should see the {{site.kic_product_name}} running:
 
 ```bash
-$ kubectl get pods -n kong
+kubectl get pods -n kong
 NAME                            READY   STATUS      RESTARTS   AGE
 ingress-kong-548b9cff98-n44zj   2/2     Running     0          21s
 kong-migrations-pzrzz           0/1     Completed   0          4m3s

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -180,5 +180,5 @@ Output:
 {"message":"no Route matched with those values"}%
 ```
 
-This `$PROXY_IP` variable will be used in future guides. Please follow our
+This `$PROXY_IP` variable will be used in future guides. Follow our
 [getting started](/kubernetes-ingress-controller/{{page.kong_version}}/guides/getting-started) tutorial to learn more.

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -48,7 +48,7 @@ kubectl create secret generic kong-enterprise-license --from-file=license=./lice
 The Kong Manager UI requires authentication. {{site.kic_product_name}} uses the `kong-enterprise-superuser-password`
 secret to set the default value for the default `kong_admin` user.
 
-Run the following, replacing `cloudnative` with a random password of your choice and note it down.
+Run the following, replacing `cloudnative` with a random password of your choice and note it down:
 
 ```bash
 $ kubectl create secret generic kong-enterprise-superuser-password  -n kong --from-literal=password=cloudnative

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -158,7 +158,7 @@ kubectl patch deployment -n kong ingress-kong -p '{"spec":{"template":{"spec":{"
 ```
 
 It will take a few minutes to roll out the updated deployment. Once the new
-`ingress-kong` pod is up and running, visit <http://manager.127-0-0-1.nip.io/> and you should be able to log
+`ingress-kong` pod is up and running, visit `http://manager.127-0-0-1.nip.io` and you should be able to log
 in to the Kong Manager UI.
 
 As you follow along with other guides on how to use your newly deployed the {{site.kic_product_name}},

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -56,7 +56,7 @@ kubectl create secret generic kong-enterprise-superuser-password  -n kong --from
 
 Once these resources have been created, you're ready to deploy {{site.kic_product_name}}.
 
-## Install Kong
+## Install {{site.base_gateway}}
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -62,7 +62,7 @@ Once these resources have been created, you're ready to deploy {{site.kic_produc
 kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.kong_version | replace: ".x", ".0" }}/deploy/single/all-in-one-postgres-enterprise.yaml
 ```
 
-This may take a few minutes if this is the first time you're running {{ site.base_gateway }} in Docker with a database.
+This may take a few minutes.
 
 Once bootstrapped, you should see the {{site.kic_product_name}} running:
 

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -40,7 +40,7 @@ kubectl create namespace kong
 If you have a Kong Enterprise license, save it to disk as `license.json` and create a secret:
 
 ```bash
-$ kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
+kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
 ```
 
 ### Set your Kong Manager password

--- a/app/_src/kubernetes-ingress-controller/deployment/kind.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/kind.md
@@ -7,7 +7,7 @@ Enterprise. This architecture is described in detail in [this doc](/kubernetes-i
 
 ### Set up Kind cluster
 
-The first thing we need to do is create a `kind` cluster to deploy {{site.kic_product_name}} to:
+First, create a `kind` cluster to deploy {{site.kic_product_name}} to:
 
 ```bash
 cat <<EOF | kind create cluster --config=-


### PR DESCRIPTION
### Description

What did you change and why?
I added a section on installing `Kong for Kubernetes with Kong Enterprise` for KIC on `kind`. I feel we have make it easy for developers to deploy Kong enterprise and be able to play around so they can use and promote the platform internally.


### Testing instructions

Netlify link: /kubernetes-ingress-controller/latest/deployment/kind/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

