### PR TITLE
docs(acme): support redis namespace

### DIFF
--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -2,6 +2,7 @@
 Kuma
 Kuma's
 _workspace
+account_key
 admin_listen
 allow_terminated
 balancer's
@@ -22,6 +23,9 @@ escape_path
 foogineer
 if_version
 included_status_codes
+key_id
+key_set
+key_sets
 kuma
 max_args
 max_headers

--- a/.github/styles/kongplugins/auto-ignore.txt
+++ b/.github/styles/kongplugins/auto-ignore.txt
@@ -27,6 +27,7 @@ max_args
 max_headers
 metatable
 myapikey
+namespace
 narr
 ngx
 ngx_stream_proxy_module

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -162,7 +162,8 @@ the `eab_kid` or `eab_hmac_key`:
         "host": "127.0.0.1",
         "ssl": false,
         "ssl_verify": false,
-        "ssl_server_name": null
+        "ssl_server_name": null,
+        "namespace": "",
       },
        "consul": {
           "host": "127.0.0.1",
@@ -562,10 +563,15 @@ own certificate.
 
 ## Changelog
 
+{% if_plugin_version gte:3.3.x %}
 **{{site.base_gateway}} 3.3.x**
 
 * Added the `account_key` configuration parameter
+* Added the `config.storage_config.redis.namespace` configuration parameter.
+  The namespace will be concated as a prefix of key and is default to empty string `""` for backward compatibility.
+  namespace can be any string that isn't prefixed with any of the reserved words.
 
+{% endif_plugin_version %}
 
 {% if_plugin_version gte:3.1.x %}
 **{{site.base_gateway}}  3.1.x**

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -568,7 +568,7 @@ own certificate.
 
 * Added the `account_key` configuration parameter
 * Added the `config.storage_config.redis.namespace` configuration parameter.
-  The namespace will be concated as a prefix of key and is default to empty string `""` for backward compatibility.
+  The namespace will be concatenated as a prefix of key and is default to empty string `""` for backward compatibility.
   namespace can be any string that isn't prefixed with any of the reserved words.
 
 {% endif_plugin_version %}

--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -568,8 +568,7 @@ own certificate.
 
 * Added the `account_key` configuration parameter
 * Added the `config.storage_config.redis.namespace` configuration parameter.
-  The namespace will be concatenated as a prefix of key and is default to empty string `""` for backward compatibility.
-  namespace can be any string that isn't prefixed with any of the reserved words.
+  The namespace will be concatenated as a prefix of the key. The default is an empty string (`""`) for backward compatibility. The namespace can be any string that isn't prefixed with any of the [Kong reserved words](/konnect/reference/labels/).
 
 {% endif_plugin_version %}
 


### PR DESCRIPTION
### Description

correspond to [Kong/kong#10562](https://github.com/Kong/kong/pull/10562)

`namespace` will be treated as a prefix of key and is default to empty string `""` for backward compatibility. `namespace` must not be prefixed with any of the reserved words.

[KAG-615](https://konghq.atlassian.net/browse/KAG-615)


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


[KAG-615]: https://konghq.atlassian.net/browse/KAG-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ