### PR TITLE
[DOCU-3149] Referenceable plugin fields table

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/index.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/index.md
@@ -54,7 +54,7 @@ Kong receives the payload and extracts the `"username"` value of `"john"` for th
 `{vault://hcv/pg/username}`.
 <!-- vale on -->
 
-### What can be stored as a secret?
+## What can be stored as a secret?
 
 Most of the [Kong configuration](/gateway/{{page.kong_version}}/reference/configuration/) values
 can be stored as a secret, such as [`pg_user`](/gateway/{{page.kong_version}}/reference/configuration/#postgres-settings) and
@@ -69,27 +69,51 @@ a `KONG_LICENSE_DATA` environment variable, can be stored as a secret.
 The Kong Admin API [certificate object](/gateway/{{page.kong_version}}/admin-api/#certificate-object)
 can be stored as a secret.
 
-The following plugins have fields that can be stored as secrets in a
-vault backend. These fields are labelled as `referenceable`. See the
-documentation for each plugin to identify the referenceable fields:
+### Referenceable plugin fields
 
-* [ACME](/hub/kong-inc/acme/)
-* [AWS Lambda](/hub/kong-inc/aws-lambda/)
-* [Azure Functions](/hub/kong-inc/azure-funtions/)
-* [Forward Proxy](/hub/kong-inc/forward-proxy/)
-* [GraphQL Rate Limiting Advanced](/hub/kong-inc/graphql-rate-limiting-advanced/)
-* [Kafka Log](/hub/kong-inc/kafka-log/)
-* [Kafka Upstream](/hub/kong-inc/kafka-upstream/)
-* [LDAP Authentication Advanced](/hub/kong-inc/ldap-auth-advanced/)
-* [Loggly](/hub/kong-inc/loggly/)
-* [OpenID Connect](/hub/kong-inc/openid-connect/)
-* [Proxy Cache Advanced](/hub/kong-inc/proxy-cache-advanced/)
-* [Rate Limiting](/hub/kong-inc/rate-limiting/)
-* [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced/)
-* [Response Rate Limiting](/hub/kong-inc/response-ratelimiting/)
-* [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
-* [Session](/hub/kong-inc/session/)
-* [Vault Authentication](/hub/kong-inc/vault-auth/)
+Some plugins have fields that can be stored as secrets in a
+vault backend. These fields are labelled as `referenceable`. 
+
+The following plugins support vault references for specific fields. 
+See each plugin's documentation for more information on each field:
+
+{% assign hub = site.data.ssg_hub %}
+{% assign kong_extns = hub | where: "publisher", "Kong Inc." %}
+
+<table>
+  <thead>
+      <th>Plugin</th>
+      <th>Referenceable fields</th>
+  </thead>
+  <tbody>
+    {% for extn in kong_extns %}
+    {% assign ref = extn.params.config | find: "referenceable", "true" %}
+    {% if ref %}
+      <tr>
+        <td>
+          <a href="{{extn.url}}">{{ extn.name }}</a>
+        </td>
+        <td> 
+          {% for c in extn.params.config %}
+            {% if c.referenceable == true %}
+            <code>{{ c.name }}</code>
+            {% endif %}
+          {% endfor %}
+        </td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+    <tr>
+      <td>
+        <a href="/hub/kong-inc/vault-auth/">Vault Authentication</a>
+      </td>
+      <td> 
+        <code>vaults.vault_token</code>
+        <code>vault_credentials.secret_token</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Supported backends
 


### PR DESCRIPTION
### Description

Added a table to the secrets documentation that lists all plugins with referenceable fields + the specific fields.
* Note: The vault auth plugin has a manually-added table row because the referenceable values for that plugin don't appear in the config table. This is because the config is nested, and our tables don't always list nested configs. This will be fixed once the plugin hub redesign stage 1 is complete, and we'll have to remove manually-added this table row then.

https://konghq.atlassian.net/browse/DOCU-3149

### Testing instructions

https://deploy-preview-5370--kongdocs.netlify.app/gateway/latest/kong-enterprise/secrets-management/#what-can-be-stored-as-a-secret

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

