### PR TITLE
Fix sync-submodules permissions

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -2,6 +2,10 @@ name: Submodule Sync
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   submodule-sync:
     name: Submodule Sync


### PR DESCRIPTION
### Description

What did you change and why?
 
The action is failing because github no longer sets all the permissions to `GITHUB_TOKEN`, just read access.
This adds write permissions to it.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

