### PR TITLE
Correct update-log-level-dynamically.md

### DIFF
--- a/app/_src/gateway/production/logging/update-log-level-dynamically.md
+++ b/app/_src/gateway/production/logging/update-log-level-dynamically.md
@@ -55,7 +55,7 @@ To change the log level of every node in your cluster, issue a `PUT` request wit
 
 ```bash
 curl --request PUT \
-  --url http://localhost:59191/debug/cluster/log-level/notice
+  --url http://localhost:8001/debug/cluster/log-level/notice
 ```
 
 If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body:
@@ -76,7 +76,7 @@ To change the log level of the control plane nodes in your cluster, issue a `PUT
 
 ```bash
 curl --request PUT \
-  --url http://localhost:59191/debug/cluster/control-planes-nodes/log-level/notice
+  --url http://localhost:8001/debug/cluster/control-planes-nodes/log-level/notice
 ```
 
 If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body:


### PR DESCRIPTION
Correct port number for dynamic log level changes update-log-level-dynamically.md. PUT requests listed port 59191; should be 8001;


### Description

What did you change and why?
Port number for 2 example Admin API requests was listed as 59191, but needed to be 8001 (default Admin API port)
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Just try the suggested dynamic logging level changes with port 59191 and again with 8001 and you will see 8001 is correct.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


