### PR TITLE
Add CTA for plus plugins to drive Konnect signups

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -182,6 +182,14 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
 
     {% capture full_content %}
     {% if page.type == "plugin" or page.type == "integration" %}
+
+      {% if page.plus and extn_publisher == "kong-inc" %}
+        <blockquote class="note" role="alert">
+          Did you know that you can try this plugin without talking to anyone with a free
+          trial of Kong Konnect? <a href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=docs-plugins&utm_content={{ extn_slug }}">Get started in under 5 minutes</a>.
+        </blockquote>
+      {% endif %}
+
       {% unless extn_publisher == "kong-inc" %}
         <div class="alert alert-info blue" role="alert">
           Partner Plugin: This plugin is <b>developed, tested, and maintained</b> by a third-party contributor.


### PR DESCRIPTION
### Description

Added a banner for any `plus` plugins to show that they're available free on Konnect during the trial period.

Applies to all `page.plus` plugins
 

### Testing instructions

Netlify link: https://deploy-preview-5386--kongdocs.netlify.app/hub/kong-inc/openid-connect/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

