### PR TITLE
Update Ubuntu install instructions to use install script

### DIFF
--- a/app/_assets/stylesheets/navtabs.less
+++ b/app/_assets/stylesheets/navtabs.less
@@ -1,3 +1,21 @@
+.external-trigger {
+  .navtab-titles {
+    display: none !important;
+  }
+
+  .navtab-contents {
+    margin-top: -22px !important;
+  }
+
+  .copy-action {
+    margin-top: 0 !important;
+  }
+
+  pre.highlight {
+    padding: 20px 12px !important;
+  }
+}
+
 .navtabs {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
@@ -41,23 +59,6 @@
     }
   }
 
-  .external-trigger {
-    .navtab-titles {
-      display: none !important;
-    }
-
-    .navtab-contents {
-      margin-top: -22px !important;
-    }
-
-    .copy-action {
-      margin-top: 0 !important;
-    }
-
-    pre.highlight {
-      padding: 20px 12px !important;
-    }
-  }
 
   &.codeblock {
     background-color: @grey-300;

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -7,12 +7,34 @@ The {{site.base_gateway}} software is governed by the
 Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
+{:.note}
+> This page will install {{ site.base_gateway }} in traditional mode, where it acts as both the Control Plane and Data Plane. Running in this mode may have a small performance impact.
+> &nbsp;
+> 
+> &nbsp;
+> 
+> We recommend using [Konnect](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=install-ubuntu) as your Control Plane to allow your Data Plane to run at maximum performance and decrease your deployment complexity
+
 ## Prerequisites
 
 * A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
 * (Enterprise only) A `license.json` file from Kong
 
-## Download and install
+## Installation
+
+The quickest way to get started with {{ site.base_gateway }} is using our install script:
+
+```bash
+bash <(curl -sS https://install-script--getkong.netlify.app/install)
+```
+
+This script will detect your operating system and automatically install the correct package. It'll also install a Postgres database and bootstrap {{ site.base_gateway }} for you.
+
+If you'd prefer to install just the package, please see the [Package Install](#package-install) section.
+
+## Advanced Installation
+
+### Package Install
 
 You can install {{site.base_gateway}} by downloading an installation package or using our APT repository.
 
@@ -21,7 +43,6 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 > If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below.
 > <br /><br />
 > To check your release name run `lsb_release -sc`.
-
 
 {% navtabs %}
 {% navtab Package %}
@@ -65,23 +86,6 @@ sudo dpkg -i kong-{{page.versions.ce}}.amd64.deb
 {% endcapture %}
 
 {{ install_package | indent | replace: " </code>", "</code>" }}
-
-3. (Optional) Prevent accidental upgrades by marking the package as `hold`:
-{% capture optional %}
-{% navtabs_ee %}
-{% navtab Kong Gateway %}
-```bash
-sudo apt-mark hold kong-enterprise-edition
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-```bash
-sudo apt-mark hold kong
-```
-{% endnavtab %}
-{% endnavtabs_ee %}
-{% endcapture %}
-{{ optional | indent | replace: " </code>", "</code>" }}
 
 {% navtabs_ee %}
 {% navtab Kong Gateway %}
@@ -129,9 +133,22 @@ apt install -y kong={{page.versions.ce}}
 
 {{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
+4. (Optional) Prevent accidental upgrades by marking the package as `hold`:
+{% capture optional %}
+{% navtabs_ee %}
+{% navtab Kong Gateway %}
+```bash
+sudo apt-mark hold kong-enterprise-edition
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo apt-mark hold kong
+```
+{% endnavtab %}
+{% endnavtabs_ee %}
+{% endcapture %}
+{{ optional | indent | replace: " </code>", "</code>" }}
+
 {% endnavtab %}
 {% endnavtabs %}
-
-{% include_cached /md/gateway/setup.md kong_version=page.kong_version %}
-
-

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -8,12 +8,12 @@ Kong is licensed under an
 [Apache 2.0 license](https://github.com/Kong/kong/blob/master/LICENSE).
 
 {:.note}
-> This page will install {{ site.base_gateway }} in traditional mode, where it acts as both the Control Plane and Data Plane. Running in this mode may have a small performance impact.
+> This page will install {{ site.base_gateway }} in traditional mode, where it acts as both the control plane and data plane. Running in this mode may have a small performance impact.
 > &nbsp;
 > 
 > &nbsp;
 > 
-> We recommend using [Konnect](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=install-ubuntu) as your Control Plane to allow your Data Plane to run at maximum performance and decrease your deployment complexity
+> We recommend using [{{site.konnect_short_name}}](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=install-ubuntu) as your control plane to allow your data plane to run at maximum performance and decrease your deployment complexity
 
 ## Prerequisites
 
@@ -37,7 +37,7 @@ bash <(curl -sS https://install-script--getkong.netlify.app/install) -p kong -v 
 {% endnavtab %}
 {% endnavtabs_ee %}
 
-This script will detect your operating system and automatically install the correct package. It'll also install a Postgres database and bootstrap {{ site.base_gateway }} for you.
+This script detects your operating system and automatically installs the correct package. It will also install a Postgres database and bootstrap {{ site.base_gateway }} for you.
 
 If you'd prefer to install just the package, please see the [Package Install](#package-install) section.
 
@@ -53,9 +53,9 @@ You should receive a `200` status code.
 
 ### Next steps
 
-Once {{ site.base_gateway }} is running, you may want to:
+Once {{ site.base_gateway }} is running, you may want to do the following:
 
-* [Add your Enterprise license (optional)](/gateway/{{ page.kong_version }}/licenses/deploy).
+* Optional: [Add your Enterprise license](/gateway/{{ page.kong_version }}/licenses/deploy).
 * [Enable Kong Manager](/gateway/{{ page.kong_version }}/kong-manager/enable/)
 * [Enable Dev Portal](/gateway/{{ page.kong_version }}/kong-enterprise/dev-portal/enable/)
 * [Create services and routes](/gateway/{{ page.kong_version }}/get-started/services-and-routes/).
@@ -161,7 +161,7 @@ apt install -y kong={{page.versions.ce}}
 
 {{ install_from_repo | indent | replace: " </code>", "</code>" }}
 
-4. (Optional) Prevent accidental upgrades by marking the package as `hold`:
+4. Optional: Prevent accidental upgrades by marking the package as `hold`:
 {% capture optional %}
 {% navtabs_ee %}
 {% navtab Kong Gateway %}

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -27,12 +27,12 @@ The quickest way to get started with {{ site.base_gateway }} is using our instal
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-bash <(curl -sS https://install-script--getkong.netlify.app/install) -v {{page.versions.ee}}
+bash <(curl -sS https://get.konghq.com/install) -v {{page.versions.ee}}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-bash <(curl -sS https://install-script--getkong.netlify.app/install) -p kong -v {{page.versions.ce}}
+bash <(curl -sS https://get.konghq.com/install) -p kong -v {{page.versions.ce}}
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,7 +83,7 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.amd64.deb "{{ site.links.download }}/gateway-3.x-ubuntu-$(lsb_release -sc)/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
@@ -102,12 +102,12 @@ curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.download }}/gateway-
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-sudo dpkg -i kong-enterprise-edition-{{page.versions.ee}}.all.deb
+sudo apt install -y ./kong-enterprise-edition-{{page.versions.ee}}.amd64.deb
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-sudo dpkg -i kong-{{page.versions.ce}}.amd64.deb
+sudo apt install -y ./kong-{{page.versions.ce}}.amd64.deb
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -24,13 +24,41 @@ Kong is licensed under an
 
 The quickest way to get started with {{ site.base_gateway }} is using our install script:
 
+{% navtabs_ee codeblock %}
+{% navtab Kong Gateway %}
 ```bash
-bash <(curl -sS https://install-script--getkong.netlify.app/install)
+bash <(curl -sS https://install-script--getkong.netlify.app/install) -v {{page.versions.ee}}
 ```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+bash <(curl -sS https://install-script--getkong.netlify.app/install) -p kong -v {{page.versions.ce}}
+```
+{% endnavtab %}
+{% endnavtabs_ee %}
 
 This script will detect your operating system and automatically install the correct package. It'll also install a Postgres database and bootstrap {{ site.base_gateway }} for you.
 
 If you'd prefer to install just the package, please see the [Package Install](#package-install) section.
+
+### Verify install
+
+Once the script completes, run the following in the same terminal window:
+
+```bash
+curl -i http://localhost:8001
+```
+
+You should receive a `200` status code.
+
+### Next steps
+
+Once {{ site.base_gateway }} is running, you may want to:
+
+* [Add your Enterprise license (optional)](/gateway/{{ page.kong_version }}/licenses/deploy).
+* [Enable Kong Manager](/gateway/{{ page.kong_version }}/kong-manager/enable/)
+* [Enable Dev Portal](/gateway/{{ page.kong_version }}/kong-enterprise/dev-portal/enable/)
+* [Create services and routes](/gateway/{{ page.kong_version }}/get-started/services-and-routes/).
 
 ## Advanced Installation
 


### PR DESCRIPTION
### Description

Initial attempt at a refactored Ubuntu install page.

The script has been tested on Ubuntu 22.04 and 20.04 (both LTS) on AWS, and on a local docker container.

I've intentionally removed the include as we have dedicated pages that I've linked to in next steps

### Testing instructions

Netlify link: https://deploy-preview-5389--kongdocs.netlify.app/gateway/3.2.x/install/linux/ubuntu/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
