### PR TITLE
[DOCU-2858] Add Mesh Overview topic to the 2.2 nav

### DIFF
--- a/app/_data/docs_nav_mesh_2.2.x.yml
+++ b/app/_data/docs_nav_mesh_2.2.x.yml
@@ -35,6 +35,9 @@ items:
   - title: Kong Mesh in Production
     icon: /assets/images/icons/documentation/icn-deployment-color.svg 
     items:
+      - text: Overview
+        url: /production/
+        src: /.repos/kuma/app/_src/production/
       - text: Deployment topologies
         items:
           - text: Overview


### PR DESCRIPTION
### Description

What did you change and why?
- Added the new Mesh in Production overview page to the 2.2 nav. This PR is the one that adds it on the Kuma side: https://github.com/kumahq/kuma-website/pull/1246 
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-2858


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

