### PR TITLE
Add revised Reference section to the 2.1.x nav

### DIFF
--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -231,7 +231,7 @@ items:
         src: /.repos/kuma/app/docs/2.0.x/policies/circuit-breaker/
       - text: Proxy Template
         url: /policies/proxy-template/
-        src: /.repos/kuma/app/docs/2.0.x/policies/proxy-template/
+        src: /.repos/kuma/app/_src/reference/proxy-template/
       - text: External Service
         url: /policies/external-services/
         src: /.repos/kuma/app/docs/2.0.x/policies/external-services/

--- a/app/_data/docs_nav_mesh_2.1.x.yml
+++ b/app/_data/docs_nav_mesh_2.1.x.yml
@@ -241,7 +241,7 @@ items:
         src: /.repos/kuma/app/_src/policies/circuit-breaker/
       - text: Proxy Template
         url: /policies/proxy-template/
-        src: /.repos/kuma/app/_src/policies/proxy-template/
+        src: /.repos/kuma/app/_src/reference/proxy-template/
       - text: External Service
         url: /policies/external-services/
         src: /.repos/kuma/app/_src/policies/external-services/


### PR DESCRIPTION
### Description

What did you change and why?

-  I updated the 2.1 and 2.0 navs with the correct file path based on the files that I moved as a result of https://github.com/kumahq/kuma-website/pull/1266.

Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-2867

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

