### PR TITLE
[DOCU-2867] Add the revised Mesh Reference section to the 2.2 nav

### DIFF
--- a/app/_data/docs_nav_mesh_2.0.x.yml
+++ b/app/_data/docs_nav_mesh_2.0.x.yml
@@ -232,7 +232,7 @@ items:
         src: /.repos/kuma/app/docs/2.0.x/policies/circuit-breaker/
       - text: Proxy Template
         url: /policies/proxy-template/
-        src: /.repos/kuma/app/docs/2.0.x/policies/proxy-template/
+        src: /.repos/kuma/app/_src/reference/proxy-template/
       - text: External Service
         url: /policies/external-services/
         src: /.repos/kuma/app/docs/2.0.x/policies/external-services/

--- a/app/_data/docs_nav_mesh_2.1.x.yml
+++ b/app/_data/docs_nav_mesh_2.1.x.yml
@@ -242,7 +242,7 @@ items:
         src: /.repos/kuma/app/_src/policies/circuit-breaker/
       - text: Proxy Template
         url: /policies/proxy-template/
-        src: /.repos/kuma/app/_src/policies/proxy-template/
+        src: /.repos/kuma/app/_src/reference/proxy-template/
       - text: External Service
         url: /policies/external-services/
         src: /.repos/kuma/app/_src/policies/external-services/

--- a/app/_data/docs_nav_mesh_2.2.x.yml
+++ b/app/_data/docs_nav_mesh_2.2.x.yml
@@ -260,9 +260,6 @@ items:
       - text: Circuit Breaker
         url: /policies/circuit-breaker/
         src: /.repos/kuma/app/_src/policies/circuit-breaker/
-      - text: Proxy Template
-        url: /policies/proxy-template/
-        src: /.repos/kuma/app/_src/policies/proxy-template/
       - text: External Service
         url: /policies/external-services/
         src: /.repos/kuma/app/_src/policies/external-services/
@@ -356,12 +353,18 @@ items:
       - text: HTTP API
         url: /reference/http-api/
         src: /.repos/kuma/app/_src/reference/http-api/
-      - text: Annotations and labels in Kubernetes mode
+      - text: Kubernetes annotations and labels
         url: /reference/kubernetes-annotations/
         src: /.repos/kuma/app/_src/reference/kubernetes-annotations/
       - text: Kong Mesh data collection
         url: /reference/data-collection/
         src: /.repos/kuma/app/_src/reference/data-collection/
+      - text: Kuma-cp configuration reference
+        url: /generated/kuma-cp
+        src: /.repos/kuma/app/docs/2.1.x/generated/kuma-cp
+      - text: Envoy proxy template
+        url: /reference/proxy-template/
+        src: /.repos/kuma/app/_src/reference/proxy-template/
       - text: Resources
         items:
           - text: Mesh
@@ -432,9 +435,6 @@ items:
           - text: kumactl
             url: /generated/cmd/kumactl/kumactl/
             src: /.repos/kuma/app/docs/2.1.x/generated/cmd/kumactl/kumactl/
-      - text: Kuma-cp configuration reference
-        url: /generated/kuma-cp
-        src: /.repos/kuma/app/docs/2.1.x/generated/kuma-cp
   - title: Community
     icon: /assets/images/icons/documentation/icn-references-color.svg
     items:


### PR DESCRIPTION
### Description

What did you change and why?
- I updated the Kuma Reference section here (https://github.com/kumahq/kuma-website/pull/1266) and moved a few files, so I also fixed the Mesh nav to match. I did this as part of the Kuma IA rework.
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-2867

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

