### PR TITLE
[DOCU-3155][DOCU-3007] Release: Gateway 3.2.2.1

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -195,7 +195,7 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.2.x"
-  ee-version: "3.2.2.0"
+  ee-version: "3.2.2.1"
   ce-version: "3.2.2"
   edition: "gateway"
   luarocks_version: "3.0.0-0"

--- a/app/_data/tables/support/gateway/versions/32.yml
+++ b/app/_data/tables/support/gateway/versions/32.yml
@@ -6,6 +6,7 @@ lts: false
 distributions:
   - <<: *alpine
     docker: true
+    arm: true
   - <<: *amazonlinux2
     docker: true
     arm: true

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -5,6 +5,16 @@ no_version: true
 
 <!-- vale off -->
 
+## 3.2.2.1
+**Release Date** 2023/04/03
+
+### Fixes
+* Fixed the Dynatrace implementation. Due to a build system issue, Kong Gateway 3.2.x packages prior to 3.2.2.1 didn't contain the debug symbols that Dynatrace requires.
+
+### Deprecations
+* **Alpine deprecation reminder:** Kong has announced our intent to remove support for Alpine images and packages later this year. These images and packages are available in 3.2 and will continue to be available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
+
+
 ## 3.2.2.0
 **Release Date** 2023/03/22
 


### PR DESCRIPTION
### Description

Version bump and changelog for 3.2.2.1.

Alpine ARM package is available as of 3.2.2.1, so set it as compatible in the 3.2 table.

https://konghq.atlassian.net/browse/DOCU-3007
https://konghq.atlassian.net/browse/DOCU-3155

### Testing instructions

Netlify links:
https://deploy-preview-5393--kongdocs.netlify.app/gateway/latest/support-policy/
https://deploy-preview-5393--kongdocs.netlify.app/gateway/changelog/ 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

