### PR TITLE
Fix grid tiles on Gateway index page to be max 3 items wide

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1338,6 +1338,12 @@ Generic Styling for Desktop
     }
   }
 
+  @media (min-width: 991px) {
+    .max-3 {
+      grid-template-columns: 1fr 1fr 1fr !important;
+    }
+  }
+
   .docs-grid-install {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/app/_src/gateway/index.md
+++ b/app/_src/gateway/index.md
@@ -6,7 +6,7 @@ subtitle: API gateway built for hybrid and multi-cloud, optimized for microservi
 
 ## Quick Links
 
-<div class="docs-grid-install">
+<div class="docs-grid-install max-3">
 
   <a href="#features" class="docs-grid-install-block no-description">
     <img class="install-icon no-image-expand" src="/assets/images/icons/documentation/icn-flag.svg" alt="">


### PR DESCRIPTION
### Description

With the addition of the cloud quickstart the tiles got pushed to 2 lines on a 1080p screen. This change makes them uniformly distributed


### Testing instructions

Netlify link: /gateway/latest/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

