### PR TITLE
Tile grid style fix + konnect runtime instances improvements

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -1404,18 +1404,15 @@ Generic Styling for Desktop
       &.no-description {
         justify-content: center;
       }
-
-      &:hover,
-      &.focus {
-        .install-text {
-          color: @blue-500;
-        }
-      }
     }
 
-    .docs-grid-install-block:hover,
-    .docs-grid-install-block:focus {
+    a.docs-grid-install-block:hover, 
+    a.docs-grid-install-block:focus {
       background-color: #f8f9fc;
+
+      .install-text {
+        color: @blue-500;
+      }
     }
 
     @media (max-width: 991px) {

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -51,7 +51,7 @@
       url: /runtime-manager/
     - text: Runtime Instances
       items:
-        - text: Overview
+        - text: Installation Options
           url: /runtime-manager/runtime-instances/
         - text: Upgrade a Runtime Instance
           url: /runtime-manager/runtime-instances/upgrade/

--- a/app/konnect/runtime-manager/runtime-instances/index.md
+++ b/app/konnect/runtime-manager/runtime-instances/index.md
@@ -1,5 +1,5 @@
 ---
-title: About Runtime Instances
+title: Installation Options
 content_type: explanation
 disable_image_expand: true
 ---
@@ -8,9 +8,14 @@ A runtime instance is a single self-managed instance of {{site.base_gateway}} th
 
 {{site.konnect_short_name}} provides runtime instance installation scripts for various platforms. 
 These runtime instances are configured to run in your {{site.konnect_short_name}} environment.
-You can access these scripts from the {{site.konnect_short_name}} **Runtime Manager**. 
 
 ## Supported installation options
+
+You can set up a runtime instance by navigating to {% konnect_icon runtimes %} [**Runtime Manager**](https://cloud.konghq.com/runtime-manager/), choosing a runtime group, then clicking on **New Runtime Instance**.
+
+This brings you to a set of installation options. Choose one of the options, then follow the instructions in {{site.konnect_short_name}} to finish setting up.
+
+{{site.konnect_short_name}} supports the following installation options:
 
 {% include install.html config=site.data.tables.install_options_konnect header='no-header' %}
 


### PR DESCRIPTION
### Description

* Removed hover & focus pseudoclasses from unlinked install grid tiles. The existence of a hover class was creating the illusion of clickable tiles, when the tiles are just visual. Hover classes are now applied only when there's a link on the tile.
* Added a short description of the runtime instance installation options and a line on how to get to them.
* Based on user testing (John and Amy), removing the "Installation Options" title from the page wasn't the right call, since it's not clear that installation options will appear on the overview. Reverted the title, but kept the URL the same.

### Testing instructions

Netlify link: https://deploy-preview-5400--kongdocs.netlify.app/konnect/runtime-manager/runtime-instances/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

