### PR TITLE
3rd party plugins banner + plugin hub filters

### DIFF
--- a/app/_assets/stylesheets/hub-landing-page.less
+++ b/app/_assets/stylesheets/hub-landing-page.less
@@ -300,7 +300,7 @@
       font-weight: 500;
       letter-spacing: 0;
       line-height: 20px;
-      margin: 15px -10px 10px;
+      margin: 15px -2px 10px;
       text-transform: uppercase;
     }
 

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -1,7 +1,7 @@
 {% assign extn_publisher = extn.extn_publisher %}
 
 <div class="card-group {{ extn.type }} {{ extn.categories | join: ' ' }} {%
-  if extn_publisher == 'kong-inc' %}pub-konghq {%
+  if extn_publisher == 'kong-inc' %}gateway {%
     if extn.kong_version_compatibility.enterprise_edition.compatible != nil %}ee-compat {% endif %}{%
       if extn.plus or extn.kong_version_compatibility.community_edition.compatible != nil %}{%
         unless extn.cloud == false %}plus {% endunless %}{% endif %}{%

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -192,7 +192,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
 
       {% unless extn_publisher == "kong-inc" %}
         <div class="alert alert-info blue" role="alert">
-          Partner Plugin: This plugin is <b>developed, tested, and maintained</b> by a third-party contributor.
+          Partner Plugin: This plugin is <b>developed, tested, and maintained</b> by {{ page.publisher }}
         </div>
       {% endunless %}
     {% endif %}

--- a/app/hub/index.html
+++ b/app/hub/index.html
@@ -54,7 +54,7 @@ body_id: page-hub
               </a>
             </li>
             <li class="nav-item">
-              <a href="#gateway" class="nav-link" data-filter="pub-konghq" role="menuitem" tabindex="0">
+              <a href="#gateway" class="nav-link" data-filter="gateway" role="menuitem" tabindex="0">
                 Bundled with Kong Gateway
               </a>
             </li>

--- a/app/hub/index.html
+++ b/app/hub/index.html
@@ -1,10 +1,9 @@
 ---
 layout: default
-title: Kong Hub | Plugins and Integrations
+title: Kong Plugin Hub
 breadcrumbs: null
 permalink: /hub/
 body_id: page-hub
-
 ---
 
 {% assign hub = site.data.ssg_hub %}
@@ -43,6 +42,7 @@ body_id: page-hub
           </ul>
           <h3>Filters</h3>
           <ul class="nav flex-column" id="facet-filters" role="menu">
+            <p class="no-link">Plugin types</p>
             <li class="nav-item">
               <a href="" class="nav-link active" data-filter="" role="menuitem" tabindex="0">
                 All Plugins
@@ -50,7 +50,12 @@ body_id: page-hub
             </li>
             <li class="nav-item">
               <a href="#konnect" class="nav-link" data-filter="konnect" role="menuitem" tabindex="0">
-                Konnect
+                Bundled with Konnect
+              </a>
+            </li>
+            <li class="nav-item">
+              <a href="#gateway" class="nav-link" data-filter="pub-konghq" role="menuitem" tabindex="0">
+                Bundled with Kong Gateway
               </a>
             </li>
             <li class="nav-item">
@@ -58,7 +63,7 @@ body_id: page-hub
                 Third-Party
               </a>
             </li>
-            <p class="no-link">Subscription tiers</p>
+            <p class="no-link">Kong subscription tiers</p>
             <li class="nav-item">
               <a href="#open-source" class="nav-link" data-filter="open-source" role="menuitem" tabindex="0">
                 Free


### PR DESCRIPTION
### Description

Various updates stemming from 3rd party plugin feedback.
* Adjusted banner to call out publisher name instead of just saying "a third-party contributor"
* Fix plugin hub title so that it appears as "Kong Plugin Hub" in google search, instead of just "Kong Hub"
* Filter adjustments:
  * "Konnect" filter is now "Bundled with Konnect"
  * Added a "Bundled with Gateway" filter
  * "Subscription tiers" filter is now "Kong subscription tiers" to hopefully make it clearer that it only refers to Kong plugins

### Testing instructions

[Filters on Plugin Hub](https://deploy-preview-5401--kongdocs.netlify.app/hub/)
Banner on 3rd party plugin should contain publisher name, eg [Imperva](https://deploy-preview-5401--kongdocs.netlify.app/hub/imperva/imp-appsec-connector/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

