### PR TITLE
Konnect labels: remove info about filtering and search

### DIFF
--- a/app/konnect/reference/labels.md
+++ b/app/konnect/reference/labels.md
@@ -4,7 +4,7 @@ content_type: reference
 ---
 
 Labels are `key:value` pairs. They are case-sensitive attributes associated with entities. 
-Labels allow an organization to specify metadata on an entity that can be used for filtering an entity list or for searching across entity types.
+Labels allow an organization to specify metadata on an entity.
 
 For example, you might use the label `location:us-west`, where `location` is the key and the `us-west` is the value.
 


### PR DESCRIPTION
### Description

Came up on Slack that we don't have filtering/search by labels yet. Removing the line from the docs.
https://kongstrong.slack.com/archives/C01888Q7PJ7/p1680615706054559


### Testing instructions

Netlify link: https://deploy-preview-5404--kongdocs.netlify.app/konnect/reference/labels/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

