### PR TITLE
Clear out old Konnect Cloud product name

### DIFF
--- a/.github/styles/kong/kongterms.yml
+++ b/.github/styles/kong/kongterms.yml
@@ -7,6 +7,6 @@ swap:
 
   Developer Portal: Dev Portal
   Kong Gateway: "{{site.base_gateway}}"
-  Konnect Cloud: "{{site.konnect_saas}}"
+  Kong Konnect: "{{site.konnect_saas}}"
   ServiceHub: Service Hub
   dbless: DB-less

--- a/.github/styles/kong/kongterms.yml
+++ b/.github/styles/kong/kongterms.yml
@@ -7,6 +7,6 @@ swap:
 
   Developer Portal: Dev Portal
   Kong Gateway: "{{site.base_gateway}}"
-  Kong Konnect: "{{site.konnect_saas}}"
+  Kong Konnect: "{{site.konnect_product_name}}"
   ServiceHub: Service Hub
   dbless: DB-less

--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -775,7 +775,7 @@ jQuery(function () {
     '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription - <a target="_blank" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>'
   );
   $(".badge.plus").append(
-    '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Konnect Cloud)</span></div>'
+    '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Kong Konnect)</span></div>'
   );
   $(".badge.free").append(
     '<div class="tooltip"><span class="tooltiptext">Available in Enterprise Free mode (without a license)</span></div>'
@@ -787,6 +787,6 @@ jQuery(function () {
     '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>'
   );
   $(".badge.konnect").append(
-    '<div class="tooltip"><span class="tooltiptext">Available in the Konnect Cloud app</span></div>'
+    '<div class="tooltip"><span class="tooltiptext">Available in the Kong Konnect app</span></div>'
   );
 });

--- a/app/_data/tables/plugin_index.yml
+++ b/app/_data/tables/plugin_index.yml
@@ -7,7 +7,7 @@
       enterprise: Yes
       konnect: No
       network_config_opts: Self-managed traditional, DB-less, and hybrid
-      notes: Application registration <b>is</b> available in Konnect Cloud, but doesn't require this plugin. <br>Learn how to <a href="/konnect/dev-portal/applications/enable-app-reg/">Enable Application Registration</a> in Konnect Cloud.
+      notes: Application registration <b>is</b> available in Konnect, but doesn't require this plugin. <br>Learn how to <a href="/konnect/dev-portal/applications/enable-app-reg/">Enable Application Registration</a> in Konnect.
       url: /hub/kong-inc/application-registration
 
     - name: Basic Auth

--- a/app/_includes/hub-examples.html
+++ b/app/_includes/hub-examples.html
@@ -200,7 +200,7 @@ Replace `SERVICE_NAME|SERVICE_ID` with the `id` or `name` of the service that th
 {% endnavtab %}
 {% endunless %}
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
-{% navtab Konnect Cloud %}
+{% navtab Konnect %}
 
 You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
 
@@ -339,7 +339,7 @@ Replace `ROUTE_NAME|ROUTE_ID` with the `id` or `name` of the route that this plu
 {% endnavtab %}
 {% endunless %}
 {% unless include.params.konnect_examples == false or include.publisher != "Kong Inc." %}
-{% navtab Konnect Cloud %}
+{% navtab Konnect %}
 
 You can configure this plugin through the [{{site.konnect_short_name}}](https://cloud.konghq.com) UI.
 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -387,7 +387,7 @@ We only want to show the compatibility matrix if the strategy = matrix (which is
         {% endunless %}
         {% if extn_publisher == "kong-inc" %}
         <tr>
-          <td>Konnect Cloud compatible?</td>
+          <td>Bundled with Konnect?</td>
           <td>
            {% if page.cloud == false %} No{%
            elsif extn_release == extn_latest %}Yes{%

--- a/app/_layouts/landing-page.html
+++ b/app/_layouts/landing-page.html
@@ -42,7 +42,7 @@ id: landing-page
       </section>
 
       <h3>
-        Get started with Kong Konnect Cloud
+        Get started with Kong Konnect
       </h3>
     <div class="cards-container">
       <div class="card">


### PR DESCRIPTION
### Description

There are a few places where the old "Konnect Cloud" name is still in use, so cleaning that out. 

Official, full product name is Kong Konnect: https://konghq.com/products/kong-konnect.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

