### PR TITLE
fix route-transformer-advanced config.path example

### DIFF
--- a/app/_hub/kong-inc/route-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/route-transformer-advanced/_index.md
@@ -28,8 +28,7 @@ params:
   config:
     - name: path
       required: semi
-      value_in_examples:
-        - /path
+      value_in_examples: /path
       datatype: string
       description: |
         Updates the upstream request path with given value/template. This value can only be used to update the path part of the URI, not the scheme, nor the hostname. One of `config.path` or `config.host` or `config.port` must be specified.


### PR DESCRIPTION
### Description

config.path is an string. Example value should also be an string, not an array.
 
current declarative example provides a   `(message: "schema violation (config.path: expected a string)")`  error while using deck

### Testing instructions


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

