### PR TITLE
[Fix] Forward proxy CP info for Konnect

### DIFF
--- a/app/konnect/runtime-manager/runtime-instances/index.md
+++ b/app/konnect/runtime-manager/runtime-instances/index.md
@@ -24,7 +24,7 @@ This brings you to a set of installation options. Choose one of the options, the
 
 ### Forward proxy support
 
-Kong Konnect supports using non-transparent forward proxies to connect your {{site.base_gateway}} data plane with the {{site.konnect_saas}} control plane. Instructions for this feature can be found in the {{site.base_gateway}} documentation under [Forward proxy connections](/gateway/latest/production/networking/cp-dp-proxy/).
+{{site.konnect_product_name}} supports using non-transparent forward proxies to connect your {{site.base_gateway}} data plane with the {{site.konnect_saas}} control plane. See the [Forward proxy connections](/gateway/latest/production/networking/cp-dp-proxy/){{site.base_gateway}} documentation for more information.
 
 ## More information
 
@@ -34,4 +34,4 @@ Kong Konnect supports using non-transparent forward proxies to connect your {{si
 - [Forward proxy connections](/gateway/latest/production/networking/cp-dp-proxy/) - Allow runtime instances to communicate with {{site.konnect_short_name}} through a forward proxy
 - [Runtime parameter reference](/konnect/runtime-manager/runtime-instances/runtime-parameter-reference/) - Reference for the default configuration parameters used in runtime instance installation
 - [Analytics dashboard](/konnect/analytics/) - Monitor and analyze your runtime instances, as well as specific entities
-- [Troubleshooting documentation](/konnect/runtime-manager/troubleshoot/) - Common troubleshooting instruction documentation.
+- [Troubleshooting documentation](/konnect/runtime-manager/troubleshoot/) - Common runtime instance troubleshooting instruction documentation.

--- a/app/konnect/runtime-manager/runtime-instances/index.md
+++ b/app/konnect/runtime-manager/runtime-instances/index.md
@@ -22,6 +22,10 @@ This brings you to a set of installation options. Choose one of the options, the
 {:.note}
 > **Note:** Kong does not host runtime instances. You must install and host your own.
 
+### Forward proxy support
+
+Kong Konnect supports using non-transparent forward proxies to connect your {{site.base_gateway}} data plane with the {{site.konnect_saas}} control plane. Instructions for this feature can be found in the {{site.base_gateway}} documentation under [Forward proxy connections](/gateway/latest/production/networking/cp-dp-proxy/).
+
 ## More information
 
 - [Upgrade a runtime instance](/konnect/runtime-manager/runtime-instances/upgrade/)
@@ -30,3 +34,4 @@ This brings you to a set of installation options. Choose one of the options, the
 - [Forward proxy connections](/gateway/latest/production/networking/cp-dp-proxy/) - Allow runtime instances to communicate with {{site.konnect_short_name}} through a forward proxy
 - [Runtime parameter reference](/konnect/runtime-manager/runtime-instances/runtime-parameter-reference/) - Reference for the default configuration parameters used in runtime instance installation
 - [Analytics dashboard](/konnect/analytics/) - Monitor and analyze your runtime instances, as well as specific entities
+- [Troubleshooting documentation](/konnect/runtime-manager/troubleshoot/) - Common troubleshooting instruction documentation.

--- a/app/konnect/runtime-manager/troubleshoot.md
+++ b/app/konnect/runtime-manager/troubleshoot.md
@@ -88,3 +88,9 @@ command:
 helm upgrade my-kong kong/kong -n kong \
   --values ./values.yaml
 ```
+
+## Connect a data plane to {{site.konnect_saas}} that is behind a non-trasparent forward proxy.
+
+In situations where forward proxies are non-transparent, you can still connect the {{site.base_gateway}} data plane with the {{site.konnect_saas}} control plane.
+To do this, you need to configure each {{site.base_gateway}} runtime instance to authenticate with the proxy server and allow traffic through.
+For more information, see [Control Plane and Data Plane Communication through a Forward Proxy](/gateway/latest/production/networking/cp-dp-proxy/) in the {{site.base_gateway}} documentation.


### PR DESCRIPTION
This PR adds the previously removed section back to the runtime IA installation options topic. It also adds it to the runtime instances troubleshooting topic. 