### PR TITLE
Update about-plugins.md

### DIFF
--- a/app/_includes/md/about-plugins.md
+++ b/app/_includes/md/about-plugins.md
@@ -101,7 +101,7 @@ To start creating your own plugins, check out the PDK documentation:
 
 If you are interested in sharing your custom plugin with other Kong users, you
 must also submit plugin reference documentation to the Kong Plugin Hub. See the
-[contribution guidelines](/contributing/)
+[contribution guidelines](/contributing/plugin-docs/)
 for adding documentation.
 
 ## Other key concepts


### PR DESCRIPTION
Updating link in Contributing custom plugins section to point to /contributing/plugin-docs/ so interested parties can see that the requests start w/ Partnership team.

Tied to recent inquiry in #docs: https://kongstrong.slack.com/archives/CDSTDSG9J/p1680269057152689


- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

