### PR TITLE
fix(kic): update KIC's feature gates

### DIFF
--- a/app/_src/kubernetes-ingress-controller/references/feature-gates.md
+++ b/app/_src/kubernetes-ingress-controller/references/feature-gates.md
@@ -12,15 +12,13 @@ See below for current features and their statuses, and follow the links to the r
 * [Kubernetes feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
 * [Feature stages](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages)
 
-
 ## Feature gates for alpha and beta features
 
 Features that reach GA and become stable are removed from this table, but they can be found in the main [KIC CRD documentation][specs] and [guides][guides]. This table is an overview of features at various maturity levels:
 
-
 | Feature                | Default | Stage | Since | Until |
 |------------------------|---------|-------|-------|-------|
-| Knative                | `true`  | Alpha | 0.8.0 | TBD   |
+| Knative                | `false` | Alpha | 0.8.0 | TBD   |
 
 {% if_version lte: 2.5.x %}
 | Gateway                | `false` | Alpha | 2.2.0 | 2.5.0 |
@@ -35,14 +33,13 @@ Features that reach GA and become stable are removed from this table, but they c
 {% if_version gte: 2.8.x %}
 | CombinedRoutes         | `true`  | Beta  | 2.8.0 | TBD   |
 {% endif_version %}
-| IngressClassParameters | `false` | Alpha | 2.6.0 | TBD   |
 
 ### Feature gates details
 
-- The **since** and **until** rows in the table refer to [KIC Releases][releases].
-- Most features will be planned using [Kubernetes Enhancement Proposals (KEP)][k8s-keps]. If you're interested in developing features, familiarize yourself with our [KEPs][kic-keps].
-- Features that are currently in alpha or beta states may become deprecated at any time. Deprecated features are removed during the next minor release. 
-- Until a feature becomes GA, there are no guarantees that it's going to continue being available. For more information, see the [changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md).
+* The **since** and **until** rows in the table refer to [KIC Releases][releases].
+* Most features will be planned using [Kubernetes Enhancement Proposals (KEP)][k8s-keps]. If you're interested in developing features, familiarize yourself with our [KEPs][kic-keps].
+* Features that are currently in alpha or beta states may become deprecated at any time. Deprecated features are removed during the next minor release.
+* Until a feature becomes GA, there are no guarantees that it's going to continue being available. For more information, see the [changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md).
 
 {:.important}
 >**Important:** To avoid disruption to your services consider not using features until they have reached GA status. 
@@ -50,7 +47,6 @@ Features that reach GA and become stable are removed from this table, but they c
 ### Documentation
 
 You can find feature preview documentation for alpha maturity features in the [kubernetes-ingress-controller repository](https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_PREVIEW_DOCUMENTATION.md)..
-
 
 [k8s]:https://kubernetes.io
 [gates]:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
@@ -60,5 +56,3 @@ You can find feature preview documentation for alpha maturity features in the [k
 [k8s-keps]:https://github.com/kubernetes/enhancements
 [kic-keps]:https://github.com/Kong/kubernetes-ingress-controller/tree/main/keps
 [releases]:https://github.com/Kong/kubernetes-ingress-controller/releases
-[kong-docs]:https://github.com/Kong/docs.konghq.com
-[kic-guides]: /kubernetes-ingress-controller/latest/guides/overview/


### PR DESCRIPTION
### Description

This PR fixes the table of current feature gates and their defaults in KIC.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

