### PR TITLE
update Gateway Discovery tutorial with client verification

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/using-gateway-discovery.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-gateway-discovery.md
@@ -32,16 +32,78 @@ This guide will be also using [`stern`][stern-gh] for easy pod logs querying.
 In order to use Gateway Discovery we need to deploy {{site.kic_product_name}}
 so that it knows where to find {{site.base_gateway}}s deployed in the cluster.
 
+### {{site.kic_product_name}}
+
+In order to make KIC aware of deployed Gateway(s) we need to provide the name of
+the Admin service as well as the Proxy service.
+
+This is being derived from the helm release name. Let's store it in a variable so
+that we can use it in helm installation steps:
+
+```terminal
+$ export GATEWAY_RELEASE_NAME=gateway
+```
+
+As {{site.kic_product_name}} and {{site.base_gateway}} deployments are separate, we
+should also enable TLS client verification for the Admin API service so that no one
+from inside the cluster can access it without a valid certificate. This can be done
+by setting `ingressController.adminApi.tls.client.enabled` option in the helm chart 
+to `true`. It will create a CA certificate and a CA-signed certificate for the 
+client, and respective Kubernetes TLS Secrets for both.
+
+The CA certificate Secret's name can be set
+with `ingressController.adminApi.tls.client.caSecretName` option. We will use that
+to have a static name for the CA certificate Secret, so that we can refer it in the
+{{site.base_gateway}} deployment.
+
+{:.note}
+> **Note**: It is possible to provide your own certificates for the client 
+> verification. `ingressController.adminApi.tls.client.certProvided=true`
+> and `ingressController.adminApi.tls.client.secretName` should be used 
+> for that purpose in the {{site.kic_product_name}} release, and 
+> `admin.tls.client.secretName` or `admin.tls.client.caBundle` in the 
+> {{site.base_gateway}} release.
+> For more information, see the [helm chart's readme][kong-chart].
+
+Now we're ready to deploy controller's helm release:
+
+```terminal
+$ helm upgrade --install controller kong/kong -n kong --create-namespace \
+  --set ingressController.enabled=true \
+  --set ingressController.gatewayDiscovery.enabled=true \
+  --set ingressController.gatewayDiscovery.adminApiService.name=${GATEWAY_RELEASE_NAME}-kong-admin \
+  --set ingressController.adminApi.tls.client.enabled=true \
+  --set ingressController.adminApi.tls.client.caSecretName=admin-api-ca-cert \
+  --set deployment.kong.enabled=false \
+  --set proxy.nameOverride=${GATEWAY_RELEASE_NAME}-kong-proxy \
+  --set replicaCount=2
+```
+
+At this point you should be able to see a {{site.kic_product_name}} deployment with 
+2 replicas, waiting for {{site.base_gateway}} to be deployed:
+
+```terminal
+$ kubectl get deployment -n kong
+NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+controller-kong   0/2     2            2           1m
+```
+
 ### {{site.base_gateway}}
 
-In order to deploy {{site.base_gateway}} we can run:
+As we enabled TLS client verification for the Admin API service, we need to provide a CA
+certificate to the {{site.base_gateway}} deployment. We can do that by setting
+`admin.tls.client.secretName` to the CA certificate Secret's name, which we set in the
+{{site.kic_product_name}} deployment.
 
-```
+Now we can deploy {{site.base_gateway}}. In order to do that we can run:
+
+```terminal
 $ helm upgrade --install gateway kong/kong -n kong --create-namespace \
   --set ingressController.enabled=false \
   --set admin.enabled=true \
   --set admin.type=ClusterIP \
   --set admin.clusterIP=None \
+  --set admin.tls.client.secretName=admin-api-ca-cert \
   --set replicaCount=2
 ```
 
@@ -50,50 +112,24 @@ which will deploy {{site.base_gateway}} with 2 replicas, without {{site.kic_prod
 Once installed, set an environment variable, $PROXY_IP with the External IP address of
 the `gateway-kong-proxy` service in `kong` namespace:
 
-```
-export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong gateway-kong-proxy)
-```
-
-At this point you should be able to access the proxy service:
-
-```
-curl $PROXY_IP
-{"message":"no Route matched with those values"}%
-```
-
-### {{site.kic_product_name}}
-
-Now we can deploy {{site.kic_product_name}}.
-
-In order to make KIC aware of deployed Gateway(s) we need to provide the name of
-the Admin service as well as the Proxy service.
-
-This is being derived from the helm release name. Let's store it in a variable so
-that we can use it in helm installation step:
-
-```
-export GATEWAY_RELEASE_NAME=gateway
-```
-
-Now we're ready to deploy controller's helm release:
-
-```
-$ helm upgrade --install controller kong/kong -n kong --create-namespace \
-  --set ingressController.enabled=true \
-  --set ingressController.gatewayDiscovery.enabled=true \
-  --set ingressController.gatewayDiscovery.adminApiService.name=${GATEWAY_RELEASE_NAME}-kong-admin \
-  --set deployment.kong.enabled=false \
-  --set proxy.nameOverride=${GATEWAY_RELEASE_NAME}-kong-proxy \
-  --set replicaCount=2
+```terminal
+$ export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong gateway-kong-proxy)
 ```
 
 At this point you should be able to see both deployments ready:
 
-```
+```terminal
 $ kubectl get deployment -n kong
 NAME              READY   UP-TO-DATE   AVAILABLE   AGE
 controller-kong   2/2     2            2           1m
 gateway-kong      2/2     2            2           1m
+```
+
+You can also access the proxy service now:
+
+```terminal
+$ curl $PROXY_IP
+{"message":"no Route matched with those values"}%
 ```
 
 ## Scaling deployments
@@ -108,14 +144,14 @@ Additional replicas, will:
 
 We can test scaling those 2 deployments by invoking:
 
-```
+```terminal
 $ kubectl scale deployment -n kong gateway-kong --replicas 4
 $ kubectl scale deployment -n kong controller-kong --replicas 3
 ```
 
 At this point we should see 4 instances of gateway and 3 instances of controller:
 
-```
+```terminal
 $ kubectl get deployment -n kong
 NAME              READY   UP-TO-DATE   AVAILABLE   AGE
 controller-kong   3/3     3            3           5m
@@ -127,7 +163,7 @@ gateway-kong      4/4     4            4           5m
 In order to verify that the configuration is indeed sent to all the Gateways we
 can deploy a simple HTTP Service:
 
-```
+```yaml
 echo "
 apiVersion: apps/v1
 kind: Deployment
@@ -169,7 +205,7 @@ spec:
 
 with an `Ingress` with an `IngressClass`:
 
-```
+```yaml
 echo "
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
@@ -203,7 +239,7 @@ spec:
 With those manifests applied we can observe controller logs for entries that
 indicate successful configuration of all the discovered Gateways:
 
-```
+```terminal
 $ stern -n kong -lapp=controller-kong --since 1m --include "synced configuration"
 ...
 controller-kong-545d798874-q6h7m ingress-controller time="2023-03-02T15:11:42Z" level=info msg="successfully synced configuration to kong" kong_url="https://10.244.0.29:8444"
@@ -214,7 +250,7 @@ controller-kong-545d798874-q6h7m ingress-controller time="2023-03-02T15:11:42Z" 
 
 At this point we should be able to access the `/echo` endpoint from our `htptbin` service:
 
-```
+```terminal
 $ curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
 <!DOCTYPE html>
 <html lang="en">
@@ -230,7 +266,7 @@ After issuing several queries against that service we can see in Gateway logs
 that we're hitting all Pods which proxy the traffic as configured (mark the first
 column that contains the pod name):
 
-```
+```terminal
 $ stern -n kong -lapp=gateway-kong --since 1m --include "/echo"
 gateway-kong-5c98495ff7-rnq5c proxy 10.244.0.1 - - [02/Mar/2023:15:16:09 +0000] "GET /echo HTTP/1.1" 200 9593 "-" "curl/7.86.0"
 gateway-kong-5c98495ff7-s6rcw proxy 10.244.0.1 - - [02/Mar/2023:15:16:09 +0000] "GET /echo HTTP/1.1" 200 9593 "-" "curl/7.86.0"


### PR DESCRIPTION
### Description

 We should recommend using client verification when GD deployment is used. Issue: https://github.com/Kong/kubernetes-ingress-controller/issues/3833

### Testing instructions

Netlify link: https://deploy-preview-5415--kongdocs.netlify.app/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

