### PR TITLE
[DOCU-2921] Status endpoint + Kong health  check

### DIFF
--- a/app/_data/docs_nav_gateway_3.3.x.yml
+++ b/app/_data/docs_nav_gateway_3.3.x.yml
@@ -178,6 +178,8 @@ items:
             url: /production/monitoring/statsd
           - text: Datadog
             url: /production/monitoring/datadog
+          - text: Health Check
+            url: /production/monitoring/health-check
       - text: Tracing
         items:
           - text: Overview

--- a/app/_data/docs_nav_gateway_3.3.x.yml
+++ b/app/_data/docs_nav_gateway_3.3.x.yml
@@ -178,8 +178,8 @@ items:
             url: /production/monitoring/statsd
           - text: Datadog
             url: /production/monitoring/datadog
-          - text: Health Check
-            url: /production/monitoring/health-check
+          - text: Readiness Check
+            url: /production/monitoring/readiness-check
       - text: Tracing
         items:
           - text: Overview

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -1,0 +1,104 @@
+---
+title: Phrase starting with a verb # e.g. Get started with dynamic plugin ordering
+content_type: tutorial
+
+# Optional values. Uncomment any that apply to your document.
+
+# alpha: true # Labels the page as alpha; adds a banner to the top of the page.
+# beta: true # Labels the page as beta; adds a banner to the top of the page.
+---
+
+Tutorials are docs that help users learn by doing. The goal of a tutorial is to guide the user, step-by-step through a series of tasks that help them achieve a certain goal. Keep in mind that the goal and the steps should be achievable even for a beginner. 
+
+Tutorials should include an introduction paragraph here. Good introductions explain who this tutorial is for and what this tutorial will help the user accomplish and learn. For example, if you were writing a tutorial about how to get started with a software product, your tutorial could include information about a general overview of what steps the user would be going through, what this software will help them accomplish, and that the end result of this tutorial will be that the software is installed with the basic settings configured. 
+
+## Prerequisites <!-- Optional -->
+
+Tutorial topics typically don't contain any prerequisites because you should be helping the user install those things in the steps. The only prerequisites you should include are those for external tools, like jq or Docker, for example. 
+
+In the rare circumstance that you need prerequisites, write them as a bulleted list.
+
+* Docker installed
+* jq installed
+
+## Task section <!-- Header optional if there's only one task section in the article -->
+
+A tutorial section title directs the user to perform an action and generally starts with a verb. For example, "Install the software" or "Configure basic settings".
+
+Each task section should include an introduction paragraph that explains what step the user doing, a brief explanation of the feature, and why the user is completing this step.
+
+### Instructions
+
+Steps in each section should break down the tasks the user will complete in sequential order.
+
+Continuing the previous example of installing software, here's an example:
+
+1. On your computer, open Terminal.
+1. Install ____ with Terminal:
+    ```sh
+    example code
+    ```
+    Explanation of the variables used in the sample code, like "Where `example` is the filename."
+1. Optional: To also install ____ to manage documents, install it using Terminal:
+    ```sh
+    example code
+    ```
+    Explanation of the variables used in the sample code, like "Where `example` is the filename."
+1. To ______, do the following:
+    1. Click **Start**.
+    1. Click **Stop**.
+1. To ____, do one of the following:
+    * If you are using Kubernetes, start the software:
+        ```sh
+        example code
+        ```
+        Explanation of the variables used in the sample code, like "Where `example` is the filename."
+    * If you are using Docker, start the software:
+        ```sh
+        example code
+        ```
+        Explanation of the variables used in the sample code, like "Where `example` is the filename."
+
+You can also use tabs in a section. For example, if you can install the software with macOS or Docker, you might have a tab with instructions for macOS and a tab with instructions for Docker.
+
+{% navtabs %}
+{% navtab macOS %}
+
+1. Open Terminal...
+1. Run....
+
+{% endnavtab %}
+{% navtab Docker %}
+
+1. Open Docker...
+1. Run....
+
+{% endnavtab %}
+{% endnavtabs %}
+
+### Explanation of instructions <!-- Optional, but recommended -->
+
+This section should contain a brief, 2-3 sentence paragraph that summarizes what the user accomplished in these steps and what the outcome was. For example, "The software is now installed on your computer. You can't use it yet because the settings haven't been configured. In the next section, you will configure the basic settings so you can start using the software." 
+
+{:.note}
+> **Note**: You can also use notes to highlight important information. Try to keep them short.
+
+## Second task section <!-- Optional -->
+
+Adding additional sections can be helpful if you have to switch from working in one product to another or if you switch from one task, like installing to configuring. 
+
+### Instructions
+
+1. First step.
+1. Second step.
+
+### Explanation of instructions <!-- Optional, but recommended -->
+
+## See also <!-- Optional, but recommended -->
+
+This section should include a list of tutorials or other pages that a user can visit to extend their learning from this tutorial.
+
+See the following examples of tutorial documentation:
+* [Get started with services and routes](https://docs.konghq.com/gateway/latest/get-started/services-and-routes/)
+* [Migrate from OSS to Enterprise](https://docs.konghq.com/gateway/latest/migrate-ce-to-ke/)
+* [Set up Vitals with InfluxDB](https://docs.konghq.com/gateway/latest/kong-enterprise/analytics/influx-strategy/)

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -27,8 +27,8 @@ In Traditional mode, the conditions that must be fulfilled simultaneously for th
 In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
 
 1. The current configuration hash is not nil and not all zeros
-2. Successful initial build or a rebuild of all routers for all workers
-3. Successful initial build or a rebuild of all plugin iterators for all workers
+2. Successful initial build or rebuild of all routers for all workers
+3. Successful initial build or rebuild of all plugin iterators for all workers
 
 ## Configuring the Status Endpoint
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -31,7 +31,7 @@ In Traditional mode, the conditions that must be fulfilled simultaneously for th
 
 In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
 
-1. The current configuration hash is not nil and not all zeros
+1. Kong has loaded a valid and non-empty config
 2. Successful initial build of all routers for all workers
 3. Successful initial build of all plugin iterators for all workers
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -38,7 +38,7 @@ To configure the Status Endpoint in your Kong instance, follow these steps:
 2. Open the Kong configuration file (e.g., `kong.conf` or `kong.yml`).
 3. Make sure the Status API is enabled by including the following line:
 
-    ```yaml
+    ```conf
     status_listen = 0.0.0.0:8100
     ```
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -47,7 +47,7 @@ To configure the Status Endpoint in your Kong instance, follow these steps:
     status_listen = 0.0.0.0:8100
     ```
 
-    This will make the Status API listen on port 8100. You can change the port number to any available port on your system.
+    This will make the Status API server listen on port `8100` on all interfaces of the system. You can change the port number to any available port on your system.
 
 4. Save the configuration file and restart Kong to apply the changes.
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -59,7 +59,7 @@ You can also use `KONG_STATUS_LISTEN` environment variable to configure it.
 
 ## Using the Node Readiness Endpoint
 
-Once you've configured the Status Endpoint, you can send requests to it to check the readiness of your Kong instance.
+Once you've configured the Node Readiness Endpoint, you can send requests to it to check the readiness of your Kong instance.
 
 1. Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -108,12 +108,13 @@ If you're using Kubernetes or Helm, you may need to update the readiness probe c
 readinessProbe:
     httpGet:
         path: /status/ready
+        # Make sure to replace the port number with the one you
+        # configured for the Status API Server.
         port: 8100
     initialDelaySeconds: 10
     periodSeconds: 5
 ```
 
-Make sure to replace the port number with the one you configured for the Status API Server.
 
 ## See also
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -57,7 +57,7 @@ To configure the Status Endpoint in your Kong instance, follow these steps:
     
 You can also use `KONG_STATUS_LISTEN` environment variable to configure it.
 
-## Using the Status Endpoint
+## Using the Node Readiness Endpoint
 
 Once you've configured the Status Endpoint, you can send requests to it to check the readiness of your Kong instance.
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -82,7 +82,7 @@ readinessProbe:
     periodSeconds: 5
 ```
 
-Make sure to replace the port number with the one you configured for the Status API.
+Make sure to replace the port number with the one you configured for the Status API Server.
 
 ## See also
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -67,7 +67,7 @@ Once you've configured the Status Endpoint, you can send requests to it to check
     curl -I <status-api-url>/status/ready
     ```
 
-2. If the response is `200 OK`, your Kong instance is ready to serve requests. If the response is `503 Service Unavailable`, Kong is still loading the configuration or has failed to load it.
+2. If the response is `200 OK`, your Kong instance is ready to serve requests. If the response is `503 Service Unavailable`, Kong does not yet have a valid configuration.
 
 ## Updating Readiness Probes
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -61,7 +61,7 @@ You can also use `KONG_STATUS_LISTEN` environment variable to configure it.
 
 Once you've configured the Status Endpoint, you can send requests to it to check the readiness of your Kong instance.
 
-1. Send a GET request to the `/status/ready` endpoint. Replace `<status-api-url>` with the appropriate URL for your Status API, including the port number:
+1. Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
 
     ```shell
     curl -I <status-api-url>/status/ready

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -32,8 +32,8 @@ In Traditional mode, the conditions that must be fulfilled simultaneously for th
 In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
 
 1. The current configuration hash is not nil and not all zeros
-2. Successful initial build/rebuild of all routers for all workers
-3. Successful initial build/rebuild of all plugin iterators for all workers
+2. Successful initial build of all routers for all workers
+3. Successful initial build of all plugin iterators for all workers
 
 ## Configuring the Status Endpoint
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -5,7 +5,7 @@ content_type: tutorial
 
 This tutorial will guide you through the process of using the new Kong Status endpoint, which provides a more reliable and simple way to determine if Kong is ready to serve requests.
 
-To put it simply, health check endpoint will return a 200 OK response when Kong is ready, or a 503 Service Unavailable response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
+To put it simply, health check endpoint will return a `200 OK` response when Kong is ready, or a `503 Service Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
 ## Prerequisites
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -41,7 +41,7 @@ To configure the Status Endpoint in your Kong instance, follow these steps:
 
 1. Ensure that Kong is setup.
 2. Open the Kong configuration file (e.g., `kong.conf` or `kong.yml`).
-3. Make sure the Status API is enabled by including the following line:
+3. Make sure the Status API server is enabled by including the following line:
 
     ```conf
     status_listen = 0.0.0.0:8100

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -15,7 +15,7 @@ amount of memory Kong node is using. You might want to check out the [`/status` 
 * Kong installed
 * Basic understanding of Kong configuration and deployment modes (Traditional, DB-less, and Hybrid)
 
-## Understanding the Status Endpoint
+## Understanding the Node Readiness Endpoint
 
 Before diving into the steps, it's important to understand the purpose of the Status Endpoint and how it determines whether a Kong instance is ready or not.
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -3,7 +3,7 @@ title: Health Check
 content_type: tutorial
 ---
 
-This tutorial will guide you through the process of using the new Kong Status endpoint, which provides a more reliable and simple way to determine if Kong is ready to serve requests.
+This tutorial will guide you through the process of using the new Node Readiness Endpoint, which provides a more reliable and simple way to determine if Kong is ready to serve user requests.
 
 To put it simply, health check endpoint will return a `200 OK` response when Kong is ready, or a `503 Service Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -16,20 +16,19 @@ Before diving into the steps, it's important to understand the purpose of the St
 
 ### Traditional mode
 
-In Traditional mode, the endpoint returns 200 OK when the Kong database connection is successful. Otherwise, it returns 503.
+In Traditional mode, the conditions that must be fulfilled simultaneously for the traditional mode are: 
+
+1. Successful connection to the database
+2. Successful initial build of all routers for all workers
+3. Successful initial build of all plugin iterators for all workers
 
 ### DB-less mode (data_plane role)
 
 In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
 
-* Kong database connection is successful
-* The current configuration hash is not nil and not all zeros
-* The counter `declarative_config:router_rebuilds` in shared memory is greater than the Nginx’s worker count
-* The counter `declarative_config:plugins_iterator_rebuilds` in shared memory is greater than the Nginx’s worker count
-
-To be short, the endpoint returns 200 OK when the router and plugins iterator are rebuilt for workers. Otherwise, it returns 503.
-
-This is the implementation details of the endpoint in DB-less mode. But if you're just using the endpoint to check the readiness of your Kong instance, you don't need to worry about the details.
+1. The current configuration hash is not nil and not all zeros
+2. Successful initial build or a rebuild of all routers for all workers
+3. Successful initial build or a rebuild of all plugin iterators for all workers
 
 ## Configuring the Status Endpoint
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -35,27 +35,15 @@ In DB-less mode, the endpoint returns 200 OK when all of the following condition
 2. Successful initial build of all routers for all workers
 3. Successful initial build of all plugin iterators for all workers
 
-## Configuring the Status Endpoint
+## Enabling the Status Endpoint
 
-To configure the Status Endpoint in your Kong instance, follow these steps:
+In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server via the [status_listen](https://docs.konghq.com/gateway/latest/reference/configuration/#status_listen) configuration parameter.
 
-1. Ensure that Kong is setup.
-2. Open the Kong configuration file (e.g., `kong.conf` or `kong.yml`).
-3. Make sure the Status API server is enabled by including the following line:
+Example `kong.conf`:
 
     ```conf
     status_listen = 0.0.0.0:8100
     ```
-
-    This will make the Status API server listen on port `8100` on all interfaces of the system. You can change the port number to any available port on your system.
-
-4. Save the configuration file and restart Kong to apply the changes.
-
-    ```shell
-    kong reload
-    ```
-    
-You can also use `KONG_STATUS_LISTEN` environment variable to configure it.
 
 ## Using the Node Readiness Endpoint
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -68,7 +68,9 @@ Content-Length: 19
 X-Kong-Admin-Latency: 3
 Server: kong/3.3.0
 
-{"message":"ready"}
+{
+  "message": "ready"
+}
 ```
 
 If the response code is `503`, your Kong instance is unhealthy and/or not yet ready to serve requests:
@@ -83,7 +85,9 @@ Content-Length: 43
 X-Kong-Admin-Latency: 3
 Server: kong/3.3.0
 
-{"message":"failed to connect to database"}
+{
+  "message": "failed to connect to database"
+}
 ```
 
 ```http
@@ -96,7 +100,9 @@ Content-Length: 70
 X-Kong-Admin-Latency: 16
 Server: kong/3.3.0
 
-{"message":"no configuration available (empty configuration present)"}
+{
+  "message": "no configuration available (empty configuration present)"
+}
 ```
 
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -71,7 +71,7 @@ Once you've configured the Status Endpoint, you can send requests to it to check
 
 ## Updating Readiness Probes
 
-If you're using Kubernetes or Helm, you may need to update the readiness probe configuration to use the new Status Endpoint. Modify the `readinessProbe` section in your configuration file to look like this:
+If you're using Kubernetes or Helm, you may need to update the readiness probe configuration to use the new Node Readiness Endpoint. Modify the `readinessProbe` section in your configuration file to look like this:
 
 ```yaml
 readinessProbe:

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -3,7 +3,9 @@ title: Health Check
 content_type: tutorial
 ---
 
-This tutorial will guide you through the process of setting up and using the new Kong Status endpoint, which provides a more reliable and simple way to determine if Kong is ready to serve requests. The endpoint will return a 200 OK response when Kong is ready, or a 503 Service Unavailable response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
+This tutorial will guide you through the process of using the new Kong Status endpoint, which provides a more reliable and simple way to determine if Kong is ready to serve requests.
+
+To put it simply, health check endpoint will return a 200 OK response when Kong is ready, or a 503 Service Unavailable response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
 ## Prerequisites
 
@@ -27,14 +29,14 @@ In Traditional mode, the conditions that must be fulfilled simultaneously for th
 In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
 
 1. The current configuration hash is not nil and not all zeros
-2. Successful initial build or rebuild of all routers for all workers
-3. Successful initial build or rebuild of all plugin iterators for all workers
+2. Successful initial build/rebuild of all routers for all workers
+3. Successful initial build/rebuild of all plugin iterators for all workers
 
 ## Configuring the Status Endpoint
 
 To configure the Status Endpoint in your Kong instance, follow these steps:
 
-1. Ensure that Kong is installed and running on your system.
+1. Ensure that Kong is setup.
 2. Open the Kong configuration file (e.g., `kong.conf` or `kong.yml`).
 3. Make sure the Status API is enabled by including the following line:
 
@@ -49,6 +51,8 @@ To configure the Status Endpoint in your Kong instance, follow these steps:
     ```shell
     kong reload
     ```
+    
+You can also use `KONG_STATUS_LISTEN` environment variable to configure it.
 
 ## Using the Status Endpoint
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -7,6 +7,9 @@ This tutorial will guide you through the process of using the new Kong Status en
 
 To put it simply, health check endpoint will return a `200 OK` response when Kong is ready, or a `503 Service Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
+Note that the readiness endpoint does not return detailed node health information such as the
+amount of memory Kong node is using. You might want to check out the [`/status` API](/gateway/{{page.kong_version}}/admin-api/#retrieve-node-status) as well.
+
 ## Prerequisites
 
 * Kong installed

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -5,7 +5,7 @@ content_type: tutorial
 
 This tutorial will guide you through the process of using the Node Readiness Endpoint, which provides a reliable and simple way to determine if Kong is ready to serve user requests.
 
-The health check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
+The health check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
 Note that the readiness endpoint does not return detailed node health information such as the
 amount of memory Kong node is using. You might want to check out the [`/status` API](/gateway/{{page.kong_version}}/admin-api/#retrieve-node-status) as well.
@@ -21,7 +21,7 @@ Before diving into the steps, it's important to understand the purpose of the No
 
 ### Traditional mode
 
-In Traditional mode, the endpoint returns 200 OK when all of the following conditions are met:
+In Traditional mode, the endpoint returns `200 OK` when all of the following conditions are met:
 
 1. Successful connection to the database
 2. Successful initial build of all routers for all workers
@@ -29,7 +29,7 @@ In Traditional mode, the endpoint returns 200 OK when all of the following condi
 
 ### DB-less mode (`data_plane` role)
 
-In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
+In DB-less mode, the endpoint returns `200 OK` when all of the following conditions are met:
 
 1. Kong has loaded a valid and non-empty config
 2. Successful initial build of all routers for all workers
@@ -56,7 +56,7 @@ Once you've enabled the Node Readiness Endpoint, you can send a GET request to i
 curl -i <status-api-host>/status/ready
 ```
 
-If the response is `200 OK`, your Kong instance is ready to serve requests:
+If the response code is `200`, your Kong instance is ready to serve requests:
 
 ```http
 HTTP/1.1 200 OK
@@ -71,7 +71,7 @@ Server: kong/3.3.0
 {"message":"ready"}
 ```
 
-If the response is `503 Service Unavailable`, your Kong instance is unhealthy and/or not yet ready to serve requests:
+If the response code is `503`, your Kong instance is unhealthy and/or not yet ready to serve requests:
 
 ```http
 HTTP/1.1 503 Service Temporarily Unavailable

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -64,7 +64,7 @@ Once you've configured the Status Endpoint, you can send requests to it to check
 1. Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
 
     ```shell
-    curl -I <status-api-url>/status/ready
+    curl -I <status-api-host>/status/ready
     ```
 
 2. If the response is `200 OK`, your Kong instance is ready to serve requests. If the response is `503 Service Unavailable`, Kong does not yet have a valid configuration.

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -47,7 +47,7 @@ Example `kong.conf`:
 
 ## Using the Node Readiness Endpoint
 
-Once you've configured the Node Readiness Endpoint, you can send requests to it to check the readiness of your Kong instance.
+Once you've enabled the Node Readiness Endpoint, you can send requests to it to check the readiness of your Kong instance.
 
 1. Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -3,9 +3,9 @@ title: Health Check
 content_type: tutorial
 ---
 
-This tutorial will guide you through the process of using the new Node Readiness Endpoint, which provides a more reliable and simple way to determine if Kong is ready to serve user requests.
+This tutorial will guide you through the process of using the Node Readiness Endpoint, which provides a reliable and simple way to determine if Kong is ready to serve user requests.
 
-To put it simply, health check endpoint will return a `200 OK` response when Kong is ready, or a `503 Service Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
+The health check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
 Note that the readiness endpoint does not return detailed node health information such as the
 amount of memory Kong node is using. You might want to check out the [`/status` API](/gateway/{{page.kong_version}}/admin-api/#retrieve-node-status) as well.
@@ -21,7 +21,7 @@ Before diving into the steps, it's important to understand the purpose of the No
 
 ### Traditional mode
 
-In Traditional mode, the conditions that must be fulfilled simultaneously for the traditional mode are: 
+In Traditional mode, the endpoint returns 200 OK when all of the following conditions are met:
 
 1. Successful connection to the database
 2. Successful initial build of all routers for all workers

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -49,13 +49,56 @@ Example `kong.conf`:
 
 Once you've enabled the Node Readiness Endpoint, you can send requests to it to check the readiness of your Kong instance.
 
-1. Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
+Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
 
     ```shell
-    curl -I <status-api-host>/status/ready
+    curl -i <status-api-host>/status/ready
     ```
 
-2. If the response is `200 OK`, your Kong instance is ready to serve requests. If the response is `503 Service Unavailable`, Kong does not yet have a valid configuration.
+If the response is `200 OK`, your Kong instance is ready to serve requests:
+
+    ```
+    HTTP/1.1 200 OK
+    Date: Thu, 04 May 2023 22:00:52 GMT
+    Content-Type: application/json; charset=utf-8
+    Connection: keep-alive
+    Access-Control-Allow-Origin: *
+    Content-Length: 19
+    X-Kong-Admin-Latency: 3
+    Server: kong/3.3.0
+
+    {"message":"ready"}
+    ```
+
+
+If the response is `503 Service Unavailable`, your Kong instance is unhealthy and/or not yet ready to serve requests:
+
+    ```
+    HTTP/1.1 503 Service Temporarily Unavailable
+    Date: Thu, 04 May 2023 22:01:11 GMT
+    Content-Type: application/json; charset=utf-8
+    Connection: keep-alive
+    Access-Control-Allow-Origin: *
+    Content-Length: 43
+    X-Kong-Admin-Latency: 3
+    Server: kong/3.3.0
+
+    {"message":"failed to connect to database"}
+    ```
+
+    ```
+    HTTP/1.1 503 Service Temporarily Unavailable
+    Date: Thu, 04 May 2023 22:06:58 GMT
+    Content-Type: application/json; charset=utf-8
+    Connection: keep-alive
+    Access-Control-Allow-Origin: *
+    Content-Length: 70
+    X-Kong-Admin-Latency: 16
+    Server: kong/3.3.0
+
+    {"message":"no configuration available (empty configuration present)"}
+    ```
+
 
 ## Updating Readiness Probes
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -27,7 +27,7 @@ In Traditional mode, the conditions that must be fulfilled simultaneously for th
 2. Successful initial build of all routers for all workers
 3. Successful initial build of all plugin iterators for all workers
 
-### DB-less mode (data_plane role)
+### DB-less mode (`data_plane` role)
 
 In DB-less mode, the endpoint returns 200 OK when all of the following conditions are met:
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -41,63 +41,63 @@ In order to use the Node Readiness Endpoint, make sure that you have enabled the
 
 Example `kong.conf`:
 
-    ```conf
-    status_listen = 0.0.0.0:8100
-    ```
+```conf
+status_listen = 0.0.0.0:8100
+```
 
 ## Using the Node Readiness Endpoint
 
-Once you've enabled the Node Readiness Endpoint, you can send requests to it to check the readiness of your Kong instance.
+Once you've enabled the Node Readiness Endpoint, you can send a GET request to it to check the readiness of your Kong instance:
 
-Send a GET request to the `/status/ready` endpoint. Replace `<status-api-host>` with the appropriate host for your Status API server, including the port number:
+```sh
+# Replace `<status-api-host>` with the appropriate host for
+# your Status API server, including the port number
 
-    ```shell
-    curl -i <status-api-host>/status/ready
-    ```
+curl -i <status-api-host>/status/ready
+```
 
 If the response is `200 OK`, your Kong instance is ready to serve requests:
 
-    ```
-    HTTP/1.1 200 OK
-    Date: Thu, 04 May 2023 22:00:52 GMT
-    Content-Type: application/json; charset=utf-8
-    Connection: keep-alive
-    Access-Control-Allow-Origin: *
-    Content-Length: 19
-    X-Kong-Admin-Latency: 3
-    Server: kong/3.3.0
+```http
+HTTP/1.1 200 OK
+Date: Thu, 04 May 2023 22:00:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Content-Length: 19
+X-Kong-Admin-Latency: 3
+Server: kong/3.3.0
 
-    {"message":"ready"}
-    ```
-
+{"message":"ready"}
+```
 
 If the response is `503 Service Unavailable`, your Kong instance is unhealthy and/or not yet ready to serve requests:
 
-    ```
-    HTTP/1.1 503 Service Temporarily Unavailable
-    Date: Thu, 04 May 2023 22:01:11 GMT
-    Content-Type: application/json; charset=utf-8
-    Connection: keep-alive
-    Access-Control-Allow-Origin: *
-    Content-Length: 43
-    X-Kong-Admin-Latency: 3
-    Server: kong/3.3.0
+```http
+HTTP/1.1 503 Service Temporarily Unavailable
+Date: Thu, 04 May 2023 22:01:11 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Content-Length: 43
+X-Kong-Admin-Latency: 3
+Server: kong/3.3.0
 
-    {"message":"failed to connect to database"}
-    ```
+{"message":"failed to connect to database"}
+```
 
-    ```
-    HTTP/1.1 503 Service Temporarily Unavailable
-    Date: Thu, 04 May 2023 22:06:58 GMT
-    Content-Type: application/json; charset=utf-8
-    Connection: keep-alive
-    Access-Control-Allow-Origin: *
-    Content-Length: 70
-    X-Kong-Admin-Latency: 16
-    Server: kong/3.3.0
+```http
+HTTP/1.1 503 Service Temporarily Unavailable
+Date: Thu, 04 May 2023 22:06:58 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Content-Length: 70
+X-Kong-Admin-Latency: 16
+Server: kong/3.3.0
 
-    {"message":"no configuration available (empty configuration present)"}
-    ```
+{"message":"no configuration available (empty configuration present)"}
+```
 
 
 ## Updating Readiness Probes

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -17,7 +17,7 @@ amount of memory Kong node is using. You might want to check out the [`/status` 
 
 ## Understanding the Node Readiness Endpoint
 
-Before diving into the steps, it's important to understand the purpose of the Status Endpoint and how it determines whether a Kong instance is ready or not.
+Before diving into the steps, it's important to understand the purpose of the Node Readiness Endpoint and how it determines whether a Kong instance is ready or not.
 
 ### Traditional mode
 

--- a/app/_src/gateway/production/monitoring/health-check.md
+++ b/app/_src/gateway/production/monitoring/health-check.md
@@ -37,7 +37,7 @@ In DB-less mode, the endpoint returns `200 OK` when all of the following conditi
 
 ## Enabling the Status Endpoint
 
-In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server via the [status_listen](https://docs.konghq.com/gateway/latest/reference/configuration/#status_listen) configuration parameter.
+In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server via the [status_listen](/gateway/{{page.kong_version}}/reference/configuration/#status_listen) configuration parameter.
 
 Example `kong.conf`:
 

--- a/app/_src/gateway/production/monitoring/index.md
+++ b/app/_src/gateway/production/monitoring/index.md
@@ -21,7 +21,7 @@ multiple solutions:
    UDP or TCP and sends aggregated values to one or more backend services. {{site.base_gateway}} directly supports StatsD
    with the [StatsD plugin](/hub/kong-inc/statsd/). [Monitoring with StatsD](/gateway/latest/production/monitoring/statsd/) provides a 
    step-by-step guide to enabling StatsD.
-* For monitoring when {{site.base_gateway}} is ready to accept requests, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/readiness-check/).
+* For monitoring when {{site.base_gateway}} is ready to accept requests, use the built-in [Node Readiness endpoint](/gateway/latest/production/monitoring/readiness-check/).
 
 Closely related to monitoring is tracing. See the {{site.base_gateway}} [Tracing Reference](/gateway/latest/production/tracing/)
 for details about instrumenting your API gateway.

--- a/app/_src/gateway/production/monitoring/index.md
+++ b/app/_src/gateway/production/monitoring/index.md
@@ -21,7 +21,7 @@ multiple solutions:
    UDP or TCP and sends aggregated values to one or more backend services. {{site.base_gateway}} directly supports StatsD
    with the [StatsD plugin](/hub/kong-inc/statsd/). [Monitoring with StatsD](/gateway/latest/production/monitoring/statsd/) provides a 
    step-by-step guide to enabling StatsD.
-* For monitoring when {{site.base_gateway}} is ready to work, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/health-check/).
+* For monitoring when {{site.base_gateway}} is ready to work, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/readiness-check/).
 
 Closely related to monitoring is tracing. See the {{site.base_gateway}} [Tracing Reference](/gateway/latest/production/tracing/)
 for details about instrumenting your API gateway.

--- a/app/_src/gateway/production/monitoring/index.md
+++ b/app/_src/gateway/production/monitoring/index.md
@@ -21,6 +21,7 @@ multiple solutions:
    UDP or TCP and sends aggregated values to one or more backend services. {{site.base_gateway}} directly supports StatsD
    with the [StatsD plugin](/hub/kong-inc/statsd/). [Monitoring with StatsD](/gateway/latest/production/monitoring/statsd/) provides a 
    step-by-step guide to enabling StatsD.
+* For HTTP health checks, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/health-check/).
 
 Closely related to monitoring is tracing. See the {{site.base_gateway}} [Tracing Reference](/gateway/latest/production/tracing/)
 for details about instrumenting your API gateway.

--- a/app/_src/gateway/production/monitoring/index.md
+++ b/app/_src/gateway/production/monitoring/index.md
@@ -21,7 +21,7 @@ multiple solutions:
    UDP or TCP and sends aggregated values to one or more backend services. {{site.base_gateway}} directly supports StatsD
    with the [StatsD plugin](/hub/kong-inc/statsd/). [Monitoring with StatsD](/gateway/latest/production/monitoring/statsd/) provides a 
    step-by-step guide to enabling StatsD.
-* For HTTP health checks, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/health-check/).
+* For monitoring when {{site.base_gateway}} is ready to work, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/health-check/).
 
 Closely related to monitoring is tracing. See the {{site.base_gateway}} [Tracing Reference](/gateway/latest/production/tracing/)
 for details about instrumenting your API gateway.

--- a/app/_src/gateway/production/monitoring/index.md
+++ b/app/_src/gateway/production/monitoring/index.md
@@ -21,7 +21,7 @@ multiple solutions:
    UDP or TCP and sends aggregated values to one or more backend services. {{site.base_gateway}} directly supports StatsD
    with the [StatsD plugin](/hub/kong-inc/statsd/). [Monitoring with StatsD](/gateway/latest/production/monitoring/statsd/) provides a 
    step-by-step guide to enabling StatsD.
-* For monitoring when {{site.base_gateway}} is ready to work, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/readiness-check/).
+* For monitoring when {{site.base_gateway}} is ready to accept requests, use the built-in [Node Readiness Endpoint](/gateway/{{page.kong_version}}/production/monitoring/readiness-check/).
 
 Closely related to monitoring is tracing. See the {{site.base_gateway}} [Tracing Reference](/gateway/latest/production/tracing/)
 for details about instrumenting your API gateway.

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -6,6 +6,7 @@ content_type: tutorial
 This tutorial guides you through the process of using the Node Readiness Endpoint, which provides a reliable way to determine if Kong is ready to serve user requests.
 
 The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
+The status endpoint responds back with a 'message' with the reason for unreadiness. This can be very helpful to debug situations where the user expects that the node should be ready but is not.
 
 The status endpoint responds back with a `message` with the reason for unreadiness. This can be very helpful to debug situations where the user expects that the node should be ready but is not.
 

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -3,24 +3,25 @@ title: Readiness Check
 content_type: tutorial
 ---
 
-This tutorial guides you through the process of using the Node Readiness Endpoint, which provides a reliable way to determine if Kong is ready to serve user requests.
+This tutorial guides you through the process of using the Node Readiness endpoint, which provides a reliable way to determine if {{site.base_gateway}} is ready to serve user requests.
 
-The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances. When Kong is not ready, the endpoint responds back with a `message` field with the reason for unreadiness. This can be helpful to debug situations where the user expects that the node should be ready but is not.
+The readiness check endpoint returns a `200 OK` response when {{site.base_gateway}} is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances. When Kong is not ready, the endpoint responds back with a `message` field with the reason for unreadiness. This can be helpful to debug situations where the user expects that the node should be ready but is not.
 
-Note that the readiness endpoint does not return detailed node status information.
+{:.note}
+> **Note:**  The readiness endpoint does not return detailed information about the node status.
 
 ## Prerequisites
 
-* Kong installed
-* Basic understanding of Kong configuration and deployment modes (Traditional, DB-less, and Hybrid)
+* {{site.base_gateway}}
+* A basic understanding of {{site.base_gateway}} configuration and deployment modes (traditional, DB-less, and hybrid)
 
-## Understanding the Node Readiness Endpoint
+## Understanding the Node Readiness endpoint
 
-Before diving into the steps, it's important to understand the purpose of the Node Readiness Endpoint and how it determines whether a Kong instance is ready or not.
+Before diving into the steps, it's important to understand the purpose of the Node Readiness endpoint and how it determines whether a Kong instance is ready or not.
 
 ### Traditional mode
 
-In Traditional mode, the endpoint returns `200 OK` when all of the following conditions are met:
+In traditional mode, the endpoint returns `200 OK` when all of the following conditions are met:
 
 1. Successful connection to the database
 2. All Kong workers are ready to route requests
@@ -28,7 +29,7 @@ In Traditional mode, the endpoint returns `200 OK` when all of the following con
 
 ### Hybrid mode (`data_plane` role) or DB-less mode
 
-In Hybrid mode (`data_plane` role) or DB-less mode, the endpoint returns `200 OK` when all of the following conditions are met:
+In Hybrid mode (`data_plane` role) or DB-less mode, the endpoint returns `200 OK` when the following conditions are met:
 
 1. Kong has loaded a valid and non-empty config (`kong.yaml`)
 2. All Kong workers are ready to route requests
@@ -36,13 +37,13 @@ In Hybrid mode (`data_plane` role) or DB-less mode, the endpoint returns `200 OK
 
 ### Hybrid mode (`control_plane` role)
 
-In Hybrid Mode (`control_plane` role), this endpoint returns `200 OK` when all of the following conditions are met:
+In Hybrid Mode (`control_plane` role), this endpoint returns `200 OK` when the following condition is met:
 
 1. Successful connection to the database
 
-## Enabling the Status Endpoint
+## Enabling the Status endpoint
 
-In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server (disabled by default) via the [status_listen](/gateway/{{page.kong_version}}/reference/configuration/#status_listen) configuration parameter.
+In order to use the Node Readiness endpoint, make sure that you have enabled the Status API server (disabled by default) via the [status_listen](/gateway/latest/reference/configuration/#status_listen) configuration parameter.
 
 Example `kong.conf`:
 
@@ -50,9 +51,9 @@ Example `kong.conf`:
 status_listen = 0.0.0.0:8100
 ```
 
-## Using the Node Readiness Endpoint
+## Using the Node Readiness endpoint
 
-Once you've enabled the Node Readiness Endpoint, you can send a GET request to it to check the readiness of your Kong instance:
+Once you've enabled the Node Readiness endpoint, you can send a GET request to check the readiness of your {{site.base_gateway}} instance:
 
 ```sh
 # Replace `<status-api-host>` with the appropriate host for
@@ -61,7 +62,7 @@ Once you've enabled the Node Readiness Endpoint, you can send a GET request to i
 curl -i <status-api-host>/status/ready
 ```
 
-If the response code is `200`, your Kong instance is ready to serve requests:
+If the response code is `200`, the {{site.base_gateway}} instance is ready to serve requests:
 
 ```http
 HTTP/1.1 200 OK
@@ -78,7 +79,7 @@ Server: kong/3.3.0
 }
 ```
 
-If the response code is `503`, your Kong instance is unhealthy and/or not yet ready to serve requests:
+If the response code is `503`, the {{site.base_gateway}} instance is unhealthy and/or not yet ready to serve requests:
 
 ```http
 HTTP/1.1 503 Service Temporarily Unavailable
@@ -113,7 +114,7 @@ Server: kong/3.3.0
 
 ## Updating Readiness Probes
 
-If you're using Kubernetes or Helm, you may need to update the readiness probe configuration to use the new Node Readiness Endpoint. Modify the `readinessProbe` section in your configuration file to look like this:
+If you're using Kubernetes or Helm, you may need to update the readiness probe configuration to use the new Node Readiness endpoint. Modify the `readinessProbe` section in your configuration file to look like this:
 
 ```yaml
 readinessProbe:

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -7,6 +7,8 @@ This tutorial guides you through the process of using the Node Readiness Endpoin
 
 The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
+The status endpoint responds back with a `message` with the reason for unreadiness. This can be very helpful to debug situations where the user expects that the node should be ready but is not.
+
 Note that the readiness endpoint does not return detailed node status information.
 
 ## Prerequisites
@@ -23,16 +25,16 @@ Before diving into the steps, it's important to understand the purpose of the No
 In Traditional mode, the endpoint returns `200 OK` when all of the following conditions are met:
 
 1. Successful connection to the database
-2. Successful initial build of all routers for all workers
-3. Successful initial build of all plugin iterators for all workers
+2. All Kong workers are ready to route requests
+3. All routes and services have their plugins ready to process requests
 
 ### Hybrid mode (`data_plane` role) or DB-less mode
 
 In Hybrid mode (`data_plane` role) or DB-less mode, the endpoint returns `200 OK` when all of the following conditions are met:
 
 1. Kong has loaded a valid and non-empty config (`kong.yaml`)
-2. Successful initial build of all routers for all workers
-3. Successful initial build of all plugin iterators for all workers
+2. All Kong workers are ready to route requests
+3. All routes and services have their plugins ready to process requests
 
 ### Hybrid mode (`control_plane` role)
 
@@ -42,7 +44,7 @@ In Hybrid Mode (`control_plane` role), this endpoint returns `200 OK` when all o
 
 ## Enabling the Status Endpoint
 
-In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server via the [status_listen](/gateway/{{page.kong_version}}/reference/configuration/#status_listen) configuration parameter.
+In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server (disabled by default) via the [status_listen](/gateway/{{page.kong_version}}/reference/configuration/#status_listen) configuration parameter.
 
 Example `kong.conf`:
 

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -1,13 +1,13 @@
 ---
-title: Health Check
+title: Readiness Check
 content_type: tutorial
 ---
 
 This tutorial will guide you through the process of using the Node Readiness Endpoint, which provides a reliable and simple way to determine if Kong is ready to serve user requests.
 
-The health check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
+The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
-Note that the readiness endpoint does not return detailed node health information such as the
+Note that the readiness endpoint does not return detailed node readiness information such as the
 amount of memory Kong node is using. You might want to check out the [`/status` API](/gateway/{{page.kong_version}}/admin-api/#retrieve-node-status) as well.
 
 ## Prerequisites
@@ -27,11 +27,11 @@ In Traditional mode, the endpoint returns `200 OK` when all of the following con
 2. Successful initial build of all routers for all workers
 3. Successful initial build of all plugin iterators for all workers
 
-### DB-less mode (`data_plane` role)
+### Hybrid mode (`data_plane` role) or DB-less mode
 
-In DB-less mode, the endpoint returns `200 OK` when all of the following conditions are met:
+In Hybrid mode (`data_plane` role) or DB-less mode, the endpoint returns `200 OK` when all of the following conditions are met:
 
-1. Kong has loaded a valid and non-empty config
+1. Kong has loaded a valid and non-empty config (`kong.yaml`)
 2. Successful initial build of all routers for all workers
 3. Successful initial build of all plugin iterators for all workers
 

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -6,7 +6,6 @@ content_type: tutorial
 This tutorial guides you through the process of using the Node Readiness Endpoint, which provides a reliable way to determine if Kong is ready to serve user requests.
 
 The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
-The status endpoint responds back with a 'message' with the reason for unreadiness. This can be very helpful to debug situations where the user expects that the node should be ready but is not.
 
 The status endpoint responds back with a `message` with the reason for unreadiness. This can be very helpful to debug situations where the user expects that the node should be ready but is not.
 

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -5,9 +5,7 @@ content_type: tutorial
 
 This tutorial guides you through the process of using the Node Readiness Endpoint, which provides a reliable way to determine if Kong is ready to serve user requests.
 
-The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
-
-The status endpoint responds back with a `message` with the reason for unreadiness. This can be very helpful to debug situations where the user expects that the node should be ready but is not.
+The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances. When Kong is not ready, the endpoint responds back with a `message` field with the reason for unreadiness. This can be helpful to debug situations where the user expects that the node should be ready but is not.
 
 Note that the readiness endpoint does not return detailed node status information.
 

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -35,6 +35,12 @@ In Hybrid mode (`data_plane` role) or DB-less mode, the endpoint returns `200 OK
 2. Successful initial build of all routers for all workers
 3. Successful initial build of all plugin iterators for all workers
 
+### Hybrid mode (`control_plane` role)
+
+In Hybrid Mode (`control_plane` role), this endpoint returns `200 OK` when all of the following conditions are met:
+
+1. Successful connection to the database
+
 ## Enabling the Status Endpoint
 
 In order to use the Node Readiness Endpoint, make sure that you have enabled the Status API Server via the [status_listen](/gateway/{{page.kong_version}}/reference/configuration/#status_listen) configuration parameter.

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -3,12 +3,11 @@ title: Readiness Check
 content_type: tutorial
 ---
 
-This tutorial will guide you through the process of using the Node Readiness Endpoint, which provides a reliable and simple way to determine if Kong is ready to serve user requests.
+This tutorial guides you through the process of using the Node Readiness Endpoint, which provides a reliable way to determine if Kong is ready to serve user requests.
 
 The readiness check endpoint returns a `200 OK` response when Kong is ready, or a `503 Service Temporarily Unavailable` response when it's not. This is useful for load balancers and other tools that need to monitor the readiness of Kong instances.
 
-Note that the readiness endpoint does not return detailed node readiness information such as the
-amount of memory Kong node is using. You might want to check out the [`/status` API](/gateway/{{page.kong_version}}/admin-api/#retrieve-node-status) as well.
+Note that the readiness endpoint does not return detailed node status information.
 
 ## Prerequisites
 


### PR DESCRIPTION
New page + tutorial tempalte for KAG-76. Can decide if this is the right location when reviewing the draft content.

### Description

DOCU-2921

### Testing instructions

Netlify link: https://deploy-preview-5419--kongdocs.netlify.app/gateway/latest/production/monitoring/health-check/


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

