### PR TITLE
removed plus badge from various analytics pages

### DIFF
--- a/app/konnect/analytics/index.md
+++ b/app/konnect/analytics/index.md
@@ -31,7 +31,6 @@ You can also [export this historical data in CSV format](/konnect/analytics/serv
 
 
 ## Summary dashboard and custom reports
-{:.badge .plus}
 
 For greater insights into your service usage, access the dedicated {% konnect_icon analytics %} [Analytics](https://cloud.konghq.com/analytics) page.
 

--- a/app/konnect/analytics/reference.md
+++ b/app/konnect/analytics/reference.md
@@ -1,7 +1,6 @@
 ---
 title: Reports Reference
 content_type: reference
-badge: plus
 ---
 
 ## Metrics

--- a/app/konnect/analytics/use-cases.md
+++ b/app/konnect/analytics/use-cases.md
@@ -1,7 +1,6 @@
 ---
 title: Report Use Cases
 content_type: tutorial
-badge: plus
 ---
 
 Custom reporting in {{site.konnect_saas}} gives you the power to monitor your API data in detail and export that data to CSV. 


### PR DESCRIPTION
### Description

Analytics capabilities are available for all tiers and are only restricted by retention today (like described in the overview page). Therefore, I removed all occurrences of the "PLUS" badge across the Analytics pages.


