### PR TITLE
Add support for `description` in frontmatter

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -5,6 +5,11 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if include.p
 {{ include.type }} | {{site.title}}{% endcapture %}
 {% endunless %}
 
+{% assign page_description = site.description %}
+{% if include.description %}
+{% assign page_description = include.description %}
+{% endif %}
+
 <head>
 
   {% if jekyll.environment == "production" %}
@@ -37,13 +42,13 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{% if include.p
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>{{ page_title }}</title>
-  <meta name="description" content="{{ site.description }}" />
+  <meta name="description" content="{{ page_description }}" />
   <meta name="author" content="KongHQ" />
   <meta property="og:title" content="{{ page_title }}" />
   <meta property="og:site_name" content="{{ site.name }}" />
   <!-- use share link for facebook -->
   <meta property="og:url" content="{{ site.links.share }}" />
-  <meta property="og:description" content="{{ site.description }}" />
+  <meta property="og:description" content="{{ page_description }}" />
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="en_US" />
   <meta

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
 <html lang="en" itemscope itemtype="http://schema.org/Article">
 
-  {% include_cached head.html seo_noindex=page.seo_noindex canonical_url=page.canonical_url path=page.path name=page.name title=page.title url=page.url kong_version=page.kong_version no_version=page.no_version type=page.type kong_latest=page.kong_latest %}
+  {% include_cached head.html
+     seo_noindex=page.seo_noindex
+     canonical_url=page.canonical_url
+     path=page.path
+     name=page.name
+     title=page.title
+     description=page.description
+     url=page.url
+     kong_version=page.kong_version
+     no_version=page.no_version
+     type=page.type
+     kong_latest=page.kong_latest %}
 
   <body
     id="{{ page.id }}"

--- a/app/_src/gateway/index.md
+++ b/app/_src/gateway/index.md
@@ -2,6 +2,7 @@
 title: Kong Gateway
 breadcrumb: Overview
 subtitle: API gateway built for hybrid and multi-cloud, optimized for microservices and distributed architectures
+description: Kong Gateway is a lightweight, fast, and flexible cloud-native API gateway. Kong is a reverse proxy that lets you manage, configure, and route requests
 ---
 
 ## Quick Links

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -23,6 +23,9 @@ Add the tag that most closely resembles the concept, even if it doesn’t perfec
 : 
 : See our [contribution templates](/contributing/contribution-templates/) for more information about each content type.
 
+`description: DESCRIPTION`
+: A short description of what the page covers. This is used by Google and appears below the page title. Target length 50-160 characters.
+
 **Optional:**
 
 `no_version: true`

--- a/tests/descriptions.test.js
+++ b/tests/descriptions.test.js
@@ -1,0 +1,15 @@
+describe("Custom page descriptions", () => {
+  [
+    {
+      title: "Gateway Index",
+      src: "/gateway/latest/",
+      expected:
+        "Kong Gateway is a lightweight, fast, and flexible cloud-native API gateway. Kong is a reverse proxy that lets you manage, configure, and route requests",
+    },
+  ].forEach((t) => {
+    test(t.title, async () => {
+      const $ = await fetchPage(t.src);
+      expect($("meta[name='description']").attr("content")).toBe(t.expected);
+    });
+  });
+});


### PR DESCRIPTION
### Description

This allows us to customise the meta description for each page. It's marked as required in the style guide, but only for new pages going forwards. Existing pages will be updated on a best-effort basis

### Testing instructions

I've updated /gateway/latest/

Here's a local test I did on the Ubuntu install page too:

<img width="1367" alt="Screenshot 2023-04-18 at 16 08 23" src="https://user-images.githubusercontent.com/59130/232803328-750934a4-d1a8-4137-824f-15a1e945214d.png">

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
