### PR TITLE
Update kic.md

### DIFF
--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -8,7 +8,7 @@ You can use native Kubernetes resources to configure your clusters in {{site.kon
 This setup is ideal for organizations who want to manage gateways in {{site.konnect_short_name}} through native Kubernetes resources without having to use a hybrid deployment model. 
 
 {:.note}
-> **Note**: KIC in Konnect is available to existing Enterprise-tier customers, and Kong is extending support to new signups for Free and Plus tier.
+> **Note**: KIC in {{site.konnect_short_name}} is available to existing Enterprise-tier customers, and Kong is extending support to new signups for Free and Plus tiers.
 
 ## About KIC in {{site.konnect_short_name}}
 

--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -7,6 +7,9 @@ beta: true
 You can use native Kubernetes resources to configure your clusters in {{site.konnect_short_name}} by associating your Kong Ingress Controller (KIC) for Kubernetes deployment with {{site.konnect_short_name}}. 
 This setup is ideal for organizations who want to manage gateways in {{site.konnect_short_name}} through native Kubernetes resources without having to use a hybrid deployment model. 
 
+{:.note}
+> **Note**: KIC in Konnect is available to existing Enterprise-tier customers, and Kong is extending support to new signups for Free and Plus tier.
+
 ## About KIC in {{site.konnect_short_name}}
 
 Kong Ingress Controller (KIC) for Kubernetes configures {{site.base_gateway}} using Ingress or [Gateway API](https://gateway-api.sigs.k8s.io/) resources created inside a Kubernetes cluster. 

--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -1,7 +1,6 @@
 ---
 title: Kong Ingress Controller for Kubernetes Association
 content_type: explanation
-badge: enterprise
 beta: true
 ---
 


### PR DESCRIPTION
remove Enterprise badge based on some changes to remove that limitation from M1 signups


### Description

Modifications coming today to remove the Enterprise-only limitations, based on updates from @smritikjaggi 


### Testing instructions

Netlify link: https://deploy-preview-5455--kongdocs.netlify.app/konnect/runtime-manager/kic/ > Enterprise badge removed from title and note added under first section for differing tier support based on new vs existing customers. 


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

