### PR TITLE
Added 'seconds' as the unit for worker_state_update_frequency

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -2030,7 +2030,7 @@ after Routes and Services updates.
 
 ### worker_state_update_frequency
 
-Defines how often the worker state changes are checked with a background job.
+Defines, in seconds, how often the worker state changes are checked with a background job.
 When a change is detected, a new router or balancer will be built, as needed.
 Raising this value will decrease the load on database servers and result in less
 jitter in proxy latency, but it might take more time to propagate changes to


### PR DESCRIPTION
### Description

Added 'seconds' as the unit for worker_state_update_frequency. This was needed as a customer had asked questions about the unit/metric for this value and it was agreed that it was unclear from the documentation what the unit used is.

### Testing instructions

N/A

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)