### PR TITLE
Update KIC examples to use kong/go-echo for ARM support

### DIFF
--- a/app/_includes/md/kic/http-test-routing-resource.md
+++ b/app/_includes/md/kic/http-test-routing-resource.md
@@ -24,7 +24,7 @@ spec:
           service:
             name: {{ service }}
             port:
-              number: 80
+              number: 1027
 " | kubectl apply -f -
 ```
 Response:
@@ -54,7 +54,7 @@ spec:
     backendRefs:
     - name: {{ service }}
       kind: Service
-      port: 80
+      port: 1027
 " | kubectl apply -f -
 ```
 Response:

--- a/app/_includes/md/kic/http-test-routing.md
+++ b/app/_includes/md/kic/http-test-routing.md
@@ -17,24 +17,18 @@ curl -i http://{{ hostname }}{{ path }} --resolve {{ hostname }}:80:$PROXY_IP
 Response:
 ```text
 HTTP/1.1 200 OK
-Content-Type: text/plain; charset=UTF-8
-Transfer-Encoding: chunked
+Content-Type: text/plain; charset=utf-8
+Content-Length: 140
 Connection: keep-alive
-Date: Thu, 10 Nov 2022 22:10:40 GMT
-Server: echoserver
+Date: Fri, 21 Apr 2023 12:24:55 GMT
 X-Kong-Upstream-Latency: 0
-X-Kong-Proxy-Latency: 0
-Via: kong/3.0.0
+X-Kong-Proxy-Latency: 1
+Via: kong/3.2.2
 
-
-
-Hostname: echo-fc6fd95b5-6lqnc
-
-Pod Information:
-	node name:	kind-control-plane
-	pod name:	echo-fc6fd95b5-6lqnc
-	pod namespace:	default
-	pod IP:	10.244.0.9
+Welcome, you are connected to node docker-desktop.
+Running on Pod echo-7f87468b8c-tzzv6.
+In namespace default.
+With IP address 10.1.0.237.
 ...
 ```
 

--- a/app/_includes/md/kic/http-test-service.md
+++ b/app/_includes/md/kic/http-test-service.md
@@ -5,7 +5,72 @@ echo server provides a simple application that returns information about the
 Pod it's running in:
 
 ```bash
-kubectl apply -f https://bit.ly/echo-service
+echo "
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  ports:
+  - port: 1025
+    name: tcp
+    protocol: TCP
+    targetPort: 1025
+  - port: 1026
+    name: udp
+    protocol: TCP
+    targetPort: 1026
+  - port: 1027
+    name: http
+    protocol: TCP
+    targetPort: 1027
+  selector:
+    app: echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: echo
+    spec:
+      containers:
+      - image: kong/go-echo:latest
+        name: echo
+        ports:
+        - containerPort: 1027
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        resources: {}
+" | kubectl apply -f -
 ```
 Response:
 ```text


### PR DESCRIPTION
### Description

Switch kubectl apply -f https://bit.ly/echo-service for a Kong maintained `go-echo` service which has ARM (M1) support


### Testing instructions

Netlify link: /kubernetes-ingress-controller/2.9.x/guides/getting-started/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
