### PR TITLE
Response transformer plugins: fix broken formatting

### DIFF
--- a/app/_hub/kong-inc/response-transformer-advanced/_index.md
+++ b/app/_hub/kong-inc/response-transformer-advanced/_index.md
@@ -26,12 +26,12 @@ description: |
   `remove.if_status`, `replace.body`, `replace.if_status`, `transform.functions`, `transform.if_status`,
   `allow.json`, `rename.if_status`, `transform.json`, and `dots_in_keys`.
 
-  <div class="alert alert-warning">
-    <strong>Note on transforming bodies:</strong> Be aware of the performance of transformations on the
-    response body. In order to parse and modify a JSON body, the plugin needs to retain it in memory,
-    which might cause pressure on the worker's Lua VM when dealing with large bodies (several MBs).
-    Because of Nginx's internals, the <code>Content-Length</code> header will not be set when transforming a response body.
-  </div>
+  {:.important}
+  > **Note on transforming bodies:** Be aware of the performance of transformations on the
+  response body. In order to parse and modify a JSON body, the plugin needs to retain it in memory,
+  which might cause pressure on the worker's Lua VM when dealing with large bodies (several MBs).
+  Because of Nginx's internals, the `Content-Length` header will not be set when transforming a response body.
+
 type: plugin
 categories:
   - transformations

--- a/app/_hub/kong-inc/response-transformer/_index.md
+++ b/app/_hub/kong-inc/response-transformer/_index.md
@@ -5,13 +5,6 @@ desc: Modify the upstream response before returning it to the client
 description: |
   Transform the response sent by the upstream server on the fly before returning the response to the client.
 
-  <div class="alert alert-warning">
-    <strong>Note on transforming bodies:</strong> Be aware of the performance of transformations
-    on the response body. In order to parse and modify a JSON body, the plugin needs to retain it in memory,
-    which might cause pressure on the worker's Lua VM when dealing with large bodies (several MBs).
-    Because of Nginx's internals, the `Content-Length` header will not be set when transforming a response body.
-  </div>
-
   For additional response transformation features, check out the
   [Response Transformer Advanced plugin](/hub/kong-inc/response-transformer-advanced/). Response Transformer
   Advanced adds the following abilities:
@@ -31,6 +24,12 @@ description: |
   Response Transformer Advanced includes the following additional configurations: `add.if_status`, `append.if_status`,
   `remove.if_status`, `replace.body`, `replace.if_status`, `transform.functions`, `transform.if_status`,
   `allow.json`, `rename.if_status`, `transform.json`, and `dots_in_keys`.
+
+  {:.important}
+  > **Note on transforming bodies:** Be aware of the performance of transformations
+    on the response body. In order to parse and modify a JSON body, the plugin needs to retain it in memory,
+    which might cause pressure on the worker's Lua VM when dealing with large bodies (several MBs).
+    Because of Nginx's internals, the `Content-Length` header will not be set when transforming a response body.
 type: plugin
 categories:
   - transformations


### PR DESCRIPTION
### Description

Fixing broken HTML tags in response transformer plugin docs.
 
Issue reported on slack.

![Screenshot 2023-04-24 at 10 15 54 AM](https://user-images.githubusercontent.com/54370747/234069379-e656349f-44e7-4cf3-a594-682c51723411.png)


### Testing instructions

Netlify link: 
https://deploy-preview-5480--kongdocs.netlify.app/hub/kong-inc/response-transformer/
https://deploy-preview-5480--kongdocs.netlify.app/hub/kong-inc/response-transformer-advanced/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

