### PR TITLE
docs(aws-lambda): add new disable_https field

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -533,7 +533,7 @@ Have fun leveraging the power of AWS Lambda in Kong!
 ## Changelog
 
 **{{site.base_gateway}} 3.3.x**
-* Added a `disable_https` configuration field to support http connection to lambda service.
+* Added the `disable_https` configuration field to support HTTP connections to a lambda service.
   [#9799](https://github.com/Kong/kong/pull/9799)
 
 **{{site.base_gateway}} 3.1.x**

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -199,6 +199,12 @@ params:
       datatype: integer
       description: |
         The TCP port that the plugin uses to connect to the server.
+    - name: disable_https
+      minimum_version: "3.3.x"
+      required: false
+      default: false
+      datatype: boolean
+      description: Whether to disable HTTPS to connect with the AWS Lambda Function service endpoint. This is useful for local test scenarios by using the [AWS SAM CLI tool](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
     - name: keepalive
       required: true
       default: '`60000`'

--- a/app/_hub/kong-inc/aws-lambda/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/_index.md
@@ -532,6 +532,10 @@ Have fun leveraging the power of AWS Lambda in Kong!
 
 ## Changelog
 
+**{{site.base_gateway}} 3.3.x**
+* Added a `disable_https` configuration field to support http connection to lambda service.
+  [#9799](https://github.com/Kong/kong/pull/9799)
+
 **{{site.base_gateway}} 3.1.x**
 * Added a `requestContext` field into `awsgateway_compatible` input data.
   [#9380](https://github.com/Kong/kong/pull/9380)


### PR DESCRIPTION
### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

This PR adds the docs of the new field of the aws-lambda plugin, `disable_https`.

Just FYI we used to have a PR in 3.2 but reverted before 3.2 release because this feature has been renamed: https://github.com/Kong/docs.konghq.com/pull/4877


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

