### PR TITLE
feat(mesh/installer.sh): pass arguments to kuma installer.sh

### DIFF
--- a/app/mesh/installer.sh
+++ b/app/mesh/installer.sh
@@ -22,4 +22,4 @@ curl -L https://kuma.io/installer.sh | \
   PRODUCT_NAME="Kong Mesh" \
   REPO="kong/kong-mesh" \
   LATEST_VERSION="https://docs.konghq.com/mesh/latest_version/" \
-  sh -
+  sh -s - "$@"


### PR DESCRIPTION
### Description

Kuma's `installer.sh` can accept args, so should KM's

### Testing instructions

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

