### PR TITLE
[DOCU-3192] Use generic region in Konnect API examples

### DIFF
--- a/app/konnect/api/identity-management/identity-integration.md
+++ b/app/konnect/api/identity-management/identity-integration.md
@@ -131,7 +131,7 @@ If [single sign on](/konnect/org-management/okta-idp/) is enabled, an organizati
 Update the team mappings by issuing a `PUT` request containing `team_ids` in the request body: 
 
     curl --request PUT \
-    --url https://us.api.konghq.com/v2/identity-provider/team-mappings \
+    --url https://global.api.konghq.com/v2/identity-provider/team-mappings \
     --header 'Content-Type: application/json' \
     --data '{
     "mappings": [

--- a/app/konnect/api/portal-auth/portal-rbac-guide.md
+++ b/app/konnect/api/portal-auth/portal-rbac-guide.md
@@ -70,7 +70,7 @@ To get a list of the available roles, make a GET request to the roles endpoint. 
 
 ```bash
 curl --request GET \
-  --url https://us.api.konghq.com/v2/portal-roles \
+  --url https://<region>.api.konghq.com/v2/portal-roles \
   --header 'Authorization: Bearer <personal-access-token>'
 ```
 
@@ -90,7 +90,7 @@ To assign a role to a team, you must make a POST request to the team roles endpo
 
 ```bash
 curl --request POST \
-  --url https://us.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/assigned-roles \
+  --url https://<region>.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/assigned-roles \
   --header 'Authorization: Bearer <personal-access-token>' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -117,7 +117,7 @@ To remove a role from a team, you must make a DELETE request to the team roles e
 
 ```bash
 curl --request DELETE \
-  --url https://us.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/assigned-roles/<role-id> \
+  --url https://<region>.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/assigned-roles/<role-id> \
   --header 'Authorization: Bearer <personal-access-token>'
 ```
 
@@ -131,7 +131,7 @@ You can make a GET request to the developers endpoint to retrieve all the inform
 
 ```bash
 curl --request GET \
-  --url https://us.api.konghq.com/v2/portals/<portal-id>/developers \
+  --url https://<region>.api.konghq.com/v2/portals/<portal-id>/developers \
   --header 'Authorization: Bearer <personal-access-token>'
 ```
 
@@ -139,7 +139,7 @@ To add a developer to a team, you make a POST request to the team members endpoi
 
 ```bash
 curl --request POST \
-  --url https://us.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/developers \
+  --url https://<region>.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/developers \
   --header 'Authorization: Bearer <personal-access-token>' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -153,7 +153,7 @@ To remove a developer from a team, you make a DELETE request to the team members
 
 ```bash
 curl --request DELETE \
-  --url https://us.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/developers/<developer-id> \
+  --url https://<region>.api.konghq.com/v2/portals/<portal-id>/teams/<team-id>/developers/<developer-id> \
   --header 'Authorization: Bearer <personal-access-token>' \
   --header 'Content-Type: application/json'
 ```

--- a/app/konnect/api/runtime-groups-config/index.md
+++ b/app/konnect/api/runtime-groups-config/index.md
@@ -787,7 +787,7 @@ a JSON representation of the data you want to send. Example:
 An example adding a Route to a Service named `test-service`:
 
 ```
-curl -i -X POST http://https://us.api.konghq.com/v2/runtime-groups/{runtime_group_id}/core-entities/routes \
+curl -i -X POST http://https://{region}.api.konghq.com/v2/runtime-groups/{runtime_group_id}/core-entities/routes \
      -H "Content-Type: application/json" \
      -d '{"name": "test-route", "paths": [ "/path/one", "/path/two" ]}'
 ```

--- a/app/konnect/api/runtime-groups-config/index.md
+++ b/app/konnect/api/runtime-groups-config/index.md
@@ -752,7 +752,7 @@ The API for configuring Kong Konnect Runtime Groups.
 
 
 
-This API is similar to the [Kong Gateway admin API](/gateway/admin-api/) with a few notable differences:
+This API is similar to the [Kong Gateway admin API](/gateway/latest/admin-api/) with a few notable differences:
 
 * `PATCH` methods are not supported
 > `PATCH` methods are not yet available in the Konnect core entities endpoint. Update operations can be performed with the `PUT` method. 

--- a/app/konnect/api/runtime-groups-config/index.md
+++ b/app/konnect/api/runtime-groups-config/index.md
@@ -2310,8 +2310,8 @@ The router adds:
 
 Learn more about the router:
 
-[Configure routes using expressions](/gateway/{{page.kong_version}}/key-concepts/routes/expressions)
-[Router Expressions language reference](/gateway/{{page.kong_version}}/reference/router-expressions-language/)
+[Configure routes using expressions](/gateway/latest/key-concepts/routes/expressions/)
+[Router Expressions language reference](/gateway/latest/reference/router-expressions-language/)
 
 
 #### Path handling algorithms
@@ -5601,11 +5601,11 @@ HTTP 204 No Content
 
 ---
 
-[clustering]: /gateway/{{page.kong_version}}/reference/clustering
-[cli]: /gateway/{{page.kong_version}}/reference/cli
-[active]: /gateway/{{page.kong_version}}/how-kong-works/health-checks/#active-health-checks
-[healthchecks]: /gateway/{{page.kong_version}}/how-kong-works/health-checks
-[secure-admin-api]: /gateway/{{page.kong_version}}/production/running-kong/secure-admin-api
-[proxy-reference]: /gateway/{{page.kong_version}}/how-kong-works/routing-traffic/
+[clustering]: /gateway/latest/reference/clustering
+[cli]: /gateway/latest/reference/cli
+[active]: /gateway/latest/how-kong-works/health-checks/#active-health-checks
+[healthchecks]: /gateway/latest/how-kong-works/health-checks
+[secure-admin-api]: /gateway/latest/production/running-kong/secure-admin-api
+[proxy-reference]: /gateway/latest/how-kong-works/routing-traffic/
 
 {% endunless %}

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -43,7 +43,7 @@ add the following hostnames to the firewall allowlist:
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
 * `<region>.api.konghq.com`: The {{site.konnect_short_name}} API.
     Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
-    Region can be `us` or `eu`.
+    Region can be `us`, `eu`, or `global`.
 * `<runtime-group-id>.<region>.cp0.konghq.com`: Handles configuration for a runtime group.
     Runtime instances connect to this host to receive configuration updates.
     This hostname is unique to each organization and runtime group.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -41,12 +41,13 @@ To let a runtime instances request and receive configuration, and send telemetry
 add the following hostnames to the firewall allowlist:
 
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
-* `us.api.konghq.com`: The {{site.konnect_short_name}} API.
+* `<region>.api.konghq.com`: The {{site.konnect_short_name}} API.
     Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
-* `RUNTIME_GROUP_ID.us.cp0.konghq.com`: Handles configuration for a runtime group.
+    Region can be `us` or `eu`.
+* `<runtime-group-id>.<region>.cp0.konghq.com`: Handles configuration for a runtime group.
     Runtime instances connect to this host to receive configuration updates.
     This hostname is unique to each organization and runtime group.
-* `RUNTIME_GROUP_ID.us.tp0.konghq.com`: Gathers telemetry data for a runtime group.
+* `<runtime-group-id>.<region>.tp0.konghq.com`: Gathers telemetry data for a runtime group.
     This hostname is unique to each organization and runtime group.
 
 You can find the configuration and telemetry hostnames through the Runtime Manager:


### PR DESCRIPTION
### Description

Replacing region in Konnect API request examples to either a placeholder or `global`, as appropriate. When region is explicitly set to `us` in examples where other placeholders exist, the user gets confused and the requests are wrong for `eu` users.

https://konghq.atlassian.net/browse/DOCU-3192

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

