### PR TITLE
docs(router/expressions): fix the description of net.protocol

### DIFF
--- a/app/_src/gateway/reference/router-expressions-language.md
+++ b/app/_src/gateway/reference/router-expressions-language.md
@@ -47,7 +47,7 @@ For example, you can not perform string comparisons on a integer type field.
 
 | Field | Description | Type |
 | --- | ----------- | -------|
-| `net.protocol` | The protocol used to communicate with the upstream application. | String |
+| `net.protocol` | The protocol used to communicate with the downstream application. | String |
 | `net.port` | Server end port number. | Int |
 | `tls.sni`  | Server name indication. | String |
 | `http.method` | HTTP methods that match a route. | String |


### PR DESCRIPTION
### Description

What did you change and why?
 
KAG-1251


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

