### PR TITLE
Clear out div tags from plugin front matter

### DIFF
--- a/app/_hub/kong-inc/jwt/_index.md
+++ b/app/_hub/kong-inc/jwt/_index.md
@@ -100,10 +100,6 @@ params:
       datatype: number
       description: |
         A value between 0 and 31536000 (365 days) limiting the lifetime of the JWT to `maximum_expiration` seconds in the future. Any JWT that has a longer lifetime is rejected (HTTP 403). If this value is specified, `exp` must be specified as well in the `claims_to_verify` property. The default value of `0` represents an indefinite period. Potential clock skew should be considered when configuring this setting.
-  extra: |
-    <div class="alert alert-warning">
-        <center>The option <code>config.run_on_preflight</code> is only available from version <code>0.11.1</code> and later.</center>
-    </div>
 ---
 
 ## Documentation

--- a/app/_hub/kong-inc/ldap-auth/_index.md
+++ b/app/_hub/kong-inc/ldap-auth/_index.md
@@ -132,7 +132,6 @@ params:
       datatype: string
       description: |
         An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to "basic", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `"ldap"` and `"basic"`.
-  extra: '<div class="alert alert-warning"> <strong>Note:</strong> The <code>config.header_type</code> option was introduced in Kong 0.12.0. Previous versions of this plugin behave as if <code>ldap</code> was set for this value. </div>'
 ---
 
 ## Usage

--- a/app/_hub/kong-inc/oauth2/_index.md
+++ b/app/_hub/kong-inc/oauth2/_index.md
@@ -1,20 +1,18 @@
 ---
 name: OAuth 2.0 Authentication
 publisher: Kong Inc.
-desc: Add OAuth 2.0 authentication to your Services
+desc: Add OAuth 2.0 authentication to your services
 description: |
   Add an OAuth 2.0 authentication layer with the [Authorization Code Grant](https://tools.ietf.org/html/rfc6749#section-4.1), [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4),
   [Implicit Grant](https://tools.ietf.org/html/rfc6749#section-4.2), or [Resource Owner Password Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.3) flow.
 
-  ----
-
-  <div class="alert alert-warning">
-    <strong>Note:</strong> As per the OAuth2 specs, this plugin requires the
+  {:.important}
+  > **Note:** As per the OAuth2 specs, this plugin requires the
     underlying service to be served over HTTPS. To avoid any
-    confusion, we recommend that you configure the Route used to serve the
-    underlying Service to only accept HTTPS traffic (using its `protocols`
+    confusion, we recommend that you configure the route used to serve the
+    underlying service to only accept HTTPS traffic (using its `protocols`
     property).
-  </div>
+
 cloud: false
 type: plugin
 categories:

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -271,13 +271,12 @@ params:
         Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream.
   extra: |
 
-    <div class="alert alert-ee red">
-    <strong>Warning:</strong> The <code>content_type</code> parameter requires
-    an exact match. For example, if your Upstream expects
-    <code>application/json; charset=utf-8</code> and the
-    <code>config.content_type</code> value is only <code>application/json</code>
-    (a partial match), then the proxy cache is bypassed.
-    </div>
+    {:.important}
+    > **Warning:** The `content_type` parameter requires
+    an exact match. For example, if your upstream expects
+    `application/json; charset=utf-8` and the
+    `config.content_type` value is only `application/json`
+    (a partial match), then the proxy cache is bypassed.  
 ---
 ### Strategies
 

--- a/app/_hub/kong-inc/proxy-cache-advanced/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_index.md
@@ -447,8 +447,8 @@ parameters.
 
 * The `redis.password`, `redis.sentinel_username`, and `redis.sentinel_password`
 configuration fields are now marked as referenceable, which means they can be
-securely stored as [secrets](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started/)
-in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/security/secrets-management/reference-format/).
+securely stored as [secrets](/gateway/latest/kong-enterprise/secrets-management/getting-started/)
+in a vault. References must follow a [specific format](/gateway/latest/kong-enterprise/secrets-management/reference-format/).
 
 * Fixed plugin versions in the documentation. Previously, the plugin versions
 were labelled as `1.3-x` and `2.2.x`. They are now updated to align with the

--- a/app/_hub/kong-inc/proxy-cache/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/_index.md
@@ -109,14 +109,13 @@ params:
       description: |
         The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.
   extra: |
-
-    <div class="alert alert-ee red">
-    <strong>Warning:</strong> The <code>content_type</code> parameter requires
-    an exact match. For example, if your Upstream expects
-    <code>application/json; charset=utf-8</code> and the
-    <code>config.content_type</code> value is only <code>application/json</code>
+  
+    {:.important}
+    > **Warning:** The `content_type` parameter requires
+    an exact match. For example, if your upstream expects
+    `application/json; charset=utf-8` and the
+    `config.content_type` value is only `application/json`
     (a partial match), then the proxy cache is bypassed.
-    </div>
 ---
 ### Strategies
 

--- a/app/_hub/kong-inc/rate-limiting/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/_index.md
@@ -188,7 +188,9 @@ params:
         Set a custom error message to return when the rate limit is exceeded.
 
 
-  extra: '<div class="alert alert-warning"> <strong>Note:</strong> At least one limit (`second`, `minute`, `hour`, `day`, `month`, `year`) must be configured. Multiple limits can be configured. </div>'
+  extra: |
+    {:.note}
+    > **Note:** At least one limit (`second`, `minute`, `hour`, `day`, `month`, `year`) must be configured. Multiple limits can be configured.
 ---
 
 ## Headers sent to the client

--- a/app/_hub/kong-inc/request-size-limiting/_index.md
+++ b/app/_hub/kong-inc/request-size-limiting/_index.md
@@ -3,12 +3,12 @@ name: Request Size Limiting
 publisher: Kong Inc.
 desc: Block requests with bodies greater than a specified size
 description: |
-  <div class="alert alert-warning">
-    For security reasons, we suggest enabling this plugin for any Service you add
-    to Kong Gateway to prevent a DOS (Denial of Service) attack.
-  </div>
+  Block incoming requests where the body is greater than a specific size in megabytes.
 
-  Block incoming requests whose body is greater than a specific size in megabytes.
+  {:.important}
+  > For security reasons, we suggest enabling this plugin for any service you add
+  to Kong Gateway to prevent a DOS (Denial of Service) attack.
+
 type: plugin
 categories:
   - traffic-control


### PR DESCRIPTION
### Description

Follow-up to https://github.com/Kong/docs.konghq.com/pull/5480. Raw html was continuing to cause problems when used in front matter. Fixing that.

Got rid of two alert divs that refer to very, very old versions of Gateway.

![image (21)](https://user-images.githubusercontent.com/54370747/234701889-19b8db18-2da8-4199-9d9f-4f7ac9f29a77.png)

### Testing instructions

Netlify links:
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/oauth2/
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/jwt/
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/ldap-auth/
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/proxy-cache/
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/proxy-cache-advanced/
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/rate-limiting/
https://deploy-preview-5505--kongdocs.netlify.app/hub/kong-inc/request-size-limiting/



### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

