### PR TITLE
Fix port to echo:http port in using-kongingress-resource.md

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-kongingress-resource.md
@@ -343,7 +343,7 @@ spec:
           service:
             name: echo
             port:
-              number: 80
+              number: 1027
 " | kubectl apply -f -
 ```
 {% endnavtab %}


### PR DESCRIPTION
err

```
time="2023-05-02T09:43:12Z" level=error msg="resource processing failed: can't find port for backend kubernetes service: no suitable port found" GVK="/v1, Kind=Service" name=echo namespace=testportroute
time="2023-05-02T09:43:12Z" level=error msg="resource processing failed: can't find port for backend kubernetes service: no suitable port found" GVK="networking.k8s.io/v1, Kind=Ingress" name=demo namespace=testportroute
```


### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

