### PR TITLE
docs(3.3) remove references to 'default tracing_sampling_rate'

### DIFF
--- a/app/_src/gateway/production/tracing/api.md
+++ b/app/_src/gateway/production/tracing/api.md
@@ -9,8 +9,8 @@ In Gateway version 3.0.0, the tracing API became part of the Kong core applicati
 The API is in the `kong.tracing` namespace.
 
 The tracing API follows the [OpenTelemetry API specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md).
-This specification defines how to use the API as an instrument to your module. 
-If you are familiar with the OpenTelemetry API, the tracing API will be familiar. 
+This specification defines how to use the API as an instrument to your module.
+If you are familiar with the OpenTelemetry API, the tracing API will be familiar.
 
 With the tracing API, you can set the instrumentation of your module with the following operations:
 - [Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span)
@@ -27,7 +27,7 @@ By default, the tracer is a [NoopTracer](https://github.com/open-telemetry/opent
 {% if_version gte:3.2.x %}
 By default, the tracer is a [NoopTracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#get-a-tracer). The tracer is first initialized when `tracing_instrumentations` configuration is enabled.
 {% endif_version %}
-You can create a new tracer manually, or use the global tracer instance: 
+You can create a new tracer manually, or use the global tracer instance:
 
 ```lua
 local tracer
@@ -41,7 +41,7 @@ tracer = kong.tracing
 
 ### Sampling traces
 
-The sampling rate of a tracer can be configured: 
+The sampling rate of a tracer can be configured:
 
 ```lua
 local tracer = kong.tracing.new("custom-tracer", {
@@ -50,7 +50,7 @@ local tracer = kong.tracing.new("custom-tracer", {
 })
 ```
 
-The default sampling rate is `1.0`, which samples all traces.
+A `sampling_rate` of `0.1` means that 1 of every 10 requests will be traced. A rate of `1` means that all requests will be traced.
 
 ## Create a span
 


### PR DESCRIPTION
### Description

We changed the default value of tracing_sampling_rate in 3.3 (from 1 to 0.01). This doc still says that de default is 1. Instead of changing it to the new default, I removed all mentions to default from here.

Our auto-generated docs for the configuration change should pick up the new default value.

FTI-5032

--

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



[FTI-5032]: https://konghq.atlassian.net/browse/FTI-5032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ