### PR TITLE
Add Konnect DP Certificate renewal with OpenSSL instructions

### DIFF
--- a/app/konnect/runtime-manager/runtime-instances/renew-certificates.md
+++ b/app/konnect/runtime-manager/runtime-instances/renew-certificates.md
@@ -23,9 +23,8 @@ files.
 
 ## Quick setup
 
-If you originally created your runtime instance container using the
-[quick setup Docker script](/konnect/runtime-manager/runtime-instances/gateway-runtime-docker/#quick-setup),
-we recommend running the script again to create a new instance with renewed
+If you originally created your runtime instance container using one of the
+Docker options in Runtime Manager, we recommend creating a new instance with renewed
 certificates.
 
 1. Stop the runtime instance container.
@@ -62,8 +61,7 @@ You can generate a new data plane certificate from the {% konnect_icon runtimes 
 
 {% navtab Konnect API %}
 
-You can generate a certificate locally and use the [pin data plane client certificate](https://developer.konghq.com/spec/3c38bff8-3b7b-4323-8e2e-690d35ef97e0/16adcd15-493a-49b2-ad53-8c73891e29bf#/DP%20Certificates/post-dp-client-certificates) endpoint to add it to Konnect
-
+You can generate a certificate locally and use the [pin data plane client certificate](https://developer.konghq.com/spec/3c38bff8-3b7b-4323-8e2e-690d35ef97e0/16adcd15-493a-49b2-ad53-8c73891e29bf#/DP%20Certificates/post-dp-client-certificates) endpoint to add it to Konnect.
 
 1.  Generate a new certificate and key:
 
@@ -71,7 +69,7 @@ You can generate a certificate locally and use the [pin data plane client certif
     openssl req -new -x509 -nodes -newkey rsa:2048 -subj "/CN=kongdp/C=US" -keyout ./tls.key -out ./tls.crt
     ```
 
-1. Reformat the certificate in to a single line for the API call
+1. Reformat the certificate into a single line for the API call:
 
     ```bash
     export CERT=$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' tls.crt)

--- a/app/konnect/runtime-manager/runtime-instances/renew-certificates.md
+++ b/app/konnect/runtime-manager/runtime-instances/renew-certificates.md
@@ -44,6 +44,8 @@ generate new certificates and replace them on the existing nodes.
 
 ### Generate new data plane certificate
 
+{% navtabs %}
+{% navtab Runtime Manager %}
 You can generate a new data plane certificate from the {% konnect_icon runtimes %} **Runtime Manager**.
 
 1. Select a runtime instance
@@ -56,6 +58,32 @@ You can generate a new data plane certificate from the {% konnect_icon runtimes 
     * private key: `tls.key`
 
 1. Store the files on the local file system.
+{% endnavtab %}
+
+{% navtab Konnect API %}
+
+You can generate a certificate locally and use the [pin data plane client certificate](https://developer.konghq.com/spec/3c38bff8-3b7b-4323-8e2e-690d35ef97e0/16adcd15-493a-49b2-ad53-8c73891e29bf#/DP%20Certificates/post-dp-client-certificates) endpoint to add it to Konnect
+
+
+1.  Generate a new certificate and key:
+
+    ```bash
+    openssl req -new -x509 -nodes -newkey rsa:2048 -subj "/CN=kongdp/C=US" -keyout ./tls.key -out ./tls.crt
+    ```
+
+1. Reformat the certificate in to a single line for the API call
+
+    ```bash
+    export CERT=$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' tls.crt)
+    ```
+
+1. `POST` the certificate to your runtime group using the Konnect API:
+
+    ```bash
+    curl https://us.api.konghq.com/v2/runtime-groups/{runtimeGroupId}/dp-client-certificates --json '{"cert":"'$CERT'"}'
+    ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ### Update data plane
 

--- a/app/konnect/runtime-manager/runtime-instances/renew-certificates.md
+++ b/app/konnect/runtime-manager/runtime-instances/renew-certificates.md
@@ -30,8 +30,7 @@ certificates.
 1. Stop the runtime instance container.
 2. Open {% konnect_icon runtimes %} **Runtime Manager**, select a runtime group,
  and click **New Runtime Instance**.
-3. Run the script again to
-[create a new runtime instance](/konnect/runtime-manager/runtime-instances/gateway-runtime-docker/#quick-setup) with
+3. Run the script to create a new runtime instance with
 updated certificates.
 4. Remove the old runtime instance container.
 


### PR DESCRIPTION
### Description

It's possible to renew DP certs with `openssl` but we didn't document the process publicly. 

### Testing instructions

Netlify link: https://deploy-preview-5518--kongdocs.netlify.app/konnect/runtime-manager/runtime-instances/renew-certificates/#:~:text=Alternatively%2C%20you%20can%20generate%20a%20certificate%20locally

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)