### PR TITLE
Fix description and retention information on the Summary page doc

### DIFF
--- a/app/konnect/analytics/index.md
+++ b/app/konnect/analytics/index.md
@@ -39,7 +39,7 @@ From {% konnect_icon analytics %} Analytics, you can view dashboards, access his
 * [Export historical data in CSV format](/konnect/analytics/services-and-routes/) for any individual service, service version, or route.
 * [Create a custom report](/konnect/analytics/generate-reports/) for any number of services, routes, or applications, filtered by time frame and grouped by metric.
 
-The summary dashboard provides metrics for services cataloged by Service Hub within a selected time interval for the following categories:
+The summary dashboard provides metrics across all services in your organization within a selected time interval for the following categories:
 
 * **Traffic**
 * **Errors**

--- a/app/konnect/analytics/index.md
+++ b/app/konnect/analytics/index.md
@@ -12,7 +12,7 @@ statistics, monitor vital signs, and pinpoint anomalies in real time.
 Depending on your {{site.konnect_saas}} subscription tier, Analytics retains
 historical data for the following lengths of time:
 * **Free:** 24 hours
-* **Plus:** 6 months
+* **Plus:** 3 months
 * **Enterprise:** 1 year
 
 ## Contextual analytics for services and routes


### PR DESCRIPTION
### Description

- Changed 6 months to 3 months retention for Analytics as per our pricing page ([MA-1657](https://konghq.atlassian.net/browse/MA-1657)).
- Changed description for what data we include on the summary page from "only Service Hub" to "all services across the entire Konnect organization" ([MA-1594](https://konghq.atlassian.net/browse/MA-1594)). 


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

