### PR TITLE
[fix] Broken link in Linux installation docs

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -1,7 +1,8 @@
 # DEPRECATED OS
-/gateway/3.0.x/install-and-run/centos    /gateway/latest/install-and-run/os-support
-/gateway/latest/install-and-run/centos   /gateway/latest/install-and-run/os-support
-/gateway/latest/install/macos/           /gateway/latest/install/
+/gateway/3.0.x/install-and-run/centos    /gateway/latest/support-policy/#supported-versions
+/gateway/latest/install-and-run/centos   /gateway/latest/support-policy/#supported-versions
+/gateway/latest/install/macos/           /gateway/latest/support-policy/#supported-versions
+/gateway/latest/install/linux/os-support/  /gateway/latest/support-policy/#supported-versions
 
 # FREE TRIALS, GENERAL LICENSING
 /free-trial/guide/                    https://konghq.com/install

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -9,7 +9,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A [supported system](/gateway/{{page.kong_version}}/install/linux/os-support/) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
+* A [supported system](/gateway/{{page.kong_version}}/support-policy/#supported-versions) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
 * (Enterprise only) A `license.json` file from Kong.
 
 ## Download and Install

--- a/app/_src/gateway/install/linux/centos.md
+++ b/app/_src/gateway/install/linux/centos.md
@@ -20,7 +20,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A [supported system](/gateway/{{page.kong_version}}/install/linux/os-support/) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
+* A [supported system](/gateway/{{page.kong_version}}/support-policy/#supported-versions) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
 * (Enterprise only) A `license.json` file from Kong.
 
 ## Download and Install

--- a/app/_src/gateway/install/linux/debian.md
+++ b/app/_src/gateway/install/linux/debian.md
@@ -9,7 +9,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-* A [supported system](/gateway/{{page.kong_version}}/install/linux/os-support/) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
+* A [supported system](/gateway/{{page.kong_version}}/support-policy/#supported-versions) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
 * The following tools are installed:
   * [`curl`](https://curl.se/)
   * [`lsb-release`](https://packages.debian.org/lsb-release)

--- a/app/_src/gateway/install/linux/rhel.md
+++ b/app/_src/gateway/install/linux/rhel.md
@@ -9,7 +9,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
+* A [supported system](/gateway/{{page.kong_version}}/support-policy/#supported-versions) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
 * (Enterprise only) A `license.json` file from Kong
 
 ## Download and Install

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -17,7 +17,7 @@ Kong is licensed under an
 
 ## Prerequisites
 
-* A supported system with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
+* A [supported system](/gateway/{{page.kong_version}}/support-policy/#supported-versions) with root or [root-equivalent](/gateway/{{page.kong_version}}/production/running-kong/kong-user/) access.
 * (Enterprise only) A `license.json` file from Kong
 
 ## Installation

--- a/app/moved_urls.yml
+++ b/app/moved_urls.yml
@@ -153,4 +153,4 @@
 /gateway/VERSION/plugin-development/plugin-configuration/: "/gateway/VERSION/plugin-development/configuration/"
 /gateway/VERSION/reference/external-plugins/: "/gateway/VERSION/plugin-development/pluginserver/go/"
 /gateway/VERSION/get-started/secure-services/: "/gateway/VERSION/get-started/key-authentication/"
-/gateway/VERSION/install/linux/os-support/: "/gateway/VERSION/os-support/"
+/gateway/VERSION/install/linux/os-support/: "/gateway/VERSION/support-policy/#supported-versions"


### PR DESCRIPTION
https://kongstrong.slack.com/archives/CDSTDSG9J/p1683122758154309

- Added a link to https://docs.konghq.com/gateway/latest/support-policy/#supported-versions in all of the installation docs. Replacing the broken link where appropriate. 
- Rewrote redirects that pointed to the broken link. 
- Added redirect for the broken link to https://docs.konghq.com/gateway/latest/support-policy/#supported-versions

