### PR TITLE
Fix missing routing by header guide

### DIFF
--- a/app/_data/docs_nav_kic_2.8.x.yml
+++ b/app/_data/docs_nav_kic_2.8.x.yml
@@ -129,6 +129,8 @@ items:
         url: /guides/using-kong-with-knative
       - text: Using Multiple Backend Services
         url: /guides/using-multiple-backends
+      - text: Routing by Header
+        url: /guides/routing-by-header/
   - title: References
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     items:

--- a/app/_data/docs_nav_kic_2.9.x.yml
+++ b/app/_data/docs_nav_kic_2.9.x.yml
@@ -133,6 +133,8 @@ items:
         url: /guides/using-multiple-backends
       - text: Using Gateway Discovery
         url: /guides/using-gateway-discovery
+      - text: Routing by Header
+        url: /guides/routing-by-header/
   - title: References
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     items:


### PR DESCRIPTION
### Description

Adding missing Routing by Header guide to the KIC 2.8.x and 2.9.x docs. It was missing from the navs, so it wasn't being generated.

Discovered via failed check here:  https://github.com/Kong/docs.konghq.com/actions/runs/4863150515/jobs/8670450676?pr=5516

### Testing instructions

Netlify links:
https://deploy-preview-5521--kongdocs.netlify.app/kubernetes-ingress-controller/2.9.x/guides/routing-by-header/
https://deploy-preview-5521--kongdocs.netlify.app/kubernetes-ingress-controller/2.8.x/guides/routing-by-header/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

