### PR TITLE
StatsD plugin: Clarify shdict_name variable

### DIFF
--- a/app/_hub/kong-inc/statsd/_index.md
+++ b/app/_hub/kong-inc/statsd/_index.md
@@ -142,7 +142,7 @@ params:
 ## Metrics
 
 {% if_plugin_version gte:3.0.x %}
-Metric                     | Description | Namespace
+Metric                     | Description | Namespace syntax
 ---                        | ---         | ---
 `request_count`            | The number of requests. | `kong.service.<service_identifier>.request.count`
 `request_size`             | The request's body size in bytes. | `kong.service.<service_identifier>.request.size`
@@ -156,7 +156,7 @@ Metric                     | Description | Namespace
 `status_count_per_user`    | Tracks the status code per consumer per service. | `kong.service.<service_identifier>.user.<consumer_identifier>.status.<status>`
 `status_count_per_workspace`         | The status code per workspace. | `kong.service.<service_identifier>.workspace.<workspace_identifier>.status.<status>`
 `status_count_per_user_per_route`    | The status code per consumer per route. | `kong.route.<route_id>.user.<consumer_identifier>.status.<status>`
-`shdict_usage`             | The usage of shared dict, sent once every minute. | `kong.node.<node_hostname>.shdict.<shdict_name>.free_space` and `kong.node.<node_hostname>.shdict.<shdict_name>.capacity`
+`shdict_usage`             | The usage of a shared dict, sent once every minute. <br><br> Monitors any `lua_shared_dict` used by {{site.base_gateway}}. You can find all the shared dicts {{site.base_gateway}} has configured using the [`/status`](/gateway/latest/admin-api/#health-routes) endpoint of the Admin API. <br><br>For example, the metric might report on `shdict.kong_locks` or `shdict.kong_counters`. | `kong.node.<node_hostname>.shdict.<lua_shared_dict>.free_space` and <br>`kong.node.<node_hostname>.shdict.<lua_shared_dict>.capacity`
 `cache_datastore_hits_total`            | The total number of cache hits. (Kong Enterprise only) | `kong.service.<service_identifier>.cache_datastore_hits_total`
 `cache_datastore_misses_total`            | The total number of cache misses. (Kong Enterprise only) | `kong.service.<service_identifier>.cache_datastore_misses_total`
 


### PR DESCRIPTION
### Description

* Adding info on where to find your lua_shared_dicts
* Changing the variable label in the syntax to `lua_shared_dict` so that the reader would know what to look for; shdict_name is a local variable only and doesn't help them find the right info

I found that you can figure out which shared dicts you have in your Kong env using the `/status` endpoint, so I ended up leaving out info on custom shared dicts. It doesn't seem relevant to talk about custom nginx templates in this context.

Issue reported on [Slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1682692187562059).

### Testing instructions

Netlify link: https://deploy-preview-5522--kongdocs.netlify.app/hub/kong-inc/statsd/#metrics

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

