### PR TITLE
fix(kic/faq): replace broken links for K8s docs

### DIFF
--- a/app/_src/kubernetes-ingress-controller/faq.md
+++ b/app/_src/kubernetes-ingress-controller/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/1.0.x/faq.md
+++ b/app/kubernetes-ingress-controller/1.0.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/1.1.x/faq.md
+++ b/app/kubernetes-ingress-controller/1.1.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/1.2.x/faq.md
+++ b/app/kubernetes-ingress-controller/1.2.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/1.3.x/faq.md
+++ b/app/kubernetes-ingress-controller/1.3.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/2.0.x/faq.md
+++ b/app/kubernetes-ingress-controller/2.0.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/2.1.x/faq.md
+++ b/app/kubernetes-ingress-controller/2.1.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy

--- a/app/kubernetes-ingress-controller/2.2.x/faq.md
+++ b/app/kubernetes-ingress-controller/2.2.x/faq.md
@@ -21,5 +21,5 @@ it creates.
 This means that if consumers and credentials are created dynamically, they
 won't be deleted by the Ingress Controller.
 
-[k8s-service]: http://kubernetes.io/docs/user-guide/services
-[kube-proxy]: http://kubernetes.io/docs/admin/kube-proxy
+[k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
+[kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy


### PR DESCRIPTION
### Description

Currently links to K8s docs in that FAQ are broken, leads to `404` empty page
<img width="1694" alt="image" src="https://user-images.githubusercontent.com/9593424/236161123-0137fb8c-7f98-4424-b4b8-d570ce453d67.png">

This PR fixes the above.


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

