### PR TITLE
Add shared rate limit example to Rate Limiting Advanced docs

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -109,7 +109,13 @@ params:
       datatype: string
       description: |
         The rate limiting library namespace to use for this plugin instance. Counter
-        data and sync configuration is isolated in each namespace.
+        data and sync configuration is isolated in each namespace. This value should be unique between
+        every instance of a plugin in most configurations.
+
+        If you use the same `namespace` value for multiple instances of the plugin, the rate limit will be shared
+        between all instances. For example, if you set `namespace: helloworld` when adding the rate limiting plugin
+        to `service-a` and use the same namespace on `service-b`, a request to either service will increment the
+        counter for the caller. This allows you to share rate limits between services.
 
         {:.important}
         > **Important**: If managing Kong Gateway with **declarative configuration** or running


### PR DESCRIPTION
### Description

Clarify how the `namespace` field works in RLA in response to feedback from @mrwanny 


### Testing instructions

Netlify link: https://deploy-preview-5526--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/#:~:text=0.02%20seconds%20(20ms).-,config.namespace

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)