### PR TITLE
fix(graphql) Removes reference to an unsupported GraphQL Example

### DIFF
--- a/app/_src/gateway/kong-plugins/graphql.md
+++ b/app/_src/gateway/kong-plugins/graphql.md
@@ -60,6 +60,3 @@ A more advanced strategy is available for GraphQL schemas that enforce quantifie
 
 Read more about rate-limiting here: [GraphQL Rate Limiting Advanced Plugin](/hub/kong-inc/graphql-rate-limiting-advanced/)
 
-### New upstream
-
-We have prepared a [quickstart guide](https://github.com/Kong/kong-apollo-quickstart) that will help you build your new GraphQL service on top of Kong and Apollo.


### PR DESCRIPTION
### Description
The referenced GraphQL example is not supported or maintained by Kong.  In additton, "New upstream" was unclear to the reader


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

