### PR TITLE
Make Org Management a Konnect nav item

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -204,10 +204,10 @@
             url: /org-management/okta-idp/
           - text: Login Sessions Reference
             url: /org-management/sessions-reference/
-      - text: Account and Org Deactivation
-        url: /org-management/deactivation/
-      - text: Troubleshoot
-        url: /org-management/troubleshoot/
+          - text: Account and Org Deactivation
+            url: /org-management/deactivation/
+          - text: Troubleshoot
+            url: /org-management/troubleshoot/
 
 - title: API
   icon: /assets/images/icons/documentation/icn-admin-api-color.svg

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -178,34 +178,36 @@
           url: /account-management/change-plan/
         - text: Manage Payment Methods and Invoices
           url: /account-management/billing/
-    - text: Authentication and Authorization
+    - text: Org Management
       items:
-        - text: Overview
-          url: /org-management/auth/
-        - text: Teams
-          items:
-            - text: Overview
-              url: /org-management/teams-and-roles/
-            - text: Manage Teams
-              url: /org-management/teams-and-roles/manage/
-            - text: Teams Reference
-              url: /org-management/teams-and-roles/teams-reference/
-            - text: Roles Reference
-              url: /org-management/teams-and-roles/roles-reference/
-        - text: Manage Users
-          url: /org-management/users/
-        - text: Manage System Accounts
-          url: /org-management/system-accounts/
-        - text: Set up SSO with OIDC
-          url: /org-management/oidc-idp/
-        - text: Set up SSO with Okta
-          url: /org-management/okta-idp/
-        - text: Login Sessions Reference
-          url: /org-management/sessions-reference/
-    - text: Account and Org Deactivation
-      url: /org-management/deactivation/
-    - text: Troubleshoot
-      url: /org-management/troubleshoot/
+      - text: Authentication and Authorization
+        items:
+          - text: Overview
+            url: /org-management/auth/
+          - text: Teams
+            items:
+              - text: Overview
+                url: /org-management/teams-and-roles/
+              - text: Manage Teams
+                url: /org-management/teams-and-roles/manage/
+              - text: Teams Reference
+                url: /org-management/teams-and-roles/teams-reference/
+              - text: Roles Reference
+                url: /org-management/teams-and-roles/roles-reference/
+          - text: Manage Users
+            url: /org-management/users/
+          - text: Manage System Accounts
+            url: /org-management/system-accounts/
+          - text: Set up SSO with OIDC
+            url: /org-management/oidc-idp/
+          - text: Set up SSO with Okta
+            url: /org-management/okta-idp/
+          - text: Login Sessions Reference
+            url: /org-management/sessions-reference/
+      - text: Account and Org Deactivation
+        url: /org-management/deactivation/
+      - text: Troubleshoot
+        url: /org-management/troubleshoot/
 
 - title: API
   icon: /assets/images/icons/documentation/icn-admin-api-color.svg


### PR DESCRIPTION
### Description

The docs under the Administer nav section in Konnect have `org-management` as part of their URL, but there's no nav item for it. This can be confusing.

Issue reported in [Slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1683210668941149).

~Do not merge yet, Jackie is going to do a review of the content structure of this section.~ Ready to go.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

